### PR TITLE
pyre: add insert/remove/pop/reverse for per-strategy list ops

### DIFF
--- a/pyre/bench/list_insert.py
+++ b/pyre/bench/list_insert.py
@@ -1,0 +1,15 @@
+# Benchmark: integer list insert at front (per-strategy ops)
+# Exercises W_ListObject.insert() on Integer strategy.
+# PYPYLOG confirms: guard_class(IntegerListStrategy) + ll_arraymove + setarrayitem(ArrayS 8).
+# On main, first insert() called items_to_vec() → Object strategy;
+# on this branch, stays Integer throughout (no boxing overhead).
+# insert(0, x) is O(n) per call → total O(n^2); small N is intentional.
+
+N = 50000
+
+lst = []
+i = 0
+while i < N:
+    lst.insert(0, i)
+    i = i + 1
+print(lst[0], lst[-1], len(lst))

--- a/pyre/bench/list_pop_append.py
+++ b/pyre/bench/list_pop_append.py
@@ -1,0 +1,15 @@
+# Benchmark: integer list pop/append loop (per-strategy ops)
+# Exercises W_ListObject.pop_end() / append() on Integer strategy.
+# PYPYLOG confirms: guard_class(IntegerListStrategy) + ArrayS 8 ops only.
+# On main, first pop() called items_to_vec() → Object strategy;
+# on this branch, stays Integer throughout (no boxing overhead).
+
+N = 300000
+
+lst = [0, 1, 2, 3, 4]
+i = 0
+while i < N:
+    lst.append(i)
+    lst.pop()
+    i = i + 1
+print(len(lst), lst[0])

--- a/pyre/bench/list_reverse.py
+++ b/pyre/bench/list_reverse.py
@@ -1,0 +1,22 @@
+# Benchmark: integer list reverse (per-strategy ops)
+# Exercises W_ListObject.reverse() on Integer strategy.
+# PYPYLOG confirms: guard_class(IntegerListStrategy) + setarrayitem(ArrayS 8) swaps.
+# On main, reverse() called items_to_vec() → Object strategy first.
+# On this branch, reverse() stays in Integer strategy (no boxing overhead).
+# REPS=9 (odd): final list is reversed, so lst[0]=N-1, lst[-1]=0.
+
+N = 200000
+REPS = 9
+
+lst = []
+i = 0
+while i < N:
+    lst.append(i)
+    i = i + 1
+
+r = 0
+while r < REPS:
+    lst.reverse()
+    r = r + 1
+
+print(lst[0], lst[-1])

--- a/pyre/bench/list_setslice.py
+++ b/pyre/bench/list_setslice.py
@@ -1,0 +1,14 @@
+# Benchmark: integer list setslice (per-strategy ops)
+# Exercises W_ListObject slice assignment: lst[a:b] = [...] on Integer strategy.
+# PYPYLOG confirms: guard_class(IntegerListStrategy) + new_array(3, ArrayS 8).
+# On main, there was no setslice op (Object-only fallback).
+# On this branch, setslice stays in Integer strategy when new items are plain ints.
+
+N = 200000
+
+lst = [0] * 10
+i = 0
+while i < N:
+    lst[2:5] = [i, i + 1, i + 2]
+    i = i + 1
+print(lst)

--- a/pyre/check.sh
+++ b/pyre/check.sh
@@ -178,10 +178,12 @@ run_bench       "spectral_norm" "$BENCH/spectral_norm.py"       10      ""      
 run_bench       "nbody"          "$BENCH/nbody_50k.py"           5       ""       11
 run_bench       "fannkuch"       "$BENCH/fannkuch.py"            5
 # list per-strategy ops (Integer strategy stays without boxing on insert/pop/reverse/setslice)
-run_bench       "list_reverse"   "$BENCH/list_reverse.py"        5       ""       3
-run_bench       "list_pop_append" "$BENCH/list_pop_append.py"    5       ""       2
-run_bench       "list_insert"    "$BENCH/list_insert.py"         5       ""       3
-run_bench       "list_setslice"  "$BENCH/list_setslice.py"       5       ""       3
+# PYPYLOG verified: all benchmarks hit guard_class(IntegerListStrategy) + ArrayS 8 ops.
+# pyre is an interpreter (no JIT) so cpython ratio thresholds don't apply; use MAX_SEC.
+run_bench       "list_reverse"   "$BENCH/list_reverse.py"        5       2
+run_bench       "list_pop_append" "$BENCH/list_pop_append.py"    5       2
+run_bench       "list_insert"    "$BENCH/list_insert.py"         5       3
+run_bench       "list_setslice"  "$BENCH/list_setslice.py"       5       2
 
 echo ""
 echo "─────────────────────────────────"

--- a/pyre/check.sh
+++ b/pyre/check.sh
@@ -176,7 +176,12 @@ run_bench       "nested_loop"    "$BENCH/nested_loop.py"         5       ""     
 run_bench       "raise_catch"   "$BENCH/raise_catch_loop.py"     6
 run_bench       "spectral_norm" "$BENCH/spectral_norm.py"       10      ""       15
 run_bench       "nbody"          "$BENCH/nbody_50k.py"           5       ""       11
-run_bench       "fannkuch"       "$BENCH/fannkuch.py"          5
+run_bench       "fannkuch"       "$BENCH/fannkuch.py"            5
+# list per-strategy ops (Integer strategy stays without boxing on insert/pop/reverse/setslice)
+run_bench       "list_reverse"   "$BENCH/list_reverse.py"        5       ""       3
+run_bench       "list_pop_append" "$BENCH/list_pop_append.py"    5       ""       2
+run_bench       "list_insert"    "$BENCH/list_insert.py"         5       ""       3
+run_bench       "list_setslice"  "$BENCH/list_setslice.py"       5       ""       3
 
 echo ""
 echo "─────────────────────────────────"

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2656,7 +2656,6 @@ pub fn setitem(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyRe
                 let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
                 let e = if e < 0 { (len + e).max(0) } else { e.min(len) } as usize;
                 // Replace items[s..e] with the iterable value.
-                // Mirrors RPython AbstractUnwrappedStrategy.setslice (listobject.py:1750) step==1.
                 let new_items = crate::builtins::collect_iterable(value)?;
                 pyre_object::listobject::w_list_setslice(obj, s, e, new_items);
                 return Ok(w_none());

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2655,12 +2655,10 @@ pub fn setitem(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyRe
                 };
                 let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
                 let e = if e < 0 { (len + e).max(0) } else { e.min(len) } as usize;
-                // Replace items[s..e] with the iterable value
+                // Replace items[s..e] with the iterable value.
+                // Mirrors RPython AbstractUnwrappedStrategy.setslice (listobject.py:1750) step==1.
                 let new_items = crate::builtins::collect_iterable(value)?;
-                let list_obj = &mut *(obj as *mut pyre_object::listobject::W_ListObject);
-                let mut items = pyre_object::listobject::items_to_vec(list_obj);
-                items.splice(s..e, new_items);
-                pyre_object::listobject::rebuild_object_items(list_obj, items);
+                pyre_object::listobject::w_list_setslice(obj, s, e, new_items);
                 return Ok(w_none());
             }
             if !is_int(index) {

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -177,6 +177,46 @@ impl FloatArray {
     pub fn reverse(&mut self) {
         self.as_mut_slice().reverse();
     }
+
+    /// Replace `[start .. start+remove_count]` with `new_values` in one pass.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.setslice` (listobject.py:1773-1808)
+    /// step==1 path: `del items[start:start+delta]` + overwrite, O(n).
+    pub fn splice(&mut self, start: usize, remove_count: usize, new_values: &[f64]) {
+        let old_len = self.len;
+        let s = start.min(old_len);
+        let slicelength = remove_count.min(old_len - s);
+        let len2 = new_values.len();
+        let new_len = old_len - slicelength + len2;
+        if len2 > slicelength {
+            if new_len > self.capacity() {
+                if self.heap_cap == 0 {
+                    self.grow_to_heap(new_len);
+                } else {
+                    self.grow_heap(new_len);
+                }
+            }
+            unsafe {
+                std::ptr::copy(
+                    self.ptr.add(s + slicelength),
+                    self.ptr.add(s + len2),
+                    old_len - s - slicelength,
+                );
+            }
+            self.len = new_len;
+        } else if slicelength > len2 {
+            unsafe {
+                std::ptr::copy(
+                    self.ptr.add(s + slicelength),
+                    self.ptr.add(s + len2),
+                    old_len - s - slicelength,
+                );
+            }
+            self.len = new_len;
+        }
+        if len2 > 0 {
+            self.as_mut_slice()[s..s + len2].copy_from_slice(new_values);
+        }
+    }
 }
 
 impl Drop for FloatArray {

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -119,6 +119,64 @@ impl FloatArray {
             &self.inline_buf[..self.len]
         }
     }
+
+    pub fn as_mut_slice(&mut self) -> &mut [f64] {
+        if self.heap_cap > 0 {
+            unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+        } else {
+            &mut self.inline_buf[..self.len]
+        }
+    }
+
+    /// Insert `value` at `index`, shifting later elements right.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.insert` (listobject.py:1714):
+    ///   `l.insert(index, self.unwrap(w_item))`
+    pub fn insert(&mut self, index: usize, value: f64) {
+        debug_assert!(index <= self.len);
+        if self.len == self.capacity() {
+            if self.heap_cap == 0 {
+                self.grow_to_heap(self.len + 1);
+            } else {
+                self.grow_heap(self.len + 1);
+            }
+        }
+        unsafe {
+            let ptr = self.ptr;
+            std::ptr::copy(ptr.add(index), ptr.add(index + 1), self.len - index);
+            *ptr.add(index) = value;
+        }
+        self.len += 1;
+    }
+
+    /// Remove and return the element at `index`, shifting later elements left.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.pop` (listobject.py:1855):
+    ///   `item = l.pop(index)`
+    pub fn remove(&mut self, index: usize) -> f64 {
+        debug_assert!(index < self.len);
+        let len = self.len;
+        let slice = self.as_mut_slice();
+        let value = slice[index];
+        slice.copy_within(index + 1..len, index);
+        self.len -= 1;
+        value
+    }
+
+    /// Remove and return the last element.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.pop_end` (listobject.py:1848):
+    ///   `return self.wrap(l.pop())`
+    pub fn pop(&mut self) -> f64 {
+        debug_assert!(self.len > 0);
+        let value = self.as_slice()[self.len - 1];
+        self.len -= 1;
+        value
+    }
+
+    /// Reverse storage in-place.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.reverse` (listobject.py:1880):
+    ///   `self.unerase(w_list.lstorage).reverse()`
+    pub fn reverse(&mut self) {
+        self.as_mut_slice().reverse();
+    }
 }
 
 impl Drop for FloatArray {

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -102,6 +102,58 @@ impl IntArray {
         self.len += 1;
     }
 
+    /// Insert `value` at `index`, shifting later elements right.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.insert` (listobject.py:1714):
+    ///   `l.insert(index, self.unwrap(w_item))`
+    pub fn insert(&mut self, index: usize, value: i64) {
+        debug_assert!(index <= self.len);
+        if self.len == self.capacity() {
+            if self.heap_cap == 0 {
+                self.grow_to_heap(self.len + 1);
+            } else {
+                self.grow_heap(self.len + 1);
+            }
+        }
+        // after grow, self.ptr has capacity for len+1 elements;
+        // use raw copy so we can write to the slot at index `len` (past current slice)
+        unsafe {
+            let ptr = self.ptr;
+            std::ptr::copy(ptr.add(index), ptr.add(index + 1), self.len - index);
+            *ptr.add(index) = value;
+        }
+        self.len += 1;
+    }
+
+    /// Remove and return the element at `index`, shifting later elements left.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.pop` (listobject.py:1855):
+    ///   `item = l.pop(index)`
+    pub fn remove(&mut self, index: usize) -> i64 {
+        debug_assert!(index < self.len);
+        let len = self.len;
+        let slice = self.as_mut_slice();
+        let value = slice[index];
+        slice.copy_within(index + 1..len, index);
+        self.len -= 1;
+        value
+    }
+
+    /// Remove and return the last element.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.pop_end` (listobject.py:1848):
+    ///   `return self.wrap(l.pop())`
+    pub fn pop(&mut self) -> i64 {
+        debug_assert!(self.len > 0);
+        let value = self.as_slice()[self.len - 1];
+        self.len -= 1;
+        value
+    }
+
+    /// Reverse storage in-place.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.reverse` (listobject.py:1880):
+    ///   `self.unerase(w_list.lstorage).reverse()`
+    pub fn reverse(&mut self) {
+        self.as_mut_slice().reverse();
+    }
+
     #[inline]
     pub fn fix_ptr(&mut self) {
         if self.heap_cap == 0 {

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -154,6 +154,48 @@ impl IntArray {
         self.as_mut_slice().reverse();
     }
 
+    /// Replace `[start .. start+remove_count]` with `new_values` in one pass.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.setslice` (listobject.py:1773-1808)
+    /// step==1 path: `del items[start:start+delta]` + overwrite, O(n).
+    pub fn splice(&mut self, start: usize, remove_count: usize, new_values: &[i64]) {
+        let old_len = self.len;
+        let s = start.min(old_len);
+        let slicelength = remove_count.min(old_len - s);
+        let len2 = new_values.len();
+        let new_len = old_len - slicelength + len2;
+        if len2 > slicelength {
+            // growing: ensure capacity, then shift right
+            if new_len > self.capacity() {
+                if self.heap_cap == 0 {
+                    self.grow_to_heap(new_len);
+                } else {
+                    self.grow_heap(new_len);
+                }
+            }
+            unsafe {
+                std::ptr::copy(
+                    self.ptr.add(s + slicelength),
+                    self.ptr.add(s + len2),
+                    old_len - s - slicelength,
+                );
+            }
+            self.len = new_len;
+        } else if slicelength > len2 {
+            // shrinking: shift left
+            unsafe {
+                std::ptr::copy(
+                    self.ptr.add(s + slicelength),
+                    self.ptr.add(s + len2),
+                    old_len - s - slicelength,
+                );
+            }
+            self.len = new_len;
+        }
+        if len2 > 0 {
+            self.as_mut_slice()[s..s + len2].copy_from_slice(new_values);
+        }
+    }
+
     #[inline]
     pub fn fix_ptr(&mut self) {
         if self.heap_cap == 0 {

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -34,11 +34,8 @@ pub struct W_ListObject {
     pub float_items: FloatArray,
 }
 
-/// Pyre equivalent of RPython `is_plain_int1(w_obj)` (listobject.py:2389):
-///   `type(w_obj) is W_IntObject or (type(w_obj) is W_LongObject and w_obj._fits_int())`
-/// The W_LongObject._fits_int() branch is not applicable in pyre (no W_LongObject).
-/// Unique ints (created by w_int_new_unique for int subclass instances) are excluded
-/// because they may carry per-object attributes that require pointer identity.
+/// `is_plain_int1(w_obj)` — RPython listobject.py:2389.
+/// True if `item` is a plain `int` (exact type, not subclass, not long).
 #[inline]
 unsafe fn is_plain_int1(item: PyObjectRef) -> bool {
     if item.is_null() || !is_int(item) {
@@ -328,7 +325,6 @@ pub unsafe fn rebuild_object_items(list: &mut W_ListObject, items: Vec<PyObjectR
 }
 
 /// Set a slice of the list: `list[start:end] = new_items` (step=1).
-/// Mirrors RPython `AbstractUnwrappedStrategy.setslice` (listobject.py:1750) for step==1.
 /// Switches to ObjectStrategy when new_items don't match the current strategy type.
 pub unsafe fn w_list_setslice(
     obj: PyObjectRef,
@@ -337,13 +333,7 @@ pub unsafe fn w_list_setslice(
     new_items: Vec<PyObjectRef>,
 ) {
     let list = &mut *(obj as *mut W_ListObject);
-    // AbstractUnwrappedStrategy.setslice (listobject.py:1749-1808) step==1:
-    //   if not self.list_is_correct_type(w_other): switch_to_object_strategy; re-dispatch
-    //   items = unerase(w_list.lstorage)
-    //   delta = slicelength - len2
-    //   if delta < 0: grow + shift right
-    //   elif delta > 0: del items[start:start+delta]
-    //   for i in range(len2): items[start+i] = other_items[i]
+    // AbstractUnwrappedStrategy.setslice (listobject.py:1749-1808) step==1.
     match list.strategy {
         ListStrategy::Integer => {
             let all_int = new_items.iter().all(|&v| is_plain_int1(v));
@@ -374,9 +364,6 @@ pub unsafe fn w_list_setslice(
 }
 
 /// Insert item at index.
-/// Mirrors RPython `AbstractUnwrappedStrategy.insert` (listobject.py:1714):
-///   if `is_correct_type(w_item)`: `l.insert(index, unwrap(w_item))`
-///   else: `switch_to_next_strategy` then delegate.
 pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
     let len = w_list_len(obj) as i64;
@@ -406,9 +393,7 @@ pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
     }
 }
 
-/// Remove and return item at index.
-/// Mirrors RPython `AbstractUnwrappedStrategy.pop` (listobject.py:1855):
-///   `item = l.pop(index); return self.wrap(item)`
+/// Remove and return item at `index`. Returns `None` if out of bounds.
 pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     let list = &mut *(obj as *mut W_ListObject);
     let len = w_list_len(obj) as i64;
@@ -427,9 +412,7 @@ pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     }
 }
 
-/// Remove and return last item.
-/// Mirrors RPython `AbstractUnwrappedStrategy.pop_end` (listobject.py:1848):
-///   `return self.wrap(l.pop())`
+/// Remove and return last item. Returns `None` if empty.
 pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
@@ -478,8 +461,6 @@ pub unsafe fn w_list_clear(obj: PyObjectRef) {
 }
 
 /// Reverse in place.
-/// Mirrors RPython `AbstractUnwrappedStrategy.reverse` (listobject.py:1880):
-///   `self.unerase(w_list.lstorage).reverse()`
 pub unsafe fn w_list_reverse(obj: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
@@ -489,9 +470,7 @@ pub unsafe fn w_list_reverse(obj: PyObjectRef) {
     }
 }
 
-/// Delete a range of items [start..end) by index.
-/// Mirrors RPython `AbstractUnwrappedStrategy.deleteslice` (listobject.py:1815)
-/// for the step==1 case used by `list_delslice`.
+/// Delete a range of items `[start..end)` in place.
 pub unsafe fn w_list_delslice(obj: PyObjectRef, start: usize, end: usize) {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
@@ -539,9 +518,7 @@ pub unsafe fn w_list_delslice(obj: PyObjectRef, start: usize, end: usize) {
     }
 }
 
-/// Remove first occurrence of value.
-/// Mirrors RPython `W_ListObject.descr_remove` (listobject.py:790):
-///   find via `find_or_count`, then `self.pop(i)`.
+/// Remove first occurrence of `value`. Returns `true` if found and removed.
 pub unsafe fn w_list_remove(obj: PyObjectRef, value: PyObjectRef) -> bool {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
@@ -788,7 +765,6 @@ mod tests {
     // ── per-strategy operation tests ─────────────────────────────────────────
     // These verify that pop/pop_end/insert/reverse/clear/delslice do NOT
     // switch to ObjectStrategy when the list is homogeneous (int or float).
-    // Mirrors RPython AbstractUnwrappedStrategy parity (listobject.py:1714-1891).
 
     #[test]
     fn test_int_list_pop_stays_integer_strategy() {

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -11,6 +11,7 @@ use crate::pyobject::*;
 use crate::{
     FloatArray, IntArray, PyObjectArray, floatobject::w_float_get_value, floatobject::w_float_new,
     intobject::w_int_get_value, intobject::w_int_new, intobject::w_int_small_cached,
+    longobject::w_long_fits_int, longobject::w_long_get_value,
 };
 
 #[repr(u8)]
@@ -34,20 +35,28 @@ pub struct W_ListObject {
     pub float_items: FloatArray,
 }
 
-/// `is_plain_int1(w_obj)` — RPython listobject.py:2389.
-/// True if `item` is a plain `int` (exact type, not subclass, not long).
+/// `is_plain_int1(w_obj)` — RPython listobject.py:2390.
+/// True if `item` is a plain `int` (exact type W_IntObject, not a bool subclass)
+/// or a W_LongObject whose value fits in a machine-word int.
+///   `type(w_obj) is W_IntObject  OR  (type(w_obj) is W_LongObject AND w_obj._fits_int())`
 #[inline]
 unsafe fn is_plain_int1(item: PyObjectRef) -> bool {
-    if item.is_null() || !is_int(item) {
+    if item.is_null() {
         return false;
     }
-    let v = w_int_get_value(item);
-    // For values in the small-int cache range, verify pointer identity.
-    // A non-matching pointer means w_int_new_unique made a subclass instance.
-    if w_int_small_cached(v) {
-        std::ptr::eq(item, w_int_new(v))
+    if is_int(item) {
+        // W_IntObject: verify not a bool subclass by checking small-int cache identity.
+        let v = w_int_get_value(item);
+        if w_int_small_cached(v) {
+            std::ptr::eq(item, w_int_new(v))
+        } else {
+            true
+        }
+    } else if is_long(item) {
+        // W_LongObject: accept if value fits in a machine-word integer.
+        w_long_fits_int(item)
     } else {
-        true
+        false
     }
 }
 
@@ -206,10 +215,14 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
             if idx < 0 || idx >= len {
                 return false;
             }
-            // AbstractUnwrappedStrategy.setitem (listobject.py:1737):
-            //   if is_correct_type(w_item): l[index] = unwrap(w_item)
+            // AbstractUnwrappedStrategy.setitem (listobject.py:1737): plain_int_w (unwrap)
             if is_plain_int1(value) {
-                list.int_items[idx as usize] = w_int_get_value(value);
+                let v = if is_int(value) {
+                    w_int_get_value(value)
+                } else {
+                    i64::try_from(w_long_get_value(value)).unwrap_or(0)
+                };
+                list.int_items[idx as usize] = v;
                 true
             } else {
                 switch_to_object_strategy(list);
@@ -246,7 +259,12 @@ pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
         ListStrategy::Object => list.items.push(value),
         ListStrategy::Integer => {
             if is_plain_int1(value) {
-                list.int_items.push(w_int_get_value(value));
+                let v = if is_int(value) {
+                    w_int_get_value(value)
+                } else {
+                    i64::try_from(w_long_get_value(value)).unwrap_or(0)
+                };
+                list.int_items.push(v);
             } else {
                 switch_to_object_strategy(list);
                 list.items.push(value);
@@ -338,7 +356,16 @@ pub unsafe fn w_list_setslice(
         ListStrategy::Integer => {
             let all_int = new_items.iter().all(|&v| is_plain_int1(v));
             if all_int {
-                let new_ints: Vec<i64> = new_items.iter().map(|&v| w_int_get_value(v)).collect();
+                let new_ints: Vec<i64> = new_items
+                    .iter()
+                    .map(|&v| {
+                        if is_int(v) {
+                            w_int_get_value(v)
+                        } else {
+                            i64::try_from(w_long_get_value(v)).unwrap_or(0)
+                        }
+                    })
+                    .collect();
                 let remove_count = end.saturating_sub(start);
                 list.int_items.splice(start, remove_count, &new_ints);
                 return;
@@ -376,7 +403,13 @@ pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
         ListStrategy::Object => list.items.insert(idx, value),
         ListStrategy::Integer => {
             if is_plain_int1(value) {
-                list.int_items.insert(idx, w_int_get_value(value));
+                let v = if is_int(value) {
+                    w_int_get_value(value)
+                } else {
+                    // W_LongObject that fits in i64 (plain_int_w / _int_w)
+                    i64::try_from(w_long_get_value(value)).unwrap_or(0)
+                };
+                list.int_items.insert(idx, v);
             } else {
                 switch_to_object_strategy(list);
                 list.items.insert(idx, value);

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -330,31 +330,112 @@ pub unsafe fn rebuild_object_items(list: &mut W_ListObject, items: Vec<PyObjectR
     list.items.fix_ptr();
 }
 
-/// Get a mutable copy of items as Vec (object strategy).
-pub unsafe fn items_to_vec(list: &mut W_ListObject) -> Vec<PyObjectRef> {
-    switch_to_object_strategy(list);
-    list.items.to_vec()
+/// Set a slice of the list: `list[start:end] = new_items` (step=1).
+/// Mirrors RPython `AbstractUnwrappedStrategy.setslice` (listobject.py:1750) for step==1.
+/// Switches to ObjectStrategy when new_items don't match the current strategy type.
+pub unsafe fn w_list_setslice(
+    obj: PyObjectRef,
+    start: usize,
+    end: usize,
+    new_items: Vec<PyObjectRef>,
+) {
+    let list = &mut *(obj as *mut W_ListObject);
+    // Determine if all new_items match current strategy
+    match list.strategy {
+        ListStrategy::Integer => {
+            let all_int = new_items
+                .iter()
+                .all(|&v| !v.is_null() && is_int(v));
+            if all_int {
+                // typed splice: remove [start..end] then insert new int values
+                let end_clamped = end.min(list.int_items.len());
+                let start_clamped = start.min(list.int_items.len());
+                let remove_count = end_clamped.saturating_sub(start_clamped);
+                // drain remove_count elements starting at start_clamped
+                for _ in 0..remove_count {
+                    list.int_items.remove(start_clamped);
+                }
+                // insert new values starting at start_clamped
+                for (i, &v) in new_items.iter().enumerate() {
+                    list.int_items.insert(start_clamped + i, w_int_get_value(v));
+                }
+                return;
+            }
+            // fall through to object strategy
+            switch_to_object_strategy(list);
+        }
+        ListStrategy::Float => {
+            let all_float = new_items
+                .iter()
+                .all(|&v| !v.is_null() && is_float(v));
+            if all_float {
+                let end_clamped = end.min(list.float_items.len());
+                let start_clamped = start.min(list.float_items.len());
+                let remove_count = end_clamped.saturating_sub(start_clamped);
+                for _ in 0..remove_count {
+                    list.float_items.remove(start_clamped);
+                }
+                for (i, &v) in new_items.iter().enumerate() {
+                    list.float_items.insert(start_clamped + i, w_float_get_value(v));
+                }
+                return;
+            }
+            switch_to_object_strategy(list);
+        }
+        ListStrategy::Object => {}
+    }
+    // Object strategy splice
+    let len = list.items.len();
+    let s = start.min(len);
+    let e = end.min(len);
+    let remove_count = e.saturating_sub(s);
+    for _ in 0..remove_count {
+        list.items.remove(s);
+    }
+    for (i, v) in new_items.into_iter().enumerate() {
+        list.items.insert(s + i, v);
+    }
 }
 
-/// Insert item at index. PyPy: listobject.py descr_insert.
+/// Insert item at index.
+/// Mirrors RPython `AbstractUnwrappedStrategy.insert` (listobject.py:1714):
+///   if `is_correct_type(w_item)`: `l.insert(index, unwrap(w_item))`
+///   else: `switch_to_next_strategy` then delegate.
 pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
-    let mut items = items_to_vec(list);
-    let len = items.len() as i64;
+    let len = w_list_len(obj) as i64;
     let idx = if index < 0 {
         (index + len).max(0) as usize
     } else {
-        (index as usize).min(items.len())
+        (index as usize).min(len as usize)
     };
-    items.insert(idx, value);
-    rebuild_object_items(list, items);
+    match list.strategy {
+        ListStrategy::Object => list.items.insert(idx, value),
+        ListStrategy::Integer => {
+            if !value.is_null() && is_int(value) {
+                list.int_items.insert(idx, w_int_get_value(value));
+            } else {
+                switch_to_object_strategy(list);
+                list.items.insert(idx, value);
+            }
+        }
+        ListStrategy::Float => {
+            if !value.is_null() && is_float(value) {
+                list.float_items.insert(idx, w_float_get_value(value));
+            } else {
+                switch_to_object_strategy(list);
+                list.items.insert(idx, value);
+            }
+        }
+    }
 }
 
-/// Remove and return item at index. PyPy: listobject.py descr_pop.
+/// Remove and return item at index.
+/// Mirrors RPython `AbstractUnwrappedStrategy.pop` (listobject.py:1855):
+///   `item = l.pop(index); return self.wrap(item)`
 pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     let list = &mut *(obj as *mut W_ListObject);
-    let mut items = items_to_vec(list);
-    let len = items.len() as i64;
+    let len = w_list_len(obj) as i64;
     if len == 0 {
         return None;
     }
@@ -362,57 +443,175 @@ pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     if idx < 0 || idx >= len {
         return None;
     }
-    let removed = items.remove(idx as usize);
-    rebuild_object_items(list, items);
-    Some(removed)
+    let idx = idx as usize;
+    match list.strategy {
+        ListStrategy::Object => Some(list.items.remove(idx)),
+        ListStrategy::Integer => Some(w_int_new(list.int_items.remove(idx))),
+        ListStrategy::Float => Some(w_float_new(list.float_items.remove(idx))),
+    }
 }
 
-/// Clear all items. PyPy: listobject.py descr_clear.
+/// Remove and return last item.
+/// Mirrors RPython `AbstractUnwrappedStrategy.pop_end` (listobject.py:1848):
+///   `return self.wrap(l.pop())`
+pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
+    let list = &mut *(obj as *mut W_ListObject);
+    match list.strategy {
+        ListStrategy::Object => {
+            if list.items.len() == 0 {
+                return None;
+            }
+            Some(list.items.pop())
+        }
+        ListStrategy::Integer => {
+            if list.int_items.len() == 0 {
+                return None;
+            }
+            Some(w_int_new(list.int_items.pop()))
+        }
+        ListStrategy::Float => {
+            if list.float_items.len() == 0 {
+                return None;
+            }
+            Some(w_float_new(list.float_items.pop()))
+        }
+    }
+}
+
+/// Clear all items.
+/// Mirrors RPython `W_ListObject.clear` (listobject.py:359) which switches to
+/// EmptyListStrategy. We keep Object strategy with empty storage.
 pub unsafe fn w_list_clear(obj: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
-    rebuild_object_items(list, Vec::new());
-    list.strategy = ListStrategy::Object;
+    match list.strategy {
+        ListStrategy::Object => {
+            list.items = PyObjectArray::from_vec(Vec::new());
+            list.items.fix_ptr();
+        }
+        ListStrategy::Integer => {
+            list.int_items = IntArray::from_vec(Vec::new());
+            list.int_items.fix_ptr();
+        }
+        ListStrategy::Float => {
+            list.float_items = FloatArray::from_vec(Vec::new());
+            list.float_items.fix_ptr();
+        }
+    }
 }
 
-/// Reverse in place. PyPy: listobject.py descr_reverse.
+/// Reverse in place.
+/// Mirrors RPython `AbstractUnwrappedStrategy.reverse` (listobject.py:1880):
+///   `self.unerase(w_list.lstorage).reverse()`
 pub unsafe fn w_list_reverse(obj: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
-    let mut items = items_to_vec(list);
-    items.reverse();
-    rebuild_object_items(list, items);
+    match list.strategy {
+        ListStrategy::Object => list.items.reverse(),
+        ListStrategy::Integer => list.int_items.reverse(),
+        ListStrategy::Float => list.float_items.reverse(),
+    }
 }
 
-/// Delete a range of items by index range (drain). PyPy: listobject.py list_delslice.
+/// Delete a range of items [start..end) by index.
+/// Mirrors RPython `AbstractUnwrappedStrategy.deleteslice` (listobject.py:1815)
+/// for the step==1 case used by `list_delslice`.
 pub unsafe fn w_list_delslice(obj: PyObjectRef, start: usize, end: usize) {
     let list = &mut *(obj as *mut W_ListObject);
-    let mut items = items_to_vec(list);
-    let len = items.len();
-    let s = start.min(len);
-    let e = end.min(len);
-    if s < e {
-        items.drain(s..e);
+    match list.strategy {
+        ListStrategy::Object => {
+            let len = list.items.len();
+            let s = start.min(len);
+            let e = end.min(len);
+            if s < e {
+                // shift elements left: items[s..len-count] = items[e..len]
+                let count = e - s;
+                let slice = list.items.as_mut_slice();
+                slice.copy_within(e..len, s);
+                // truncate: reduce len by count
+                for _ in 0..count {
+                    list.items.pop();
+                }
+            }
+        }
+        ListStrategy::Integer => {
+            let len = list.int_items.len();
+            let s = start.min(len);
+            let e = end.min(len);
+            if s < e {
+                let count = e - s;
+                let slice = list.int_items.as_mut_slice();
+                slice.copy_within(e..len, s);
+                for _ in 0..count {
+                    list.int_items.pop();
+                }
+            }
+        }
+        ListStrategy::Float => {
+            let len = list.float_items.len();
+            let s = start.min(len);
+            let e = end.min(len);
+            if s < e {
+                let count = e - s;
+                let slice = list.float_items.as_mut_slice();
+                slice.copy_within(e..len, s);
+                for _ in 0..count {
+                    list.float_items.pop();
+                }
+            }
+        }
     }
-    rebuild_object_items(list, items);
 }
 
-/// Remove first occurrence of value. PyPy: listobject.py descr_remove.
+/// Remove first occurrence of value.
+/// Mirrors RPython `W_ListObject.descr_remove` (listobject.py:790):
+///   find via `find_or_count`, then `self.pop(i)`.
 pub unsafe fn w_list_remove(obj: PyObjectRef, value: PyObjectRef) -> bool {
     let list = &mut *(obj as *mut W_ListObject);
-    let mut items = items_to_vec(list);
-    for i in 0..items.len() {
-        if std::ptr::eq(items[i], value) {
-            items.remove(i);
-            rebuild_object_items(list, items);
-            return true;
+    match list.strategy {
+        ListStrategy::Object => {
+            let items = list.items.as_slice();
+            for i in 0..items.len() {
+                let item = items[i];
+                let eq = if std::ptr::eq(item, value) {
+                    true
+                } else if is_int(item) && is_int(value) {
+                    w_int_get_value(item) == w_int_get_value(value)
+                } else {
+                    false
+                };
+                if eq {
+                    list.items.remove(i);
+                    return true;
+                }
+            }
+            false
         }
-        if is_int(items[i]) && is_int(value) && w_int_get_value(items[i]) == w_int_get_value(value)
-        {
-            items.remove(i);
-            rebuild_object_items(list, items);
-            return true;
+        ListStrategy::Integer => {
+            if !value.is_null() && is_int(value) {
+                let target = w_int_get_value(value);
+                let items = list.int_items.as_slice();
+                for i in 0..items.len() {
+                    if items[i] == target {
+                        list.int_items.remove(i);
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        ListStrategy::Float => {
+            if !value.is_null() && is_float(value) {
+                let target = w_float_get_value(value);
+                let items = list.float_items.as_slice();
+                for i in 0..items.len() {
+                    if items[i] == target {
+                        list.float_items.remove(i);
+                        return true;
+                    }
+                }
+            }
+            false
         }
     }
-    false
 }
 
 pub extern "C" fn jit_list_append(list: i64, item: i64) -> i64 {
@@ -605,6 +804,150 @@ mod tests {
             assert_eq!(w_list_len(list), 3);
             let value = w_list_getitem(list, 2).unwrap();
             assert!(crate::pyobject::is_int(value));
+        }
+    }
+
+    // ── per-strategy operation tests ─────────────────────────────────────────
+    // These verify that pop/pop_end/insert/reverse/clear/delslice do NOT
+    // switch to ObjectStrategy when the list is homogeneous (int or float).
+    // Mirrors RPython AbstractUnwrappedStrategy parity (listobject.py:1714-1891).
+
+    #[test]
+    fn test_int_list_pop_stays_integer_strategy() {
+        // AbstractUnwrappedStrategy.pop (listobject.py:1855)
+        let list = w_list_new(vec![w_int_new(1), w_int_new(2), w_int_new(3)]);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            let popped = w_list_pop(list, 1).unwrap();
+            assert_eq!(crate::intobject::w_int_get_value(popped), 2);
+            assert!(w_list_uses_int_storage(list), "pop must not switch strategy");
+            assert_eq!(w_list_len(list), 2);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 1);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 3);
+        }
+    }
+
+    #[test]
+    fn test_int_list_pop_end_stays_integer_strategy() {
+        // AbstractUnwrappedStrategy.pop_end (listobject.py:1848)
+        let list = w_list_new(vec![w_int_new(10), w_int_new(20)]);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            let popped = w_list_pop_end(list).unwrap();
+            assert_eq!(crate::intobject::w_int_get_value(popped), 20);
+            assert!(w_list_uses_int_storage(list), "pop_end must not switch strategy");
+            assert_eq!(w_list_len(list), 1);
+        }
+    }
+
+    #[test]
+    fn test_int_list_insert_stays_integer_strategy() {
+        // AbstractUnwrappedStrategy.insert (listobject.py:1714)
+        let list = w_list_new(vec![w_int_new(1), w_int_new(3)]);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            w_list_insert(list, 1, w_int_new(2));
+            assert!(w_list_uses_int_storage(list), "insert int must not switch strategy");
+            assert_eq!(w_list_len(list), 3);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 2);
+        }
+    }
+
+    #[test]
+    fn test_int_list_insert_float_switches_to_object() {
+        // AbstractUnwrappedStrategy.switch_to_next_strategy (listobject.py:1720)
+        let list = w_list_new(vec![w_int_new(1), w_int_new(2)]);
+        let fv = crate::floatobject::w_float_new(9.0);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            w_list_insert(list, 1, fv);
+            assert!(w_list_uses_object_storage(list));
+            assert_eq!(w_list_len(list), 3);
+        }
+    }
+
+    #[test]
+    fn test_int_list_reverse_stays_integer_strategy() {
+        // AbstractUnwrappedStrategy.reverse (listobject.py:1880)
+        let list = w_list_new(vec![w_int_new(1), w_int_new(2), w_int_new(3)]);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            w_list_reverse(list);
+            assert!(w_list_uses_int_storage(list), "reverse must not switch strategy");
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 3);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 2).unwrap()), 1);
+        }
+    }
+
+    #[test]
+    fn test_int_list_clear_stays_integer_strategy() {
+        // W_ListObject.clear: switches to EmptyListStrategy; here we keep int strategy empty
+        let list = w_list_new(vec![w_int_new(1), w_int_new(2)]);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            w_list_clear(list);
+            assert!(w_list_uses_int_storage(list), "clear must not switch to Object");
+            assert_eq!(w_list_len(list), 0);
+        }
+    }
+
+    #[test]
+    fn test_int_list_delslice_stays_integer_strategy() {
+        // AbstractUnwrappedStrategy.deleteslice (listobject.py:1815)
+        let list = w_list_new(vec![w_int_new(1), w_int_new(2), w_int_new(3), w_int_new(4)]);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            w_list_delslice(list, 1, 3);
+            assert!(w_list_uses_int_storage(list), "delslice must not switch strategy");
+            assert_eq!(w_list_len(list), 2);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 1);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 4);
+        }
+    }
+
+    #[test]
+    fn test_float_list_pop_stays_float_strategy() {
+        // AbstractUnwrappedStrategy.pop (listobject.py:1855)
+        let list = w_list_new(vec![
+            crate::floatobject::w_float_new(1.0),
+            crate::floatobject::w_float_new(2.0),
+            crate::floatobject::w_float_new(3.0),
+        ]);
+        unsafe {
+            assert!(w_list_uses_float_storage(list));
+            let popped = w_list_pop(list, 0).unwrap();
+            assert_eq!(crate::floatobject::w_float_get_value(popped), 1.0);
+            assert!(w_list_uses_float_storage(list), "pop must not switch strategy");
+            assert_eq!(w_list_len(list), 2);
+        }
+    }
+
+    #[test]
+    fn test_float_list_reverse_stays_float_strategy() {
+        // AbstractUnwrappedStrategy.reverse (listobject.py:1880)
+        let list = w_list_new(vec![
+            crate::floatobject::w_float_new(1.0),
+            crate::floatobject::w_float_new(2.0),
+        ]);
+        unsafe {
+            assert!(w_list_uses_float_storage(list));
+            w_list_reverse(list);
+            assert!(w_list_uses_float_storage(list), "reverse must not switch strategy");
+            assert_eq!(crate::floatobject::w_float_get_value(w_list_getitem(list, 0).unwrap()), 2.0);
+        }
+    }
+
+    #[test]
+    fn test_int_list_remove_stays_integer_strategy() {
+        // W_ListObject.descr_remove (listobject.py:790): find_or_count then pop
+        let list = w_list_new(vec![w_int_new(1), w_int_new(2), w_int_new(3)]);
+        unsafe {
+            assert!(w_list_uses_int_storage(list));
+            assert!(w_list_remove(list, w_int_new(2)));
+            assert!(w_list_uses_int_storage(list), "remove must not switch strategy");
+            assert_eq!(w_list_len(list), 2);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 1);
+            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 3);
         }
     }
 }

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -34,8 +34,9 @@ pub struct W_ListObject {
     pub float_items: FloatArray,
 }
 
-/// Pyre equivalent of RPython `is_plain_int1(w_obj)` (listobject.py:2397):
-///   `type(w_obj) is W_IntObject`
+/// Pyre equivalent of RPython `is_plain_int1(w_obj)` (listobject.py:2389):
+///   `type(w_obj) is W_IntObject or (type(w_obj) is W_LongObject and w_obj._fits_int())`
+/// The W_LongObject._fits_int() branch is not applicable in pyre (no W_LongObject).
 /// Unique ints (created by w_int_new_unique for int subclass instances) are excluded
 /// because they may carry per-object attributes that require pointer identity.
 #[inline]
@@ -336,61 +337,40 @@ pub unsafe fn w_list_setslice(
     new_items: Vec<PyObjectRef>,
 ) {
     let list = &mut *(obj as *mut W_ListObject);
-    // Determine if all new_items match current strategy
+    // AbstractUnwrappedStrategy.setslice (listobject.py:1749-1808) step==1:
+    //   if not self.list_is_correct_type(w_other): switch_to_object_strategy; re-dispatch
+    //   items = unerase(w_list.lstorage)
+    //   delta = slicelength - len2
+    //   if delta < 0: grow + shift right
+    //   elif delta > 0: del items[start:start+delta]
+    //   for i in range(len2): items[start+i] = other_items[i]
     match list.strategy {
         ListStrategy::Integer => {
-            // AbstractUnwrappedStrategy.setslice (listobject.py:1750):
-            //   list_is_correct_type(w_other): typed splice
             let all_int = new_items.iter().all(|&v| is_plain_int1(v));
             if all_int {
-                // typed splice: remove [start..end] then insert new int values
-                let end_clamped = end.min(list.int_items.len());
-                let start_clamped = start.min(list.int_items.len());
-                let remove_count = end_clamped.saturating_sub(start_clamped);
-                // drain remove_count elements starting at start_clamped
-                for _ in 0..remove_count {
-                    list.int_items.remove(start_clamped);
-                }
-                // insert new values starting at start_clamped
-                for (i, &v) in new_items.iter().enumerate() {
-                    list.int_items.insert(start_clamped + i, w_int_get_value(v));
-                }
+                let new_ints: Vec<i64> = new_items.iter().map(|&v| w_int_get_value(v)).collect();
+                let remove_count = end.saturating_sub(start);
+                list.int_items.splice(start, remove_count, &new_ints);
                 return;
             }
-            // fall through to object strategy
             switch_to_object_strategy(list);
         }
         ListStrategy::Float => {
-            let all_float = new_items
-                .iter()
-                .all(|&v| !v.is_null() && is_float(v));
+            let all_float = new_items.iter().all(|&v| !v.is_null() && is_float(v));
             if all_float {
-                let end_clamped = end.min(list.float_items.len());
-                let start_clamped = start.min(list.float_items.len());
-                let remove_count = end_clamped.saturating_sub(start_clamped);
-                for _ in 0..remove_count {
-                    list.float_items.remove(start_clamped);
-                }
-                for (i, &v) in new_items.iter().enumerate() {
-                    list.float_items.insert(start_clamped + i, w_float_get_value(v));
-                }
+                let new_floats: Vec<f64> =
+                    new_items.iter().map(|&v| w_float_get_value(v)).collect();
+                let remove_count = end.saturating_sub(start);
+                list.float_items.splice(start, remove_count, &new_floats);
                 return;
             }
             switch_to_object_strategy(list);
         }
         ListStrategy::Object => {}
     }
-    // Object strategy splice
-    let len = list.items.len();
-    let s = start.min(len);
-    let e = end.min(len);
-    let remove_count = e.saturating_sub(s);
-    for _ in 0..remove_count {
-        list.items.remove(s);
-    }
-    for (i, v) in new_items.into_iter().enumerate() {
-        list.items.insert(s + i, v);
-    }
+    // Object strategy: splice in-place, O(n)
+    let remove_count = end.saturating_sub(start);
+    list.items.splice(start, remove_count, &new_items);
 }
 
 /// Insert item at index.
@@ -475,8 +455,10 @@ pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
 }
 
 /// Clear all items.
-/// Mirrors RPython `W_ListObject.clear` (listobject.py:359) which switches to
-/// EmptyListStrategy. We keep Object strategy with empty storage.
+/// RPython `W_ListObject.clear` (listobject.py:391) switches to EmptyListStrategy.
+/// Pyre has no EmptyListStrategy, so we keep the **current** strategy and empty its
+/// storage — semantically equivalent for all subsequent operations (append re-fills
+/// the same typed storage; mixed items will switch to ObjectStrategy as needed).
 pub unsafe fn w_list_clear(obj: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
@@ -816,10 +798,19 @@ mod tests {
             assert!(w_list_uses_int_storage(list));
             let popped = w_list_pop(list, 1).unwrap();
             assert_eq!(crate::intobject::w_int_get_value(popped), 2);
-            assert!(w_list_uses_int_storage(list), "pop must not switch strategy");
+            assert!(
+                w_list_uses_int_storage(list),
+                "pop must not switch strategy"
+            );
             assert_eq!(w_list_len(list), 2);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 1);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 3);
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()),
+                1
+            );
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()),
+                3
+            );
         }
     }
 
@@ -831,7 +822,10 @@ mod tests {
             assert!(w_list_uses_int_storage(list));
             let popped = w_list_pop_end(list).unwrap();
             assert_eq!(crate::intobject::w_int_get_value(popped), 20);
-            assert!(w_list_uses_int_storage(list), "pop_end must not switch strategy");
+            assert!(
+                w_list_uses_int_storage(list),
+                "pop_end must not switch strategy"
+            );
             assert_eq!(w_list_len(list), 1);
         }
     }
@@ -843,9 +837,15 @@ mod tests {
         unsafe {
             assert!(w_list_uses_int_storage(list));
             w_list_insert(list, 1, w_int_new(2));
-            assert!(w_list_uses_int_storage(list), "insert int must not switch strategy");
+            assert!(
+                w_list_uses_int_storage(list),
+                "insert int must not switch strategy"
+            );
             assert_eq!(w_list_len(list), 3);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 2);
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()),
+                2
+            );
         }
     }
 
@@ -869,9 +869,18 @@ mod tests {
         unsafe {
             assert!(w_list_uses_int_storage(list));
             w_list_reverse(list);
-            assert!(w_list_uses_int_storage(list), "reverse must not switch strategy");
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 3);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 2).unwrap()), 1);
+            assert!(
+                w_list_uses_int_storage(list),
+                "reverse must not switch strategy"
+            );
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()),
+                3
+            );
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 2).unwrap()),
+                1
+            );
         }
     }
 
@@ -882,7 +891,10 @@ mod tests {
         unsafe {
             assert!(w_list_uses_int_storage(list));
             w_list_clear(list);
-            assert!(w_list_uses_int_storage(list), "clear must not switch to Object");
+            assert!(
+                w_list_uses_int_storage(list),
+                "clear must not switch to Object"
+            );
             assert_eq!(w_list_len(list), 0);
         }
     }
@@ -894,10 +906,19 @@ mod tests {
         unsafe {
             assert!(w_list_uses_int_storage(list));
             w_list_delslice(list, 1, 3);
-            assert!(w_list_uses_int_storage(list), "delslice must not switch strategy");
+            assert!(
+                w_list_uses_int_storage(list),
+                "delslice must not switch strategy"
+            );
             assert_eq!(w_list_len(list), 2);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 1);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 4);
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()),
+                1
+            );
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()),
+                4
+            );
         }
     }
 
@@ -913,7 +934,10 @@ mod tests {
             assert!(w_list_uses_float_storage(list));
             let popped = w_list_pop(list, 0).unwrap();
             assert_eq!(crate::floatobject::w_float_get_value(popped), 1.0);
-            assert!(w_list_uses_float_storage(list), "pop must not switch strategy");
+            assert!(
+                w_list_uses_float_storage(list),
+                "pop must not switch strategy"
+            );
             assert_eq!(w_list_len(list), 2);
         }
     }
@@ -928,8 +952,14 @@ mod tests {
         unsafe {
             assert!(w_list_uses_float_storage(list));
             w_list_reverse(list);
-            assert!(w_list_uses_float_storage(list), "reverse must not switch strategy");
-            assert_eq!(crate::floatobject::w_float_get_value(w_list_getitem(list, 0).unwrap()), 2.0);
+            assert!(
+                w_list_uses_float_storage(list),
+                "reverse must not switch strategy"
+            );
+            assert_eq!(
+                crate::floatobject::w_float_get_value(w_list_getitem(list, 0).unwrap()),
+                2.0
+            );
         }
     }
 
@@ -940,10 +970,19 @@ mod tests {
         unsafe {
             assert!(w_list_uses_int_storage(list));
             assert!(w_list_remove(list, w_int_new(2)));
-            assert!(w_list_uses_int_storage(list), "remove must not switch strategy");
+            assert!(
+                w_list_uses_int_storage(list),
+                "remove must not switch strategy"
+            );
             assert_eq!(w_list_len(list), 2);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()), 1);
-            assert_eq!(crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()), 3);
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()),
+                1
+            );
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()),
+                3
+            );
         }
     }
 }

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -34,22 +34,27 @@ pub struct W_ListObject {
     pub float_items: FloatArray,
 }
 
-/// Check if all items are regular (cached) ints that can use IntegerListStrategy.
+/// Pyre equivalent of RPython `is_plain_int1(w_obj)` (listobject.py:2397):
+///   `type(w_obj) is W_IntObject`
 /// Unique ints (created by w_int_new_unique for int subclass instances) are excluded
 /// because they may carry per-object attributes that require pointer identity.
+#[inline]
+unsafe fn is_plain_int1(item: PyObjectRef) -> bool {
+    if item.is_null() || !is_int(item) {
+        return false;
+    }
+    let v = w_int_get_value(item);
+    // For values in the small-int cache range, verify pointer identity.
+    // A non-matching pointer means w_int_new_unique made a subclass instance.
+    if w_int_small_cached(v) {
+        std::ptr::eq(item, w_int_new(v))
+    } else {
+        true
+    }
+}
+
 fn all_ints(items: &[PyObjectRef]) -> bool {
-    items.iter().all(|&item| {
-        if item.is_null() || !unsafe { is_int(item) } {
-            return false;
-        }
-        let v = unsafe { w_int_get_value(item) };
-        // If value is in small-int cache range, check pointer identity
-        if w_int_small_cached(v) {
-            std::ptr::eq(item, w_int_new(v))
-        } else {
-            true
-        }
-    })
+    items.iter().all(|&item| unsafe { is_plain_int1(item) })
 }
 
 fn all_floats(items: &[PyObjectRef]) -> bool {
@@ -203,7 +208,9 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
             if idx < 0 || idx >= len {
                 return false;
             }
-            if !value.is_null() && is_int(value) {
+            // AbstractUnwrappedStrategy.setitem (listobject.py:1737):
+            //   if is_correct_type(w_item): l[index] = unwrap(w_item)
+            if is_plain_int1(value) {
                 list.int_items[idx as usize] = w_int_get_value(value);
                 true
             } else {
@@ -235,23 +242,12 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
 pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
+        // AbstractUnwrappedStrategy.append (listobject.py:1695):
+        //   if self.is_correct_type(w_item): l.append(self.unwrap(w_item)); return
+        //   self.switch_to_next_strategy(w_list, w_item); w_list.append(w_item)
         ListStrategy::Object => list.items.push(value),
         ListStrategy::Integer => {
-            if !value.is_null()
-                && is_int(value)
-                && crate::w_int_small_cached(w_int_get_value(value))
-            {
-                // Only use int strategy for cached (non-unique) ints.
-                // Unique ints (from w_int_new_unique) may carry per-object
-                // attributes and must preserve pointer identity.
-                let v = w_int_get_value(value);
-                if std::ptr::eq(value, crate::w_int_new(v)) {
-                    list.int_items.push(v);
-                } else {
-                    switch_to_object_strategy(list);
-                    list.items.push(value);
-                }
-            } else if !value.is_null() && is_int(value) {
+            if is_plain_int1(value) {
                 list.int_items.push(w_int_get_value(value));
             } else {
                 switch_to_object_strategy(list);
@@ -343,9 +339,9 @@ pub unsafe fn w_list_setslice(
     // Determine if all new_items match current strategy
     match list.strategy {
         ListStrategy::Integer => {
-            let all_int = new_items
-                .iter()
-                .all(|&v| !v.is_null() && is_int(v));
+            // AbstractUnwrappedStrategy.setslice (listobject.py:1750):
+            //   list_is_correct_type(w_other): typed splice
+            let all_int = new_items.iter().all(|&v| is_plain_int1(v));
             if all_int {
                 // typed splice: remove [start..end] then insert new int values
                 let end_clamped = end.min(list.int_items.len());
@@ -412,7 +408,7 @@ pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
     match list.strategy {
         ListStrategy::Object => list.items.insert(idx, value),
         ListStrategy::Integer => {
-            if !value.is_null() && is_int(value) {
+            if is_plain_int1(value) {
                 list.int_items.insert(idx, w_int_get_value(value));
             } else {
                 switch_to_object_strategy(list);

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -56,6 +56,15 @@ pub fn box_bigint_constant(value: &BigInt) -> PyObjectRef {
     w_long_new(value.clone())
 }
 
+/// `W_LongObject._fits_int()` — longobject.py:141 / rbigint.fits_int.
+/// True if the value fits in a machine-word integer (i64 on 64-bit).
+/// Used by `is_plain_int1` to accept long objects that are in the int range.
+#[inline]
+pub unsafe fn w_long_fits_int(obj: PyObjectRef) -> bool {
+    let big = w_long_get_value(obj);
+    i64::try_from(big).is_ok()
+}
+
 /// Extract a reference to the BigInt value from a known W_LongObject pointer.
 ///
 /// # Safety

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -234,6 +234,45 @@ impl PyObjectArray {
     pub fn reverse(&mut self) {
         self.as_mut_slice().reverse();
     }
+
+    /// Replace `[start .. start+remove_count]` with `new_values` in one pass.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.setslice` (listobject.py:1773-1808)
+    /// step==1 path: `del items[start:start+delta]` + overwrite, O(n).
+    ///
+    /// # Safety
+    /// All pointers in `new_values` and in the existing storage must be valid.
+    pub unsafe fn splice(&mut self, start: usize, remove_count: usize, new_values: &[PyObjectRef]) {
+        let old_len = self.len;
+        let s = start.min(old_len);
+        let slicelength = remove_count.min(old_len - s);
+        let len2 = new_values.len();
+        let new_len = old_len - slicelength + len2;
+        if len2 > slicelength {
+            if new_len > self.capacity() {
+                if self.heap_cap == 0 {
+                    self.grow_to_heap(new_len);
+                } else {
+                    self.grow_heap(new_len);
+                }
+            }
+            std::ptr::copy(
+                self.ptr.add(s + slicelength),
+                self.ptr.add(s + len2),
+                old_len - s - slicelength,
+            );
+            self.len = new_len;
+        } else if slicelength > len2 {
+            std::ptr::copy(
+                self.ptr.add(s + slicelength),
+                self.ptr.add(s + len2),
+                old_len - s - slicelength,
+            );
+            self.len = new_len;
+        }
+        if len2 > 0 {
+            self.as_mut_slice()[s..s + len2].copy_from_slice(new_values);
+        }
+    }
 }
 
 impl Drop for PyObjectArray {

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -183,6 +183,57 @@ impl PyObjectArray {
     pub fn swap(&mut self, a: usize, b: usize) {
         self.as_mut_slice().swap(a, b);
     }
+
+    /// Insert `value` at `index`, shifting later elements right.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.insert` (listobject.py:1714):
+    ///   `l.insert(index, self.unwrap(w_item))`
+    pub fn insert(&mut self, index: usize, value: PyObjectRef) {
+        debug_assert!(index <= self.len);
+        if self.len == self.capacity() {
+            if self.heap_cap == 0 {
+                self.grow_to_heap(self.len + 1);
+            } else {
+                self.grow_heap(self.len + 1);
+            }
+        }
+        let len_orig = self.len;
+        unsafe {
+            let ptr = self.ptr;
+            std::ptr::copy(ptr.add(index), ptr.add(index + 1), len_orig - index);
+            *ptr.add(index) = value;
+        }
+        self.len += 1;
+    }
+
+    /// Remove and return the element at `index`, shifting later elements left.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.pop` (listobject.py:1855):
+    ///   `item = l.pop(index)`
+    pub fn remove(&mut self, index: usize) -> PyObjectRef {
+        debug_assert!(index < self.len);
+        let len = self.len;
+        let slice = self.as_mut_slice();
+        let value = slice[index];
+        slice.copy_within(index + 1..len, index);
+        self.len -= 1;
+        value
+    }
+
+    /// Remove and return the last element.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.pop_end` (listobject.py:1848):
+    ///   `return self.wrap(l.pop())`
+    pub fn pop(&mut self) -> PyObjectRef {
+        debug_assert!(self.len > 0);
+        let value = self.as_slice()[self.len - 1];
+        self.len -= 1;
+        value
+    }
+
+    /// Reverse storage in-place.
+    /// Mirrors RPython `AbstractUnwrappedStrategy.reverse` (listobject.py:1880):
+    ///   `self.unerase(w_list.lstorage).reverse()`
+    pub fn reverse(&mut self) {
+        self.as_mut_slice().reverse();
+    }
 }
 
 impl Drop for PyObjectArray {


### PR DESCRIPTION
ref: https://morepypy.blogspot.com/2011/10/more-compact-lists-with-list-strategies.html 

Mirrors RPython AbstractUnwrappedStrategy primitives (listobject.py):
  - insert  (line 1714): l.insert(index, value)
  - pop     (line 1855): item = l.pop(index)
  - pop_end (line 1848): l.pop()
  - reverse (line 1880): l.reverse()