### PR TITLE
Fix fannkuch(5): Fix fused LOAD_FAST handling in virtualizable frames

### DIFF
--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4856,42 +4856,20 @@ impl CodeWriter {
                         emit_vsd!(current_depth);
                     }
 
-                    // CPython 3.13 super-instructions LOAD_FAST_LOAD_FAST /
+                    // CPython super-instructions LOAD_FAST_LOAD_FAST /
                     // LOAD_FAST_BORROW_LOAD_FAST_BORROW decompose to two plain
-                    // LOAD_FAST reads. Portal parity with plain LoadFast would
-                    // route both halves through vable_getarrayitem_ref, but
-                    // flipping this arm (attempted multiple times, most
-                    // recently 2026-04-27) reproduces the same
-                    // `set_virtualizable_entry_at: index X out of range for
-                    // X slots` bridge re-trace panic. The 2026-04-24 LFLF
-                    // flip (commit 776c763575) recovered correctness on
-                    // top-level benches but was reverted at 2648598f9da
-                    // because float-typed locals returned NaN — and even the
-                    // 2026-04-27 retry on the post-Phase-2.2 base hits the
-                    // same bridge re-trace push_value overflow.
+                    // LOAD_FAST reads. Keep the portal virtualizable lowering
+                    // identical to plain LoadFast: every local read goes
+                    // through getarrayitem_vable_r so blackhole resume can
+                    // reload dead-at-resume locals on demand, as RPython does
+                    // via jtransform.py:1877 do_fixed_list_getitem.
                     Instruction::LoadFastBorrowLoadFastBorrow { var_nums }
                     | Instruction::LoadFastLoadFast { var_nums } => {
                         let pair = var_nums.get(op_arg);
                         let reg_a = u32::from(pair.idx_1()) as u16;
                         let reg_b = u32::from(pair.idx_2()) as u16;
-                        let value_a = current_state
-                            .locals_w
-                            .get(reg_a as usize)
-                            .and_then(|value| value.clone())
-                            .unwrap_or_else(|| fresh_ref_value(&mut graph));
-                        emit_ref_copy!(ssarepr, stack_base + current_depth, reg_a);
-                        current_state.stack.push(value_a);
-                        current_depth += 1;
-                        emit_vsd!(current_depth);
-                        let value_b = current_state
-                            .locals_w
-                            .get(reg_b as usize)
-                            .and_then(|value| value.clone())
-                            .unwrap_or_else(|| fresh_ref_value(&mut graph));
-                        emit_ref_copy!(ssarepr, stack_base + current_depth, reg_b);
-                        current_state.stack.push(value_b);
-                        current_depth += 1;
-                        emit_vsd!(current_depth);
+                        emit_load_fast_ref!(ssarepr, current_depth, reg_a);
+                        emit_load_fast_ref!(ssarepr, current_depth, reg_b);
                     }
 
                     // Super-instruction STORE_FAST; LOAD_FAST: pop TOS into


### PR DESCRIPTION
## Summary

This pull request refines the handling of CPython super-instructions related to local variable access within the `CodeWriter` implementation. The changes ensure that all local reads, including those in super-instructions like `LOAD_FAST_LOAD_FAST` and `LOAD_FAST_BORROW_LOAD_FAST_BORROW`, are routed through the same virtualizable lowering path as plain `LoadFast`. This aligns with RPython's approach and improves correctness for blackhole resume scenarios.

Key improvements to super-instruction handling:

* Updated the handling of `LoadFastLoadFast` and `LoadFastBorrowLoadFastBorrow` instructions to ensure both local reads are routed through `getarrayitem_vable_r`, matching the behavior of plain `LoadFast` and supporting correct blackhole resume semantics.
* Removed prior workaround code and detailed comments about past issues, clarifying the rationale for this unified approach and referencing RPython's `jtransform.py:1877 do_fixed_list_getitem`.

As a result, fannkuch(5), previously an infinite loop, now quickly finishes.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
• Static review only. I found no parity regressions in git diff upstream/main.

  1. Cases Where Our Patch Regressed PyPy Parity Compared To Main

  None found.

  The changed arm at pyre/pyre-jit/src/jit/codewriter.rs:4859 now lowers LOAD_FAST_LOAD_FAST / LOAD_FAST_BORROW_LOAD_FAST_BORROW by
  calling emit_load_fast_ref! twice. That is closer to PyPy/RPython than upstream/main, which copied from pyre’s local shadow
  registers directly.

  2. Other Mismatches Introduced By Our Patch

  None found.

  For portal code, emit_load_fast_ref! emits the same virtualizable read/write shape as plain LOAD_FAST: getarrayitem_vable_r for the
  local read, then setarrayitem_vable_r plus valuestackdepth update for the push. That matches:

  - PyPy LOAD_FAST: read locals_cells_stack_w[varindex], then pushvalue at pypy/interpreter/pyopcode.py:519
  - PyPy pushvalue: write locals_cells_stack_w[depth], increment valuestackdepth at pypy/interpreter/pyframe.py:363
  - RPython virtualizable list get lowering: getarrayitem_vable_* at rpython/jit/codewriter/jtransform.py:1877
  - RPython virtualizable list set lowering: setarrayitem_vable_* at rpython/jit/codewriter/jtransform.py:1898

  3. Mismatches That Already Existed Before This Patch

  The prior upstream/main implementation of this same arm was a mismatch: portal LOAD_FAST_LOAD_FAST read local shadow registers with
  ref_copy, bypassing the virtualizable locals_cells_stack_w[*] path used by plain LOAD_FAST. This patch removes that mismatch rather
  than adding one.

  No remaining pre-existing mismatch specific to this changed hunk was found.

  4. Structural Adaptations

  LOAD_FAST_LOAD_FAST and LOAD_FAST_BORROW_LOAD_FAST_BORROW are CPython super-instructions, while the local PyPy source has only
  plain LOAD_FAST dispatch. Treating each super-instruction as two plain fast-local reads is therefore a structural adaptation for
  CPython-compatible bytecode, and it matches the project’s existing super-instruction expansion model in pyre/pyre-jit-trace/src/
  super_inst_expand.rs:1.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated bytecode instruction handling to optimize local variable access patterns.

---

**Note:** This release contains internal code optimizations with no direct user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->