### PR TITLE
Implement list slice assignment JIT path with BUILD_SLICE tracing

### DIFF
--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -1473,6 +1473,109 @@ pub fn generated_list_setitem_by_strategy(
     }
 }
 
+/// Trace same-length list slice assignment for the strategy-preserving case:
+/// ```text
+///     list[start:stop:1] = other_list
+/// ```
+///
+/// PyPy's `AbstractUnwrappedStrategy.setslice` mutates the underlying
+/// strategy storage directly when both lists have the same strategy.  This
+/// helper deliberately handles only the no-resize case; same-list replacement
+/// can only enter this path for full-list replacement, so the forward copy is
+/// harmless. Other cases fall back to the generic STORE_SUBSCR residual path
+/// rather than risking an incorrect partial port of listobject.py's resizing
+/// and overlap rules.
+#[inline]
+pub fn generated_list_setslice_same_len_by_strategy(
+    frame: &mut crate::state::MIFrame,
+    ctx: &mut majit_metainterp::TraceCtx,
+    obj: majit_ir::OpRef,
+    value: majit_ir::OpRef,
+    raw_start: i64,
+    raw_stop: i64,
+    start: i64,
+    stop: i64,
+    strategy_id: i64,
+    obj_len: usize,
+    value_len: usize,
+) {
+    frame.guard_class(
+        ctx,
+        obj,
+        &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType,
+    );
+    frame.guard_class(
+        ctx,
+        value,
+        &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType,
+    );
+    frame.guard_list_strategy(ctx, obj, strategy_id);
+    frame.guard_list_strategy(ctx, value, strategy_id);
+
+    let len_descr = list_len_descr_for_strategy(strategy_id);
+    let obj_len_box = crate::state::opimpl_getfield_gc_i(ctx, obj, len_descr.clone());
+    if raw_start == start && raw_stop == stop {
+        let raw_stop_box = ctx.const_int(raw_stop);
+        let lower_bound_ok =
+            ctx.record_op(majit_ir::OpCode::IntGe, &[obj_len_box, raw_stop_box]);
+        frame.generate_guard(ctx, majit_ir::OpCode::GuardTrue, &[lower_bound_ok]);
+    } else {
+        frame.implement_guard_value(ctx, obj_len_box, obj_len as i64);
+    }
+    let value_len_box = crate::state::opimpl_getfield_gc_i(ctx, value, len_descr);
+    frame.implement_guard_value(ctx, value_len_box, value_len as i64);
+
+    match strategy_id {
+        0 => {
+            let dst_items = load_items_block(ctx, obj, crate::descr::list_items_descr());
+            let src_items = load_items_block(ctx, value, crate::descr::list_items_descr());
+            for i in 0..value_len {
+                let src_idx = ctx.const_int(i as i64);
+                let dst_idx = ctx.const_int(start + i as i64);
+                let item = crate::state::trace_items_block_getitem_value(ctx, src_items, src_idx);
+                crate::state::trace_items_block_setitem_value(ctx, dst_items, dst_idx, item);
+            }
+        }
+        1 => {
+            let dst_items =
+                crate::state::opimpl_getfield_gc_i(ctx, obj, crate::descr::list_int_items_ptr_descr());
+            let src_items = crate::state::opimpl_getfield_gc_i(
+                ctx,
+                value,
+                crate::descr::list_int_items_ptr_descr(),
+            );
+            for i in 0..value_len {
+                let src_idx = ctx.const_int(i as i64);
+                let dst_idx = ctx.const_int(start + i as i64);
+                let item = crate::state::trace_raw_int_array_getitem_value(ctx, src_items, src_idx);
+                crate::state::trace_raw_int_array_setitem_value(ctx, dst_items, dst_idx, item);
+            }
+        }
+        2 => {
+            let dst_items = crate::state::opimpl_getfield_gc_i(
+                ctx,
+                obj,
+                crate::descr::list_float_items_ptr_descr(),
+            );
+            let src_items = crate::state::opimpl_getfield_gc_i(
+                ctx,
+                value,
+                crate::descr::list_float_items_ptr_descr(),
+            );
+            for i in 0..value_len {
+                let src_idx = ctx.const_int(i as i64);
+                let dst_idx = ctx.const_int(start + i as i64);
+                let item =
+                    crate::state::trace_raw_float_array_getitem_value(ctx, src_items, src_idx);
+                crate::state::trace_raw_float_array_setitem_value(ctx, dst_items, dst_idx, item);
+            }
+        }
+        _ => unreachable!(),
+    }
+
+    debug_assert_eq!(stop - start, value_len as i64);
+}
+
 /// Unbox a Python int into a raw i64 for the int-strategy list path.
 /// `unbox_long=true` selects `trace_unbox_long_with_resume(LONG_TYPE)` to
 /// accept fits_int W_LongObject (`listobject.py:1957-1958 IntegerListStrategy

--- a/majit/majit-translate/src/handler_spec.rs
+++ b/majit/majit-translate/src/handler_spec.rs
@@ -166,10 +166,10 @@ fn emit_constant_impl(out: &mut String) {
     // `pypy/interpreter/pyopcode.py:1463 BUILD_SLICE` →
     // `op.newslice(w_start, w_end, w_step)` so the three operands stay
     // live in the trace as field dependencies (NewWithVtable + 3
-    // SetfieldGc per `emit_box_slice_inline`). `concrete` is left
-    // `Null`: every iteration allocates a distinct W_SliceObject, so
-    // there is no canonical concrete heap pointer to box — matching
-    // the `bool_value_from_truth` shape for fresh-per-iteration values.
+    // SetfieldGc per `emit_box_slice_inline`). The concrete shadow mirrors
+    // the root interpreter's W_SliceObject so STORE_SUBSCR can take the same
+    // list slice-assignment specialization decision PyPy takes after
+    // `space.newslice(...)`.
     out.push('\n');
     out.push_str("    fn slice_constant(\n");
     out.push_str("        &mut self,\n");
@@ -190,9 +190,14 @@ fn emit_constant_impl(out: &mut String) {
     out.push_str("            );\n");
     out.push_str("            Ok::<_, pyre_interpreter::PyError>(new_op)\n");
     out.push_str("        })?;\n");
-    out.push_str(
-        "        Ok(crate::state::FrontendOp::new(opref, crate::state::ConcreteValue::Null))\n",
-    );
+    out.push_str("        let concrete = crate::state::ConcreteValue::Ref(\n");
+    out.push_str("            pyre_object::w_slice_new(\n");
+    out.push_str("                start.concrete.to_pyobj(),\n");
+    out.push_str("                stop.concrete.to_pyobj(),\n");
+    out.push_str("                step.concrete.to_pyobj(),\n");
+    out.push_str("            ),\n");
+    out.push_str("        );\n");
+    out.push_str("        Ok(crate::state::FrontendOp::new(opref, concrete))\n");
     out.push_str("    }\n");
 
     out.push_str("}\n");

--- a/pyre/bench/list_setslice.py
+++ b/pyre/bench/list_setslice.py
@@ -4,16 +4,14 @@
 # On main, there was no setslice op (Object-only fallback).
 # On this branch, setslice stays in Integer strategy when new items are plain ints.
 #
-# NOTE: kept at module level intentionally — wrapping in def main() lets the
-# JIT fire and exposes a TypeError("list indices must be integers, not tuple")
-# panic in opcode_ops.rs:178 (slice assignment lowering bug). Re-wrap once
-# that's fixed.
-
 N = 200000
 
-lst = [0] * 10
-i = 0
-while i < N:
-    lst[2:5] = [i, i + 1, i + 2]
-    i = i + 1
-print(lst)
+def main():
+    lst = [0] * 10
+    i = 0
+    while i < N:
+        lst[2:5] = [i, i + 1, i + 2]
+        i = i + 1
+    print(lst)
+
+main()

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -368,7 +368,20 @@ pub trait TraceHelperAccess {
     }
 
     fn trace_build_list(&mut self, items: &[OpRef]) -> Result<OpRef, PyError> {
-        self.with_trace_ctx(|ctx| emit_trace_build_flat(ctx, FlatBuildKind::List, items))
+        self.with_trace_ctx(|ctx| {
+            // STRUCTURAL ADAPTATION: PyPy lowers `newlist(*items)` as
+            // trace-visible allocation + item stores, so virtual boxed items
+            // remain live through the list construction naturally.  Pyre still
+            // routes flat list construction through an opaque helper call;
+            // dynasm can otherwise drop a virtual item that is only consumed by
+            // that helper (`list_setslice`: `[i, i+1, i+2]` lost item2).  Keep
+            // item OpRefs pinned until list construction is ported to the
+            // PyPy/RPython `newlist` allocation shape.
+            for &item in items {
+                ctx.record_op(OpCode::Keepalive, &[item]);
+            }
+            emit_trace_build_flat(ctx, FlatBuildKind::List, items)
+        })
     }
 
     fn trace_build_tuple(&mut self, items: &[OpRef]) -> Result<OpRef, PyError> {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4581,7 +4581,9 @@ impl MIFrame {
                 let obj_len = w_list_len(concrete_obj);
                 let value_len = w_list_len(concrete_value);
                 let slice_len = (stop - start) as usize;
-                if value_len == slice_len {
+                if concrete_obj == concrete_value {
+                    None
+                } else if value_len == slice_len {
                     match (
                         concrete_list_strategy_id(concrete_obj),
                         concrete_list_strategy_id(concrete_value),

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -195,9 +195,75 @@ use pyre_object::{
     w_list_uses_float_storage, w_list_uses_int_storage, w_list_uses_object_storage, w_tuple_len,
 };
 
+fn const_step_one_slice_bounds(
+    concrete_obj: PyObjectRef,
+    concrete_key: PyObjectRef,
+    concrete_value: PyObjectRef,
+) -> Option<(i64, i64, i64, i64, bool)> {
+    unsafe {
+        if concrete_obj.is_null()
+            || concrete_key.is_null()
+            || concrete_value.is_null()
+            || !is_list(concrete_obj)
+            || !pyre_object::sliceobject::is_slice(concrete_key)
+            || !is_list(concrete_value)
+        {
+            return None;
+        }
+        let step = pyre_object::sliceobject::w_slice_get_step(concrete_key);
+        let step_is_none = pyre_object::is_none(step);
+        let step_is_one = if step_is_none {
+            true
+        } else if is_int(step) {
+            pyre_object::w_int_get_value(step) == 1
+        } else {
+            false
+        };
+        if !step_is_one {
+            return None;
+        }
+        let start = pyre_object::sliceobject::w_slice_get_start(concrete_key);
+        let stop = pyre_object::sliceobject::w_slice_get_stop(concrete_key);
+        if pyre_object::is_none(start)
+            || pyre_object::is_none(stop)
+            || !is_int(start)
+            || !is_int(stop)
+        {
+            return None;
+        }
+        let start = pyre_object::w_int_get_value(start);
+        let stop = pyre_object::w_int_get_value(stop);
+        if start < 0 || stop < start {
+            return None;
+        }
+        let len = w_list_len(concrete_obj) as i64;
+        // PyPy `W_ListObject.descr_setitem` routes slices through
+        // `_unpack_slice` before `setslice`, so storage-level code sees
+        // adjusted positive-step bounds, not the raw slice fields.  This
+        // helper only accepts non-negative constant bounds, so adjustment
+        // reduces to CPython/PyPy's upper clamp.
+        Some((start, stop, start.min(len), stop.min(len), step_is_none))
+    }
+}
+
+fn concrete_list_strategy_id(concrete: PyObjectRef) -> Option<i64> {
+    unsafe {
+        if w_list_uses_object_storage(concrete) {
+            Some(0)
+        } else if w_list_uses_int_storage(concrete) {
+            Some(1)
+        } else if w_list_uses_float_storage(concrete) {
+            Some(2)
+        } else {
+            None
+        }
+    }
+}
+
 use crate::descr::{
     dict_storage_values_len_descr, dict_storage_values_ptr_descr, float_floatval_descr,
-    int_intval_descr, list_strategy_descr, ob_type_descr, w_float_size_descr, w_int_size_descr,
+    int_intval_descr, list_strategy_descr, ob_type_descr, slice_w_start_descr, slice_w_step_descr,
+    slice_w_stop_descr, w_float_size_descr, w_int_size_descr,
 };
 use crate::frame_layout::{
     PYFRAME_DEBUGDATA_OFFSET, PYFRAME_LASTBLOCK_OFFSET, PYFRAME_PYCODE_OFFSET,
@@ -4508,6 +4574,67 @@ impl MIFrame {
         concrete_key: PyObjectRef,
         concrete_value: PyObjectRef,
     ) -> Result<(), PyError> {
+        if let Some((raw_start, raw_stop, start, stop, step_is_none)) =
+            const_step_one_slice_bounds(concrete_obj, concrete_key, concrete_value)
+        {
+            let specialized_same_len = unsafe {
+                let obj_len = w_list_len(concrete_obj);
+                let value_len = w_list_len(concrete_value);
+                let slice_len = (stop - start) as usize;
+                if value_len == slice_len {
+                    match (
+                        concrete_list_strategy_id(concrete_obj),
+                        concrete_list_strategy_id(concrete_value),
+                    ) {
+                        (Some(obj_sid), Some(value_sid)) if obj_sid == value_sid => {
+                            Some((obj_sid, obj_len, value_len))
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            };
+            if let Some((strategy_id, obj_len, value_len)) = specialized_same_len {
+                self.with_ctx(|this, ctx| {
+                    this.guard_class(
+                        ctx,
+                        key,
+                        &pyre_object::sliceobject::SLICE_TYPE as *const _
+                            as *const pyre_object::PyType,
+                    );
+                    let start_box =
+                        crate::state::opimpl_getfield_gc_r(ctx, key, slice_w_start_descr());
+                    this.guard_int_object_value(ctx, start_box, raw_start);
+                    let stop_box =
+                        crate::state::opimpl_getfield_gc_r(ctx, key, slice_w_stop_descr());
+                    this.guard_int_object_value(ctx, stop_box, raw_stop);
+                    let step_box =
+                        crate::state::opimpl_getfield_gc_r(ctx, key, slice_w_step_descr());
+                    if step_is_none {
+                        this.implement_guard_value(ctx, step_box, pyre_object::w_none() as i64);
+                    } else {
+                        this.guard_int_object_value(ctx, step_box, 1);
+                    }
+                    crate::generated_list_setslice_same_len_by_strategy(
+                        this,
+                        ctx,
+                        obj,
+                        value,
+                        raw_start,
+                        raw_stop,
+                        start,
+                        stop,
+                        strategy_id,
+                        obj_len,
+                        value_len,
+                    );
+                    Ok::<_, PyError>(())
+                })?;
+                self.suppress_guard_no_exception_for_opcode = true;
+                return Ok(());
+            }
+        }
         // jtransform do_resizable_list_setitem dispatch.
         let handled: bool = self.with_ctx(|this, ctx| {
             Ok::<_, PyError>(crate::generated_store_subscr_value(

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -353,7 +353,14 @@ impl pyre_interpreter::ConstantOpcodeHandler for crate::state::MIFrame {
             );
             Ok::<_, pyre_interpreter::PyError>(new_op)
         })?;
-        Ok(crate::state::FrontendOp::new(opref, crate::state::ConcreteValue::Null))
+        let concrete = crate::state::ConcreteValue::Ref(
+            pyre_object::w_slice_new(
+                start.concrete.to_pyobj(),
+                stop.concrete.to_pyobj(),
+                step.concrete.to_pyobj(),
+            ),
+        );
+        Ok(crate::state::FrontendOp::new(opref, concrete))
     }
 }
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3591,7 +3591,7 @@ pub extern "C" fn bh_build_list_fn(argc: i64, item0: i64, item1: i64, item2: i64
             item1 as pyre_object::PyObjectRef,
             item2 as pyre_object::PyObjectRef,
         ],
-        _ => vec![], // argc > 3 not supported via this helper
+        _ => panic!("unsupported argc {} in bh_build_list_fn", argc),
     };
     pyre_interpreter::runtime_ops::build_list_from_refs(&items) as i64
 }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3577,7 +3577,7 @@ pub extern "C" fn bh_binary_op_fn(lhs: i64, rhs: i64, op_code: i64) -> i64 {
 /// RPython bhimpl_newlist: create a list from N items.
 /// argc is a raw integer count; items follow as PyObjectRef args.
 /// Blackhole's call_may_force_ref passes args from registers.
-pub extern "C" fn bh_build_list_fn(argc: i64, item0: i64, item1: i64) -> i64 {
+pub extern "C" fn bh_build_list_fn(argc: i64, item0: i64, item1: i64, item2: i64) -> i64 {
     let n = argc as usize;
     let items: Vec<pyre_object::PyObjectRef> = match n {
         0 => vec![],
@@ -3586,9 +3586,30 @@ pub extern "C" fn bh_build_list_fn(argc: i64, item0: i64, item1: i64) -> i64 {
             item0 as pyre_object::PyObjectRef,
             item1 as pyre_object::PyObjectRef,
         ],
-        _ => vec![], // argc > 2 not supported via this helper
+        3 => vec![
+            item0 as pyre_object::PyObjectRef,
+            item1 as pyre_object::PyObjectRef,
+            item2 as pyre_object::PyObjectRef,
+        ],
+        _ => vec![], // argc > 3 not supported via this helper
     };
     pyre_interpreter::runtime_ops::build_list_from_refs(&items) as i64
+}
+
+/// BUILD_SLICE: `space.newslice(w_start, w_end, w_step)`.
+/// `argc` is 2 or 3; for argc=2 the CPython/PyPy opcode semantics use None
+/// for `w_step` (`pypy/interpreter/pyopcode.py:1463-1472`).
+pub extern "C" fn bh_build_slice_fn(argc: i64, start: i64, stop: i64, step: i64) -> i64 {
+    let step = if argc == 2 {
+        pyre_object::w_none()
+    } else {
+        step as pyre_object::PyObjectRef
+    };
+    pyre_object::w_slice_new(
+        start as pyre_object::PyObjectRef,
+        stop as pyre_object::PyObjectRef,
+        step,
+    ) as i64
 }
 
 pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1470,6 +1470,29 @@ fn emit_frontend_newlist(
     )
 }
 
+fn emit_frontend_newslice(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    start: super::flow::FlowValue,
+    stop: super::flow::FlowValue,
+    step: super::flow::FlowValue,
+    offset: i64,
+) -> super::flow::Variable {
+    // flowcontext.py:1154-1161 BUILD_SLICE -> `op.newslice(w_start,
+    // w_end, w_step).eval(self)`. Preserve all three operands in the
+    // shadow graph so graph-side analysis sees the same dependency shape
+    // as RPython/PyPy, even while the bytecode-level SSA stream still uses
+    // the pyre helper-call adaptation below.
+    emit_graph_op_with_result(
+        graph,
+        block,
+        "newslice",
+        vec![start.into(), stop.into(), step.into()],
+        Kind::Ref,
+        offset,
+    )
+}
+
 fn emit_frontend_setitem(
     _graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -2065,6 +2088,7 @@ struct FnPtrIndices {
     load_const_fn: HelperHandle,
     store_subscr_fn: HelperHandle,
     build_list_fn: HelperHandle,
+    build_slice_fn: HelperHandle,
     normalize_raise_varargs_fn: HelperHandle,
     call_fn_0: HelperHandle,
     call_fn_2: HelperHandle,
@@ -2096,7 +2120,7 @@ struct FnPtrIndices {
 ///   exception-class `__init__`); arbitrary user code that observes
 ///   virtualizables.  Matches `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`
 ///   (`effectinfo.py:23`) → `MayForce`.
-/// * `load_global_fn` / `build_list_fn`: namespace dict lookup +
+/// * `load_global_fn` / `build_list_fn` / `build_slice_fn`: namespace dict lookup +
 ///   list allocation; can raise (`NameError` / `MemoryError`) but do
 ///   not force virtuals — `EF_CAN_RAISE` → `Plain`.
 /// * `box_int_fn` / `load_const_fn`: kept on `Plain` until the
@@ -2194,6 +2218,14 @@ fn register_helper_fn_pointers(
     // Matches `EF_CAN_RAISE` (allocation can `MemoryError`) without
     // virtual-force.
     let build_list_fn = bind(assembler, cpu.build_list_fn as *const (), CallFlavor::Plain);
+    // `pypy/interpreter/pyopcode.py:1463-1472 BUILD_SLICE` calls
+    // `space.newslice(w_start, w_end, w_step)`.  Pyre mirrors that with
+    // a flat allocation helper; no user code runs, but allocation can fail.
+    let build_slice_fn = bind(
+        assembler,
+        cpu.build_slice_fn as *const (),
+        CallFlavor::Plain,
+    );
     // `bh_normalize_raise_varargs_fn` walks the exception class /
     // value pair and instantiates user `__init__` — arbitrary
     // user code that may observe virtualizables.  Matches
@@ -2240,6 +2272,7 @@ fn register_helper_fn_pointers(
         load_const_fn,
         store_subscr_fn,
         build_list_fn,
+        build_slice_fn,
         normalize_raise_varargs_fn,
         call_fn_0,
         call_fn_2,
@@ -2931,6 +2964,11 @@ impl CodeWriter {
                 HelperHandle {
                     idx: build_list_fn_idx,
                     flavor: _build_list_fn_flavor,
+                },
+            build_slice_fn:
+                HelperHandle {
+                    idx: build_slice_fn_idx,
+                    flavor: _build_slice_fn_flavor,
                 },
             normalize_raise_varargs_fn:
                 HelperHandle {
@@ -5760,13 +5798,14 @@ impl CodeWriter {
 
                     // flowcontext.py:1168 BUILD_LIST -> `op.newlist(*items).eval(self)`
                     // consumes all `itemcount` items and returns the list.
-                    // pyre's `build_list_fn` helper only accepts 0..=2 items, so
-                    // argc > 2 falls back to `abort_permanent` + interpreter —
+                    // pyre's `build_list_fn` helper accepts the small fixed
+                    // arities this bytecode lowering can pass directly; larger
+                    // lists fall back to `abort_permanent` + interpreter —
                     // silently dropping items was the prior behaviour and would
                     // have produced wrong list contents at runtime.
                     Instruction::BuildList { count } => {
                         let argc = count.get(op_arg) as usize;
-                        if argc > 2 {
+                        if argc > 3 {
                             for _ in 0..argc {
                                 let _ = emit_popvalue_ref!(ssarepr, current_depth);
                                 let _ = current_state
@@ -5793,8 +5832,8 @@ impl CodeWriter {
                             emit_ref_copy!(ssarepr, arg_regs[i], item_reg);
                             item_values_rev.push(item_value);
                         }
-                        // build_list_fn(argc, item0, item1) → list. The C ABI is
-                        // `extern "C" fn(i64, i64, i64)`; the helper dispatches
+                        // build_list_fn(argc, item0, item1, item2) → list. The C ABI is
+                        // `extern "C" fn(i64, i64, i64, i64)`; the helper dispatches
                         // internally by `argc`, so unused item slots may be any
                         // bit pattern. Encode unused slots as `ConstInt(0)` —
                         // routed through the int constants pool, matches
@@ -5828,6 +5867,65 @@ impl CodeWriter {
                                 build_list_fn_idx,
                                 argc,
                                 &arg_regs,
+                                stack_base + current_depth,
+                            ),
+                        );
+                        current_state.stack.push(result_value.into());
+                        current_depth += 1;
+                        emit_vsd!(current_depth);
+                    }
+
+                    // pyopcode.py:1463 BUILD_SLICE:
+                    //   if numargs == 3: w_step = popvalue()
+                    //   elif numargs == 2: w_step = space.w_None
+                    //   w_end = popvalue(); w_start = popvalue()
+                    //   pushvalue(space.newslice(w_start, w_end, w_step))
+                    Instruction::BuildSlice { argc } => {
+                        use pyre_interpreter::bytecode::BuildSliceArgCount;
+                        let argc = argc.get(op_arg);
+                        let raw_argc = match argc {
+                            BuildSliceArgCount::Two => 2usize,
+                            BuildSliceArgCount::Three => 3usize,
+                        };
+                        let step_info = if raw_argc == 3 {
+                            let reg = emit_popvalue_ref!(ssarepr, current_depth);
+                            let step_value = current_state
+                                .stack
+                                .pop()
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            Some((reg, step_value))
+                        } else {
+                            None
+                        };
+                        let stop_reg = emit_popvalue_ref!(ssarepr, current_depth);
+                        let stop_value = current_state
+                            .stack
+                            .pop()
+                            .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                        let start_reg = emit_popvalue_ref!(ssarepr, current_depth);
+                        let start_value = current_state
+                            .stack
+                            .pop()
+                            .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                        let (step_reg, step_value) = match step_info {
+                            Some((reg, value)) => (Some(reg), value),
+                            None => (None, super::flow::Constant::none().into()),
+                        };
+                        let result_value = emit_frontend_newslice(
+                            &mut graph,
+                            &current_block.block(),
+                            start_value,
+                            stop_value,
+                            step_value,
+                            py_pc as i64,
+                        );
+                        ssarepr.insns.push(
+                            super::flatten::build_build_slice_fn_residual_call_ir_r_insn(
+                                build_slice_fn_idx,
+                                raw_argc,
+                                start_reg,
+                                stop_reg,
+                                step_reg,
                                 stack_base + current_depth,
                             ),
                         );

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1493,6 +1493,26 @@ fn emit_frontend_newslice(
     )
 }
 
+fn emit_frontend_buildslice_shadow_graph(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    argc: pyre_interpreter::bytecode::BuildSliceArgCount,
+    start: super::flow::FlowValue,
+    stop: super::flow::FlowValue,
+    step: Option<super::flow::FlowValue>,
+    offset: i64,
+) -> super::flow::Variable {
+    use pyre_interpreter::bytecode::BuildSliceArgCount;
+    let step = match argc {
+        BuildSliceArgCount::Two => {
+            debug_assert!(step.is_none(), "BUILD_SLICE argc=2 must synthesize None");
+            super::flow::Constant::none().into()
+        }
+        BuildSliceArgCount::Three => step.expect("BUILD_SLICE argc=3 must preserve explicit step"),
+    };
+    emit_frontend_newslice(graph, block, start, stop, step, offset)
+}
+
 fn emit_frontend_setitem(
     _graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -5907,16 +5927,14 @@ impl CodeWriter {
                             .stack
                             .pop()
                             .unwrap_or_else(|| fresh_ref_value(&mut graph));
-                        let (step_reg, step_value) = match step_info {
-                            Some((reg, value)) => (Some(reg), value),
-                            None => (None, super::flow::Constant::none().into()),
-                        };
-                        let result_value = emit_frontend_newslice(
+                        let step_reg = step_info.as_ref().map(|(reg, _)| *reg);
+                        let result_value = emit_frontend_buildslice_shadow_graph(
                             &mut graph,
                             &current_block.block(),
+                            argc,
                             start_value,
                             stop_value,
-                            step_value,
+                            step_info.map(|(_, value)| value),
                             py_pc as i64,
                         );
                         ssarepr.insns.push(
@@ -8670,6 +8688,99 @@ mod tests {
         assert_eq!(op.offset, 44);
         assert_eq!(op.args, vec![item0.into(), item1.into(), item2.into()]);
         assert_eq!(op.result, Some(result.into()));
+    }
+
+    #[test]
+    fn emit_frontend_newslice_records_three_ref_operands() {
+        let start = Block::shared(Vec::new());
+        let mut graph = FunctionGraph::new("newslice", start.clone(), None);
+        let w_start = Variable::new(VariableId(22), Kind::Ref);
+        let w_stop = Variable::new(VariableId(23), Kind::Ref);
+        let w_step = Variable::new(VariableId(24), Kind::Ref);
+
+        let result = emit_frontend_newslice(
+            &mut graph,
+            &start,
+            w_start.into(),
+            w_stop.into(),
+            w_step.into(),
+            46,
+        );
+
+        let block = start.borrow();
+        let op = block
+            .operations
+            .last()
+            .expect("newslice op should be recorded");
+        assert_eq!(op.opname, "newslice");
+        assert_eq!(op.offset, 46);
+        assert_eq!(op.args, vec![w_start.into(), w_stop.into(), w_step.into()]);
+        assert_eq!(op.result, Some(result.into()));
+        assert_eq!(result.kind, Some(Kind::Ref));
+    }
+
+    #[test]
+    fn emit_frontend_buildslice_shadow_graph_two_arg_synthesizes_none_step() {
+        use pyre_interpreter::bytecode::BuildSliceArgCount;
+        let start = Block::shared(Vec::new());
+        let mut graph = FunctionGraph::new("build_slice_two", start.clone(), None);
+        let w_start = Variable::new(VariableId(25), Kind::Ref);
+        let w_stop = Variable::new(VariableId(26), Kind::Ref);
+
+        let result = emit_frontend_buildslice_shadow_graph(
+            &mut graph,
+            &start,
+            BuildSliceArgCount::Two,
+            w_start.into(),
+            w_stop.into(),
+            None,
+            47,
+        );
+
+        let block = start.borrow();
+        let op = block
+            .operations
+            .last()
+            .expect("BUILD_SLICE argc=2 should record newslice");
+        assert_eq!(op.opname, "newslice");
+        assert_eq!(op.offset, 47);
+        assert_eq!(
+            op.args,
+            vec![w_start.into(), w_stop.into(), Constant::none().into()],
+        );
+        assert_eq!(op.result, Some(result.into()));
+        assert_eq!(result.kind, Some(Kind::Ref));
+    }
+
+    #[test]
+    fn emit_frontend_buildslice_shadow_graph_three_arg_preserves_step() {
+        use pyre_interpreter::bytecode::BuildSliceArgCount;
+        let start = Block::shared(Vec::new());
+        let mut graph = FunctionGraph::new("build_slice_three", start.clone(), None);
+        let w_start = Variable::new(VariableId(27), Kind::Ref);
+        let w_stop = Variable::new(VariableId(28), Kind::Ref);
+        let w_step = Variable::new(VariableId(29), Kind::Ref);
+
+        let result = emit_frontend_buildslice_shadow_graph(
+            &mut graph,
+            &start,
+            BuildSliceArgCount::Three,
+            w_start.into(),
+            w_stop.into(),
+            Some(w_step.into()),
+            48,
+        );
+
+        let block = start.borrow();
+        let op = block
+            .operations
+            .last()
+            .expect("BUILD_SLICE argc=3 should record newslice");
+        assert_eq!(op.opname, "newslice");
+        assert_eq!(op.offset, 48);
+        assert_eq!(op.args, vec![w_start.into(), w_stop.into(), w_step.into()]);
+        assert_eq!(op.result, Some(result.into()));
+        assert_eq!(result.kind, Some(Kind::Ref));
     }
 
     #[test]

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -51,8 +51,10 @@ pub struct Cpu {
     pub load_const_fn: extern "C" fn(i64, i64) -> i64,
     /// `bhimpl_store_subscr` — obj[key] = value.
     pub store_subscr_fn: extern "C" fn(i64, i64, i64) -> i64,
-    /// `bhimpl_build_list` — (argc, item0, item1) → new list.
-    pub build_list_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bhimpl_build_list` — (argc, item0, item1, item2) → new list.
+    pub build_list_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
+    /// `bhimpl_build_slice` — (argc, start, stop, step) → new slice.
+    pub build_slice_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// `RAISE_VARARGS` normalization helper used before `raise/r`.
     pub normalize_raise_varargs_fn: extern "C" fn(i64, i64) -> i64,
     /// Read per-thread `CURRENT_EXCEPTION` — used by `PUSH_EXC_INFO`.
@@ -85,6 +87,7 @@ impl Cpu {
             load_const_fn: crate::call_jit::bh_load_const_fn,
             store_subscr_fn: crate::call_jit::bh_store_subscr_fn,
             build_list_fn: crate::call_jit::bh_build_list_fn,
+            build_slice_fn: crate::call_jit::bh_build_slice_fn,
             normalize_raise_varargs_fn: crate::call_jit::bh_normalize_raise_varargs_fn,
             get_current_exception_fn: crate::call_jit::bh_get_current_exception,
             set_current_exception_fn: crate::call_jit::bh_set_current_exception,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3138,11 +3138,11 @@ pub fn build_build_list_fn_residual_call_ir_r_insn(
     arg_regs: &[u16],
     dst_reg: u16,
 ) -> Insn {
-    debug_assert!(
+    assert!(
         argc <= 3,
         "BuildList helper only supports argc ∈ {{0, 1, 2, 3}}"
     );
-    debug_assert_eq!(arg_regs.len(), argc, "arg_regs length must match argc");
+    assert_eq!(arg_regs.len(), argc, "arg_regs length must match argc");
     let mut arg_kinds: Vec<Kind> = Vec::with_capacity(4);
     let mut args_i: Vec<Operand> = Vec::with_capacity(4);
     let mut args_r: Vec<Operand> = Vec::with_capacity(3);
@@ -3188,7 +3188,10 @@ pub fn build_build_slice_fn_residual_call_ir_r_insn(
     step_reg: Option<u16>,
     dst_reg: u16,
 ) -> Insn {
-    debug_assert!(argc == 2 || argc == 3, "BUILD_SLICE argc must be 2 or 3");
+    assert!(
+        matches!((argc, step_reg), (2, None) | (3, Some(_))),
+        "BUILD_SLICE expects argc=2 without step or argc=3 with step"
+    );
     let mut arg_kinds = vec![Kind::Int, Kind::Ref, Kind::Ref];
     let mut args_i = vec![Operand::ConstInt(argc as i64)];
     let mut args_r = vec![
@@ -6410,6 +6413,30 @@ mod tests {
             .expect("residual_call SpaceOperation must lower");
         let prod = build_build_list_fn_residual_call_ir_r_insn(18, 2, &[3, 4], 5);
         assert_eq!(format!("{prod:?}"), format!("{dual:?}"));
+    }
+
+    #[test]
+    #[should_panic(expected = "BuildList helper only supports argc")]
+    fn build_build_list_fn_residual_call_ir_r_insn_rejects_unsupported_argc() {
+        let _ = build_build_list_fn_residual_call_ir_r_insn(18, 4, &[1, 2, 3, 4], 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "arg_regs length must match argc")]
+    fn build_build_list_fn_residual_call_ir_r_insn_rejects_arg_reg_mismatch() {
+        let _ = build_build_list_fn_residual_call_ir_r_insn(18, 2, &[1], 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "BUILD_SLICE expects argc=2 without step or argc=3 with step")]
+    fn build_build_slice_fn_residual_call_ir_r_insn_rejects_two_arg_with_step() {
+        let _ = build_build_slice_fn_residual_call_ir_r_insn(19, 2, 1, 2, Some(3), 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "BUILD_SLICE expects argc=2 without step or argc=3 with step")]
+    fn build_build_slice_fn_residual_call_ir_r_insn_rejects_three_arg_without_step() {
+        let _ = build_build_slice_fn_residual_call_ir_r_insn(19, 3, 1, 2, None, 4);
     }
 
     #[test]

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -6206,10 +6206,11 @@ mod tests {
     #[test]
     fn build_build_list_fn_residual_call_ir_r_insn_emits_residual_call_ir_r_for_argc_2() {
         // Task #48 micro-slice 13: BuildList factor refactor.  argc=2:
-        // both item slots are real Refs, no padding.  Expected shape:
-        // `[ConstInt(fn_idx), ListI([ConstInt(2)]), ListR([Reg(item0),
-        // Reg(item1)]), Descr(CallDescrStub{Plain, [Int, Ref, Ref]})]
-        // → Reg(Ref, dst)`.
+        // two item slots are real Refs, and the third trailing ABI slot
+        // is an Int dummy.  Expected shape:
+        // `[ConstInt(fn_idx), ListI([ConstInt(2), ConstInt(0)]),
+        // ListR([Reg(item0), Reg(item1)]),
+        // Descr(CallDescrStub{Plain, [Int, Ref, Ref, Int]})] → Reg(Ref, dst)`.
         let insn = build_build_list_fn_residual_call_ir_r_insn(
             /* build_list_fn_idx */ 18,
             /* argc */ 2,
@@ -6232,11 +6233,16 @@ mod tests {
                 }
                 if let Operand::ListOfKind(list) = &args[1] {
                     assert_eq!(list.kind, Kind::Int);
-                    assert_eq!(list.content.len(), 1, "argc=2 → ListI=[2] only");
+                    assert_eq!(list.content.len(), 2, "argc=2 → ListI=[2, 0]");
                     if let Operand::ConstInt(v) = &list.content[0] {
                         assert_eq!(*v, 2);
                     } else {
                         panic!("expected ConstInt(2) in ListI");
+                    }
+                    if let Operand::ConstInt(v) = &list.content[1] {
+                        assert_eq!(*v, 0);
+                    } else {
+                        panic!("expected trailing ConstInt(0) in ListI");
                     }
                 } else {
                     panic!("expected ListOfKind(Int) at args[1]");
@@ -6249,7 +6255,10 @@ mod tests {
                 }
                 if let Operand::Descr(rc) = &args[3] {
                     if let DescrOperand::CallDescrStub(stub) = &**rc {
-                        assert_eq!(stub.arg_kinds, vec![Kind::Int, Kind::Ref, Kind::Ref]);
+                        assert_eq!(
+                            stub.arg_kinds,
+                            vec![Kind::Int, Kind::Ref, Kind::Ref, Kind::Int],
+                        );
                         assert_eq!(
                             stub.effect_info,
                             effect_info_for_call_flavor(CallFlavor::Plain),
@@ -6267,13 +6276,13 @@ mod tests {
 
     #[test]
     fn build_build_list_fn_residual_call_ir_r_insn_pads_argc_0_and_1() {
-        // argc=0: no real items.  arg_kinds=[Int, Int, Int], args_i=
-        // [argc=0, dummy=0, dummy=0], args_r=[].  ListR is still
+        // argc=0: no real items.  arg_kinds=[Int, Int, Int, Int], args_i=
+        // [argc=0, dummy=0, dummy=0, dummy=0], args_r=[].  ListR is still
         // pushed (empty) because kinds="ir" includes 'r'.
         let argc_0 = build_build_list_fn_residual_call_ir_r_insn(18, 0, &[], 5);
         if let Insn::Op { args, .. } = &argc_0 {
             if let Operand::ListOfKind(list) = &args[1] {
-                assert_eq!(list.content.len(), 3, "argc=0 → ListI=[0, 0, 0]");
+                assert_eq!(list.content.len(), 4, "argc=0 → ListI=[0, 0, 0, 0]");
                 for op in &list.content {
                     if let Operand::ConstInt(v) = op {
                         assert_eq!(*v, 0);
@@ -6291,19 +6300,30 @@ mod tests {
             }
             if let Operand::Descr(rc) = &args[3] {
                 if let DescrOperand::CallDescrStub(stub) = &**rc {
-                    assert_eq!(stub.arg_kinds, vec![Kind::Int, Kind::Int, Kind::Int]);
+                    assert_eq!(
+                        stub.arg_kinds,
+                        vec![Kind::Int, Kind::Int, Kind::Int, Kind::Int],
+                    );
                 }
             }
         } else {
             panic!("expected Insn::Op");
         }
 
-        // argc=1: 1 real item, 1 padding.  arg_kinds=[Int, Ref, Int],
-        // args_i=[argc=1, dummy=0], args_r=[reg].
+        // argc=1: 1 real item, 2 padding slots.  arg_kinds=[Int, Ref, Int, Int],
+        // args_i=[argc=1, dummy=0, dummy=0], args_r=[reg].
         let argc_1 = build_build_list_fn_residual_call_ir_r_insn(18, 1, &[7], 5);
         if let Insn::Op { args, .. } = &argc_1 {
             if let Operand::ListOfKind(list) = &args[1] {
-                assert_eq!(list.content.len(), 2, "argc=1 → ListI=[1, 0]");
+                assert_eq!(list.content.len(), 3, "argc=1 → ListI=[1, 0, 0]");
+                let expected = [1, 0, 0];
+                for (op, expected) in list.content.iter().zip(expected) {
+                    if let Operand::ConstInt(v) = op {
+                        assert_eq!(*v, expected);
+                    } else {
+                        panic!("expected ConstInt in ListI");
+                    }
+                }
             } else {
                 panic!("expected ListOfKind(Int) at args[1]");
             }
@@ -6314,7 +6334,41 @@ mod tests {
             }
             if let Operand::Descr(rc) = &args[3] {
                 if let DescrOperand::CallDescrStub(stub) = &**rc {
-                    assert_eq!(stub.arg_kinds, vec![Kind::Int, Kind::Ref, Kind::Int]);
+                    assert_eq!(
+                        stub.arg_kinds,
+                        vec![Kind::Int, Kind::Ref, Kind::Int, Kind::Int],
+                    );
+                }
+            }
+        } else {
+            panic!("expected Insn::Op");
+        }
+
+        // argc=3: all trailing ABI slots are Refs.  arg_kinds=
+        // [Int, Ref, Ref, Ref], args_i=[argc=3], args_r=[reg, reg, reg].
+        let argc_3 = build_build_list_fn_residual_call_ir_r_insn(18, 3, &[7, 8, 9], 5);
+        if let Insn::Op { args, .. } = &argc_3 {
+            if let Operand::ListOfKind(list) = &args[1] {
+                assert_eq!(list.content.len(), 1, "argc=3 → ListI=[3]");
+                if let Operand::ConstInt(v) = &list.content[0] {
+                    assert_eq!(*v, 3);
+                } else {
+                    panic!("expected ConstInt(3) in ListI");
+                }
+            } else {
+                panic!("expected ListOfKind(Int) at args[1]");
+            }
+            if let Operand::ListOfKind(list) = &args[2] {
+                assert_eq!(list.content.len(), 3, "argc=3 → ListR=[reg, reg, reg]");
+            } else {
+                panic!("expected ListOfKind(Ref) at args[2]");
+            }
+            if let Operand::Descr(rc) = &args[3] {
+                if let DescrOperand::CallDescrStub(stub) = &**rc {
+                    assert_eq!(
+                        stub.arg_kinds,
+                        vec![Kind::Int, Kind::Ref, Kind::Ref, Kind::Ref],
+                    );
                 }
             }
         } else {
@@ -6332,14 +6386,18 @@ mod tests {
         let dst = Variable::new(VariableId(5), Kind::Ref);
         let descr = intern_call_descr_stub(
             effect_info_for_call_flavor(CallFlavor::Plain),
-            vec![Kind::Int, Kind::Ref, Kind::Ref],
+            vec![Kind::Int, Kind::Ref, Kind::Ref, Kind::Int],
             Some(Kind::Ref),
         );
         let dual_op = SpaceOperation::new(
             "residual_call_ir_r",
             vec![
                 Constant::signed(18).into(),
-                FlowListOfKind::new(Kind::Int, vec![Constant::signed(2).into()]).into(),
+                FlowListOfKind::new(
+                    Kind::Int,
+                    vec![Constant::signed(2).into(), Constant::signed(0).into()],
+                )
+                .into(),
                 FlowListOfKind::new(Kind::Ref, vec![item0.into(), item1.into()]).into(),
                 descr.into(),
             ],

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -1253,11 +1253,11 @@ pub fn is_graph_only_artifact(insn: &Insn) -> bool {
     }
     matches!(
         opname.as_str(),
-        // Container subscript store / unary / call / list construction
-        // (emit_frontend_{setitem,bool,neg,simple_call,newlist}).
+        // Container subscript store / unary / call / sequence construction
+        // (emit_frontend_{setitem,bool,neg,simple_call,newlist,newslice}).
         // `setattr` and `getattr` are intentionally NOT here — see
         // function-level docstring for the abort_permanent rationale.
-        "setitem" | "bool" | "neg" | "simple_call" | "newlist"
+        "setitem" | "bool" | "neg" | "simple_call" | "newlist" | "newslice"
     )
 }
 
@@ -3098,23 +3098,23 @@ fn build_residual_call_ir_r_insn_from_int_only_operands(
 /// `newlist(items)` HLOp via `emit_frontend_newlist`); this is a
 /// clean factor refactor with no asymmetry.
 ///
-/// `build_list_fn` has C ABI `extern "C" fn(i64, i64, i64)` —
-/// always 3 i64 parameters dispatched internally by the leading
-/// `argc` (`bh_build_list_fn` per `cpu.rs`).  The trailing 2 slots
+/// `build_list_fn` has C ABI `extern "C" fn(i64, i64, i64, i64)` —
+/// always 4 i64 parameters dispatched internally by the leading
+/// `argc` (`bh_build_list_fn` per `cpu.rs`).  The trailing 3 slots
 /// hold real boxed-Ref pointers when the corresponding item is
 /// present, or `0` (dummy bit pattern, routed through the int
 /// constants pool per `make_three_lists` jtransform.py:437-445)
-/// when absent.  Per codewriter.rs:5945-5954, `argc > 2` falls
+/// when absent.  Per codewriter.rs:5945-5954, `argc > 3` falls
 /// through to `emit_abort_permanent` and never invokes this
-/// helper, so `argc ∈ {0, 1, 2}`.
+/// helper, so `argc ∈ {0, 1, 2, 3}`.
 ///
 /// Inline arg order from `emit_residual_call_shape` for call-args
 /// `[ConstInt(argc), maybe_Reg_or_ConstInt(item0),
-/// maybe_Reg_or_ConstInt(item1)]`:
+/// maybe_Reg_or_ConstInt(item1), maybe_Reg_or_ConstInt(item2)]`:
 ///   * `args_i` = leading argc + each absent item's `0` dummy.
 ///   * `args_r` = each present item's Reg.
 ///   * `arg_kinds` preserves call-order (NOT bucket-order): always
-///     `[Int, item0_kind, item1_kind]` where each item kind is
+///     `[Int, item0_kind, item1_kind, item2_kind]` where each item kind is
 ///     `Ref` when present and `Int` when dummy.
 ///
 /// Both `ListI` and `ListR` are always pushed because `args_i` is
@@ -3139,18 +3139,18 @@ pub fn build_build_list_fn_residual_call_ir_r_insn(
     dst_reg: u16,
 ) -> Insn {
     debug_assert!(
-        argc <= 2,
-        "BuildList helper only supports argc ∈ {{0, 1, 2}}"
+        argc <= 3,
+        "BuildList helper only supports argc ∈ {{0, 1, 2, 3}}"
     );
     debug_assert_eq!(arg_regs.len(), argc, "arg_regs length must match argc");
-    let mut arg_kinds: Vec<Kind> = Vec::with_capacity(3);
-    let mut args_i: Vec<Operand> = Vec::with_capacity(3);
-    let mut args_r: Vec<Operand> = Vec::with_capacity(2);
+    let mut arg_kinds: Vec<Kind> = Vec::with_capacity(4);
+    let mut args_i: Vec<Operand> = Vec::with_capacity(4);
+    let mut args_r: Vec<Operand> = Vec::with_capacity(3);
     // Leading argc slot — always Int.
     arg_kinds.push(Kind::Int);
     args_i.push(Operand::ConstInt(argc as i64));
-    // Trailing 2 slots — Ref if present, Int dummy `0` if absent.
-    for i in 0..2 {
+    // Trailing 3 slots — Ref if present, Int dummy `0` if absent.
+    for i in 0..3 {
         if i < argc {
             arg_kinds.push(Kind::Ref);
             args_r.push(Operand::Register(Register::new(Kind::Ref, arg_regs[i])));
@@ -3169,6 +3169,49 @@ pub fn build_build_list_fn_residual_call_ir_r_insn(
         "residual_call_ir_r",
         vec![
             Operand::ConstInt(build_list_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(Kind::Int, args_i)),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, args_r)),
+            descr_operand,
+        ],
+        Register::new(Kind::Ref, dst_reg),
+    )
+}
+
+/// Construct the BUILD_SLICE helper call.  Mirrors
+/// `pypy/interpreter/pyopcode.py:1463-1472`: argc is 2 or 3, start/stop are
+/// refs, and step is either a ref (argc=3) or an ignored int dummy (argc=2).
+pub fn build_build_slice_fn_residual_call_ir_r_insn(
+    build_slice_fn_idx: u16,
+    argc: usize,
+    start_reg: u16,
+    stop_reg: u16,
+    step_reg: Option<u16>,
+    dst_reg: u16,
+) -> Insn {
+    debug_assert!(argc == 2 || argc == 3, "BUILD_SLICE argc must be 2 or 3");
+    let mut arg_kinds = vec![Kind::Int, Kind::Ref, Kind::Ref];
+    let mut args_i = vec![Operand::ConstInt(argc as i64)];
+    let mut args_r = vec![
+        Operand::Register(Register::new(Kind::Ref, start_reg)),
+        Operand::Register(Register::new(Kind::Ref, stop_reg)),
+    ];
+    if let Some(step_reg) = step_reg {
+        arg_kinds.push(Kind::Ref);
+        args_r.push(Operand::Register(Register::new(Kind::Ref, step_reg)));
+    } else {
+        arg_kinds.push(Kind::Int);
+        args_i.push(Operand::ConstInt(0));
+    }
+    let effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds,
+        result_kind: Some(Kind::Ref),
+    }));
+    Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(build_slice_fn_idx as i64),
             Operand::ListOfKind(ListOfKind::new(Kind::Int, args_i)),
             Operand::ListOfKind(ListOfKind::new(Kind::Ref, args_r)),
             descr_operand,
@@ -4847,7 +4890,15 @@ mod tests {
         }
         // Out-of-family opnames must return None so the lowering
         // arm falls through.
-        for opname in ["lt", "bool", "neg", "simple_call", "setitem", "newlist"] {
+        for opname in [
+            "lt",
+            "bool",
+            "neg",
+            "simple_call",
+            "setitem",
+            "newlist",
+            "newslice",
+        ] {
             assert_eq!(
                 binary_op_tag_for_opname(opname),
                 None,


### PR DESCRIPTION
## Summary

This pull request implements a specialization for list slice assignment in the JIT, aligning Pyre's behavior with PyPy for cases where the source and destination lists use the same storage strategy and the slice assignment does not resize the list. It also improves the handling of slice objects and their concrete representations, and adapts the code generation and JIT interfaces to support these changes. The most important changes are grouped below.

### List Slice Assignment Specialization

* Added `generated_list_setslice_same_len_by_strategy` to directly trace same-length list slice assignments for lists with the same strategy, avoiding unnecessary fallback to generic paths and improving performance for common patterns (`majit/majit-translate/src/codegen.rs`).
* Updated the JIT opcode handler to detect and use this specialized path for list slice assignments with a constant step of 1 and matching strategies, including all necessary guards (`pyre/pyre-jit-trace/src/trace_opcode.rs`).

### Slice Object Handling and Representation

* Changed slice constant emission to create a concrete `W_SliceObject` shadow in addition to the IR node, ensuring downstream code can inspect slice bounds and step at runtime (`majit/majit-translate/src/handler_spec.rs`).
* Added a JIT helper function and codegen support for constructing slice objects (`bh_build_slice_fn` and related registration and codewriter changes), mirroring PyPy's allocation and making slice objects available for guards and specialization (`pyre/pyre-jit/src/call_jit.rs`, `pyre/pyre-jit/src/jit/codewriter.rs`).

### JIT and Trace Robustness

* Ensured that all list items remain live in the trace during list construction by emitting `Keepalive` ops, preventing premature dropping of virtual items and fixing a bug where items could be lost (`pyre/pyre-jit-trace/src/helpers.rs`).
* Updated the list slice assignment microbenchmark to wrap the test in a function, now that the JIT path is correct and no longer triggers a panic (`pyre/bench/list_setslice.py`).

These changes collectively improve the performance and correctness of list slice assignments in the Pyre JIT, and bring its behavior closer to PyPy for these cases.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Cases Where Patch Regressed PyPy Parity Compared To Main

  None found that look behaviorally incorrect.

  The only new non-PyPy trace shape is the added keepalive around list build operands in pyre/pyre-jit-trace/src/helpers.rs:370, but
  that is explicitly compensating for Pyre’s already non-PyPy opaque list-build helper. I classify it below as a structural
  adaptation, not an incorrect port.

  2. Other Mismatches Introduced By Patch

  None found that appear to produce wrong behavior within the guarded specialization.

  The same-length slice assignment specialization in majit/majit-translate/src/codegen.rs:1489 is narrower than PyPy’s
  AbstractUnwrappedStrategy.setslice in pypy/objspace/std/listobject.py:1746: PyPy handles resizing, extended slices, strategy
  conversion, and self-overlap. The Rust code only enters for non-negative constant start:stop:1, same list strategy, and value_len
  == slicelength, then falls back otherwise. That is incomplete structurally, but the guards in pyre/pyre-jit-trace/src/
  trace_opcode.rs:4577 appear strong enough for the accepted subset.

  BUILD_SLICE lowering matches PyPy stack order and None step semantics from pypy/interpreter/pyopcode.py:1463 and flowspace rpython/
  flowspace/flowcontext.py:1145. I did not find an operand-order mismatch in pyre/pyre-jit/src/jit/codewriter.rs:5883 or pyre/pyre-
  jit/src/call_jit.rs:3602.

  3. Mismatches That Already Existed Before This Patch

  List construction is still not PyPy/RPython-shaped. RPython lowers resizable list allocation to newlist(length, structdescr,
  lengthdescr, itemsdescr, arraydescr) in rpython/jit/codewriter/jtransform.py:1930, and blackhole allocates the list object plus
  backing array in rpython/jit/metainterp/blackhole.py:1161. Pyre still uses fixed-arity opaque helper calls. This patch raises the
  bytecode-lowering cap from 2 to 3 in pyre/pyre-jit/src/jit/codewriter.rs:5806, but argc > 3 still aborts and pyre/pyre-jit/src/
  call_jit.rs:3580 is not RPython’s descriptor-driven bhimpl_newlist.

  Generic slice assignment is also still not line-by-line PyPy parity. PyPy’s path is descr_setitem -> _unpack_slice -> setslice,
  with broad strategy and resizing handling in pypy/objspace/std/listobject.py:708. Pyre has a narrow JIT specialization plus
  fallback residual store.

  4. Structural Adaptations

  pyre/pyre-jit-trace/src/helpers.rs:370: added Keepalive ops for list-build items. PyPy does not need this for normal newlist
  because item stores keep operands visible naturally; Pyre needs it because list construction is still an opaque helper call.

  pyre/pyre-jit/src/jit/codewriter.rs:5883 and pyre/pyre-jit/src/jit/flatten.rs:3183: BUILD_SLICE uses both a graph-only newslice and
  a residual allocation helper. PyPy flowspace has a direct op.newslice(...).eval(self) shape; Pyre’s residual helper is an
  implementation adaptation.

  pyre/pyre-jit-trace/src/trace_opcode.rs:198: slice-bound recognition only accepts exact concrete list/slice/list with non-negative
  integer start/stop and step None or 1. PyPy accepts the full _unpack_slice semantics. This is a conservative specialization gate,
  not a wrong port, because rejected cases fall back.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for slice object construction in JIT compilation
  * Introduced optimized fast path for same-length list slice assignments
  * Extended list construction to handle lists up to 3 elements

* **Bug Fixes**
  * Improved list element lifecycle management during construction

* **Performance**
  * Enhanced specialized tracing for list operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/40)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->