### PR TITLE
Increase stack size for build.rs to prevent overflow on Windows

### DIFF
--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -13,6 +13,19 @@ use walkdir::WalkDir;
 /// - pyre-object (Python object types: W_IntObject, W_FloatObject, etc.)
 /// - pyre-interpreter (object space, bytecode dispatch, eval loop)
 fn main() {
+    // Run on a worker thread with a large stack: on Windows the main
+    // thread's default stack is 1 MiB, which `syn`'s recursive parsing
+    // of the ~90 collected source files overflows
+    // (STATUS_STACK_OVERFLOW 0xc00000fd).
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(real_main)
+        .expect("spawn build-script worker")
+        .join()
+        .expect("build-script worker panicked");
+}
+
+fn real_main() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let pyre_base = format!("{manifest_dir}/..");
     let repo_root = format!("{manifest_dir}/../..");


### PR DESCRIPTION
This pull request modifies the build script in `pyre/pyre-jit-trace/build.rs` to address stack overflow issues during parsing on Windows. The main change is running the build logic on a worker thread with an increased stack size to prevent overflows when parsing many source files.

Build process robustness:

* The build logic is now executed on a worker thread with a 64 MiB stack, instead of the main thread, to avoid stack overflows caused by deep recursion during parsing with `syn` on Windows. The actual build logic has been moved to a new `real_main` function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build system stability to prevent build failures during large-scale source code compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->