### PR TITLE
Fix dynasm issues and stabilize CI feature tests

### DIFF
--- a/majit/majit-backend-cranelift/Cargo.toml
+++ b/majit/majit-backend-cranelift/Cargo.toml
@@ -19,12 +19,12 @@ cranelift-native = "0.130"
 target-lexicon = "0.13"
 
 [features]
-# No-op feature — declared so workspace-wide `cargo test --all
-# --features dynasm` does not error on a crate that has no dynasm
-# code path. The cranelift backend has no dynasm-specific code; this
-# crate stays unaffected when the workspace selects the dynasm feature.
-dynasm = []
+# Workspace-wide `cargo test --all --features dynasm` also selects this
+# crate's tests. The cranelift backend itself has no dynasm code path, but
+# its integration tests depend on `majit-metainterp::recorder::Trace`, and
+# `majit-metainterp` requires one backend feature to compile.
+dynasm = ["majit-metainterp/dynasm"]
 
 [dev-dependencies]
-majit-metainterp = { workspace = true, features = ["cranelift"] }
+majit-metainterp = { workspace = true }
 smallvec = "1"

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -10585,7 +10585,9 @@ impl CraneliftBackend {
                         let bit_idx = builder.ins().band(bit_idx, seven);
                         let one = builder.ins().iconst(cl_types::I64, 1);
                         let bit_mask = builder.ins().ishl(one, bit_idx);
-                        let card_addr = builder.ins().iadd(obj, byteofs_val);
+                        let card_header_base =
+                            builder.ins().iadd_imm(obj, -(majit_gc::header::GcHeader::SIZE as i64));
+                        let card_addr = builder.ins().iadd(card_header_base, byteofs_val);
                         let card_byte =
                             builder
                                 .ins()

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -5439,6 +5439,7 @@ impl<'a> AssemblerARM64<'a> {
                     ; and x17, x16, 7
                     ; mov x16, 1
                     ; lsl x17, x16, x17
+                    ; sub x30, x30, majit_gc::header::GcHeader::SIZE as u32
                     ; ldrb w16, [X(loc_base.value), x30]
                     ; orr w16, w16, w17
                     ; strb w16, [X(loc_base.value), x30]

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -1024,6 +1024,15 @@ impl<'a> Assembler386<'a> {
             ; .arch x64
             ; push rbp
             ; push r12               // save r12 (used by genop_call_assembler)
+        );
+        #[cfg(target_os = "windows")]
+        dynasm!(self.mc
+            ; .arch x64
+            ; mov rbp, rcx
+        );
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(self.mc
+            ; .arch x64
             ; mov rbp, rdi
         );
         let propagate_descr = self.propagate_exception_descr_ptr();

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2118,6 +2118,60 @@ impl<'a> Assembler386<'a> {
                     }
                 }
             }
+            // Structural adaptation: PyPy's llsupport/rewrite.py:132-154
+            // normally lowers SETARRAYITEM_* to GC_STORE(_INDEXED), but
+            // pyre's CI also exercises direct backend emission paths before
+            // that rewrite has run.
+            OpCode::SetarrayitemGc | OpCode::SetarrayitemRaw => {
+                if let (Some(Loc::Reg(base)), Some(index_loc), Some(value_loc)) =
+                    (arglocs.first(), arglocs.get(1), arglocs.get(2))
+                {
+                    let (base_size, item_size) = op
+                        .descr
+                        .as_ref()
+                        .and_then(|d| d.as_array_descr())
+                        .map(|ad| (ad.base_size() as i32, ad.item_size() as i32))
+                        .unwrap_or((0, 8));
+                    let index_reg = crate::regloc::X86_64_SCRATCH_REG.value;
+                    let value_reg = crate::regloc::X86_64_SCRATCH_REG_2.value;
+
+                    self.regalloc_mov(
+                        index_loc,
+                        &Loc::Reg(crate::regloc::RegLoc::new(index_reg, false)),
+                    );
+                    if item_size != 1 {
+                        dynasm!(self.mc ; .arch x64 ; imul Rq(index_reg), Rq(index_reg), item_size);
+                    }
+                    if base_size != 0 {
+                        dynasm!(self.mc ; .arch x64 ; add Rq(index_reg), base_size);
+                    }
+                    dynasm!(self.mc ; .arch x64 ; add Rq(index_reg), Rq(base.value));
+
+                    match value_loc {
+                        Loc::Reg(val) if val.is_xmm => {
+                            dynasm!(self.mc ; .arch x64 ; movsd [Rq(index_reg)], Rx(val.value));
+                        }
+                        Loc::Reg(val) => match item_size {
+                            1 => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rb(val.value)),
+                            2 => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rw(val.value)),
+                            4 => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rd(val.value)),
+                            _ => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rq(val.value)),
+                        },
+                        _ => {
+                            self.regalloc_mov(
+                                value_loc,
+                                &Loc::Reg(crate::regloc::RegLoc::new(value_reg, false)),
+                            );
+                            match item_size {
+                                1 => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rb(value_reg)),
+                                2 => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rw(value_reg)),
+                                4 => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rd(value_reg)),
+                                _ => dynasm!(self.mc ; .arch x64 ; mov [Rq(index_reg)], Rq(value_reg)),
+                            }
+                        }
+                    }
+                }
+            }
             // ── Control flow ──
             OpCode::Jump => {
                 let jump_descr = loop_target_descr(op);

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -5136,36 +5136,23 @@ impl<'a> Assembler386<'a> {
             // Inline card bit set (x86/assembler.py:2398 WriteBarrierSlowPath parity)
             dynasm!(self.mc ; .arch x64 ; =>card_mark);
             if let Some(Loc::Reg(loc_index)) = arglocs.get(1) {
-                let shift = (3 + wb.jit_wb_card_page_shift) as i8;
-                // byte_index = ~(index >> (3+page_shift))
-                dynasm!(self.mc ; .arch x64
-                    ; mov rcx, Rq(loc_index.value as u8)
-                    ; shr rcx, shift
-                    ; not rcx
-                );
-                // bit_index = (index >> page_shift) & 7 → set bit
                 let page_shift = wb.jit_wb_card_page_shift as i8;
+                let byte_shift = (3 + wb.jit_wb_card_page_shift) as i8;
                 dynasm!(self.mc ; .arch x64
-                    ; mov rax, Rq(loc_index.value as u8)
-                    ; shr rax, page_shift
-                    ; and rax, 7
-                    ; mov rdx, 1
-                    ; shl rdx, cl  // cl = bit_index? no, need rax
-                );
-                // Actually simpler: use BTS instruction
-                // card_byte_ofs = rcx, bit = (index >> page_shift) & 7
-                // Just OR the byte directly
-                dynasm!(self.mc ; .arch x64
-                    ; mov rdx, 1
-                    ; mov r8, Rq(loc_index.value as u8)
-                    ; shr r8, page_shift
-                    ; and r8, 7
-                );
-                // set bit: load byte, or, store
-                dynasm!(self.mc ; .arch x64
-                    ; mov cl, r8b
+                    ; push rcx
+                    ; push rdx
+                    ; mov r11, Rq(loc_index.value as u8)
+                    ; shr r11, byte_shift
+                    ; not r11
+                    ; sub r11, majit_gc::header::GcHeader::SIZE as i32
+                    ; mov rcx, Rq(loc_index.value as u8)
+                    ; shr rcx, page_shift
+                    ; and rcx, 7
+                    ; mov dl, 1
                     ; shl dl, cl
-                    ; or BYTE [Rq(loc_base.value as u8) + rcx], dl
+                    ; or BYTE [Rq(loc_base.value as u8) + r11], dl
+                    ; pop rdx
+                    ; pop rcx
                 );
             }
         } else {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2830,7 +2830,6 @@ impl<'a> Assembler386<'a> {
 
     /// Emit SETcc into a register (zero-extend to 64-bit).
     fn emit_setcc(&mut self, cc: u8, dst_reg: u8) {
-        dynasm!(self.mc ; .arch x64 ; xor Rd(dst_reg), Rd(dst_reg));
         match cc {
             CC_E => {
                 dynasm!(self.mc ; .arch x64 ; sete  Rb(dst_reg));
@@ -2878,6 +2877,7 @@ impl<'a> Assembler386<'a> {
                 dynasm!(self.mc ; .arch x64 ; sete  Rb(dst_reg));
             }
         }
+        dynasm!(self.mc ; .arch x64 ; movzx Rd(dst_reg), Rb(dst_reg));
     }
 
     /// Map an integer comparison OpCode to a condition code.

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2758,18 +2758,25 @@ mod tests {
             "CARDS_SET should be set before collection"
         );
 
+        let mut root = obj;
+        unsafe {
+            gc.roots.add(&mut root);
+        }
+
         // Minor collection clears card bytes.
         gc.do_collect_nursery();
 
-        let hdr = unsafe { header_of(obj.0) };
+        let hdr = unsafe { header_of(root.0) };
         assert!(
             unsafe { !(*hdr).has_flag(flags::CARDS_SET) },
             "CARDS_SET flag should be cleared after collection"
         );
         assert!(
-            !gc.is_card_dirty(obj, 0),
+            !gc.is_card_dirty(root, 0),
             "card 0 should be cleared after collection"
         );
+
+        gc.roots.clear();
     }
 
     #[test]

--- a/majit/majit-ir/src/descr_registry.rs
+++ b/majit/majit-ir/src/descr_registry.rs
@@ -144,17 +144,27 @@ mod tests {
         Arc::new(SimpleFieldDescr::new(idx, 0, 8, Type::Int, false))
     }
 
+    fn count_arc(haystack: &[DescrRef], needle: &DescrRef) -> usize {
+        haystack
+            .iter()
+            .filter(|descr| Arc::ptr_eq(descr, needle))
+            .count()
+    }
+
     /// Same `Arc` clone re-registered via the facade collapses to a
     /// single `_cache_field_order` entry — `Arc::ptr_eq` dedup at the
     /// `gc_cache.register_external_*` level.
     #[test]
     fn dedup_by_arc_identity_within_category() {
         let f = fresh_field(42);
-        let before = gc_cache().lock().unwrap().snapshot_fields().len();
         register_field(f.clone());
-        register_field(f);
-        let after = gc_cache().lock().unwrap().snapshot_fields().len();
-        assert_eq!(after - before, 1, "same Arc should collapse to one entry");
+        register_field(f.clone());
+        let fields = gc_cache().lock().unwrap().snapshot_fields();
+        assert_eq!(
+            count_arc(&fields, &f),
+            1,
+            "same Arc should collapse to one entry"
+        );
     }
 
     /// Distinct Arcs that share `descr.index() == 0` (e.g. two
@@ -164,10 +174,19 @@ mod tests {
     /// `(STRUCT, fieldname)` keyed dict.
     #[test]
     fn distinct_arcs_share_index_stay_separate() {
-        let before = gc_cache().lock().unwrap().snapshot_fields().len();
-        register_field(fresh_field(0));
-        register_field(fresh_field(0));
-        let after = gc_cache().lock().unwrap().snapshot_fields().len();
-        assert_eq!(after - before, 2);
+        let f_a = fresh_field(0);
+        let f_b = fresh_field(0);
+        register_field(f_a.clone());
+        register_field(f_b.clone());
+        let fields = gc_cache().lock().unwrap().snapshot_fields();
+        assert_eq!(count_arc(&fields, &f_a), 1);
+        assert_eq!(count_arc(&fields, &f_b), 1);
+        assert!(
+            fields
+                .iter()
+                .filter(|descr| Arc::ptr_eq(descr, &f_a) || Arc::ptr_eq(descr, &f_b))
+                .count()
+                == 2
+        );
     }
 }


### PR DESCRIPTION
## Summary

This pull request introduces several improvements and bug fixes across the Cranelift and Dynasm backends, as well as enhancements to tests and feature handling. The most significant changes include a fix to the card marking calculation in the Cranelift backend, new support for array item stores in the x86 Dynasm backend, and improvements to test robustness and deduplication logic. Additionally, feature dependencies are clarified for workspace-wide builds.

**Backend bug fixes and improvements:**

* Fixed the calculation of the card marking address in the Cranelift backend to account for the GC header size, ensuring correct memory management.
* Reworked the x86 Dynasm backend's card marking logic to match the Cranelift fix, including proper offset calculation and register preservation.
* Fixed `emit_setcc` in the x86 Dynasm backend to zero-extend the result to 64 bits after setting the condition code, ensuring correct register values.
* Added platform-specific calling convention handling for Windows in the x86 Dynasm prologue.

**Build and feature configuration:**

* Updated the Cranelift backend's `dynasm` feature to depend on `majit-metainterp/dynasm`, ensuring integration tests compile correctly when features are enabled workspace-wide.

**Test improvements:**

* Improved GC and IR registry tests for robustness: ensured roots are registered/cleared in GC tests and improved deduplication checks in IR descriptor registry tests by using pointer equality instead of length deltas.
* As a result, 4 or 5 out of 6 combinations in the CI matrix are now live. (4 or 5 because Windows has some flakiness issue.)

**Documentation and comments:**

* Updated comments and inline documentation to clarify changes in backend logic and test behavior, including card marking and register usage.

These changes collectively improve correctness, maintainability, and test reliability across the project.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Cases Where Our Patch Regressed PyPy Parity Compared To Main

  None found.

  The card-table address changes in:

  - majit/majit-backend-cranelift/src/compiler.rs:10588
  - majit/majit-backend-dynasm/src/aarch64/assembler.rs:5442
  - majit/majit-backend-dynasm/src/x86/assembler.rs:5210

  look correct for Pyre’s object-pointer convention. RPython’s incminimark.get_card() computes the card byte from obj - size_gc_header +
  ~byteindex at rpython/memory/gc/incminimark.py:1622, and Pyre GcRef points after GcHeader, so subtracting GcHeader::SIZE is the required
  adaptation.

  2. Other Mismatches Introduced By Our Patch

  None found as incorrect ports.

  The new x86 SETcc sequence in majit/majit-backend-dynasm/src/x86/assembler.rs:2895 is closer to RPython than main: RPython zeroes with
  MOV_ri before SET_ir in rpython/jit/backend/x86/assembler.py:1297, which does not clobber flags. The previous xor before setcc did clobber
  flags; setcc then movzx avoids that.

  3. Mismatches That Already Existed Before This Patch

  No newly relevant pre-existing parity bugs were exposed by this diff.

  There are broader non-literal areas around write-barrier slowpath plumbing and helper calls, but those were already present and are better
  classified as structural adaptations: Pyre emits direct Rust/C shim calls and saves registers inline, while RPython builds reusable
  pending slowpaths via WriteBarrierSlowPath / _build_wb_slowpath.

  4. Structural Adaptations

  - GcHeader::SIZE in card marking is intentional. RPython backend snippets such as rpython/jit/backend/x86/assembler.py:2361 and rpython/
    jit/backend/aarch64/opassembler.py:1002 address cards relative to RPython’s object address. Pyre’s GcRef is payload-relative, and majit/
    majit-gc/src/collector.rs:302 confirms card bytes are reached by subtracting GcHeader::SIZE.
  - Direct x86 SETARRAYITEM_GC/RAW emission in majit/majit-backend-dynasm/src/x86/assembler.rs:2121 is not a literal PyPy backend path. PyPy
    normally rewrites this through GC_STORE / GC_STORE_INDEXED in rpython/jit/backend/llsupport/rewrite.py:132. The comment accurately marks
    this as a Pyre test/CI adaptation for direct backend emission before that rewrite.
  - Windows x86-64 entry now uses rcx for the incoming jitframe in majit/majit-backend-dynasm/src/x86/assembler.rs:1028, matching the
    platform ABI equivalent of RPython’s ARG0 selection in rpython/jit/backend/x86/assembler.py:1060. This is an ABI adaptation.
  - Test and feature changes in majit/majit-gc/src/collector.rs:2761, majit/majit-ir/src/descr_registry.rs:76, and majit/majit-backend-
    cranelift/Cargo.toml:22 have no direct RPython behavioral counterpart.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed write-barrier/card-marking address calculations across architectures (adjusts base offsets to account for object headers).
  * Corrected platform-specific x64 prologue initialization on Windows vs non-Windows.

* **Refactor**
  * Improved emitted instruction sequences for register operations, bit manipulation, and array element stores.

* **Tests**
  * Strengthened tests for card-marking behavior and descriptor deduplication.

* **Chores**
  * Updated dependency feature configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/18)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->