### PR TITLE
Enhance dict lookup caching and propagate extra descriptors

### DIFF
--- a/majit/COMPATIBILITY_MATRIX.md
+++ b/majit/COMPATIBILITY_MATRIX.md
@@ -42,7 +42,7 @@ Tracks equivalence between majit (Rust, 81k LOC) and the in-tree RPython JIT sou
 | descr.rs | effectinfo.py | 1,500 | 85% | bitstring optimization |
 | rewrite.rs | rewrite.py | 3,546 | 95% | ~~INT_PY_DIV~~ ~~oois_ooisnot~~ ~~replace_old_guard_with_guard_value~~ ~~CALL_N arraycopy~~ 추가됨. try_boolinvers 분리, serialize/deserialize 이름 parity. ~~optimize_float_abs~~ 메서드 추출 |
 | virtualize.rs | virtualize.py | 3,986 | 80% | ~~COND_CALL, JIT_FORCE_VIRTUAL~~ 추가됨 |
-| heap.rs | heap.py | 3,592 | 85% | ~~pendingfields, DICT_LOOKUP, serialization, variable-index, aliasing~~ 추가됨. clean_caches 정제 남음 |
+| heap.rs | heap.py | 3,592 | 90% | ~~pendingfields, DICT_LOOKUP, serialization, variable-index, aliasing~~ 추가됨. ~~_optimize_CALL_DICT_LOOKUP~~ 추가됨 (cached_dict_reads, corresponding_array_descrs, GUARD_NO_EXCEPTION REMOVED 연동). clean_caches 정제 남음 |
 | vstring.rs | vstring.py | 1,298 | 80% | ~~STR_CONCAT, copy_str_content~~ 추가됨. ~~메서드 이름 parity~~ (strgetitem, getstrlen, int_add/int_sub, force_box, handle_str_equal_level1, opt_call_stroruni_* 분리). handle_str_equal_level2, generate_modified_call 남음 |
 | bridgeopt.rs | bridgeopt.py | 829 | 95% | serialize/deserialize/tag_box/decode_box 모두 구현됨 |
 | guard.rs | guard.py | 931 | 85% | ~~implies~~ ~~transitive_imply~~ ~~eliminate_array_bound_checks~~ 추가됨. IndexVar 연동 |
@@ -124,13 +124,14 @@ Tracks equivalence between majit (Rust, 81k LOC) and the in-tree RPython JIT sou
 - Implemented: `optimize_float_abs()` 별도 메서드 추출 (rewrite.py:155-161)
 - Note: GUARD_SUBCLASS/IS_OBJECT/NONNULL/CLASS, COND_CALL, INT_PY_DIV는 propagate_forward match arm으로 구현됨
 
-**heap.rs** (85%)
+**heap.rs** (90%)
 - Implemented: variable-index array caching (`cached_arrayitems_var` HashMap)
 - Implemented: aliasing analysis (`cannot_alias_via_content`, `_cannot_alias_via_classes_or_lengths` inline)
 - Implemented: `export_cached_fields()` / `import_cached_fields()` (bridge 지식 직렬화)
 - Implemented: `force_lazy_sets_for_guard()` (가드 전용 선택적 lazy set forcing → pendingfields → rd_pendingfields)
+- Implemented: `_optimize_CALL_DICT_LOOKUP()` — FLAG_LOOKUP/FLAG_STORE 캐싱, cached_dict_reads, corresponding_array_descrs, GUARD_NO_EXCEPTION REMOVED 연동, clean_caches/force_from_effectinfo 무효화
 - Missing: `clean_caches()` 정제 (순수 필드만 보존하는 선택적 무효화 — 부분 구현)
-- Note: pendingfields, DICT_LOOKUP, postponed ops, GUARD_NO_EXCEPTION, arraycopy 무효화 모두 구현됨
+- Note: pendingfields, ~~DICT_LOOKUP~~, postponed ops, GUARD_NO_EXCEPTION, arraycopy 무효화 모두 구현됨
 
 **virtualize.rs** (80%)
 - Missing: `optimize_INT_ADD()` raw slice optimization

--- a/majit/COMPATIBILITY_MATRIX.md
+++ b/majit/COMPATIBILITY_MATRIX.md
@@ -125,7 +125,7 @@ Tracks equivalence between majit (Rust, 81k LOC) and the in-tree RPython JIT sou
 - Note: GUARD_SUBCLASS/IS_OBJECT/NONNULL/CLASS, COND_CALL, INT_PY_DIV는 propagate_forward match arm으로 구현됨
 
 **heap.rs** (90%)
-- Implemented: variable-index array caching (`cached_arrayitems_var` HashMap)
+- Implemented: variable-index array caching (`ArrayCacheSubMap::cached_varindex_triples`)
 - Implemented: aliasing analysis (`cannot_alias_via_content`, `_cannot_alias_via_classes_or_lengths` inline)
 - Implemented: `export_cached_fields()` / `import_cached_fields()` (bridge 지식 직렬화)
 - Implemented: `force_lazy_sets_for_guard()` (가드 전용 선택적 lazy set forcing → pendingfields → rd_pendingfields)

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -6233,4 +6233,148 @@ mod tests {
             "arrays with different constant at index 1 cannot alias"
         );
     }
+
+    fn dict_lookup_descr(idx: u32, extra0: DescrRef, extra1: DescrRef) -> DescrRef {
+        Arc::new(TestCallDescr {
+            idx,
+            effect: EffectInfo {
+                extraeffect: ExtraEffect::CanRaise,
+                oopspecindex: OopSpecIndex::DictLookup,
+                extradescrs: Some(vec![extra0, extra1]),
+                ..Default::default()
+            },
+        })
+    }
+
+    /// heap.py:480-528 parity: FLAG_LOOKUP deduplicates consecutive dict lookups.
+    #[test]
+    fn test_dict_lookup_cache_flag_lookup() {
+        let extra_field: DescrRef = Arc::new(TestDescr(80));
+        let extra_array: DescrRef = Arc::new(TestDescr(81));
+        let descr = dict_lookup_descr(90, extra_field, extra_array);
+
+        let mut heap = OptHeap::new();
+        let mut ctx = OptContext::new(256);
+
+        // Build args: [func_addr, dict, key, hash, flag=FLAG_LOOKUP(0)]
+        let func_addr = ctx.make_constant_int(0xDEAD);
+        let dict = OpRef::input_arg_typed(0, Type::Ref);
+        let key = OpRef::input_arg_typed(1, Type::Ref);
+        let hash = ctx.make_constant_int(42);
+        let flag = ctx.make_constant_int(0); // FLAG_LOOKUP
+
+        // First lookup — not cached yet, should return false (emit).
+        let pos1 = ctx.reserve_pos_typed(Type::Int);
+        let mut op1 = Op::new(OpCode::CallI, &[func_addr, dict, key, hash, flag]);
+        op1.descr = Some(descr.clone());
+        op1.pos = pos1;
+        assert!(!heap._optimize_call_dict_lookup(&op1, &mut ctx));
+
+        // Second lookup with same dict+key — should be cached.
+        let pos2 = ctx.reserve_pos_typed(Type::Int);
+        let mut op2 = Op::new(OpCode::CallI, &[func_addr, dict, key, hash, flag]);
+        op2.descr = Some(descr.clone());
+        op2.pos = pos2;
+        assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
+        assert_eq!(ctx.get_box_replacement(pos2), pos1);
+        assert!(heap.last_emitted_removed);
+    }
+
+    /// heap.py:495-499 parity: FLAG_STORE reuses only if cached value >= 0.
+    #[test]
+    fn test_dict_lookup_cache_flag_store_nonneg() {
+        let extra_field: DescrRef = Arc::new(TestDescr(80));
+        let extra_array: DescrRef = Arc::new(TestDescr(81));
+        let descr = dict_lookup_descr(90, extra_field, extra_array);
+
+        let mut heap = OptHeap::new();
+        let mut ctx = OptContext::new(256);
+
+        let func_addr = ctx.make_constant_int(0xDEAD);
+        let dict = OpRef::input_arg_typed(0, Type::Ref);
+        let key = OpRef::input_arg_typed(1, Type::Ref);
+        let hash = ctx.make_constant_int(42);
+        let flag_lookup = ctx.make_constant_int(0); // FLAG_LOOKUP
+        let flag_store = ctx.make_constant_int(1); // FLAG_STORE
+
+        // Seed cache with FLAG_LOOKUP, then try FLAG_STORE.
+        let pos1 = ctx.reserve_pos_typed(Type::Int);
+        let mut op1 = Op::new(OpCode::CallI, &[func_addr, dict, key, hash, flag_lookup]);
+        op1.descr = Some(descr.clone());
+        op1.pos = pos1;
+        // Pretend the result is known >= 0.
+        ctx.setintbound(
+            pos1,
+            &crate::optimizeopt::intutils::IntBound::from_constant(5),
+        );
+        assert!(!heap._optimize_call_dict_lookup(&op1, &mut ctx));
+
+        // FLAG_STORE with known non-negative cached value → reuse.
+        let pos2 = ctx.reserve_pos_typed(Type::Int);
+        let mut op2 = Op::new(OpCode::CallI, &[func_addr, dict, key, hash, flag_store]);
+        op2.descr = Some(descr.clone());
+        op2.pos = pos2;
+        assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
+        assert_eq!(ctx.get_box_replacement(pos2), pos1);
+    }
+
+    /// heap.py:390 parity: clean_caches clears cached_dict_reads.
+    #[test]
+    fn test_dict_lookup_cache_cleared_by_clean_caches() {
+        let extra_field: DescrRef = Arc::new(TestDescr(80));
+        let extra_array: DescrRef = Arc::new(TestDescr(81));
+        let descr = dict_lookup_descr(90, extra_field, extra_array);
+
+        let mut heap = OptHeap::new();
+        let mut ctx = OptContext::new(256);
+
+        let func_addr = ctx.make_constant_int(0xDEAD);
+        let dict = OpRef::input_arg_typed(0, Type::Ref);
+        let key = OpRef::input_arg_typed(1, Type::Ref);
+        let hash = ctx.make_constant_int(42);
+        let flag = ctx.make_constant_int(0);
+
+        // Seed cache.
+        let pos1 = ctx.reserve_pos_typed(Type::Int);
+        let mut op1 = Op::new(OpCode::CallI, &[func_addr, dict, key, hash, flag]);
+        op1.descr = Some(descr.clone());
+        op1.pos = pos1;
+        heap._optimize_call_dict_lookup(&op1, &mut ctx);
+        assert!(!heap.cached_dict_reads.is_empty());
+
+        // clean_caches should clear it.
+        heap.clean_caches(&mut ctx);
+        assert!(heap.cached_dict_reads.is_empty());
+
+        // Second lookup after clean — should NOT be cached.
+        let pos2 = ctx.reserve_pos_typed(Type::Int);
+        let mut op2 = Op::new(OpCode::CallI, &[func_addr, dict, key, hash, flag]);
+        op2.descr = Some(descr.clone());
+        op2.pos = pos2;
+        assert!(!heap._optimize_call_dict_lookup(&op2, &mut ctx));
+    }
+
+    /// FLAG_DELETE (2+) should never cache or reuse.
+    #[test]
+    fn test_dict_lookup_cache_flag_delete_no_cache() {
+        let extra_field: DescrRef = Arc::new(TestDescr(80));
+        let extra_array: DescrRef = Arc::new(TestDescr(81));
+        let descr = dict_lookup_descr(90, extra_field, extra_array);
+
+        let mut heap = OptHeap::new();
+        let mut ctx = OptContext::new(256);
+
+        let func_addr = ctx.make_constant_int(0xDEAD);
+        let dict = OpRef::input_arg_typed(0, Type::Ref);
+        let key = OpRef::input_arg_typed(1, Type::Ref);
+        let hash = ctx.make_constant_int(42);
+        let flag_delete = ctx.make_constant_int(2); // FLAG_DELETE
+
+        let pos1 = ctx.reserve_pos_typed(Type::Int);
+        let mut op1 = Op::new(OpCode::CallI, &[func_addr, dict, key, hash, flag_delete]);
+        op1.descr = Some(descr.clone());
+        op1.pos = pos1;
+        assert!(!heap._optimize_call_dict_lookup(&op1, &mut ctx));
+        assert!(heap.cached_dict_reads.is_empty());
+    }
 }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -713,18 +713,16 @@ pub struct OptHeap {
     /// all its dependencies are transitively escaped.
     heapc_deps: HashMap<OpRef, Vec<OpRef>>,
 
-    // heap.py:27 OptHeap inherits Optimization.last_emitted_operation,
-    // which is set to REMOVED by `_optimize_CALL_DICT_LOOKUP`
-    // (heap.py:527) when a folded CALL_PURE collapses into its cached
-    // result. `optimize_GUARD_NO_EXCEPTION` (heap.py:530-533) reads the
-    // flag and skips emitting the trailing guard.
-    //
-    // _optimize_CALL_DICT_LOOKUP is not yet ported — it depends on
-    // `extradescrs` on EffectInfo (rpython rordereddict descriptor
-    // pairing) which majit-ir does not carry. Until that lands the
-    // OptHeap REMOVED setter does not exist, so the corresponding
-    // reader is omitted in optimize_GUARD_NO_EXCEPTION rather than
-    // installed as dead code.
+    /// heap.py:27 Optimization.last_emitted_operation is REMOVED.
+    /// Set to true when `_optimize_CALL_DICT_LOOKUP` folds a lookup;
+    /// read by `optimize_GUARD_NO_EXCEPTION` to suppress the trailing guard.
+    last_emitted_removed: bool,
+    /// heap.py:337: cached_dict_reads — descr_identity(extradescrs[0]) → { [dict,key] → result_opref }.
+    /// Consecutive dict lookups on the same dict+key are deduplicated.
+    cached_dict_reads: HashMap<usize, HashMap<[OpRef; 2], OpRef>>,
+    /// heap.py:560: corresponding_array_descrs — maps extradescrs[1] bitstring index → extradescrs[0] identity.
+    /// Used in force_from_effectinfo to clear dict_reads when the entries array is written.
+    corresponding_array_descrs: HashMap<u32, usize>,
     /// Fields known to be quasi-immutable: (obj, field_idx) -> cached value OpRef.
     /// Populated by QUASIIMMUT_FIELD, consumed by subsequent GETFIELD_GC_*.
     /// Survives calls (guarded by GUARD_NOT_INVALIDATED).
@@ -744,6 +742,9 @@ impl OptHeap {
             unescaped: Vec::new(),
             known_nonnull: Vec::new(),
             heapc_deps: HashMap::new(),
+            last_emitted_removed: false,
+            cached_dict_reads: HashMap::new(),
+            corresponding_array_descrs: HashMap::new(),
             quasi_immut_cache: HashMap::new(),
         }
     }
@@ -1256,7 +1257,7 @@ impl OptHeap {
             }
         }
         // heap.py:390: self.cached_dict_reads.clear()
-        // (no dict_reads cache in majit)
+        self.cached_dict_reads.clear();
     }
 
     /// heapcache.py:363-369 invalidate_unescaped / clear_caches_varargs
@@ -1428,6 +1429,84 @@ impl OptHeap {
             .and_then(|d| d.as_call_descr())
             .map(|cd| cd.get_extra_info().oopspecindex)
             .unwrap_or(OopSpecIndex::None)
+    }
+
+    /// heap.py:480-528 _optimize_CALL_DICT_LOOKUP.
+    ///
+    /// Cache consecutive dict lookup calls on the same dict+key.
+    /// FLAG_LOOKUP (0): always cache and reuse.
+    /// FLAG_STORE  (1): don't cache new; reuse only if cached value ≥ 0.
+    /// FLAG_DELETE (2+): never cache, never reuse.
+    fn _optimize_call_dict_lookup(
+        &mut self,
+        op: &Op,
+        ctx: &mut OptContext,
+    ) -> bool {
+        const FLAG_LOOKUP: i64 = 0;
+        const FLAG_STORE: i64 = 1;
+
+        // heap.py:497: flag_value = self.getintbound(op.getarg(4))
+        if op.args.len() < 5 {
+            return false;
+        }
+        let flag_ref = ctx.get_box_replacement(op.arg(4));
+        let flag = match ctx.get_constant_int(flag_ref) {
+            Some(v) => v,
+            None => return false,
+        };
+        if flag != FLAG_LOOKUP && flag != FLAG_STORE {
+            return false;
+        }
+
+        // heap.py:504: descrs = op.getdescr().get_extra_info().extradescrs
+        let extradescrs = op
+            .descr
+            .as_ref()
+            .and_then(|d| d.as_call_descr())
+            .and_then(|cd| cd.get_extra_info().extradescrs.as_ref())
+            .cloned();
+        let descrs = match extradescrs {
+            Some(ref d) if d.len() >= 2 => d,
+            _ => return false,
+        };
+        let descr1_id = descr_identity(&descrs[0]);
+        let descr2_idx = descrs[1].index();
+
+        // heap.py:506-510: d = cached_dict_reads[descr1]; register corresponding_array_descrs
+        let d = self
+            .cached_dict_reads
+            .entry(descr1_id)
+            .or_default();
+        self.corresponding_array_descrs
+            .entry(descr2_idx)
+            .or_insert(descr1_id);
+
+        // heap.py:513-514: key = [get_box_replacement(arg1), get_box_replacement(arg2)]
+        let key = [
+            ctx.get_box_replacement(op.arg(1)),
+            ctx.get_box_replacement(op.arg(2)),
+        ];
+
+        if let Some(&res_v) = d.get(&key) {
+            // heap.py:520: flag != FLAG_LOOKUP → check known_ge_const(0)
+            if flag != FLAG_LOOKUP {
+                let bound = ctx.get_int_bound(res_v);
+                let known_ge_zero = bound.map_or(false, |b| b.known_ge_const(0));
+                if !known_ge_zero {
+                    return false;
+                }
+            }
+            // heap.py:525-527: make_equal_to + last_emitted_operation = REMOVED
+            ctx.make_equal_to(op.pos, res_v);
+            self.last_emitted_removed = true;
+            return true;
+        }
+
+        // heap.py:517-518: no hit — cache if FLAG_LOOKUP
+        if flag == FLAG_LOOKUP {
+            d.insert(key, op.pos);
+        }
+        false
     }
 
     /// Mark call arguments as escaped.
@@ -1718,6 +1797,39 @@ impl OptHeap {
                     submap.clear_varindex();
                 }
             }
+        }
+
+        // heap.py:542-551: invalidate cached_dict_reads for written field descrs.
+        let field_ids_to_clear: Vec<usize> = self
+            .cached_fields
+            .iter()
+            .filter_map(|(_, descr, _)| {
+                let fid = Self::field_effect_index(descr);
+                if ei.check_write_descr_field(fid) && !descr.is_always_pure() {
+                    Some(descr_identity(descr))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for fid in field_ids_to_clear {
+            self.cached_dict_reads.remove(&fid);
+        }
+
+        // heap.py:560-563: invalidate cached_dict_reads via corresponding_array_descrs.
+        let array_ids_to_clear: Vec<usize> = self
+            .corresponding_array_descrs
+            .iter()
+            .filter_map(|(&arr_idx, &dict_id)| {
+                if ei.check_write_descr_array(arr_idx) {
+                    Some(dict_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for dict_id in array_ids_to_clear {
+            self.cached_dict_reads.remove(&dict_id);
         }
     }
 
@@ -2540,10 +2652,12 @@ impl OptHeap {
                 // heap.py: DICT_LOOKUP caching — consecutive dict lookups
                 // on the same dict with the same key can be deduplicated.
                 OopSpecIndex::DictLookup => {
+                    // heap.py:472-475: try caching first
+                    if self._optimize_call_dict_lookup(op, ctx) {
+                        return OptimizationResult::Remove;
+                    }
                     self.mark_escaped_varargs(op, ctx);
                     self.force_all_lazy_sets(ctx.current_pass_idx, ctx);
-                    // Invalidate dict-related caches but keep field/array caches.
-                    // Dict operations don't affect struct fields.
                     return OptimizationResult::Emit(op.clone());
                 }
                 OopSpecIndex::Arraycopy | OopSpecIndex::Arraymove => {
@@ -2781,33 +2895,16 @@ impl OptHeap {
                 OptimizationResult::PassOn
             }
 
-            // heap.py:530-535 optimize_GUARD_NO_EXCEPTION
-            // (alias optimize_GUARD_EXCEPTION = optimize_GUARD_NO_EXCEPTION):
-            //
-            //     def optimize_GUARD_NO_EXCEPTION(self, op):
-            //         if self.last_emitted_operation is REMOVED:
-            //             return
-            //         return self.emit(op)
-            //     optimize_GUARD_EXCEPTION = optimize_GUARD_NO_EXCEPTION
-            //
-            // The REMOVED check is the only path the upstream guard arm
-            // shortcuts on. last_emitted_operation is set to REMOVED only
-            // by _optimize_CALL_DICT_LOOKUP (heap.py:527), which majit
-            // does not yet port (see the field comment near the top of
-            // OptHeap). Until that helper lands the REMOVED branch has no
-            // producer, so the unconditional emit is the structurally
-            // correct port.
-            //
-            // Returning Emit hands the guard back to the propagate_forward
-            // wrapper, which (1) flushes self.postponed_op via the standard
-            // emit() override and (2) routes the guard through
-            // emit_operation. emit_operation then invokes
-            // emitting_operation for OptHeap, whose guard branch
-            // (heap.py:432-435) calls force_lazy_sets_for_guard — preserving
-            // immutable cache entries and writing the lazy sets only into
-            // the guard's pendingfields, never as new ops in the trace.
+            // heap.py:530-535 optimize_GUARD_NO_EXCEPTION / optimize_GUARD_EXCEPTION.
+            // When _optimize_CALL_DICT_LOOKUP folds a lookup, it sets
+            // last_emitted_removed; the trailing GUARD_NO_EXCEPTION is dead.
             OpCode::GuardNoException | OpCode::GuardException => {
-                OptimizationResult::Emit(op.clone())
+                if self.last_emitted_removed {
+                    self.last_emitted_removed = false;
+                    OptimizationResult::Remove
+                } else {
+                    OptimizationResult::Emit(op.clone())
+                }
             }
 
             // ── GUARD_NOT_INVALIDATED deduplication ──
@@ -2897,6 +2994,14 @@ impl Default for OptHeap {
 
 impl Optimization for OptHeap {
     fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        // Reset last_emitted_removed before non-guard ops (mirrors RPython's
+        // natural overwrite of last_emitted_operation on every emit).
+        if !matches!(
+            op.opcode,
+            OpCode::GuardNoException | OpCode::GuardException
+        ) {
+            self.last_emitted_removed = false;
+        }
         let result = self.dispatch_propagate(op, ctx);
         // RPython heap.py:417-425 emit() override parity:
         // Before emitting any new op, flush the postponed op. Then

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3020,6 +3020,9 @@ impl Optimization for OptHeap {
         self.seen_allocation.clear();
         self.unescaped.clear();
         self.known_nonnull.clear();
+        self.last_emitted_removed = false;
+        self.cached_dict_reads.clear();
+        self.corresponding_array_descrs.clear();
         self.quasi_immut_cache.clear();
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1445,12 +1445,13 @@ impl OptHeap {
         const FLAG_LOOKUP: i64 = 0;
         const FLAG_STORE: i64 = 1;
 
-        // heap.py:497: flag_value = self.getintbound(op.getarg(4))
+        // heap.py:497-500: flag_value = self.getintbound(op.getarg(4))
+        //   if not flag_value.is_constant(): return False
+        //   flag = flag_value.get_constant_int()
         if op.args.len() < 5 {
             return false;
         }
-        let flag_ref = ctx.get_box_replacement(op.arg(4));
-        let flag = match ctx.get_constant_int(flag_ref) {
+        let flag = match ctx.get_constant_int_or_bound(op.arg(4)) {
             Some(v) => v,
             None => return false,
         };
@@ -1488,9 +1489,10 @@ impl OptHeap {
         ];
 
         if let Some(&res_v) = d.get(&key) {
-            // heap.py:520: flag != FLAG_LOOKUP → check known_ge_const(0)
+            // heap.py:523-525: flag != FLAG_LOOKUP → self.getintbound(res_v).known_ge_const(0)
             if flag != FLAG_LOOKUP {
-                let bound = ctx.get_int_bound(res_v);
+                let resolved = ctx.get_box_replacement(res_v);
+                let bound = ctx.get_int_bound(resolved);
                 let known_ge_zero = bound.map_or(false, |b| b.known_ge_const(0));
                 if !known_ge_zero {
                     return false;
@@ -1695,6 +1697,10 @@ impl OptHeap {
                         }
                     }
                 }
+                // heap.py:547-552: del self.cached_dict_reads[fielddescr]
+                if !descr.is_always_pure() {
+                    self.cached_dict_reads.remove(&descr_identity(&descr));
+                }
             }
         }
 
@@ -1797,23 +1803,6 @@ impl OptHeap {
                     submap.clear_varindex();
                 }
             }
-        }
-
-        // heap.py:542-551: invalidate cached_dict_reads for written field descrs.
-        let field_ids_to_clear: Vec<usize> = self
-            .cached_fields
-            .iter()
-            .filter_map(|(_, descr, _)| {
-                let fid = Self::field_effect_index(descr);
-                if ei.check_write_descr_field(fid) && !descr.is_always_pure() {
-                    Some(descr_identity(descr))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        for fid in field_ids_to_clear {
-            self.cached_dict_reads.remove(&fid);
         }
 
         // heap.py:560-563: invalidate cached_dict_reads via corresponding_array_descrs.

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use majit_ir::descr::{EffectInfo, ExtraEffect, OopSpecIndex};
+use majit_ir::descr::{DescrRef, EffectInfo, ExtraEffect, OopSpecIndex};
 use majit_ir::value::Type;
 use serde::{Deserialize, Serialize};
 
@@ -2804,6 +2804,7 @@ impl CallControl {
         oopspecindex: OopSpecIndex,
         extraeffect: Option<ExtraEffect>,
         cache: &mut AnalysisCache,
+        extradescrs: Option<Vec<DescrRef>>,
     ) -> CallDescriptor {
         // Extract the direct-call target (if any) and indirect-call family
         // (if any).  Exactly one is Some after the initial dispatch;
@@ -3060,6 +3061,7 @@ impl CallControl {
             oopspecindex,
             can_invalidate,
             can_collect,
+            extradescrs,
         );
 
         // RPython call.py:326-332 post-conditions on elidable / loopinvariant.
@@ -3237,6 +3239,7 @@ fn effectinfo_from_writeanalyze(
     oopspecindex: OopSpecIndex,
     can_invalidate: bool,
     can_collect: bool,
+    extradescrs: Option<Vec<DescrRef>>,
 ) -> EffectInfo {
     // effectinfo.py:285: if effects is top_set or extraeffect == EF_RANDOM_EFFECTS:
     if effects.is_top || extraeffect == ExtraEffect::RandomEffects {
@@ -3250,7 +3253,7 @@ fn effectinfo_from_writeanalyze(
             readonly_descrs_interiorfields: !0,
             write_descrs_interiorfields: !0,
             single_write_descr_array: None,
-            extradescrs: None,
+            extradescrs: extradescrs.clone(),
             can_invalidate,
             can_collect: true, // effectinfo.py:364-365: forces → can_collect = True
             call_release_gil_target: EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
@@ -3307,7 +3310,7 @@ fn effectinfo_from_writeanalyze(
         readonly_descrs_interiorfields,
         write_descrs_interiorfields,
         single_write_descr_array,
-        extradescrs: None,
+        extradescrs,
         can_invalidate,
         can_collect,
         call_release_gil_target: EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
@@ -4694,6 +4697,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(descriptor.extra_info.extraeffect, ExtraEffect::CannotRaise);
         assert!(!descriptor.extra_info.can_invalidate);
@@ -4716,6 +4720,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(descriptor.extra_info.extraeffect, ExtraEffect::CanRaise);
     }
@@ -4738,6 +4743,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(
             descriptor.extra_info.extraeffect,
@@ -4763,6 +4769,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(
             descriptor.extra_info.extraeffect,
@@ -4788,6 +4795,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(
             descriptor.extra_info.extraeffect,
@@ -4817,6 +4825,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(
             descriptor.extra_info.extraeffect,
@@ -4841,6 +4850,7 @@ mod tests {
             OopSpecIndex::None,
             Some(ExtraEffect::ElidableCannotRaise),
             &mut cache,
+            None,
         );
         assert_eq!(
             descriptor.extra_info.extraeffect,
@@ -4882,6 +4892,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(descriptor.extra_info.extraeffect, ExtraEffect::CanRaise);
     }
@@ -4902,6 +4913,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(descriptor.extra_info.extraeffect, ExtraEffect::CanRaise);
         // RandomEffects is false, QuasiImmut is false → can_invalidate is false.
@@ -4948,6 +4960,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         // Should have non-zero bitsets for field reads and writes.
         assert_ne!(descriptor.extra_info.readonly_descrs_fields, 0);
@@ -5011,6 +5024,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         assert_eq!(
             descriptor.extra_info.extraeffect,
@@ -5107,6 +5121,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
         // Write is set, but readonly should NOT have the same bit set.
         // RPython: readonly = reads & ~writes
@@ -5559,6 +5574,7 @@ mod tests {
             OopSpecIndex::None,
             None,
             &mut cache,
+            None,
         );
     }
 

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -5698,4 +5698,78 @@ mod tests {
             segs(&bare_family),
         );
     }
+
+    #[test]
+    fn test_getcalldescr_extradescrs_propagated() {
+        use std::sync::Arc;
+
+        #[derive(Debug)]
+        struct StubDescr(u32);
+        impl majit_ir::Descr for StubDescr {
+            fn index(&self) -> u32 {
+                self.0
+            }
+        }
+
+        let mut cc = CallControl::new();
+        let path = CallPath::from_segments(["pure_add"]);
+        register_int_result_graph(&mut cc, path.clone(), simple_graph("pure_add"));
+        cc.find_all_graphs_for_tests();
+
+        let extra0: DescrRef = Arc::new(StubDescr(80));
+        let extra1: DescrRef = Arc::new(StubDescr(81));
+        let extras = Some(vec![extra0.clone(), extra1.clone()]);
+
+        let target = CallTarget::function_path(["pure_add"]);
+        let mut cache = AnalysisCache::default();
+        let descriptor = cc.getcalldescr(
+            &direct_call_op(target.clone()),
+            Vec::new(),
+            Type::Int,
+            OopSpecIndex::DictLookup,
+            None,
+            &mut cache,
+            extras,
+        );
+        let got = descriptor.extra_info.extradescrs.as_ref().unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].index(), 80);
+        assert_eq!(got[1].index(), 81);
+    }
+
+    #[test]
+    fn test_getcalldescr_extradescrs_survives_random_effects() {
+        use std::sync::Arc;
+
+        #[derive(Debug)]
+        struct StubDescr(u32);
+        impl majit_ir::Descr for StubDescr {
+            fn index(&self) -> u32 {
+                self.0
+            }
+        }
+
+        let mut cc = CallControl::new();
+        let path = CallPath::from_segments(["chaotic"]);
+        cc.register_function_graph(path.clone(), raising_graph("chaotic"));
+        cc.find_all_graphs_for_tests();
+
+        let extra0: DescrRef = Arc::new(StubDescr(90));
+        let extras = Some(vec![extra0.clone()]);
+
+        let target = CallTarget::function_path(["chaotic"]);
+        let mut cache = AnalysisCache::default();
+        let descriptor = cc.getcalldescr(
+            &direct_call_op(target.clone()),
+            Vec::new(),
+            Type::Int,
+            OopSpecIndex::DictLookup,
+            Some(ExtraEffect::RandomEffects),
+            &mut cache,
+            extras,
+        );
+        let got = descriptor.extra_info.extradescrs.as_ref().unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].index(), 90);
+    }
 }

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -3309,6 +3309,8 @@ fn map_user_oopspec_to_index(spec: &str) -> majit_ir::descr::OopSpecIndex {
         // All jit.* oopspecs are intercepted by _handle_jit_call() before
         // reaching this function. Remaining oopspecs map to OS_* indices.
         "virtual_ref" | "virtual_ref_finish" => OopSpecIndex::JitForceVirtualizable,
+        // jtransform.py:507-509: oopspec_name.endswith('dict.lookup')
+        _ if base.ends_with("dict.lookup") => OopSpecIndex::DictLookup,
         _ => OopSpecIndex::None,
     }
 }
@@ -5411,5 +5413,26 @@ mod tests {
             &[arg],
             &ValueType::Ref,
         ));
+    }
+
+    #[test]
+    fn map_user_oopspec_dict_lookup() {
+        use majit_ir::descr::OopSpecIndex;
+        assert_eq!(
+            super::map_user_oopspec_to_index("ordereddict.lookup(d, key, hash, flag)"),
+            OopSpecIndex::DictLookup
+        );
+        assert_eq!(
+            super::map_user_oopspec_to_index("ordereddict.lookup"),
+            OopSpecIndex::DictLookup
+        );
+        assert_eq!(
+            super::map_user_oopspec_to_index("dict.lookup"),
+            OopSpecIndex::DictLookup
+        );
+        assert_eq!(
+            super::map_user_oopspec_to_index("dict.setitem"),
+            OopSpecIndex::None
+        );
     }
 }

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -1503,6 +1503,7 @@ impl<'a> Transformer<'a> {
                         OopSpecIndex::None,
                         extraeffect,
                         &mut self.analysis_cache,
+                        None,
                     );
                     self.handle_residual_call(op, target, descriptor, args, result_ty, graph_name)
                 }
@@ -1610,6 +1611,7 @@ impl<'a> Transformer<'a> {
                 oopspecindex,
                 extraeffect_override,
                 &mut self.analysis_cache,
+                None,
             )
         };
 
@@ -1902,6 +1904,7 @@ impl<'a> Transformer<'a> {
                 graph_name,
                 OopSpecIndex::JitForceVirtual,
                 Some(majit_ir::descr::ExtraEffect::ForcesVirtualOrVirtualizable),
+                None,
             ),
             // jtransform.py:1748-1755
             "jit.not_in_trace" => {
@@ -1917,6 +1920,7 @@ impl<'a> Transformer<'a> {
                     result_ty,
                     graph_name,
                     OopSpecIndex::NotInTrace,
+                    None,
                     None,
                 )
             }
@@ -1941,6 +1945,7 @@ impl<'a> Transformer<'a> {
         graph_name: &str,
         oopspecindex: OopSpecIndex,
         extraeffect: Option<majit_ir::descr::ExtraEffect>,
+        extradescrs: Option<Vec<majit_ir::DescrRef>>,
     ) -> RewriteResult {
         // jtransform.py:1990-1993
         let non_void_args = resolve_non_void_arg_types(args, self.type_state);
@@ -1954,6 +1959,7 @@ impl<'a> Transformer<'a> {
                 oopspecindex,
                 extraeffect,
                 &mut self.analysis_cache,
+                extradescrs,
             )
         };
         self.notes.push(GraphTransformNote {
@@ -2032,6 +2038,7 @@ impl<'a> Transformer<'a> {
                 OopSpecIndex::None,
                 None,
                 &mut self.analysis_cache,
+                None,
             )
         };
         // jtransform.py:1677: assert not forces_virtual_or_virtualizable
@@ -2286,6 +2293,7 @@ impl<'a> Transformer<'a> {
                 OopSpecIndex::None,
                 None,
                 &mut self.analysis_cache,
+                None,
             )
         };
         // jtransform.py:301: assert calldescr.get_extra_info().check_is_elidable()
@@ -2460,6 +2468,7 @@ impl<'a> Transformer<'a> {
             OopSpecIndex::None,
             None,
             &mut self.analysis_cache,
+            None,
         );
         match cc_mut.guess_call_kind(op) {
             crate::call::CallKind::Regular => {


### PR DESCRIPTION
This pull request implements full support for dictionary lookup caching and invalidation in the `OptHeap` optimizer, closely matching the RPython JIT's `heap.py` logic. It adds a dedicated cache for deduplicating consecutive `DICT_LOOKUP` operations, ensures proper invalidation on writes, and updates the guard removal logic to match upstream behavior. The changes also include comprehensive tests and documentation updates.

**DICT_LOOKUP Caching and Invalidation:**

* Added `cached_dict_reads` and `corresponding_array_descrs` caches to `OptHeap`, enabling deduplication of consecutive dictionary lookups on the same dict+key, and ensuring correct invalidation when the underlying array is written. (`majit-metainterp/src/optimizeopt/heap.rs`)
* Implemented `_optimize_call_dict_lookup` method to handle caching logic for `DICT_LOOKUP` operations, including handling of `FLAG_LOOKUP`, `FLAG_STORE`, and `FLAG_DELETE` semantics. (`majit-metainterp/src/optimizeopt/heap.rs`)
* Updated `clean_caches` to clear the dictionary lookup cache, ensuring cache coherence. (`majit-metainterp/src/optimizeopt/heap.rs`)
* Modified `propagate_forward` and guard handling to remove redundant `GUARD_NO_EXCEPTION` operations after a folded dict lookup, mirroring RPython's behavior. (`majit-metainterp/src/optimizeopt/heap.rs`)

**Testing and Documentation:**

* Added comprehensive tests for all cache behaviors, including deduplication, cache clearing, and correct handling of all flag values. (`majit-metainterp/src/optimizeopt/heap.rs`)
* Updated the compatibility matrix and documentation to reflect the new implementation and improved parity with RPython. (`majit/COMPATIBILITY_MATRIX.md`)

**Translation Layer Support:**

* Extended call descriptor generation to support passing `extradescrs` for dictionary lookups, enabling correct cache keying in the optimizer. (`majit-translate/src/jit_codewriter/call.rs`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved dictionary-lookup caching for faster consecutive lookups, with smarter reuse for lookup/store cases and targeted cache invalidation.

* **Stability**
  * Enhanced invalidation and preservation of cache state to reduce incorrect reuse; added tests covering lookup/store/delete semantics and cache clearing.
  * JIT now recognizes dict.lookup oopspecs more broadly for consistent optimization.

* **Documentation**
  * Compatibility matrix updated to reflect 90% parity for the optimization subsystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->