### PR TITLE
Optimize function call dispatch with fast_natural_arity annotations

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3301,16 +3301,20 @@ pub fn getattr(obj: PyObjectRef, name: &str) -> PyResult {
     // Return W_Method(func, gen) so the generator is passed as args[0].
     unsafe {
         if pyre_object::generatorobject::is_generator(obj) {
-            let (sname, func): (&str, fn(&[PyObjectRef]) -> PyResult) = match name {
-                "send" => ("send", generator_send_method),
-                "throw" => ("throw", generator_throw_method),
-                "close" => ("close", generator_close_method),
-                "__next__" => ("__next__", generator_next_method),
+            let (sname, func, arity): (&str, fn(&[PyObjectRef]) -> PyResult, Option<u16>) = match name {
+                "send" => ("send", generator_send_method, Some(2)),
+                "throw" => ("throw", generator_throw_method, None),
+                "close" => ("close", generator_close_method, Some(1)),
+                "__next__" => ("__next__", generator_next_method, Some(1)),
                 "__iter__" => return Ok(obj),
-                _ => ("", generator_next_method), // sentinel — won't match
+                _ => ("", generator_next_method, None), // sentinel — won't match
             };
             if !sname.is_empty() {
-                let func_obj = crate::make_builtin_function(sname, func);
+                let func_obj = if let Some(a) = arity {
+                    crate::make_builtin_function_with_arity(sname, func, a)
+                } else {
+                    crate::make_builtin_function(sname, func)
+                };
                 return Ok(pyre_object::w_method_new(
                     func_obj,
                     obj,
@@ -3330,7 +3334,7 @@ pub fn getattr(obj: PyObjectRef, name: &str) -> PyResult {
             match name {
                 "__iter__" => return Ok(obj),
                 "__next__" => {
-                    let func_obj = crate::make_builtin_function("__next__", iter_next_method);
+                    let func_obj = crate::make_builtin_function_with_arity("__next__", iter_next_method, 1);
                     return Ok(pyre_object::w_method_new(
                         func_obj,
                         obj,
@@ -3357,7 +3361,7 @@ pub fn getattr(obj: PyObjectRef, name: &str) -> PyResult {
                 _ => None,
             };
             if let Some((sname, func)) = static_name {
-                let builtin = crate::make_builtin_function(sname, func);
+                let builtin = crate::make_builtin_function_with_arity(sname, func, 2);
                 return Ok(pyre_object::methodobject::w_method_new(
                     builtin,
                     obj,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2,7 +2,7 @@ use malachite_bigint::BigInt;
 use num_traits::ToPrimitive;
 
 use crate::executioncontext::DictStorage;
-use crate::{PyDisplay, make_builtin_function, make_module_builtin_function, make_module_builtin_function_with_arity};
+use crate::{PyDisplay, make_builtin_function, make_builtin_function_with_arity, make_module_builtin_function, make_module_builtin_function_with_arity};
 use pyre_object::*;
 
 /// Install the default builtins into a namespace.
@@ -131,7 +131,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
             crate::dict_storage_store(
                 ns,
                 "__new__",
-                make_builtin_function("__new__", |args| {
+                make_builtin_function_with_arity("__new__", |args| {
                     // args[0] = cls (memoryview), args[1] = buffer-like
                     let cls = args.get(0).copied().unwrap_or(w_none());
                     let buf = args.get(1).copied().unwrap_or(w_none());
@@ -140,12 +140,12 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                     crate::baseobjspace::setattr(inst, "__pyre_fmt__", w_str_new("B"))?;
                     crate::baseobjspace::setattr(inst, "__pyre_itemsize__", w_int_new(1))?;
                     Ok(inst)
-                }),
+                }, 2),
             );
             crate::dict_storage_store(
                 ns,
                 "cast",
-                make_builtin_function("cast", |args| {
+                make_builtin_function_with_arity("cast", |args| {
                     let mv = args.get(0).copied().unwrap_or(w_none());
                     let fmt_obj = args.get(1).copied().unwrap_or(w_none());
                     let fmt = if unsafe { pyre_object::is_str(fmt_obj) } {
@@ -166,12 +166,12 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                     crate::baseobjspace::setattr(inst, "__pyre_fmt__", w_str_new(fmt))?;
                     crate::baseobjspace::setattr(inst, "__pyre_itemsize__", w_int_new(itemsize))?;
                     Ok(inst)
-                }),
+                }, 2),
             );
             crate::dict_storage_store(
                 ns,
                 "tolist",
-                make_builtin_function("tolist", |args| {
+                make_builtin_function_with_arity("tolist", |args| {
                     let mv = args.get(0).copied().unwrap_or(w_none());
                     let buf = crate::baseobjspace::getattr(mv, "__pyre_buf__")?;
                     let itemsize_obj = crate::baseobjspace::getattr(mv, "__pyre_itemsize__")?;
@@ -192,12 +192,12 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                         i += itemsize;
                     }
                     Ok(w_list_new(items))
-                }),
+                }, 1),
             );
             crate::dict_storage_store(
                 ns,
                 "__len__",
-                make_builtin_function("__len__", |args| {
+                make_builtin_function_with_arity("__len__", |args| {
                     let mv = args.get(0).copied().unwrap_or(w_none());
                     let buf = crate::baseobjspace::getattr(mv, "__pyre_buf__")?;
                     let itemsize_obj = crate::baseobjspace::getattr(mv, "__pyre_itemsize__")?;
@@ -208,7 +208,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                         0
                     };
                     Ok(w_int_new((n / itemsize.max(1)) as i64))
-                }),
+                }, 1),
             );
             // memoryview.itemsize attribute — read from the per-instance
             // __pyre_itemsize__ slot via property descriptor.
@@ -216,10 +216,10 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                 ns,
                 "itemsize",
                 pyre_object::w_property_new(
-                    make_builtin_function("itemsize", |args| {
+                    make_builtin_function_with_arity("itemsize", |args| {
                         let mv = args.get(0).copied().unwrap_or(w_none());
                         crate::baseobjspace::getattr(mv, "__pyre_itemsize__")
-                    }),
+                    }, 1),
                     pyre_object::PY_NULL,
                     pyre_object::PY_NULL,
                 ),
@@ -2978,32 +2978,32 @@ fn init_file_wrapper_type(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "readline",
-        make_builtin_function("readline", file_method_readline),
+        make_builtin_function_with_arity("readline", file_method_readline, 1),
     );
     crate::dict_storage_store(
         ns,
         "readlines",
-        make_builtin_function("readlines", file_method_readlines),
+        make_builtin_function_with_arity("readlines", file_method_readlines, 1),
     );
     crate::dict_storage_store(
         ns,
         "write",
-        make_builtin_function("write", file_method_write),
+        make_builtin_function_with_arity("write", file_method_write, 2),
     );
     crate::dict_storage_store(
         ns,
         "close",
-        make_builtin_function("close", file_method_close),
+        make_builtin_function_with_arity("close", file_method_close, 1),
     );
     crate::dict_storage_store(
         ns,
         "flush",
-        make_builtin_function("flush", file_method_close),
+        make_builtin_function_with_arity("flush", file_method_close, 1),
     );
     crate::dict_storage_store(
         ns,
         "__enter__",
-        make_builtin_function("__enter__", |args| Ok(args[0])),
+        make_builtin_function_with_arity("__enter__", |args| Ok(args[0]), 1),
     );
     crate::dict_storage_store(
         ns,
@@ -3017,12 +3017,12 @@ fn init_file_wrapper_type(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "__iter__",
-        make_builtin_function("__iter__", |args| Ok(args[0])),
+        make_builtin_function_with_arity("__iter__", |args| Ok(args[0]), 1),
     );
     crate::dict_storage_store(
         ns,
         "__next__",
-        make_builtin_function("__next__", |args| {
+        make_builtin_function_with_arity("__next__", |args| {
             let line = file_method_readline(args)?;
             unsafe {
                 let s = pyre_object::w_str_get_value(line);
@@ -3031,7 +3031,7 @@ fn init_file_wrapper_type(ns: &mut DictStorage) {
                 }
             }
             Ok(line)
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
@@ -3046,13 +3046,13 @@ fn init_file_wrapper_type(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "tell",
-        make_builtin_function("tell", |args| {
+        make_builtin_function_with_arity("tell", |args| {
             if let Ok(pos) = crate::baseobjspace::getattr(args[0], "__file_pos__") {
                 Ok(pos)
             } else {
                 Ok(w_int_new(0))
             }
-        }),
+        }, 1),
     );
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2,7 +2,7 @@ use malachite_bigint::BigInt;
 use num_traits::ToPrimitive;
 
 use crate::executioncontext::DictStorage;
-use crate::{PyDisplay, make_builtin_function, make_module_builtin_function};
+use crate::{PyDisplay, make_builtin_function, make_module_builtin_function, make_module_builtin_function_with_arity};
 use pyre_object::*;
 
 /// Install the default builtins into a namespace.
@@ -13,17 +13,17 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     namespace.get_or_insert_with("range", || {
         make_module_builtin_function("range", builtin_range)
     });
-    namespace.get_or_insert_with("len", || make_module_builtin_function("len", builtin_len));
-    namespace.get_or_insert_with("abs", || make_module_builtin_function("abs", builtin_abs));
+    namespace.get_or_insert_with("len", || make_module_builtin_function_with_arity("len", builtin_len, 1));
+    namespace.get_or_insert_with("abs", || make_module_builtin_function_with_arity("abs", builtin_abs, 1));
     namespace.get_or_insert_with("min", || make_module_builtin_function("min", builtin_min));
     namespace.get_or_insert_with("max", || make_module_builtin_function("max", builtin_max));
     namespace.get_or_insert_with("type", || crate::typedef::w_type());
     namespace.get_or_insert_with("isinstance", || {
-        make_module_builtin_function("isinstance", builtin_isinstance)
+        make_module_builtin_function_with_arity("isinstance", builtin_isinstance, 2)
     });
     namespace.get_or_insert_with("str", || crate::typedef::gettypeobject(&STR_TYPE));
     namespace.get_or_insert_with("repr", || {
-        make_module_builtin_function("repr", builtin_repr)
+        make_module_builtin_function_with_arity("repr", builtin_repr, 1)
     });
     namespace.get_or_insert_with("int", || crate::typedef::gettypeobject(&INT_TYPE));
     namespace.get_or_insert_with("float", || crate::typedef::gettypeobject(&FLOAT_TYPE));
@@ -33,16 +33,16 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     namespace.get_or_insert_with("None", || w_none());
     namespace.get_or_insert_with("NotImplemented", || w_not_implemented());
     namespace.get_or_insert_with("hasattr", || {
-        make_module_builtin_function("hasattr", builtin_hasattr)
+        make_module_builtin_function_with_arity("hasattr", builtin_hasattr, 2)
     });
     namespace.get_or_insert_with("getattr", || {
         make_module_builtin_function("getattr", builtin_getattr)
     });
     namespace.get_or_insert_with("setattr", || {
-        make_module_builtin_function("setattr", builtin_setattr)
+        make_module_builtin_function_with_arity("setattr", builtin_setattr, 3)
     });
     namespace.get_or_insert_with("delattr", || {
-        make_module_builtin_function("delattr", builtin_delattr)
+        make_module_builtin_function_with_arity("delattr", builtin_delattr, 2)
     });
     namespace.get_or_insert_with("tuple", || crate::typedef::gettypeobject(&TUPLE_TYPE));
     namespace.get_or_insert_with("list", || crate::typedef::gettypeobject(&LIST_TYPE));
@@ -55,19 +55,19 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     namespace.get_or_insert_with("super", || {
         make_module_builtin_function("super", builtin_super)
     });
-    namespace.get_or_insert_with("id", || make_module_builtin_function("id", builtin_id));
+    namespace.get_or_insert_with("id", || make_module_builtin_function_with_arity("id", builtin_id, 1));
     namespace.get_or_insert_with("hash", || {
-        make_module_builtin_function("hash", builtin_hash)
+        make_module_builtin_function_with_arity("hash", builtin_hash, 1)
     });
-    namespace.get_or_insert_with("ord", || make_module_builtin_function("ord", builtin_ord));
-    namespace.get_or_insert_with("chr", || make_module_builtin_function("chr", builtin_chr));
+    namespace.get_or_insert_with("ord", || make_module_builtin_function_with_arity("ord", builtin_ord, 1));
+    namespace.get_or_insert_with("chr", || make_module_builtin_function_with_arity("chr", builtin_chr, 1));
     namespace.get_or_insert_with("map", || make_module_builtin_function("map", builtin_map));
     namespace.get_or_insert_with("zip", || make_module_builtin_function("zip", builtin_zip));
     namespace.get_or_insert_with("enumerate", || {
         make_module_builtin_function("enumerate", builtin_enumerate)
     });
     namespace.get_or_insert_with("reversed", || {
-        make_module_builtin_function("reversed", builtin_reversed)
+        make_module_builtin_function_with_arity("reversed", builtin_reversed, 1)
     });
     namespace.get_or_insert_with("sorted", || {
         make_module_builtin_function("sorted", builtin_sorted)
@@ -79,7 +79,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
         make_module_builtin_function("next", builtin_next)
     });
     namespace.get_or_insert_with("callable", || {
-        make_module_builtin_function("callable", builtin_callable)
+        make_module_builtin_function_with_arity("callable", builtin_callable, 1)
     });
     namespace.get_or_insert_with("vars", || {
         make_module_builtin_function("vars", builtin_vars)
@@ -230,10 +230,10 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
         tp
     });
     namespace.get_or_insert_with("globals", || {
-        make_module_builtin_function("globals", builtin_globals)
+        make_module_builtin_function_with_arity("globals", builtin_globals, 0)
     });
     namespace.get_or_insert_with("locals", || {
-        make_module_builtin_function("locals", builtin_locals)
+        make_module_builtin_function_with_arity("locals", builtin_locals, 0)
     });
     namespace.get_or_insert_with("exec", || {
         make_module_builtin_function("exec", builtin_exec)
@@ -577,8 +577,8 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
             runtime_error,
         ),
     );
-    namespace.get_or_insert_with("any", || make_module_builtin_function("any", builtin_any));
-    namespace.get_or_insert_with("all", || make_module_builtin_function("all", builtin_all));
+    namespace.get_or_insert_with("any", || make_module_builtin_function_with_arity("any", builtin_any, 1));
+    namespace.get_or_insert_with("all", || make_module_builtin_function_with_arity("all", builtin_all, 1));
     namespace.get_or_insert_with("sum", || make_module_builtin_function("sum", builtin_sum));
     namespace.get_or_insert_with("round", || {
         make_module_builtin_function("round", builtin_round)
@@ -594,7 +594,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
         make_module_builtin_function("format", builtin_format)
     });
     namespace.get_or_insert_with("issubclass", || {
-        make_module_builtin_function("issubclass", builtin_issubclass)
+        make_module_builtin_function_with_arity("issubclass", builtin_issubclass, 2)
     });
     namespace.get_or_insert_with("__import__", || {
         make_module_builtin_function("__import__", builtin_import_stub)

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -90,15 +90,6 @@ impl Drop for CallDepthGuardPublic {
     }
 }
 
-/// RAII guard that decrements CALL_DEPTH on drop.
-struct CallDepthGuard;
-impl Drop for CallDepthGuard {
-    #[inline(always)]
-    fn drop(&mut self) {
-        CALL_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
-    }
-}
-
 /// Register the JIT-aware eval function. Called by pyre-jit at startup.
 pub fn register_eval_override(f: EvalFn) {
     let _ = EVAL_OVERRIDE.set(f);
@@ -323,8 +314,7 @@ pub fn call_user_function_resolved(
     callable: PyObjectRef,
     args: &[PyObjectRef],
 ) -> PyResult {
-    CALL_DEPTH.with(|d| d.set(d.get() + 1));
-    let _depth_guard = CallDepthGuard;
+    let _depth_guard = increment_call_depth();
 
     let w_code = unsafe { crate::getcode(callable) };
     let globals = unsafe { function_get_globals(callable) };
@@ -350,12 +340,7 @@ pub fn call_user_function_resolved(
         return gen_frame.run();
     }
 
-    let plain_mode = FORCE_PLAIN_EVAL.with(|c| c.get() > 0);
-    let eval_fn = if plain_mode {
-        eval_frame_plain
-    } else {
-        EVAL_OVERRIDE.get().copied().unwrap_or(eval_frame_plain)
-    };
+    let eval_fn = get_eval_fn();
 
     let mut func_frame =
         PyFrame::new_for_call_with_closure(w_code, args, globals, frame.execution_context, closure);
@@ -449,15 +434,8 @@ pub fn call_user_function(
     callable: PyObjectRef,
     args: &[PyObjectRef],
 ) -> PyResult {
-    // Direct TLS increment — no Box allocation. Replaces DEPTH_BUMP_OVERRIDE callback.
-    CALL_DEPTH.with(|d| d.set(d.get() + 1));
-    let _depth_guard = CallDepthGuard;
-    let plain_mode = FORCE_PLAIN_EVAL.with(|c| c.get() > 0);
-    let eval_fn = if plain_mode {
-        eval_frame_plain
-    } else {
-        EVAL_OVERRIDE.get().copied().unwrap_or(eval_frame_plain)
-    };
+    let _depth_guard = increment_call_depth();
+    let eval_fn = get_eval_fn();
     call_user_function_with_eval(frame, callable, args, eval_fn)
 }
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -73,6 +73,23 @@ pub fn call_depth() -> u32 {
     CALL_DEPTH.with(|d| d.get())
 }
 
+/// Increment call depth and return an RAII guard that decrements on drop.
+/// Used by _flat_pycall to match call_user_function's depth tracking.
+#[inline(always)]
+pub fn increment_call_depth() -> CallDepthGuardPublic {
+    CALL_DEPTH.with(|d| d.set(d.get() + 1));
+    CallDepthGuardPublic
+}
+
+/// RAII guard that decrements CALL_DEPTH on drop.
+pub struct CallDepthGuardPublic;
+impl Drop for CallDepthGuardPublic {
+    #[inline(always)]
+    fn drop(&mut self) {
+        CALL_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+    }
+}
+
 /// RAII guard that decrements CALL_DEPTH on drop.
 struct CallDepthGuard;
 impl Drop for CallDepthGuard {
@@ -85,6 +102,18 @@ impl Drop for CallDepthGuard {
 /// Register the JIT-aware eval function. Called by pyre-jit at startup.
 pub fn register_eval_override(f: EvalFn) {
     let _ = EVAL_OVERRIDE.set(f);
+}
+
+/// Get the current eval function (JIT-aware if registered, plain otherwise).
+/// Respects the force-plain-eval mode.
+#[inline]
+pub fn get_eval_fn() -> fn(&mut PyFrame) -> PyResult {
+    let plain_mode = FORCE_PLAIN_EVAL.with(|c| c.get() > 0);
+    if plain_mode {
+        eval_frame_plain
+    } else {
+        EVAL_OVERRIDE.get().copied().unwrap_or(eval_frame_plain)
+    }
 }
 
 // ── JIT parameter injection ──────────────────────────────────────

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2193,11 +2193,36 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     // ── call ──
-    // PyPy: CALL_FUNCTION — interpreter-only override.
-    // Handles null_or_self prepend for instance method calls.
-    // The default trait impl (opcode_call) always discards null_or_self,
-    // which is what the JIT tracer uses — no trace/concrete divergence.
+    // PyPy: baseobjspace.py:1240-1267 `call_valuestack` +
+    // function.py:139-203 `funccall_valuestack`.
+    //
+    // CPython 3.12+ CALL: stack is [callable, null_or_self, arg0..argN-1].
+    // null_or_self is NULL for plain calls, `self` for method calls.
     fn call(&mut self, nargs: usize) -> Result<(), Self::Error> {
+        // baseobjspace.py:1250-1261 fast path: Function + no method binding
+        //
+        // Guard: only enter when the value stack has at least nargs + 2
+        // items above stack_base (callable + null_or_self + args).
+        let stack_items = self.valuestackdepth.saturating_sub(self.stack_base());
+        if stack_items >= nargs + 2 {
+            let null_or_self = self.peekvalue_maybe_none(nargs);
+            let callable = self.peekvalue_maybe_none(nargs + 1);
+            if null_or_self.is_null() && !callable.is_null() && unsafe { crate::is_function(callable) } {
+                let result = crate::function::funccall_valuestack(
+                    callable, nargs, self, nargs + 2, false,
+                );
+                if result.is_null() {
+                    return Err(crate::call::take_call_error()
+                        .unwrap_or_else(|| crate::PyError::type_error("call failed"))
+                        .into());
+                }
+                self.push(result);
+                return Ok(());
+            }
+        }
+
+        // Slow path: method call or non-Function callable.
+        // Must allocate Vec for args.
         let mut args = Vec::with_capacity(nargs);
         for _ in 0..nargs {
             args.push(self.pop());

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1365,10 +1365,10 @@ impl OpcodeStepExecutor for PyFrame {
                 crate::typedef::gettypeobject(&pyre_object::pyobject::TUPLE_TYPE)
             }
             CommonConstant::BuiltinAll => {
-                crate::make_module_builtin_function("all", crate::builtins::builtin_all_fn)
+                crate::make_module_builtin_function_with_arity("all", crate::builtins::builtin_all_fn, 1)
             }
             CommonConstant::BuiltinAny => {
-                crate::make_module_builtin_function("any", crate::builtins::builtin_any_fn)
+                crate::make_module_builtin_function_with_arity("any", crate::builtins::builtin_any_fn, 1)
             }
             CommonConstant::BuiltinList => {
                 crate::typedef::gettypeobject(&pyre_object::pyobject::LIST_TYPE)

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2199,12 +2199,17 @@ impl OpcodeStepExecutor for PyFrame {
     // CPython 3.12+ CALL: stack is [callable, null_or_self, arg0..argN-1].
     // null_or_self is NULL for plain calls, `self` for method calls.
     fn call(&mut self, nargs: usize) -> Result<(), Self::Error> {
-        // baseobjspace.py:1250-1261 fast path: Function + no method binding
+        // baseobjspace.py:1240-1261 fast path: Function + no method binding
+        //
+        // baseobjspace.py:1243 — skip fast path when profiling is active
+        // and the function wraps a builtin code (c_call/c_return events).
+        // Conservative: skip entire fast path if profiled, since
+        // funccall_valuestack's builtin dispatch also bypasses profiling.
         //
         // Guard: only enter when the value stack has at least nargs + 2
         // items above stack_base (callable + null_or_self + args).
         let stack_items = self.valuestackdepth.saturating_sub(self.stack_base());
-        if stack_items >= nargs + 2 {
+        if stack_items >= nargs + 2 && !self.get_is_being_profiled() {
             let null_or_self = self.peekvalue_maybe_none(nargs);
             let callable = self.peekvalue_maybe_none(nargs + 1);
             if null_or_self.is_null() && !callable.is_null() && unsafe { crate::is_function(callable) } {

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1180,6 +1180,10 @@ pub fn funccall_valuestack(
 
     // function.py:153-184 — nargs == fast_natural_arity: builtin fast path
     if nargs == fast_natural_arity && nargs <= 4 {
+        debug_assert!(
+            (fast_natural_arity & crate::FLATPYCALL as usize) == 0,
+            "FLATPYCALL bit set on arity {fast_natural_arity} — not a builtin code"
+        );
         let builtin_fn = unsafe { crate::builtin_code_get(code as PyObjectRef) };
         // function.py:154-184 — BuiltinCodeN.fastcall_N dispatch.
         // Pyre builtins share a single fn(&[PyObjectRef]) signature, so we
@@ -1236,23 +1240,24 @@ pub fn funccall_valuestack(
     if (fast_natural_arity & crate::FLATPYCALL as usize) != 0 {
         let natural_arity = fast_natural_arity & 0xff;
         if nargs < natural_arity {
-            let defs = unsafe { crate::function_get_defaults(func) };
-            let defs_len = if defs.is_null() {
+            let raw_defs = unsafe { crate::function_get_defaults(func) };
+            let defs = if raw_defs.is_null() {
+                std::ptr::null_mut()
+            } else {
+                crate::baseobjspace::unwrap_cell(raw_defs)
+            };
+            let defs_len = if defs.is_null() || !unsafe { pyre_object::is_tuple(defs) } {
                 0
             } else {
-                let defs = crate::baseobjspace::unwrap_cell(defs);
-                if unsafe { pyre_object::is_tuple(defs) } {
-                    unsafe { pyre_object::w_tuple_len(defs) }
-                } else {
-                    0
-                }
+                unsafe { pyre_object::w_tuple_len(defs) }
             };
-            if nargs >= natural_arity - defs_len {
+            if nargs >= natural_arity.saturating_sub(defs_len) {
                 return _flat_pycall_defaults(
                     func,
                     code,
                     nargs,
                     frame,
+                    defs,
                     natural_arity - nargs,
                     dropvalues,
                 );
@@ -1321,11 +1326,14 @@ fn _flat_pycall(
 ///
 /// Same as `_flat_pycall` but also fills missing positional args from
 /// `self.defs_w[ndefs - defs_to_load ..]`.
+/// `defs` is the pre-unwrapped defaults tuple (already null-checked and
+/// verified as a tuple by the caller in `funccall_valuestack`).
 fn _flat_pycall_defaults(
     func: PyObjectRef,
     code: *const (),
     nargs: usize,
     frame: &mut crate::pyframe::PyFrame,
+    defs: PyObjectRef,
     defs_to_load: usize,
     dropvalues: usize,
 ) -> PyObjectRef {
@@ -1347,9 +1355,7 @@ fn _flat_pycall_defaults(
     }
 
     // function.py:224-229 — fill remaining from defs_w
-    let defs = unsafe { crate::function_get_defaults(func) };
-    let defs = crate::baseobjspace::unwrap_cell(defs);
-    if !defs.is_null() && unsafe { pyre_object::is_tuple(defs) } {
+    if !defs.is_null() {
         let ndefs = unsafe { pyre_object::w_tuple_len(defs) };
         let start = ndefs - defs_to_load;
         let mut i = nargs;
@@ -1364,7 +1370,6 @@ fn _flat_pycall_defaults(
     frame.dropvalues(dropvalues);
     new_frame.fix_array_ptrs();
 
-    // Use the JIT-aware eval override (same as call_user_function in call.rs).
     let eval_fn = crate::call::get_eval_fn();
     match eval_fn(&mut new_frame) {
         Ok(v) => v,

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1159,8 +1159,13 @@ pub fn funccall(func: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
     call_args(func, args)
 }
 
-/// PyPy-compatible `funccall_valuestack` helper.
-#[inline]
+/// function.py:139-203 `funccall_valuestack` — fast-path call dispatcher.
+///
+/// Dispatches based on `code.fast_natural_arity`:
+/// - nargs == arity (0-4): direct builtin fastcall from stack (no Vec alloc)
+/// - (nargs | FLATPYCALL) == arity: _flat_pycall (user code, exact arity)
+/// - FLATPYCALL + defaults: _flat_pycall_defaults
+/// - Fallback: allocate Vec via peekvalues + generic call path
 pub fn funccall_valuestack(
     func: PyObjectRef,
     nargs: usize,
@@ -1168,34 +1173,206 @@ pub fn funccall_valuestack(
     dropvalues: usize,
     methodcall: bool,
 ) -> PyObjectRef {
-    let _ = methodcall;
-    let args = frame.peekvalues(nargs);
-    frame.dropvalues(dropvalues);
-    funccall(func, &args)
+    let _ = methodcall; // function.py:140 — only for better error messages
+    let code = unsafe { crate::getcode(func) };
+    let fast_natural_arity =
+        unsafe { crate::pycode::code_get_fast_natural_arity(code as PyObjectRef) } as usize;
+
+    // function.py:153-184 — nargs == fast_natural_arity: builtin fast path
+    if nargs == fast_natural_arity && nargs <= 4 {
+        let builtin_fn = unsafe { crate::builtin_code_get(code as PyObjectRef) };
+        // function.py:154-184 — BuiltinCodeN.fastcall_N dispatch.
+        // Pyre builtins share a single fn(&[PyObjectRef]) signature, so we
+        // build a fixed-size stack array instead of heap-allocating a Vec.
+        let result = match nargs {
+            0 => {
+                frame.dropvalues(dropvalues);
+                builtin_fn(&[])
+            }
+            1 => {
+                let a0 = frame.peekvalue(0);
+                frame.dropvalues(dropvalues);
+                builtin_fn(&[a0])
+            }
+            2 => {
+                // function.py:168 — peekvalue order: 0=top, 1=below top
+                let a0 = frame.peekvalue(1);
+                let a1 = frame.peekvalue(0);
+                frame.dropvalues(dropvalues);
+                builtin_fn(&[a0, a1])
+            }
+            3 => {
+                let a0 = frame.peekvalue(2);
+                let a1 = frame.peekvalue(1);
+                let a2 = frame.peekvalue(0);
+                frame.dropvalues(dropvalues);
+                builtin_fn(&[a0, a1, a2])
+            }
+            4 => {
+                let a0 = frame.peekvalue(3);
+                let a1 = frame.peekvalue(2);
+                let a2 = frame.peekvalue(1);
+                let a3 = frame.peekvalue(0);
+                frame.dropvalues(dropvalues);
+                builtin_fn(&[a0, a1, a2, a3])
+            }
+            _ => unreachable!(),
+        };
+        return match result {
+            Ok(v) => v,
+            Err(e) => {
+                crate::call::set_call_error(e);
+                pyre_object::PY_NULL
+            }
+        };
+    }
+
+    // function.py:185-187 — (nargs | FLATPYCALL) == fast_natural_arity
+    if (nargs | crate::FLATPYCALL as usize) == fast_natural_arity {
+        return _flat_pycall(func, code, nargs, frame, dropvalues);
+    }
+
+    // function.py:188-193 — FLATPYCALL bit set + nargs within defaults range
+    if (fast_natural_arity & crate::FLATPYCALL as usize) != 0 {
+        let natural_arity = fast_natural_arity & 0xff;
+        if nargs < natural_arity {
+            let defs = unsafe { crate::function_get_defaults(func) };
+            let defs_len = if defs.is_null() {
+                0
+            } else {
+                let defs = crate::baseobjspace::unwrap_cell(defs);
+                if unsafe { pyre_object::is_tuple(defs) } {
+                    unsafe { pyre_object::w_tuple_len(defs) }
+                } else {
+                    0
+                }
+            };
+            if nargs >= natural_arity - defs_len {
+                return _flat_pycall_defaults(
+                    func,
+                    code,
+                    nargs,
+                    frame,
+                    natural_arity - nargs,
+                    dropvalues,
+                );
+            }
+        }
+    }
+
+    // Fallback: Vec allocation path (function.py:201-203)
+    if nargs == 0 {
+        frame.dropvalues(dropvalues);
+        funccall(func, &[])
+    } else {
+        let args = frame.peekvalues(nargs);
+        frame.dropvalues(dropvalues);
+        funccall(func, &args)
+    }
 }
 
-/// PyPy-compatible `_flat_pycall` helper.
-#[inline]
-pub fn _flat_pycall(
+/// function.py:206-214 `_flat_pycall` — create frame directly from stack.
+///
+/// For user functions with exact arity match (no defaults needed).
+/// Copies args from caller's value stack into the new frame's locals
+/// without intermediate Vec allocation.
+fn _flat_pycall(
     func: PyObjectRef,
+    code: *const (),
     nargs: usize,
     frame: &mut crate::pyframe::PyFrame,
     dropvalues: usize,
 ) -> PyObjectRef {
-    funccall_valuestack(func, nargs, frame, dropvalues, false)
+    // call.rs:423-424 parity — increment call depth for JIT depth tracking.
+    let _depth_guard = crate::call::increment_call_depth();
+    let globals = unsafe { function_get_globals(func) };
+    let closure = unsafe { function_get_closure(func) };
+
+    // function.py:208-209 — createframe(code, w_func_globals, self)
+    let mut new_frame = crate::pyframe::PyFrame::new_for_call_with_closure(
+        code,
+        &[], // locals filled below directly from stack
+        globals,
+        frame.execution_context,
+        closure,
+    );
+
+    // function.py:210-211 — copy from stack into locals directly
+    // peekvalue(nargs-1-i) gives bottom-to-top order (matching local slot order)
+    for i in 0..nargs {
+        new_frame.locals_w_mut()[i] = frame.peekvalue(nargs - 1 - i);
+    }
+    frame.dropvalues(dropvalues);
+    new_frame.fix_array_ptrs();
+
+    // function.py:214 — return new_frame.run(self.name, self.qualname)
+    // Use the JIT-aware eval override (same as call_user_function in call.rs).
+    let eval_fn = crate::call::get_eval_fn();
+    match eval_fn(&mut new_frame) {
+        Ok(v) => v,
+        Err(e) => {
+            crate::call::set_call_error(e);
+            pyre_object::PY_NULL
+        }
+    }
 }
 
-/// PyPy-compatible `_flat_pycall_defaults` helper.
-#[inline]
-pub fn _flat_pycall_defaults(
+/// function.py:217-231 `_flat_pycall_defaults` — flat call with defaults.
+///
+/// Same as `_flat_pycall` but also fills missing positional args from
+/// `self.defs_w[ndefs - defs_to_load ..]`.
+fn _flat_pycall_defaults(
     func: PyObjectRef,
+    code: *const (),
     nargs: usize,
     frame: &mut crate::pyframe::PyFrame,
     defs_to_load: usize,
     dropvalues: usize,
 ) -> PyObjectRef {
-    let _ = defs_to_load;
-    funccall_valuestack(func, nargs, frame, dropvalues, false)
+    let _depth_guard = crate::call::increment_call_depth();
+    let globals = unsafe { function_get_globals(func) };
+    let closure = unsafe { function_get_closure(func) };
+
+    let mut new_frame = crate::pyframe::PyFrame::new_for_call_with_closure(
+        code,
+        &[], // locals filled below
+        globals,
+        frame.execution_context,
+        closure,
+    );
+
+    // function.py:221-222 — copy positional args from stack
+    for i in 0..nargs {
+        new_frame.locals_w_mut()[i] = frame.peekvalue(nargs - 1 - i);
+    }
+
+    // function.py:224-229 — fill remaining from defs_w
+    let defs = unsafe { crate::function_get_defaults(func) };
+    let defs = crate::baseobjspace::unwrap_cell(defs);
+    if !defs.is_null() && unsafe { pyre_object::is_tuple(defs) } {
+        let ndefs = unsafe { pyre_object::w_tuple_len(defs) };
+        let start = ndefs - defs_to_load;
+        let mut i = nargs;
+        for j in start..ndefs {
+            if let Some(val) = unsafe { pyre_object::w_tuple_getitem(defs, j as i64) } {
+                new_frame.locals_w_mut()[i] = val;
+            }
+            i += 1;
+        }
+    }
+
+    frame.dropvalues(dropvalues);
+    new_frame.fix_array_ptrs();
+
+    // Use the JIT-aware eval override (same as call_user_function in call.rs).
+    let eval_fn = crate::call::get_eval_fn();
+    match eval_fn(&mut new_frame) {
+        Ok(v) => v,
+        Err(e) => {
+            crate::call::set_call_error(e);
+            pyre_object::PY_NULL
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1179,7 +1179,8 @@ pub fn funccall_valuestack(
         unsafe { crate::pycode::code_get_fast_natural_arity(code as PyObjectRef) } as usize;
 
     // function.py:153-184 — nargs == fast_natural_arity: builtin fast path
-    if nargs == fast_natural_arity && nargs <= 4 {
+    // baseobjspace.py:1243 — skip when profiling (c_call/c_return events)
+    if nargs == fast_natural_arity && nargs <= 4 && !frame.get_is_being_profiled() {
         debug_assert!(
             (fast_natural_arity & crate::FLATPYCALL as usize) == 0,
             "FLATPYCALL bit set on arity {fast_natural_arity} — not a builtin code"

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1311,13 +1311,24 @@ fn _flat_pycall(
     new_frame.fix_array_ptrs();
 
     // function.py:214 — return new_frame.run(self.name, self.qualname)
-    // Use the JIT-aware eval override (same as call_user_function in call.rs).
-    let eval_fn = crate::call::get_eval_fn();
-    match eval_fn(&mut new_frame) {
-        Ok(v) => v,
-        Err(e) => {
-            crate::call::set_call_error(e);
-            pyre_object::PY_NULL
+    // Check generator/coroutine: run() wraps into generator object instead
+    // of executing the body. For normal functions, use the JIT-aware eval.
+    if new_frame._is_generator_or_coroutine() {
+        match new_frame.run() {
+            Ok(v) => v,
+            Err(e) => {
+                crate::call::set_call_error(e);
+                pyre_object::PY_NULL
+            }
+        }
+    } else {
+        let eval_fn = crate::call::get_eval_fn();
+        match eval_fn(&mut new_frame) {
+            Ok(v) => v,
+            Err(e) => {
+                crate::call::set_call_error(e);
+                pyre_object::PY_NULL
+            }
         }
     }
 }
@@ -1370,12 +1381,23 @@ fn _flat_pycall_defaults(
     frame.dropvalues(dropvalues);
     new_frame.fix_array_ptrs();
 
-    let eval_fn = crate::call::get_eval_fn();
-    match eval_fn(&mut new_frame) {
-        Ok(v) => v,
-        Err(e) => {
-            crate::call::set_call_error(e);
-            pyre_object::PY_NULL
+    // function.py:231 — return new_frame.run(self.name, self.qualname)
+    if new_frame._is_generator_or_coroutine() {
+        match new_frame.run() {
+            Ok(v) => v,
+            Err(e) => {
+                crate::call::set_call_error(e);
+                pyre_object::PY_NULL
+            }
+        }
+    } else {
+        let eval_fn = crate::call::get_eval_fn();
+        match eval_fn(&mut new_frame) {
+            Ok(v) => v,
+            Err(e) => {
+                crate::call::set_call_error(e);
+                pyre_object::PY_NULL
+            }
         }
     }
 }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -509,6 +509,10 @@ pub struct BuiltinCode {
     pub name: &'static str,
     pub func: BuiltinCodeFn,
     pub docstring: Option<&'static str>,
+    /// eval.py:16-23 — `fast_natural_arity`. For builtins with fixed
+    /// positional arity 0-4, this equals the arity directly. Builtins
+    /// with optional/variadic args use HOPELESS (0x400).
+    pub fast_natural_arity: u16,
 }
 
 /// Fixed payload size used by `gct_fv_gc_malloc`'s `c_size`
@@ -523,9 +527,27 @@ impl pyre_object::lltype::GcType for BuiltinCode {
     const SIZE: usize = BUILTIN_CODE_OBJECT_SIZE;
 }
 
+/// eval.py:16 — `FLATPYCALL = 0x100`.
+pub const FLATPYCALL: u16 = 0x100;
+/// eval.py:17 — `PASSTHROUGHARGS1 = 0x200`.
+pub const PASSTHROUGHARGS1: u16 = 0x200;
+/// eval.py:18 — `HOPELESS = 0x400`. Default for code that cannot fast-path.
+pub const HOPELESS: u16 = 0x400;
+
 /// Allocate a new `BuiltinCode` with no docstring.
+/// `fast_natural_arity` defaults to HOPELESS (no fast path).
 pub fn builtin_code_new(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
     builtin_code_new_with_doc(name, func, None)
+}
+
+/// Allocate a new `BuiltinCode` with known fixed arity (0-4).
+/// gateway.py:843 — `self.__class__ = globals()['BuiltinCode%d' % arity]`
+pub fn builtin_code_new_with_arity(
+    name: &'static str,
+    func: BuiltinCodeFn,
+    arity: u16,
+) -> PyObjectRef {
+    builtin_code_new_full(name, func, None, arity)
 }
 
 /// Allocate a new `BuiltinCode` with an explicit docstring.
@@ -538,6 +560,16 @@ pub fn builtin_code_new_with_doc(
     func: BuiltinCodeFn,
     docstring: Option<&'static str>,
 ) -> PyObjectRef {
+    builtin_code_new_full(name, func, docstring, HOPELESS)
+}
+
+/// Full constructor for `BuiltinCode`.
+fn builtin_code_new_full(
+    name: &'static str,
+    func: BuiltinCodeFn,
+    docstring: Option<&'static str>,
+    fast_natural_arity: u16,
+) -> PyObjectRef {
     pyre_object::lltype::malloc_typed(BuiltinCode {
         ob: PyObject {
             ob_type: &BUILTIN_CODE_TYPE,
@@ -546,6 +578,7 @@ pub fn builtin_code_new_with_doc(
         name,
         func,
         docstring,
+        fast_natural_arity,
     }) as PyObjectRef
 }
 
@@ -566,6 +599,15 @@ pub unsafe fn is_builtin_code(obj: PyObjectRef) -> bool {
 pub unsafe fn builtin_code_get(obj: PyObjectRef) -> BuiltinCodeFn {
     let func_obj = obj as *const BuiltinCode;
     unsafe { (*func_obj).func }
+}
+
+/// eval.py:16-23 — read `fast_natural_arity` from a BuiltinCode.
+///
+/// # Safety
+/// `obj` must point to a valid `BuiltinCode`.
+#[inline]
+pub unsafe fn builtin_code_get_fast_natural_arity(obj: PyObjectRef) -> u16 {
+    unsafe { (*(obj as *const BuiltinCode)).fast_natural_arity }
 }
 
 /// Get the name of a built-in function.
@@ -602,12 +644,32 @@ pub fn make_builtin_function(name: &'static str, func: BuiltinCodeFn) -> PyObjec
     crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
 }
 
+/// `make_builtin_function` with known fixed arity for fast-path dispatch.
+pub fn make_builtin_function_with_arity(
+    name: &'static str,
+    func: BuiltinCodeFn,
+    arity: u16,
+) -> PyObjectRef {
+    let code = builtin_code_new_with_arity(name, func, arity);
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
+}
+
 /// mixedmodule.py:116 parity — wrap a BuiltinCodeFn as BuiltinFunction.
 ///
 /// Module-level builtins are not descriptors: storing them on a user class
 /// must not synthesize a bound method.
 pub fn make_module_builtin_function(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
     let code = builtin_code_new(name, func);
+    crate::function_new_builtin(code as *const (), name.to_string(), std::ptr::null_mut())
+}
+
+/// `make_module_builtin_function` with known fixed arity for fast-path dispatch.
+pub fn make_module_builtin_function_with_arity(
+    name: &'static str,
+    func: BuiltinCodeFn,
+    arity: u16,
+) -> PyObjectRef {
+    let code = builtin_code_new_with_arity(name, func, arity);
     crate::function_new_builtin(code as *const (), name.to_string(), std::ptr::null_mut())
 }
 

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -547,6 +547,7 @@ pub fn builtin_code_new_with_arity(
     func: BuiltinCodeFn,
     arity: u16,
 ) -> PyObjectRef {
+    debug_assert!(arity <= 4, "builtin arity {arity} for {name} exceeds fast-path max 4");
     builtin_code_new_full(name, func, None, arity)
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -216,12 +216,12 @@ fn init_gc(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "is_tracked",
-        crate::make_builtin_function_with_arity("is_tracked", |_| Ok(pyre_object::w_bool_from(false)), 0),
+        crate::make_builtin_function_with_arity("is_tracked", |_| Ok(pyre_object::w_bool_from(false)), 1),
     );
     crate::dict_storage_store(
         ns,
         "is_finalized",
-        crate::make_builtin_function_with_arity("is_finalized", |_| Ok(pyre_object::w_bool_from(false)), 0),
+        crate::make_builtin_function_with_arity("is_finalized", |_| Ok(pyre_object::w_bool_from(false)), 1),
     );
     crate::dict_storage_store(
         ns,
@@ -255,7 +255,7 @@ fn init_unicodedata(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "category",
-        crate::make_builtin_function_with_arity("category", |_| Ok(pyre_object::w_str_new("Cn")), 0),
+        crate::make_builtin_function_with_arity("category", |_| Ok(pyre_object::w_str_new("Cn")), 1),
     );
     // unicodedata.name(chr, default=None) → str
     crate::dict_storage_store(
@@ -275,7 +275,7 @@ fn init_unicodedata(ns: &mut DictStorage) {
         "lookup",
         crate::make_builtin_function_with_arity("lookup", |_| {
             Err(crate::PyError::key_error("character not found"))
-        }, 0),
+        }, 1),
     );
     // unicodedata.decimal(chr, default=None) → int
     crate::dict_storage_store(
@@ -556,12 +556,12 @@ fn init_struct(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "unpack_from",
-        crate::make_builtin_function_with_arity("unpack_from", |_| Ok(pyre_object::w_tuple_new(vec![])), 0),
+        crate::make_builtin_function("unpack_from", |_| Ok(pyre_object::w_tuple_new(vec![]))),
     );
     crate::dict_storage_store(
         ns,
         "iter_unpack",
-        crate::make_builtin_function_with_arity("iter_unpack", |_| Ok(pyre_object::w_list_new(vec![])), 0),
+        crate::make_builtin_function_with_arity("iter_unpack", |_| Ok(pyre_object::w_list_new(vec![])), 2),
     );
     // Struct class — minimal constructor returning instance with format
     // attribute. Used by struct.Struct(fmt).pack/unpack.
@@ -788,12 +788,12 @@ fn init_locale(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "setlocale",
-        crate::make_builtin_function_with_arity("setlocale", |_| Ok(pyre_object::w_str_new("C")), 0),
+        crate::make_builtin_function("setlocale", |_| Ok(pyre_object::w_str_new("C"))),
     );
     crate::dict_storage_store(
         ns,
         "nl_langinfo",
-        crate::make_builtin_function_with_arity("nl_langinfo", |_| Ok(pyre_object::w_str_new("")), 0),
+        crate::make_builtin_function_with_arity("nl_langinfo", |_| Ok(pyre_object::w_str_new("")), 1),
     );
     crate::dict_storage_store(
         ns,
@@ -987,7 +987,7 @@ fn init_atexit(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "unregister",
-        crate::make_builtin_function_with_arity("unregister", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("unregister", |_| Ok(pyre_object::w_none()), 1),
     );
     crate::dict_storage_store(
         ns,
@@ -1020,17 +1020,17 @@ fn init_signal_stub(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "getsignal",
-        crate::make_builtin_function_with_arity("getsignal", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("getsignal", |_| Ok(pyre_object::w_none()), 1),
     );
     crate::dict_storage_store(
         ns,
         "default_int_handler",
-        crate::make_builtin_function_with_arity("default_int_handler", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("default_int_handler", |_| Ok(pyre_object::w_none()), 2),
     );
     crate::dict_storage_store(
         ns,
         "set_wakeup_fd",
-        crate::make_builtin_function_with_arity("set_wakeup_fd", |_| Ok(pyre_object::w_int_new(-1)), 0),
+        crate::make_builtin_function_with_arity("set_wakeup_fd", |_| Ok(pyre_object::w_int_new(-1)), 1),
     );
     crate::dict_storage_store(ns, "SIG_DFL", pyre_object::w_int_new(0));
     crate::dict_storage_store(ns, "SIG_IGN", pyre_object::w_int_new(1));
@@ -1068,7 +1068,7 @@ fn init_itertools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "starmap",
-        crate::make_builtin_function_with_arity("starmap", |_| Ok(pyre_object::w_list_new(vec![])), 0),
+        crate::make_builtin_function_with_arity("starmap", |_| Ok(pyre_object::w_list_new(vec![])), 2),
     );
     // count(start=0, step=1) — PyPy: W_Count___new__
     //
@@ -1115,13 +1115,13 @@ fn init_itertools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "islice",
-        crate::make_builtin_function_with_arity("islice", |_| Ok(pyre_object::w_list_new(vec![])), 0),
+        crate::make_builtin_function("islice", |_| Ok(pyre_object::w_list_new(vec![]))),
     );
     // groupby
     crate::dict_storage_store(
         ns,
         "groupby",
-        crate::make_builtin_function_with_arity("groupby", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function("groupby", |_| Ok(pyre_object::w_none())),
     );
     // permutations(iterable, r=None) — PyPy: pypy/module/itertools/interp_itertools.py
     crate::dict_storage_store(
@@ -1337,7 +1337,7 @@ fn init_contextvars(ns: &mut DictStorage) {
             let _ = crate::baseobjspace::setattr(
                 obj,
                 "set",
-                crate::make_builtin_function_with_arity("set", |_| Ok(pyre_object::w_none()), 0),
+                crate::make_builtin_function_with_arity("set", |_| Ok(pyre_object::w_none()), 2),
             );
             Ok(obj)
         }),
@@ -1369,12 +1369,12 @@ fn init_abc(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "_abc_init",
-        crate::make_builtin_function_with_arity("_abc_init", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("_abc_init", |_| Ok(pyre_object::w_none()), 1),
     );
     crate::dict_storage_store(
         ns,
         "_abc_register",
-        crate::make_builtin_function_with_arity("_abc_register", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("_abc_register", |_| Ok(pyre_object::w_none()), 2),
     );
     // _abc_instancecheck(cls, instance) — CPython: Modules/_abc.c _abc__abc_instancecheck.
     //
@@ -1427,12 +1427,12 @@ fn init_abc(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "_get_dump",
-        crate::make_builtin_function_with_arity("_get_dump", |_| Ok(pyre_object::w_tuple_new(vec![])), 0),
+        crate::make_builtin_function_with_arity("_get_dump", |_| Ok(pyre_object::w_tuple_new(vec![])), 1),
     );
     crate::dict_storage_store(
         ns,
         "_reset_registry",
-        crate::make_builtin_function_with_arity("_reset_registry", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("_reset_registry", |_| Ok(pyre_object::w_none()), 1),
     );
     crate::dict_storage_store(
         ns,
@@ -1446,9 +1446,9 @@ fn init_functools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "reduce",
-        crate::make_builtin_function_with_arity("reduce", |_| {
+        crate::make_builtin_function("reduce", |_| {
             Err(crate::PyError::type_error("reduce not implemented"))
-        }, 0),
+        }),
     );
     // functools.cmp_to_key(cmp) — returns a callable that wraps a value in
     // an opaque key. For sorting str / int / tuple of those (the only paths
@@ -1610,12 +1610,12 @@ fn thread_handle_type() -> PyObjectRef {
                 crate::dict_storage_store(
                     ns,
                     "join",
-                    crate::make_builtin_function_with_arity("join", |_| Ok(pyre_object::w_none()), 1),
+                    crate::make_builtin_function("join", |_| Ok(pyre_object::w_none())),
                 );
                 crate::dict_storage_store(
                     ns,
                     "set_result",
-                    crate::make_builtin_function_with_arity("set_result", |_| Ok(pyre_object::w_none()), 1),
+                    crate::make_builtin_function_with_arity("set_result", |_| Ok(pyre_object::w_none()), 2),
                 );
                 crate::dict_storage_store(
                     ns,
@@ -1658,7 +1658,7 @@ fn init_thread(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "start_joinable_thread",
-        crate::make_builtin_function_with_arity("start_joinable_thread", |_| Ok(pyre_object::w_int_new(0)), 0),
+        crate::make_builtin_function("start_joinable_thread", |_| Ok(pyre_object::w_int_new(0))),
     );
     crate::dict_storage_store(
         ns,
@@ -1698,7 +1698,7 @@ fn init_thread(ns: &mut DictStorage) {
         "_make_thread_handle",
         crate::make_builtin_function_with_arity("_make_thread_handle", |_| {
             Ok(pyre_object::w_instance_new(thread_handle_type()))
-        }, 0),
+        }, 1),
     );
     // _get_main_thread_ident — threading.py:43
     crate::dict_storage_store(
@@ -1716,13 +1716,13 @@ fn init_thread(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "set_name",
-        crate::make_builtin_function_with_arity("set_name", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("set_name", |_| Ok(pyre_object::w_none()), 1),
     );
     // _excepthook — threading.py:1262
     crate::dict_storage_store(
         ns,
         "_excepthook",
-        crate::make_builtin_function_with_arity("_excepthook", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("_excepthook", |_| Ok(pyre_object::w_none()), 1),
     );
     // _local — PyPy: pypy/module/thread/os_local.py Local
     // Thread-local data. Single-threaded: equivalent to a plain object with dict.
@@ -3321,17 +3321,17 @@ fn init_imp(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "is_frozen",
-        crate::make_builtin_function_with_arity("is_frozen", |_| Ok(pyre_object::w_bool_from(false)), 0),
+        crate::make_builtin_function_with_arity("is_frozen", |_| Ok(pyre_object::w_bool_from(false)), 1),
     );
     crate::dict_storage_store(
         ns,
         "is_frozen_package",
-        crate::make_builtin_function_with_arity("is_frozen_package", |_| Ok(pyre_object::w_bool_from(false)), 0),
+        crate::make_builtin_function_with_arity("is_frozen_package", |_| Ok(pyre_object::w_bool_from(false)), 1),
     );
     crate::dict_storage_store(
         ns,
         "get_frozen_object",
-        crate::make_builtin_function_with_arity("get_frozen_object", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("get_frozen_object", |_| Ok(pyre_object::w_none()), 1),
     );
     crate::dict_storage_store(
         ns,
@@ -3346,12 +3346,12 @@ fn init_imp(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "exec_builtin",
-        crate::make_builtin_function_with_arity("exec_builtin", |_| Ok(pyre_object::w_int_new(0)), 0),
+        crate::make_builtin_function_with_arity("exec_builtin", |_| Ok(pyre_object::w_int_new(0)), 1),
     );
     crate::dict_storage_store(
         ns,
         "exec_dynamic",
-        crate::make_builtin_function_with_arity("exec_dynamic", |_| Ok(pyre_object::w_int_new(0)), 0),
+        crate::make_builtin_function_with_arity("exec_dynamic", |_| Ok(pyre_object::w_int_new(0)), 1),
     );
     crate::dict_storage_store(
         ns,

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -154,79 +154,79 @@ fn init_gc(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "collect",
-        crate::make_builtin_function("collect", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("collect", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
         "disable",
-        crate::make_builtin_function("disable", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("disable", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "enable",
-        crate::make_builtin_function("enable", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("enable", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "isenabled",
-        crate::make_builtin_function("isenabled", |_| Ok(pyre_object::w_bool_from(false))),
+        crate::make_builtin_function_with_arity("isenabled", |_| Ok(pyre_object::w_bool_from(false)), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_objects",
-        crate::make_builtin_function("get_objects", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("get_objects", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_referrers",
-        crate::make_builtin_function("get_referrers", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("get_referrers", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_referents",
-        crate::make_builtin_function("get_referents", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("get_referents", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
     crate::dict_storage_store(
         ns,
         "set_threshold",
-        crate::make_builtin_function("set_threshold", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("set_threshold", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_threshold",
-        crate::make_builtin_function("get_threshold", |_| {
+        crate::make_builtin_function_with_arity("get_threshold", |_| {
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(700),
                 pyre_object::w_int_new(10),
                 pyre_object::w_int_new(10),
             ]))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "get_count",
-        crate::make_builtin_function("get_count", |_| {
+        crate::make_builtin_function_with_arity("get_count", |_| {
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(0),
                 pyre_object::w_int_new(0),
                 pyre_object::w_int_new(0),
             ]))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "is_tracked",
-        crate::make_builtin_function("is_tracked", |_| Ok(pyre_object::w_bool_from(false))),
+        crate::make_builtin_function_with_arity("is_tracked", |_| Ok(pyre_object::w_bool_from(false)), 0),
     );
     crate::dict_storage_store(
         ns,
         "is_finalized",
-        crate::make_builtin_function("is_finalized", |_| Ok(pyre_object::w_bool_from(false))),
+        crate::make_builtin_function_with_arity("is_finalized", |_| Ok(pyre_object::w_bool_from(false)), 0),
     );
     crate::dict_storage_store(
         ns,
         "freeze",
-        crate::make_builtin_function("freeze", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("freeze", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(ns, "callbacks", pyre_object::w_list_new(vec![]));
     crate::dict_storage_store(ns, "garbage", pyre_object::w_list_new(vec![]));
@@ -243,19 +243,19 @@ fn init_unicodedata(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "normalize",
-        crate::make_builtin_function("normalize", |args| {
+        crate::make_builtin_function_with_arity("normalize", |args| {
             if args.len() >= 2 {
                 Ok(args[1])
             } else {
                 Ok(pyre_object::w_str_new(""))
             }
-        }),
+        }, 2),
     );
     // unicodedata.category(chr) → str (stub: returns "Cn" = unassigned)
     crate::dict_storage_store(
         ns,
         "category",
-        crate::make_builtin_function("category", |_| Ok(pyre_object::w_str_new("Cn"))),
+        crate::make_builtin_function_with_arity("category", |_| Ok(pyre_object::w_str_new("Cn")), 0),
     );
     // unicodedata.name(chr, default=None) → str
     crate::dict_storage_store(
@@ -273,9 +273,9 @@ fn init_unicodedata(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "lookup",
-        crate::make_builtin_function("lookup", |_| {
+        crate::make_builtin_function_with_arity("lookup", |_| {
             Err(crate::PyError::key_error("character not found"))
-        }),
+        }, 0),
     );
     // unicodedata.decimal(chr, default=None) → int
     crate::dict_storage_store(
@@ -340,13 +340,13 @@ fn init_struct(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "_clearcache",
-        crate::make_builtin_function("_clearcache", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_clearcache", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(ns, "error", crate::typedef::w_object());
     crate::dict_storage_store(
         ns,
         "calcsize",
-        crate::make_builtin_function("calcsize", |args| {
+        crate::make_builtin_function_with_arity("calcsize", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_int_new(0));
             }
@@ -363,7 +363,7 @@ fn init_struct(ns: &mut DictStorage) {
             let (_, codes) = parse_format(&fmt);
             let total: usize = codes.iter().copied().map(code_size).sum();
             Ok(pyre_object::w_int_new(total as i64))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
@@ -455,7 +455,7 @@ fn init_struct(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "unpack",
-        crate::make_builtin_function("unpack", |args| {
+        crate::make_builtin_function_with_arity("unpack", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("unpack requires (fmt, buffer)"));
             }
@@ -551,29 +551,29 @@ fn init_struct(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_tuple_new(out))
-        }),
+        }, 2),
     );
     crate::dict_storage_store(
         ns,
         "unpack_from",
-        crate::make_builtin_function("unpack_from", |_| Ok(pyre_object::w_tuple_new(vec![]))),
+        crate::make_builtin_function_with_arity("unpack_from", |_| Ok(pyre_object::w_tuple_new(vec![])), 0),
     );
     crate::dict_storage_store(
         ns,
         "iter_unpack",
-        crate::make_builtin_function("iter_unpack", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("iter_unpack", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
     // Struct class — minimal constructor returning instance with format
     // attribute. Used by struct.Struct(fmt).pack/unpack.
     crate::dict_storage_store(
         ns,
         "Struct",
-        crate::make_builtin_function("Struct", |args| {
+        crate::make_builtin_function_with_arity("Struct", |args| {
             let fmt = args.first().copied().unwrap_or(pyre_object::w_str_new(""));
             let obj = pyre_object::w_instance_new(crate::typedef::w_object());
             let _ = crate::baseobjspace::setattr(obj, "format", fmt);
             Ok(obj)
-        }),
+        }, 1),
     );
 }
 
@@ -643,7 +643,7 @@ fn init_random(ns: &mut DictStorage) {
                     crate::dict_storage_store(
                         ns,
                         "random",
-                        crate::make_builtin_function("random", |args| {
+                        crate::make_builtin_function_with_arity("random", |args| {
                             // Tiny xorshift PRNG — ok for import-time construction.
                             let self_obj = args[0];
                             let state = crate::baseobjspace::getattr(self_obj, "__rand_state__")
@@ -660,7 +660,7 @@ fn init_random(ns: &mut DictStorage) {
                                 pyre_object::w_int_new(x as i64),
                             );
                             Ok(pyre_object::w_float_new((x as f64) / (u64::MAX as f64)))
-                        }),
+                        }, 1),
                     );
                     crate::dict_storage_store(
                         ns,
@@ -691,16 +691,16 @@ fn init_random(ns: &mut DictStorage) {
                     crate::dict_storage_store(
                         ns,
                         "getstate",
-                        crate::make_builtin_function("getstate", |args| {
+                        crate::make_builtin_function_with_arity("getstate", |args| {
                             let state = crate::baseobjspace::getattr(args[0], "__rand_state__")
                                 .unwrap_or_else(|_| pyre_object::w_int_new(0));
                             Ok(pyre_object::w_tuple_new(vec![state]))
-                        }),
+                        }, 1),
                     );
                     crate::dict_storage_store(
                         ns,
                         "setstate",
-                        crate::make_builtin_function("setstate", |args| {
+                        crate::make_builtin_function_with_arity("setstate", |args| {
                             if args.len() >= 2 {
                                 unsafe {
                                     if pyre_object::is_tuple(args[1])
@@ -719,7 +719,7 @@ fn init_random(ns: &mut DictStorage) {
                                 }
                             }
                             Ok(pyre_object::w_none())
-                        }),
+                        }, 2),
                     );
                 });
                 unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
@@ -756,7 +756,7 @@ fn init_locale(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "localeconv",
-        crate::make_builtin_function("localeconv", |_| {
+        crate::make_builtin_function_with_arity("localeconv", |_| {
             let d = pyre_object::w_dict_new();
             unsafe {
                 pyre_object::w_dict_setitem_str(
@@ -783,22 +783,22 @@ fn init_locale(ns: &mut DictStorage) {
                 pyre_object::w_dict_setitem_str(d, "int_frac_digits", pyre_object::w_int_new(127));
             }
             Ok(d)
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "setlocale",
-        crate::make_builtin_function("setlocale", |_| Ok(pyre_object::w_str_new("C"))),
+        crate::make_builtin_function_with_arity("setlocale", |_| Ok(pyre_object::w_str_new("C")), 0),
     );
     crate::dict_storage_store(
         ns,
         "nl_langinfo",
-        crate::make_builtin_function("nl_langinfo", |_| Ok(pyre_object::w_str_new(""))),
+        crate::make_builtin_function_with_arity("nl_langinfo", |_| Ok(pyre_object::w_str_new("")), 0),
     );
     crate::dict_storage_store(
         ns,
         "strcoll",
-        crate::make_builtin_function("strcoll", |args| {
+        crate::make_builtin_function_with_arity("strcoll", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_int_new(0));
             }
@@ -810,19 +810,19 @@ fn init_locale(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_int_new(0))
-        }),
+        }, 2),
     );
     crate::dict_storage_store(
         ns,
         "strxfrm",
-        crate::make_builtin_function("strxfrm", |args| {
+        crate::make_builtin_function_with_arity("strxfrm", |args| {
             Ok(args.first().copied().unwrap_or(pyre_object::w_str_new("")))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "getencoding",
-        crate::make_builtin_function("getencoding", |_| Ok(pyre_object::w_str_new("utf-8"))),
+        crate::make_builtin_function_with_arity("getencoding", |_| Ok(pyre_object::w_str_new("utf-8")), 0),
     );
 }
 
@@ -909,7 +909,7 @@ fn init_pwd(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "getpwuid",
-        crate::make_builtin_function("getpwuid", |args| {
+        crate::make_builtin_function_with_arity("getpwuid", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("getpwuid() missing argument"));
             }
@@ -932,12 +932,12 @@ fn init_pwd(ns: &mut DictStorage) {
             }
             #[cfg(not(unix))]
             Err(crate::PyError::key_error("getpwuid(): uid not found"))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "getpwnam",
-        crate::make_builtin_function("getpwnam", |args| {
+        crate::make_builtin_function_with_arity("getpwnam", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("getpwnam() missing argument"));
             }
@@ -963,12 +963,12 @@ fn init_pwd(ns: &mut DictStorage) {
             }
             #[cfg(not(unix))]
             Err(crate::PyError::key_error("getpwnam(): name not found"))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "getpwall",
-        crate::make_builtin_function("getpwall", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("getpwall", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
 }
 
@@ -987,22 +987,22 @@ fn init_atexit(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "unregister",
-        crate::make_builtin_function("unregister", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("unregister", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "_run_exitfuncs",
-        crate::make_builtin_function("_run_exitfuncs", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_run_exitfuncs", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "_clear",
-        crate::make_builtin_function("_clear", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_clear", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "_ncallbacks",
-        crate::make_builtin_function("_ncallbacks", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("_ncallbacks", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
 }
 
@@ -1020,17 +1020,17 @@ fn init_signal_stub(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "getsignal",
-        crate::make_builtin_function("getsignal", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("getsignal", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "default_int_handler",
-        crate::make_builtin_function("default_int_handler", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("default_int_handler", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "set_wakeup_fd",
-        crate::make_builtin_function("set_wakeup_fd", |_| Ok(pyre_object::w_int_new(-1))),
+        crate::make_builtin_function_with_arity("set_wakeup_fd", |_| Ok(pyre_object::w_int_new(-1)), 0),
     );
     crate::dict_storage_store(ns, "SIG_DFL", pyre_object::w_int_new(0));
     crate::dict_storage_store(ns, "SIG_IGN", pyre_object::w_int_new(1));
@@ -1068,7 +1068,7 @@ fn init_itertools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "starmap",
-        crate::make_builtin_function("starmap", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("starmap", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
     // count(start=0, step=1) — PyPy: W_Count___new__
     //
@@ -1115,13 +1115,13 @@ fn init_itertools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "islice",
-        crate::make_builtin_function("islice", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("islice", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
     // groupby
     crate::dict_storage_store(
         ns,
         "groupby",
-        crate::make_builtin_function("groupby", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("groupby", |_| Ok(pyre_object::w_none()), 0),
     );
     // permutations(iterable, r=None) — PyPy: pypy/module/itertools/interp_itertools.py
     crate::dict_storage_store(
@@ -1178,7 +1178,7 @@ fn init_itertools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "combinations",
-        crate::make_builtin_function("combinations", |args| {
+        crate::make_builtin_function_with_arity("combinations", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_list_new(vec![]));
             }
@@ -1210,7 +1210,7 @@ fn init_itertools(ns: &mut DictStorage) {
             let n = tuples.len();
             let list = pyre_object::w_list_new(tuples);
             Ok(pyre_object::w_seq_iter_new(list, n))
-        }),
+        }, 2),
     );
     // product(*iterables, repeat=1)
     crate::dict_storage_store(
@@ -1290,7 +1290,7 @@ fn init_itertools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "compress",
-        crate::make_builtin_function("compress", |args| {
+        crate::make_builtin_function_with_arity("compress", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_list_new(vec![]));
             }
@@ -1305,7 +1305,7 @@ fn init_itertools(ns: &mut DictStorage) {
             let n = out.len();
             let list = pyre_object::w_list_new(out);
             Ok(pyre_object::w_seq_iter_new(list, n))
-        }),
+        }, 2),
     );
 }
 
@@ -1337,7 +1337,7 @@ fn init_contextvars(ns: &mut DictStorage) {
             let _ = crate::baseobjspace::setattr(
                 obj,
                 "set",
-                crate::make_builtin_function("set", |_| Ok(pyre_object::w_none())),
+                crate::make_builtin_function_with_arity("set", |_| Ok(pyre_object::w_none()), 0),
             );
             Ok(obj)
         }),
@@ -1345,17 +1345,17 @@ fn init_contextvars(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "Context",
-        crate::make_builtin_function("Context", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("Context", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "Token",
-        crate::make_builtin_function("Token", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("Token", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "copy_context",
-        crate::make_builtin_function("copy_context", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("copy_context", |_| Ok(pyre_object::w_none()), 0),
     );
 }
 
@@ -1364,17 +1364,17 @@ fn init_abc(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "get_cache_token",
-        crate::make_builtin_function("get_cache_token", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("get_cache_token", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
         "_abc_init",
-        crate::make_builtin_function("_abc_init", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_abc_init", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "_abc_register",
-        crate::make_builtin_function("_abc_register", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_abc_register", |_| Ok(pyre_object::w_none()), 0),
     );
     // _abc_instancecheck(cls, instance) — CPython: Modules/_abc.c _abc__abc_instancecheck.
     //
@@ -1387,7 +1387,7 @@ fn init_abc(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "_abc_instancecheck",
-        crate::make_builtin_function("_abc_instancecheck", |args| {
+        crate::make_builtin_function_with_arity("_abc_instancecheck", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
@@ -1398,13 +1398,13 @@ fn init_abc(ns: &mut DictStorage) {
                     instance, cls,
                 )))
             }
-        }),
+        }, 2),
     );
     // _abc_subclasscheck(cls, subclass) — CPython: Modules/_abc.c _abc__abc_subclasscheck.
     crate::dict_storage_store(
         ns,
         "_abc_subclasscheck",
-        crate::make_builtin_function("_abc_subclasscheck", |args| {
+        crate::make_builtin_function_with_arity("_abc_subclasscheck", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
@@ -1422,22 +1422,22 @@ fn init_abc(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_bool_from(false))
-        }),
+        }, 2),
     );
     crate::dict_storage_store(
         ns,
         "_get_dump",
-        crate::make_builtin_function("_get_dump", |_| Ok(pyre_object::w_tuple_new(vec![]))),
+        crate::make_builtin_function_with_arity("_get_dump", |_| Ok(pyre_object::w_tuple_new(vec![])), 0),
     );
     crate::dict_storage_store(
         ns,
         "_reset_registry",
-        crate::make_builtin_function("_reset_registry", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_reset_registry", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "_reset_caches",
-        crate::make_builtin_function("_reset_caches", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_reset_caches", |_| Ok(pyre_object::w_none()), 0),
     );
 }
 
@@ -1446,9 +1446,9 @@ fn init_functools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "reduce",
-        crate::make_builtin_function("reduce", |_| {
+        crate::make_builtin_function_with_arity("reduce", |_| {
             Err(crate::PyError::type_error("reduce not implemented"))
-        }),
+        }, 0),
     );
     // functools.cmp_to_key(cmp) — returns a callable that wraps a value in
     // an opaque key. For sorting str / int / tuple of those (the only paths
@@ -1457,11 +1457,11 @@ fn init_functools(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "cmp_to_key",
-        crate::make_builtin_function("cmp_to_key", |_args| {
-            Ok(crate::make_builtin_function("cmp_to_key.K", |args| {
+        crate::make_builtin_function_with_arity("cmp_to_key", |_args| {
+            Ok(crate::make_builtin_function_with_arity("cmp_to_key.K", |args| {
                 Ok(args.first().copied().unwrap_or(pyre_object::w_none()))
-            }))
-        }),
+            }, 1))
+        }, 0),
     );
 }
 
@@ -1474,12 +1474,12 @@ fn init_lock_type(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "__enter__",
-        crate::make_builtin_function("__enter__", |args| {
+        crate::make_builtin_function_with_arity("__enter__", |args| {
             if let Some(&obj) = args.first() {
                 lock_acquire_impl(obj)?;
             }
             Ok(args.first().copied().unwrap_or(pyre_object::w_none()))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
@@ -1505,40 +1505,40 @@ fn init_lock_type(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "release",
-        crate::make_builtin_function("release", |args| {
+        crate::make_builtin_function_with_arity("release", |args| {
             let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             lock_release_impl(obj)?;
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
     // descr_lock_locked — PyPy: os_lock.Lock.descr_lock_locked
     crate::dict_storage_store(
         ns,
         "locked",
-        crate::make_builtin_function("locked", |args| {
+        crate::make_builtin_function_with_arity("locked", |args| {
             let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             Ok(pyre_object::w_bool_from(lock_count(obj) > 0))
-        }),
+        }, 1),
     );
     // _is_owned — used by RLock/Condition in threading.py
     crate::dict_storage_store(
         ns,
         "_is_owned",
-        crate::make_builtin_function("_is_owned", |args| {
+        crate::make_builtin_function_with_arity("_is_owned", |args| {
             let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             Ok(pyre_object::w_bool_from(lock_count(obj) > 0))
-        }),
+        }, 1),
     );
     // _at_fork_reinit — PyPy: os_lock.Lock._at_fork_reinit (reset to unlocked)
     crate::dict_storage_store(
         ns,
         "_at_fork_reinit",
-        crate::make_builtin_function("_at_fork_reinit", |args| {
+        crate::make_builtin_function_with_arity("_at_fork_reinit", |args| {
             if let Some(&obj) = args.first() {
                 lock_set_count(obj, 0);
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
 }
 
@@ -1605,22 +1605,22 @@ fn thread_handle_type() -> PyObjectRef {
                 crate::dict_storage_store(
                     ns,
                     "is_done",
-                    crate::make_builtin_function("is_done", |_| Ok(pyre_object::w_bool_from(true))),
+                    crate::make_builtin_function_with_arity("is_done", |_| Ok(pyre_object::w_bool_from(true)), 1),
                 );
                 crate::dict_storage_store(
                     ns,
                     "join",
-                    crate::make_builtin_function("join", |_| Ok(pyre_object::w_none())),
+                    crate::make_builtin_function_with_arity("join", |_| Ok(pyre_object::w_none()), 1),
                 );
                 crate::dict_storage_store(
                     ns,
                     "set_result",
-                    crate::make_builtin_function("set_result", |_| Ok(pyre_object::w_none())),
+                    crate::make_builtin_function_with_arity("set_result", |_| Ok(pyre_object::w_none()), 1),
                 );
                 crate::dict_storage_store(
                     ns,
                     "_set_done",
-                    crate::make_builtin_function("_set_done", |_| Ok(pyre_object::w_none())),
+                    crate::make_builtin_function_with_arity("_set_done", |_| Ok(pyre_object::w_none()), 1),
                 );
             })
         })
@@ -1634,95 +1634,95 @@ fn init_thread(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "RLock",
-        crate::make_builtin_function("RLock", |_| Ok(pyre_object::w_instance_new(lock_type()))),
+        crate::make_builtin_function_with_arity("RLock", |_| Ok(pyre_object::w_instance_new(lock_type())), 0),
     );
     crate::dict_storage_store(
         ns,
         "allocate_lock",
-        crate::make_builtin_function("allocate_lock", |_| {
+        crate::make_builtin_function_with_arity("allocate_lock", |_| {
             Ok(pyre_object::w_instance_new(lock_type()))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "get_ident",
-        crate::make_builtin_function("get_ident", |_| Ok(pyre_object::w_int_new(1))),
+        crate::make_builtin_function_with_arity("get_ident", |_| Ok(pyre_object::w_int_new(1)), 0),
     );
     crate::dict_storage_store(
         ns,
         "_count",
-        crate::make_builtin_function("_count", |_| Ok(pyre_object::w_int_new(1))),
+        crate::make_builtin_function_with_arity("_count", |_| Ok(pyre_object::w_int_new(1)), 0),
     );
     crate::dict_storage_store(ns, "TIMEOUT_MAX", pyre_object::w_float_new(f64::MAX));
     crate::dict_storage_store(ns, "error", crate::typedef::w_object());
     crate::dict_storage_store(
         ns,
         "start_joinable_thread",
-        crate::make_builtin_function("start_joinable_thread", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("start_joinable_thread", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
         "_set_sentinel",
-        crate::make_builtin_function("_set_sentinel", |_| {
+        crate::make_builtin_function_with_arity("_set_sentinel", |_| {
             Ok(pyre_object::w_instance_new(lock_type()))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "stack_size",
-        crate::make_builtin_function("stack_size", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("stack_size", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
         "_is_main_interpreter",
-        crate::make_builtin_function("_is_main_interpreter", |_| {
+        crate::make_builtin_function_with_arity("_is_main_interpreter", |_| {
             Ok(pyre_object::w_bool_from(true))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "daemon_threads_allowed",
-        crate::make_builtin_function("daemon_threads_allowed", |_| {
+        crate::make_builtin_function_with_arity("daemon_threads_allowed", |_| {
             Ok(pyre_object::w_bool_from(true))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "_shutdown",
-        crate::make_builtin_function("_shutdown", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_shutdown", |_| Ok(pyre_object::w_none()), 0),
     );
     // _make_thread_handle / _ThreadHandle — threading.py:40-41
     crate::dict_storage_store(ns, "_ThreadHandle", thread_handle_type());
     crate::dict_storage_store(
         ns,
         "_make_thread_handle",
-        crate::make_builtin_function("_make_thread_handle", |_| {
+        crate::make_builtin_function_with_arity("_make_thread_handle", |_| {
             Ok(pyre_object::w_instance_new(thread_handle_type()))
-        }),
+        }, 0),
     );
     // _get_main_thread_ident — threading.py:43
     crate::dict_storage_store(
         ns,
         "_get_main_thread_ident",
-        crate::make_builtin_function("_get_main_thread_ident", |_| Ok(pyre_object::w_int_new(1))),
+        crate::make_builtin_function_with_arity("_get_main_thread_ident", |_| Ok(pyre_object::w_int_new(1)), 0),
     );
     // get_native_id — threading.py:46
     crate::dict_storage_store(
         ns,
         "get_native_id",
-        crate::make_builtin_function("get_native_id", |_| Ok(pyre_object::w_int_new(1))),
+        crate::make_builtin_function_with_arity("get_native_id", |_| Ok(pyre_object::w_int_new(1)), 0),
     );
     // set_name — threading.py:52
     crate::dict_storage_store(
         ns,
         "set_name",
-        crate::make_builtin_function("set_name", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("set_name", |_| Ok(pyre_object::w_none()), 0),
     );
     // _excepthook — threading.py:1262
     crate::dict_storage_store(
         ns,
         "_excepthook",
-        crate::make_builtin_function("_excepthook", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_excepthook", |_| Ok(pyre_object::w_none()), 0),
     );
     // _local — PyPy: pypy/module/thread/os_local.py Local
     // Thread-local data. Single-threaded: equivalent to a plain object with dict.
@@ -2022,7 +2022,7 @@ fn init_posix(ns: &mut DictStorage) {
         crate::dict_storage_store(
             ns,
             name,
-            crate::make_builtin_function(name, |_| Ok(pyre_object::w_none())),
+            crate::make_builtin_function_with_arity(name, |_| Ok(pyre_object::w_none()), 0),
         );
     }
 
@@ -2087,7 +2087,7 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "close",
-        crate::make_builtin_function("close", |args| {
+        crate::make_builtin_function_with_arity("close", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("close() requires 1 argument"));
             }
@@ -2097,14 +2097,14 @@ fn init_posix(ns: &mut DictStorage) {
                 return Err(io_err(std::io::Error::last_os_error(), ""));
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
 
     // ── posix.read(fd, n) → bytes ──
     crate::dict_storage_store(
         ns,
         "read",
-        crate::make_builtin_function("read", |args| {
+        crate::make_builtin_function_with_arity("read", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("read() requires 2 arguments"));
             }
@@ -2117,14 +2117,14 @@ fn init_posix(ns: &mut DictStorage) {
             }
             buf.truncate(ret as usize);
             Ok(pyre_object::w_bytes_from_bytes(&buf))
-        }),
+        }, 2),
     );
 
     // ── posix.write(fd, data) → nbytes ──
     crate::dict_storage_store(
         ns,
         "write",
-        crate::make_builtin_function("write", |args| {
+        crate::make_builtin_function_with_arity("write", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("write() requires 2 arguments"));
             }
@@ -2146,14 +2146,14 @@ fn init_posix(ns: &mut DictStorage) {
                 return Err(io_err(std::io::Error::last_os_error(), ""));
             }
             Ok(pyre_object::w_int_new(ret as i64))
-        }),
+        }, 2),
     );
 
     // ── posix.lseek(fd, offset, whence) → position ──
     crate::dict_storage_store(
         ns,
         "lseek",
-        crate::make_builtin_function("lseek", |args| {
+        crate::make_builtin_function_with_arity("lseek", |args| {
             if args.len() < 3 {
                 return Err(crate::PyError::type_error("lseek() requires 3 arguments"));
             }
@@ -2165,7 +2165,7 @@ fn init_posix(ns: &mut DictStorage) {
                 return Err(io_err(std::io::Error::last_os_error(), ""));
             }
             Ok(pyre_object::w_int_new(ret as i64))
-        }),
+        }, 3),
     );
 
     // ── posix.unlink(path) / posix.remove(path) ──
@@ -2187,12 +2187,12 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "unlink",
-        crate::make_builtin_function("unlink", posix_unlink),
+        crate::make_builtin_function_with_arity("unlink", posix_unlink, 1),
     );
     crate::dict_storage_store(
         ns,
         "remove",
-        crate::make_builtin_function("remove", posix_unlink),
+        crate::make_builtin_function_with_arity("remove", posix_unlink, 1),
     );
 
     // ── posix.mkdir(path, mode=0o777) ──
@@ -2226,7 +2226,7 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "rmdir",
-        crate::make_builtin_function("rmdir", |args| {
+        crate::make_builtin_function_with_arity("rmdir", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("rmdir() requires 1 argument"));
             }
@@ -2238,14 +2238,14 @@ fn init_posix(ns: &mut DictStorage) {
                 return Err(io_err(std::io::Error::last_os_error(), &path));
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
 
     // ── posix.rename(src, dst) ──
     crate::dict_storage_store(
         ns,
         "rename",
-        crate::make_builtin_function("rename", |args| {
+        crate::make_builtin_function_with_arity("rename", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("rename() requires 2 arguments"));
             }
@@ -2253,7 +2253,7 @@ fn init_posix(ns: &mut DictStorage) {
             let dst = extract_path(args[1])?;
             std::fs::rename(&src, &dst).map_err(|e| io_err(e, &src))?;
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
 
     // ── posix.listdir(path=".") → list of str ──
@@ -2281,21 +2281,21 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "isatty",
-        crate::make_builtin_function("isatty", |args| {
+        crate::make_builtin_function_with_arity("isatty", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_bool_from(false));
             }
             let fd = unsafe { pyre_object::w_int_get_value(args[0]) } as libc::c_int;
             let ret = unsafe { libc::isatty(fd) };
             Ok(pyre_object::w_bool_from(ret != 0))
-        }),
+        }, 1),
     );
 
     // ── posix.urandom(n) → bytes ──
     crate::dict_storage_store(
         ns,
         "urandom",
-        crate::make_builtin_function("urandom", |args| {
+        crate::make_builtin_function_with_arity("urandom", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("urandom() requires 1 argument"));
             }
@@ -2310,7 +2310,7 @@ fn init_posix(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_bytes_from_bytes(&buf))
-        }),
+        }, 1),
     );
     // os.terminal_size — namedtuple-like type with columns/lines.
     // Uses stat_result_type (hasdict instance) so setattr works.
@@ -2353,7 +2353,7 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "get_terminal_size",
-        crate::make_builtin_function("get_terminal_size", |_args| {
+        crate::make_builtin_function_with_arity("get_terminal_size", |_args| {
             let (cols, rows) = {
                 #[cfg(unix)]
                 {
@@ -2379,7 +2379,7 @@ fn init_posix(ns: &mut DictStorage) {
             let _ = crate::baseobjspace::setattr(wrapper, "lines", pyre_object::w_int_new(rows));
             let _ = crate::baseobjspace::setattr(wrapper, "__tuple__", result);
             Ok(wrapper)
-        }),
+        }, 0),
     );
     // os.fspath() — PyPy: posixmodule.c posix_fspath. Returns the argument
     // unchanged for str/bytes/bytearray (the protocol's identity case);
@@ -2388,7 +2388,7 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "fspath",
-        crate::make_builtin_function("fspath", |args| {
+        crate::make_builtin_function_with_arity("fspath", |args| {
             let arg = args.first().copied().unwrap_or(pyre_object::w_none());
             unsafe {
                 if pyre_object::is_str(arg) || pyre_object::bytesobject::is_bytes_like(arg) {
@@ -2403,7 +2403,7 @@ fn init_posix(ns: &mut DictStorage) {
                 }
             }
             Ok(arg)
-        }),
+        }, 1),
     );
     // os.stat / os.lstat / os.fstat — return stat_result structseq.
     // PyPy: posixmodule.c posix_do_stat → build_stat_result.
@@ -2603,7 +2603,7 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "uname",
-        crate::make_builtin_function("uname", |_| {
+        crate::make_builtin_function_with_arity("uname", |_| {
             let wrapper = pyre_object::w_instance_new(stat_result_type());
             let sysname = std::env::consts::OS.to_string();
             let machine = std::env::consts::ARCH.to_string();
@@ -2615,22 +2615,22 @@ fn init_posix(ns: &mut DictStorage) {
             let _ =
                 crate::baseobjspace::setattr(wrapper, "machine", pyre_object::w_str_new(&machine));
             Ok(wrapper)
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "stat",
-        crate::make_builtin_function("stat", |args| stat_impl(args, true)),
+        crate::make_builtin_function_with_arity("stat", |args| stat_impl(args, true), 1),
     );
     crate::dict_storage_store(
         ns,
         "lstat",
-        crate::make_builtin_function("lstat", |args| stat_impl(args, false)),
+        crate::make_builtin_function_with_arity("lstat", |args| stat_impl(args, false), 1),
     );
     crate::dict_storage_store(
         ns,
         "fstat",
-        crate::make_builtin_function("fstat", |args| {
+        crate::make_builtin_function_with_arity("fstat", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("fstat() missing argument"));
             }
@@ -2654,7 +2654,7 @@ fn init_posix(ns: &mut DictStorage) {
                 9,
                 "fstat unsupported".to_string(),
             ))
-        }),
+        }, 1),
     );
     // stat_result type — simple instance with hasdict so setattr works.
     // Exported so that `posix.stat_result` can be looked up.
@@ -2663,7 +2663,7 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "getcwd",
-        crate::make_builtin_function("getcwd", |_| {
+        crate::make_builtin_function_with_arity("getcwd", |_| {
             #[cfg(feature = "host_env")]
             {
                 if let Ok(cwd) = std::env::current_dir() {
@@ -2671,13 +2671,13 @@ fn init_posix(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_str_new(""))
-        }),
+        }, 0),
     );
     // os.getcwdb() — bytes form of getcwd.
     crate::dict_storage_store(
         ns,
         "getcwdb",
-        crate::make_builtin_function("getcwdb", |_| {
+        crate::make_builtin_function_with_arity("getcwdb", |_| {
             #[cfg(feature = "host_env")]
             {
                 if let Ok(cwd) = std::env::current_dir() {
@@ -2687,7 +2687,7 @@ fn init_posix(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_bytes_from_bytes(b""))
-        }),
+        }, 0),
     );
     // os.getuid / geteuid / getgid / getegid — real syscalls.
     #[cfg(unix)]
@@ -2700,58 +2700,58 @@ fn init_posix(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "getuid",
-        crate::make_builtin_function("getuid", |_| {
+        crate::make_builtin_function_with_arity("getuid", |_| {
             #[cfg(unix)]
             unsafe {
                 return Ok(pyre_object::w_int_new(getuid() as i64));
             }
             #[cfg(not(unix))]
             Ok(pyre_object::w_int_new(0))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "geteuid",
-        crate::make_builtin_function("geteuid", |_| {
+        crate::make_builtin_function_with_arity("geteuid", |_| {
             #[cfg(unix)]
             unsafe {
                 return Ok(pyre_object::w_int_new(geteuid() as i64));
             }
             #[cfg(not(unix))]
             Ok(pyre_object::w_int_new(0))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "getgid",
-        crate::make_builtin_function("getgid", |_| {
+        crate::make_builtin_function_with_arity("getgid", |_| {
             #[cfg(unix)]
             unsafe {
                 return Ok(pyre_object::w_int_new(getgid() as i64));
             }
             #[cfg(not(unix))]
             Ok(pyre_object::w_int_new(0))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "getegid",
-        crate::make_builtin_function("getegid", |_| {
+        crate::make_builtin_function_with_arity("getegid", |_| {
             #[cfg(unix)]
             unsafe {
                 return Ok(pyre_object::w_int_new(getegid() as i64));
             }
             #[cfg(not(unix))]
             Ok(pyre_object::w_int_new(0))
-        }),
+        }, 0),
     );
     // os.getpid — std::process::id.
     crate::dict_storage_store(
         ns,
         "getpid",
-        crate::make_builtin_function("getpid", |_| {
+        crate::make_builtin_function_with_arity("getpid", |_| {
             Ok(pyre_object::w_int_new(std::process::id() as i64))
-        }),
+        }, 0),
     );
     // os.environ lookups from setenv / unsetenv / putenv / getenv — mutate
     // posix.environ (the dict) rather than calling libc; os.py writes back
@@ -2837,19 +2837,19 @@ fn init_deque_type(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "append",
-        crate::make_builtin_function("append", |args| {
+        crate::make_builtin_function_with_arity("append", |args| {
             if args.len() >= 2 {
                 if let Ok(data) = crate::baseobjspace::getattr(args[0], "__data__") {
                     unsafe { pyre_object::w_list_append(data, args[1]) };
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     crate::dict_storage_store(
         ns,
         "appendleft",
-        crate::make_builtin_function("appendleft", |args| {
+        crate::make_builtin_function_with_arity("appendleft", |args| {
             if args.len() >= 2 {
                 if let Ok(data) = crate::baseobjspace::getattr(args[0], "__data__") {
                     unsafe {
@@ -2864,12 +2864,12 @@ fn init_deque_type(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     crate::dict_storage_store(
         ns,
         "pop",
-        crate::make_builtin_function("pop", |args| {
+        crate::make_builtin_function_with_arity("pop", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
@@ -2889,12 +2889,12 @@ fn init_deque_type(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "popleft",
-        crate::make_builtin_function("popleft", |args| {
+        crate::make_builtin_function_with_arity("popleft", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
@@ -2914,12 +2914,12 @@ fn init_deque_type(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "clear",
-        crate::make_builtin_function("clear", |args| {
+        crate::make_builtin_function_with_arity("clear", |args| {
             if !args.is_empty() {
                 let _ = crate::baseobjspace::setattr(
                     args[0],
@@ -2928,12 +2928,12 @@ fn init_deque_type(ns: &mut DictStorage) {
                 );
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "extend",
-        crate::make_builtin_function("extend", |args| {
+        crate::make_builtin_function_with_arity("extend", |args| {
             if args.len() >= 2 {
                 let items = crate::builtins::collect_iterable(args[1])?;
                 if let Ok(data) = crate::baseobjspace::getattr(args[0], "__data__") {
@@ -2943,12 +2943,12 @@ fn init_deque_type(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     crate::dict_storage_store(
         ns,
         "__len__",
-        crate::make_builtin_function("__len__", |args| {
+        crate::make_builtin_function_with_arity("__len__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_int_new(0));
             }
@@ -2958,12 +2958,12 @@ fn init_deque_type(ns: &mut DictStorage) {
                 ));
             }
             Ok(pyre_object::w_int_new(0))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "__iter__",
-        crate::make_builtin_function("__iter__", |args| {
+        crate::make_builtin_function_with_arity("__iter__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_seq_iter_new(
                     pyre_object::w_list_new(vec![]),
@@ -2977,12 +2977,12 @@ fn init_deque_type(ns: &mut DictStorage) {
                 pyre_object::w_list_new(vec![]),
                 0,
             ))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "__getitem__",
-        crate::make_builtin_function("__getitem__", |args| {
+        crate::make_builtin_function_with_arity("__getitem__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_none());
             }
@@ -2990,7 +2990,7 @@ fn init_deque_type(ns: &mut DictStorage) {
                 return crate::baseobjspace::getitem(data, args[1]);
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
 }
 
@@ -3017,7 +3017,7 @@ fn init_defaultdict_type(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "__getitem__",
-        crate::make_builtin_function("__getitem__", |args| {
+        crate::make_builtin_function_with_arity("__getitem__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_none());
             }
@@ -3040,19 +3040,19 @@ fn init_defaultdict_type(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     crate::dict_storage_store(
         ns,
         "__setitem__",
-        crate::make_builtin_function("__setitem__", |args| {
+        crate::make_builtin_function_with_arity("__setitem__", |args| {
             if args.len() >= 3 {
                 if let Ok(data) = crate::baseobjspace::getattr(args[0], "__data__") {
                     unsafe { pyre_object::w_dict_store(data, args[1], args[2]) };
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 3),
     );
 }
 
@@ -3064,7 +3064,7 @@ fn init_opcode_c(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "stack_effect",
-        crate::make_builtin_function("stack_effect", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("stack_effect", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     for name in [
         "has_arg",
@@ -3080,73 +3080,74 @@ fn init_opcode_c(ns: &mut DictStorage) {
         crate::dict_storage_store(
             ns,
             name,
-            crate::make_builtin_function(name, |_| Ok(pyre_object::w_bool_from(false))),
+            crate::make_builtin_function_with_arity(name, |_| Ok(pyre_object::w_bool_from(false)), 0),
         );
     }
     crate::dict_storage_store(
         ns,
         "get_executor",
-        crate::make_builtin_function("get_executor", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("get_executor", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_specialization_stats",
-        crate::make_builtin_function(
+        crate::make_builtin_function_with_arity(
             "get_specialization_stats",
             |_| Ok(pyre_object::w_dict_new()),
+            0,
         ),
     );
     crate::dict_storage_store(
         ns,
         "get_intrinsic1_descs",
-        crate::make_builtin_function("get_intrinsic1_descs", |_| {
+        crate::make_builtin_function_with_arity("get_intrinsic1_descs", |_| {
             Ok(pyre_object::w_list_new(vec![]))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "get_intrinsic2_descs",
-        crate::make_builtin_function("get_intrinsic2_descs", |_| {
+        crate::make_builtin_function_with_arity("get_intrinsic2_descs", |_| {
             Ok(pyre_object::w_list_new(vec![]))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "get_opname",
-        crate::make_builtin_function("get_opname", |args| {
+        crate::make_builtin_function_with_arity("get_opname", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_str_new("<0>"));
             }
             let code = unsafe { pyre_object::w_int_get_value(args[0]) };
             Ok(pyre_object::w_str_new(&format!("<{code}>")))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "get_nb_ops",
-        crate::make_builtin_function("get_nb_ops", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("get_nb_ops", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_special_method_names",
-        crate::make_builtin_function("get_special_method_names", |_| {
+        crate::make_builtin_function_with_arity("get_special_method_names", |_| {
             Ok(pyre_object::w_list_new(vec![
                 pyre_object::w_str_new("__enter__"),
                 pyre_object::w_str_new("__exit__"),
                 pyre_object::w_str_new("__aenter__"),
                 pyre_object::w_str_new("__aexit__"),
             ]))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "get_executor_count",
-        crate::make_builtin_function("get_executor_count", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("get_executor_count", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_hot_code",
-        crate::make_builtin_function("get_hot_code", |_| Ok(pyre_object::w_list_new(vec![]))),
+        crate::make_builtin_function_with_arity("get_hot_code", |_| Ok(pyre_object::w_list_new(vec![])), 0),
     );
 }
 
@@ -3183,14 +3184,14 @@ fn init_importlib_pkg(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "invalidate_caches",
-        crate::make_builtin_function("invalidate_caches", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("invalidate_caches", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "reload",
-        crate::make_builtin_function("reload", |args| {
+        crate::make_builtin_function_with_arity("reload", |args| {
             Ok(args.first().copied().unwrap_or(pyre_object::w_none()))
-        }),
+        }, 1),
     );
     // Mark as a package so dotted imports treat it as such.
     crate::dict_storage_store(ns, "__path__", pyre_object::w_list_new(vec![]));
@@ -3201,17 +3202,17 @@ fn init_importlib_util(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "spec_from_file_location",
-        crate::make_builtin_function("spec_from_file_location", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("spec_from_file_location", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "module_from_spec",
-        crate::make_builtin_function("module_from_spec", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("module_from_spec", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "find_spec",
-        crate::make_builtin_function("find_spec", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("find_spec", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
@@ -3272,13 +3273,13 @@ fn init_importlib_machinery(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "all_suffixes",
-        crate::make_builtin_function("all_suffixes", |_| {
+        crate::make_builtin_function_with_arity("all_suffixes", |_| {
             Ok(pyre_object::w_list_new(vec![
                 pyre_object::w_str_new(".py"),
                 pyre_object::w_str_new(".pyc"),
                 pyre_object::w_str_new(".so"),
             ]))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(ns, "ModuleSpec", crate::typedef::w_object());
     crate::dict_storage_store(ns, "BuiltinImporter", crate::typedef::w_object());
@@ -3302,7 +3303,7 @@ fn init_imp(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "is_builtin",
-        crate::make_builtin_function("is_builtin", |args| {
+        crate::make_builtin_function_with_arity("is_builtin", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_int_new(0));
             }
@@ -3315,74 +3316,74 @@ fn init_imp(ns: &mut DictStorage) {
             };
             let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(name));
             Ok(pyre_object::w_int_new(if is_builtin { 1 } else { 0 }))
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "is_frozen",
-        crate::make_builtin_function("is_frozen", |_| Ok(pyre_object::w_bool_from(false))),
+        crate::make_builtin_function_with_arity("is_frozen", |_| Ok(pyre_object::w_bool_from(false)), 0),
     );
     crate::dict_storage_store(
         ns,
         "is_frozen_package",
-        crate::make_builtin_function("is_frozen_package", |_| Ok(pyre_object::w_bool_from(false))),
+        crate::make_builtin_function_with_arity("is_frozen_package", |_| Ok(pyre_object::w_bool_from(false)), 0),
     );
     crate::dict_storage_store(
         ns,
         "get_frozen_object",
-        crate::make_builtin_function("get_frozen_object", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("get_frozen_object", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "create_builtin",
-        crate::make_builtin_function("create_builtin", |args| {
+        crate::make_builtin_function_with_arity("create_builtin", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
             Ok(args[0])
-        }),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "exec_builtin",
-        crate::make_builtin_function("exec_builtin", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("exec_builtin", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
         "exec_dynamic",
-        crate::make_builtin_function("exec_dynamic", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("exec_dynamic", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
         "acquire_lock",
-        crate::make_builtin_function("acquire_lock", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("acquire_lock", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "release_lock",
-        crate::make_builtin_function("release_lock", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("release_lock", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "lock_held",
-        crate::make_builtin_function("lock_held", |_| Ok(pyre_object::w_bool_from(false))),
+        crate::make_builtin_function_with_arity("lock_held", |_| Ok(pyre_object::w_bool_from(false)), 0),
     );
     crate::dict_storage_store(
         ns,
         "_fix_co_filename",
-        crate::make_builtin_function("_fix_co_filename", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("_fix_co_filename", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "extension_suffixes",
-        crate::make_builtin_function("extension_suffixes", |_| {
+        crate::make_builtin_function_with_arity("extension_suffixes", |_| {
             Ok(pyre_object::w_list_new(vec![]))
-        }),
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "source_hash",
-        crate::make_builtin_function("source_hash", |_| Ok(pyre_object::w_int_new(0))),
+        crate::make_builtin_function_with_arity("source_hash", |_| Ok(pyre_object::w_int_new(0)), 0),
     );
     crate::dict_storage_store(
         ns,
@@ -3616,47 +3617,47 @@ fn init_codecs(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "lookup_error",
-        crate::make_builtin_function("lookup_error", |_| {
-            Ok(crate::make_builtin_function("error_handler", |args| {
+        crate::make_builtin_function_with_arity("lookup_error", |_| {
+            Ok(crate::make_builtin_function_with_arity("error_handler", |args| {
                 Ok(if args.is_empty() {
                     pyre_object::w_none()
                 } else {
                     args[0]
                 })
-            }))
-        }),
+            }, 1))
+        }, 0),
     );
     crate::dict_storage_store(
         ns,
         "register_error",
-        crate::make_builtin_function("register_error", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("register_error", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "register",
-        crate::make_builtin_function("register", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("register", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(
         ns,
         "lookup",
-        crate::make_builtin_function("lookup", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("lookup", |_| Ok(pyre_object::w_none()), 0),
     );
     // encode/decode — return input unchanged. Matches PyPy _codecs.encode
     // when the codec is the identity.
-    let identity = crate::make_builtin_function("identity", |args| {
+    let identity = crate::make_builtin_function_with_arity("identity", |args| {
         Ok(if args.is_empty() {
             pyre_object::w_none()
         } else {
             args[0]
         })
-    });
+    }, 1);
     crate::dict_storage_store(ns, "encode", identity);
     crate::dict_storage_store(ns, "decode", identity);
     crate::dict_storage_store(ns, "_forget_codec", identity);
     crate::dict_storage_store(
         ns,
         "charmap_build",
-        crate::make_builtin_function("charmap_build", |_| Ok(pyre_object::w_dict_new())),
+        crate::make_builtin_function_with_arity("charmap_build", |_| Ok(pyre_object::w_dict_new()), 0),
     );
 }
 
@@ -3667,7 +3668,7 @@ fn init_copyreg(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "pickle",
-        crate::make_builtin_function("pickle", |_| Ok(pyre_object::w_none())),
+        crate::make_builtin_function_with_arity("pickle", |_| Ok(pyre_object::w_none()), 0),
     );
     crate::dict_storage_store(ns, "dispatch_table", pyre_object::w_dict_new());
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1461,7 +1461,7 @@ fn init_functools(ns: &mut DictStorage) {
             Ok(crate::make_builtin_function_with_arity("cmp_to_key.K", |args| {
                 Ok(args.first().copied().unwrap_or(pyre_object::w_none()))
             }, 1))
-        }, 0),
+        }, 1),
     );
 }
 
@@ -2022,7 +2022,7 @@ fn init_posix(ns: &mut DictStorage) {
         crate::dict_storage_store(
             ns,
             name,
-            crate::make_builtin_function_with_arity(name, |_| Ok(pyre_object::w_none()), 0),
+            crate::make_builtin_function(name, |_| Ok(pyre_object::w_none())),
         );
     }
 
@@ -3625,22 +3625,22 @@ fn init_codecs(ns: &mut DictStorage) {
                     args[0]
                 })
             }, 1))
-        }, 0),
+        }, 1),
     );
     crate::dict_storage_store(
         ns,
         "register_error",
-        crate::make_builtin_function_with_arity("register_error", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("register_error", |_| Ok(pyre_object::w_none()), 2),
     );
     crate::dict_storage_store(
         ns,
         "register",
-        crate::make_builtin_function_with_arity("register", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("register", |_| Ok(pyre_object::w_none()), 1),
     );
     crate::dict_storage_store(
         ns,
         "lookup",
-        crate::make_builtin_function_with_arity("lookup", |_| Ok(pyre_object::w_none()), 0),
+        crate::make_builtin_function_with_arity("lookup", |_| Ok(pyre_object::w_none()), 1),
     );
     // encode/decode — return input unchanged. Matches PyPy _codecs.encode
     // when the codec is the identity.
@@ -3657,7 +3657,7 @@ fn init_codecs(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "charmap_build",
-        crate::make_builtin_function_with_arity("charmap_build", |_| Ok(pyre_object::w_dict_new()), 0),
+        crate::make_builtin_function_with_arity("charmap_build", |_| Ok(pyre_object::w_dict_new()), 1),
     );
 }
 

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -51,8 +51,11 @@ pub use executioncontext::*;
 pub use frame_array::*;
 pub use function::*;
 pub use gateway::{
-    BUILTIN_CODE_TYPE, BuiltinCode, BuiltinCodeFn, builtin_code_get, builtin_code_name,
-    builtin_code_new, is_builtin_code, make_builtin_function, make_module_builtin_function,
+    BUILTIN_CODE_TYPE, BuiltinCode, BuiltinCodeFn, FLATPYCALL, HOPELESS, PASSTHROUGHARGS1,
+    builtin_code_get, builtin_code_get_fast_natural_arity, builtin_code_name,
+    builtin_code_new, builtin_code_new_with_arity, is_builtin_code,
+    make_builtin_function, make_builtin_function_with_arity,
+    make_module_builtin_function, make_module_builtin_function_with_arity,
 };
 pub use jit_fnaddr::*;
 pub use malachite_bigint::BigInt as PyBigInt;

--- a/pyre/pyre-interpreter/src/module/_sre/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/moduledef.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses sre-engine crate (RustPython's SRE bytecode interpreter).
 
-use crate::{DictStorage, dict_storage_store, make_builtin_function, make_builtin_function_with_arity, make_module_builtin_function, make_module_builtin_function_with_arity};
+use crate::{DictStorage, dict_storage_store, make_builtin_function, make_module_builtin_function, make_module_builtin_function_with_arity};
 use pyre_object::*;
 use sre_engine::engine::{Request, State};
 use std::cell::RefCell;
@@ -88,7 +88,7 @@ pub fn init(ns: &mut DictStorage) {
             Ok(w_int_new(sre_engine::string::lower_unicode(
                 unsafe { w_int_get_value(args[0]) } as u32
             ) as i64))
-        }, 1),
+        }, 2),
     );
     // Create SRE_Pattern and SRE_Match types.
     // PyPy: interp_sre.py W_SRE_Pattern, W_SRE_Match
@@ -143,10 +143,10 @@ fn init_sre_match_type(ns: &mut DictStorage) {
     // protocol and binds `m` as the first positional argument. PyPy:
     // interp_sre.W_SRE_Match typedef — same layout.
     dict_storage_store(ns, "group", make_builtin_function("group", sre_match_group));
-    dict_storage_store(ns, "groups", make_builtin_function_with_arity("groups", sre_match_groups, 1));
-    dict_storage_store(ns, "start", make_builtin_function_with_arity("start", sre_match_start, 1));
-    dict_storage_store(ns, "end", make_builtin_function_with_arity("end", sre_match_end, 1));
-    dict_storage_store(ns, "span", make_builtin_function_with_arity("span", sre_match_span, 1));
+    dict_storage_store(ns, "groups", make_builtin_function("groups", sre_match_groups));
+    dict_storage_store(ns, "start", make_builtin_function("start", sre_match_start));
+    dict_storage_store(ns, "end", make_builtin_function("end", sre_match_end));
+    dict_storage_store(ns, "span", make_builtin_function("span", sre_match_span));
 }
 
 /// _sre.compile(pattern, flags, code, groups, groupindex, indexgroup)

--- a/pyre/pyre-interpreter/src/module/_sre/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/moduledef.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses sre-engine crate (RustPython's SRE bytecode interpreter).
 
-use crate::{DictStorage, dict_storage_store, make_builtin_function, make_module_builtin_function};
+use crate::{DictStorage, dict_storage_store, make_builtin_function, make_builtin_function_with_arity, make_module_builtin_function, make_module_builtin_function_with_arity};
 use pyre_object::*;
 use sre_engine::engine::{Request, State};
 use std::cell::RefCell;
@@ -29,66 +29,66 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "ascii_iscased",
-        make_module_builtin_function("ascii_iscased", |args| {
+        make_module_builtin_function_with_arity("ascii_iscased", |args| {
             if args.is_empty() {
                 return Ok(w_bool_from(false));
             }
             let ch = unsafe { w_int_get_value(args[0]) } as u8 as char;
             Ok(w_bool_from(ch.is_ascii_alphabetic()))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "unicode_iscased",
-        make_module_builtin_function("unicode_iscased", |args| {
+        make_module_builtin_function_with_arity("unicode_iscased", |args| {
             if args.is_empty() {
                 return Ok(w_bool_from(false));
             }
             let ch = char::from_u32(unsafe { w_int_get_value(args[0]) } as u32).unwrap_or('\0');
             Ok(w_bool_from(ch.is_alphabetic()))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "ascii_tolower",
-        make_module_builtin_function("ascii_tolower", |args| {
+        make_module_builtin_function_with_arity("ascii_tolower", |args| {
             if args.is_empty() {
                 return Ok(w_int_new(0));
             }
             Ok(w_int_new(
                 (unsafe { w_int_get_value(args[0]) } as u8).to_ascii_lowercase() as i64,
             ))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "unicode_tolower",
-        make_module_builtin_function("unicode_tolower", |args| {
+        make_module_builtin_function_with_arity("unicode_tolower", |args| {
             if args.is_empty() {
                 return Ok(w_int_new(0));
             }
             let c = char::from_u32(unsafe { w_int_get_value(args[0]) } as u32).unwrap_or('\0');
             Ok(w_int_new(c.to_lowercase().next().unwrap_or(c) as i64))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "getcodesize",
-        make_module_builtin_function("getcodesize", |_| {
+        make_module_builtin_function_with_arity("getcodesize", |_| {
             Ok(w_int_new(sre_engine::CODESIZE as i64))
-        }),
+        }, 0),
     );
     dict_storage_store(
         ns,
         "getlower",
-        make_module_builtin_function("getlower", |args| {
+        make_module_builtin_function_with_arity("getlower", |args| {
             if args.is_empty() {
                 return Ok(w_int_new(0));
             }
             Ok(w_int_new(sre_engine::string::lower_unicode(
                 unsafe { w_int_get_value(args[0]) } as u32
             ) as i64))
-        }),
+        }, 1),
     );
     // Create SRE_Pattern and SRE_Match types.
     // PyPy: interp_sre.py W_SRE_Pattern, W_SRE_Match
@@ -142,15 +142,11 @@ fn init_sre_match_type(ns: &mut DictStorage) {
     // Register methods on the type so `m.group()` goes through the descriptor
     // protocol and binds `m` as the first positional argument. PyPy:
     // interp_sre.W_SRE_Match typedef — same layout.
-    for (name, func) in [
-        ("group", sre_match_group as fn(&[PyObjectRef]) -> _),
-        ("groups", sre_match_groups),
-        ("start", sre_match_start),
-        ("end", sre_match_end),
-        ("span", sre_match_span),
-    ] {
-        dict_storage_store(ns, name, make_builtin_function(name, func));
-    }
+    dict_storage_store(ns, "group", make_builtin_function("group", sre_match_group));
+    dict_storage_store(ns, "groups", make_builtin_function_with_arity("groups", sre_match_groups, 1));
+    dict_storage_store(ns, "start", make_builtin_function_with_arity("start", sre_match_start, 1));
+    dict_storage_store(ns, "end", make_builtin_function_with_arity("end", sre_match_end, 1));
+    dict_storage_store(ns, "span", make_builtin_function_with_arity("span", sre_match_span, 1));
 }
 
 /// _sre.compile(pattern, flags, code, groups, groupindex, indexgroup)

--- a/pyre/pyre-interpreter/src/module/_weakref/interp_weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp_weakref.rs
@@ -11,7 +11,7 @@
 
 #![allow(non_camel_case_types, non_snake_case)]
 
-use crate::{DictStorage, PyError, dict_storage_store, make_builtin_function};
+use crate::{DictStorage, PyError, dict_storage_store, make_builtin_function, make_builtin_function_with_arity};
 use pyre_object::*;
 
 use std::sync::OnceLock;
@@ -99,22 +99,22 @@ fn init_weakref_type(ns: &mut DictStorage) {
         "__init__",
         make_builtin_function("__init__", descr__init__weakref),
     );
-    dict_storage_store(ns, "__eq__", make_builtin_function("__eq__", descr__eq__));
-    dict_storage_store(ns, "__ne__", make_builtin_function("__ne__", descr__ne__));
+    dict_storage_store(ns, "__eq__", make_builtin_function_with_arity("__eq__", descr__eq__, 2));
+    dict_storage_store(ns, "__ne__", make_builtin_function_with_arity("__ne__", descr__ne__, 2));
     dict_storage_store(
         ns,
         "__hash__",
-        make_builtin_function("__hash__", descr_hash),
+        make_builtin_function_with_arity("__hash__", descr_hash, 1),
     );
     dict_storage_store(
         ns,
         "__call__",
-        make_builtin_function("__call__", descr_call),
+        make_builtin_function_with_arity("__call__", descr_call, 1),
     );
     dict_storage_store(
         ns,
         "__repr__",
-        make_builtin_function("__repr__", descr__repr__),
+        make_builtin_function_with_arity("__repr__", descr__repr__, 1),
     );
 }
 
@@ -147,12 +147,12 @@ fn init_proxy_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__hash__",
-        make_builtin_function("__hash__", proxy_descr__hash__),
+        make_builtin_function_with_arity("__hash__", proxy_descr__hash__, 1),
     );
     dict_storage_store(
         ns,
         "__repr__",
-        make_builtin_function("__repr__", descr__repr__),
+        make_builtin_function_with_arity("__repr__", descr__repr__, 1),
     );
     // **proxy_typedef_dict — interp__weakref.py:409.
     register_proxy_typedef_dict(ns, /*include_comparisons=*/ true);
@@ -191,12 +191,12 @@ fn init_callable_proxy_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__hash__",
-        make_builtin_function("__hash__", proxy_descr__hash__),
+        make_builtin_function_with_arity("__hash__", proxy_descr__hash__, 1),
     );
     dict_storage_store(
         ns,
         "__repr__",
-        make_builtin_function("__repr__", descr__repr__),
+        make_builtin_function_with_arity("__repr__", descr__repr__, 1),
     );
     dict_storage_store(
         ns,
@@ -1282,49 +1282,49 @@ pub fn proxy_delete(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
 /// typedefs end up with the same set of methods PyPy generates.
 fn register_proxy_typedef_dict(ns: &mut DictStorage, include_comparisons: bool) {
     // Forward + reflected binary arithmetic — interp__weakref.py:376-389.
-    dict_storage_store(ns, "__add__", make_builtin_function("__add__", proxy_add));
+    dict_storage_store(ns, "__add__", make_builtin_function_with_arity("__add__", proxy_add, 2));
     dict_storage_store(
         ns,
         "__radd__",
-        make_builtin_function("__radd__", proxy_radd),
+        make_builtin_function_with_arity("__radd__", proxy_radd, 2),
     );
-    dict_storage_store(ns, "__sub__", make_builtin_function("__sub__", proxy_sub));
+    dict_storage_store(ns, "__sub__", make_builtin_function_with_arity("__sub__", proxy_sub, 2));
     dict_storage_store(
         ns,
         "__rsub__",
-        make_builtin_function("__rsub__", proxy_rsub),
+        make_builtin_function_with_arity("__rsub__", proxy_rsub, 2),
     );
-    dict_storage_store(ns, "__mul__", make_builtin_function("__mul__", proxy_mul));
+    dict_storage_store(ns, "__mul__", make_builtin_function_with_arity("__mul__", proxy_mul, 2));
     dict_storage_store(
         ns,
         "__rmul__",
-        make_builtin_function("__rmul__", proxy_rmul),
+        make_builtin_function_with_arity("__rmul__", proxy_rmul, 2),
     );
     dict_storage_store(
         ns,
         "__truediv__",
-        make_builtin_function("__truediv__", proxy_truediv),
+        make_builtin_function_with_arity("__truediv__", proxy_truediv, 2),
     );
     dict_storage_store(
         ns,
         "__rtruediv__",
-        make_builtin_function("__rtruediv__", proxy_rtruediv),
+        make_builtin_function_with_arity("__rtruediv__", proxy_rtruediv, 2),
     );
     dict_storage_store(
         ns,
         "__floordiv__",
-        make_builtin_function("__floordiv__", proxy_floordiv),
+        make_builtin_function_with_arity("__floordiv__", proxy_floordiv, 2),
     );
     dict_storage_store(
         ns,
         "__rfloordiv__",
-        make_builtin_function("__rfloordiv__", proxy_rfloordiv),
+        make_builtin_function_with_arity("__rfloordiv__", proxy_rfloordiv, 2),
     );
-    dict_storage_store(ns, "__mod__", make_builtin_function("__mod__", proxy_mod));
+    dict_storage_store(ns, "__mod__", make_builtin_function_with_arity("__mod__", proxy_mod, 2));
     dict_storage_store(
         ns,
         "__rmod__",
-        make_builtin_function("__rmod__", proxy_rmod),
+        make_builtin_function_with_arity("__rmod__", proxy_rmod, 2),
     );
     dict_storage_store(ns, "__pow__", make_builtin_function("__pow__", proxy_pow));
     dict_storage_store(
@@ -1335,217 +1335,217 @@ fn register_proxy_typedef_dict(ns: &mut DictStorage, include_comparisons: bool) 
     dict_storage_store(
         ns,
         "__lshift__",
-        make_builtin_function("__lshift__", proxy_lshift),
+        make_builtin_function_with_arity("__lshift__", proxy_lshift, 2),
     );
     dict_storage_store(
         ns,
         "__rlshift__",
-        make_builtin_function("__rlshift__", proxy_rlshift),
+        make_builtin_function_with_arity("__rlshift__", proxy_rlshift, 2),
     );
     dict_storage_store(
         ns,
         "__rshift__",
-        make_builtin_function("__rshift__", proxy_rshift),
+        make_builtin_function_with_arity("__rshift__", proxy_rshift, 2),
     );
     dict_storage_store(
         ns,
         "__rrshift__",
-        make_builtin_function("__rrshift__", proxy_rrshift),
+        make_builtin_function_with_arity("__rrshift__", proxy_rrshift, 2),
     );
-    dict_storage_store(ns, "__and__", make_builtin_function("__and__", proxy_and));
+    dict_storage_store(ns, "__and__", make_builtin_function_with_arity("__and__", proxy_and, 2));
     dict_storage_store(
         ns,
         "__rand__",
-        make_builtin_function("__rand__", proxy_rand),
+        make_builtin_function_with_arity("__rand__", proxy_rand, 2),
     );
-    dict_storage_store(ns, "__or__", make_builtin_function("__or__", proxy_or));
-    dict_storage_store(ns, "__ror__", make_builtin_function("__ror__", proxy_ror));
-    dict_storage_store(ns, "__xor__", make_builtin_function("__xor__", proxy_xor));
+    dict_storage_store(ns, "__or__", make_builtin_function_with_arity("__or__", proxy_or, 2));
+    dict_storage_store(ns, "__ror__", make_builtin_function_with_arity("__ror__", proxy_ror, 2));
+    dict_storage_store(ns, "__xor__", make_builtin_function_with_arity("__xor__", proxy_xor, 2));
     dict_storage_store(
         ns,
         "__rxor__",
-        make_builtin_function("__rxor__", proxy_rxor),
+        make_builtin_function_with_arity("__rxor__", proxy_rxor, 2),
     );
     // baseobjspace.py:2159 divmod row — forward + reflected.
     dict_storage_store(
         ns,
         "__divmod__",
-        make_builtin_function("__divmod__", proxy_divmod),
+        make_builtin_function_with_arity("__divmod__", proxy_divmod, 2),
     );
     dict_storage_store(
         ns,
         "__rdivmod__",
-        make_builtin_function("__rdivmod__", proxy_rdivmod),
+        make_builtin_function_with_arity("__rdivmod__", proxy_rdivmod, 2),
     );
 
     // Inplace ops — interp__weakref.py:367-369.
     dict_storage_store(
         ns,
         "__iadd__",
-        make_builtin_function("__iadd__", proxy_iadd),
+        make_builtin_function_with_arity("__iadd__", proxy_iadd, 2),
     );
     dict_storage_store(
         ns,
         "__isub__",
-        make_builtin_function("__isub__", proxy_isub),
+        make_builtin_function_with_arity("__isub__", proxy_isub, 2),
     );
     dict_storage_store(
         ns,
         "__imul__",
-        make_builtin_function("__imul__", proxy_imul),
+        make_builtin_function_with_arity("__imul__", proxy_imul, 2),
     );
     dict_storage_store(
         ns,
         "__itruediv__",
-        make_builtin_function("__itruediv__", proxy_itruediv),
+        make_builtin_function_with_arity("__itruediv__", proxy_itruediv, 2),
     );
     dict_storage_store(
         ns,
         "__ifloordiv__",
-        make_builtin_function("__ifloordiv__", proxy_ifloordiv),
+        make_builtin_function_with_arity("__ifloordiv__", proxy_ifloordiv, 2),
     );
     dict_storage_store(
         ns,
         "__imod__",
-        make_builtin_function("__imod__", proxy_imod),
+        make_builtin_function_with_arity("__imod__", proxy_imod, 2),
     );
     dict_storage_store(
         ns,
         "__ipow__",
-        make_builtin_function("__ipow__", proxy_ipow),
+        make_builtin_function_with_arity("__ipow__", proxy_ipow, 2),
     );
     dict_storage_store(
         ns,
         "__ilshift__",
-        make_builtin_function("__ilshift__", proxy_ilshift),
+        make_builtin_function_with_arity("__ilshift__", proxy_ilshift, 2),
     );
     dict_storage_store(
         ns,
         "__irshift__",
-        make_builtin_function("__irshift__", proxy_irshift),
+        make_builtin_function_with_arity("__irshift__", proxy_irshift, 2),
     );
     dict_storage_store(
         ns,
         "__iand__",
-        make_builtin_function("__iand__", proxy_iand),
+        make_builtin_function_with_arity("__iand__", proxy_iand, 2),
     );
-    dict_storage_store(ns, "__ior__", make_builtin_function("__ior__", proxy_ior));
+    dict_storage_store(ns, "__ior__", make_builtin_function_with_arity("__ior__", proxy_ior, 2));
     dict_storage_store(
         ns,
         "__ixor__",
-        make_builtin_function("__ixor__", proxy_ixor),
+        make_builtin_function_with_arity("__ixor__", proxy_ixor, 2),
     );
 
     // Single-dunder rows — interp__weakref.py:393-395.
     dict_storage_store(
         ns,
         "__format__",
-        make_builtin_function("__format__", proxy_format),
+        make_builtin_function_with_arity("__format__", proxy_format, 2),
     );
-    dict_storage_store(ns, "__str__", make_builtin_function("__str__", proxy_str));
-    dict_storage_store(ns, "__len__", make_builtin_function("__len__", proxy_len));
+    dict_storage_store(ns, "__str__", make_builtin_function_with_arity("__str__", proxy_str, 1));
+    dict_storage_store(ns, "__len__", make_builtin_function_with_arity("__len__", proxy_len, 1));
     dict_storage_store(
         ns,
         "__getattribute__",
-        make_builtin_function("__getattribute__", proxy_getattribute),
+        make_builtin_function_with_arity("__getattribute__", proxy_getattribute, 2),
     );
     dict_storage_store(
         ns,
         "__setattr__",
-        make_builtin_function("__setattr__", proxy_setattr),
+        make_builtin_function_with_arity("__setattr__", proxy_setattr, 3),
     );
     dict_storage_store(
         ns,
         "__delattr__",
-        make_builtin_function("__delattr__", proxy_delattr),
+        make_builtin_function_with_arity("__delattr__", proxy_delattr, 2),
     );
     dict_storage_store(
         ns,
         "__getitem__",
-        make_builtin_function("__getitem__", proxy_getitem),
+        make_builtin_function_with_arity("__getitem__", proxy_getitem, 2),
     );
     dict_storage_store(
         ns,
         "__setitem__",
-        make_builtin_function("__setitem__", proxy_setitem),
+        make_builtin_function_with_arity("__setitem__", proxy_setitem, 3),
     );
     dict_storage_store(
         ns,
         "__delitem__",
-        make_builtin_function("__delitem__", proxy_delitem),
+        make_builtin_function_with_arity("__delitem__", proxy_delitem, 2),
     );
     dict_storage_store(
         ns,
         "__trunc__",
-        make_builtin_function("__trunc__", proxy_trunc),
+        make_builtin_function_with_arity("__trunc__", proxy_trunc, 1),
     );
-    dict_storage_store(ns, "__pos__", make_builtin_function("__pos__", proxy_pos));
-    dict_storage_store(ns, "__neg__", make_builtin_function("__neg__", proxy_neg));
+    dict_storage_store(ns, "__pos__", make_builtin_function_with_arity("__pos__", proxy_pos, 1));
+    dict_storage_store(ns, "__neg__", make_builtin_function_with_arity("__neg__", proxy_neg, 1));
     dict_storage_store(
         ns,
         "__bool__",
-        make_builtin_function("__bool__", proxy_bool),
+        make_builtin_function_with_arity("__bool__", proxy_bool, 1),
     );
-    dict_storage_store(ns, "__abs__", make_builtin_function("__abs__", proxy_abs));
+    dict_storage_store(ns, "__abs__", make_builtin_function_with_arity("__abs__", proxy_abs, 1));
     dict_storage_store(
         ns,
         "__invert__",
-        make_builtin_function("__invert__", proxy_invert),
+        make_builtin_function_with_arity("__invert__", proxy_invert, 1),
     );
-    dict_storage_store(ns, "__int__", make_builtin_function("__int__", proxy_int));
+    dict_storage_store(ns, "__int__", make_builtin_function_with_arity("__int__", proxy_int, 1));
     dict_storage_store(
         ns,
         "__index__",
-        make_builtin_function("__index__", proxy_index),
+        make_builtin_function_with_arity("__index__", proxy_index, 1),
     );
     dict_storage_store(
         ns,
         "__float__",
-        make_builtin_function("__float__", proxy_float),
+        make_builtin_function_with_arity("__float__", proxy_float, 1),
     );
     dict_storage_store(
         ns,
         "__contains__",
-        make_builtin_function("__contains__", proxy_contains),
+        make_builtin_function_with_arity("__contains__", proxy_contains, 2),
     );
     dict_storage_store(
         ns,
         "__iter__",
-        make_builtin_function("__iter__", proxy_iter),
+        make_builtin_function_with_arity("__iter__", proxy_iter, 1),
     );
     dict_storage_store(
         ns,
         "__next__",
-        make_builtin_function("__next__", proxy_next),
+        make_builtin_function_with_arity("__next__", proxy_next, 1),
     );
-    dict_storage_store(ns, "__get__", make_builtin_function("__get__", proxy_get));
-    dict_storage_store(ns, "__set__", make_builtin_function("__set__", proxy_set));
+    dict_storage_store(ns, "__get__", make_builtin_function_with_arity("__get__", proxy_get, 3));
+    dict_storage_store(ns, "__set__", make_builtin_function_with_arity("__set__", proxy_set, 3));
     dict_storage_store(
         ns,
         "__delete__",
-        make_builtin_function("__delete__", proxy_delete),
+        make_builtin_function_with_arity("__delete__", proxy_delete, 2),
     );
     // baseobjspace.py:2127-2128 isinstance / issubtype rows.
     dict_storage_store(
         ns,
         "__instancecheck__",
-        make_builtin_function("__instancecheck__", proxy_instancecheck),
+        make_builtin_function_with_arity("__instancecheck__", proxy_instancecheck, 2),
     );
     dict_storage_store(
         ns,
         "__subclasscheck__",
-        make_builtin_function("__subclasscheck__", proxy_subclasscheck),
+        make_builtin_function_with_arity("__subclasscheck__", proxy_subclasscheck, 2),
     );
 
     // interp__weakref.py:390-391 — comparison ops are registered only on
     // `proxy_typedef_dict`, not `callable_proxy_typedef_dict`.
     if include_comparisons {
-        dict_storage_store(ns, "__lt__", make_builtin_function("__lt__", proxy_lt));
-        dict_storage_store(ns, "__le__", make_builtin_function("__le__", proxy_le));
-        dict_storage_store(ns, "__gt__", make_builtin_function("__gt__", proxy_gt));
-        dict_storage_store(ns, "__ge__", make_builtin_function("__ge__", proxy_ge));
-        dict_storage_store(ns, "__eq__", make_builtin_function("__eq__", proxy_eq));
-        dict_storage_store(ns, "__ne__", make_builtin_function("__ne__", proxy_ne));
+        dict_storage_store(ns, "__lt__", make_builtin_function_with_arity("__lt__", proxy_lt, 2));
+        dict_storage_store(ns, "__le__", make_builtin_function_with_arity("__le__", proxy_le, 2));
+        dict_storage_store(ns, "__gt__", make_builtin_function_with_arity("__gt__", proxy_gt, 2));
+        dict_storage_store(ns, "__ge__", make_builtin_function_with_arity("__ge__", proxy_ge, 2));
+        dict_storage_store(ns, "__eq__", make_builtin_function_with_arity("__eq__", proxy_eq, 2));
+        dict_storage_store(ns, "__ne__", make_builtin_function_with_arity("__ne__", proxy_ne, 2));
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_weakref/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/moduledef.rs
@@ -19,6 +19,7 @@
 
 use crate::DictStorage;
 use crate::module::_weakref::interp_weakref;
+use crate::make_module_builtin_function_with_arity;
 
 pub fn init(ns: &mut DictStorage) {
     // pypy/module/_weakref/moduledef.py:6-13 interpleveldefs:
@@ -44,12 +45,12 @@ pub fn init(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "getweakrefcount",
-        crate::make_builtin_function("getweakrefcount", interp_weakref::getweakrefcount),
+        make_module_builtin_function_with_arity("getweakrefcount", interp_weakref::getweakrefcount, 1),
     );
     crate::dict_storage_store(
         ns,
         "getweakrefs",
-        crate::make_builtin_function("getweakrefs", interp_weakref::getweakrefs),
+        make_module_builtin_function_with_arity("getweakrefs", interp_weakref::getweakrefs, 1),
     );
     // CPython-specific helper used by weakref.py to clean up dead refs
     // from WeakValueDictionary. PyPy doesn't expose it because PyPy's
@@ -57,6 +58,6 @@ pub fn init(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "_remove_dead_weakref",
-        crate::make_builtin_function("_remove_dead_weakref", |_| Ok(pyre_object::w_none())),
+        make_module_builtin_function_with_arity("_remove_dead_weakref", |_| Ok(pyre_object::w_none()), 2),
     );
 }

--- a/pyre/pyre-interpreter/src/module/math/cmath_moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/math/cmath_moduledef.rs
@@ -6,7 +6,7 @@
 //! Functions are registered so `import cmath` succeeds, but complex
 //! arithmetic requires W_ComplexObject (future work).
 
-use crate::{DictStorage, dict_storage_store, make_builtin_function};
+use crate::{DictStorage, dict_storage_store, make_builtin_function, make_builtin_function_with_arity};
 use pyre_object::*;
 
 pub fn init(ns: &mut DictStorage) {
@@ -22,58 +22,58 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "phase",
-        make_builtin_function("phase", |args| {
+        make_builtin_function_with_arity("phase", |args| {
             Ok(floatobject::w_float_new(
                 super::interp_math::get_double(args[0]).atan2(0.0),
             ))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "polar",
-        make_builtin_function("polar", |args| {
+        make_builtin_function_with_arity("polar", |args| {
             let x = super::interp_math::get_double(args[0]);
             Ok(w_tuple_new(vec![
                 floatobject::w_float_new(x.abs()),
                 floatobject::w_float_new(0.0),
             ]))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "rect",
-        make_builtin_function("rect", |args| {
+        make_builtin_function_with_arity("rect", |args| {
             let r = super::interp_math::get_double(args[0]);
             let phi = super::interp_math::get_double(args[1]);
             Ok(floatobject::w_float_new(r * phi.cos()))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "isfinite",
-        make_builtin_function("isfinite", |args| {
+        make_builtin_function_with_arity("isfinite", |args| {
             Ok(w_bool_from(
                 super::interp_math::get_double(args[0]).is_finite(),
             ))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "isinf",
-        make_builtin_function("isinf", |args| {
+        make_builtin_function_with_arity("isinf", |args| {
             Ok(w_bool_from(
                 super::interp_math::get_double(args[0]).is_infinite(),
             ))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "isnan",
-        make_builtin_function("isnan", |args| {
+        make_builtin_function_with_arity("isnan", |args| {
             Ok(w_bool_from(
                 super::interp_math::get_double(args[0]).is_nan(),
             ))
-        }),
+        }, 1),
     );
 
     // Forward trig/exp functions to math equivalents for real input
@@ -83,7 +83,6 @@ pub fn init(ns: &mut DictStorage) {
             super::interp_math::sqrt as fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
         ),
         ("exp", super::interp_math::exp),
-        ("log", super::interp_math::log),
         ("log10", super::interp_math::log10),
         ("sin", super::interp_math::sin),
         ("cos", super::interp_math::cos),
@@ -98,6 +97,8 @@ pub fn init(ns: &mut DictStorage) {
         ("acosh", super::interp_math::acosh),
         ("atanh", super::interp_math::atanh),
     ] {
-        dict_storage_store(ns, name, make_builtin_function(name, func));
+        dict_storage_store(ns, name, make_builtin_function_with_arity(name, func, 1));
     }
+    // log accepts optional base argument — variable arity
+    dict_storage_store(ns, "log", make_builtin_function("log", super::interp_math::log));
 }

--- a/pyre/pyre-interpreter/src/module/math/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/math/moduledef.rs
@@ -3,7 +3,7 @@
 //! PyPy equivalent: pypy/module/math/moduledef.py
 
 use super::interp_math;
-use crate::{DictStorage, dict_storage_store, make_builtin_function};
+use crate::{DictStorage, dict_storage_store, make_builtin_function, make_builtin_function_with_arity};
 
 pub fn init(ns: &mut DictStorage) {
     // ── Constants (PyPy: interp_math.State.__init__) ─────────────────
@@ -34,134 +34,134 @@ pub fn init(ns: &mut DictStorage) {
     );
 
     // ── Trigonometric ────────────────────────────────────────────────
-    dict_storage_store(ns, "sin", make_builtin_function("sin", interp_math::sin));
-    dict_storage_store(ns, "cos", make_builtin_function("cos", interp_math::cos));
-    dict_storage_store(ns, "tan", make_builtin_function("tan", interp_math::tan));
-    dict_storage_store(ns, "asin", make_builtin_function("asin", interp_math::asin));
-    dict_storage_store(ns, "acos", make_builtin_function("acos", interp_math::acos));
-    dict_storage_store(ns, "atan", make_builtin_function("atan", interp_math::atan));
+    dict_storage_store(ns, "sin", make_builtin_function_with_arity("sin", interp_math::sin, 1));
+    dict_storage_store(ns, "cos", make_builtin_function_with_arity("cos", interp_math::cos, 1));
+    dict_storage_store(ns, "tan", make_builtin_function_with_arity("tan", interp_math::tan, 1));
+    dict_storage_store(ns, "asin", make_builtin_function_with_arity("asin", interp_math::asin, 1));
+    dict_storage_store(ns, "acos", make_builtin_function_with_arity("acos", interp_math::acos, 1));
+    dict_storage_store(ns, "atan", make_builtin_function_with_arity("atan", interp_math::atan, 1));
     dict_storage_store(
         ns,
         "atan2",
-        make_builtin_function("atan2", interp_math::atan2),
+        make_builtin_function_with_arity("atan2", interp_math::atan2, 2),
     );
-    dict_storage_store(ns, "sinh", make_builtin_function("sinh", interp_math::sinh));
-    dict_storage_store(ns, "cosh", make_builtin_function("cosh", interp_math::cosh));
-    dict_storage_store(ns, "tanh", make_builtin_function("tanh", interp_math::tanh));
+    dict_storage_store(ns, "sinh", make_builtin_function_with_arity("sinh", interp_math::sinh, 1));
+    dict_storage_store(ns, "cosh", make_builtin_function_with_arity("cosh", interp_math::cosh, 1));
+    dict_storage_store(ns, "tanh", make_builtin_function_with_arity("tanh", interp_math::tanh, 1));
     dict_storage_store(
         ns,
         "asinh",
-        make_builtin_function("asinh", interp_math::asinh),
+        make_builtin_function_with_arity("asinh", interp_math::asinh, 1),
     );
     dict_storage_store(
         ns,
         "acosh",
-        make_builtin_function("acosh", interp_math::acosh),
+        make_builtin_function_with_arity("acosh", interp_math::acosh, 1),
     );
     dict_storage_store(
         ns,
         "atanh",
-        make_builtin_function("atanh", interp_math::atanh),
+        make_builtin_function_with_arity("atanh", interp_math::atanh, 1),
     );
 
     // ── Exponential / logarithmic ───────────────────────────────────
-    dict_storage_store(ns, "sqrt", make_builtin_function("sqrt", interp_math::sqrt));
-    dict_storage_store(ns, "cbrt", make_builtin_function("cbrt", interp_math::cbrt));
-    dict_storage_store(ns, "exp", make_builtin_function("exp", interp_math::exp));
-    dict_storage_store(ns, "exp2", make_builtin_function("exp2", interp_math::exp2));
+    dict_storage_store(ns, "sqrt", make_builtin_function_with_arity("sqrt", interp_math::sqrt, 1));
+    dict_storage_store(ns, "cbrt", make_builtin_function_with_arity("cbrt", interp_math::cbrt, 1));
+    dict_storage_store(ns, "exp", make_builtin_function_with_arity("exp", interp_math::exp, 1));
+    dict_storage_store(ns, "exp2", make_builtin_function_with_arity("exp2", interp_math::exp2, 1));
     dict_storage_store(
         ns,
         "expm1",
-        make_builtin_function("expm1", interp_math::expm1),
+        make_builtin_function_with_arity("expm1", interp_math::expm1, 1),
     );
     dict_storage_store(ns, "log", make_builtin_function("log", interp_math::log));
-    dict_storage_store(ns, "log2", make_builtin_function("log2", interp_math::log2));
+    dict_storage_store(ns, "log2", make_builtin_function_with_arity("log2", interp_math::log2, 1));
     dict_storage_store(
         ns,
         "log10",
-        make_builtin_function("log10", interp_math::log10),
+        make_builtin_function_with_arity("log10", interp_math::log10, 1),
     );
     dict_storage_store(
         ns,
         "log1p",
-        make_builtin_function("log1p", interp_math::log1p),
+        make_builtin_function_with_arity("log1p", interp_math::log1p, 1),
     );
-    dict_storage_store(ns, "pow", make_builtin_function("pow", interp_math::pow));
+    dict_storage_store(ns, "pow", make_builtin_function_with_arity("pow", interp_math::pow, 2));
 
     // ── Gamma / error ───────────────────────────────────────────────
-    dict_storage_store(ns, "erf", make_builtin_function("erf", interp_math::erf));
-    dict_storage_store(ns, "erfc", make_builtin_function("erfc", interp_math::erfc));
+    dict_storage_store(ns, "erf", make_builtin_function_with_arity("erf", interp_math::erf, 1));
+    dict_storage_store(ns, "erfc", make_builtin_function_with_arity("erfc", interp_math::erfc, 1));
     dict_storage_store(
         ns,
         "gamma",
-        make_builtin_function("gamma", interp_math::gamma),
+        make_builtin_function_with_arity("gamma", interp_math::gamma, 1),
     );
     dict_storage_store(
         ns,
         "lgamma",
-        make_builtin_function("lgamma", interp_math::lgamma),
+        make_builtin_function_with_arity("lgamma", interp_math::lgamma, 1),
     );
 
     // ── Rounding / truncation ───────────────────────────────────────
     dict_storage_store(
         ns,
         "floor",
-        make_builtin_function("floor", interp_math::floor),
+        make_builtin_function_with_arity("floor", interp_math::floor, 1),
     );
-    dict_storage_store(ns, "ceil", make_builtin_function("ceil", interp_math::ceil));
+    dict_storage_store(ns, "ceil", make_builtin_function_with_arity("ceil", interp_math::ceil, 1));
     dict_storage_store(
         ns,
         "trunc",
-        make_builtin_function("trunc", interp_math::trunc),
+        make_builtin_function_with_arity("trunc", interp_math::trunc, 1),
     );
 
     // ── Floating-point manipulation ─────────────────────────────────
-    dict_storage_store(ns, "fabs", make_builtin_function("fabs", interp_math::fabs));
-    dict_storage_store(ns, "fmod", make_builtin_function("fmod", interp_math::fmod));
+    dict_storage_store(ns, "fabs", make_builtin_function_with_arity("fabs", interp_math::fabs, 1));
+    dict_storage_store(ns, "fmod", make_builtin_function_with_arity("fmod", interp_math::fmod, 2));
     dict_storage_store(
         ns,
         "copysign",
-        make_builtin_function("copysign", interp_math::copysign),
+        make_builtin_function_with_arity("copysign", interp_math::copysign, 2),
     );
     dict_storage_store(
         ns,
         "remainder",
-        make_builtin_function("remainder", interp_math::remainder),
+        make_builtin_function_with_arity("remainder", interp_math::remainder, 2),
     );
     dict_storage_store(
         ns,
         "frexp",
-        make_builtin_function("frexp", interp_math::frexp),
+        make_builtin_function_with_arity("frexp", interp_math::frexp, 1),
     );
     dict_storage_store(
         ns,
         "ldexp",
-        make_builtin_function("ldexp", interp_math::ldexp),
+        make_builtin_function_with_arity("ldexp", interp_math::ldexp, 2),
     );
-    dict_storage_store(ns, "modf", make_builtin_function("modf", interp_math::modf));
+    dict_storage_store(ns, "modf", make_builtin_function_with_arity("modf", interp_math::modf, 1));
     dict_storage_store(
         ns,
         "nextafter",
-        make_builtin_function("nextafter", interp_math::nextafter),
+        make_builtin_function_with_arity("nextafter", interp_math::nextafter, 2),
     );
-    dict_storage_store(ns, "ulp", make_builtin_function("ulp", interp_math::ulp));
-    dict_storage_store(ns, "fma", make_builtin_function("fma", interp_math::fma));
+    dict_storage_store(ns, "ulp", make_builtin_function_with_arity("ulp", interp_math::ulp, 1));
+    dict_storage_store(ns, "fma", make_builtin_function_with_arity("fma", interp_math::fma, 3));
 
     // ── Classification ──────────────────────────────────────────────
     dict_storage_store(
         ns,
         "isinf",
-        make_builtin_function("isinf", interp_math::isinf),
+        make_builtin_function_with_arity("isinf", interp_math::isinf, 1),
     );
     dict_storage_store(
         ns,
         "isnan",
-        make_builtin_function("isnan", interp_math::isnan),
+        make_builtin_function_with_arity("isnan", interp_math::isnan, 1),
     );
     dict_storage_store(
         ns,
         "isfinite",
-        make_builtin_function("isfinite", interp_math::isfinite),
+        make_builtin_function_with_arity("isfinite", interp_math::isfinite, 1),
     );
     dict_storage_store(
         ns,
@@ -173,12 +173,12 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "degrees",
-        make_builtin_function("degrees", interp_math::degrees),
+        make_builtin_function_with_arity("degrees", interp_math::degrees, 1),
     );
     dict_storage_store(
         ns,
         "radians",
-        make_builtin_function("radians", interp_math::radians),
+        make_builtin_function_with_arity("radians", interp_math::radians, 1),
     );
 
     // ── Multi-dimensional ───────────────────────────────────────────
@@ -187,30 +187,30 @@ pub fn init(ns: &mut DictStorage) {
         "hypot",
         make_builtin_function("hypot", interp_math::hypot),
     );
-    dict_storage_store(ns, "dist", make_builtin_function("dist", interp_math::dist));
+    dict_storage_store(ns, "dist", make_builtin_function_with_arity("dist", interp_math::dist, 2));
 
     // ── Aggregation ─────────────────────────────────────────────────
-    dict_storage_store(ns, "fsum", make_builtin_function("fsum", interp_math::fsum));
+    dict_storage_store(ns, "fsum", make_builtin_function_with_arity("fsum", interp_math::fsum, 1));
     dict_storage_store(ns, "prod", make_builtin_function("prod", interp_math::prod));
     dict_storage_store(
         ns,
         "sumprod",
-        make_builtin_function("sumprod", interp_math::sumprod),
+        make_builtin_function_with_arity("sumprod", interp_math::sumprod, 2),
     );
 
     // ── Integer math ────────────────────────────────────────────────
     dict_storage_store(
         ns,
         "factorial",
-        make_builtin_function("factorial", interp_math::factorial),
+        make_builtin_function_with_arity("factorial", interp_math::factorial, 1),
     );
     dict_storage_store(ns, "gcd", make_builtin_function("gcd", interp_math::gcd));
     dict_storage_store(ns, "lcm", make_builtin_function("lcm", interp_math::lcm));
-    dict_storage_store(ns, "comb", make_builtin_function("comb", interp_math::comb));
+    dict_storage_store(ns, "comb", make_builtin_function_with_arity("comb", interp_math::comb, 2));
     dict_storage_store(ns, "perm", make_builtin_function("perm", interp_math::perm));
     dict_storage_store(
         ns,
         "isqrt",
-        make_builtin_function("isqrt", interp_math::isqrt),
+        make_builtin_function_with_arity("isqrt", interp_math::isqrt, 1),
     );
 }

--- a/pyre/pyre-interpreter/src/module/math/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/math/moduledef.rs
@@ -142,7 +142,7 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "nextafter",
-        make_builtin_function_with_arity("nextafter", interp_math::nextafter, 2),
+        make_builtin_function("nextafter", interp_math::nextafter),
     );
     dict_storage_store(ns, "ulp", make_builtin_function_with_arity("ulp", interp_math::ulp, 1));
     dict_storage_store(ns, "fma", make_builtin_function_with_arity("fma", interp_math::fma, 3));

--- a/pyre/pyre-interpreter/src/module/operator/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/operator/moduledef.rs
@@ -2,7 +2,7 @@
 //!
 //! PyPy equivalent: pypy/module/operator/
 
-use crate::{DictStorage, dict_storage_store, make_builtin_function};
+use crate::{DictStorage, dict_storage_store, make_builtin_function, make_builtin_function_with_arity};
 use pyre_object::*;
 
 fn op_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -60,210 +60,210 @@ fn op_gt(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 pub fn init(ns: &mut DictStorage) {
-    dict_storage_store(ns, "index", make_builtin_function("index", op_index));
-    dict_storage_store(ns, "add", make_builtin_function("add", op_add));
-    dict_storage_store(ns, "sub", make_builtin_function("sub", op_sub));
-    dict_storage_store(ns, "mul", make_builtin_function("mul", op_mul));
+    dict_storage_store(ns, "index", make_builtin_function_with_arity("index", op_index, 1));
+    dict_storage_store(ns, "add", make_builtin_function_with_arity("add", op_add, 2));
+    dict_storage_store(ns, "sub", make_builtin_function_with_arity("sub", op_sub, 2));
+    dict_storage_store(ns, "mul", make_builtin_function_with_arity("mul", op_mul, 2));
     dict_storage_store(
         ns,
         "truediv",
-        make_builtin_function("truediv", |args| {
+        make_builtin_function_with_arity("truediv", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::truediv(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "floordiv",
-        make_builtin_function("floordiv", |args| {
+        make_builtin_function_with_arity("floordiv", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::floordiv(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "mod",
-        make_builtin_function("mod", |args| {
+        make_builtin_function_with_arity("mod", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::mod_(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "pow",
-        make_builtin_function("pow", |args| {
+        make_builtin_function_with_arity("pow", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::pow(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "neg",
-        make_builtin_function("neg", |args| {
+        make_builtin_function_with_arity("neg", |args| {
             assert!(args.len() == 1);
             crate::baseobjspace::neg(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "pos",
-        make_builtin_function("pos", |args| {
+        make_builtin_function_with_arity("pos", |args| {
             assert!(args.len() == 1);
             crate::baseobjspace::pos(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "abs",
-        make_builtin_function("abs", |args| {
+        make_builtin_function_with_arity("abs", |args| {
             assert!(args.len() == 1);
             crate::builtins::builtin_abs(args)
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "invert",
-        make_builtin_function("invert", |args| {
+        make_builtin_function_with_arity("invert", |args| {
             assert!(args.len() == 1);
             crate::baseobjspace::invert(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "lshift",
-        make_builtin_function("lshift", |args| {
+        make_builtin_function_with_arity("lshift", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::lshift(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "rshift",
-        make_builtin_function("rshift", |args| {
+        make_builtin_function_with_arity("rshift", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::rshift(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "and_",
-        make_builtin_function("and_", |args| {
+        make_builtin_function_with_arity("and_", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::and_(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "or_",
-        make_builtin_function("or_", |args| {
+        make_builtin_function_with_arity("or_", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::or_(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "xor",
-        make_builtin_function("xor", |args| {
+        make_builtin_function_with_arity("xor", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::xor(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "not_",
-        make_builtin_function("not_", |args| {
+        make_builtin_function_with_arity("not_", |args| {
             assert!(args.len() == 1);
             Ok(w_bool_from(!crate::baseobjspace::is_true(args[0])))
-        }),
+        }, 1),
     );
     // interp_operator.py:138
     dict_storage_store(
         ns,
         "truth",
-        make_builtin_function("truth", |args| {
+        make_builtin_function_with_arity("truth", |args| {
             assert!(args.len() == 1);
             Ok(w_bool_from(crate::baseobjspace::is_true(args[0])))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "is_",
-        make_builtin_function("is_", |args| {
+        make_builtin_function_with_arity("is_", |args| {
             assert!(args.len() == 2);
             Ok(w_bool_from(std::ptr::eq(args[0], args[1])))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "is_not",
-        make_builtin_function("is_not", |args| {
+        make_builtin_function_with_arity("is_not", |args| {
             assert!(args.len() == 2);
             Ok(w_bool_from(!std::ptr::eq(args[0], args[1])))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "contains",
-        make_builtin_function("contains", |args| {
+        make_builtin_function_with_arity("contains", |args| {
             assert!(args.len() == 2);
             Ok(w_bool_from(crate::baseobjspace::contains(
                 args[0], args[1],
             )?))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "getitem",
-        make_builtin_function("getitem", |args| {
+        make_builtin_function_with_arity("getitem", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::getitem(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "setitem",
-        make_builtin_function("setitem", |args| {
+        make_builtin_function_with_arity("setitem", |args| {
             assert!(args.len() == 3);
             crate::baseobjspace::setitem(args[0], args[1], args[2])?;
             Ok(w_none())
-        }),
+        }, 3),
     );
     dict_storage_store(
         ns,
         "delitem",
-        make_builtin_function("delitem", |args| {
+        make_builtin_function_with_arity("delitem", |args| {
             assert!(args.len() == 2);
             crate::baseobjspace::delitem(args[0], args[1])?;
             Ok(w_none())
-        }),
+        }, 2),
     );
     // Underscore aliases (CPython: __add__/__sub__/... via operator module).
-    dict_storage_store(ns, "__add__", make_builtin_function("__add__", op_add));
-    dict_storage_store(ns, "__sub__", make_builtin_function("__sub__", op_sub));
-    dict_storage_store(ns, "__mul__", make_builtin_function("__mul__", op_mul));
-    dict_storage_store(ns, "eq", make_builtin_function("eq", op_eq));
-    dict_storage_store(ns, "lt", make_builtin_function("lt", op_lt));
-    dict_storage_store(ns, "gt", make_builtin_function("gt", op_gt));
+    dict_storage_store(ns, "__add__", make_builtin_function_with_arity("__add__", op_add, 2));
+    dict_storage_store(ns, "__sub__", make_builtin_function_with_arity("__sub__", op_sub, 2));
+    dict_storage_store(ns, "__mul__", make_builtin_function_with_arity("__mul__", op_mul, 2));
+    dict_storage_store(ns, "eq", make_builtin_function_with_arity("eq", op_eq, 2));
+    dict_storage_store(ns, "lt", make_builtin_function_with_arity("lt", op_lt, 2));
+    dict_storage_store(ns, "gt", make_builtin_function_with_arity("gt", op_gt, 2));
     dict_storage_store(
         ns,
         "le",
-        make_builtin_function("le", |args| {
+        make_builtin_function_with_arity("le", |args| {
             crate::baseobjspace::compare(args[0], args[1], crate::baseobjspace::CompareOp::Le)
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "ge",
-        make_builtin_function("ge", |args| {
+        make_builtin_function_with_arity("ge", |args| {
             crate::baseobjspace::compare(args[0], args[1], crate::baseobjspace::CompareOp::Ge)
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "ne",
-        make_builtin_function("ne", |args| {
+        make_builtin_function_with_arity("ne", |args| {
             crate::baseobjspace::compare(args[0], args[1], crate::baseobjspace::CompareOp::Ne)
-        }),
+        }, 2),
     );
     // itemgetter/attrgetter stubs — return callable objects
     dict_storage_store(

--- a/pyre/pyre-interpreter/src/module/sys/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/sys/moduledef.rs
@@ -2,7 +2,7 @@
 //!
 //! PyPy equivalent: pypy/module/sys/
 
-use crate::{DictStorage, dict_storage_store};
+use crate::{DictStorage, dict_storage_store, make_builtin_function_with_arity};
 use pyre_object::*;
 use std::sync::OnceLock;
 
@@ -174,7 +174,7 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "exc_info",
-        crate::make_builtin_function("exc_info", |_| {
+        make_builtin_function_with_arity("exc_info", |_| {
             let exc = crate::eval::get_current_exception();
             unsafe {
                 if exc.is_null() || pyre_object::is_none(exc) || !pyre_object::is_exception(exc) {
@@ -185,7 +185,7 @@ pub fn init(ns: &mut DictStorage) {
                     Ok(w_tuple_new(vec![exc_type, exc, w_none()]))
                 }
             }
-        }),
+        }, 0),
     );
     // sys.flags — pypy/module/sys/app.py:99-119 `class sysflags` with
     // `__metaclass__ = structseqtype`. PyPy exposes it as a structseq
@@ -233,7 +233,7 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "getdefaultencoding",
-        crate::make_builtin_function("getdefaultencoding", |_| Ok(w_str_new("utf-8"))),
+        make_builtin_function_with_arity("getdefaultencoding", |_| Ok(w_str_new("utf-8")), 0),
     );
     // sys.getrecursionlimit / setrecursionlimit — pypy/module/sys/vm.py:45.
     // The runtime stack budget lives in `crate::stack_check`; both
@@ -242,7 +242,7 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "getrecursionlimit",
-        crate::make_builtin_function("getrecursionlimit", |args| {
+        make_builtin_function_with_arity("getrecursionlimit", |args| {
             // pypy/module/sys/vm.py:72 — no arguments.
             if !args.is_empty() {
                 return Err(crate::PyError::type_error(
@@ -250,12 +250,12 @@ pub fn init(ns: &mut DictStorage) {
                 ));
             }
             Ok(w_int_new(crate::stack_check::get_recursion_limit() as i64))
-        }),
+        }, 0),
     );
     dict_storage_store(
         ns,
         "setrecursionlimit",
-        crate::make_builtin_function("setrecursionlimit", |args| {
+        make_builtin_function_with_arity("setrecursionlimit", |args| {
             // pypy/module/sys/vm.py:63 `@unwrap_spec(new_limit="c_int")`
             // — exactly one positional argument, coerced through
             // baseobjspace.c_int_w (gateway_int_w + 32-bit range
@@ -270,19 +270,19 @@ pub fn init(ns: &mut DictStorage) {
             let new_limit = crate::baseobjspace::c_int_w(args[0])?;
             crate::stack_check::set_recursion_limit(new_limit)?;
             Ok(w_none())
-        }),
+        }, 1),
     );
     // sys.intern
     dict_storage_store(
         ns,
         "intern",
-        crate::make_builtin_function("intern", |args| {
+        make_builtin_function_with_arity("intern", |args| {
             Ok(if args.is_empty() {
                 w_str_new("")
             } else {
                 args[0]
             })
-        }),
+        }, 1),
     );
     // sys.implementation — structseq-like namespace with name, version, ...
     {
@@ -361,12 +361,12 @@ pub fn init(ns: &mut DictStorage) {
         let _ = crate::baseobjspace::setattr(
             jit,
             "is_enabled",
-            crate::make_builtin_function("is_enabled", |_| Ok(w_bool_from(false))),
+            make_builtin_function_with_arity("is_enabled", |_| Ok(w_bool_from(false)), 0),
         );
         let _ = crate::baseobjspace::setattr(
             jit,
             "is_available",
-            crate::make_builtin_function("is_available", |_| Ok(w_bool_from(false))),
+            make_builtin_function_with_arity("is_available", |_| Ok(w_bool_from(false)), 0),
         );
         dict_storage_store(ns, "_jit", jit);
     }
@@ -478,48 +478,48 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "exception",
-        crate::make_builtin_function("exception", |_| Ok(w_none())),
+        make_builtin_function_with_arity("exception", |_| Ok(w_none()), 0),
     );
     // sys.exc_clear — no-op
     dict_storage_store(
         ns,
         "exc_clear",
-        crate::make_builtin_function("exc_clear", |_| Ok(w_none())),
+        make_builtin_function_with_arity("exc_clear", |_| Ok(w_none()), 0),
     );
     // sys.gettrace / settrace
     dict_storage_store(
         ns,
         "gettrace",
-        crate::make_builtin_function("gettrace", sys_gettrace_impl),
+        make_builtin_function_with_arity("gettrace", sys_gettrace_impl, 0),
     );
     dict_storage_store(
         ns,
         "settrace",
-        crate::make_builtin_function("settrace", sys_settrace_impl),
+        make_builtin_function_with_arity("settrace", sys_settrace_impl, 1),
     );
     // sys.getprofile / setprofile
     dict_storage_store(
         ns,
         "getprofile",
-        crate::make_builtin_function("getprofile", sys_getprofile_impl),
+        make_builtin_function_with_arity("getprofile", sys_getprofile_impl, 0),
     );
     dict_storage_store(
         ns,
         "setprofile",
-        crate::make_builtin_function("setprofile", sys_setprofile_impl),
+        make_builtin_function_with_arity("setprofile", sys_setprofile_impl, 1),
     );
     // sys.getfilesystemencoding
     dict_storage_store(
         ns,
         "getfilesystemencoding",
-        crate::make_builtin_function("getfilesystemencoding", |_| Ok(w_str_new("utf-8"))),
+        make_builtin_function_with_arity("getfilesystemencoding", |_| Ok(w_str_new("utf-8")), 0),
     );
     dict_storage_store(
         ns,
         "getfilesystemencodeerrors",
-        crate::make_builtin_function("getfilesystemencodeerrors", |_| {
+        make_builtin_function_with_arity("getfilesystemencodeerrors", |_| {
             Ok(w_str_new("surrogateescape"))
-        }),
+        }, 0),
     );
     // sys.audit — no-op
     dict_storage_store(
@@ -531,18 +531,18 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "is_finalizing",
-        crate::make_builtin_function("is_finalizing", |_| Ok(w_bool_from(false))),
+        make_builtin_function_with_arity("is_finalizing", |_| Ok(w_bool_from(false)), 0),
     );
     // sys.displayhook / excepthook
     dict_storage_store(
         ns,
         "displayhook",
-        crate::make_builtin_function("displayhook", |_| Ok(w_none())),
+        make_builtin_function_with_arity("displayhook", |_| Ok(w_none()), 1),
     );
     dict_storage_store(
         ns,
         "excepthook",
-        crate::make_builtin_function("excepthook", |_| Ok(w_none())),
+        make_builtin_function_with_arity("excepthook", |_| Ok(w_none()), 3),
     );
     // sys.path_hooks / path_importer_cache
     dict_storage_store(ns, "path_hooks", w_list_new(vec![]));
@@ -555,7 +555,7 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "addaudithook",
-        crate::make_builtin_function("addaudithook", |_| Ok(w_none())),
+        make_builtin_function_with_arity("addaudithook", |_| Ok(w_none()), 1),
     );
 }
 

--- a/pyre/pyre-interpreter/src/module/time/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/time/moduledef.rs
@@ -2,31 +2,31 @@
 //!
 //! PyPy equivalent: pypy/module/time/moduledef.py
 
-use crate::{DictStorage, dict_storage_store, make_builtin_function};
+use crate::{DictStorage, dict_storage_store, make_builtin_function, make_builtin_function_with_arity};
 
 use super::interp_time;
 
 pub fn init(ns: &mut DictStorage) {
-    dict_storage_store(ns, "time", make_builtin_function("time", interp_time::time));
+    dict_storage_store(ns, "time", make_builtin_function_with_arity("time", interp_time::time, 0));
     dict_storage_store(
         ns,
         "time_ns",
-        make_builtin_function("time_ns", interp_time::time_ns),
+        make_builtin_function_with_arity("time_ns", interp_time::time_ns, 0),
     );
     dict_storage_store(
         ns,
         "monotonic",
-        make_builtin_function("monotonic", interp_time::monotonic),
+        make_builtin_function_with_arity("monotonic", interp_time::monotonic, 0),
     );
     dict_storage_store(
         ns,
         "sleep",
-        make_builtin_function("sleep", interp_time::sleep),
+        make_builtin_function_with_arity("sleep", interp_time::sleep, 1),
     );
     dict_storage_store(
         ns,
         "perf_counter",
-        make_builtin_function("perf_counter", interp_time::perf_counter),
+        make_builtin_function_with_arity("perf_counter", interp_time::perf_counter, 0),
     );
     dict_storage_store(
         ns,
@@ -46,7 +46,7 @@ pub fn init(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "mktime",
-        make_builtin_function("mktime", interp_time::mktime),
+        make_builtin_function_with_arity("mktime", interp_time::mktime, 1),
     );
     dict_storage_store(
         ns,

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -49,6 +49,11 @@ pub struct W_CodeObject {
     /// field exists so that `frame.hide()` can read the canonical
     /// `pyframe.py:521-522 return self.pycode.hidden_applevel`.
     pub hidden_applevel: bool,
+    /// pycode.py:226-238 `_compute_flatcall`. Cached arity descriptor:
+    /// - 0-4: impossible (builtins only)
+    /// - FLATPYCALL | co_argcount: simple user function
+    /// - HOPELESS: has *args/**kwargs/kwonly/too many params
+    pub fast_natural_arity: u16,
 }
 
 /// Field offset of `code_ptr` within `W_CodeObject`.
@@ -120,6 +125,13 @@ pub fn _convert_const(_space: PyObjectRef, w_a: PyObjectRef) -> PyObjectRef {
 /// `code_ptr` must be a valid pointer to a `CodeObject` obtained
 /// via `Box::into_raw`.
 pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: bool) -> PyObjectRef {
+    let fast_natural_arity = if code_ptr.is_null()
+        || (code_ptr as usize) % std::mem::align_of::<crate::CodeObject>() != 0
+    {
+        crate::gateway::HOPELESS
+    } else {
+        compute_flatcall(unsafe { &*(code_ptr as *const crate::CodeObject) })
+    };
     let obj = Box::new(W_CodeObject {
         ob_header: PyObject {
             ob_type: &CODE_TYPE as *const PyType,
@@ -128,6 +140,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         code_ptr,
         w_globals: std::ptr::null_mut(),
         hidden_applevel,
+        fast_natural_arity,
     });
     Box::into_raw(obj) as PyObjectRef
 }
@@ -231,6 +244,68 @@ pub unsafe fn w_code_frame_stores_global(
         return false;
     }
     !std::ptr::eq(code.w_globals, w_globals)
+}
+
+/// pycode.py:226-238 `_compute_flatcall`.
+///
+/// Returns FLATPYCALL | co_argcount for simple user functions (no *args,
+/// **kwargs, keyword-only args). Returns HOPELESS otherwise.
+fn compute_flatcall(code: &crate::CodeObject) -> u16 {
+    use crate::CodeFlags;
+    use crate::gateway::{FLATPYCALL, HOPELESS};
+    if code.flags.intersects(CodeFlags::VARARGS | CodeFlags::VARKEYWORDS) {
+        return HOPELESS;
+    }
+    if code.kwonlyarg_count > 0 {
+        return HOPELESS;
+    }
+    if code.arg_count > 0xff {
+        return HOPELESS;
+    }
+    // pycode.py:234 — disqualify if any arg is also a cellvar.
+    // Pyre's CodeObject exposes cellvars; check for overlap.
+    let argcount = code.arg_count as usize;
+    if !code.cellvars.is_empty() && argcount > 0 {
+        for cellname in &code.cellvars {
+            for j in 0..argcount {
+                if j < code.varnames.len() && *cellname == code.varnames[j] {
+                    return HOPELESS;
+                }
+            }
+        }
+    }
+    FLATPYCALL | (code.arg_count as u16)
+}
+
+/// eval.py:16-23 — read `fast_natural_arity` from a W_CodeObject.
+///
+/// # Safety
+/// `obj` must point to a valid `W_CodeObject`.
+#[inline]
+pub unsafe fn w_code_get_fast_natural_arity(obj: PyObjectRef) -> u16 {
+    if obj.is_null() {
+        return crate::gateway::HOPELESS;
+    }
+    unsafe { (*(obj as *const W_CodeObject)).fast_natural_arity }
+}
+
+/// Unified accessor: read `fast_natural_arity` from any code object
+/// (BuiltinCode or W_CodeObject).
+///
+/// # Safety
+/// `obj` must point to a valid code object (either type).
+#[inline]
+pub unsafe fn code_get_fast_natural_arity(obj: PyObjectRef) -> u16 {
+    if obj.is_null() {
+        return crate::gateway::HOPELESS;
+    }
+    unsafe {
+        if crate::gateway::is_builtin_code(obj) {
+            crate::gateway::builtin_code_get_fast_natural_arity(obj)
+        } else {
+            w_code_get_fast_natural_arity(obj)
+        }
+    }
 }
 
 /// Check if an object is a code object.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1733,11 +1733,29 @@ fn init_dict_type(ns: &mut DictStorage) {
         ns,
         "__or__",
         make_builtin_function_with_arity("__or__", |args| {
-            // dict | dict → merge
             if args.len() < 2 {
                 return Ok(args[0]);
             }
-            Ok(args[0]) // stub
+            let src = crate::type_methods::resolve_dict_backing(args[0]);
+            let other = crate::type_methods::resolve_dict_backing(args[1]);
+            let dst = pyre_object::w_dict_new();
+            if !src.is_null() {
+                unsafe {
+                    let d = &*(src as *const pyre_object::dictobject::W_DictObject);
+                    for &(k, v) in &*d.entries {
+                        pyre_object::w_dict_store(dst, k, v);
+                    }
+                }
+            }
+            if !other.is_null() {
+                unsafe {
+                    let d = &*(other as *const pyre_object::dictobject::W_DictObject);
+                    for &(k, v) in &*d.entries {
+                        pyre_object::w_dict_store(dst, k, v);
+                    }
+                }
+            }
+            Ok(dst)
         }, 2),
     );
     dict_storage_store(
@@ -1748,7 +1766,18 @@ fn init_dict_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "clear",
-        make_builtin_function_with_arity("clear", |_args| Ok(pyre_object::w_none()), 1),
+        make_builtin_function_with_arity("clear", |args| {
+            if !args.is_empty() {
+                let d = crate::type_methods::resolve_dict_backing(args[0]);
+                if !d.is_null() {
+                    unsafe {
+                        let dict = &mut *(d as *mut pyre_object::dictobject::W_DictObject);
+                        (*dict.entries).clear();
+                    }
+                }
+            }
+            Ok(pyre_object::w_none())
+        }, 1),
     );
     // dict.fromkeys(iterable, value=None) — classmethod
     dict_storage_store(
@@ -3405,6 +3434,14 @@ fn init_object_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity("__format__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_str_new(""));
+            }
+            if args.len() > 1 {
+                let spec = unsafe { crate::py_str(args[1]) };
+                if !spec.is_empty() {
+                    return Err(crate::PyError::type_error(
+                        "unsupported format string passed to object.__format__",
+                    ));
+                }
             }
             Ok(pyre_object::w_str_new(&unsafe { crate::py_str(args[0]) }))
         }, 2),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1773,9 +1773,18 @@ fn init_dict_type(ns: &mut DictStorage) {
             if !args.is_empty() {
                 let d = crate::type_methods::resolve_dict_backing(args[0]);
                 if !d.is_null() {
-                    unsafe {
-                        let dict = &mut *(d as *mut pyre_object::dictobject::W_DictObject);
-                        (*dict.entries).clear();
+                    let keys: Vec<_> = unsafe { pyre_object::w_dict_items(d) }
+                        .into_iter()
+                        .filter_map(|(k, _)| {
+                            if unsafe { pyre_object::is_str(k) } {
+                                Some(unsafe { pyre_object::w_str_get_value(k).to_string() })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    for key in &keys {
+                        unsafe { pyre_object::w_dict_delitem_str(d, key) };
                     }
                 }
             }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1738,6 +1738,9 @@ fn init_dict_type(ns: &mut DictStorage) {
             }
             let src = crate::type_methods::resolve_dict_backing(args[0]);
             let other = crate::type_methods::resolve_dict_backing(args[1]);
+            if other.is_null() {
+                return Ok(pyre_object::w_not_implemented());
+            }
             let dst = pyre_object::w_dict_new();
             if !src.is_null() {
                 unsafe {
@@ -1747,7 +1750,7 @@ fn init_dict_type(ns: &mut DictStorage) {
                     }
                 }
             }
-            if !other.is_null() {
+            {
                 unsafe {
                     let d = &*(other as *const pyre_object::dictobject::W_DictObject);
                     for &(k, v) in &*d.entries {
@@ -2096,18 +2099,15 @@ fn init_tuple_type(ns: &mut DictStorage) {
 /// types.UnionType — PyPy: _pypy_generic_alias.py UnionType
 fn init_union_type(ns: &mut DictStorage) {
     // UnionType.__args__ — returns the tuple of union member types
-    dict_storage_store(
-        ns,
-        "__args__",
-        make_builtin_function_with_arity("__args__", |args| {
-            let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-            if unsafe { pyre_object::is_union(self_) } {
-                Ok(unsafe { pyre_object::w_union_get_args(self_) })
-            } else {
-                Ok(pyre_object::PY_NULL)
-            }
-        }, 1),
-    );
+    let args_getter = make_builtin_function_with_arity("__args__", |args| {
+        let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+        if unsafe { pyre_object::is_union(self_) } {
+            Ok(unsafe { pyre_object::w_union_get_args(self_) })
+        } else {
+            Ok(pyre_object::PY_NULL)
+        }
+    }, 1);
+    dict_storage_store(ns, "__args__", make_getset_descriptor(args_getter));
     // UnionType.__or__ — PyPy: UnionType.__or__ → _create_union
     dict_storage_store(
         ns,
@@ -2684,41 +2684,32 @@ fn patch_builtin_function_descriptors() {
 /// PyPy exposes co_name, co_varnames, co_argcount, co_flags, co_consts.
 /// No __get__ — BuiltinCode is a code object, not a descriptor.
 fn init_builtin_code_type(ns: &mut DictStorage) {
-    dict_storage_store(
-        ns,
-        "co_name",
-        make_builtin_function_with_arity("co_name", |args| {
-            let code = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-            if code.is_null() {
-                return Ok(pyre_object::w_none());
-            }
-            let name = unsafe { crate::builtin_code_name(code) };
-            Ok(pyre_object::w_str_new(name))
-        }, 1),
-    );
+    let co_name_getter = make_builtin_function_with_arity("co_name", |args| {
+        let code = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+        if code.is_null() {
+            return Ok(pyre_object::w_none());
+        }
+        let name = unsafe { crate::builtin_code_name(code) };
+        Ok(pyre_object::w_str_new(name))
+    }, 1);
+    dict_storage_store(ns, "co_name", make_getset_descriptor(co_name_getter));
 }
 
 fn init_method_type(ns: &mut DictStorage) {
-    dict_storage_store(
-        ns,
-        "__func__",
-        make_builtin_function_with_arity("__func__", |args| {
-            Ok(args
-                .first()
-                .map(|&method| unsafe { pyre_object::w_method_get_func(method) })
-                .unwrap_or(pyre_object::w_none()))
-        }, 1),
-    );
-    dict_storage_store(
-        ns,
-        "__self__",
-        make_builtin_function_with_arity("__self__", |args| {
-            Ok(args
-                .first()
-                .map(|&method| unsafe { pyre_object::w_method_get_self(method) })
-                .unwrap_or(pyre_object::w_none()))
-        }, 1),
-    );
+    let func_getter = make_builtin_function_with_arity("__func__", |args| {
+        Ok(args
+            .first()
+            .map(|&method| unsafe { pyre_object::w_method_get_func(method) })
+            .unwrap_or(pyre_object::w_none()))
+    }, 1);
+    dict_storage_store(ns, "__func__", make_getset_descriptor(func_getter));
+    let self_getter = make_builtin_function_with_arity("__self__", |args| {
+        Ok(args
+            .first()
+            .map(|&method| unsafe { pyre_object::w_method_get_self(method) })
+            .unwrap_or(pyre_object::w_none()))
+    }, 1);
+    dict_storage_store(ns, "__self__", make_getset_descriptor(self_getter));
 }
 
 fn init_code_type(ns: &mut DictStorage) {
@@ -2868,31 +2859,25 @@ fn init_member_descriptor_type(ns: &mut DictStorage) {
         }),
     );
     // typedef.py:497 __name__ = interp_attrproperty('name', ...)
-    dict_storage_store(
-        ns,
-        "__name__",
-        make_builtin_function_with_arity("__name__", |args| {
-            let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-            if member.is_null() || !unsafe { pyre_object::memberobject::is_member(member) } {
-                return Ok(pyre_object::w_none());
-            }
-            Ok(pyre_object::w_str_new(unsafe {
-                pyre_object::w_member_get_name(member)
-            }))
-        }, 1),
-    );
+    let name_getter = make_builtin_function_with_arity("__name__", |args| {
+        let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+        if member.is_null() || !unsafe { pyre_object::memberobject::is_member(member) } {
+            return Ok(pyre_object::w_none());
+        }
+        Ok(pyre_object::w_str_new(unsafe {
+            pyre_object::w_member_get_name(member)
+        }))
+    }, 1);
+    dict_storage_store(ns, "__name__", make_getset_descriptor(name_getter));
     // typedef.py:498 __objclass__ = interp_attrproperty_w('w_cls', ...)
-    dict_storage_store(
-        ns,
-        "__objclass__",
-        make_builtin_function_with_arity("__objclass__", |args| {
-            let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-            if member.is_null() || !unsafe { pyre_object::memberobject::is_member(member) } {
-                return Ok(pyre_object::w_none());
-            }
-            Ok(unsafe { pyre_object::w_member_get_cls(member) })
-        }, 1),
-    );
+    let objclass_getter = make_builtin_function_with_arity("__objclass__", |args| {
+        let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+        if member.is_null() || !unsafe { pyre_object::memberobject::is_member(member) } {
+            return Ok(pyre_object::w_none());
+        }
+        Ok(unsafe { pyre_object::w_member_get_cls(member) })
+    }, 1);
+    dict_storage_store(ns, "__objclass__", make_getset_descriptor(objclass_getter));
 }
 
 /// `staticmethod.__new__(cls, func)` — PyPy: function.py StaticMethod.descr__new__
@@ -3118,11 +3103,8 @@ fn init_int_type(ns: &mut DictStorage) {
             pyre_object::PY_NULL,
         ),
     );
-    dict_storage_store(
-        ns,
-        "denominator",
-        make_builtin_function_with_arity("denominator", |_| Ok(pyre_object::w_int_new(1)), 1),
-    );
+    let denom_getter = make_builtin_function_with_arity("denominator", |_| Ok(pyre_object::w_int_new(1)), 1);
+    dict_storage_store(ns, "denominator", make_getset_descriptor(denom_getter));
 }
 fn init_float_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(float_descr_new));
@@ -3473,6 +3455,11 @@ fn init_object_type(ns: &mut DictStorage) {
                     "__setattr__ requires 3 arguments",
                 ));
             }
+            if !unsafe { pyre_object::is_str(args[1]) } {
+                return Err(crate::PyError::type_error(
+                    "attribute name must be string",
+                ));
+            }
             let name = unsafe { pyre_object::w_str_get_value(args[1]) };
             crate::baseobjspace::setattr(args[0], name, args[2])
         }, 3),
@@ -3487,6 +3474,11 @@ fn init_object_type(ns: &mut DictStorage) {
                     "__delattr__ requires 2 arguments",
                 ));
             }
+            if !unsafe { pyre_object::is_str(args[1]) } {
+                return Err(crate::PyError::type_error(
+                    "attribute name must be string",
+                ));
+            }
             let name = unsafe { pyre_object::w_str_get_value(args[1]) };
             crate::baseobjspace::delattr(args[0], name)
         }, 2),
@@ -3499,6 +3491,11 @@ fn init_object_type(ns: &mut DictStorage) {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error(
                     "__getattribute__ requires 2 arguments",
+                ));
+            }
+            if !unsafe { pyre_object::is_str(args[1]) } {
+                return Err(crate::PyError::type_error(
+                    "attribute name must be string",
                 ));
             }
             let name = unsafe { pyre_object::w_str_get_value(args[1]) };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -16,7 +16,7 @@ use std::sync::OnceLock;
 use pyre_object::pyobject::*;
 use pyre_object::*;
 
-use crate::{DictStorage, dict_storage_store, make_builtin_function};
+use crate::{DictStorage, dict_storage_store, make_builtin_function, make_builtin_function_with_arity};
 
 /// Compatibility stand-ins for PyPy `typedef.py` API (type descriptor helpers).
 #[derive(Debug, Default)]
@@ -757,12 +757,12 @@ fn init_ellipsis_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__repr__",
-        make_builtin_function("__repr__", |_args| Ok(w_str_new("Ellipsis"))),
+        make_builtin_function_with_arity("__repr__", |_args| Ok(w_str_new("Ellipsis")), 1),
     );
     dict_storage_store(
         ns,
         "__reduce__",
-        make_builtin_function("__reduce__", |_args| Ok(w_str_new("Ellipsis"))),
+        make_builtin_function_with_arity("__reduce__", |_args| Ok(w_str_new("Ellipsis")), 1),
     );
 }
 
@@ -781,21 +781,21 @@ fn init_notimplemented_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__repr__",
-        make_builtin_function("__repr__", |_args| Ok(w_str_new("NotImplemented"))),
+        make_builtin_function_with_arity("__repr__", |_args| Ok(w_str_new("NotImplemented")), 1),
     );
     dict_storage_store(
         ns,
         "__reduce__",
-        make_builtin_function("__reduce__", |_args| Ok(w_str_new("NotImplemented"))),
+        make_builtin_function_with_arity("__reduce__", |_args| Ok(w_str_new("NotImplemented")), 1),
     );
     // special.py:28-33 descr_bool
     dict_storage_store(
         ns,
         "__bool__",
-        make_builtin_function("__bool__", |_args| {
+        make_builtin_function_with_arity("__bool__", |_args| {
             crate::warn::warn_deprecation("NotImplemented should not be used in a boolean context");
             Ok(pyre_object::boolobject::w_bool_from(true))
-        }),
+        }, 1),
     );
 }
 
@@ -1117,22 +1117,22 @@ fn init_list_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "append",
-        make_builtin_function("append", crate::type_methods::list_method_append),
+        make_builtin_function_with_arity("append", crate::type_methods::list_method_append, 2),
     );
     dict_storage_store(
         ns,
         "extend",
-        make_builtin_function("extend", crate::type_methods::list_method_extend),
+        make_builtin_function_with_arity("extend", crate::type_methods::list_method_extend, 2),
     );
     dict_storage_store(
         ns,
         "copy",
-        make_builtin_function("copy", crate::type_methods::list_method_copy),
+        make_builtin_function_with_arity("copy", crate::type_methods::list_method_copy, 1),
     );
     dict_storage_store(
         ns,
         "insert",
-        make_builtin_function("insert", crate::type_methods::list_method_insert),
+        make_builtin_function_with_arity("insert", crate::type_methods::list_method_insert, 3),
     );
     dict_storage_store(
         ns,
@@ -1142,12 +1142,12 @@ fn init_list_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "clear",
-        make_builtin_function("clear", crate::type_methods::list_method_clear),
+        make_builtin_function_with_arity("clear", crate::type_methods::list_method_clear, 1),
     );
     dict_storage_store(
         ns,
         "reverse",
-        make_builtin_function("reverse", crate::type_methods::list_method_reverse),
+        make_builtin_function_with_arity("reverse", crate::type_methods::list_method_reverse, 1),
     );
     dict_storage_store(
         ns,
@@ -1162,12 +1162,12 @@ fn init_list_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "count",
-        make_builtin_function("count", crate::type_methods::list_method_count),
+        make_builtin_function_with_arity("count", crate::type_methods::list_method_count, 2),
     );
     dict_storage_store(
         ns,
         "remove",
-        make_builtin_function("remove", crate::type_methods::list_method_remove),
+        make_builtin_function_with_arity("remove", crate::type_methods::list_method_remove, 2),
     );
 }
 
@@ -1179,7 +1179,7 @@ fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "join",
-        make_builtin_function("join", crate::type_methods::str_method_join),
+        make_builtin_function_with_arity("join", crate::type_methods::str_method_join, 2),
     );
     dict_storage_store(
         ns,
@@ -1229,12 +1229,12 @@ fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "upper",
-        make_builtin_function("upper", crate::type_methods::str_method_upper),
+        make_builtin_function_with_arity("upper", crate::type_methods::str_method_upper, 1),
     );
     dict_storage_store(
         ns,
         "lower",
-        make_builtin_function("lower", crate::type_methods::str_method_lower),
+        make_builtin_function_with_arity("lower", crate::type_methods::str_method_lower, 1),
     );
     dict_storage_store(
         ns,
@@ -1249,37 +1249,37 @@ fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "isdigit",
-        make_builtin_function("isdigit", crate::type_methods::str_method_isdigit),
+        make_builtin_function_with_arity("isdigit", crate::type_methods::str_method_isdigit, 1),
     );
     dict_storage_store(
         ns,
         "isdecimal",
-        make_builtin_function("isdecimal", crate::type_methods::str_method_isdecimal),
+        make_builtin_function_with_arity("isdecimal", crate::type_methods::str_method_isdecimal, 1),
     );
     dict_storage_store(
         ns,
         "isnumeric",
-        make_builtin_function("isnumeric", crate::type_methods::str_method_isnumeric),
+        make_builtin_function_with_arity("isnumeric", crate::type_methods::str_method_isnumeric, 1),
     );
     dict_storage_store(
         ns,
         "istitle",
-        make_builtin_function("istitle", crate::type_methods::str_method_istitle),
+        make_builtin_function_with_arity("istitle", crate::type_methods::str_method_istitle, 1),
     );
     dict_storage_store(
         ns,
         "isalpha",
-        make_builtin_function("isalpha", crate::type_methods::str_method_isalpha),
+        make_builtin_function_with_arity("isalpha", crate::type_methods::str_method_isalpha, 1),
     );
     dict_storage_store(
         ns,
         "isidentifier",
-        make_builtin_function("isidentifier", crate::type_methods::str_method_isidentifier),
+        make_builtin_function_with_arity("isidentifier", crate::type_methods::str_method_isidentifier, 1),
     );
     dict_storage_store(
         ns,
         "zfill",
-        make_builtin_function("zfill", crate::type_methods::str_method_zfill),
+        make_builtin_function_with_arity("zfill", crate::type_methods::str_method_zfill, 2),
     );
     dict_storage_store(
         ns,
@@ -1294,17 +1294,17 @@ fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "title",
-        make_builtin_function("title", crate::type_methods::str_method_title),
+        make_builtin_function_with_arity("title", crate::type_methods::str_method_title, 1),
     );
     dict_storage_store(
         ns,
         "capitalize",
-        make_builtin_function("capitalize", crate::type_methods::str_method_capitalize),
+        make_builtin_function_with_arity("capitalize", crate::type_methods::str_method_capitalize, 1),
     );
     dict_storage_store(
         ns,
         "swapcase",
-        make_builtin_function("swapcase", crate::type_methods::str_method_swapcase),
+        make_builtin_function_with_arity("swapcase", crate::type_methods::str_method_swapcase, 1),
     );
     dict_storage_store(
         ns,
@@ -1324,37 +1324,37 @@ fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "isspace",
-        make_builtin_function("isspace", crate::type_methods::str_method_isspace),
+        make_builtin_function_with_arity("isspace", crate::type_methods::str_method_isspace, 1),
     );
     dict_storage_store(
         ns,
         "isupper",
-        make_builtin_function("isupper", crate::type_methods::str_method_isupper),
+        make_builtin_function_with_arity("isupper", crate::type_methods::str_method_isupper, 1),
     );
     dict_storage_store(
         ns,
         "islower",
-        make_builtin_function("islower", crate::type_methods::str_method_islower),
+        make_builtin_function_with_arity("islower", crate::type_methods::str_method_islower, 1),
     );
     dict_storage_store(
         ns,
         "isalnum",
-        make_builtin_function("isalnum", crate::type_methods::str_method_isalnum),
+        make_builtin_function_with_arity("isalnum", crate::type_methods::str_method_isalnum, 1),
     );
     dict_storage_store(
         ns,
         "isascii",
-        make_builtin_function("isascii", crate::type_methods::str_method_isascii),
+        make_builtin_function_with_arity("isascii", crate::type_methods::str_method_isascii, 1),
     );
     dict_storage_store(
         ns,
         "partition",
-        make_builtin_function("partition", crate::type_methods::str_method_partition),
+        make_builtin_function_with_arity("partition", crate::type_methods::str_method_partition, 2),
     );
     dict_storage_store(
         ns,
         "rpartition",
-        make_builtin_function("rpartition", crate::type_methods::str_method_rpartition),
+        make_builtin_function_with_arity("rpartition", crate::type_methods::str_method_rpartition, 2),
     );
     dict_storage_store(
         ns,
@@ -1364,12 +1364,12 @@ fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "removeprefix",
-        make_builtin_function("removeprefix", crate::type_methods::str_method_removeprefix),
+        make_builtin_function_with_arity("removeprefix", crate::type_methods::str_method_removeprefix, 2),
     );
     dict_storage_store(
         ns,
         "removesuffix",
-        make_builtin_function("removesuffix", crate::type_methods::str_method_removesuffix),
+        make_builtin_function_with_arity("removesuffix", crate::type_methods::str_method_removesuffix, 2),
     );
     dict_storage_store(
         ns,
@@ -1379,80 +1379,80 @@ fn init_str_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "translate",
-        make_builtin_function("translate", crate::type_methods::str_method_translate),
+        make_builtin_function_with_arity("translate", crate::type_methods::str_method_translate, 2),
     );
     // str dunder methods
     dict_storage_store(
         ns,
         "__contains__",
-        make_builtin_function("__contains__", |args| {
+        make_builtin_function_with_arity("__contains__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
             Ok(pyre_object::w_bool_from(
                 crate::baseobjspace::contains(args[0], args[1]).unwrap_or(false),
             ))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__len__",
-        make_builtin_function("__len__", |args| {
+        make_builtin_function_with_arity("__len__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_int_new(0));
             }
             crate::baseobjspace::len(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__getitem__",
-        make_builtin_function("__getitem__", |args| {
+        make_builtin_function_with_arity("__getitem__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__getitem__"));
             }
             crate::baseobjspace::getitem(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__iter__",
-        make_builtin_function("__iter__", |args| {
+        make_builtin_function_with_arity("__iter__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
             crate::baseobjspace::iter(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__add__",
-        make_builtin_function("__add__", |args| {
+        make_builtin_function_with_arity("__add__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__add__"));
             }
             crate::baseobjspace::add(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__mul__",
-        make_builtin_function("__mul__", |args| {
+        make_builtin_function_with_arity("__mul__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__mul__"));
             }
             crate::baseobjspace::mul(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__mod__",
-        make_builtin_function("__mod__", |args| {
+        make_builtin_function_with_arity("__mod__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__mod__"));
             }
             crate::baseobjspace::mod_(args[0], args[1])
-        }),
+        }, 2),
     );
     // maketrans — PyPy: unicodeobject.py descr_maketrans
     dict_storage_store(
@@ -1586,17 +1586,17 @@ fn init_dict_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "keys",
-        make_builtin_function("keys", crate::type_methods::dict_method_keys),
+        make_builtin_function_with_arity("keys", crate::type_methods::dict_method_keys, 1),
     );
     dict_storage_store(
         ns,
         "values",
-        make_builtin_function("values", crate::type_methods::dict_method_values),
+        make_builtin_function_with_arity("values", crate::type_methods::dict_method_values, 1),
     );
     dict_storage_store(
         ns,
         "items",
-        make_builtin_function("items", crate::type_methods::dict_method_items),
+        make_builtin_function_with_arity("items", crate::type_methods::dict_method_items, 1),
     );
     dict_storage_store(
         ns,
@@ -1616,7 +1616,7 @@ fn init_dict_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__setitem__",
-        make_builtin_function("__setitem__", |args| {
+        make_builtin_function_with_arity("__setitem__", |args| {
             if args.len() < 3 {
                 return Err(crate::PyError::type_error("__setitem__ requires 3 args"));
             }
@@ -1634,12 +1634,12 @@ fn init_dict_type(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 3),
     );
     dict_storage_store(
         ns,
         "__getitem__",
-        make_builtin_function("__getitem__", |args| {
+        make_builtin_function_with_arity("__getitem__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__getitem__ requires 2 args"));
             }
@@ -1656,12 +1656,12 @@ fn init_dict_type(ns: &mut DictStorage) {
                 }
             }
             crate::baseobjspace::getitem(args[0], args[1])
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__contains__",
-        make_builtin_function("__contains__", |args| {
+        make_builtin_function_with_arity("__contains__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
@@ -1675,12 +1675,12 @@ fn init_dict_type(ns: &mut DictStorage) {
             Ok(pyre_object::w_bool_from(
                 crate::baseobjspace::contains(args[0], args[1]).unwrap_or(false),
             ))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__len__",
-        make_builtin_function("__len__", |args| {
+        make_builtin_function_with_arity("__len__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_int_new(0));
             }
@@ -1691,12 +1691,12 @@ fn init_dict_type(ns: &mut DictStorage) {
                 ));
             }
             crate::baseobjspace::len(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__iter__",
-        make_builtin_function("__iter__", |args| {
+        make_builtin_function_with_arity("__iter__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
@@ -1706,49 +1706,49 @@ fn init_dict_type(ns: &mut DictStorage) {
                 return crate::baseobjspace::iter(dict);
             }
             crate::baseobjspace::iter(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__delitem__",
-        make_builtin_function("__delitem__", |args| {
+        make_builtin_function_with_arity("__delitem__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__delitem__ requires 2 args"));
             }
             crate::baseobjspace::delitem(args[0], args[1])?;
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__eq__",
-        make_builtin_function("__eq__", |args| {
+        make_builtin_function_with_arity("__eq__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
             crate::baseobjspace::compare(args[0], args[1], crate::baseobjspace::CompareOp::Eq)
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__or__",
-        make_builtin_function("__or__", |args| {
+        make_builtin_function_with_arity("__or__", |args| {
             // dict | dict → merge
             if args.len() < 2 {
                 return Ok(args[0]);
             }
             Ok(args[0]) // stub
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "copy",
-        make_builtin_function("copy", crate::type_methods::dict_method_copy),
+        make_builtin_function_with_arity("copy", crate::type_methods::dict_method_copy, 1),
     );
     dict_storage_store(
         ns,
         "clear",
-        make_builtin_function("clear", |_args| Ok(pyre_object::w_none())),
+        make_builtin_function_with_arity("clear", |_args| Ok(pyre_object::w_none()), 1),
     );
     // dict.fromkeys(iterable, value=None) — classmethod
     dict_storage_store(
@@ -2021,41 +2021,41 @@ fn init_tuple_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "count",
-        make_builtin_function("count", crate::type_methods::tuple_method_count),
+        make_builtin_function_with_arity("count", crate::type_methods::tuple_method_count, 2),
     );
     dict_storage_store(
         ns,
         "__contains__",
-        make_builtin_function("__contains__", |args| {
+        make_builtin_function_with_arity("__contains__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
             Ok(pyre_object::w_bool_from(
                 crate::baseobjspace::contains(args[0], args[1]).unwrap_or(false),
             ))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__len__",
-        make_builtin_function("__len__", |args| {
+        make_builtin_function_with_arity("__len__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_int_new(0));
             }
             Ok(pyre_object::w_int_new(
                 unsafe { pyre_object::w_tuple_len(args[0]) } as i64,
             ))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__iter__",
-        make_builtin_function("__iter__", |args| {
+        make_builtin_function_with_arity("__iter__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
             crate::baseobjspace::iter(args[0])
-        }),
+        }, 1),
     );
 }
 
@@ -2070,36 +2070,36 @@ fn init_union_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__args__",
-        make_builtin_function("__args__", |args| {
+        make_builtin_function_with_arity("__args__", |args| {
             let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             if unsafe { pyre_object::is_union(self_) } {
                 Ok(unsafe { pyre_object::w_union_get_args(self_) })
             } else {
                 Ok(pyre_object::PY_NULL)
             }
-        }),
+        }, 1),
     );
     // UnionType.__or__ — PyPy: UnionType.__or__ → _create_union
     dict_storage_store(
         ns,
         "__or__",
-        make_builtin_function("__or__", |args| {
+        make_builtin_function_with_arity("__or__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__or__ requires 2 arguments"));
             }
             Ok(pyre_object::w_union_new(args[0], args[1]))
-        }),
+        }, 2),
     );
     // UnionType.__ror__
     dict_storage_store(
         ns,
         "__ror__",
-        make_builtin_function("__ror__", |args| {
+        make_builtin_function_with_arity("__ror__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("__ror__ requires 2 arguments"));
             }
             Ok(pyre_object::w_union_new(args[1], args[0]))
-        }),
+        }, 2),
     );
 }
 
@@ -2579,7 +2579,7 @@ fn init_builtin_function_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__repr__",
-        make_builtin_function("__repr__", |args| {
+        make_builtin_function_with_arity("__repr__", |args| {
             let func = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             let name = if func.is_null() {
                 "<unknown>"
@@ -2589,7 +2589,7 @@ fn init_builtin_function_type(ns: &mut DictStorage) {
             Ok(pyre_object::w_str_new(&format!(
                 "<built-in function {name}>"
             )))
-        }),
+        }, 1),
     );
 
     // function.py:395 getset_func_doc = GetSetProperty(fget_func_doc,
@@ -2658,14 +2658,14 @@ fn init_builtin_code_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "co_name",
-        make_builtin_function("co_name", |args| {
+        make_builtin_function_with_arity("co_name", |args| {
             let code = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             if code.is_null() {
                 return Ok(pyre_object::w_none());
             }
             let name = unsafe { crate::builtin_code_name(code) };
             Ok(pyre_object::w_str_new(name))
-        }),
+        }, 1),
     );
 }
 
@@ -2673,22 +2673,22 @@ fn init_method_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__func__",
-        make_builtin_function("__func__", |args| {
+        make_builtin_function_with_arity("__func__", |args| {
             Ok(args
                 .first()
                 .map(|&method| unsafe { pyre_object::w_method_get_func(method) })
                 .unwrap_or(pyre_object::w_none()))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__self__",
-        make_builtin_function("__self__", |args| {
+        make_builtin_function_with_arity("__self__", |args| {
             Ok(args
                 .first()
                 .map(|&method| unsafe { pyre_object::w_method_get_self(method) })
                 .unwrap_or(pyre_object::w_none()))
-        }),
+        }, 1),
     );
 }
 
@@ -2842,7 +2842,7 @@ fn init_member_descriptor_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__name__",
-        make_builtin_function("__name__", |args| {
+        make_builtin_function_with_arity("__name__", |args| {
             let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             if member.is_null() || !unsafe { pyre_object::memberobject::is_member(member) } {
                 return Ok(pyre_object::w_none());
@@ -2850,19 +2850,19 @@ fn init_member_descriptor_type(ns: &mut DictStorage) {
             Ok(pyre_object::w_str_new(unsafe {
                 pyre_object::w_member_get_name(member)
             }))
-        }),
+        }, 1),
     );
     // typedef.py:498 __objclass__ = interp_attrproperty_w('w_cls', ...)
     dict_storage_store(
         ns,
         "__objclass__",
-        make_builtin_function("__objclass__", |args| {
+        make_builtin_function_with_arity("__objclass__", |args| {
             let member = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             if member.is_null() || !unsafe { pyre_object::memberobject::is_member(member) } {
                 return Ok(pyre_object::w_none());
             }
             Ok(unsafe { pyre_object::w_member_get_cls(member) })
-        }),
+        }, 1),
     );
 }
 
@@ -2920,7 +2920,7 @@ fn init_int_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "bit_length",
-        make_builtin_function("bit_length", |args| {
+        make_builtin_function_with_arity("bit_length", |args| {
             let val = if !args.is_empty() && unsafe { pyre_object::is_int(args[0]) } {
                 unsafe { pyre_object::w_int_get_value(args[0]) }
             } else {
@@ -2932,7 +2932,7 @@ fn init_int_type(ns: &mut DictStorage) {
                 64 - val.unsigned_abs().leading_zeros()
             };
             Ok(pyre_object::w_int_new(bits as i64))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
@@ -2942,14 +2942,14 @@ fn init_int_type(ns: &mut DictStorage) {
         // `pyre_object::int_bit_count` (`@jit.elidable` parity port of
         // `_bit_count`) so the call graph matches upstream
         // `descr_bit_count -> _bit_count` 1:1.
-        make_builtin_function("bit_count", |args| {
+        make_builtin_function_with_arity("bit_count", |args| {
             let val = if !args.is_empty() && unsafe { pyre_object::is_int(args[0]) } {
                 unsafe { pyre_object::w_int_get_value(args[0]) }
             } else {
                 0
             };
             Ok(pyre_object::w_int_new(pyre_object::int_bit_count(val)))
-        }),
+        }, 1),
     );
     // int.to_bytes(length=1, byteorder='big', *, signed=False)
     // PyPy: longobject.py descr_to_bytes
@@ -3035,18 +3035,18 @@ fn init_int_type(ns: &mut DictStorage) {
         dict_storage_store(
             ns,
             method,
-            make_builtin_function(method, |args| {
+            make_builtin_function_with_arity(method, |args| {
                 Ok(args.first().copied().unwrap_or(pyre_object::w_int_new(0)))
-            }),
+            }, 1),
         );
     }
     // int.conjugate — identity
     dict_storage_store(
         ns,
         "conjugate",
-        make_builtin_function("conjugate", |args| {
+        make_builtin_function_with_arity("conjugate", |args| {
             Ok(args.first().copied().unwrap_or(pyre_object::w_int_new(0)))
-        }),
+        }, 1),
     );
     // int.real / int.imag / int.numerator — properties
     // True.real → 1 (int, not bool), False.real → 0
@@ -3092,7 +3092,7 @@ fn init_int_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "denominator",
-        make_builtin_function("denominator", |_| Ok(pyre_object::w_int_new(1))),
+        make_builtin_function_with_arity("denominator", |_| Ok(pyre_object::w_int_new(1)), 1),
     );
 }
 fn init_float_type(ns: &mut DictStorage) {
@@ -3132,7 +3132,7 @@ fn init_float_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "hex",
-        make_builtin_function("hex", |args| {
+        make_builtin_function_with_arity("hex", |args| {
             // float.hex() — PyPy: descr_hex. Format the float as a hex
             // literal compatible with float.fromhex.
             if args.is_empty() {
@@ -3146,7 +3146,7 @@ fn init_float_type(ns: &mut DictStorage) {
                 return Ok(pyre_object::w_str_new(if v > 0.0 { "inf" } else { "-inf" }));
             }
             Ok(pyre_object::w_str_new(&format!("{v:e}")))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
@@ -3225,18 +3225,18 @@ fn init_float_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "is_integer",
-        make_builtin_function("is_integer", |args| {
+        make_builtin_function_with_arity("is_integer", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_bool_from(false));
             }
             let v = unsafe { pyre_object::w_float_get_value(args[0]) };
             Ok(pyre_object::w_bool_from(v.is_finite() && v == v.trunc()))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "as_integer_ratio",
-        make_builtin_function("as_integer_ratio", |args| {
+        make_builtin_function_with_arity("as_integer_ratio", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::type_error(
                     "as_integer_ratio() requires self",
@@ -3266,20 +3266,20 @@ fn init_float_type(ns: &mut DictStorage) {
                     pyre_object::w_int_new(denom),
                 ]))
             }
-        }),
+        }, 1),
     );
     // floatobject.py:713: __int__ = interp2app(W_FloatObject.descr_trunc)
     for method in ["__trunc__", "__int__"] {
         dict_storage_store(
             ns,
             method,
-            make_builtin_function(method, |args| {
+            make_builtin_function_with_arity(method, |args| {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("__trunc__() requires self"));
                 }
                 let v = unsafe { pyre_object::w_float_get_value(args[0]) };
                 Ok(pyre_object::w_int_new(v.trunc() as i64))
-            }),
+            }, 1),
         );
     }
 }
@@ -3338,37 +3338,37 @@ fn init_object_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__eq__",
-        make_builtin_function("__eq__", |args| {
+        make_builtin_function_with_arity("__eq__", |args| {
             Ok(pyre_object::w_bool_from(
                 args.len() >= 2 && std::ptr::eq(args[0], args[1]),
             ))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__ne__",
-        make_builtin_function("__ne__", |args| {
+        make_builtin_function_with_arity("__ne__", |args| {
             Ok(pyre_object::w_bool_from(
                 args.len() >= 2 && !std::ptr::eq(args[0], args[1]),
             ))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__hash__",
-        make_builtin_function("__hash__", |args| {
+        make_builtin_function_with_arity("__hash__", |args| {
             Ok(pyre_object::w_int_new(if args.is_empty() {
                 0
             } else {
                 args[0] as i64
             }))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__repr__",
         // PyPy: objectobject.py descr___repr__ — base __repr__ for all objects
-        make_builtin_function("__repr__", |args| {
+        make_builtin_function_with_arity("__repr__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_str_new("<object>"));
             }
@@ -3384,19 +3384,19 @@ fn init_object_type(ns: &mut DictStorage) {
             }
             // For non-instances, delegate to display
             Ok(pyre_object::w_str_new(&format!("<object at {:?}>", obj)))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__str__",
-        make_builtin_function("__str__", |args| {
+        make_builtin_function_with_arity("__str__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_str_new("<object>"));
             }
             // Delegate to __repr__ to avoid infinite recursion
             // PyPy: objectobject.py descr___str__ → space.repr(w_self)
             Ok(pyre_object::w_str_new(&unsafe { crate::py_repr(args[0]) }))
-        }),
+        }, 1),
     );
     // PyPy: objectobject.py descr___format__
     dict_storage_store(
@@ -3430,7 +3430,7 @@ fn init_object_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__setattr__",
-        make_builtin_function("__setattr__", |args| {
+        make_builtin_function_with_arity("__setattr__", |args| {
             if args.len() < 3 {
                 return Err(crate::PyError::type_error(
                     "__setattr__ requires 3 arguments",
@@ -3438,13 +3438,13 @@ fn init_object_type(ns: &mut DictStorage) {
             }
             let name = unsafe { pyre_object::w_str_get_value(args[1]) };
             crate::baseobjspace::setattr(args[0], name, args[2])
-        }),
+        }, 3),
     );
     // PyPy: objectobject.py descr___delattr__
     dict_storage_store(
         ns,
         "__delattr__",
-        make_builtin_function("__delattr__", |args| {
+        make_builtin_function_with_arity("__delattr__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error(
                     "__delattr__ requires 2 arguments",
@@ -3452,13 +3452,13 @@ fn init_object_type(ns: &mut DictStorage) {
             }
             let name = unsafe { pyre_object::w_str_get_value(args[1]) };
             crate::baseobjspace::delattr(args[0], name)
-        }),
+        }, 2),
     );
     // PyPy: objectobject.py descr___getattribute__
     dict_storage_store(
         ns,
         "__getattribute__",
-        make_builtin_function("__getattribute__", |args| {
+        make_builtin_function_with_arity("__getattribute__", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error(
                     "__getattribute__ requires 2 arguments",
@@ -3466,7 +3466,7 @@ fn init_object_type(ns: &mut DictStorage) {
             }
             let name = unsafe { pyre_object::w_str_get_value(args[1]) };
             crate::baseobjspace::getattr(args[0], name)
-        }),
+        }, 2),
     );
 }
 
@@ -3523,12 +3523,12 @@ fn init_bytes_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__repr__",
-        make_builtin_function("__repr__", bytes_method_repr),
+        make_builtin_function_with_arity("__repr__", bytes_method_repr, 1),
     );
     dict_storage_store(
         ns,
         "__str__",
-        make_builtin_function("__str__", bytes_method_repr),
+        make_builtin_function_with_arity("__str__", bytes_method_repr, 1),
     );
     // bytes methods are mostly shared with bytearray — add as needed.
 }
@@ -3657,7 +3657,7 @@ fn init_bytearray_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__add__",
-        make_builtin_function("__add__", |args| {
+        make_builtin_function_with_arity("__add__", |args| {
             assert!(args.len() >= 2, "__add__ requires 2 arguments");
             let a = args[0];
             let b = args[1];
@@ -3674,12 +3674,12 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                     &result,
                 ))
             }
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__iadd__",
-        make_builtin_function("__iadd__", |args| {
+        make_builtin_function_with_arity("__iadd__", |args| {
             assert!(args.len() >= 2);
             let ba = args[0];
             let other = args[1];
@@ -3690,12 +3690,12 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                 }
             }
             Ok(ba)
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "translate",
-        make_builtin_function("translate", |args| {
+        make_builtin_function_with_arity("translate", |args| {
             assert!(args.len() >= 2);
             let ba = args[0];
             let table = args[1];
@@ -3722,7 +3722,7 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                     &result,
                 ))
             }
-        }),
+        }, 2),
     );
 }
 
@@ -3735,7 +3735,7 @@ fn init_setlike_common(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__contains__",
-        make_builtin_function("__contains__", |args| {
+        make_builtin_function_with_arity("__contains__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
@@ -3747,12 +3747,12 @@ fn init_setlike_common(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_bool_from(false))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__len__",
-        make_builtin_function("__len__", |args| {
+        make_builtin_function_with_arity("__len__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_int_new(0));
             }
@@ -3764,22 +3764,22 @@ fn init_setlike_common(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_int_new(0))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__iter__",
-        make_builtin_function("__iter__", |args| {
+        make_builtin_function_with_arity("__iter__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_none());
             }
             crate::baseobjspace::iter(args[0])
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__bool__",
-        make_builtin_function("__bool__", |args| {
+        make_builtin_function_with_arity("__bool__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_bool_from(false));
             }
@@ -3791,54 +3791,54 @@ fn init_setlike_common(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_bool_from(true))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "__or__",
-        make_builtin_function("__or__", set_method_union),
+        make_builtin_function_with_arity("__or__", set_method_union, 2),
     );
     dict_storage_store(
         ns,
         "__and__",
-        make_builtin_function("__and__", set_method_intersection),
+        make_builtin_function_with_arity("__and__", set_method_intersection, 2),
     );
     dict_storage_store(
         ns,
         "__sub__",
-        make_builtin_function("__sub__", set_method_difference),
+        make_builtin_function_with_arity("__sub__", set_method_difference, 2),
     );
     dict_storage_store(
         ns,
         "__xor__",
-        make_builtin_function("__xor__", set_method_symmetric_difference),
+        make_builtin_function_with_arity("__xor__", set_method_symmetric_difference, 2),
     );
-    dict_storage_store(ns, "__eq__", make_builtin_function("__eq__", set_method_eq));
-    dict_storage_store(ns, "__le__", make_builtin_function("__le__", set_method_le));
-    dict_storage_store(ns, "__ge__", make_builtin_function("__ge__", set_method_ge));
+    dict_storage_store(ns, "__eq__", make_builtin_function_with_arity("__eq__", set_method_eq, 2));
+    dict_storage_store(ns, "__le__", make_builtin_function_with_arity("__le__", set_method_le, 2));
+    dict_storage_store(ns, "__ge__", make_builtin_function_with_arity("__ge__", set_method_ge, 2));
     dict_storage_store(
         ns,
         "__lt__",
-        make_builtin_function("__lt__", |args| {
+        make_builtin_function_with_arity("__lt__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
             let le = unsafe { pyre_object::w_bool_get_value(set_method_le(args)?) };
             let eq = unsafe { pyre_object::w_bool_get_value(set_method_eq(args)?) };
             Ok(pyre_object::w_bool_from(le && !eq))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "__gt__",
-        make_builtin_function("__gt__", |args| {
+        make_builtin_function_with_arity("__gt__", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(false));
             }
             let ge = unsafe { pyre_object::w_bool_get_value(set_method_ge(args)?) };
             let eq = unsafe { pyre_object::w_bool_get_value(set_method_eq(args)?) };
             Ok(pyre_object::w_bool_from(ge && !eq))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
@@ -3858,22 +3858,22 @@ fn init_setlike_common(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "symmetric_difference",
-        make_builtin_function("symmetric_difference", set_method_symmetric_difference),
+        make_builtin_function_with_arity("symmetric_difference", set_method_symmetric_difference, 2),
     );
     dict_storage_store(
         ns,
         "issubset",
-        make_builtin_function("issubset", set_method_le),
+        make_builtin_function_with_arity("issubset", set_method_le, 2),
     );
     dict_storage_store(
         ns,
         "issuperset",
-        make_builtin_function("issuperset", set_method_ge),
+        make_builtin_function_with_arity("issuperset", set_method_ge, 2),
     );
     dict_storage_store(
         ns,
         "isdisjoint",
-        make_builtin_function("isdisjoint", |args| {
+        make_builtin_function_with_arity("isdisjoint", |args| {
             if args.len() < 2 {
                 return Ok(pyre_object::w_bool_from(true));
             }
@@ -3886,12 +3886,12 @@ fn init_setlike_common(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_bool_from(true))
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "copy",
-        make_builtin_function("copy", |args| {
+        make_builtin_function_with_arity("copy", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_set_new());
             }
@@ -3902,7 +3902,7 @@ fn init_setlike_common(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_set_from_items(&items))
-        }),
+        }, 1),
     );
 }
 
@@ -4070,27 +4070,27 @@ fn init_set_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "add",
-        make_builtin_function("add", |args| {
+        make_builtin_function_with_arity("add", |args| {
             if args.len() >= 2 {
                 unsafe { pyre_object::w_set_add(args[0], args[1]) };
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "discard",
-        make_builtin_function("discard", |args| {
+        make_builtin_function_with_arity("discard", |args| {
             if args.len() >= 2 {
                 unsafe { pyre_object::w_set_discard(args[0], args[1]) };
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "remove",
-        make_builtin_function("remove", |args| {
+        make_builtin_function_with_arity("remove", |args| {
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("remove() requires an argument"));
             }
@@ -4102,12 +4102,12 @@ fn init_set_type(ns: &mut DictStorage) {
                 ));
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 2),
     );
     dict_storage_store(
         ns,
         "pop",
-        make_builtin_function("pop", |args| {
+        make_builtin_function_with_arity("pop", |args| {
             if args.is_empty() {
                 return Err(crate::PyError::new(
                     crate::PyErrorKind::KeyError,
@@ -4123,12 +4123,12 @@ fn init_set_type(ns: &mut DictStorage) {
                 crate::PyErrorKind::KeyError,
                 "pop from an empty set",
             ))
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,
         "clear",
-        make_builtin_function("clear", |args| {
+        make_builtin_function_with_arity("clear", |args| {
             if !args.is_empty() {
                 let items = unsafe { pyre_object::w_set_items(args[0]) };
                 for item in items {
@@ -4136,7 +4136,7 @@ fn init_set_type(ns: &mut DictStorage) {
                 }
             }
             Ok(pyre_object::w_none())
-        }),
+        }, 1),
     );
     dict_storage_store(
         ns,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2244,7 +2244,7 @@ fn init_getset_descriptor_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__set__",
-        make_builtin_function("__set__", |args| {
+        make_builtin_function_with_arity("__set__", |args| {
             let w_self = args[0];
             let w_obj = args[1];
             let w_value = args[2];
@@ -2272,7 +2272,7 @@ fn init_getset_descriptor_type(ns: &mut DictStorage) {
                 ),
                 Err(e) => Err(e),
             }
-        }),
+        }, 3),
     );
     // typedef.py:388-400 GetSetProperty.descr_property_del
     //
@@ -2292,7 +2292,7 @@ fn init_getset_descriptor_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__delete__",
-        make_builtin_function("__delete__", |args| {
+        make_builtin_function_with_arity("__delete__", |args| {
             let w_self = args[0];
             let w_obj = args[1];
             let fdel = read_fdel(w_self);
@@ -2322,7 +2322,7 @@ fn init_getset_descriptor_type(ns: &mut DictStorage) {
                 ),
                 Err(e) => Err(e),
             }
-        }),
+        }, 2),
     );
 }
 
@@ -2399,7 +2399,7 @@ fn init_type_type(ns: &mut DictStorage) {
     // GetSetProperty fget callbacks receive (descriptor_self, w_obj) so the
     // wrapped object is at args[1] (matches PyPy's typecheck wrapper that
     // passes (closure, space, w_obj)).
-    let annotations_getter = make_builtin_function("__annotations__", |args| {
+    let annotations_getter = make_builtin_function_with_arity("__annotations__", |args| {
         // GetSetProperty fget callbacks receive (descriptor_self, w_obj),
         // so the cls is at args[1].
         let cls = args[1];
@@ -2428,14 +2428,14 @@ fn init_type_type(ns: &mut DictStorage) {
             }
         }
         Ok(pyre_object::w_dict_new())
-    });
+    }, 2);
     dict_storage_store(
         ns,
         "__annotations__",
         make_getset_descriptor(annotations_getter),
     );
 
-    let mro_getter = make_builtin_function("__mro__", |args| {
+    let mro_getter = make_builtin_function_with_arity("__mro__", |args| {
         let cls = args[1];
         unsafe {
             let mro_ptr = pyre_object::w_type_get_mro(cls);
@@ -2444,10 +2444,10 @@ fn init_type_type(ns: &mut DictStorage) {
             }
             Ok(pyre_object::w_tuple_new((*mro_ptr).clone()))
         }
-    });
+    }, 2);
     dict_storage_store(ns, "__mro__", make_getset_descriptor(mro_getter));
 
-    let dict_getter = make_builtin_function("__dict__", |args| {
+    let dict_getter = make_builtin_function_with_arity("__dict__", |args| {
         let cls = args[1];
         unsafe {
             let ns_ptr = pyre_object::typeobject::w_type_get_dict_ptr(cls);
@@ -2462,22 +2462,22 @@ fn init_type_type(ns: &mut DictStorage) {
             let canonical = crate::baseobjspace::dict_storage_to_dict(ns_ptr as *const DictStorage);
             Ok(pyre_object::w_dict_proxy_new(canonical))
         }
-    });
+    }, 2);
     dict_storage_store(ns, "__dict__", make_getset_descriptor(dict_getter));
 
-    let name_getter = make_builtin_function("__name__", |args| unsafe {
+    let name_getter = make_builtin_function_with_arity("__name__", |args| unsafe {
         let name = pyre_object::w_type_get_name(args[1]);
         Ok(pyre_object::w_str_new(name))
-    });
+    }, 2);
     dict_storage_store(ns, "__name__", make_getset_descriptor(name_getter));
 
-    let bases_getter = make_builtin_function("__bases__", |args| unsafe {
+    let bases_getter = make_builtin_function_with_arity("__bases__", |args| unsafe {
         let bases = pyre_object::w_type_get_bases(args[1]);
         if bases.is_null() {
             return Ok(pyre_object::w_tuple_new(vec![]));
         }
         Ok(bases)
-    });
+    }, 2);
     dict_storage_store(ns, "__bases__", make_getset_descriptor(bases_getter));
 }
 
@@ -2573,7 +2573,7 @@ fn init_builtin_function_type(ns: &mut DictStorage) {
     // W_TypeObject is still under construction, so `cls` cannot be
     // resolved here; `patch_builtin_function_descriptors` runs after the
     // type cache is populated and writes the missing reqcls.
-    let self_getter = make_builtin_function("__self__", |_args| Ok(pyre_object::w_none()));
+    let self_getter = make_builtin_function_with_arity("__self__", |_args| Ok(pyre_object::w_none()), 2);
     dict_storage_store(ns, "__self__", make_getset_descriptor(self_getter));
 
     dict_storage_store(
@@ -3054,7 +3054,7 @@ fn init_int_type(ns: &mut DictStorage) {
         ns,
         "real",
         pyre_object::w_property_new(
-            make_builtin_function("real", |args| {
+            make_builtin_function_with_arity("real", |args| {
                 let obj = args.first().copied().unwrap_or(pyre_object::w_int_new(0));
                 unsafe {
                     if pyre_object::is_bool(obj) {
@@ -3064,7 +3064,7 @@ fn init_int_type(ns: &mut DictStorage) {
                     }
                 }
                 Ok(obj)
-            }),
+            }, 1),
             pyre_object::PY_NULL,
             pyre_object::PY_NULL,
         ),
@@ -3073,7 +3073,7 @@ fn init_int_type(ns: &mut DictStorage) {
         ns,
         "imag",
         pyre_object::w_property_new(
-            make_builtin_function("imag", |_| Ok(pyre_object::w_int_new(0))),
+            make_builtin_function_with_arity("imag", |_| Ok(pyre_object::w_int_new(0)), 1),
             pyre_object::PY_NULL,
             pyre_object::PY_NULL,
         ),
@@ -3082,9 +3082,9 @@ fn init_int_type(ns: &mut DictStorage) {
         ns,
         "numerator",
         pyre_object::w_property_new(
-            make_builtin_function("numerator", |args| {
+            make_builtin_function_with_arity("numerator", |args| {
                 Ok(args.first().copied().unwrap_or(pyre_object::w_int_new(0)))
-            }),
+            }, 1),
             pyre_object::PY_NULL,
             pyre_object::PY_NULL,
         ),
@@ -3402,18 +3402,18 @@ fn init_object_type(ns: &mut DictStorage) {
     dict_storage_store(
         ns,
         "__format__",
-        make_builtin_function("__format__", |args| {
+        make_builtin_function_with_arity("__format__", |args| {
             if args.is_empty() {
                 return Ok(pyre_object::w_str_new(""));
             }
             Ok(pyre_object::w_str_new(&unsafe { crate::py_str(args[0]) }))
-        }),
+        }, 2),
     );
     // PyPy: objectobject.py descr___reduce_ex__
     dict_storage_store(
         ns,
         "__reduce_ex__",
-        make_builtin_function("__reduce_ex__", |_| Ok(pyre_object::w_none())),
+        make_builtin_function_with_arity("__reduce_ex__", |_| Ok(pyre_object::w_none()), 2),
     );
     dict_storage_store(
         ns,
@@ -4174,9 +4174,9 @@ pub fn dict_descr() -> pyre_object::PyObjectRef {
     use std::sync::OnceLock;
     static CACHED: OnceLock<usize> = OnceLock::new();
     let addr = *CACHED.get_or_init(|| {
-        let fget = make_builtin_function("descr_get_dict", descr_get_dict);
-        let fset = make_builtin_function("descr_set_dict", descr_set_dict);
-        let fdel = make_builtin_function("descr_del_dict", descr_del_dict);
+        let fget = make_builtin_function_with_arity("descr_get_dict", descr_get_dict, 2);
+        let fset = make_builtin_function_with_arity("descr_set_dict", descr_set_dict, 3);
+        let fdel = make_builtin_function_with_arity("descr_del_dict", descr_del_dict, 2);
         let descr = make_getset_property(fget, fset, fdel);
         let _ = crate::baseobjspace::setattr(descr, "__name__", pyre_object::w_str_new("__dict__"));
         descr as usize
@@ -4195,7 +4195,7 @@ pub fn weakref_descr() -> pyre_object::PyObjectRef {
     use std::sync::OnceLock;
     static CACHED: OnceLock<usize> = OnceLock::new();
     let addr = *CACHED.get_or_init(|| {
-        let fget = make_builtin_function("descr_get_weakref", descr_get_weakref);
+        let fget = make_builtin_function_with_arity("descr_get_weakref", descr_get_weakref, 2);
         let descr = make_getset_property(fget, pyre_object::PY_NULL, pyre_object::PY_NULL);
         let _ =
             crate::baseobjspace::setattr(descr, "__name__", pyre_object::w_str_new("__weakref__"));


### PR DESCRIPTION
This pull request introduces improvements to function arity handling in the Pyre interpreter, ensuring built-in and method functions are registered with explicit argument counts. It also adds a new public API for tracking call depth and provides a utility to get the current evaluation function (supporting JIT overrides). These changes enhance correctness, introspection, and maintainability of the interpreter's core.

**Built-in and method function arity enforcement:**

- Updated registration of built-in and module functions throughout `builtins.rs` to use `make_builtin_function_with_arity` or `make_module_builtin_function_with_arity`, specifying the expected number of arguments for each function (e.g., `len`, `abs`, `isinstance`, `repr`, `setattr`, `delattr`, `id`, `hash`, `ord`, `chr`, `reversed`, `callable`, `globals`, `locals`, `any`, `all`, `issubclass`, and various file methods). This improves error handling and introspection for built-in functions.

- Modified `getattr` in `baseobjspace.rs` to pass explicit arity when creating generator and iterator method objects, ensuring correct method signatures for special methods like `send`, `close`, and `__next__`.

**Call depth tracking and evaluation function selection:**

- Added a new public API `increment_call_depth` and a corresponding RAII guard `CallDepthGuardPublic` to allow external code to safely increment and decrement the call depth counter, improving tracking of nested calls.

- Introduced a `get_eval_fn` utility to retrieve the currently active evaluation function, respecting JIT overrides and force-plain-eval mode, making it easier for other components to use the correct evaluation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved call dispatch and builtin registration to speed up common function calls and reduce interpreter overhead.
  * Added cached call-metadata to make repeated calls more efficient.

* **Bug Fixes**
  * Builtins and descriptors now enforce expected positional arities more consistently, yielding clearer errors for incorrect calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/9)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->