### PR TITLE
Fix fannkuch(7) through (9): Fix fallthrough label aliases and improve bridge trace performance

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3870,7 +3870,6 @@ fn assemble_peeled_trace_with_jump_args(
         filtered_extra_label_args.push(label_arg);
         filtered_extra_jump_args.push(jump_arg);
     }
-
     let next_free_pos = |mut next: u32| {
         next = next.max(inputarg_base + body_num_inputs as u32);
         while constants.contains_key(&next) {
@@ -4025,6 +4024,7 @@ fn assemble_peeled_trace_with_jump_args(
     // to share an OpRef — it is RPython parity: the same Box appears
     // once in the label arglist.
     let mut label_set: std::collections::HashSet<OpRef> = full_label_args.iter().copied().collect();
+    let mut fallthrough_aliases = Vec::new();
     {
         let mut seen_body_defs = std::collections::HashSet::new();
         for op in p2_ops {
@@ -4051,6 +4051,25 @@ fn assemble_peeled_trace_with_jump_args(
                 {
                     continue;
                 }
+                // RPython Box identity parity: Phase 2 may forward a
+                // preamble-defined Box to a fresh body-visible Box. The
+                // Label carries the forwarded Box, but first fall-through
+                // only has the preamble source; pyre's flat OpRef model
+                // needs an explicit SameAs bridge before the Label.
+                if let Some(source) = preamble_defs
+                    .iter()
+                    .copied()
+                    .find(|&source| source != arg && ctx.get_box_replacement(source) == arg)
+                {
+                    let tp = ctx
+                        .opref_type(arg)
+                        .or_else(|| ctx.opref_type(source))
+                        .or_else(|| arg.ty())
+                        .unwrap_or(Type::Int);
+                    let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[source]);
+                    same_as.pos = arg;
+                    fallthrough_aliases.push(same_as);
+                }
                 full_label_args.push(arg);
                 label_set.insert(arg);
             }
@@ -4060,12 +4079,6 @@ fn assemble_peeled_trace_with_jump_args(
         }
     }
 
-    // RPython Box identity parity: in RPython, the JUMP's Box IS the
-    // label's Box — no mapping needed. The flat OpRef model previously
-    // required a Phase 1 end_arg → label_arg SameAs bridge here for cases
-    // where the two diverged. Probe across 14 benchmarks (both backends)
-    // showed this block fires 0 times after Commit D1/D2's disjoint Phase
-    // 2 OpRef range eliminated the divergence cases. Removed.
     let mut label_op = Op::new(OpCode::Label, &full_label_args);
     // resoperation.py:260 AbstractResOp.type = 'v' default — Label has no
     // result Box, so its OpRef position carries the Void tag rather than
@@ -4073,6 +4086,7 @@ fn assemble_peeled_trace_with_jump_args(
     // shadows a real Box-bearing op at the same raw position.
     label_op.pos = OpRef::op_typed(label_pos, label_op.result_type());
     label_op.descr = loop_label_descr;
+    result.extend(fallthrough_aliases);
     result.push(label_op);
 
     // Body: 2-pass remap (inputarg refs -> label args, body results -> fresh boxes)

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4065,10 +4065,20 @@ fn assemble_peeled_trace_with_jump_args(
                         .opref_type(arg)
                         .or_else(|| ctx.opref_type(source))
                         .or_else(|| arg.ty())
-                        .unwrap_or(Type::Int);
-                    let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[source]);
-                    same_as.pos = arg;
-                    fallthrough_aliases.push(same_as);
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "assemble_peeled_trace_with_jump_args: cannot type \
+                                 fallthrough SameAs alias arg={:?} source={:?}; \
+                                 ctx.opref_type(arg), ctx.opref_type(source), and \
+                                 arg.ty() all returned None",
+                                arg, source
+                            )
+                        });
+                    if tp != Type::Void {
+                        let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[source]);
+                        same_as.pos = arg;
+                        fallthrough_aliases.push(same_as);
+                    }
                 }
                 full_label_args.push(arg);
                 label_set.insert(arg);

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -248,7 +248,10 @@ impl PyreMetaInterp {
                             // No compiled targets for this loop — continue tracing.
                             // RPython: reached_loop_header returns without closing.
                             let top = self.framestack.last_mut().unwrap();
-                            top.pc = pc;
+                            top.pc = target_pc;
+                            if let Some(ref mut cf) = top.owned_concrete_frame {
+                                cf.set_last_instr_from_next_instr(target_pc);
+                            }
                             return LoopAction::Continue;
                         }
                     }


### PR DESCRIPTION
## Summary

This pull request introduces improvements to the trace unrolling and loop header handling logic in the JIT metainterpreter. The main focus is on ensuring correct aliasing of variables during trace unrolling to match RPython's box identity semantics, and refining the handling of program counters when continuing tracing at loop headers.

Trace unrolling and aliasing improvements:

* Added logic in `assemble_peeled_trace_with_jump_args` to explicitly insert `SameAs` operations when a preamble-defined box is forwarded to a fresh body-visible box, ensuring RPython box identity parity in the flat `OpRef` model. This change introduces a `fallthrough_aliases` vector to collect these bridging operations and inserts them before the label operation.
* Removed obsolete code that previously inserted a `SameAs` bridge for jump arguments, as recent changes have eliminated cases where this was necessary.

Loop header and frame handling:

* Updated the loop header handling in `PyreMetaInterp` to set the program counter (`pc`) to `target_pc` and, if a concrete frame exists, to update its last instruction accordingly, ensuring consistency when continuing tracing after a loop header.

Other minor changes:

* Minor cleanup in argument filtering logic in `assemble_peeled_trace_with_jump_args`.

As a result, fannkuch(7) and (8), previously crashing, now finishes quickly and fannkuch(9) runtime has been significantly improved.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
• Static analysis result: I did not find any incorrect ports in the current git diff upstream/main.

  1. Cases Where Our Patch Regressed PyPy Parity Compared To Main

  None found.

  The unroll.rs change adds an explicit SameAs bridge only for pyre’s flat OpRef representation when a preamble-defined source
  forwards to a body-visible box. That is not a PyPy semantic regression; it preserves the box-identity behavior PyPy gets
  implicitly.

  The metainterp.rs change from pc to target_pc also does not regress parity. PyPy reaches reached_loop_header() at the loop header/
  jit-merge-point and resumes from the saved fallthrough PC when it does not compile. Pyre detects the event while executing a
  CPython-style backward branch, so continuing at the branch target is the equivalent control-flow state.

  2. Other Mismatches Introduced By Our Patch

  None found as incorrect ports.

  The new code in majit/majit-metainterp/src/optimizeopt/unroll.rs:4054 emits:

  SameAs(source) -> arg

  before the loop LABEL when ctx.get_box_replacement(source) == arg. PyPy does not have this exact emitted op in the same form, but
  the corresponding PyPy mechanics are object identity and forwarding:

  - rpython/jit/metainterp/optimizeopt/unroll.py:490: source.set_forwarded(target)
  - rpython/jit/metainterp/optimizeopt/shortpreamble.py:436: op = preamble_op.op.get_box_replacement()
  - rpython/jit/metainterp/compile.py:327: preamble ops and extra_same_as are emitted before label_op

  So this is a representation bridge, not a semantic mismatch.

  3. Mismatches That Already Existed Before This Patch

  The old upstream/main version of pyre/pyre-jit-trace/src/metainterp.rs:250 continued bridge tracing with top.pc = pc when the
  current loop header had no compiled target. Static analysis suggests that was already mismatched for pyre’s branch-based loop-
  header detection: after a backward branch reports CloseLoopWithArgs { loop_header_pc: Some(target_pc) }, continuing at pc risks
  reusing the branch opcode location rather than the semantic loop-header target.

  The patch fixes that by setting both symbolic and concrete frame PCs to target_pc.

  4. Structural Adaptations

  - pyre/pyre-jit-trace/src/metainterp.rs:239: Pyre uses CloseLoopWithArgs { loop_header_pc } from CPython-compatible bytecode branch
    execution. PyPy’s comparable logic is split between opimpl_jit_merge_point() and reached_loop_header() in rpython/jit/metainterp/
    pyjitpl.py:1536 and rpython/jit/metainterp/pyjitpl.py:2974.
  - majit/majit-metainterp/src/optimizeopt/unroll.rs:4059: The new fallthrough_aliases logic is a flat-OpRef adaptation for PyPy Box
    identity / _forwarded behavior. PyPy does not need a side operation here because boxes are distinct Python objects and forwarding
    is attached to the box.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop optimization handling to correctly manage value aliasing during trace assembly.
  * Enhanced trace execution state consistency to maintain accurate program counter alignment during loop operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->