### PR TITLE
Align exceptiontable

### DIFF
--- a/majit/majit-translate/src/flowspace/bytecode.rs
+++ b/majit/majit-translate/src/flowspace/bytecode.rs
@@ -250,42 +250,91 @@ impl HostCode {
 
     /// Find the exception-table handler covering the given byte offset.
     ///
-    /// RustPython stores exception-table offsets in code-unit indices.
-    /// `HostCode.read` and flowspace operate in byte offsets for
-    /// parity with RPython's `co_code` walk, so the adapter converts
-    /// to/from byte offsets here.
+    /// `pypy/interpreter/pycode.py:229-254 lookup_exceptiontable` parity:
+    /// last-matching-wins, byte-offset I/O.  `HostCode.read` and flowspace
+    /// operate in byte offsets (RPython's `co_code` walk convention), so
+    /// the result is byte-offset natively.
+    ///
+    /// Mirrors `pyre_interpreter::exception_table::lookup_exceptiontable`
+    /// but lives here because `majit-translate` does not depend on
+    /// `pyre-interpreter`; the varint decoder is small and the entry
+    /// format is frozen by CPython 3.11 bytecode.
     pub fn find_exception_handler(&self, offset: u32) -> Option<ExceptionTableEntry> {
         if !offset.is_multiple_of(2) {
             return None;
         }
-        let unit_offset = offset / 2;
-        rustpython_compiler_core::bytecode::find_exception_handler(
-            &self.exceptiontable,
-            unit_offset,
-        )
-        .map(|entry| ExceptionTableEntry {
-            start: entry.start * 2,
-            end: entry.end * 2,
-            target: entry.target * 2,
-            depth: entry.depth,
-            push_lasti: entry.push_lasti,
-        })
+        let table = &self.exceptiontable;
+        let n = table.len();
+        let mut best: Option<ExceptionTableEntry> = None;
+        let mut i = 0;
+        while i < n {
+            let (start_raw, ni) = decode_table_varint(table, i);
+            let start = start_raw * 2;
+            let (length_raw, ni) = decode_table_varint(table, ni);
+            let length = length_raw * 2;
+            let (target_raw, ni) = decode_table_varint(table, ni);
+            let target = target_raw * 2;
+            let (dl, ni) = decode_table_varint(table, ni);
+            i = ni;
+            if start <= offset && offset < start + length {
+                best = Some(ExceptionTableEntry {
+                    start,
+                    end: start + length,
+                    target,
+                    depth: (dl >> 1) as u16,
+                    push_lasti: (dl & 1) != 0,
+                });
+            } else if start > offset {
+                break;
+            }
+        }
+        best
     }
 
     /// Decode the entire exception table into byte-offset entries.
     pub fn decode_exception_table(&self) -> Vec<ExceptionTableEntry> {
-        rustpython_compiler_core::bytecode::decode_exception_table(&self.exceptiontable)
-            .into_iter()
-            .map(|entry| ExceptionTableEntry {
-                start: entry.start * 2,
-                end: entry.end * 2,
-                target: entry.target * 2,
-                depth: entry.depth,
-                push_lasti: entry.push_lasti,
-            })
-            .collect()
+        let table = &self.exceptiontable;
+        let n = table.len();
+        let mut entries = Vec::new();
+        let mut i = 0;
+        while i < n {
+            let (start_raw, ni) = decode_table_varint(table, i);
+            let start = start_raw * 2;
+            let (length_raw, ni) = decode_table_varint(table, ni);
+            let length = length_raw * 2;
+            let (target_raw, ni) = decode_table_varint(table, ni);
+            let target = target_raw * 2;
+            let (dl, ni) = decode_table_varint(table, ni);
+            i = ni;
+            entries.push(ExceptionTableEntry {
+                start,
+                end: start + length,
+                target,
+                depth: (dl >> 1) as u16,
+                push_lasti: (dl & 1) != 0,
+            });
+        }
+        entries
     }
+}
 
+/// `pypy/interpreter/pycode.py:683-695 _decode_varint`.  Reads 6 bits per
+/// byte, MSB first; bit 6 is the continuation flag, bit 7 is the start-of-
+/// entry marker (ignored — masked along with continuation via `& 63`).
+#[inline]
+fn decode_table_varint(table: &[u8], mut i: usize) -> (u32, usize) {
+    let mut b = table[i] as u32;
+    i += 1;
+    let mut value = b & 63;
+    while b & 64 != 0 {
+        b = table[i] as u32;
+        i += 1;
+        value = (value << 6) | (b & 63);
+    }
+    (value, i)
+}
+
+impl HostCode {
     /// Decode the instruction starting at byte position `offset`.
     ///
     /// Returns `(next_offset, op, oparg)` where `next_offset` is the byte

--- a/pyre/extra_tests/parity_tests/exception_table_co_attribute.py
+++ b/pyre/extra_tests/parity_tests/exception_table_co_attribute.py
@@ -1,0 +1,33 @@
+"""`code.co_exceptiontable` is exposed as a `bytes` attribute.
+
+`pypy/interpreter/typedef.py:720` declares
+`co_exceptiontable = interp_attrproperty('co_exceptiontable', cls=PyCode,
+                                          wrapfn="newbytes")`.
+A function with any try/except must have a non-empty exception table;
+a function with no exception handling has an empty one.
+"""
+
+
+def with_try(x):
+    try:
+        return int(x)
+    except ValueError:
+        return -1
+
+
+def without_try(x):
+    return x + 1
+
+
+assert isinstance(with_try.__code__.co_exceptiontable, bytes), (
+    type(with_try.__code__.co_exceptiontable),
+)
+assert len(with_try.__code__.co_exceptiontable) > 0, "try/except function should have entries"
+assert isinstance(without_try.__code__.co_exceptiontable, bytes), (
+    type(without_try.__code__.co_exceptiontable),
+)
+assert len(without_try.__code__.co_exceptiontable) == 0, (
+    "no-except function should have empty table"
+)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/exception_table_nested.py
+++ b/pyre/extra_tests/parity_tests/exception_table_nested.py
@@ -1,0 +1,43 @@
+"""Nested try/except picks the innermost (last-matching-wins) handler.
+
+`pypy/interpreter/pycode.py:250-253 lookup_exceptiontable` keeps walking
+the table even after a match, choosing the *later* (innermost) entry
+when multiple ranges cover the raise site.  Earlier pyre `.find(...)`
+returned the first match, which diverges in nested cases.
+"""
+
+
+def go():
+    log = []
+    try:
+        try:
+            raise ValueError("inner")
+        except KeyError:
+            log.append("wrong-outer")
+        except ValueError as e:
+            log.append(f"inner-caught:{e}")
+    except Exception as e:
+        log.append(f"outer-caught:{e}")
+    return log
+
+
+def deeper():
+    log = []
+    try:
+        try:
+            try:
+                raise RuntimeError("deep")
+            except TypeError:
+                log.append("wrong-1")
+        except KeyError:
+            log.append("wrong-2")
+        except RuntimeError as e:
+            log.append(f"deep-caught:{e}")
+    except Exception as e:
+        log.append(f"propagated:{e}")
+    return log
+
+
+assert go() == ["inner-caught:inner"], go()
+assert deeper() == ["deep-caught:deep"], deeper()
+print("OK")

--- a/pyre/extra_tests/parity_tests/exception_table_reraise_lasti.py
+++ b/pyre/extra_tests/parity_tests/exception_table_reraise_lasti.py
@@ -1,0 +1,58 @@
+"""RERAISE re-raises the same exception object without loss.
+
+`pypy/interpreter/pyopcode.py:1361-1376 RERAISE` reads the original
+raise-site lasti via `peekvalue(oparg)` and threads it through
+`RaiseWithExplicitTraceback` so the unwound frame's `last_instr` points
+back to the original raise — needed for `f_lineno`.  Without the lasti
+field on the carrier, the bare-`raise` in a handler loses the
+information.  We exercise the round-trip at the value level: both
+exception identity and message must survive a nested re-raise.
+"""
+
+
+sentinel = ValueError("orig-payload")
+
+
+def inner():
+    raise sentinel
+
+
+def middle():
+    try:
+        inner()
+    except ValueError:
+        # RERAISE (bare `raise` inside except) — must preserve identity.
+        raise
+
+
+def outer():
+    try:
+        middle()
+    except ValueError as caught:
+        return caught
+
+
+got = outer()
+assert got is sentinel, ("identity lost across RERAISE", id(got), id(sentinel))
+assert str(got) == "orig-payload", str(got)
+
+# Now exercise a deeper RERAISE chain — the inner reraise carries
+# through two handlers.
+def chain():
+    try:
+        try:
+            try:
+                raise KeyError("k")
+            except KeyError:
+                raise  # RERAISE 1
+        except KeyError:
+            raise  # RERAISE 2
+    except KeyError as e:
+        return e
+
+
+got2 = chain()
+assert isinstance(got2, KeyError), type(got2)
+assert got2.args == ("k",), got2.args
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/exception_table_reraise_lasti.py
+++ b/pyre/extra_tests/parity_tests/exception_table_reraise_lasti.py
@@ -55,4 +55,84 @@ got2 = chain()
 assert isinstance(got2, KeyError), type(got2)
 assert got2.args == ("k",), got2.args
 
+
+# Verify `pyopcode.py:181-184` no-handler propagation: the unwound
+# frame's `last_instr` is restored to the original raise-site offset
+# (visible via `tb.tb_lineno` of the deepest frame).  Without the
+# restoration the traceback would point at the RERAISE site, not the
+# original `raise`.
+def raise_here():
+    raise RuntimeError("original")  # ORIGINAL_RAISE_LINE
+
+
+_ORIGINAL_RAISE_LINE = raise_here.__code__.co_firstlineno + 1
+
+
+def reraise_here():
+    try:
+        raise_here()
+    except RuntimeError:
+        raise  # propagate via bare-`raise`; line != _ORIGINAL_RAISE_LINE
+
+
+def collect_tb():
+    try:
+        reraise_here()
+    except RuntimeError as e:
+        return e.__traceback__
+
+
+tb = collect_tb()
+# Walk to the deepest frame in the traceback chain.
+deepest = tb
+while deepest.tb_next is not None:
+    deepest = deepest.tb_next
+assert deepest.tb_lineno == _ORIGINAL_RAISE_LINE, (
+    "tb_lineno should point to the original raise, not the RERAISE",
+    deepest.tb_lineno,
+    _ORIGINAL_RAISE_LINE,
+)
+
+
+# Exercise RERAISE oparg > 0 via a `with` block: the __exit__ returning
+# a falsy value re-raises with the saved lasti pushed by the exception
+# table.  This is the path that requires `reraise_lasti` threading
+# (pyopcode.py:1361 `peekvalue(oparg)` with oparg != 0).
+class _NoSuppress:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        return None  # falsy → re-raise
+
+
+def raise_in_with():
+    raise IndexError("from-with")  # WITH_RAISE_LINE
+
+
+_WITH_RAISE_LINE = raise_in_with.__code__.co_firstlineno + 1
+
+
+def with_block():
+    with _NoSuppress():
+        raise_in_with()
+
+
+def collect_with_tb():
+    try:
+        with_block()
+    except IndexError as e:
+        return e.__traceback__
+
+
+tb_with = collect_with_tb()
+deepest_with = tb_with
+while deepest_with.tb_next is not None:
+    deepest_with = deepest_with.tb_next
+assert deepest_with.tb_lineno == _WITH_RAISE_LINE, (
+    "with-block reraise lost the original raise lineno",
+    deepest_with.tb_lineno,
+    _WITH_RAISE_LINE,
+)
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/exception_table_reraise_lasti.py
+++ b/pyre/extra_tests/parity_tests/exception_table_reraise_lasti.py
@@ -37,21 +37,26 @@ assert got is sentinel, ("identity lost across RERAISE", id(got), id(sentinel))
 assert str(got) == "orig-payload", str(got)
 
 # Now exercise a deeper RERAISE chain — the inner reraise carries
-# through two handlers.
+# through two handlers.  Capture the original exception in the
+# innermost handler so the outermost return can also be checked for
+# object identity, not just type/args.
 def chain():
+    first = None
     try:
         try:
             try:
                 raise KeyError("k")
-            except KeyError:
+            except KeyError as e:
+                first = e
                 raise  # RERAISE 1
         except KeyError:
             raise  # RERAISE 2
     except KeyError as e:
-        return e
+        return first, e
 
 
-got2 = chain()
+first2, got2 = chain()
+assert got2 is first2, ("identity lost across nested RERAISE", id(got2), id(first2))
 assert isinstance(got2, KeyError), type(got2)
 assert got2.args == ("k",), got2.args
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4706,6 +4706,15 @@ pub fn getattr(obj: PyObjectRef, name: &str) -> PyResult {
                 "co_name" => return Ok(w_str_new(code.obj_name.as_ref())),
                 "co_filename" => return Ok(w_str_new(code.source_path.as_ref())),
                 "co_flags" => return Ok(w_int_new(code.flags.bits() as i64)),
+                // `pypy/interpreter/pycode.py:143` — `self.co_firstlineno = firstlineno`,
+                // `typedef.py:718` — `co_firstlineno = interp_attrproperty('co_firstlineno', cls=PyCode, wrapfn="newint")`.
+                // RustPython exposes the field as `Option<OneIndexed>`; map None to 1
+                // (matching CPython's default for module-level code).
+                "co_firstlineno" => {
+                    return Ok(w_int_new(
+                        code.first_line_number.map_or(1, |n| n.get() as i64),
+                    ));
+                }
                 _ => {}
             }
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7465,6 +7465,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 message: "".to_string(),
                 exc_object: std::ptr::null_mut(),
                 attach_tb: true,
+                reraise_lasti: -1,
             });
         }
         // Range iterator
@@ -7487,6 +7488,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 message: "".to_string(),
                 exc_object: std::ptr::null_mut(),
                 attach_tb: true,
+                reraise_lasti: -1,
             });
         }
         // Generator __next__ — PyPy: generator.py GeneratorIterator.next
@@ -7856,6 +7858,7 @@ fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
         message: String::new(),
         exc_object: std::ptr::null_mut(),
         attach_tb: true,
+        reraise_lasti: -1,
     };
     match generator_send_ex(gen_obj, w_none(), Some(err)) {
         Ok(_) => {
@@ -7900,6 +7903,7 @@ fn normalize_throw_args(w_type: PyObjectRef, w_val: PyObjectRef) -> PyError {
                     message: msg,
                     exc_object: std::ptr::null_mut(),
                     attach_tb: true,
+                    reraise_lasti: -1,
                 };
             }
         }

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -275,6 +275,7 @@ impl From<OperationError> for PyError {
             message,
             exc_object: value.w_value,
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 }
@@ -308,6 +309,15 @@ pub struct PyError {
     /// `record_application_traceback`.  Default `true` for any
     /// normally-constructed PyError; reraise flips it off.
     pub attach_tb: bool,
+    /// `pypy/interpreter/pyopcode.py:122 handle_operation_error(..., reraise_lasti=-1)`
+    /// parity.  RERAISE N reads the original raise-site lasti from the
+    /// value stack and carries it through `RaiseWithExplicitTraceback`
+    /// so the next exception-table dispatch can push the original
+    /// raise-site offset (not the RERAISE instruction itself) as the
+    /// `lasti` value, and so the no-handler propagation path can
+    /// restore `last_instr` for correct `f_lineno`.  `-1` means "no
+    /// reraise lasti carried" (default for primary raises).
+    pub reraise_lasti: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -381,6 +391,7 @@ impl PyError {
             message: message.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -390,6 +401,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -399,6 +411,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -408,6 +421,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -417,6 +431,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -426,6 +441,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -435,6 +451,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -444,6 +461,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -453,6 +471,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -469,6 +488,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -480,6 +500,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -489,6 +510,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -502,6 +524,7 @@ impl PyError {
             message: msg.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -511,6 +534,7 @@ impl PyError {
             message: String::new(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         }
     }
 
@@ -588,6 +612,7 @@ impl PyError {
                 message,
                 exc_object: obj,
                 attach_tb: true,
+                reraise_lasti: -1,
             }
         }
     }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -540,32 +540,52 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
         }
     }
     let code = unsafe { &*crate::pyframe_get_pycode(frame) };
-    let pc = frame.last_instr as u32;
+    let pc_units = frame.last_instr as u32;
+    // pyre's `last_instr` is a rustpython code-unit index; the PyPy-shaped
+    // `lookup_exceptiontable` lookup takes byte offsets, so multiply by 2.
+    // (See exception_table.rs: varint values are word offsets but the lookup
+    // operates in byte space, mirroring `pycode.py:241-246`.)
+    let pc_bytes = pc_units * 2;
 
-    // Python 3.11+ exception table dispatch
-    if let Some(entry) = crate::bytecode::find_exception_handler(&code.exceptiontable, pc) {
-        // Unwind stack to handler's expected depth
-        let target_depth = frame.nlocals() + frame.ncells() + entry.depth as usize;
+    // `pypy/interpreter/pyopcode.py:151-173` exception-table dispatch.
+    if let Some((target_bytes, depth, lasti)) =
+        crate::exception_table::lookup_exceptiontable(&code.exceptiontable, pc_bytes)
+    {
+        // `pyopcode.py:155-156` — depth is relative (0 = empty value
+        // stack); convert to absolute by adding the frame's locals+cells
+        // base, then drop the stack to that depth.
+        let target_depth = frame.nlocals() + frame.ncells() + depth as usize;
         while frame.valuestackdepth > target_depth {
             frame.pop();
         }
-        if entry.push_lasti {
-            frame.push(pyre_object::w_int_new(pc as i64));
+        // `pyopcode.py:157-170` — lasti=True: push the raise-site offset
+        // as an int below the exception, so RERAISE N can read it for
+        // traceback/f_lineno correctness.  If this dispatch was triggered
+        // by RERAISE (reraise_lasti from PyError, mirroring PyPy's
+        // `handle_operation_error(reraise_lasti=...)`), use the original
+        // raise-site lasti the RERAISE carried; otherwise use the current
+        // instruction (the raising site itself).
+        if lasti {
+            let lasti_value: i64 = if err.reraise_lasti >= 0 {
+                err.reraise_lasti as i64
+            } else {
+                pc_units as i64
+            };
+            frame.push(pyre_object::w_int_new(lasti_value));
         }
-        // Push exception value as W_ExceptionObject
         let exc_obj = err.to_exc_object();
         frame.push(exc_obj);
-        *next_instr = entry.target as usize;
+        // The decoded `target` is a byte offset; pyre's `next_instr` is a
+        // code-unit index, so divide by 2.
+        *next_instr = (target_bytes / 2) as usize;
         return true;
     }
 
-    // Fallback: lastblock (old-style SETUP_FINALLY/SETUP_EXCEPT)
-    if let Some(block) = frame.pop_block() {
-        block.cleanupstack(frame);
-        let exc_obj = err.to_exc_object();
-        frame.push(exc_obj);
-        *next_instr = block.handlerposition;
-        return true;
+    // `pyopcode.py:175-185` no-handler propagation: if this unwind was
+    // triggered by RERAISE N, restore `last_instr` to the original
+    // raise-site offset so `frame.f_lineno` reports the right line.
+    if err.reraise_lasti >= 0 {
+        frame.last_instr = err.reraise_lasti as isize;
     }
 
     false
@@ -1894,17 +1914,36 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     // ── Reraise ──
-    // CPython: RERAISE raises the exception that's on TOS.
-    // The exception table handler (handle_exception) unwinds the stack.
-    // We peek TOS to get the exception but do NOT pop — handle_exception
-    // will set the stack to the correct depth.
-    fn reraise(&mut self) -> Result<(), Self::Error> {
-        // TOS is the exception, TOS1 is prev_exc_info
+    // `pypy/interpreter/pyopcode.py:1348-1376 RERAISE`.
+    //
+    // CPython 3.11 `RERAISE N` re-raises the exception currently on TOS.
+    // When `N > 0`, the original raise-site lasti integer sits `N` slots
+    // below TOS (`peekvalue(oparg)`), and is carried through
+    // `RaiseWithExplicitTraceback(operr, reraise_lasti)` so the next
+    // exception-table dispatch can push the original offset (not the
+    // RERAISE site) for the handler's `lasti` slot.  `N == 0` is a plain
+    // reraise — no lasti carried.
+    //
+    // `handle_exception` reads `reraise_lasti` from the PyError; the
+    // stack is left untouched here (PyPy pops the exception in RERAISE
+    // itself but pyre's `handle_exception` walks the stack down to the
+    // handler depth, so popping early would corrupt nlocals + ncells +
+    // depth bookkeeping).
+    fn reraise(&mut self, oparg: u32) -> Result<(), Self::Error> {
+        let reraise_lasti: i32 = if oparg != 0 {
+            let w_lasti = self.peekvalue(oparg as usize);
+            unsafe {
+                if w_lasti.is_null() || !pyre_object::is_int(w_lasti) {
+                    -1
+                } else {
+                    pyre_object::w_int_get_value(w_lasti) as i32
+                }
+            }
+        } else {
+            -1
+        };
+        // TOS is the exception object.
         let exc = self.peek();
-        // `pyopcode.py:1370-1376 RERAISE raise
-        // RaiseWithExplicitTraceback` parity — flip `attach_tb` so
-        // `handle_exception` skips `record_application_traceback`
-        // and the cleanup-RERAISE doesn't double-stamp the traceback.
         let mut err = unsafe {
             if pyre_object::is_exception(exc) {
                 PyError::from_exc_object(exc)
@@ -1914,7 +1953,10 @@ impl OpcodeStepExecutor for PyFrame {
                 PyError::runtime_error("exception re-raised")
             }
         };
+        // `pyopcode.py:1370-1376` — RaiseWithExplicitTraceback routes via
+        // `handle_operation_error(attach_tb=False, reraise_lasti=...)`.
         err.attach_tb = false;
+        err.reraise_lasti = reraise_lasti;
         Err(err)
     }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -540,17 +540,34 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
         }
     }
     let code = unsafe { &*crate::pyframe_get_pycode(frame) };
-    let pc_units = frame.last_instr as u32;
     // pyre's `last_instr` is a rustpython code-unit index; the PyPy-shaped
     // `lookup_exceptiontable` lookup takes byte offsets, so multiply by 2.
     // (See exception_table.rs: varint values are word offsets but the lookup
     // operates in byte space, mirroring `pycode.py:241-246`.)
-    let pc_bytes = pc_units * 2;
+    //
+    // `frame.last_instr == -1` is the pre-first-opcode sentinel
+    // (`pyframe.py:227-235` initialization).  An injected operr
+    // (`eval_frame_plain_with_operr`) drives `handle_exception` before any
+    // bytecode has executed, so the lookup must mirror PyPy
+    // `pycode.py:250-253`: with `instr_offset == -1`, the first entry's
+    // `start <= -1` is False and `start > -1` is True, returning the
+    // `depth == -1` sentinel (no handler).  Skip the table lookup outright
+    // rather than casting -1 to `u32::MAX` (panic in debug, wrap in
+    // release).
+    let lookup_result = if frame.last_instr < 0 {
+        None
+    } else {
+        let pc_bytes = (frame.last_instr as u32) * 2;
+        crate::exception_table::lookup_exceptiontable(&code.exceptiontable, pc_bytes)
+    };
+    let pc_units = if frame.last_instr < 0 {
+        0u32
+    } else {
+        frame.last_instr as u32
+    };
 
     // `pypy/interpreter/pyopcode.py:151-173` exception-table dispatch.
-    if let Some((target_bytes, depth, lasti)) =
-        crate::exception_table::lookup_exceptiontable(&code.exceptiontable, pc_bytes)
-    {
+    if let Some((target_bytes, depth, lasti)) = lookup_result {
         // `pyopcode.py:155-156` — depth is relative (0 = empty value
         // stack); convert to absolute by adding the frame's locals+cells
         // base, then drop the stack to that depth.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -573,6 +573,10 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
             };
             frame.push(pyre_object::w_int_new(lasti_value));
         }
+        // pyopcode.py: reraise_lasti is a local of handle_operation_error;
+        // OperationError raised from this function carries no lasti.  Clear
+        // here so a re-thrown PyError does not double-consume.
+        err.reraise_lasti = -1;
         let exc_obj = err.to_exc_object();
         frame.push(exc_obj);
         // The decoded `target` is a byte offset; pyre's `next_instr` is a
@@ -587,6 +591,8 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
     if err.reraise_lasti >= 0 {
         frame.last_instr = err.reraise_lasti as isize;
     }
+    err.reraise_lasti = -1;
+    frame.frame_finished_execution = true;
 
     false
 }
@@ -1915,46 +1921,25 @@ impl OpcodeStepExecutor for PyFrame {
 
     // ── Reraise ──
     // `pypy/interpreter/pyopcode.py:1348-1376 RERAISE`.
-    //
-    // CPython 3.11 `RERAISE N` re-raises the exception currently on TOS.
-    // When `N > 0`, the original raise-site lasti integer sits `N` slots
-    // below TOS (`peekvalue(oparg)`), and is carried through
-    // `RaiseWithExplicitTraceback(operr, reraise_lasti)` so the next
-    // exception-table dispatch can push the original offset (not the
-    // RERAISE site) for the handler's `lasti` slot.  `N == 0` is a plain
-    // reraise — no lasti carried.
-    //
-    // `handle_exception` reads `reraise_lasti` from the PyError; the
-    // stack is left untouched here (PyPy pops the exception in RERAISE
-    // itself but pyre's `handle_exception` walks the stack down to the
-    // handler depth, so popping early would corrupt nlocals + ncells +
-    // depth bookkeeping).
     fn reraise(&mut self, oparg: u32) -> Result<(), Self::Error> {
+        // pyopcode.py:1357-1363
         let reraise_lasti: i32 = if oparg != 0 {
-            let w_lasti = self.peekvalue(oparg as usize);
-            unsafe {
-                if w_lasti.is_null() || !pyre_object::is_int(w_lasti) {
-                    -1
-                } else {
-                    pyre_object::w_int_get_value(w_lasti) as i32
-                }
-            }
+            // pyopcode.py:1361 — self.space.int_w(self.peekvalue(oparg))
+            crate::baseobjspace::int_w(self.peekvalue(oparg as usize))? as i32
         } else {
             -1
         };
-        // TOS is the exception object.
-        let exc = self.peek();
-        let mut err = unsafe {
-            if pyre_object::is_exception(exc) {
-                PyError::from_exc_object(exc)
-            } else if pyre_object::is_str(exc) {
-                PyError::runtime_error(pyre_object::w_str_get_value(exc).to_string())
-            } else {
-                PyError::runtime_error("exception re-raised")
-            }
-        };
-        // `pyopcode.py:1370-1376` — RaiseWithExplicitTraceback routes via
-        // `handle_operation_error(attach_tb=False, reraise_lasti=...)`.
+        // pyopcode.py:1364 — w_exc = self.popvalue()
+        let w_exc = self.popvalue();
+        // pyopcode.py:1367 — w_value = space.interp_w(W_BaseException, w_exc)
+        if w_exc.is_null() || !unsafe { pyre_object::is_exception(w_exc) } {
+            return Err(PyError::type_error(
+                "exception must derive from BaseException",
+            ));
+        }
+        // pyopcode.py:1368-1369 — w_type = space.type(w_exc); operr = OperationError(w_type, w_exc, w_value.w_traceback)
+        let mut err = unsafe { PyError::from_exc_object(w_exc) };
+        // pyopcode.py:1376 — raise RaiseWithExplicitTraceback(operr, reraise_lasti)
         err.attach_tb = false;
         err.reraise_lasti = reraise_lasti;
         Err(err)

--- a/pyre/pyre-interpreter/src/exception_table.rs
+++ b/pyre/pyre-interpreter/src/exception_table.rs
@@ -1,0 +1,221 @@
+//! Exception-table varint decoder and lookup.
+//!
+//! Line-by-line port of `pypy/interpreter/pycode.py:229-254`
+//! (`lookup_exceptiontable`) and `:682-695` (`_decode_varint`).
+//!
+//! All offsets here are **byte offsets** into `co_code`.  The on-disk
+//! varint format stores word offsets (CPython 3.11 wordcode), so each
+//! decoded raw value is multiplied by 2 to recover the byte offset.
+
+/// pycode.py:683-695 — decode one CPython-3.11 varint at `i`.
+///
+/// Returns `(value, new_i)`.  Reads 6 bits per byte, MSB first.  Bit 6
+/// (0x40) is the continuation flag; bit 7 (0x80) is the start-of-entry
+/// marker, ignored here and masked off along with the continuation bit
+/// via `& 63`.
+#[inline]
+pub fn decode_varint(table: &[u8], mut i: usize) -> (u32, usize) {
+    let mut b = table[i] as u32;
+    i += 1;
+    let mut value = b & 63;
+    while b & 64 != 0 {
+        b = table[i] as u32;
+        i += 1;
+        value = (value << 6) | (b & 63);
+    }
+    (value, i)
+}
+
+/// Decoded exception-table entry.  Byte offsets throughout.
+///
+/// Field shape mirrors PyPy's `(start, length, target, depth, lasti)`
+/// per-entry varint sequence; `end = start + length` is precomputed for
+/// callers that want a half-open `start..end` range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExceptionTableEntry {
+    pub start: u32,
+    pub end: u32,
+    pub target: u32,
+    pub depth: u32,
+    pub lasti: bool,
+}
+
+/// pycode.py:229-254 `lookup_exceptiontable`.
+///
+/// Search `table` for a handler covering `instr_offset` (byte offset
+/// into `co_code`).  Returns `Some((target, depth, lasti))` when found,
+/// `None` otherwise.
+///
+/// **Last matching wins**: entries are scanned in encoding order; if
+/// multiple entries cover `instr_offset`, the later one (innermost in
+/// CPython's emission order) is returned.  Scanning short-circuits when
+/// `start > instr_offset`, since entries are emitted in ascending
+/// `start` order.
+pub fn lookup_exceptiontable(table: &[u8], instr_offset: u32) -> Option<(u32, u32, bool)> {
+    let n = table.len();
+    if n == 0 {
+        return None;
+    }
+    let mut best: Option<(u32, u32, bool)> = None;
+    let mut i = 0;
+    while i < n {
+        let (start_raw, ni) = decode_varint(table, i);
+        let start = start_raw * 2;
+        let (length_raw, ni) = decode_varint(table, ni);
+        let length = length_raw * 2;
+        let (target_raw, ni) = decode_varint(table, ni);
+        let target = target_raw * 2;
+        let (dl, ni) = decode_varint(table, ni);
+        let depth = dl >> 1;
+        let lasti = (dl & 1) != 0;
+        i = ni;
+        if start <= instr_offset && instr_offset < start + length {
+            best = Some((target, depth, lasti));
+        } else if start > instr_offset {
+            break;
+        }
+    }
+    best
+}
+
+/// Iterator over all decoded entries in `table`.
+///
+/// Convenience for callers that want a structural view (JIT codewriter,
+/// liveness, the PyPy-style `mark_stacks` handler-shape seeder).  The
+/// runtime `handle_operation_error` dispatch uses [`lookup_exceptiontable`]
+/// directly.
+pub fn decode_exceptiontable(table: &[u8]) -> ExceptionTableIter<'_> {
+    ExceptionTableIter { table, i: 0 }
+}
+
+pub struct ExceptionTableIter<'a> {
+    table: &'a [u8],
+    i: usize,
+}
+
+impl Iterator for ExceptionTableIter<'_> {
+    type Item = ExceptionTableEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i >= self.table.len() {
+            return None;
+        }
+        let (start_raw, i) = decode_varint(self.table, self.i);
+        let start = start_raw * 2;
+        let (length_raw, i) = decode_varint(self.table, i);
+        let length = length_raw * 2;
+        let (target_raw, i) = decode_varint(self.table, i);
+        let target = target_raw * 2;
+        let (dl, i) = decode_varint(self.table, i);
+        self.i = i;
+        Some(ExceptionTableEntry {
+            start,
+            end: start + length,
+            target,
+            depth: dl >> 1,
+            lasti: (dl & 1) != 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal varint-encoded exception table from `(start, length,
+    /// target, depth, lasti)` tuples, mirroring the encoding produced by
+    /// `assemble.py::_encode_varint`.  Values are passed as word offsets
+    /// (the on-disk unit), not byte offsets.
+    fn encode_table(entries: &[(u32, u32, u32, u32, bool)]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (start, length, target, depth, lasti) in entries.iter().copied() {
+            push_varint(&mut out, start, true);
+            push_varint(&mut out, length, false);
+            push_varint(&mut out, target, false);
+            push_varint(&mut out, (depth << 1) | (lasti as u32), false);
+        }
+        out
+    }
+
+    fn push_varint(out: &mut Vec<u8>, mut value: u32, entry_start: bool) {
+        let mut chunks = [0u8; 6];
+        let mut n = 0;
+        loop {
+            chunks[n] = (value & 63) as u8;
+            n += 1;
+            value >>= 6;
+            if value == 0 {
+                break;
+            }
+        }
+        for j in (0..n).rev() {
+            let mut byte = chunks[j];
+            if j != 0 {
+                byte |= 0x40;
+            }
+            if j == n - 1 && entry_start {
+                byte |= 0x80;
+            }
+            out.push(byte);
+        }
+    }
+
+    #[test]
+    fn empty_table_returns_none() {
+        assert_eq!(lookup_exceptiontable(&[], 0), None);
+    }
+
+    #[test]
+    fn lookup_returns_byte_offsets() {
+        // entry: word offsets start=4 (byte 8), length=10 (byte 20), target=20 (byte 40), depth=2, lasti=false
+        let table = encode_table(&[(4, 10, 20, 2, false)]);
+        assert_eq!(lookup_exceptiontable(&table, 8), Some((40, 2, false)));
+        assert_eq!(lookup_exceptiontable(&table, 27), Some((40, 2, false)));
+        assert_eq!(lookup_exceptiontable(&table, 28), None);
+        assert_eq!(lookup_exceptiontable(&table, 7), None);
+    }
+
+    #[test]
+    fn last_matching_wins() {
+        // Two overlapping ranges; outer first, inner second (CPython emission order).
+        // outer: 0..20 (byte) -> target 40 depth 1
+        // inner: 6..14 (byte) -> target 60 depth 3 lasti=true
+        let table = encode_table(&[(0, 10, 20, 1, false), (3, 4, 30, 3, true)]);
+        assert_eq!(lookup_exceptiontable(&table, 2), Some((40, 1, false)));
+        // PC 8 (byte) is covered by both. PyPy returns the later (inner) entry.
+        assert_eq!(lookup_exceptiontable(&table, 8), Some((60, 3, true)));
+        assert_eq!(lookup_exceptiontable(&table, 14), Some((40, 1, false)));
+    }
+
+    #[test]
+    fn lasti_low_bit() {
+        let table = encode_table(&[(0, 2, 10, 5, true)]);
+        // depth_lasti raw = (5 << 1) | 1 = 11
+        let (target, depth, lasti) = lookup_exceptiontable(&table, 0).unwrap();
+        assert_eq!((target, depth, lasti), (20, 5, true));
+    }
+
+    #[test]
+    fn iter_matches_lookup_count() {
+        let table = encode_table(&[
+            (0, 4, 8, 1, false),
+            (10, 6, 20, 2, true),
+            (30, 2, 40, 0, false),
+        ]);
+        let entries: Vec<_> = decode_exceptiontable(&table).collect();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[1].start, 20);
+        assert_eq!(entries[1].end, 32);
+        assert_eq!(entries[1].target, 40);
+        assert_eq!(entries[1].depth, 2);
+        assert!(entries[1].lasti);
+    }
+
+    #[test]
+    fn early_break_when_start_past_offset() {
+        let table = encode_table(&[(0, 2, 10, 1, false), (100, 2, 200, 2, false)]);
+        // PC at byte 50 is past the first entry's range but before the second's start.
+        // The second entry's start (200) > 50 so the loop should short-circuit there.
+        assert_eq!(lookup_exceptiontable(&table, 50), None);
+    }
+}

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -4663,6 +4663,7 @@ fn load_part(
             message: format!("builtin module '{modulename}' failed to initialize"),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         })?;
         set_sys_module(modulename, m);
         return Ok(Some(m));
@@ -4693,6 +4694,7 @@ fn load_part(
                 message: format!("builtin module '{modulename}' failed to initialize"),
                 exc_object: std::ptr::null_mut(),
                 attach_tb: true,
+                reraise_lasti: -1,
             })?;
             // Store builtin modules in cache immediately
             set_sys_module(modulename, m);
@@ -4795,6 +4797,7 @@ fn relative_import(
         message: "attempted relative import with no known parent package".to_string(),
         exc_object: std::ptr::null_mut(),
         attach_tb: true,
+        reraise_lasti: -1,
     })?;
 
     // Strip (level - 1) trailing components from package
@@ -4809,6 +4812,7 @@ fn relative_import(
             ),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            reraise_lasti: -1,
         });
     }
     for _ in 0..strips {

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -19,6 +19,7 @@ pub mod baseobjspace;
 pub mod builtins;
 pub mod display;
 pub mod error;
+pub mod exception_table;
 pub mod executioncontext;
 pub mod frame_array;
 pub mod function;

--- a/pyre/pyre-interpreter/src/module/sys/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/sys/moduledef.rs
@@ -572,6 +572,7 @@ pub fn init(ns: &mut DictStorage) {
                 message: code.to_string(),
                 exc_object: std::ptr::null_mut(),
                 attach_tb: true,
+                reraise_lasti: -1,
             })
         }),
     );

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -327,7 +327,11 @@ pub unsafe fn w_code_lookup_exceptiontable(
     if obj.is_null() {
         return None;
     }
-    let code = unsafe { &*((*(obj as *const W_CodeObject)).code_ptr as *const crate::CodeObject) };
+    let code_ptr = unsafe { (*(obj as *const W_CodeObject)).code_ptr };
+    if code_ptr.is_null() {
+        return None;
+    }
+    let code = unsafe { &*(code_ptr as *const crate::CodeObject) };
     crate::exception_table::lookup_exceptiontable(&code.exceptiontable, instr_offset)
 }
 
@@ -346,7 +350,11 @@ pub unsafe fn w_code_exceptiontable(obj: PyObjectRef) -> Vec<u8> {
     if obj.is_null() {
         return Vec::new();
     }
-    let code = unsafe { &*((*(obj as *const W_CodeObject)).code_ptr as *const crate::CodeObject) };
+    let code_ptr = unsafe { (*(obj as *const W_CodeObject)).code_ptr };
+    if code_ptr.is_null() {
+        return Vec::new();
+    }
+    let code = unsafe { &*(code_ptr as *const crate::CodeObject) };
     code.exceptiontable.to_vec()
 }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -311,6 +311,45 @@ pub unsafe fn code_get_fast_natural_arity(obj: PyObjectRef) -> u16 {
     }
 }
 
+/// pycode.py:229-254 `PyCode.lookup_exceptiontable`.
+///
+/// Search the wrapped code object's exception table for a handler
+/// covering `instr_offset` (byte offset into `co_code`).  Returns
+/// `Some((target, depth, lasti))` with byte-offset `target` when found.
+///
+/// # Safety
+/// `obj` must point to a valid `W_CodeObject`.
+#[inline]
+pub unsafe fn w_code_lookup_exceptiontable(
+    obj: PyObjectRef,
+    instr_offset: u32,
+) -> Option<(u32, u32, bool)> {
+    if obj.is_null() {
+        return None;
+    }
+    let code = unsafe { &*((*(obj as *const W_CodeObject)).code_ptr as *const crate::CodeObject) };
+    crate::exception_table::lookup_exceptiontable(&code.exceptiontable, instr_offset)
+}
+
+/// pycode.py:145 `self.co_exceptiontable = exceptiontable` — copy the
+/// varint-packed table bytes out of the wrapped `CodeObject`.
+///
+/// The bytes are owned by the inner `CodeObject` (`Box<[u8]>` field), so
+/// returning a reference would tie the lifetime to the obj's heap
+/// allocation.  Callers that need to hand the bytes to Python (where
+/// they get copied into a `W_BytesObject`) take the owned `Vec<u8>`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_CodeObject`.
+#[inline]
+pub unsafe fn w_code_exceptiontable(obj: PyObjectRef) -> Vec<u8> {
+    if obj.is_null() {
+        return Vec::new();
+    }
+    let code = unsafe { &*((*(obj as *const W_CodeObject)).code_ptr as *const crate::CodeObject) };
+    code.exceptiontable.to_vec()
+}
+
 /// Check if an object is a code object.
 ///
 /// # Safety

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -23,8 +23,20 @@ pub struct Return;
 
 pub struct Yield;
 
+/// pypy/interpreter/pyopcode.py:91-94 — `RaiseWithExplicitTraceback(operr, lasti)`.
+///
+/// Carries the original raise-site `lasti` (instruction byte offset) from a
+/// `RERAISE N` so the next exception-table dispatch can push that offset as
+/// the handler's `lasti` value instead of the RERAISE instruction itself.
+/// `lasti == -1` means no reraise lasti (default for primary raises).
+///
+/// pyre also routes this value through `PyError.reraise_lasti` because the
+/// interpreter dispatch loop uses a single `Err(PyError)` channel rather
+/// than two distinct exception classes; this struct exists for line-by-line
+/// parity surface.
 pub struct RaiseWithExplicitTraceback {
     pub operr: crate::error::OperationError,
+    pub lasti: i32,
 }
 
 pub struct SuspendedUnroller {
@@ -1080,7 +1092,14 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn check_exc_match(&mut self) -> Result<(), Self::Error> {
         Err(crate::PyError::type_error("check_exc_match not implemented").into())
     }
-    fn reraise(&mut self) -> Result<(), Self::Error> {
+    /// `pypy/interpreter/pyopcode.py:1348-1376 RERAISE`.
+    ///
+    /// `oparg` is the depth (0..) at which the original raise-site lasti
+    /// integer sits on the value stack.  When `oparg > 0` the handler
+    /// peeks lasti at `peekvalue(oparg)` and carries it through
+    /// `RaiseWithExplicitTraceback(operr, reraise_lasti=...)`.  When
+    /// `oparg == 0` no lasti is attached (default `-1`).
+    fn reraise(&mut self, _oparg: u32) -> Result<(), Self::Error> {
         Err(crate::PyError::type_error("reraise not implemented").into())
     }
 
@@ -1732,8 +1751,8 @@ where
             executor.raise_varargs(raise_kind_as_usize(argc.get(op_arg)))?;
             Ok(StepResult::Continue)
         }
-        Instruction::Reraise { .. } => {
-            executor.reraise()?;
+        Instruction::Reraise { depth } => {
+            executor.reraise(depth.get(op_arg))?;
             Ok(StepResult::Continue)
         }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -4502,6 +4502,31 @@ fn init_code_type(ns: &mut DictStorage) {
             Ok(args.first().copied().unwrap_or(pyre_object::w_none()))
         }),
     );
+    // `pypy/interpreter/typedef.py:720`
+    // `co_exceptiontable = interp_attrproperty('co_exceptiontable', cls=PyCode,
+    //                                          wrapfn="newbytes")`.
+    //
+    // Read-only attribute exposing the raw varint-packed table.  The
+    // matching getset descriptor wraps the field as a `bytes` object
+    // (PyPy `wrapfn="newbytes"`).  `args[0]` is the descriptor itself,
+    // `args[1]` is the W_CodeObject instance (typedef.py:467-470 calling
+    // convention via `descr_property_get`).
+    dict_storage_store(
+        ns,
+        "co_exceptiontable",
+        make_getset_descriptor(make_builtin_function_with_arity(
+            "co_exceptiontable",
+            |args| {
+                let w_self = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+                if w_self.is_null() {
+                    return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&[]));
+                }
+                let bytes = unsafe { crate::pycode::w_code_exceptiontable(w_self) };
+                Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
+            },
+            2,
+        )),
+    );
 }
 
 /// typedef.py:492-500 Member.typedef

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -4521,6 +4521,11 @@ fn init_code_type(ns: &mut DictStorage) {
                 if w_self.is_null() {
                     return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&[]));
                 }
+                if !unsafe { crate::pycode::is_code(w_self) } {
+                    return Err(crate::PyError::type_error(
+                        "descriptor 'co_exceptiontable' requires a 'code' object",
+                    ));
+                }
                 let bytes = unsafe { crate::pycode::w_code_exceptiontable(w_self) };
                 Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
             },

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -71,13 +71,18 @@ impl LiveVars {
         // control flow. Any instruction in [start, end) can jump to
         // target on exception — the target's live set must be unioned
         // into every PC in the range.
-        let exc_handlers: Vec<(usize, usize, usize)> = {
-            let entries = pyre_interpreter::bytecode::decode_exception_table(&code.exceptiontable);
-            entries
-                .iter()
-                .map(|e| (e.start as usize, e.end as usize, e.target as usize))
-                .collect()
-        };
+        // `decode_exceptiontable` yields byte offsets; liveness operates
+        // in code-unit indices (offset/2).
+        let exc_handlers: Vec<(usize, usize, usize)> =
+            pyre_interpreter::exception_table::decode_exceptiontable(&code.exceptiontable)
+                .map(|e| {
+                    (
+                        e.start as usize / 2,
+                        e.end as usize / 2,
+                        e.target as usize / 2,
+                    )
+                })
+                .collect();
 
         // Fixed-point backward analysis for local liveness.
         let mut changed = true;

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -37,6 +37,17 @@ pub struct MetaInterpFrame {
     pub caller_result_stack_idx: Option<usize>,
     pub caller_result_type: Option<Type>,
     pub arg_state: pyre_interpreter::bytecode::OpArgState,
+    /// The CALL bytecode's pc on THIS frame at the moment it pushed an
+    /// inline callee.  `top.pc` is advanced to the post-CALL fallthrough
+    /// before the callee is pushed (PRE-EXISTING-ADAPTATION vs PyPy where
+    /// `self.last_instr` stays at the CALL during the call); when the
+    /// callee raises and `finishframe_exception` walks up to this frame,
+    /// the exception-table lookup must probe the CALL site, not the
+    /// post-call fallthrough, to mirror PyPy
+    /// `pyopcode.handle_operation_error` reading `self.last_instr` from
+    /// the still-at-CALL frame.  `None` when no inline call is in progress
+    /// from this frame.
+    pub call_site_pc: Option<usize>,
 }
 
 impl MetaInterpFrame {
@@ -183,6 +194,12 @@ impl PyreMetaInterp {
                 .pending_next_instr
                 .take()
                 .unwrap_or_else(|| semantic_fallthrough_pc(code, pc));
+            // Save the CALL-site pc on the caller before advancing
+            // `top.pc` past it.  `finishframe_exception` uses this when an
+            // inline callee raises, so the caller's exception_table is
+            // probed at the CALL bytecode (matching PyPy
+            // `pyopcode.handle_operation_error` reading `self.last_instr`).
+            top.call_site_pc = Some(pc);
             top.pc = next_pc;
             let result_idx = sym
                 .valuestackdepth
@@ -287,6 +304,7 @@ impl PyreMetaInterp {
                 let top = self.framestack.last_mut().unwrap();
                 let sym = unsafe { &mut *top.sym };
                 let sfall = semantic_fallthrough_pc(code, pc);
+                top.call_site_pc = Some(pc);
                 top.pc = sym.pending_next_instr.take().unwrap_or(sfall);
                 let result_idx = sym
                     .valuestackdepth
@@ -371,6 +389,7 @@ impl PyreMetaInterp {
                 };
                 let sym = unsafe { &mut *top.sym };
                 let sfall = semantic_fallthrough_pc(code, pc);
+                top.call_site_pc = Some(pc);
                 top.pc = sym.pending_next_instr.take().unwrap_or(sfall);
                 let result_idx = sym
                     .valuestackdepth
@@ -445,6 +464,10 @@ impl PyreMetaInterp {
             caller_result_stack_idx: caller_result_idx,
             caller_result_type: pending.caller_result_type,
             arg_state: pyre_interpreter::bytecode::OpArgState::default(),
+            // Freshly pushed inline frames have no outstanding call of
+            // their own; cleared when this frame becomes a caller via a
+            // subsequent inline push.
+            call_site_pc: None,
         };
 
         self.portal_call_depth += 1;
@@ -494,6 +517,12 @@ impl PyreMetaInterp {
 
         // make_result_of_lastop: store in parent
         let parent = self.framestack.last_mut().unwrap();
+        // The inline callee returned successfully — clear the saved CALL
+        // pc on the parent.  Mirrors PyPy `pyopcode.handle_bytecode`: after
+        // a normal return, `self.last_instr` advances past the call so a
+        // subsequent exception dispatched from this frame looks up the
+        // table at the post-call instruction, not the (now-consumed) CALL.
+        parent.call_site_pc = None;
         let parent_sym = unsafe { &mut *parent.sym };
 
         if let Some(result_idx) = popped.caller_result_stack_idx {
@@ -636,7 +665,16 @@ impl PyreMetaInterp {
                     as *const pyre_interpreter::CodeObject)
             };
             let sym = unsafe { &*top.sym };
-            let pc = top.pc;
+            // `top.pc` was advanced past the CALL bytecode before any
+            // inline callee was pushed (PRE-EXISTING-ADAPTATION).  When a
+            // callee raises and we walk up to this caller, the
+            // exception-table lookup must probe the CALL site (the saved
+            // `call_site_pc`) — mirroring PyPy
+            // `pyopcode.handle_operation_error` reading `self.last_instr`
+            // from the still-at-CALL frame (`pyopcode.py:151`).  Frames
+            // with no outstanding inline call (the original raiser or any
+            // frame whose call already returned) keep using `top.pc`.
+            let lookup_pc = top.call_site_pc.unwrap_or(top.pc);
 
             // RPython: if opcode == op_catch_exception → handler found.
             // `lookup_exceptiontable` takes byte offsets and returns byte
@@ -645,7 +683,7 @@ impl PyreMetaInterp {
             if let Some((target_bytes, depth, lasti)) =
                 pyre_interpreter::exception_table::lookup_exceptiontable(
                     &code.exceptiontable,
-                    (pc * 2) as u32,
+                    (lookup_pc * 2) as u32,
                 )
             {
                 let handler_pc = target_bytes as usize / 2;
@@ -715,15 +753,15 @@ impl PyreMetaInterp {
                     //       lasti_value = intmask(self.last_instr)
                     //   self.pushvalue(self.space.newint(lasti_value))
                     //
-                    // Python 3.11 exception-table adaptation: `push_lasti`
-                    // pushes a real W_Int object onto `locals_cells_stack_w`.
-                    // Route it through the common stack/vable mirror so the
-                    // handler frame's `virtualizable_boxes` snapshot matches
-                    // the concrete PyFrame stack.
+                    // `self.last_instr` in PyPy is the call/raise site —
+                    // the same offset we use for the table lookup
+                    // (`lookup_pc`), NOT the post-call fallthrough.  Route
+                    // through `lookup_pc` so a handler in a caller frame
+                    // sees the CALL bytecode's offset.
                     let lasti_value: i64 = if reraise_lasti >= 0 {
                         reraise_lasti as i64
                     } else {
-                        pc as i64
+                        lookup_pc as i64
                     };
                     let lasti_obj = pyre_object::w_int_new(lasti_value);
                     let lasti_opref = ctx.const_ref(lasti_obj as i64);
@@ -752,6 +790,12 @@ impl PyreMetaInterp {
                     sym.valuestackdepth += 1;
                 }
                 sym.pending_next_instr = Some(handler_pc);
+                // Handler dispatch unwound the outstanding inline call —
+                // the frame is no longer in the middle of a CALL.  Clear
+                // call_site_pc so a subsequent exception dispatched from
+                // this frame's handler code uses the in-handler pc, not
+                // the stale CALL pc.
+                top.call_site_pc = None;
 
                 // Sync concrete frame
                 if let Some(ref mut cf) = top.owned_concrete_frame {

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -346,7 +346,15 @@ impl PyreMetaInterp {
                     !sym.last_exc_value.is_null() && sym.last_exc_box != OpRef::NONE
                 };
                 if has_exc {
-                    if let Some(action) = self.finishframe_exception(ctx) {
+                    // Single-frame finishframe_exception (called from the
+                    // inline trace step) already consumed any saved
+                    // reraise_lasti for the RERAISE-issuing frame (handler
+                    // push or no-handler last_instr restoration).  Multi-
+                    // frame escalation walks remaining frames whose handler
+                    // dispatch carries no lasti — match PyPy's
+                    // `pyopcode.handle_operation_error(reraise_lasti=-1)`
+                    // default.
+                    if let Some(action) = self.finishframe_exception(ctx, -1) {
                         return action;
                     }
                 }
@@ -607,8 +615,20 @@ impl PyreMetaInterp {
     /// frames that don't have one. Structurally matches RPython's
     /// `while self.framestack: ... self.popframe()` loop.
     ///
+    /// `reraise_lasti` mirrors `pypy/interpreter/pyopcode.py:122
+    /// handle_operation_error`'s like-named parameter: when non-negative it
+    /// is the original raise-site offset extracted by a RERAISE bytecode.
+    /// Per PyPy's single-call locality (`:181-184`), only the FIRST frame
+    /// visited consumes it — either for the handler-entry lasti push
+    /// (`:165-170`) or for the no-handler `last_instr` restoration
+    /// (`:181-184`).  Subsequent frames see -1.
+    ///
     /// Returns Some(LoopAction) if handled, None if all frames exhausted.
-    fn finishframe_exception(&mut self, ctx: &mut TraceCtx) -> Option<LoopAction> {
+    fn finishframe_exception(
+        &mut self,
+        ctx: &mut TraceCtx,
+        mut reraise_lasti: i32,
+    ) -> Option<LoopAction> {
         // RPython pyjitpl.py:2506: while self.framestack:
         while let Some(top) = self.framestack.last() {
             let code = unsafe {
@@ -688,12 +708,24 @@ impl PyreMetaInterp {
                 }
 
                 let lasti_obj = if lasti {
+                    // pyopcode.py:165-170 lasti push:
+                    //   if reraise_lasti >= 0:
+                    //       lasti_value = reraise_lasti
+                    //   else:
+                    //       lasti_value = intmask(self.last_instr)
+                    //   self.pushvalue(self.space.newint(lasti_value))
+                    //
                     // Python 3.11 exception-table adaptation: `push_lasti`
                     // pushes a real W_Int object onto `locals_cells_stack_w`.
                     // Route it through the common stack/vable mirror so the
                     // handler frame's `virtualizable_boxes` snapshot matches
                     // the concrete PyFrame stack.
-                    let lasti_obj = pyre_object::w_int_new(pc as i64);
+                    let lasti_value: i64 = if reraise_lasti >= 0 {
+                        reraise_lasti as i64
+                    } else {
+                        pc as i64
+                    };
+                    let lasti_obj = pyre_object::w_int_new(lasti_value);
                     let lasti_opref = ctx.const_ref(lasti_obj as i64);
                     let stack_idx = sym.valuestackdepth - sym.nlocals;
                     super::trace_opcode::write_stack_slot(
@@ -751,6 +783,27 @@ impl PyreMetaInterp {
                 let exc_box = sym.last_exc_box;
                 let exc_const = sym.class_of_last_exc_is_const;
 
+                // pyopcode.py:181-184 no-handler propagation, applied to
+                // the about-to-be-popped frame's concrete shadow:
+                //   if reraise_lasti >= 0:
+                //       self.last_instr = reraise_lasti
+                //   self.frame_finished_execution = True
+                //
+                // Per `:122` single-call locality, reraise_lasti is
+                // consumed here for the RERAISE-issuing frame; further
+                // iterations see -1 so parent frames behave as if their
+                // own `handle_operation_error(reraise_lasti=-1)` was
+                // called.
+                if let Some(top_mut) = self.framestack.last_mut() {
+                    if let Some(ref mut cf) = top_mut.owned_concrete_frame {
+                        if reraise_lasti >= 0 {
+                            cf.last_instr = reraise_lasti as isize;
+                        }
+                        cf.frame_finished_execution = true;
+                    }
+                }
+                reraise_lasti = -1;
+
                 // Pop the inline frame
                 let popped = self.framestack.pop().unwrap();
                 self.portal_call_depth -= 1;
@@ -793,6 +846,23 @@ impl PyreMetaInterp {
             let exc_opref = sym.last_exc_box;
             if majit_metainterp::majit_log_enabled() {
                 eprintln!("[jit][finishframe_exception] root frame, no handler → FINISH");
+            }
+            // pyopcode.py:181-184 applied to the root concrete frame
+            // before FINISH escapes the trace.  Mirror the same shape as
+            // the inline-pop branch: if this root frame was the RERAISE
+            // origin, restore `last_instr`; either way, set
+            // `frame_finished_execution = True` so the dead frame surfaces
+            // the same flag state the interpreter would.
+            {
+                let concrete_frame_ptr =
+                    sym.concrete_vable_ptr as *mut pyre_interpreter::pyframe::PyFrame;
+                if !concrete_frame_ptr.is_null() {
+                    let cf = unsafe { &mut *concrete_frame_ptr };
+                    if reraise_lasti >= 0 {
+                        cf.last_instr = reraise_lasti as isize;
+                    }
+                    cf.frame_finished_execution = true;
+                }
             }
             // pyjitpl.py:3239: self.store_token_in_vable()
             // Record SetfieldGc on vable_token + GUARD_NOT_FORCED_2 with

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -618,12 +618,18 @@ impl PyreMetaInterp {
             let sym = unsafe { &*top.sym };
             let pc = top.pc;
 
-            // RPython: if opcode == op_catch_exception → handler found
-            if let Some(entry) =
-                pyre_interpreter::bytecode::find_exception_handler(&code.exceptiontable, pc as u32)
+            // RPython: if opcode == op_catch_exception → handler found.
+            // `lookup_exceptiontable` takes byte offsets and returns byte
+            // offsets; pyre's JIT trace uses code-unit indices for `pc`
+            // and handler PC, so multiply/divide by 2 at the boundary.
+            if let Some((target_bytes, depth, lasti)) =
+                pyre_interpreter::exception_table::lookup_exceptiontable(
+                    &code.exceptiontable,
+                    (pc * 2) as u32,
+                )
             {
-                let handler_pc = entry.target as usize;
-                let handler_depth = entry.depth as usize;
+                let handler_pc = target_bytes as usize / 2;
+                let handler_depth = depth as usize;
                 let exc_opref = sym.last_exc_box;
                 let exc_obj = sym.last_exc_value;
 
@@ -681,7 +687,7 @@ impl PyreMetaInterp {
                     }
                 }
 
-                let lasti_obj = if entry.push_lasti {
+                let lasti_obj = if lasti {
                     // Python 3.11 exception-table adaptation: `push_lasti`
                     // pushes a real W_Int object onto `locals_cells_stack_w`.
                     // Route it through the common stack/vable mirror so the

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6398,7 +6398,7 @@ mod tests {
             pre_opcode_semantic_depth: None,
         };
 
-        let err = OpcodeStepExecutor::reraise(&mut state).expect_err("reraise should raise");
+        let err = OpcodeStepExecutor::reraise(&mut state, 0).expect_err("reraise should raise");
         assert_eq!(err.to_exc_object(), exc);
     }
 
@@ -6704,12 +6704,14 @@ mod tests {
                 )
             })
             .expect("test bytecode should contain RAISE_VARARGS");
-        let handler_pc = pyre_interpreter::bytecode::find_exception_handler(
-            &code.exceptiontable,
-            raise_pc as u32,
-        )
-        .expect("raise should be covered by exception table")
-        .target as usize;
+        // Byte offsets in/out; pyre PC is a code-unit index.
+        let (target_bytes, _depth, _lasti) =
+            pyre_interpreter::exception_table::lookup_exceptiontable(
+                &code.exceptiontable,
+                (raise_pc * 2) as u32,
+            )
+            .expect("raise should be covered by exception table");
+        let handler_pc = target_bytes as usize / 2;
         let code_ref =
             pyre_interpreter::w_code_new(Box::into_raw(Box::new(code.clone())) as *const ())
                 as *const ();

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6500,11 +6500,7 @@ mod tests {
             &mut ctx,
             &mut sym,
             &[
-                (
-                    non_int_opref,
-                    ConcreteValue::Ref(exc),
-                    majit_ir::Type::Ref,
-                ),
+                (non_int_opref, ConcreteValue::Ref(exc), majit_ir::Type::Ref),
                 (exc_opref, ConcreteValue::Ref(exc), majit_ir::Type::Ref),
             ],
         );

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6376,13 +6376,43 @@ mod tests {
         }));
     }
 
+    /// Seed `sym` with `slots` on the symbolic value stack (TOS last).
+    ///
+    /// Mirrors the invariant a real trace would carry into RERAISE:
+    /// `pyopcode.py:1361` reads `peekvalue(oparg)` and `:1364` does
+    /// `popvalue()`, both of which require the stack to be populated with
+    /// the saved lasti (when `oparg != 0`) and the exception object on
+    /// top.  Sets `concrete_stack`, `symbolic_stack_types`, `registers_r`,
+    /// and `valuestackdepth` in lockstep.
+    fn seed_stack(
+        ctx: &mut TraceCtx,
+        sym: &mut PyreSym,
+        slots: &[(OpRef, ConcreteValue, majit_ir::Type)],
+    ) {
+        sym.nlocals = 0;
+        sym.valuestackdepth = slots.len();
+        sym.concrete_stack = slots.iter().map(|(_, cv, _)| *cv).collect();
+        sym.symbolic_stack_types = slots.iter().map(|(_, _, t)| *t).collect();
+        sym.registers_r = slots.iter().map(|(op, _, _)| *op).collect();
+        // Tests don't exercise the vable shadow path; pop_value's
+        // `is_active_vable_owner` branch stays inactive.
+        sym.locals_cells_stack_array_ref = ctx.const_ref(0);
+    }
+
     #[test]
     fn test_reraise_reuses_last_exception_object() {
         let mut ctx = TraceCtx::for_test(1);
         let exc = pyre_interpreter::PyError::runtime_error("boom").to_exc_object();
+        let exc_opref = ctx.const_ref(exc as i64);
         let mut sym = PyreSym::new_uninit(OpRef::NONE);
         sym.last_exc_value = exc;
-        sym.last_exc_box = ctx.const_ref(exc as i64);
+        sym.last_exc_box = exc_opref;
+        // pyopcode.py:1353 — for `RERAISE 0`, stack is `[..., exc]`.
+        seed_stack(
+            &mut ctx,
+            &mut sym,
+            &[(exc_opref, ConcreteValue::Ref(exc), majit_ir::Type::Ref)],
+        );
 
         let mut state = MIFrame {
             ctx: &mut ctx,
@@ -6400,6 +6430,105 @@ mod tests {
 
         let err = OpcodeStepExecutor::reraise(&mut state, 0).expect_err("reraise should raise");
         assert_eq!(err.to_exc_object(), exc);
+        // pyopcode.py:1363 — oparg==0 → reraise_lasti = -1.
+        assert_eq!(err.reraise_lasti, -1);
+        // pyopcode.py:1376 — RaiseWithExplicitTraceback → attach_tb=False.
+        assert!(!err.attach_tb);
+    }
+
+    #[test]
+    fn test_reraise_nonzero_oparg_threads_saved_lasti() {
+        let mut ctx = TraceCtx::for_test(1);
+        let exc = pyre_interpreter::PyError::runtime_error("boom").to_exc_object();
+        let exc_opref = ctx.const_ref(exc as i64);
+        // pyopcode.py:165-170 lasti push synthesizes
+        // `space.newint(lasti_value)` — a fresh W_IntObject.
+        let saved_lasti_value: i64 = 42;
+        let saved_lasti_obj = pyre_object::w_int_new(saved_lasti_value);
+        let lasti_opref = ctx.const_ref(saved_lasti_obj as i64);
+        let mut sym = PyreSym::new_uninit(OpRef::NONE);
+        sym.last_exc_value = exc;
+        sym.last_exc_box = exc_opref;
+        // pyopcode.py:1353 — for `RERAISE 1`, stack is `[..., lasti, exc]`.
+        seed_stack(
+            &mut ctx,
+            &mut sym,
+            &[
+                (
+                    lasti_opref,
+                    ConcreteValue::Ref(saved_lasti_obj),
+                    majit_ir::Type::Ref,
+                ),
+                (exc_opref, ConcreteValue::Ref(exc), majit_ir::Type::Ref),
+            ],
+        );
+
+        let mut state = MIFrame {
+            ctx: &mut ctx,
+            sym: &mut sym,
+            fallthrough_pc: 0,
+            parent_frames: Vec::new(),
+            pending_result_stack_idx: None,
+            pending_result_type: None,
+            pending_inline_frame: None,
+            orgpc: 0,
+            concrete_frame_addr: 0,
+            pre_opcode_registers_r: None,
+            pre_opcode_semantic_depth: None,
+        };
+
+        let err = OpcodeStepExecutor::reraise(&mut state, 1).expect_err("reraise should raise");
+        assert_eq!(err.to_exc_object(), exc);
+        // pyopcode.py:1361 — `reraise_lasti = self.space.int_w(self.peekvalue(oparg))`.
+        assert_eq!(err.reraise_lasti, saved_lasti_value as i32);
+        assert!(!err.attach_tb);
+    }
+
+    #[test]
+    fn test_reraise_nonconst_lasti_signals_abort_to_dispatcher() {
+        let mut ctx = TraceCtx::for_test(1);
+        let exc = pyre_interpreter::PyError::runtime_error("boom").to_exc_object();
+        let exc_opref = ctx.const_ref(exc as i64);
+        // Non-Int slot at peek(oparg): an exception object stands in for
+        // any non-Int concrete value (a const-int box is the only shape
+        // the trace can fold at compile time).
+        let non_int_opref = ctx.const_ref(exc as i64);
+        let mut sym = PyreSym::new_uninit(OpRef::NONE);
+        sym.last_exc_value = exc;
+        sym.last_exc_box = exc_opref;
+        seed_stack(
+            &mut ctx,
+            &mut sym,
+            &[
+                (
+                    non_int_opref,
+                    ConcreteValue::Ref(exc),
+                    majit_ir::Type::Ref,
+                ),
+                (exc_opref, ConcreteValue::Ref(exc), majit_ir::Type::Ref),
+            ],
+        );
+
+        let mut state = MIFrame {
+            ctx: &mut ctx,
+            sym: &mut sym,
+            fallthrough_pc: 0,
+            parent_frames: Vec::new(),
+            pending_result_stack_idx: None,
+            pending_result_type: None,
+            pending_inline_frame: None,
+            orgpc: 0,
+            concrete_frame_addr: 0,
+            pre_opcode_registers_r: None,
+            pre_opcode_semantic_depth: None,
+        };
+
+        let err = OpcodeStepExecutor::reraise(&mut state, 1).expect_err("reraise should raise");
+        // Non-Int lasti slot → reraise_lasti < 0; dispatcher detects the
+        // combination `oparg != 0 && reraise_lasti < 0` and routes to
+        // TraceAction::Abort, letting the interpreter handle the rare
+        // non-const case via the concrete-frame fallback.
+        assert!(err.reraise_lasti < 0);
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -51,6 +51,7 @@ pub fn trace_bytecode(
         caller_result_stack_idx: None,
         caller_result_type: None,
         arg_state: pyre_interpreter::bytecode::OpArgState::default(),
+        call_site_pc: None,
     };
 
     let mut metainterp = PyreMetaInterp::new(w_code, std::ptr::null_mut());

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6004,9 +6004,34 @@ impl MIFrame {
                 }
             }
         }
-        if matches!(instruction, Instruction::Reraise { .. }) {
+        if let Instruction::Reraise { depth } = instruction {
+            // `pyopcode.py:1361` RERAISE extracts the saved lasti from the
+            // stack and routes through RaiseWithExplicitTraceback, which
+            // becomes `err.reraise_lasti` on our PyError.  When `oparg != 0`
+            // and the trace could not fold a const-int from the symbolic
+            // slot (`reraise()` returned -1), bail to the interpreter — the
+            // trace cannot represent a dynamic lasti at handler-entry push
+            // time as a constant int box.
+            let oparg_val = depth.get(op_arg);
+            let reraise_lasti = step_result
+                .as_ref()
+                .err()
+                .map(|e| e.reraise_lasti)
+                .unwrap_or(-1);
+            if oparg_val != 0 && reraise_lasti < 0 {
+                return TraceAction::Abort;
+            }
             if self.sym().last_exc_box != OpRef::NONE {
-                return self.handle_reraise(code, pc);
+                return self.handle_reraise(code, pc, reraise_lasti);
+            }
+            // `last_exc_box == NONE` for RERAISE means the trace entered an
+            // except* handler without observing the prior PUSH_EXC_INFO —
+            // anomalous.  If the RERAISE carried a saved lasti, the
+            // generic handle_possible_exception fallback would drop it
+            // (its inner finishframe_exception call passes -1).  Abort so
+            // the interpreter handles the case faithfully.
+            if oparg_val != 0 {
+                return TraceAction::Abort;
             }
             if step_result.is_err() {
                 return self.handle_possible_exception(code, pc);
@@ -6131,7 +6156,9 @@ impl MIFrame {
             }
             self.sym_mut().class_of_last_exc_is_const = true;
 
-            self.finishframe_exception(code, pc)
+            // pyopcode.py: generic raise paths carry no saved lasti; the
+            // RERAISE-issuing site is the only producer of reraise_lasti.
+            self.finishframe_exception(code, pc, -1)
         } else {
             // pyjitpl.py:3397: GUARD_NO_EXCEPTION
             self.with_ctx(|this, ctx| {
@@ -6146,12 +6173,22 @@ impl MIFrame {
     /// Unlike generic exc=True ops, RERAISE does not go through
     /// GUARD_EXCEPTION. It resumes directly from the already-known
     /// `last_exc_value` and unwinds to the enclosing handler.
-    fn handle_reraise(&mut self, code: &CodeObject, pc: usize) -> TraceAction {
+    ///
+    /// `reraise_lasti` mirrors PyPy `pyopcode.py:122 handle_operation_error`'s
+    /// like-named parameter: when non-negative it is the original raise-site
+    /// offset the RERAISE bytecode extracted from the stack via
+    /// `pyopcode.py:1361 self.space.int_w(self.peekvalue(oparg))`.
+    fn handle_reraise(
+        &mut self,
+        code: &CodeObject,
+        pc: usize,
+        reraise_lasti: i32,
+    ) -> TraceAction {
         let s = self.sym();
         if s.last_exc_value.is_null() || s.last_exc_box == OpRef::NONE {
             return TraceAction::Abort;
         }
-        self.finishframe_exception(code, pc)
+        self.finishframe_exception(code, pc, reraise_lasti)
     }
 
     /// RPython pyjitpl.py:1688 opimpl_raise parity.
@@ -6161,7 +6198,9 @@ impl MIFrame {
     /// going through GUARD_EXCEPTION.
     fn handle_raise_varargs(&mut self, code: &CodeObject, pc: usize, argc: usize) -> TraceAction {
         if argc == 0 {
-            return self.handle_reraise(code, pc);
+            // RAISE_VARARGS 0 is the bare `raise` re-raise.  It carries no
+            // saved lasti — only the explicit `RERAISE N` opcode does.
+            return self.handle_reraise(code, pc, -1);
         }
         {
             let s = self.sym();
@@ -6169,7 +6208,7 @@ impl MIFrame {
                 return TraceAction::Abort;
             }
         }
-        self.finishframe_exception(code, pc)
+        self.finishframe_exception(code, pc, -1)
     }
 
     /// PyPy `RAISE_VARARGS` materialization paired with RPython
@@ -6201,7 +6240,19 @@ impl MIFrame {
     /// Checks current frame for an exception handler.
     /// If found: unwind stack to handler depth, push exception, continue.
     /// If not found: return Abort (metainterp handles multi-frame unwind).
-    fn finishframe_exception(&mut self, code: &CodeObject, pc: usize) -> TraceAction {
+    ///
+    /// `reraise_lasti` is PyPy `pyopcode.py:122 handle_operation_error`'s
+    /// like-named parameter — non-negative when this dispatch was driven by
+    /// a `RERAISE N` opcode that saved the original raise-site offset.  Used
+    /// (a) for the synthesized `lasti` push at handler entry per
+    /// `pyopcode.py:165-170`, and (b) to restore `frame.last_instr` on the
+    /// no-handler propagation path per `pyopcode.py:181-184`.
+    fn finishframe_exception(
+        &mut self,
+        code: &CodeObject,
+        pc: usize,
+        reraise_lasti: i32,
+    ) -> TraceAction {
         let exc_opref = self.sym().last_exc_box;
         let exc_obj = self.sym().last_exc_value;
         let concrete_frame_addr = self.concrete_frame_addr;
@@ -6261,13 +6312,25 @@ impl MIFrame {
                 });
             }
             let lasti_obj = if lasti {
+                // pyopcode.py:165-170 lasti push:
+                //   if reraise_lasti >= 0:
+                //       lasti_value = reraise_lasti
+                //   else:
+                //       lasti_value = intmask(self.last_instr)
+                //   self.pushvalue(self.space.newint(lasti_value))
+                //
                 // Python 3.11 exception-table adaptation: `push_lasti`
                 // pushes a real W_Int object onto `locals_cells_stack_w`.
                 // Mirror it through the same stack/vable helper as every
                 // other W_Root push so guard/resume snapshots see the
                 // object in `virtualizable_boxes`, not a PY_NULL lazy-fill
                 // placeholder.
-                let lasti_obj = pyre_object::w_int_new(pc as i64);
+                let lasti_value: i64 = if reraise_lasti >= 0 {
+                    reraise_lasti as i64
+                } else {
+                    pc as i64
+                };
+                let lasti_obj = pyre_object::w_int_new(lasti_value);
                 let lasti_opref = self.with_ctx(|_this, ctx| ctx.const_ref(lasti_obj as i64));
                 self.with_ctx(|this, ctx| {
                     let s = this.sym_mut();
@@ -6305,6 +6368,21 @@ impl MIFrame {
             self.sym_mut().pending_next_instr = Some(handler_pc);
             TraceAction::Continue
         } else {
+            // pyopcode.py:175-184 no-handler propagation:
+            //   if reraise_lasti >= 0:
+            //       self.last_instr = reraise_lasti
+            //   self.frame_finished_execution = True
+            //
+            // The trace bails to the interpreter (Abort).  The interpreter's
+            // `handle_exception` will continue propagation through parent
+            // frames, so the RERAISE-issuing frame's `last_instr` must be
+            // restored here for `f_lineno` to report the original raise
+            // site rather than the RERAISE site.
+            if reraise_lasti >= 0 {
+                let frame =
+                    unsafe { &mut *(concrete_frame_addr as *mut pyre_interpreter::PyFrame) };
+                frame.last_instr = reraise_lasti as isize;
+            }
             // No handler in this frame — return Abort so metainterp's
             // multi-frame finishframe_exception can pop this frame and
             // try the parent (pyjitpl.py:2520 self.popframe() loop).
@@ -6410,9 +6488,30 @@ impl MIFrame {
                 }
             }
         }
-        if matches!(instruction, Instruction::Reraise { .. }) {
+        if let Instruction::Reraise { depth } = instruction {
+            // Mirror the root-frame dispatcher: thread `err.reraise_lasti`
+            // into `handle_reraise`, abort if `oparg != 0 && lasti < 0`
+            // (trace cannot fold a const-int from the symbolic stack — fall
+            // back to interpreter via TraceAction::Abort).
+            let oparg_val = depth.get(op_arg);
+            let reraise_lasti = step_result
+                .as_ref()
+                .err()
+                .map(|e| e.reraise_lasti)
+                .unwrap_or(-1);
+            if oparg_val != 0 && reraise_lasti < 0 {
+                return InlineTraceStepAction::Trace(TraceAction::Abort);
+            }
             if self.sym().last_exc_box != OpRef::NONE {
-                return InlineTraceStepAction::Trace(self.handle_reraise(code, pc));
+                return InlineTraceStepAction::Trace(
+                    self.handle_reraise(code, pc, reraise_lasti),
+                );
+            }
+            // Same rationale as root dispatcher: abort RERAISE-with-saved-
+            // lasti when the trace lacks a tracked exception box (generic
+            // fallback would drop the lasti).
+            if oparg_val != 0 {
+                return InlineTraceStepAction::Trace(TraceAction::Abort);
             }
             if step_result.is_err() {
                 return InlineTraceStepAction::Trace(self.handle_possible_exception(code, pc));
@@ -7238,24 +7337,55 @@ impl OpcodeStepExecutor for MIFrame {
         ))
     }
 
-    /// RPython opimpl_reraise (pyjitpl.py:1701).
-    ///
-    /// `oparg` is the RERAISE N depth — when non-zero the original raise-
-    /// site lasti integer sits `oparg` slots below TOS.  The trace path
-    /// reads the same symbolic stack as the interpreter `reraise`
-    /// (`eval.rs:reraise`) so any preserved lasti would have to be
-    /// extracted from there.  At the trace-bridge layer we currently only
-    /// surface the exception object; full reraise_lasti propagation is
-    /// inherited via the concrete-frame fallback in `metainterp.rs`.
-    fn reraise(&mut self, _oparg: u32) -> Result<(), Self::Error> {
-        let exc = self.sym().last_exc_value;
-        unsafe {
-            if pyre_object::is_exception(exc) {
-                Err(PyError::from_exc_object(exc))
-            } else {
-                Err(PyError::runtime_error("reraise during tracing"))
+    /// `pypy/interpreter/pyopcode.py:1348-1376 RERAISE`.
+    fn reraise(&mut self, oparg: u32) -> Result<(), Self::Error> {
+        // pyopcode.py:1357-1363
+        let reraise_lasti: i32 = if oparg != 0 {
+            // pyopcode.py:1361 — self.space.int_w(self.peekvalue(oparg))
+            //
+            // Trace-time peek: the lasti slot was pushed by a prior
+            // exception-table dispatch (`finishframe_exception` lasti push)
+            // as a const-int box `w_int_new(pc as i64)`, so the symbolic
+            // `concrete_stack` carries the value verbatim.  When the slot
+            // has been displaced and the trace can no longer fold a
+            // const-int, signal abort with -1; the dispatcher's RERAISE
+            // branch detects `oparg != 0 && reraise_lasti < 0` and routes
+            // to the interpreter via `TraceAction::Abort`.
+            let s = self.sym();
+            match s.valuestackdepth.checked_sub(s.nlocals + oparg as usize + 1) {
+                Some(stack_idx) => match s.concrete_stack.get(stack_idx).copied() {
+                    Some(crate::state::ConcreteValue::Int(v)) => v as i32,
+                    Some(crate::state::ConcreteValue::Ref(obj))
+                        if !obj.is_null() && unsafe { pyre_object::is_int(obj) } =>
+                    {
+                        unsafe { pyre_object::w_int_get_value(obj) as i32 }
+                    }
+                    _ => -1,
+                },
+                None => -1,
             }
+        } else {
+            -1
+        };
+        // pyopcode.py:1364 — w_exc = self.popvalue()
+        let _ = self.with_ctx(|this, ctx| this.pop_value(ctx))?;
+        // The popped value's identity is cached in `sym.last_exc_value`
+        // (seeded by PUSH_EXC_INFO / GUARD_EXCEPTION), so the type check
+        // and PyError construction read from there rather than re-deriving
+        // the concrete from the popped symbolic slot.
+        let w_exc = self.sym().last_exc_value;
+        // pyopcode.py:1367 — w_value = space.interp_w(W_BaseException, w_exc)
+        if w_exc.is_null() || !unsafe { pyre_object::is_exception(w_exc) } {
+            return Err(PyError::type_error(
+                "exception must derive from BaseException",
+            ));
         }
+        // pyopcode.py:1368-1369 — w_type = space.type(w_exc); operr = OperationError(...)
+        let mut err = unsafe { PyError::from_exc_object(w_exc) };
+        // pyopcode.py:1376 — raise RaiseWithExplicitTraceback(operr, reraise_lasti)
+        err.attach_tb = false;
+        err.reraise_lasti = reraise_lasti;
+        Err(err)
     }
 
     fn unsupported(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6207,12 +6207,17 @@ impl MIFrame {
         let concrete_frame_addr = self.concrete_frame_addr;
 
         // pyjitpl.py:2510-2520: scan for catch_exception handler
-        // (Python 3.11+ exception table replaces RPython's op_catch_exception)
-        if let Some(entry) =
-            pyre_interpreter::bytecode::find_exception_handler(&code.exceptiontable, pc as u32)
+        // (Python 3.11+ exception table replaces RPython's op_catch_exception).
+        // `lookup_exceptiontable` takes byte offsets; pyre tracks `pc` as
+        // a code-unit index, so multiply/divide by 2 at the boundary.
+        if let Some((target_bytes, depth, lasti)) =
+            pyre_interpreter::exception_table::lookup_exceptiontable(
+                &code.exceptiontable,
+                (pc * 2) as u32,
+            )
         {
-            let handler_pc = entry.target as usize;
-            let handler_depth = entry.depth as usize;
+            let handler_pc = target_bytes as usize / 2;
+            let handler_depth = depth as usize;
             if majit_metainterp::majit_log_enabled() {
                 eprintln!(
                     "[jit][finishframe_exception] pc={} handler={} depth={}",
@@ -6255,7 +6260,7 @@ impl MIFrame {
                     }
                 });
             }
-            let lasti_obj = if entry.push_lasti {
+            let lasti_obj = if lasti {
                 // Python 3.11 exception-table adaptation: `push_lasti`
                 // pushes a real W_Int object onto `locals_cells_stack_w`.
                 // Mirror it through the same stack/vable helper as every
@@ -7234,7 +7239,15 @@ impl OpcodeStepExecutor for MIFrame {
     }
 
     /// RPython opimpl_reraise (pyjitpl.py:1701).
-    fn reraise(&mut self) -> Result<(), Self::Error> {
+    ///
+    /// `oparg` is the RERAISE N depth — when non-zero the original raise-
+    /// site lasti integer sits `oparg` slots below TOS.  The trace path
+    /// reads the same symbolic stack as the interpreter `reraise`
+    /// (`eval.rs:reraise`) so any preserved lasti would have to be
+    /// extracted from there.  At the trace-bridge layer we currently only
+    /// surface the exception object; full reraise_lasti propagation is
+    /// inherited via the concrete-frame fallback in `metainterp.rs`.
+    fn reraise(&mut self, _oparg: u32) -> Result<(), Self::Error> {
         let exc = self.sym().last_exc_value;
         unsafe {
             if pyre_object::is_exception(exc) {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6500,6 +6500,21 @@ impl MIFrame {
                 .map(|e| e.reraise_lasti)
                 .unwrap_or(-1);
             if oparg_val != 0 && reraise_lasti < 0 {
+                // Wipe the trace's tracked exception state so the
+                // metainterp's Abort handler skips its in-trace
+                // `finishframe_exception` (which would otherwise dispatch
+                // a handler-entry push with `reraise_lasti=-1`,
+                // synthesizing the WRONG lasti and mutating
+                // `owned_concrete_frame` in a way the interpreter would
+                // then resume with).  `executor.reraise()` only mutated
+                // the symbolic stack and emitted IR — both abandoned on
+                // abort.  The concrete PyFrame is untouched, so the
+                // interpreter re-runs RERAISE freshly via its own
+                // `peekvalue(oparg)` path and gets the correct saved
+                // lasti from runtime state.
+                let s = self.sym_mut();
+                s.last_exc_value = pyre_object::PY_NULL;
+                s.last_exc_box = OpRef::NONE;
                 return InlineTraceStepAction::Trace(TraceAction::Abort);
             }
             if self.sym().last_exc_box != OpRef::NONE {
@@ -6509,6 +6524,11 @@ impl MIFrame {
             // lasti when the trace lacks a tracked exception box (generic
             // fallback would drop the lasti).
             if oparg_val != 0 {
+                // last_exc_box is already NONE here; keep last_exc_value
+                // clear for symmetry with the const-fold-abort branch
+                // above so metainterp's `has_exc` check observes no
+                // tracked exception either way.
+                self.sym_mut().last_exc_value = pyre_object::PY_NULL;
                 return InlineTraceStepAction::Trace(TraceAction::Abort);
             }
             if step_result.is_err() {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6178,12 +6178,7 @@ impl MIFrame {
     /// like-named parameter: when non-negative it is the original raise-site
     /// offset the RERAISE bytecode extracted from the stack via
     /// `pyopcode.py:1361 self.space.int_w(self.peekvalue(oparg))`.
-    fn handle_reraise(
-        &mut self,
-        code: &CodeObject,
-        pc: usize,
-        reraise_lasti: i32,
-    ) -> TraceAction {
+    fn handle_reraise(&mut self, code: &CodeObject, pc: usize, reraise_lasti: i32) -> TraceAction {
         let s = self.sym();
         if s.last_exc_value.is_null() || s.last_exc_box == OpRef::NONE {
             return TraceAction::Abort;
@@ -6377,11 +6372,16 @@ impl MIFrame {
             // `handle_exception` will continue propagation through parent
             // frames, so the RERAISE-issuing frame's `last_instr` must be
             // restored here for `f_lineno` to report the original raise
-            // site rather than the RERAISE site.
-            if reraise_lasti >= 0 {
+            // site rather than the RERAISE site, and `frame_finished_execution`
+            // must mirror PyPy so anything inspecting the dead frame (clear,
+            // generator close, traceback walkers) sees the same flag state.
+            {
                 let frame =
                     unsafe { &mut *(concrete_frame_addr as *mut pyre_interpreter::PyFrame) };
-                frame.last_instr = reraise_lasti as isize;
+                if reraise_lasti >= 0 {
+                    frame.last_instr = reraise_lasti as isize;
+                }
+                frame.frame_finished_execution = true;
             }
             // No handler in this frame — return Abort so metainterp's
             // multi-frame finishframe_exception can pop this frame and
@@ -6503,9 +6503,7 @@ impl MIFrame {
                 return InlineTraceStepAction::Trace(TraceAction::Abort);
             }
             if self.sym().last_exc_box != OpRef::NONE {
-                return InlineTraceStepAction::Trace(
-                    self.handle_reraise(code, pc, reraise_lasti),
-                );
+                return InlineTraceStepAction::Trace(self.handle_reraise(code, pc, reraise_lasti));
             }
             // Same rationale as root dispatcher: abort RERAISE-with-saved-
             // lasti when the trace lacks a tracked exception box (generic
@@ -7352,14 +7350,15 @@ impl OpcodeStepExecutor for MIFrame {
             // branch detects `oparg != 0 && reraise_lasti < 0` and routes
             // to the interpreter via `TraceAction::Abort`.
             let s = self.sym();
-            match s.valuestackdepth.checked_sub(s.nlocals + oparg as usize + 1) {
+            match s
+                .valuestackdepth
+                .checked_sub(s.nlocals + oparg as usize + 1)
+            {
                 Some(stack_idx) => match s.concrete_stack.get(stack_idx).copied() {
                     Some(crate::state::ConcreteValue::Int(v)) => v as i32,
                     Some(crate::state::ConcreteValue::Ref(obj))
                         if !obj.is_null() && unsafe { pyre_object::is_int(obj) } =>
-                    {
-                        unsafe { pyre_object::w_int_get_value(obj) as i32 }
-                    }
+                    unsafe { pyre_object::w_int_get_value(obj) as i32 },
                     _ => -1,
                 },
                 None => -1,
@@ -7368,12 +7367,24 @@ impl OpcodeStepExecutor for MIFrame {
             -1
         };
         // pyopcode.py:1364 — w_exc = self.popvalue()
+        //
+        // PyPy's `popvalue()` returns the concrete W_Root that was on TOS;
+        // type validation and OperationError construction run against THAT
+        // object (`:1367-1369`).  Our `pop_value` returns the symbolic
+        // OpRef only — the concrete is in `concrete_stack[TOS]`.  Snapshot
+        // the TOS concrete first, then pop, then validate.  Matching the
+        // popped value (not `sym.last_exc_value`) keeps trace semantics
+        // identical to PyPy even when the stack and the tracker drift
+        // (malformed bytecode or a buggy upstream opcode).
+        let w_exc: PyObjectRef = {
+            let s = self.sym();
+            s.valuestackdepth
+                .checked_sub(s.nlocals + 1)
+                .and_then(|idx| s.concrete_stack.get(idx).copied())
+                .map(|cv| cv.to_pyobj())
+                .unwrap_or(pyre_object::PY_NULL)
+        };
         let _ = self.with_ctx(|this, ctx| this.pop_value(ctx))?;
-        // The popped value's identity is cached in `sym.last_exc_value`
-        // (seeded by PUSH_EXC_INFO / GUARD_EXCEPTION), so the type check
-        // and PyError construction read from there rather than re-deriving
-        // the concrete from the popped symbolic slot.
-        let w_exc = self.sym().last_exc_value;
         // pyopcode.py:1367 — w_value = space.interp_w(W_BaseException, w_exc)
         if w_exc.is_null() || !unsafe { pyre_object::is_exception(w_exc) } {
             return Err(PyError::type_error(

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -164,15 +164,27 @@ fn frame_blocks_for_offset(code: &CodeObject, next_offset: usize) -> Vec<FrameBl
         return Vec::new();
     }
 
-    pyre_interpreter::bytecode::decode_exception_table(&code.exceptiontable)
-        .into_iter()
-        .filter(|entry| next_offset >= entry.start as usize && next_offset < entry.end as usize)
-        .map(|entry| FrameBlock {
-            start_offset: entry.start as usize,
-            end_offset: entry.end as usize,
-            handler_offset: entry.target as usize,
-            stack_depth: entry.depth as u16,
-            push_lasti: entry.push_lasti,
+    // `exception_table::decode_exceptiontable` yields byte offsets; pyre's
+    // JIT codewriter tracks instruction-index offsets (`next_offset` is a
+    // code-unit index into `code.instructions`), so divide by 2 at the
+    // boundary.  Entries are emitted in ascending `start` order so we walk
+    // the whole list rather than break early — multiple ranges may cover
+    // the same PC (`pypy/interpreter/pycode.py:250-253` last-matching-wins).
+    pyre_interpreter::exception_table::decode_exceptiontable(&code.exceptiontable)
+        .filter_map(|entry| {
+            let start = entry.start as usize / 2;
+            let end = entry.end as usize / 2;
+            if next_offset >= start && next_offset < end {
+                Some(FrameBlock {
+                    start_offset: start,
+                    end_offset: end,
+                    handler_offset: entry.target as usize / 2,
+                    stack_depth: entry.depth as u16,
+                    push_lasti: entry.lasti,
+                })
+            } else {
+                None
+            }
         })
         .collect()
 }
@@ -2509,18 +2521,41 @@ fn decode_exception_catch_sites(
     Vec<ExceptionCatchSite>,
     std::collections::HashMap<usize, u16>,
 ) {
-    let exception_entries =
-        pyre_interpreter::bytecode::decode_exception_table(&code.exceptiontable);
+    // `decode_exceptiontable` yields byte offsets; codewriter operates in
+    // instruction-index units.  Convert at the boundary.
+    let exception_entries: Vec<_> =
+        pyre_interpreter::exception_table::decode_exceptiontable(&code.exceptiontable)
+            .map(|e| {
+                (
+                    e.start as usize / 2,
+                    e.end as usize / 2,
+                    e.target as usize / 2,
+                    e.depth as u16,
+                    e.lasti,
+                )
+            })
+            .collect();
     let mut catch_for_pc: Vec<Option<u16>> = vec![None; num_instrs];
     let mut catch_sites: Vec<ExceptionCatchSite> = Vec::new();
     for py_pc in 0..num_instrs {
-        let Some(entry) = exception_entries
-            .iter()
-            .find(|entry| py_pc >= entry.start as usize && py_pc < entry.end as usize)
-        else {
+        // `pypy/interpreter/pycode.py:250-253` last-matching-wins: walk the
+        // entries in encoding order, keep the *last* match for this PC.
+        // Multiple ranges may cover one PC (nested try/finally/with), and
+        // CPython's emission order puts the innermost (most-specific) entry
+        // last.  Earlier pyre used `.find(...)` which returned the first
+        // match — divergence from PyPy in nested cases.
+        let mut chosen: Option<&(usize, usize, usize, u16, bool)> = None;
+        for entry in &exception_entries {
+            let (start, end, _target, _depth, _lasti) = *entry;
+            if py_pc >= start && py_pc < end {
+                chosen = Some(entry);
+            } else if start > py_pc {
+                break;
+            }
+        }
+        let Some(&(_start, _end, handler_py_pc, depth, push_lasti)) = chosen else {
             continue;
         };
-        let handler_py_pc = entry.target as usize;
         if handler_py_pc >= num_instrs {
             continue;
         }
@@ -2529,16 +2564,16 @@ fn decode_exception_catch_sites(
         catch_sites.push(ExceptionCatchSite {
             landing_label,
             handler_py_pc,
-            stack_depth: entry.depth,
-            push_lasti: entry.push_lasti,
+            stack_depth: depth,
+            push_lasti,
             lasti_py_pc: py_pc,
         });
     }
     let handler_depth_at: std::collections::HashMap<usize, u16> = exception_entries
         .iter()
-        .map(|e| {
-            let extra = if e.push_lasti { 1u16 } else { 0 };
-            (e.target as usize, e.depth as u16 + extra + 1)
+        .map(|(_start, _end, target, depth, lasti)| {
+            let extra = if *lasti { 1u16 } else { 0 };
+            (*target, *depth + extra + 1)
         })
         .collect();
     (catch_for_pc, catch_sites, handler_depth_at)
@@ -9666,18 +9701,23 @@ mod tests {
         let code = first_nested_function_code(
             "def f(a):\n    try:\n        return a\n    except Exception:\n        return 0\n",
         );
-        let entries = pyre_interpreter::bytecode::decode_exception_table(&code.exceptiontable);
+        // `exception_table::decode_exceptiontable` yields byte offsets;
+        // codewriter operates in code-unit indices (offset/2).
+        let entries: Vec<_> =
+            pyre_interpreter::exception_table::decode_exceptiontable(&code.exceptiontable)
+                .collect();
         assert!(!entries.is_empty());
 
         let first = &entries[0];
-        let blocks = frame_blocks_for_offset(&code, first.start as usize);
+        let first_start_units = first.start as usize / 2;
+        let blocks = frame_blocks_for_offset(&code, first_start_units);
 
         assert_eq!(blocks.len(), 1);
-        assert_eq!(blocks[0].start_offset, first.start as usize);
-        assert_eq!(blocks[0].end_offset, first.end as usize);
-        assert_eq!(blocks[0].handler_offset, first.target as usize);
+        assert_eq!(blocks[0].start_offset, first_start_units);
+        assert_eq!(blocks[0].end_offset, first.end as usize / 2);
+        assert_eq!(blocks[0].handler_offset, first.target as usize / 2);
         assert_eq!(blocks[0].stack_depth, first.depth as u16);
-        assert_eq!(blocks[0].push_lasti, first.push_lasti);
+        assert_eq!(blocks[0].push_lasti, first.lasti);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Fix #4


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: gpt-5.5

Prompt: Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->

  1. Regressions vs Main

  None found.

  2. Other Mismatches Introduced

  - co_exceptiontable does not enforce the PyPy cls=PyCode descriptor check.
    PyPy defines it with interp_attrproperty(..., cls=PyCode, wrapfn="newbytes"), so direct descriptor access on a non-code object goes through the normal descriptor
    mismatch path. Pyre currently installs it with make_getset_descriptor, which has no required class, then unsafe-casts the receiver as W_CodeObject. This can
    diverge from PyPy and may be unsafe. Relevant files: pyre/pyre-interpreter/src/typedef.rs:4517, pyre/pyre-interpreter/src/pycode.rs:345.
  - git diff main is incomplete by itself.
    The tracked diff adds pub mod exception_table;, but pyre/pyre-interpreter/src/exception_table.rs:1 is untracked. Applying only the diff against main would not
    compile.

  3. Mismatches Already Present Before This Patch

  - code.replace(co_exceptiontable=...) is still not PyPy-compatible.
    PyPy’s descr_replace accepts co_exceptiontable; Pyre’s replace remains a stub returning self: pyre/pyre-interpreter/src/typedef.rs:4493.
  - No-handler exception propagation still does not set frame_finished_execution = true.
    PyPy sets it before propagating out of the frame. Pyre currently returns false without setting it: pyre/pyre-interpreter/src/eval.rs:584. This was also true on
    main.
  - JIT trace RERAISE N still ignores oparg/reraise_lasti.
    The interpreter path now handles it, but trace execution ignores _oparg: pyre/pyre-jit-trace/src/trace_opcode.rs:7241. JIT handler entry then pushes current pc,
    not the original raise-site lasti.

  4. Structural Adaptations

  - PyPy returns (target, depth, lasti) with depth == -1 as the no-handler sentinel. Pyre uses Option<(target, depth, lasti)>, which is a reasonable Rust adaptation.
  - PyPy uses byte offsets for last_instr; Pyre internally uses RustPython code-unit indices and converts at exception-table boundaries with *2//2. That is
    acceptable as a Python 3.11+/RustPython compiler adaptation, but comments saying “byte offset” should be adjusted where they refer to Pyre’s internal last_instr.
  - PyPy pops the exception in RERAISE; Pyre leaves the stack intact and lets handler unwind truncate to the table depth. For the handler path this appears to be an
    intentional structural adaptation, not a parity bug.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose code.co_exceptiontable as read-only bytes for inspection
  * Added support for CPython 3.11-style exception table decoding and handler lookup

* **Bug Fixes**
  * Preserve original raise-site information across re-raises
  * Correct nested handler resolution using "last matching wins" semantics

* **Tests**
  * New parity tests validating exception-table exposure, nested-handler selection, and reraise/traceback behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/22)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->