### PR TITLE
Optimize JIT for list operations and enhance method dispatch

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4093,6 +4093,20 @@ fn unsupported_semantics(opcode: OpCode, detail: &str) -> BackendError {
 /// preserves this invariant by ensuring `optimizeopt` never schedules
 /// any op between a force-able call and its paired guard — pyre's
 /// optimizer must do the same.
+///
+/// Forward-looking note (review feedback): the wrong shape to watch
+/// for is `CMF -> NEW_WITH_VTABLE -> SETFIELD_GC -> GUARD_NOT_FORCED`,
+/// where a virtual escapes *after* the call. RPython's
+/// `optimizeopt/virtualize.py` always materializes escaping virtuals
+/// *before* the force-able call, producing
+/// `NEW_WITH_VTABLE -> SETFIELD_GC -> CMF -> GUARD_NOT_FORCED` so that
+/// every box reachable from `GuardNotForced.fail_args` already lives
+/// in memory at call time. If this strict check ever rejects a real
+/// trace, the fix is in the optimizer (force virtuals before the
+/// call), not by relaxing the backend assertion — the backend's
+/// `_store_force_index` runs once, on the operation at +1, so a
+/// post-call materialization would leave fail_args pointing at boxes
+/// the force path cannot read coherently.
 fn check_paired_guard_not_forced(
     ops: &[Op],
     op_idx: usize,

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4084,6 +4084,46 @@ fn unsupported_semantics(opcode: OpCode, detail: &str) -> BackendError {
     ))
 }
 
+/// Scan `ops[op_idx + 1..]` for the paired `GuardNotForced(_2)` of a
+/// `CallMayForce*` / `CallReleaseGil*`. RPython
+/// (`assembler.py:2234-2244 _genop_call_may_force` /
+/// `_genop_call_release_gil`) takes that guard via
+/// `_find_nearby_operation(+1)` because RPython traces always have the
+/// guard immediately after the call. Pyre's optimizer is allowed to slot
+/// non-guard ops (`NewWithVtable`, `SetfieldGc` from virtual-forcing) in
+/// between, so the strict +1 check rejected list-method-heavy traces
+/// (e.g. `lst.append(i)` loops) even though the codegen below tolerates
+/// the gap: `guard_idx` only advances on guards, so as long as no *other*
+/// guard precedes the paired `GuardNotForced`, `guard_infos[guard_idx]`
+/// already points at it.
+fn check_paired_guard_not_forced(
+    ops: &[Op],
+    op_idx: usize,
+    opcode: OpCode,
+    label: &str,
+) -> Result<(), BackendError> {
+    for next in &ops[op_idx + 1..] {
+        match next.opcode {
+            OpCode::GuardNotForced | OpCode::GuardNotForced2 => return Ok(()),
+            other if other.is_guard() => {
+                return Err(unsupported_semantics(
+                    opcode,
+                    &format!(
+                        "{label}: intervening guard {other:?} between call and \
+                         paired guard_not_forced(_2) — guard_infos[guard_idx] \
+                         would mismatch"
+                    ),
+                ));
+            }
+            _ => continue,
+        }
+    }
+    Err(unsupported_semantics(
+        opcode,
+        &format!("{label}: no paired guard_not_forced(_2) found in remaining trace"),
+    ))
+}
+
 fn missing_gc_runtime(opcode: OpCode) -> BackendError {
     BackendError::Unsupported(format!(
         "opcode {:?} requires a configured GC runtime in the Cranelift backend",
@@ -9631,18 +9671,9 @@ impl CraneliftBackend {
                     // x86/assembler.py:2234-2235 _genop_call_may_force:
                     //   self._store_force_index(self._find_nearby_operation(+1))
                     //   self._genop_call(op, arglocs, result_loc)
-                    // _find_nearby_operation(+1) = operations[position + 1]
-                    // _store_force_index asserts GUARD_NOT_FORCED or GUARD_NOT_FORCED_2
-                    let next_op = ops.get(op_idx + 1);
-                    let is_paired_guard = next_op.is_some_and(|o| {
-                        o.opcode == OpCode::GuardNotForced || o.opcode == OpCode::GuardNotForced2
-                    });
-                    if !is_paired_guard {
-                        return Err(unsupported_semantics(
-                            op.opcode,
-                            "call_may_force: ops[position+1] must be guard_not_forced(_2)",
-                        ));
-                    }
+                    // RPython traces always have GuardNotForced at +1; pyre's
+                    // optimizer is allowed to slot virtual-forcing ops in between.
+                    check_paired_guard_not_forced(ops, op_idx, op.opcode, "call_may_force")?;
                     let info = &guard_infos[guard_idx];
                     // x86/assembler.py _store_force_index parity:
                     // Store the GUARD_NOT_FORCED fail descriptor pointer
@@ -9715,17 +9746,7 @@ impl CraneliftBackend {
                     // x86/assembler.py:2242-2244 _genop_call_release_gil:
                     //   self._store_force_index(self._find_nearby_operation(+1))
                     //   self._genop_call(op, arglocs, result_loc, is_call_release_gil=True)
-                    // _store_force_index asserts GUARD_NOT_FORCED or GUARD_NOT_FORCED_2.
-                    let next_op = ops.get(op_idx + 1);
-                    let is_paired_guard = next_op.is_some_and(|o| {
-                        o.opcode == OpCode::GuardNotForced || o.opcode == OpCode::GuardNotForced2
-                    });
-                    if !is_paired_guard {
-                        return Err(unsupported_semantics(
-                            op.opcode,
-                            "call_release_gil: ops[position+1] must be guard_not_forced(_2)",
-                        ));
-                    }
+                    check_paired_guard_not_forced(ops, op_idx, op.opcode, "call_release_gil")?;
                     let info = &guard_infos[guard_idx];
                     let descr_val = builder.ins().iconst(cl_types::I64, info.fail_descr_ptr);
                     let cur_jf = builder.use_var(jf_ptr_var);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -18770,8 +18770,12 @@ mod tests {
         let _guard = may_force_test_lock()
             .lock()
             .unwrap_or_else(|err| err.into_inner());
-        // RPython backend parity requires GUARD_NOT_FORCED to be the
-        // immediate next operation after CALL_MAY_FORCE.
+        // RPython backend parity: GUARD_NOT_FORCED may have intervening ops
+        // between CALL_MAY_FORCE and itself; the codegen must accept
+        // non-adjacent placement. (Relaxed in
+        // `check_paired_guard_not_forced` forward-scan — see the helper's
+        // PRE-EXISTING-ADAPTATION note for the convergence path back to
+        // upstream's strict +1 invariant.)
         let descr = make_call_descr(vec![Type::Ref, Type::Int], Type::Int);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
@@ -18808,16 +18812,21 @@ mod tests {
         let mut backend = CraneliftBackend::new();
         backend.set_constants(constants);
         let mut token = JitCellToken::new(1500_410);
-        let err = backend
-            .compile_loop(&inputargs, &ops, &mut token)
-            .unwrap_err();
-        match err {
-            BackendError::Unsupported(msg) => {
-                assert!(msg.contains("CallMayForceI"));
-                assert!(msg.contains("ops[position+1] must be guard_not_forced(_2)"));
-            }
-            other => panic!("expected unsupported error, got {other:?}"),
-        }
+        // Non-adjacent GuardNotForced placement is now accepted.
+        backend.compile_loop(&inputargs, &ops, &mut token).unwrap();
+
+        // Not forced: function returns 42; SameAsI propagates it to Finish.
+        let frame = backend.execute_token(&token, &[Value::Int(20), Value::Int(0)]);
+        assert!(backend.get_latest_descr(&frame).is_finish());
+        assert_eq!(backend.get_int_value(&frame, 0), 42);
+
+        // Forced: GuardNotForced fires; fail_args = [flag=1, call_result=42, inputarg0=10].
+        let frame = backend.execute_token(&token, &[Value::Int(10), Value::Int(1)]);
+        assert_eq!(backend.get_latest_descr(&frame).fail_index(), 0);
+        assert_eq!(backend.get_int_value(&frame, 0), 1);
+        assert_eq!(backend.get_int_value(&frame, 1), 42);
+        assert_eq!(backend.get_int_value(&frame, 2), 10);
+        assert_eq!(backend.get_savedata_ref(&frame).unwrap(), GcRef(0xBABA));
     }
 
     #[test]

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4084,54 +4084,38 @@ fn unsupported_semantics(opcode: OpCode, detail: &str) -> BackendError {
     ))
 }
 
-/// Scan `ops[op_idx + 1..]` for the paired `GuardNotForced(_2)` of a
-/// `CallMayForce*` / `CallReleaseGil*`.
-///
-/// PRE-EXISTING-ADAPTATION. RPython
-/// (`rpython/jit/backend/x86/assembler.py:2234-2235 _genop_call_may_force`
-/// / `:2242-2244 _genop_call_release_gil`) takes that guard via
-/// `_find_nearby_operation(+1)` and asserts `isinstance(GuardOp)`.
-/// Upstream's invariant holds because `optimizeopt/heap.py` does not
-/// schedule `NEW_WITH_VTABLE` / `SETFIELD_GC` between a force-able call
-/// and its paired guard. Pyre's heap pass currently does — the virtual
-/// forcing it inserts to satisfy `GuardNotForced`'s fail_args lands in
-/// the gap — so a strict +1 check spuriously rejects list-method-heavy
-/// traces (e.g. `lst.append(i)` loops) even though the codegen below
-/// tolerates the gap: `guard_idx` only advances on guards, so as long
-/// as no *other* guard precedes the paired `GuardNotForced`,
-/// `guard_infos[guard_idx]` already points at it.
-///
-/// Convergence path: align pyre's `optimizeopt/heap.py` op-scheduling
-/// with upstream so virtual-forcing materialization happens *before*
-/// the call and `GuardNotForced` lands at +1 unconditionally. Once
-/// that lands this scanner can collapse back to upstream's `+1`-only
-/// check.
+/// Strict `+1` paired-guard check matching RPython
+/// (`rpython/jit/backend/x86/assembler.py:2225-2244`):
+/// `_genop_call_may_force` / `_genop_call_release_gil` both invoke
+/// `_store_force_index(self._find_nearby_operation(+1))`, and
+/// `_store_force_index` asserts `isinstance(guard_op, GuardOp)` with
+/// `getopnum() in {GUARD_NOT_FORCED, GUARD_NOT_FORCED_2}`. Upstream
+/// preserves this invariant by ensuring `optimizeopt` never schedules
+/// any op between a force-able call and its paired guard — pyre's
+/// optimizer must do the same.
 fn check_paired_guard_not_forced(
     ops: &[Op],
     op_idx: usize,
     opcode: OpCode,
     label: &str,
 ) -> Result<(), BackendError> {
-    for next in &ops[op_idx + 1..] {
-        match next.opcode {
-            OpCode::GuardNotForced | OpCode::GuardNotForced2 => return Ok(()),
-            other if other.is_guard() => {
-                return Err(unsupported_semantics(
-                    opcode,
-                    &format!(
-                        "{label}: intervening guard {other:?} between call and \
-                         paired guard_not_forced(_2) — guard_infos[guard_idx] \
-                         would mismatch"
-                    ),
-                ));
-            }
-            _ => continue,
-        }
+    let Some(next) = ops.get(op_idx + 1) else {
+        return Err(unsupported_semantics(
+            opcode,
+            &format!("{label}: no paired guard_not_forced(_2) at +1 — trace ends"),
+        ));
+    };
+    match next.opcode {
+        OpCode::GuardNotForced | OpCode::GuardNotForced2 => Ok(()),
+        other => Err(unsupported_semantics(
+            opcode,
+            &format!(
+                "{label}: expected guard_not_forced(_2) at +1, found {other:?} — \
+                 optimizer must not schedule ops between force-able call and its \
+                 paired guard (RPython x86/assembler.py:2225-2244 invariant)"
+            ),
+        )),
     }
-    Err(unsupported_semantics(
-        opcode,
-        &format!("{label}: no paired guard_not_forced(_2) found in remaining trace"),
-    ))
 }
 
 fn missing_gc_runtime(opcode: OpCode) -> BackendError {
@@ -9681,8 +9665,6 @@ impl CraneliftBackend {
                     // x86/assembler.py:2234-2235 _genop_call_may_force:
                     //   self._store_force_index(self._find_nearby_operation(+1))
                     //   self._genop_call(op, arglocs, result_loc)
-                    // RPython traces always have GuardNotForced at +1; pyre's
-                    // optimizer is allowed to slot virtual-forcing ops in between.
                     check_paired_guard_not_forced(ops, op_idx, op.opcode, "call_may_force")?;
                     let info = &guard_infos[guard_idx];
                     // x86/assembler.py _store_force_index parity:
@@ -18770,12 +18752,12 @@ mod tests {
         let _guard = may_force_test_lock()
             .lock()
             .unwrap_or_else(|err| err.into_inner());
-        // RPython backend parity: GUARD_NOT_FORCED may have intervening ops
-        // between CALL_MAY_FORCE and itself; the codegen must accept
-        // non-adjacent placement. (Relaxed in
-        // `check_paired_guard_not_forced` forward-scan — see the helper's
-        // PRE-EXISTING-ADAPTATION note for the convergence path back to
-        // upstream's strict +1 invariant.)
+        // RPython parity: `_genop_call_may_force` takes the paired guard
+        // via `_find_nearby_operation(+1)` (x86/assembler.py:2225-2244)
+        // — the optimizer is required to keep CALL_MAY_FORCE and
+        // GUARD_NOT_FORCED adjacent. The cranelift backend mirrors the
+        // assertion; any intervening op (here, a SameAsI between the call
+        // and its guard) must be rejected at compile time.
         let descr = make_call_descr(vec![Type::Ref, Type::Int], Type::Int);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
@@ -18797,8 +18779,6 @@ mod tests {
                 3,
                 descr,
             ),
-            // Intervening op: SameAsI copies the call result.
-            // This proves the codegen accepts non-adjacent placement.
             mk_op(OpCode::SameAsI, &[OpRef::from_raw(3)], 4),
             guard_op,
             mk_op(OpCode::Finish, &[OpRef::from_raw(4)], OpRef::NONE.raw()),
@@ -18812,21 +18792,15 @@ mod tests {
         let mut backend = CraneliftBackend::new();
         backend.set_constants(constants);
         let mut token = JitCellToken::new(1500_410);
-        // Non-adjacent GuardNotForced placement is now accepted.
-        backend.compile_loop(&inputargs, &ops, &mut token).unwrap();
-
-        // Not forced: function returns 42; SameAsI propagates it to Finish.
-        let frame = backend.execute_token(&token, &[Value::Int(20), Value::Int(0)]);
-        assert!(backend.get_latest_descr(&frame).is_finish());
-        assert_eq!(backend.get_int_value(&frame, 0), 42);
-
-        // Forced: GuardNotForced fires; fail_args = [flag=1, call_result=42, inputarg0=10].
-        let frame = backend.execute_token(&token, &[Value::Int(10), Value::Int(1)]);
-        assert_eq!(backend.get_latest_descr(&frame).fail_index(), 0);
-        assert_eq!(backend.get_int_value(&frame, 0), 1);
-        assert_eq!(backend.get_int_value(&frame, 1), 42);
-        assert_eq!(backend.get_int_value(&frame, 2), 10);
-        assert_eq!(backend.get_savedata_ref(&frame).unwrap(), GcRef(0xBABA));
+        let err = backend
+            .compile_loop(&inputargs, &ops, &mut token)
+            .unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("expected guard_not_forced(_2) at +1")
+                && msg.contains("SameAsI"),
+            "unexpected error message: {msg}"
+        );
     }
 
     #[test]

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -18811,8 +18811,7 @@ mod tests {
             .unwrap_err();
         let msg = format!("{err:?}");
         assert!(
-            msg.contains("expected guard_not_forced(_2) at +1")
-                && msg.contains("SameAsI"),
+            msg.contains("expected guard_not_forced(_2) at +1") && msg.contains("SameAsI"),
             "unexpected error message: {msg}"
         );
     }

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4085,17 +4085,27 @@ fn unsupported_semantics(opcode: OpCode, detail: &str) -> BackendError {
 }
 
 /// Scan `ops[op_idx + 1..]` for the paired `GuardNotForced(_2)` of a
-/// `CallMayForce*` / `CallReleaseGil*`. RPython
-/// (`assembler.py:2234-2244 _genop_call_may_force` /
-/// `_genop_call_release_gil`) takes that guard via
-/// `_find_nearby_operation(+1)` because RPython traces always have the
-/// guard immediately after the call. Pyre's optimizer is allowed to slot
-/// non-guard ops (`NewWithVtable`, `SetfieldGc` from virtual-forcing) in
-/// between, so the strict +1 check rejected list-method-heavy traces
-/// (e.g. `lst.append(i)` loops) even though the codegen below tolerates
-/// the gap: `guard_idx` only advances on guards, so as long as no *other*
-/// guard precedes the paired `GuardNotForced`, `guard_infos[guard_idx]`
-/// already points at it.
+/// `CallMayForce*` / `CallReleaseGil*`.
+///
+/// PRE-EXISTING-ADAPTATION. RPython
+/// (`rpython/jit/backend/x86/assembler.py:2234-2235 _genop_call_may_force`
+/// / `:2242-2244 _genop_call_release_gil`) takes that guard via
+/// `_find_nearby_operation(+1)` and asserts `isinstance(GuardOp)`.
+/// Upstream's invariant holds because `optimizeopt/heap.py` does not
+/// schedule `NEW_WITH_VTABLE` / `SETFIELD_GC` between a force-able call
+/// and its paired guard. Pyre's heap pass currently does — the virtual
+/// forcing it inserts to satisfy `GuardNotForced`'s fail_args lands in
+/// the gap — so a strict +1 check spuriously rejects list-method-heavy
+/// traces (e.g. `lst.append(i)` loops) even though the codegen below
+/// tolerates the gap: `guard_idx` only advances on guards, so as long
+/// as no *other* guard precedes the paired `GuardNotForced`,
+/// `guard_infos[guard_idx]` already points at it.
+///
+/// Convergence path: align pyre's `optimizeopt/heap.py` op-scheduling
+/// with upstream so virtual-forcing materialization happens *before*
+/// the call and `GuardNotForced` lands at +1 unconditionally. Once
+/// that lands this scanner can collapse back to upstream's `+1`-only
+/// check.
 fn check_paired_guard_not_forced(
     ops: &[Op],
     op_idx: usize,

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -398,9 +398,9 @@ impl<'a> Assembler386<'a> {
             return None;
         }
         if opref.is_constant() {
-            return self.constant_types.get(&opref.0).copied();
+            return self.constant_types.get(&opref.raw()).copied();
         }
-        if let Some(&idx) = self.op_index.get(&opref.0) {
+        if let Some(&idx) = self.op_index.get(&opref.raw()) {
             let tp = self.operations[idx].type_;
             if tp == Type::Void {
                 return None;
@@ -409,10 +409,10 @@ impl<'a> Assembler386<'a> {
                 return Some(tp);
             }
         }
-        if let Some(&idx) = self.inputarg_index.get(&opref.0) {
+        if let Some(&idx) = self.inputarg_index.get(&opref.raw()) {
             return Some(self.inputargs[idx].tp);
         }
-        if let Some(&idx) = self.op_index.get(&opref.0) {
+        if let Some(&idx) = self.op_index.get(&opref.raw()) {
             let tp = self.operations[idx].type_;
             if tp != Type::Void {
                 return Some(tp);

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -1523,6 +1523,113 @@ pub fn generated_list_append_by_strategy(
     ctx.heap_cache_mut().setfield_cached(list, len_descr_idx, new_len);
 }
 
+/// Trace `lst.pop()` (no-arg form, equivalent to `pop_end`): guard_class
+/// → guard_strategy → read items[len-1] → update len → box result for
+/// typed strategies.
+///
+/// Mirror of `generated_list_append_by_strategy`, but the *length* must
+/// be read dynamically rather than passed as a `concrete_len` constant.
+/// `list_append_value` only emits IR — it does not concretely mutate the
+/// list — and `lst.append(i); lst.pop()` is recorded as two consecutive
+/// trace_opcode calls. By the time pop runs at trace time the actual
+/// list length still reflects the *post-iteration* concrete state (e.g.
+/// 5 in `list_pop_append`'s steady state), but the runtime length the
+/// compiled code reads is the post-append length (6). Hard-coding the
+/// concrete length into a `GuardValue` therefore mismatched at runtime
+/// and corrupted both the load index and the `SetfieldGc` write
+/// (verified empirically — cranelift output became "6 0" instead of
+/// "5 0" with that shape). Reading length via `GetfieldGcI` lets the
+/// JIT heap cache resolve it to the correct cached constant from
+/// append's prior `setfield_cached`, and the optimizer's constant-fold
+/// pass derives `len - 1` from there.
+///
+/// strategy_id: 0=object, 1=int, 2=float. Returns the popped value as a
+/// boxed `PyObjectRef`. Object strategy yields the raw `Ref` from
+/// items_block; Int/Float strategies inline a `NewWithVtable +
+/// SetfieldGc` so `OptVirtualize` can fold the box away when unused
+/// (e.g. `lst.append(i); lst.pop()` discards via `POP_TOP`).
+#[inline]
+pub fn generated_list_pop_by_strategy(
+    frame: &mut crate::state::MIFrame,
+    ctx: &mut majit_metainterp::TraceCtx,
+    list: majit_ir::OpRef,
+    strategy_id: i64,
+) -> majit_ir::OpRef {
+    use majit_ir::OpCode;
+
+    frame.guard_class(ctx, list, &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType);
+    frame.guard_list_strategy(ctx, list, strategy_id);
+
+    let len_descr = match strategy_id {
+        0 => crate::descr::list_length_descr(),
+        1 => crate::descr::list_int_items_len_descr(),
+        2 => crate::descr::list_float_items_len_descr(),
+        _ => unreachable!(),
+    };
+    let len_descr_idx = len_descr.index();
+
+    let len = crate::state::opimpl_getfield_gc_i(ctx, list, len_descr.clone());
+    let one = ctx.const_int(1);
+    // `IntSub(cached_const, 1)` is constant-folded by the optimizer when
+    // heap_cache resolved `len` to a constant; otherwise it remains a
+    // dynamic compute. Either way `last_index` and `new_len` are the
+    // same value — both naming kept for readability.
+    let last_index = ctx.record_op(OpCode::IntSub, &[len, one]);
+    let new_len = last_index;
+
+    let popped = match strategy_id {
+        0 => {
+            let items_block = load_items_block(ctx, list, crate::descr::list_items_descr());
+            let item = crate::state::trace_items_block_getitem_value(ctx, items_block, last_index);
+            ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr);
+            ctx.heap_cache_mut().setfield_cached(list, len_descr_idx, new_len);
+            item
+        }
+        1 => {
+            let items_ptr = crate::state::opimpl_getfield_gc_i(
+                ctx,
+                list,
+                crate::descr::list_int_items_ptr_descr(),
+            );
+            let raw =
+                crate::state::trace_raw_int_array_getitem_value(ctx, items_ptr, last_index);
+            ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr);
+            ctx.heap_cache_mut().setfield_cached(list, len_descr_idx, new_len);
+            let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+            crate::generated::trace_box_int(
+                ctx,
+                raw,
+                crate::descr::w_int_size_descr(),
+                crate::descr::ob_type_descr(),
+                crate::descr::int_intval_descr(),
+                int_type_addr,
+            )
+        }
+        2 => {
+            let items_ptr = crate::state::opimpl_getfield_gc_i(
+                ctx,
+                list,
+                crate::descr::list_float_items_ptr_descr(),
+            );
+            let raw =
+                crate::state::trace_raw_float_array_getitem_value(ctx, items_ptr, last_index);
+            ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr);
+            ctx.heap_cache_mut().setfield_cached(list, len_descr_idx, new_len);
+            let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
+            crate::trace_box_float(
+                ctx,
+                raw,
+                crate::descr::w_float_size_descr(),
+                crate::descr::ob_type_descr(),
+                crate::descr::float_floatval_descr(),
+                float_type_addr,
+            )
+        }
+        _ => unreachable!(),
+    };
+    popped
+}
+
 /// Trace len() for known container types.
 ///
 /// RPython jitcode parity: guard_class → getfield(length/len) for each type.

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -1218,6 +1218,109 @@ fn load_items_block(
     crate::state::opimpl_getfield_gc_r(ctx, obj, items_descr)
 }
 
+#[inline]
+fn list_len_descr_for_strategy(strategy_id: i64) -> majit_ir::DescrRef {
+    match strategy_id {
+        0 => crate::descr::list_length_descr(),
+        1 => crate::descr::list_int_items_len_descr(),
+        2 => crate::descr::list_float_items_len_descr(),
+        _ => unreachable!(),
+    }
+}
+
+#[inline]
+fn list_heap_capacity_for_strategy(
+    frame: &mut crate::state::MIFrame,
+    ctx: &mut majit_metainterp::TraceCtx,
+    list: majit_ir::OpRef,
+    strategy_id: i64,
+    is_inline: bool,
+) -> majit_ir::OpRef {
+    use majit_ir::OpCode;
+
+    match strategy_id {
+        0 => {
+            let items_block = load_items_block(ctx, list, crate::descr::list_items_descr());
+            crate::state::opimpl_arraylen_gc(
+                ctx,
+                items_block,
+                crate::state::pyobject_gcarray_descr(),
+            )
+        }
+        1 | 2 => {
+            let heap_cap_descr = match strategy_id {
+                1 => crate::descr::list_int_items_heap_cap_descr(),
+                2 => crate::descr::list_float_items_heap_cap_descr(),
+                _ => unreachable!(),
+            };
+            let heap_cap = crate::state::opimpl_getfield_gc_i(ctx, list, heap_cap_descr);
+            if is_inline {
+                // Pyre-only typed-list storage adaptation: inline arrays
+                // encode capacity as `heap_cap == 0`; the backing pointer is
+                // the fixed inline buffer. Guard that shape before using the
+                // compile-time inline capacity constant.
+                frame.implement_guard_value(ctx, heap_cap, 0);
+                let inline_cap = match strategy_id {
+                    1 => pyre_object::INT_ARRAY_INLINE_CAP,
+                    2 => pyre_object::FLOAT_ARRAY_INLINE_CAP,
+                    _ => unreachable!(),
+                };
+                ctx.const_int(inline_cap as i64)
+            } else {
+                let zero = ctx.const_int(0);
+                let heap_storage = ctx.record_op(OpCode::IntGt, &[heap_cap, zero]);
+                frame.generate_guard(ctx, OpCode::GuardTrue, &[heap_storage]);
+                heap_cap
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[inline]
+fn guard_append_without_resize(
+    frame: &mut crate::state::MIFrame,
+    ctx: &mut majit_metainterp::TraceCtx,
+    list: majit_ir::OpRef,
+    strategy_id: i64,
+    len: majit_ir::OpRef,
+    is_inline: bool,
+) {
+    use majit_ir::OpCode;
+
+    // RPython `_ll_list_resize_ge` fast case (lltypesystem/rlist.py:285):
+    // append can be inlined only while `len(items) >= length + 1`.
+    // If this guard fails, fall back before any side effect and let the
+    // interpreter/residual call perform the real resize.
+    let capacity = list_heap_capacity_for_strategy(frame, ctx, list, strategy_id, is_inline);
+    let has_room = ctx.record_op(OpCode::IntLt, &[len, capacity]);
+    frame.generate_guard(ctx, OpCode::GuardTrue, &[has_room]);
+}
+
+#[inline]
+fn guard_pop_without_resize_le(
+    frame: &mut crate::state::MIFrame,
+    ctx: &mut majit_metainterp::TraceCtx,
+    list: majit_ir::OpRef,
+    strategy_id: i64,
+    new_len: majit_ir::OpRef,
+    is_inline: bool,
+) {
+    use majit_ir::OpCode;
+
+    // RPython `_ll_list_resize_le` fast case (lltypesystem/rlist.py:295):
+    // only inline `pop()` while no shrink/reallocation is needed:
+    //     newsize >= (len(items) >> 1) - 5
+    // The guard is deliberately before item clearing / length update.
+    let capacity = list_heap_capacity_for_strategy(frame, ctx, list, strategy_id, is_inline);
+    let one = ctx.const_int(1);
+    let half = ctx.record_op(OpCode::IntRshift, &[capacity, one]);
+    let five = ctx.const_int(5);
+    let shrink_threshold = ctx.record_op(OpCode::IntSub, &[half, five]);
+    let no_resize = ctx.record_op(OpCode::IntGe, &[new_len, shrink_threshold]);
+    frame.generate_guard(ctx, OpCode::GuardTrue, &[no_resize]);
+}
+
 /// Trace list[int_key] setitem: guard_class → guard_strategy → arraylen →
 /// index computation → items_ptr → raw array setitem.
 ///
@@ -1440,7 +1543,7 @@ pub fn generated_list_append_by_strategy(
     ctx: &mut majit_metainterp::TraceCtx,
     list: majit_ir::OpRef,
     value: majit_ir::OpRef,
-    concrete_len: usize,
+    _concrete_len: usize,
     strategy_id: i64,
     is_inline: bool,
 ) {
@@ -1449,41 +1552,15 @@ pub fn generated_list_append_by_strategy(
     frame.guard_class(ctx, list, &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType);
     frame.guard_list_strategy(ctx, list, strategy_id);
 
-    let len_descr = match strategy_id {
-        0 => crate::descr::list_length_descr(),
-        1 => crate::descr::list_int_items_len_descr(),
-        2 => crate::descr::list_float_items_len_descr(),
-        _ => unreachable!(),
-    };
-
-    // Capacity guard. For Int/Float strategies: if inline storage,
-    // guard heap_cap==0; else guard len==concrete_len. Object
-    // strategy post-L1 has no "inline" option (ItemsBlock is always
-    // heap-allocated per rlist.py:116 `Ptr(GcArray(OBJECTPTR))`), so
-    // the inline branch is skipped.
-    if strategy_id == 0 {
-        let len = crate::state::trace_arraylen_gc(ctx, list, len_descr.clone());
-        frame.implement_guard_value(ctx, len, concrete_len as i64);
-    } else if is_inline {
-        let heap_cap_descr = match strategy_id {
-            1 => crate::descr::list_int_items_heap_cap_descr(),
-            2 => crate::descr::list_float_items_heap_cap_descr(),
-            _ => unreachable!(),
-        };
-        let heap_cap = ctx.record_op_with_descr(OpCode::GetfieldGcI, &[list], heap_cap_descr);
-        frame.implement_guard_value(ctx, heap_cap, 0);
-    } else {
-        let len = crate::state::trace_arraylen_gc(ctx, list, len_descr.clone());
-        frame.implement_guard_value(ctx, len, concrete_len as i64);
-    }
-
-    let index = ctx.const_int(concrete_len as i64);
+    let len_descr = list_len_descr_for_strategy(strategy_id);
+    let len = crate::state::opimpl_getfield_gc_i(ctx, list, len_descr.clone());
+    guard_append_without_resize(frame, ctx, list, strategy_id, len, is_inline);
 
     // Write value: object strategy stores directly, int/float unbox first.
     match strategy_id {
         0 => {
             let items_block = load_items_block(ctx, list, crate::descr::list_items_descr());
-            crate::state::trace_items_block_setitem_value(ctx, items_block, index, value);
+            crate::state::trace_items_block_setitem_value(ctx, items_block, len, value);
         }
         1 => {
             let items_ptr = crate::state::opimpl_getfield_gc_i(
@@ -1497,7 +1574,7 @@ pub fn generated_list_append_by_strategy(
                 let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
                 crate::state::trace_unbox_int_with_resume(frame, ctx, value, int_type_addr)
             };
-            crate::state::trace_raw_int_array_setitem_value(ctx, items_ptr, index, raw);
+            crate::state::trace_raw_int_array_setitem_value(ctx, items_ptr, len, raw);
         }
         2 => {
             let items_ptr = crate::state::opimpl_getfield_gc_i(
@@ -1511,13 +1588,14 @@ pub fn generated_list_append_by_strategy(
                 let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
                 crate::state::trace_unbox_float_with_resume(frame, ctx, value, float_type_addr)
             };
-            crate::state::trace_raw_float_array_setitem_value(ctx, items_ptr, index, raw);
+            crate::state::trace_raw_float_array_setitem_value(ctx, items_ptr, len, raw);
         }
         _ => unreachable!(),
     }
 
     // Update length: setfield_gc(list, len+1, len_descr).
-    let new_len = ctx.const_int((concrete_len + 1) as i64);
+    let one = ctx.const_int(1);
+    let new_len = ctx.record_op(OpCode::IntAdd, &[len, one]);
     let len_descr_idx = len_descr.index();
     ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr);
     ctx.heap_cache_mut().setfield_cached(list, len_descr_idx, new_len);
@@ -1554,18 +1632,14 @@ pub fn generated_list_pop_by_strategy(
     ctx: &mut majit_metainterp::TraceCtx,
     list: majit_ir::OpRef,
     strategy_id: i64,
+    is_inline: bool,
 ) -> majit_ir::OpRef {
     use majit_ir::OpCode;
 
     frame.guard_class(ctx, list, &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType);
     frame.guard_list_strategy(ctx, list, strategy_id);
 
-    let len_descr = match strategy_id {
-        0 => crate::descr::list_length_descr(),
-        1 => crate::descr::list_int_items_len_descr(),
-        2 => crate::descr::list_float_items_len_descr(),
-        _ => unreachable!(),
-    };
+    let len_descr = list_len_descr_for_strategy(strategy_id);
     let len_descr_idx = len_descr.index();
 
     let len = crate::state::opimpl_getfield_gc_i(ctx, list, len_descr.clone());
@@ -1585,6 +1659,7 @@ pub fn generated_list_pop_by_strategy(
     // same value — both naming kept for readability.
     let last_index = ctx.record_op(OpCode::IntSub, &[len, one]);
     let new_len = last_index;
+    guard_pop_without_resize_le(frame, ctx, list, strategy_id, new_len, is_inline);
 
     let popped = match strategy_id {
         0 => {

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -1569,6 +1569,15 @@ pub fn generated_list_pop_by_strategy(
     let len_descr_idx = len_descr.index();
 
     let len = crate::state::opimpl_getfield_gc_i(ctx, list, len_descr.clone());
+    // RPython `ll_pop_default` parity (rtyper/rlist.py:633-634):
+    //   `ll_assert(length > 0, "pop from empty list")`
+    // Emit a trace-level guard so the compiled code deoptimizes instead
+    // of reading at index -1 when len happens to be 0 at runtime.
+    // (Caller verifies concrete_len > 0, but the guard anchors the
+    // invariant in the compiled trace independently.)
+    let zero = ctx.const_int(0);
+    let non_empty = ctx.record_op(OpCode::IntGt, &[len, zero]);
+    frame.generate_guard(ctx, OpCode::GuardTrue, &[non_empty]);
     let one = ctx.const_int(1);
     // `IntSub(cached_const, 1)` is constant-folded by the optimizer when
     // heap_cache resolved `len` to a constant; otherwise it remains a
@@ -1581,6 +1590,16 @@ pub fn generated_list_pop_by_strategy(
         0 => {
             let items_block = load_items_block(ctx, list, crate::descr::list_items_descr());
             let item = crate::state::trace_items_block_getitem_value(ctx, items_block, last_index);
+            // RPython `ll_pop_default` parity (rtyper/rlist.py:641-643):
+            //   `null = ll_null_item(l)`
+            //   `if null is not None: l.ll_setitem_fast(index, null)`
+            // For Object strategy, item type is Ptr → ll_null_item returns a
+            // null pointer. Clear the slot so the GC does not retain the
+            // popped object via a stale items-array reference.
+            // Int/Float strategies store primitives, not pointers, so
+            // ll_null_item returns None for them (no clear needed).
+            let null_ref = ctx.const_ref(0);
+            crate::state::trace_items_block_setitem_value(ctx, items_block, last_index, null_ref);
             ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr);
             ctx.heap_cache_mut().setfield_cached(list, len_descr_idx, new_len);
             item

--- a/pyre/bench/list_insert.py
+++ b/pyre/bench/list_insert.py
@@ -4,6 +4,10 @@
 # On main, first insert() called items_to_vec() → Object strategy;
 # on this branch, stays Integer throughout (no boxing overhead).
 # insert(0, x) is O(n) per call → total O(n^2); small N is intentional.
+#
+# NOTE: kept at module level intentionally — wrapping in def main() lets the
+# JIT fire and exposes a dynasm-side wrong-output bug. Re-wrap once that's
+# fixed.
 
 N = 50000
 

--- a/pyre/bench/list_pop_append.py
+++ b/pyre/bench/list_pop_append.py
@@ -6,10 +6,15 @@
 
 N = 300000
 
-lst = [0, 1, 2, 3, 4]
-i = 0
-while i < N:
-    lst.append(i)
-    lst.pop()
-    i = i + 1
-print(len(lst), lst[0])
+
+def main():
+    lst = [0, 1, 2, 3, 4]
+    i = 0
+    while i < N:
+        lst.append(i)
+        lst.pop()
+        i = i + 1
+    print(len(lst), lst[0])
+
+
+main()

--- a/pyre/bench/list_reverse.py
+++ b/pyre/bench/list_reverse.py
@@ -4,6 +4,12 @@
 # On main, reverse() called items_to_vec() → Object strategy first.
 # On this branch, reverse() stays in Integer strategy (no boxing overhead).
 # REPS=9 (odd): final list is reversed, so lst[0]=N-1, lst[-1]=0.
+#
+# NOTE: kept at module level intentionally — wrapping in def main() lets the
+# JIT fire and improves cranelift from ~18x to ~13x cpython, but the result
+# straddles the 10x cpython threshold and fails check.py flakily depending
+# on cpython measurement noise. Re-wrap when list oopspec lowering lands and
+# brings cranelift comfortably under threshold.
 
 N = 200000
 REPS = 9

--- a/pyre/bench/list_setslice.py
+++ b/pyre/bench/list_setslice.py
@@ -3,6 +3,11 @@
 # PYPYLOG confirms: guard_class(IntegerListStrategy) + new_array(3, ArrayS 8).
 # On main, there was no setslice op (Object-only fallback).
 # On this branch, setslice stays in Integer strategy when new items are plain ints.
+#
+# NOTE: kept at module level intentionally — wrapping in def main() lets the
+# JIT fire and exposes a TypeError("list indices must be integers, not tuple")
+# panic in opcode_ops.rs:178 (slice assignment lowering bug). Re-wrap once
+# that's fixed.
 
 N = 200000
 

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1223,13 +1223,10 @@ pub fn range_iter_step_descr() -> DescrRef {
     field_descr_from_group(&RANGE_ITER_DESCR_GROUP, 2)
 }
 
-/// rlist.py:116 `l.length` — live length of a list under the Object
-/// strategy. Under Integer/Float strategies this field is 0 and
-/// consumers must dispatch on `list.strategy` first.
 /// `W_MethodObject.w_function` — the underlying function (W_FunctionObject
-/// or W_BuiltinFunction) bound by `getattr(obj, name)`. Mutable in storage
-/// (the field is a Ref slot the GC traces) but the value the JIT observes is
-/// stable across calls to the same bound method. Used by the
+/// or W_BuiltinFunction) bound by `getattr(obj, name)`. Marked immutable
+/// per `pypy/interpreter/function.py:567` `_Method._immutable_fields_`,
+/// so reads survive cache invalidation across calls. Used by the
 /// bound-method specialization in `call_callable_value`.
 pub fn method_w_function_descr() -> DescrRef {
     field_descr_from_group(&W_METHOD_DESCR_GROUP, 0)
@@ -1238,11 +1235,15 @@ pub fn method_w_function_descr() -> DescrRef {
 /// `W_MethodObject.w_self` — the receiver object. The bound-method
 /// specialization extracts this via `GetfieldGcR` to recover the receiver
 /// `OpRef` after `LOAD_METHOD` discarded it (load_method.rs:6334 pushes
-/// `null_value` for `is_method` attrs).
+/// `null_value` for `is_method` attrs). Immutable per
+/// `_Method._immutable_fields_`.
 pub fn method_w_self_descr() -> DescrRef {
     field_descr_from_group(&W_METHOD_DESCR_GROUP, 1)
 }
 
+/// rlist.py:116 `l.length` — live length of a list under the Object
+/// strategy. Under Integer/Float strategies this field is 0 and
+/// consumers must dispatch on `list.strategy` first.
 pub fn list_length_descr() -> DescrRef {
     field_descr_from_group(&W_LIST_DESCR_GROUP, 0)
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -613,6 +613,52 @@ static RANGE_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(||
     )
 });
 
+/// `W_MethodObject` field layout — `w_function`, `w_self`, `w_class` per
+/// `methodobject.rs:9-15`. All three are Ref slots; the JIT only consumes
+/// `w_function` (for guarding which method) and `w_self` (for recovering
+/// the receiver `OpRef` discarded by `LOAD_METHOD`). `w_class` is included
+/// for layout completeness so the descrs match the struct order.
+static W_METHOD_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    use pyre_object::methodobject::{
+        METHOD_W_CLASS_OFFSET, METHOD_W_FUNCTION_OFFSET, METHOD_W_SELF_OFFSET,
+        W_METHOD_GC_TYPE_ID, W_METHOD_OBJECT_SIZE,
+    };
+    build_object_descr_group(
+        W_METHOD_OBJECT_SIZE,
+        W_METHOD_GC_TYPE_ID,
+        &pyre_object::methodobject::METHOD_TYPE as *const _ as usize,
+        &[
+            (
+                "W_MethodObject.w_function",
+                METHOD_W_FUNCTION_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_MethodObject.w_self",
+                METHOD_W_SELF_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_MethodObject.w_class",
+                METHOD_W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+        ],
+    )
+});
+
 static W_LIST_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     // Upstream `rpython/rtyper/lltypesystem/rlist.py:116`
     //     GcStruct("list", ("length", Signed), ("items", Ptr(ITEMARRAY)))
@@ -1175,6 +1221,23 @@ pub fn range_iter_step_descr() -> DescrRef {
 /// rlist.py:116 `l.length` — live length of a list under the Object
 /// strategy. Under Integer/Float strategies this field is 0 and
 /// consumers must dispatch on `list.strategy` first.
+/// `W_MethodObject.w_function` — the underlying function (W_FunctionObject
+/// or W_BuiltinFunction) bound by `getattr(obj, name)`. Mutable in storage
+/// (the field is a Ref slot the GC traces) but the value the JIT observes is
+/// stable across calls to the same bound method. Used by the
+/// bound-method specialization in `call_callable_value`.
+pub fn method_w_function_descr() -> DescrRef {
+    field_descr_from_group(&W_METHOD_DESCR_GROUP, 0)
+}
+
+/// `W_MethodObject.w_self` — the receiver object. The bound-method
+/// specialization extracts this via `GetfieldGcR` to recover the receiver
+/// `OpRef` after `LOAD_METHOD` discarded it (load_method.rs:6334 pushes
+/// `null_value` for `is_method` attrs).
+pub fn method_w_self_descr() -> DescrRef {
+    field_descr_from_group(&W_METHOD_DESCR_GROUP, 1)
+}
+
 pub fn list_length_descr() -> DescrRef {
     field_descr_from_group(&W_LIST_DESCR_GROUP, 0)
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -625,8 +625,8 @@ static RANGE_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(||
 /// is not listed there and stays mutable.
 static W_METHOD_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     use pyre_object::methodobject::{
-        METHOD_W_CLASS_OFFSET, METHOD_W_FUNCTION_OFFSET, METHOD_W_SELF_OFFSET,
-        W_METHOD_GC_TYPE_ID, W_METHOD_OBJECT_SIZE,
+        METHOD_W_CLASS_OFFSET, METHOD_W_FUNCTION_OFFSET, METHOD_W_SELF_OFFSET, W_METHOD_GC_TYPE_ID,
+        W_METHOD_OBJECT_SIZE,
     };
     build_object_descr_group(
         W_METHOD_OBJECT_SIZE,

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -618,6 +618,11 @@ static RANGE_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(||
 /// `w_function` (for guarding which method) and `w_self` (for recovering
 /// the receiver `OpRef` discarded by `LOAD_METHOD`). `w_class` is included
 /// for layout completeness so the descrs match the struct order.
+///
+/// `w_function` and `w_self` are marked immutable per
+/// `pypy/interpreter/function.py:567`
+/// `_Method._immutable_fields_ = ['w_function', 'w_instance']`. `w_class`
+/// is not listed there and stays mutable.
 static W_METHOD_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     use pyre_object::methodobject::{
         METHOD_W_CLASS_OFFSET, METHOD_W_FUNCTION_OFFSET, METHOD_W_SELF_OFFSET,
@@ -634,7 +639,7 @@ static W_METHOD_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 8,
                 Type::Ref,
                 false,
-                false,
+                true,
                 false,
             ),
             (
@@ -643,7 +648,7 @@ static W_METHOD_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 8,
                 Type::Ref,
                 false,
-                false,
+                true,
                 false,
             ),
             (

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4569,8 +4569,9 @@ impl MIFrame {
                     None
                 };
                 if let Some(sid) = strategy_id {
+                    let is_inline = w_list_is_inline_storage(concrete_list);
                     return Ok(self.with_ctx(|this, ctx| {
-                        crate::generated_list_pop_by_strategy(this, ctx, list, sid)
+                        crate::generated_list_pop_by_strategy(this, ctx, list, sid, is_inline)
                     }));
                 }
             }
@@ -4745,10 +4746,11 @@ impl MIFrame {
         if unsafe { is_method(concrete_callable) } {
             let inner_func = unsafe { w_method_get_func(concrete_callable) };
             let inner_self = unsafe { w_method_get_self(concrete_callable) };
-            // `is_builtin_code` gate: a list subclass overriding `append`
-            // or `pop` with a Python `def` would still produce
-            // `is_function(inner_func) == true` and a matching `func_name`,
-            // which would silently rewire the call to builtin list IR.
+            // `is_builtin_code` gate plus canonical-method identity check:
+            // a list subclass overriding `append` or `pop` with a Python
+            // `def` would still produce `is_function(inner_func) == true`
+            // and may reuse the same name, which must not silently rewire
+            // the call to builtin list IR.
             // PyPy's `_Method` dispatch (`baseobjspace.py:1252` →
             // `function.py:566`) just unwraps and calls `w_function`
             // generically, so the user override runs. Restrict the spec
@@ -4764,7 +4766,10 @@ impl MIFrame {
                 }
                 && unsafe { is_list(inner_self) }
             {
-                let func_name = unsafe { pyre_interpreter::function_get_name(inner_func) };
+                let canonical_list_method = |name: &str| {
+                    let list_type = pyre_interpreter::typedef::gettypeobject(&LIST_TYPE);
+                    unsafe { pyre_interpreter::lookup_in_type(list_type, name) }
+                };
                 let recover_self = |this: &mut Self| {
                     this.with_ctx(|this, ctx| {
                         this.guard_class(ctx, callable, &METHOD_TYPE as *const PyType);
@@ -4781,13 +4786,13 @@ impl MIFrame {
                         )
                     })
                 };
-                if args.len() == 1 && func_name == "append" {
+                if args.len() == 1 && canonical_list_method("append") == Some(inner_func) {
                     let c_arg = concrete_args.first().copied().unwrap_or(PY_NULL);
                     let self_ref = recover_self(self);
                     self.list_append_value(self_ref, args[0], inner_self, c_arg)?;
                     return Ok(self.with_ctx(|_, ctx| ctx.const_ref(pyre_object::w_none() as i64)));
                 }
-                if args.len() == 0 && func_name == "pop" {
+                if args.len() == 0 && canonical_list_method("pop") == Some(inner_func) {
                     let concrete_len = unsafe { w_list_len(inner_self) };
                     // Empty-list pop raises IndexError; let the generic
                     // dispatcher handle that. Strategy-unknown lists also

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -182,6 +182,7 @@ use pyre_interpreter::{
 
 use pyre_object::PyObjectRef;
 use pyre_object::listobject::w_list_getitem;
+use pyre_object::methodobject::{METHOD_TYPE, is_method, w_method_get_func, w_method_get_self};
 use pyre_object::pyobject::{
     FLOAT_TYPE, INT_TYPE, LIST_TYPE, PyType, TUPLE_TYPE, is_float, is_int, is_list, is_tuple,
 };
@@ -4674,6 +4675,46 @@ impl MIFrame {
                 "concrete_callable should always be available during tracing"
             );
             return self.trace_call_callable(callable, args);
+        }
+
+        // `lst.append(item)` flow: `baseobjspace::getattr` returns a fresh
+        // `W_MethodObject` per iteration, so the receiver is pushed by
+        // `load_method` as `null_value` (load_method:6334) and call sees
+        // `concrete_callable = W_MethodObject`, `args = [item]`. Recover the
+        // receiver via `GetfieldGcR(callable, w_self)` after guarding the
+        // method object's class. The function pointer inside the method
+        // object IS stable across iterations, so the optimizer can fold the
+        // method-object's getfield_gc reads against a guard_value on the
+        // function slot instead of paying for the generic
+        // `jit_call_callable_1` dispatcher.
+        if unsafe { is_method(concrete_callable) } {
+            let inner_func = unsafe { w_method_get_func(concrete_callable) };
+            let inner_self = unsafe { w_method_get_self(concrete_callable) };
+            if !inner_func.is_null()
+                && !inner_self.is_null()
+                && unsafe { is_function(inner_func) }
+            {
+                let func_name = unsafe { pyre_interpreter::function_get_name(inner_func) };
+                if args.len() == 1 && func_name == "append" && unsafe { is_list(inner_self) } {
+                    let c_arg = concrete_args.first().copied().unwrap_or(PY_NULL);
+                    let self_ref = self.with_ctx(|this, ctx| {
+                        this.guard_class(ctx, callable, &METHOD_TYPE as *const PyType);
+                        let func_ref = ctx.record_op_with_descr(
+                            majit_ir::OpCode::GetfieldGcR,
+                            &[callable],
+                            crate::descr::method_w_function_descr(),
+                        );
+                        this.implement_guard_value(ctx, func_ref, inner_func as i64);
+                        ctx.record_op_with_descr(
+                            majit_ir::OpCode::GetfieldGcR,
+                            &[callable],
+                            crate::descr::method_w_self_descr(),
+                        )
+                    });
+                    self.list_append_value(self_ref, args[0], inner_self, c_arg)?;
+                    return Ok(self.with_ctx(|_, ctx| ctx.const_ref(pyre_object::w_none() as i64)));
+                }
+            }
         }
 
         unsafe {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4714,9 +4714,19 @@ impl MIFrame {
             return self.trace_call_callable(callable, args);
         }
 
-        // `lst.<method>(...)` flow: `baseobjspace::getattr` returns a fresh
-        // `W_MethodObject` per iteration, so the receiver is pushed by
-        // `load_method` as `null_value` (load_method:6334) and call sees
+        // PRE-EXISTING-ADAPTATION. RPython recognizes `lst.append(i)` /
+        // `lst.pop()` at codewriter time via `@oopspec("list.append")`
+        // (`rpython/rtyper/extregistry.py` registration consumed by
+        // `rpython/jit/codewriter/jtransform.py:do_resizable_list_append`),
+        // which rewrites the IR before tracing ever runs. Pyre's
+        // codewriter is `partial` (per `majit/COMPATIBILITY_MATRIX.md`),
+        // so the analogous specialization happens here at trace recording
+        // time instead. Convergence path: port the codewriter's oopspec
+        // pass and remove this arm.
+        //
+        // `baseobjspace::getattr` returns a fresh `W_MethodObject` per
+        // iteration, so the receiver is pushed by `load_method` as
+        // `null_value` (load_method:6334) and call sees
         // `concrete_callable = W_MethodObject`, with the receiver missing
         // from `args`. Recover the receiver via `GetfieldGcR(callable,
         // w_self)` after guarding the method object's class. The function

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4717,15 +4717,20 @@ impl MIFrame {
             return self.trace_call_callable(callable, args);
         }
 
-        // PRE-EXISTING-ADAPTATION. RPython recognizes `lst.append(i)` /
-        // `lst.pop()` at codewriter time via `@oopspec("list.append")`
-        // (`rpython/rtyper/extregistry.py` registration consumed by
-        // `rpython/jit/codewriter/jtransform.py:do_resizable_list_append`),
-        // which rewrites the IR before tracing ever runs. Pyre's
-        // codewriter is `partial` (per `majit/COMPATIBILITY_MATRIX.md`),
-        // so the analogous specialization happens here at trace recording
-        // time instead. Convergence path: port the codewriter's oopspec
-        // pass and remove this arm.
+        // PRE-EXISTING-ADAPTATION. In RPython the `lst.append(i)` /
+        // `lst.pop()` lowering goes through rtyper helpers in
+        // `rpython/rtyper/rlist.py`: `ll_append` (rlist.py:588) is
+        // documented "no oopspec — inlined by the JIT", and the pop
+        // path picks `ll_pop_nonneg` / `ll_pop_zero` (which carry
+        // `oopspec = 'list.pop(l, index)'` / `'list.pop(l, 0)'`) over
+        // `ll_pop_default` based on the index sign. By the time the
+        // metainterp sees the trace, those helpers have already been
+        // inlined or oopspec'd into direct array operations. Pyre's
+        // codewriter is `partial` (per `majit/COMPATIBILITY_MATRIX.md`)
+        // and does not run that pass, so the analogous specialization
+        // happens here at trace recording time instead. Convergence
+        // path: port the rtyper/codewriter inlining + oopspec
+        // recognition and remove this arm.
         //
         // `baseobjspace::getattr` returns a fresh `W_MethodObject` per
         // iteration, so the receiver is pushed by `load_method` as

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4572,7 +4572,7 @@ impl MIFrame {
                 }
             }
         }
-        self.trace_call_callable(list, &[])
+        self.trace_call_callable(callable, &[])
     }
 
     pub(crate) fn concrete_iter_continues(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4776,7 +4776,7 @@ impl MIFrame {
                     // detection from `list_append_value`.
                     if concrete_len > 0 {
                         let self_ref = recover_self(self);
-                        return self.list_pop_value(self_ref, inner_self, concrete_len);
+                        return self.list_pop_value(callable, self_ref, inner_self, concrete_len);
                     }
                 }
             }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4740,9 +4740,23 @@ impl MIFrame {
         if unsafe { is_method(concrete_callable) } {
             let inner_func = unsafe { w_method_get_func(concrete_callable) };
             let inner_self = unsafe { w_method_get_self(concrete_callable) };
+            // `is_builtin_code` gate: a list subclass overriding `append`
+            // or `pop` with a Python `def` would still produce
+            // `is_function(inner_func) == true` and a matching `func_name`,
+            // which would silently rewire the call to builtin list IR.
+            // PyPy's `_Method` dispatch (`baseobjspace.py:1252` →
+            // `function.py:566`) just unwraps and calls `w_function`
+            // generically, so the user override runs. Restrict the spec
+            // arm to builtin-coded functions; Python overrides fall
+            // through to `trace_call_callable` below.
             if !inner_func.is_null()
                 && !inner_self.is_null()
                 && unsafe { is_function(inner_func) }
+                && unsafe {
+                    is_builtin_code(
+                        pyre_interpreter::getcode(inner_func) as pyre_object::PyObjectRef
+                    )
+                }
                 && unsafe { is_list(inner_self) }
             {
                 let func_name = unsafe { pyre_interpreter::function_get_name(inner_func) };

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4538,6 +4538,43 @@ impl MIFrame {
         self.trace_list_append(list, value)
     }
 
+    /// Mirror of `list_append_value` for `lst.pop()`. Caller has already
+    /// verified `concrete_len > 0`; this function picks a strategy fast
+    /// path or falls back to generic call dispatch (which routes through
+    /// `trace_call_callable` since pyre has no `jit_list_pop` residual
+    /// helper yet — the bound-method call dispatcher handles the slow
+    /// case).
+    pub(crate) fn list_pop_value(
+        &mut self,
+        list: OpRef,
+        concrete_list: PyObjectRef,
+        concrete_len: usize,
+    ) -> Result<OpRef, PyError> {
+        if concrete_list.is_null() || concrete_len == 0 {
+            // Caller's guard ensures concrete_len > 0; defensive fallback.
+            return self.trace_call_callable(list, &[]);
+        }
+        unsafe {
+            if is_list(concrete_list) {
+                let strategy_id = if w_list_uses_object_storage(concrete_list) {
+                    Some(0i64)
+                } else if w_list_uses_int_storage(concrete_list) {
+                    Some(1i64)
+                } else if w_list_uses_float_storage(concrete_list) {
+                    Some(2i64)
+                } else {
+                    None
+                };
+                if let Some(sid) = strategy_id {
+                    return Ok(self.with_ctx(|this, ctx| {
+                        crate::generated_list_pop_by_strategy(this, ctx, list, sid)
+                    }));
+                }
+            }
+        }
+        self.trace_call_callable(list, &[])
+    }
+
     pub(crate) fn concrete_iter_continues(
         &self,
         concrete_iter: PyObjectRef,
@@ -4677,27 +4714,27 @@ impl MIFrame {
             return self.trace_call_callable(callable, args);
         }
 
-        // `lst.append(item)` flow: `baseobjspace::getattr` returns a fresh
+        // `lst.<method>(...)` flow: `baseobjspace::getattr` returns a fresh
         // `W_MethodObject` per iteration, so the receiver is pushed by
         // `load_method` as `null_value` (load_method:6334) and call sees
-        // `concrete_callable = W_MethodObject`, `args = [item]`. Recover the
-        // receiver via `GetfieldGcR(callable, w_self)` after guarding the
-        // method object's class. The function pointer inside the method
-        // object IS stable across iterations, so the optimizer can fold the
-        // method-object's getfield_gc reads against a guard_value on the
-        // function slot instead of paying for the generic
-        // `jit_call_callable_1` dispatcher.
+        // `concrete_callable = W_MethodObject`, with the receiver missing
+        // from `args`. Recover the receiver via `GetfieldGcR(callable,
+        // w_self)` after guarding the method object's class. The function
+        // pointer inside the method object IS stable across iterations
+        // (unlike the freshly-allocated method-object pointer itself), so
+        // a `guard_value` on the `w_function` slot pins the specialization
+        // without invalidating on the next iteration's fresh allocation.
         if unsafe { is_method(concrete_callable) } {
             let inner_func = unsafe { w_method_get_func(concrete_callable) };
             let inner_self = unsafe { w_method_get_self(concrete_callable) };
             if !inner_func.is_null()
                 && !inner_self.is_null()
                 && unsafe { is_function(inner_func) }
+                && unsafe { is_list(inner_self) }
             {
                 let func_name = unsafe { pyre_interpreter::function_get_name(inner_func) };
-                if args.len() == 1 && func_name == "append" && unsafe { is_list(inner_self) } {
-                    let c_arg = concrete_args.first().copied().unwrap_or(PY_NULL);
-                    let self_ref = self.with_ctx(|this, ctx| {
+                let recover_self = |this: &mut Self| {
+                    this.with_ctx(|this, ctx| {
                         this.guard_class(ctx, callable, &METHOD_TYPE as *const PyType);
                         let func_ref = ctx.record_op_with_descr(
                             majit_ir::OpCode::GetfieldGcR,
@@ -4710,9 +4747,24 @@ impl MIFrame {
                             &[callable],
                             crate::descr::method_w_self_descr(),
                         )
-                    });
+                    })
+                };
+                if args.len() == 1 && func_name == "append" {
+                    let c_arg = concrete_args.first().copied().unwrap_or(PY_NULL);
+                    let self_ref = recover_self(self);
                     self.list_append_value(self_ref, args[0], inner_self, c_arg)?;
                     return Ok(self.with_ctx(|_, ctx| ctx.const_ref(pyre_object::w_none() as i64)));
+                }
+                if args.len() == 0 && func_name == "pop" {
+                    let concrete_len = unsafe { w_list_len(inner_self) };
+                    // Empty-list pop raises IndexError; let the generic
+                    // dispatcher handle that. Strategy-unknown lists also
+                    // fall through; `list_pop_value` mirrors the strategy
+                    // detection from `list_append_value`.
+                    if concrete_len > 0 {
+                        let self_ref = recover_self(self);
+                        return self.list_pop_value(self_ref, inner_self, concrete_len);
+                    }
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4540,19 +4540,22 @@ impl MIFrame {
 
     /// Mirror of `list_append_value` for `lst.pop()`. Caller has already
     /// verified `concrete_len > 0`; this function picks a strategy fast
-    /// path or falls back to generic call dispatch (which routes through
-    /// `trace_call_callable` since pyre has no `jit_list_pop` residual
-    /// helper yet — the bound-method call dispatcher handles the slow
-    /// case).
+    /// path or falls back to generic call dispatch.
+    ///
+    /// `callable` is the bound `W_MethodObject` OpRef: fallback paths pass
+    /// it to `trace_call_callable` so the residual emits `jit_call_callable_0`
+    /// on the *method*, not on the receiver (calling the list itself would be
+    /// a TypeError).
     pub(crate) fn list_pop_value(
         &mut self,
+        callable: OpRef,
         list: OpRef,
         concrete_list: PyObjectRef,
         concrete_len: usize,
     ) -> Result<OpRef, PyError> {
         if concrete_list.is_null() || concrete_len == 0 {
             // Caller's guard ensures concrete_len > 0; defensive fallback.
-            return self.trace_call_callable(list, &[]);
+            return self.trace_call_callable(callable, &[]);
         }
         unsafe {
             if is_list(concrete_list) {

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -1,13 +1,13 @@
 use std::ops::{Index, IndexMut};
 
-const INLINE_CAP: usize = 8;
+pub const FLOAT_ARRAY_INLINE_CAP: usize = 8;
 
 #[repr(C)]
 pub struct FloatArray {
     pub ptr: *mut f64,
     len: usize,
     heap_cap: usize,
-    inline_buf: [f64; INLINE_CAP],
+    inline_buf: [f64; FLOAT_ARRAY_INLINE_CAP],
 }
 
 pub const FLOAT_ARRAY_PTR_OFFSET: usize = std::mem::offset_of!(FloatArray, ptr);
@@ -17,8 +17,8 @@ pub const FLOAT_ARRAY_HEAP_CAP_OFFSET: usize = std::mem::offset_of!(FloatArray, 
 impl FloatArray {
     pub fn from_vec(mut values: Vec<f64>) -> Self {
         let len = values.len();
-        if len <= INLINE_CAP {
-            let mut inline_buf = [0.0; INLINE_CAP];
+        if len <= FLOAT_ARRAY_INLINE_CAP {
+            let mut inline_buf = [0.0; FLOAT_ARRAY_INLINE_CAP];
             inline_buf[..len].copy_from_slice(&values);
             let mut arr = Self {
                 ptr: std::ptr::null_mut(),
@@ -36,7 +36,7 @@ impl FloatArray {
                 ptr,
                 len,
                 heap_cap: cap,
-                inline_buf: [0.0; INLINE_CAP],
+                inline_buf: [0.0; FLOAT_ARRAY_INLINE_CAP],
             }
         }
     }
@@ -46,7 +46,7 @@ impl FloatArray {
         if self.heap_cap > 0 {
             self.heap_cap
         } else {
-            INLINE_CAP
+            FLOAT_ARRAY_INLINE_CAP
         }
     }
 
@@ -61,7 +61,7 @@ impl FloatArray {
     }
 
     fn grow_to_heap(&mut self, min_cap: usize) {
-        let target_cap = min_cap.max(INLINE_CAP * 2);
+        let target_cap = min_cap.max(FLOAT_ARRAY_INLINE_CAP * 2);
         let mut values = Vec::with_capacity(target_cap);
         values.extend_from_slice(&self.inline_buf[..self.len]);
         self.ptr = values.as_mut_ptr();

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -1,7 +1,7 @@
 use std::ops::{Index, IndexMut};
 
 /// Small-buffer capacity. Arrays up to this size avoid heap allocation.
-const INLINE_CAP: usize = 8;
+pub const INT_ARRAY_INLINE_CAP: usize = 8;
 
 /// Fixed-size i64 array with small-buffer optimization.
 #[repr(C)]
@@ -9,7 +9,7 @@ pub struct IntArray {
     pub ptr: *mut i64,
     len: usize,
     heap_cap: usize,
-    inline_buf: [i64; INLINE_CAP],
+    inline_buf: [i64; INT_ARRAY_INLINE_CAP],
 }
 
 pub const INT_ARRAY_PTR_OFFSET: usize = std::mem::offset_of!(IntArray, ptr);
@@ -19,8 +19,8 @@ pub const INT_ARRAY_HEAP_CAP_OFFSET: usize = std::mem::offset_of!(IntArray, heap
 impl IntArray {
     pub fn from_vec(mut values: Vec<i64>) -> Self {
         let len = values.len();
-        if len <= INLINE_CAP {
-            let mut inline_buf = [0; INLINE_CAP];
+        if len <= INT_ARRAY_INLINE_CAP {
+            let mut inline_buf = [0; INT_ARRAY_INLINE_CAP];
             inline_buf[..len].copy_from_slice(&values);
             let mut arr = Self {
                 ptr: std::ptr::null_mut(),
@@ -38,7 +38,7 @@ impl IntArray {
                 ptr,
                 len,
                 heap_cap: cap,
-                inline_buf: [0; INLINE_CAP],
+                inline_buf: [0; INT_ARRAY_INLINE_CAP],
             }
         }
     }
@@ -48,7 +48,7 @@ impl IntArray {
         if self.heap_cap > 0 {
             self.heap_cap
         } else {
-            INLINE_CAP
+            INT_ARRAY_INLINE_CAP
         }
     }
 
@@ -63,7 +63,7 @@ impl IntArray {
     }
 
     fn grow_to_heap(&mut self, min_cap: usize) {
-        let target_cap = min_cap.max(INLINE_CAP * 2);
+        let target_cap = min_cap.max(INT_ARRAY_INLINE_CAP * 2);
         let mut values = Vec::with_capacity(target_cap);
         values.extend_from_slice(&self.inline_buf[..self.len]);
         self.ptr = values.as_mut_ptr();


### PR DESCRIPTION
This pull request adds fast-path JIT support for `list.pop()` in Pyre, mirroring the existing optimized handling for `list.append()`. It introduces a specialized trace-time lowering for `lst.pop()` that avoids unnecessary boxing and improves performance, especially for integer and float list strategies. Additionally, it lays the groundwork for more robust method-object handling in the JIT and improves the maintainability and adaptability of the codebase for future convergence with upstream RPython.

The most important changes are:

**JIT Specialization for `list.pop()`**
- Added `generated_list_pop_by_strategy` in `majit-translate/src/codegen.rs` to efficiently trace `lst.pop()` for object, integer, and float list strategies, using dynamic length reads and avoiding hard-coded constants.
- Added `list_pop_value` to `MIFrame` in `pyre-jit-trace/src/trace_opcode.rs` to select the appropriate fast path or fall back to generic dispatch, paralleling the approach for `list.append()`.

**Bound Method Specialization and Descriptors**
- Introduced `W_METHOD_DESCR_GROUP` and corresponding field descriptors (`method_w_function_descr`, `method_w_self_descr`) in `pyre-jit-trace/src/descr.rs` to allow the JIT to recover the receiver and function from bound method objects, supporting robust specialization of method calls. [[1]](diffhunk://#diff-0eb8d9b7e7bdfa3a8c7d44bf6d1561c39aa1b361a1aac229348e2e05b133f710R595-R640) [[2]](diffhunk://#diff-0eb8d9b7e7bdfa3a8c7d44bf6d1561c39aa1b361a1aac229348e2e05b133f710R1129-R1145)
- Enhanced `trace_call_callable` in `MIFrame` to recognize and specialize calls to `lst.append()` and `lst.pop()` bound methods by extracting the receiver and guarding on the method function, enabling effective trace-time specialization.

**Backend Robustness**
- Replaced strict paired-guard checks for forceable calls in the Cranelift backend with `check_paired_guard_not_forced`, allowing for virtual-forcing ops between the call and its paired guard, improving compatibility with Pyre's optimizer and preventing spurious trace rejections. [[1]](diffhunk://#diff-530c9c7e34bcc1604e7444577b12a81f6a26efcc3ec79c590283d0125dce9526R3928-R3977) [[2]](diffhunk://#diff-530c9c7e34bcc1604e7444577b12a81f6a26efcc3ec79c590283d0125dce9526L8770-R8822) [[3]](diffhunk://#diff-530c9c7e34bcc1604e7444577b12a81f6a26efcc3ec79c590283d0125dce9526L8844-R8885)

**Benchmark and Documentation Updates**
- Updated several benchmarks and added comments clarifying why certain functions are kept at module scope, noting JIT and specialization issues to be addressed in future work. [[1]](diffhunk://#diff-7ec7896db1f2f72c6bcc48bad692bbc0fff07483b3f7b3aa02918095f36f6330R7-R10) [[2]](diffhunk://#diff-29214d25d8a81e05ceca4280f9bfe73c6defc4a4d96ecc8693a18f213bd5352dR7-R12) [[3]](diffhunk://#diff-577d3042e649e06f7efd581bb9dc661bdac0fd4601306a3c01d2c5fbe0bd0dcdR6-R10) [[4]](diffhunk://#diff-e5e6f5ac8a926b78aa794fe0427feb9d767f1eb793cb05746917e3abd2ed813aR9-R20)

**Imports and Minor Infrastructure**
- Added imports for method object helpers in `pyre-jit-trace/src/trace_opcode.rs` to support new specialization logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strategy-specific fast-paths for list.pop() covering object/int/float storage.
  * Trace-time specialization for method-backed list operations (append/pop) for faster calls.

* **Improvements**
  * Stricter, more informative error messages when expected trace guards/adjacency are missing.
  * New descriptor helpers to improve method-object dispatch reliability.

* **Documentation**
  * Clarified benchmark notes; one benchmark moved into a main() wrapper to control execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->