### PR TITLE
Fix Windows dynasm test failures in debug and release

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -18786,7 +18786,9 @@ mod tests {
         let mut token = JitCellToken::new(99);
         backend.compile_loop(&inputargs, &ops, &mut token).unwrap();
 
-        let mut data = vec![0u8; 8];
+        // 8-byte f64 write at offset 2 needs at least 10 bytes; round up so
+        // the buffer also satisfies stricter heap-block layouts on Windows.
+        let mut data = vec![0u8; 16];
         let ptr = data.as_mut_ptr() as usize;
 
         let frame = backend.execute_token(&token, &[Value::Ref(GcRef(ptr)), Value::Float(6.25)]);

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -625,6 +625,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic]
     fn set_forwarded_to_self_panics_in_debug() {
         let a = BoxRef::new_resop(Type::Int, 0);

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -1505,6 +1505,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "_resulttypes")]
     fn make_result_of_lastop_panics_on_recorded_resulttype_mismatch() {
         // Same writer setup as the matching variant — but the reader

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -15560,6 +15560,7 @@ mod metainterp_static_data_tests {
     /// caller that forgets to wire `portal_runner_adr` fails fast in
     /// dev/test builds (the bench harness runs in dev profile).
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "portal_runner_adr is 0")]
     fn do_recursive_call_panics_when_portal_runner_adr_is_zero() {
         use crate::BackEdgeAction;
@@ -16359,6 +16360,7 @@ mod metainterp_static_data_tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "MetaInterp.assert_no_exception")]
     fn assert_no_exception_panics_when_value_set() {
         let mut meta = MetaInterp::<()>::new(0);

--- a/majit/majit-translate/src/jit_codewriter/support.rs
+++ b/majit/majit-translate/src/jit_codewriter/support.rs
@@ -985,6 +985,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "extra and extrakey must be supplied together")]
     fn builtin_func_for_spec_rejects_mismatched_extra_extrakey() {
         // `support.py:769 assert (extra is None) == (extrakey is None)`

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -826,6 +826,7 @@ pub(crate) mod tests {
         lower_indirect_calls(&mut graph, &mut type_state, &cc);
 
         // Post-lowering: invariant — zero Indirect targets.
+        #[cfg(debug_assertions)]
         assert_no_indirect_call_targets(&graph);
 
         // Post-lowering: exactly one VtableMethodPtr and one IndirectCall.


### PR DESCRIPTION
Fix #20

- cranelift test_raw_store_and_load_f_roundtrip: enlarge data buffer from 8 to 16 bytes so the 8-byte f64 write at offset 2 stays in bounds; the prior 2-byte overrun corrupted heap metadata and tripped STATUS_HEAP_CORRUPTION on Windows during process teardown.
- gate four `#[should_panic]` tests on `#[cfg(debug_assertions)]` (set_forwarded_to_self_panics_in_debug, make_result_of_lastop_panics_on_recorded_resulttype_mismatch, do_recursive_call_panics_when_portal_runner_adr_is_zero, assert_no_exception_panics_when_value_set, builtin_func_for_spec_rejects_mismatched_extra_extrakey): their assertions are `debug_assert*!` and elided in release, so the expected panic never fires.
- gate the `assert_no_indirect_call_targets` call in rpbc.rs tests on `#[cfg(debug_assertions)]` to match the function's own gating, fixing the release-mode build error.

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized debug-only tests to execute only in debug builds, reducing test suite overhead in release builds.

* **Bug Fixes**
  * Adjusted buffer allocation to improve compatibility across platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->