### PR TITLE
Fix blackhole failure handling and update documentation references

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3135,13 +3135,9 @@ impl<S: JitState> JitDriver<S> {
         self.meta.invalidate_loop(green_key);
     }
 
-    /// Record a blackhole resume failure and optionally invalidate.
-    ///
-    /// Increments the abort counter for the green key. Below the limit
-    /// the loop is invalidated (allowing retrace); at the limit the
-    /// loop is left as-is and the key is marked DONT_TRACE_HERE so the
-    /// compile → guard-fail → bh-fail → invalidate cycle stops.
-    pub fn record_blackhole_failure_and_maybe_invalidate(&mut self, green_key: u64) -> bool {
+    /// Record a blackhole resume failure, invalidate the compiled loop,
+    /// and at the abort limit also set DONT_TRACE_HERE to stop retracing.
+    pub fn record_blackhole_failure_and_maybe_invalidate(&mut self, green_key: u64) {
         self.meta.record_blackhole_failure_and_maybe_invalidate(green_key)
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3135,6 +3135,16 @@ impl<S: JitState> JitDriver<S> {
         self.meta.invalidate_loop(green_key);
     }
 
+    /// Record a blackhole resume failure and optionally invalidate.
+    ///
+    /// Increments the abort counter for the green key. Below the limit
+    /// the loop is invalidated (allowing retrace); at the limit the
+    /// loop is left as-is and the key is marked DONT_TRACE_HERE so the
+    /// compile → guard-fail → bh-fail → invalidate cycle stops.
+    pub fn record_blackhole_failure_and_maybe_invalidate(&mut self, green_key: u64) -> bool {
+        self.meta.record_blackhole_failure_and_maybe_invalidate(green_key)
+    }
+
     /// Check whether a compiled loop exists for a given green key.
     #[inline]
     pub fn has_compiled_loop(&self, green_key: u64) -> bool {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -7036,6 +7036,25 @@ impl<M: Clone> MetaInterp<M> {
         }
     }
 
+    /// Record a blackhole resume failure and optionally invalidate.
+    ///
+    /// Returns `true` when the abort limit was reached (loop NOT
+    /// invalidated — retracing is permanently disabled for this key).
+    /// Returns `false` when below the limit (loop invalidated so it
+    /// can be retraced).
+    pub fn record_blackhole_failure_and_maybe_invalidate(&mut self, green_key: u64) -> bool {
+        let limit_reached = self.warm_state.record_blackhole_failure(green_key);
+        if !limit_reached {
+            self.invalidate_loop(green_key);
+        } else if crate::majit_log_enabled() {
+            eprintln!(
+                "[jit] blackhole abort limit reached for key={} — not invalidating",
+                green_key
+            );
+        }
+        limit_reached
+    }
+
     /// rpython/rlib/rstack.py:75-90 `stack_almost_full` — delegates to
     /// the interpreter-registered hook (see
     /// `majit_metainterp::register_stack_almost_full_hook`) which reads

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -7036,23 +7036,17 @@ impl<M: Clone> MetaInterp<M> {
         }
     }
 
-    /// Record a blackhole resume failure and optionally invalidate.
-    ///
-    /// Returns `true` when the abort limit was reached (loop NOT
-    /// invalidated — retracing is permanently disabled for this key).
-    /// Returns `false` when below the limit (loop invalidated so it
-    /// can be retraced).
-    pub fn record_blackhole_failure_and_maybe_invalidate(&mut self, green_key: u64) -> bool {
+    /// Record a blackhole resume failure, invalidate the compiled loop,
+    /// and at the abort limit also set DONT_TRACE_HERE to stop retracing.
+    pub fn record_blackhole_failure_and_maybe_invalidate(&mut self, green_key: u64) {
         let limit_reached = self.warm_state.record_blackhole_failure(green_key);
-        if !limit_reached {
-            self.invalidate_loop(green_key);
-        } else if crate::majit_log_enabled() {
+        self.invalidate_loop(green_key);
+        if limit_reached && crate::majit_log_enabled() {
             eprintln!(
-                "[jit] blackhole abort limit reached for key={} — not invalidating",
+                "[jit] blackhole abort limit reached for key={} — will not retrace",
                 green_key
             );
         }
-        limit_reached
     }
 
     /// rpython/rlib/rstack.py:75-90 `stack_almost_full` — delegates to

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -768,6 +768,29 @@ impl WarmEnterState {
         }
     }
 
+    /// Record a blackhole resume failure for a green key.
+    ///
+    /// Unlike `abort_tracing` (which handles trace-compilation failures),
+    /// this handles the case where compiled code ran successfully but the
+    /// blackhole resume after a guard failure failed.  Each failure
+    /// increments `abort_count` so that `force_start_tracing` will
+    /// eventually refuse to retrace, breaking the
+    /// compile → guard-fail → bh-fail → invalidate → retrace cycle.
+    ///
+    /// Returns `true` if the abort limit has been reached and the caller
+    /// should NOT invalidate (further retracing is pointless).
+    pub fn record_blackhole_failure(&mut self, green_key_hash: u64) -> bool {
+        if let Some(cell) = self.cells.get_mut(&green_key_hash) {
+            cell.abort_count += 1;
+            if cell.abort_count >= MAX_TRACE_ABORT_COUNT {
+                cell.flags |= jc_flags::DONT_TRACE_HERE;
+                cell.state = BaseJitCellState::DontTraceHere;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Install a compiled loop token for a green key.
     ///
     /// The cell transitions to Compiled state and takes ownership of

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3553,11 +3553,11 @@ fn execute_assembler(
                             // decoder work should eliminate the remaining
                             // triggers.
                             //
-                            // Increment abort_count so that the compile /
-                            // guard-fail / bh-fail / invalidate / retrace
-                            // cycle is bounded. Once the limit is reached
-                            // the loop is not invalidated again and the key
-                            // is marked DONT_TRACE_HERE.
+                            // Increment abort_count and invalidate the
+                            // compiled loop. Once the limit is reached the
+                            // key is also marked DONT_TRACE_HERE so the
+                            // compile / guard-fail / bh-fail / invalidate /
+                            // retrace cycle stops.
                             if majit_metainterp::majit_log_enabled() {
                                 eprintln!(
                                     "[jit][BUG] blackhole failed key={} trace={} guard={} — recording failure",
@@ -3955,8 +3955,8 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
                             // 3b-2/3b-3 should eliminate the triggers by
                             // reading/writing registers_r at post-regalloc
                             // color instead of semantic slot index.
-                            // Increment abort_count to bound the retrace
-                            // cycle (see execute_assembler's handler).
+                            // Increment abort_count, invalidate compiled
+                            // loop, and at limit mark DONT_TRACE_HERE.
                             if majit_metainterp::majit_log_enabled() {
                                 eprintln!(
                                     "[jit][BUG] blackhole failed key={} — recording failure",

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3551,17 +3551,20 @@ fn execute_assembler(
                             // Pyre's `BlackholeResult::Failed` is a layered
                             // adaptation; SSA-authoritative live_r encoder /
                             // decoder work should eliminate the remaining
-                            // triggers. Until then
-                            // the bare `invalidate_loop` keeps the cell
-                            // retraceable; the failure surfaces in
-                            // check.py rather than being masked.
+                            // triggers.
+                            //
+                            // Increment abort_count so that the compile /
+                            // guard-fail / bh-fail / invalidate / retrace
+                            // cycle is bounded. Once the limit is reached
+                            // the loop is not invalidated again and the key
+                            // is marked DONT_TRACE_HERE.
                             if majit_metainterp::majit_log_enabled() {
                                 eprintln!(
-                                    "[jit][BUG] blackhole failed key={} trace={} guard={} — invalidating",
+                                    "[jit][BUG] blackhole failed key={} trace={} guard={} — recording failure",
                                     green_key, trace_id, fail_index,
                                 );
                             }
-                            driver.invalidate_loop(green_key);
+                            driver.record_blackhole_failure_and_maybe_invalidate(green_key);
                             None
                         }
                         _ => bh_result.to_pyresult().map(LoopResult::Done),
@@ -3770,7 +3773,9 @@ fn bound_reached(
                             }
                             return Some(LoopResult::ContinueRunningNormally);
                         }
-                        crate::call_jit::BlackholeResult::Failed => {}
+                        crate::call_jit::BlackholeResult::Failed => {
+                            driver.record_blackhole_failure_and_maybe_invalidate(green_key);
+                        }
                         _ => {
                             if let Some(r) = bh_result.to_pyresult() {
                                 return Some(LoopResult::Done(r));
@@ -3950,14 +3955,16 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
                             // 3b-2/3b-3 should eliminate the triggers by
                             // reading/writing registers_r at post-regalloc
                             // color instead of semantic slot index.
+                            // Increment abort_count to bound the retrace
+                            // cycle (see execute_assembler's handler).
                             if majit_metainterp::majit_log_enabled() {
                                 eprintln!(
-                                    "[jit][BUG] blackhole failed key={} — invalidating",
+                                    "[jit][BUG] blackhole failed key={} — recording failure",
                                     green_key,
                                 );
                             }
                             let (driver, _) = driver_pair();
-                            driver.invalidate_loop(green_key);
+                            driver.record_blackhole_failure_and_maybe_invalidate(green_key);
                         }
                         _ => {
                             if let Some(r) = bh_result.to_pyresult() {


### PR DESCRIPTION
## Summary

This pull request primarily updates documentation and code to reflect the migration of the main test script from `pyre/check.sh` (a shell script) to `pyre/check.py` (a Python script). In addition, it introduces a new mechanism in the JIT system to record and limit repeated blackhole resume failures, preventing infinite retracing cycles and marking problematic code paths as non-traceable after a threshold. The changes improve robustness in JIT error handling and ensure all documentation and workflows reference the correct test entry point.

**Documentation and Workflow Updates:**

* Updated all references in documentation (`.claude/skills/merge/SKILL.md`, `.claude/skills/parity/SKILL.md`, `.claude/skills/rebase/SKILL.md`, and `pyre/README.md`) from `pyre/check.sh` to `pyre/check.py`, ensuring consistency across merge, rebase, and parity workflows.

**JIT Blackhole Failure Handling Improvements:**

* Added a new method `record_blackhole_failure_and_maybe_invalidate` in `JitDriver`, `MetaInterp`, and `WarmEnterState` to track blackhole resume failures per loop ("green key"), incrementing an abort counter and marking the loop as non-traceable after a set limit, thus preventing infinite retrace cycles.

## Self-review

### Prompt & Model

Model: opus-4.6[1m]

Prompt: `/parity`

### Answer

```
  Parity audit

  Files modified and their RPython counterparts:

  Modified file: majit/majit-metainterp/src/warmstate.rs
  RPython counterpart: rpython/jit/metainterp/warmstate.py        
  Status: Exists
  ────────────────────────────────────────
  Modified file: majit/majit-metainterp/src/pyjitpl/mod.rs
  RPython counterpart: rpython/jit/metainterp/pyjitpl.py
  Status: Exists
  ────────────────────────────────────────
  Modified file: majit/majit-metainterp/src/jitdriver.rs
  RPython counterpart: No direct counterpart (pyre-specific driver abstraction)
  Status: PRE-EXISTING-ADAPTATION
  ────────────────────────────────────────
  Modified file: pyre/pyre-jit/src/eval.rs
  RPython counterpart: rpython/jit/metainterp/warmstate.py (warm-entry paths)
  Status: PRE-EXISTING-ADAPTATION (pyre-jit crate)

  Findings:

  1. warmstate.rs:786 — record_blackhole_failure() — No RPython counterpart. RPython's blackhole resume never fails (full SSA liveness), so
  no bounding mechanism exists upstream. This function is defensive hardening of the BlackholeResult::Failed PRE-EXISTING-ADAPTATION. It
  reuses abort_count and DONT_TRACE_HERE in the same pattern as the parity-correct abort_tracing() at :751. [deferred: requires Task #110 
  SSA liveness port to eliminate BlackholeResult::Failed entirely — removing this bound without fixing the root cause reintroduces the 
  thrashing it was written to stop]
  2. pyjitpl/mod.rs:6737 — record_blackhole_failure_and_maybe_invalidate() — No RPython counterpart, same reason. Wrapper combining
  record_blackhole_failure + conditional invalidate_loop. [deferred: same dependency as #1]
  3. jitdriver.rs:3274 — record_blackhole_failure_and_maybe_invalidate() — Passthrough to MetaInterp. [deferred: same dependency as #1]
  4. eval.rs:2979–3000, 3203–3205, 3372–3389 — BlackholeResult::Failed handlers — Changed from bare invalidate_loop to bounded
  record_blackhole_failure_and_maybe_invalidate. The BlackholeResult::Failed path itself is a PRE-EXISTING-ADAPTATION (Task #110). The diff
  replaces unbounded invalidation with bounded invalidation — strictly better behavior within the adaptation. [deferred: same root 
  dependency]

  Summary: All NEW-DEVIATIONs in this diff are defensive hardening of the BlackholeResult::Failed PRE-EXISTING-ADAPTATION. They follow the
  same abort_count / DONT_TRACE_HERE pattern used by the parity-correct abort_tracing(). Removing them without porting RPython's
  SSA-authoritative liveness (Task #110) would reintroduce the compile-guard-blackhole-invalidate-retrace thrashing cycle. No auto-fixes
  warranted — the root cause fix (eliminating BlackholeResult::Failed entirely) exceeds session scope.

  No regressions to auto-fix. The deviations are all in the "defensive hardening of existing adaptation, root fix requires unported
  dependency" category.

  Clean from a regression standpoint — the diff doesn't break any existing parity; it bounds an already-deviant path using parity-correct
  building blocks (abort_count, DONT_TRACE_HERE, MAX_TRACE_ABORT_COUNT).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge, rebase, and parity validation procedures to reference the updated checker tool.
  * Updated benchmark reproduction instructions in README.

* **Bug Fixes**
  * Enhanced blackhole failure handling with improved abort counting and loop invalidation logic to prevent excessive retracing cycles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->