### PR TITLE
Wire portal red args through the regular liveness/inputarg path

### DIFF
--- a/majit/majit-macros/tests/jit_module_test.rs
+++ b/majit/majit-macros/tests/jit_module_test.rs
@@ -220,22 +220,28 @@ fn test_jit_module_emits_structured_impl_trace_fnaddrs() {
         .find(|(_, ty, m, _)| *ty == "Adder" && *m == "add")
         .expect("Adder::add entry");
     assert_eq!(add_entry.0, expected_module_path);
-    assert_eq!(
-        add_entry.3,
-        impl_walk_module::Adder::add as *const () as usize as i64,
-    );
+    // Rust does not guarantee that two `<Type>::method as *const ()`
+    // casts at different call sites yield the same numeric address —
+    // release-mode LLVM may instantiate the fn item per cast site
+    // (debug mode incidentally produces a single instance). Verify the
+    // recorded address is callable as the right function instead of
+    // comparing it against an independent cast.
+    let add_fn: fn(i64, i64) -> i64 = unsafe { std::mem::transmute(add_entry.3 as *const ()) };
+    assert_eq!(add_fn(3, 4), impl_walk_module::Adder::add(3, 4));
 
     let bump_entry = entries
         .iter()
         .find(|(_, ty, m, _)| *ty == "Adder" && *m == "bump")
         .expect("Adder::bump entry");
     assert_eq!(bump_entry.0, expected_module_path);
-    // Casting a `&self` associated fn to a plain `*const ()` works —
-    // confirms Rust allows the coercion the reviewer called out.
-    assert_eq!(
-        bump_entry.3,
-        impl_walk_module::Adder::bump as *const () as usize as i64,
-    );
+    // `&self` associated fn lowers to `fn(&Adder, i64) -> i64` — the
+    // cast through `*const ()` is still valid (the reviewer's
+    // structural concern); verify functionally for release-mode
+    // address stability.
+    let adder = impl_walk_module::Adder { value: 10 };
+    let bump_fn: fn(&impl_walk_module::Adder, i64) -> i64 =
+        unsafe { std::mem::transmute(bump_entry.3 as *const ()) };
+    assert_eq!(bump_fn(&adder, 5), adder.bump(5));
 }
 
 // Trait-impl disambiguation: when a type implements a trait method
@@ -435,19 +441,39 @@ fn test_passthrough_free_fn_discovery_uses_direct_fn_address() {
     let trace_fnaddrs = passthrough_free_fn_module::__majit_helper_trace_fnaddrs();
     assert_eq!(trace_fnaddrs.len(), 3);
     // No `__majit_call_policy_*` exists for any of these, so the only
-    // legal address is the function's direct cast.
-    assert!(trace_fnaddrs.iter().any(|(path, addr)| {
-        *path == concat!(module_path!(), "::passthrough_free_fn_module::pure_xor")
-            && *addr == passthrough_free_fn_module::pure_xor as *const () as usize as i64
-    }));
-    assert!(trace_fnaddrs.iter().any(|(path, addr)| {
-        *path == concat!(module_path!(), "::passthrough_free_fn_module::unrolled")
-            && *addr == passthrough_free_fn_module::unrolled as *const () as usize as i64
-    }));
-    assert!(trace_fnaddrs.iter().any(|(path, addr)| {
-        *path == concat!(module_path!(), "::passthrough_free_fn_module::out_of_trace")
-            && *addr == passthrough_free_fn_module::out_of_trace as *const () as usize as i64
-    }));
+    // legal address is the function's direct cast. Verify functionally
+    // by invoking through the recorded address — Rust does not
+    // guarantee numeric equality across independent fn-item casts in
+    // release mode (LLVM may instantiate the fn item per cast site),
+    // so a structural assertion via fn pointer equality is unreliable.
+    let pure_xor_entry = trace_fnaddrs
+        .iter()
+        .find(|(p, _)| *p == concat!(module_path!(), "::passthrough_free_fn_module::pure_xor"))
+        .expect("pure_xor entry");
+    let pure_xor_fn: fn(i64, i64) -> i64 =
+        unsafe { std::mem::transmute(pure_xor_entry.1 as *const ()) };
+    assert_eq!(
+        pure_xor_fn(0b1010, 0b0110),
+        passthrough_free_fn_module::pure_xor(0b1010, 0b0110),
+    );
+
+    let unrolled_entry = trace_fnaddrs
+        .iter()
+        .find(|(p, _)| *p == concat!(module_path!(), "::passthrough_free_fn_module::unrolled"))
+        .expect("unrolled entry");
+    let unrolled_fn: fn(i64) -> i64 = unsafe { std::mem::transmute(unrolled_entry.1 as *const ()) };
+    assert_eq!(unrolled_fn(7), passthrough_free_fn_module::unrolled(7));
+
+    let out_of_trace_entry = trace_fnaddrs
+        .iter()
+        .find(|(p, _)| *p == concat!(module_path!(), "::passthrough_free_fn_module::out_of_trace"))
+        .expect("out_of_trace entry");
+    let out_of_trace_fn: fn(i64) -> i64 =
+        unsafe { std::mem::transmute(out_of_trace_entry.1 as *const ()) };
+    assert_eq!(
+        out_of_trace_fn(5),
+        passthrough_free_fn_module::out_of_trace(5),
+    );
 }
 
 #[test]

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1269,25 +1269,6 @@ impl BlackholeInterpreter {
         self.reset_position_state(position);
     }
 
-    /// interp_jit.py:64 parity: fill dedicated portal red-arg registers
-    /// with virtualizable_ptr (frame) and ec (execution context).
-    ///
-    /// The register indices are produced by pyre's portal codewriter and
-    /// passed as side metadata. RPython `JitCode` has no portal-register
-    /// fields, so they must not be stored on `jitcode.py`'s Rust port.
-    ///
-    /// Must be called AFTER virtualizable_ptr is assigned — setposition()
-    /// runs before the caller sets virtualizable_ptr, so portal registers
-    /// are filled as a separate step.
-    pub fn fill_portal_registers(&mut self, frame_reg: u16, ec_reg: u16, ec: i64) {
-        if frame_reg != u16::MAX && (frame_reg as usize) < self.registers_r.len() {
-            self.registers_r[frame_reg as usize] = self.virtualizable_ptr;
-        }
-        if ec_reg != u16::MAX && (ec_reg as usize) < self.registers_r.len() {
-            self.registers_r[ec_reg as usize] = ec;
-        }
-    }
-
     /// blackhole.py:1095-1099 `get_portal_runner(jdindex)`.
     ///
     /// ```python

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -26,6 +26,19 @@ pub mod trace;
 pub mod virtualizable_gen;
 pub mod virtualizable_spec;
 
+// pyre-jit-trace local invariant: PyFrame's `_virtualizable_` declares
+// exactly one extra red (ec, see `virtualizable_gen.rs:29-31` and
+// `pypy/module/pypyjit/interp_jit.py:67 reds = ['frame', 'ec']`).
+// `majit-macros::virtualizable!` itself is generic over `extra_reds.len()`
+// (mod.rs:515), so this assertion is *pyre-local*. Tracing-time helpers
+// that seed/push the ec slot rely on this invariant; bumping it requires
+// re-auditing every ec wiring callsite — see the v3 plan at
+// `~/.claude/plans/ec-wiring-gentle-wave.md`.
+const _: () = assert!(
+    virtualizable_gen::NUM_EXTRA_REDS == 1,
+    "pyre's PyFrame virtualizable layout requires exactly one extra red (ec)",
+);
+
 /// Auto-generated trace functions from majit-translate.
 #[allow(dead_code, unsafe_op_in_unsafe_fn, unused_imports, unused_variables)]
 pub mod generated {

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -393,8 +393,15 @@ impl PyJitCode {
             PyJitCodeMetadata {
                 pc_map: Vec::new(),
                 depth_at_py_pc: Vec::new(),
-                portal_frame_reg: 0,
-                portal_ec_reg: 0,
+                // u16::MAX sentinel mirrors `canonical_bridge::install_portal_for`
+                // (canonical_bridge.rs:165-166). Encoder/decoder readers in
+                // `get_list_of_active_boxes`, `regalloc::external/input_indices`,
+                // and `setup_bridge_sym::portal_red_regs_at` sentinel-skip both
+                // values together. A real `0` here would alias every locals-
+                // bank color 0 read and silently substitute `sym.frame` for
+                // unrelated locals/stack slots.
+                portal_frame_reg: u16::MAX,
+                portal_ec_reg: u16::MAX,
                 stack_base: 0,
                 stack_slot_color_map: Vec::new(),
                 pyre_color_for_semantic_local: Vec::new(),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1103,6 +1103,32 @@ pub fn stack_slot_color_map_at(jitcode_index: i32) -> Vec<u16> {
     })
 }
 
+/// Return the post-regalloc Ref-bank colors of the portal red args
+/// (`pypy/module/pypyjit/interp_jit.py:67 reds = ['frame', 'ec']`) for
+/// the registered jitcode at `jitcode_index`. Both `u16::MAX` for
+/// portal-bridge installs that skip per-CodeObject regalloc.
+///
+/// Used by bridge resume to thread the ec OpRef from
+/// `sym.registers_r[portal_ec_reg]` (populated by the liveness-driven
+/// `consume_boxes` fill) back into `sym.execution_context`, mirroring
+/// `resume.py:1077-1081 _callback_r` which writes the same slot in
+/// RPython's BH register bank.
+pub fn portal_red_regs_at(jitcode_index: i32) -> (u16, u16) {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| {
+        let sd = r.borrow();
+        sd.jitcodes
+            .get(jitcode_index as usize)
+            .map(|jc| {
+                (
+                    jc.payload.metadata.portal_frame_reg,
+                    jc.payload.metadata.portal_ec_reg,
+                )
+            })
+            .unwrap_or((u16::MAX, u16::MAX))
+    })
+}
+
 /// Map a post-regalloc Ref-bank color back to the semantic
 /// `locals_cells_stack_w` slot it denotes at the current PC.
 ///
@@ -3256,7 +3282,10 @@ impl PyreJitState {
     fn pypyjit_collect_jump_args(sym: &PyreSym) -> Vec<OpRef> {
         let base = sym.vable_collect_jump_args();
         let Some((&frame, tail)) = base.split_first() else {
-            return vec![sym.execution_context];
+            unreachable!(
+                "vable_collect_jump_args returned empty — virtualizable macro \
+                 did not emit frame_field push (see majit-macros/.../derive.rs:381)"
+            );
         };
         let mut args = Vec::with_capacity(base.len() + 1);
         args.push(frame);
@@ -3269,7 +3298,11 @@ impl PyreJitState {
     fn pypyjit_collect_typed_jump_args(sym: &PyreSym) -> Vec<(OpRef, Type)> {
         let base = sym.vable_collect_typed_jump_args();
         let Some(&(frame, frame_tp)) = base.first() else {
-            return vec![(sym.execution_context, Type::Ref)];
+            unreachable!(
+                "vable_collect_typed_jump_args returned empty — virtualizable \
+                 macro did not emit frame_field push \
+                 (see majit-macros/.../derive.rs:389)"
+            );
         };
         let mut args = Vec::with_capacity(base.len() + 1);
         args.push((frame, frame_tp));
@@ -4546,11 +4579,9 @@ impl JitState for PyreJitState {
             // `extra_reds = { ec: Ref }` in virtualizable_gen.rs places ec
             // at OpRef::from_raw(1). `init_vable_indices` shifts the vable static
             // field + array_base OpRefs but does not own the extra_red
-            // sym storage; initialize it explicitly when the constant
-            // declares an ec slot.
-            if crate::virtualizable_gen::NUM_EXTRA_REDS > 0 {
-                sym.execution_context = OpRef::input_arg_typed(1, Type::Ref);
-            }
+            // sym storage; initialize it explicitly. NUM_EXTRA_REDS == 1 is
+            // a crate-level const-assertion (see `lib.rs`).
+            sym.execution_context = OpRef::input_arg_typed(1, Type::Ref);
             sym.become_active_vable_owner();
             sym.nlocals = _meta.num_locals;
             sym.valuestackdepth = _meta.valuestackdepth;
@@ -4941,39 +4972,33 @@ impl JitState for PyreJitState {
         // the vable_array_base branch uses the heap-array path instead
         // of synthesizing parent OpRefs.
         sym.clear_active_vable();
-        // pypy/module/pypyjit/interp_jit.py:68 `reds = ['frame', 'ec']`:
-        // PyPy threads ec as a JIT red so it survives guard resume.
-        // pyre's macro flip lands the same shape (`extra_reds = { ec:
-        // Ref }`, `_meta.trace_extra_reds = 1` at state.rs:4967) and the
-        // root portal seeds `sym.execution_context = OpRef::from_raw(1)` from the
-        // ec inputarg.
+        // `pypy/module/pypyjit/interp_jit.py:67 reds = ['frame', 'ec']`:
+        // ec is a portal red arg, hence a JitCode inputarg present in
+        // every `-live-` op's R-bank. After the codewriter Step 1 fix
+        // (jit/codewriter.rs:2364 `filter_liveness_in_place` seeds
+        // `portal_ec_reg` into `lv_live`), bridge resume's liveness-
+        // driven `consume_boxes` fill at lines 4880-4893 has already
+        // written the resolved ec OpRef into
+        // `bridge_registers_r[portal_ec_reg]` — the same slot
+        // `_callback_r(register_index)` (resume.py:1077-1081) writes
+        // in RPython's BH register bank.
         //
-        // Bridge resume in pyre rebuilds the MIFrame register banks from
-        // `frame0.values` via jitcode liveness (see the int/ref/float
-        // loops above): each value lands in `sym.registers_{i,r,f}` at
-        // its register-bank index, not at a fixed trace inputarg
-        // position.  ec is a TRACE inputarg, not a frame register, so it
-        // does not appear in any bank — there is no "ec slot" in
-        // `frame0.values` to read out.  Recovering ec from
-        // `frame0.values` would require either Box identity (so the
-        // optimizer's forwarding chain for the original OpRef::from_raw(1) survives
-        // through to the bridge resume layout) or a side-table on the
-        // guard descr recording "ec lives at fail_arg[X]" — both touch
-        // the resume encoder and the optimizer across crates.
-        //
-        // Read ec from `PyFrame.execution_context` instead.  This is a
-        // pyre layout that PyPy does not have (PyPy fetches ec via
-        // `space.getexecutioncontext()` thread-local in
-        // `pyframe.py:282`); pyre stores it on the frame at frame entry
-        // (`pyre-interpreter/src/pyframe.rs:51`).  The load is
-        // semantically identical to RPython's resume-data ec recovery
-        // because ec is invariant during a `dispatch()` call and PyPy's
-        // and pyre's frame entries both seed it from the same source.
-        sym.execution_context = ctx.record_op_with_descr(
-            OpCode::GetfieldGcR,
-            &[sym.frame],
-            crate::descr::pyframe_execution_context_descr(),
-        );
+        // Thread that slot back into the dedicated `sym.execution_context`
+        // field so the symbolic state retains pyre's split shape (ec
+        // accessed through a named field rather than by register index).
+        // The OpRef value is identical to what RPython's ec inputarg
+        // OpRef would be after resume.
+        let (_pfr, portal_ec_reg) = crate::state::portal_red_regs_at(frame0.jitcode_index);
+        if portal_ec_reg != u16::MAX {
+            let slot = portal_ec_reg as usize;
+            assert!(
+                slot < sym.registers_r.len(),
+                "setup_bridge_sym: portal_ec_reg={} out of registers_r range (len={})",
+                slot,
+                sym.registers_r.len(),
+            );
+            sym.execution_context = sym.registers_r[slot];
+        }
         // pyjitpl.py:3400-3430 rebuild_state_after_failure parity: after
         // a guard failure the tracing-time `virtualizable_boxes` mirror
         // must be rebuilt from the resume data so subsequent vable

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1536,9 +1536,31 @@ impl MIFrame {
             cursor = it.offset;
         }
         if length_r != 0 {
+            // PyPy parity: portal red args (`pypy/module/pypyjit/
+            // interp_jit.py:67 reds = ['frame', 'ec']`) are JitCode
+            // inputargs that appear in every `-live-` op's R-bank
+            // (`liveness.py compute_liveness`). pyre's MIFrame stores
+            // them on dedicated PyreSym fields (`sym.frame`,
+            // `sym.execution_context`) rather than at color positions
+            // in `sym.registers_r` — adapt by substituting at the
+            // encoder boundary. After guard capture the wire-format
+            // payload contains the OpRefs at the canonical portal
+            // color positions; `_prepare_next_section` (resume.py:1381)
+            // fills the BH bank from there, mirroring RPython exactly.
+            let portal_frame_reg = jc.payload.metadata.portal_frame_reg as u32;
+            let portal_ec_reg = jc.payload.metadata.portal_ec_reg as u32;
+            let sym_frame = self.sym().frame;
+            let sym_ec = self.sym().execution_context;
             let mut it = LivenessIterator::new(cursor, length_r, &all_liveness);
             while let Some(reg_idx) = it.next() {
-                boxes.push(registers_r_bank[reg_idx as usize]);
+                let opref = if reg_idx == portal_frame_reg {
+                    sym_frame
+                } else if reg_idx == portal_ec_reg {
+                    sym_ec
+                } else {
+                    registers_r_bank[reg_idx as usize]
+                };
+                boxes.push(opref);
             }
             cursor = it.offset;
         }
@@ -2868,9 +2890,8 @@ impl MIFrame {
             )
         };
         let mut args = vec![frame];
-        if extra_reds == 1 {
-            args.push(execution_context);
-        }
+        // NUM_EXTRA_REDS == 1 (crate const-assert): `reds = ['frame', 'ec']`.
+        args.push(execution_context);
         args.extend_from_slice(&[
             next_instr,
             code,
@@ -3036,7 +3057,8 @@ impl MIFrame {
                 if idx < total_scalar_prefix {
                     match idx {
                         0 => s.frame = new_opref,
-                        1 if extra_reds == 1 => s.execution_context = new_opref,
+                        // NUM_EXTRA_REDS == 1 (crate const-assert).
+                        1 => s.execution_context = new_opref,
                         _ => match idx - extra_reds {
                             1 => s.vable_last_instr = new_opref,
                             2 => s.vable_pycode = new_opref,
@@ -3125,9 +3147,9 @@ impl MIFrame {
         let mut fa =
             Vec::with_capacity(crate::virtualizable_gen::NUM_SCALAR_INPUTARGS + active_boxes.len());
         fa.push(s.frame);
-        if crate::virtualizable_gen::NUM_EXTRA_REDS > 0 {
-            fa.push(s.execution_context);
-        }
+        // NUM_EXTRA_REDS == 1 (crate const-assert in `lib.rs`).
+        // `interp_jit.py:67 reds = ['frame', 'ec']`.
+        fa.push(s.execution_context);
         fa.extend_from_slice(&[
             s.vable_last_instr,
             s.vable_pycode,
@@ -5248,9 +5270,10 @@ impl MIFrame {
                                 )?;
                             // pyjitpl.py:2017: do_residual_call step 1
                             this.vable_and_vrefs_before_residual_call(ctx);
+                            let ec = this.ensure_execution_context(ctx);
                             let ca_result = ctx.call_assembler_red_only_ref(
                                 token_number,
-                                &[callee_frame, this.sym().execution_context],
+                                &[callee_frame, ec],
                                 &[Type::Ref, Type::Ref],
                             );
                             // pyjitpl.py:2080-2081 direct_assembler_call:

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1005,13 +1005,13 @@ pub fn resume_in_blackhole(
         bh.virtualizable_ptr = frame_ptr as i64;
         bh.virtualizable_info = crate::eval::get_virtualizable_info();
         bh.virtualizable_stack_base = nlocals + pyre_interpreter::pyframe::ncells(code);
-        // Portal red-arg registers must be filled AFTER virtualizable_ptr.
-        let ec = unsafe { (*frame_ptr).execution_context as i64 };
-        bh.fill_portal_registers(
-            pyjitcode.metadata.portal_frame_reg,
-            pyjitcode.metadata.portal_ec_reg,
-            ec,
-        );
+        // Portal red-arg registers (`pypy/module/pypyjit/interp_jit.py:67
+        // reds = ['frame', 'ec']`) are filled by `consume_one_section`
+        // (resume.py:1381 / `_prepare_next_section` resume.py:1017) from
+        // the regular `-live-` op slot list — the codewriter now seeds
+        // `portal_frame_reg` / `portal_ec_reg` into every -live- op's
+        // R-bank via `filter_liveness_in_place` (jit/codewriter.rs:2364).
+        // No separate fill step is needed; RPython has no counterpart.
 
         // resume.py:1342 `curbh.handle_rvmprof_enter()` — runs the rvmprof
         // `entering=0` hook immediately after consume_one_section. For the
@@ -1956,36 +1956,15 @@ pub fn blackhole_resume_via_rd_numb(
         mainjitcode_calldescr: bh.jitcode.calldescr.clone(),
     }];
 
-    // interp_jit.py:64 parity (pyre-adaptation): fill dedicated portal
-    // red-arg registers (frame_ptr, execution_context) for each jitcode
-    // in the chain. RPython encodes these as regular inputargs of the
-    // portal jitcode, so `_prepare_next_section` fills them during
-    // `consume_one_section` without a side channel. Pyre's codewriter
-    // assigns portal registers separately (PyJitCodeMetadata
-    // .portal_frame_reg / .portal_ec_reg) and omits them from liveness,
-    // so the orthodox `blackhole_from_resumedata` path leaves them zero.
-    // Walk the chain and fill them explicitly until the codewriter
-    // change lands; chains are short (typically 1–3 frames) so the
-    // O(jitcodes) scan per frame is inexpensive.
-    let callcontrol = crate::jit::codewriter::CodeWriter::instance().callcontrol();
-    let mut cur: Option<&mut majit_metainterp::blackhole::BlackholeInterpreter> = Some(&mut bh);
-    while let Some(bh_ref) = cur {
-        let jitcode_ptr = std::sync::Arc::as_ptr(&bh_ref.jitcode);
-        if let Some(pyjit) = callcontrol.find_pyjitcode_by_jitcode_ptr(jitcode_ptr) {
-            let vable_ptr = bh_ref.virtualizable_ptr;
-            let ec = if vable_ptr != 0 {
-                unsafe { (*(vable_ptr as *const PyFrame)).execution_context as i64 }
-            } else {
-                0
-            };
-            bh_ref.fill_portal_registers(
-                pyjit.metadata.portal_frame_reg,
-                pyjit.metadata.portal_ec_reg,
-                ec,
-            );
-        }
-        cur = bh_ref.nextblackholeinterp.as_deref_mut();
-    }
+    // Portal red-arg registers (`pypy/module/pypyjit/interp_jit.py:67
+    // reds = ['frame', 'ec']`) are filled per-frame by
+    // `consume_one_section` from each section's `-live-` op (resume.py
+    // :1381 / `_prepare_next_section` resume.py:1017). With the
+    // codewriter now seeding `portal_frame_reg` / `portal_ec_reg` into
+    // every -live- op's R-bank (jit/codewriter.rs:2364), each chained
+    // `BlackholeInterpreter` gets its frame_ptr + ec values via the
+    // regular `setarg_r` callback path. No pyre-side fixup is needed;
+    // RPython has no chain fill-up step either.
 
     if majit_metainterp::majit_log_enabled() {
         eprintln!("[blackhole-resume] rd_numb path, chain built, running _run_forever",);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2419,6 +2419,8 @@ fn filter_liveness_in_place(
     depth_at_pc: &[u16],
     local_color_map: &[u16],
     stack_slot_color_map: &[u16],
+    portal_frame_reg: u16,
+    portal_ec_reg: u16,
 ) {
     use super::flatten::{Kind as SsaKind, Operand as SsaOperand};
     super::liveness::compute_liveness(ssarepr);
@@ -2523,6 +2525,53 @@ fn filter_liveness_in_place(
         };
         if std::env::var_os("MAJIT_PHASE06_DROP_LV").is_none() {
             live_r.retain(|idx| lv_live.contains(idx));
+        }
+        // PRE-EXISTING-ADAPTATION (pyre architectural divergence, not a
+        // `compute_liveness` parity fix): keep portal red args
+        // (`pypy/module/pypyjit/interp_jit.py:67 reds = ['frame', 'ec']`)
+        // alive at every `-live-` op for canonical installs.
+        //
+        // RPython does NOT special-case portal reds in liveness; its
+        // `compute_liveness` (`rpython/jit/codewriter/liveness.py:44-69`)
+        // discovers them naturally from SSA Register operands. That
+        // works in upstream because the canonical JitCode encodes the
+        // FULL interpreter — every bytecode handler, including
+        // `CALL_ASSEMBLER` emit sites — so ec appears as a Register
+        // operand at many points in the SSA stream.
+        //
+        // pyre's codewriter only encodes the dispatch-loop skeleton
+        // (vable reads, residual_call helpers, portal jit_merge_point).
+        // The per-Python-bytecode handlers (CALL_FUNCTION → CALL_ASSEMBLER,
+        // LOAD_FAST → vable_getarrayitem, etc.) are emitted by the
+        // tracer (`pyre-jit-trace/src/trace_opcode.rs:5124, 5262, 5661`)
+        // into the trace IR at trace time — they never enter the
+        // codewriter's SSARepr. The compiled trace, however, reads ec
+        // from register file slot `portal_ec_reg` at every
+        // CALL_ASSEMBLER, so that slot MUST be populated after BH
+        // resume (`consume_one_section` → `_prepare_next_section` →
+        // `_callback_r(portal_ec_reg)`). The slot is filled iff the
+        // jitcode's `-live-` op at the resume PC lists `portal_ec_reg`.
+        // Similarly frame must remain alive across tracer-injected
+        // vable reads.
+        //
+        // Two parity options exist:
+        //   (a) emit every Python bytecode handler into the codewriter
+        //       SSA so `compute_liveness` sees ec/frame uses naturally —
+        //       a structural refactor on the scale of porting the entire
+        //       interpreter to RPython-style SSA;
+        //   (b) inject placeholder Register operands referencing
+        //       portal_ec_reg / portal_frame_reg into the SSA before
+        //       `compute_liveness` runs — semantically equivalent to
+        //       this explicit append, only more indirect.
+        //
+        // The explicit append below is option (c): document the
+        // adaptation at the single site that needs it. Portal-bridge
+        // installs sentinel-skip (`u16::MAX`).
+        if portal_frame_reg != u16::MAX && !live_r.contains(&portal_frame_reg) {
+            live_r.push(portal_frame_reg);
+        }
+        if portal_ec_reg != u16::MAX && !live_r.contains(&portal_ec_reg) {
+            live_r.push(portal_ec_reg);
         }
 
         existing.clear();
@@ -7977,6 +8026,8 @@ impl CodeWriter {
             &depth_at_pc,
             &pyre_color_for_semantic_local,
             &stack_slot_color_map,
+            portal_frame_reg,
+            portal_ec_reg,
         );
         // Runtime entry/liveness lookups expect the byte offset of the
         // surviving `-live-` marker for each Python PC
@@ -9528,6 +9579,8 @@ mod tests {
             &depth_at_pc,
             &local_color_map,
             &stack_slot_color_map,
+            u16::MAX,
+            u16::MAX,
         );
 
         let live_idx = live_marker_indices_by_pc(&ssarepr, code.instructions.len())[reachable_pc];

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2521,57 +2521,31 @@ fn filter_liveness_in_place(
                 .map(|idx| local_color_map[idx])
                 .collect();
             s.extend(live_stack_colors.iter().copied());
+            // Portal red args (`pypy/module/pypyjit/interp_jit.py:67
+            // reds = ['frame', 'ec']`) reach `live_r` through the RPython
+            // force-alive mechanism (`liveness.py:11-12`): the
+            // `emit_live_placeholder!` macro at codewriter.rs:3773 emits
+            // every PC's `-live-` op with explicit Register args for
+            // `portal_frame_reg` / `portal_ec_reg`, and `compute_liveness`
+            // (`liveness.rs:101-107` line-by-line port of
+            // `liveness.py:46-48`) adds those Register args to the
+            // backward-propagating `alive` set, leaving them in `existing`
+            // as live Register operands by the time this filter runs.
+            //
+            // The LV∩SSA `retain` below is a pyre adaptation for scratch
+            // colors; gate the portal colors past it explicitly so the
+            // retain does not drop the RPython-tracked live registers.
+            // Portal-bridge installs sentinel-skip (`u16::MAX`).
+            if portal_frame_reg != u16::MAX {
+                s.insert(portal_frame_reg);
+            }
+            if portal_ec_reg != u16::MAX {
+                s.insert(portal_ec_reg);
+            }
             s
         };
         if std::env::var_os("MAJIT_PHASE06_DROP_LV").is_none() {
             live_r.retain(|idx| lv_live.contains(idx));
-        }
-        // PRE-EXISTING-ADAPTATION (pyre architectural divergence, not a
-        // `compute_liveness` parity fix): keep portal red args
-        // (`pypy/module/pypyjit/interp_jit.py:67 reds = ['frame', 'ec']`)
-        // alive at every `-live-` op for canonical installs.
-        //
-        // RPython does NOT special-case portal reds in liveness; its
-        // `compute_liveness` (`rpython/jit/codewriter/liveness.py:44-69`)
-        // discovers them naturally from SSA Register operands. That
-        // works in upstream because the canonical JitCode encodes the
-        // FULL interpreter — every bytecode handler, including
-        // `CALL_ASSEMBLER` emit sites — so ec appears as a Register
-        // operand at many points in the SSA stream.
-        //
-        // pyre's codewriter only encodes the dispatch-loop skeleton
-        // (vable reads, residual_call helpers, portal jit_merge_point).
-        // The per-Python-bytecode handlers (CALL_FUNCTION → CALL_ASSEMBLER,
-        // LOAD_FAST → vable_getarrayitem, etc.) are emitted by the
-        // tracer (`pyre-jit-trace/src/trace_opcode.rs:5124, 5262, 5661`)
-        // into the trace IR at trace time — they never enter the
-        // codewriter's SSARepr. The compiled trace, however, reads ec
-        // from register file slot `portal_ec_reg` at every
-        // CALL_ASSEMBLER, so that slot MUST be populated after BH
-        // resume (`consume_one_section` → `_prepare_next_section` →
-        // `_callback_r(portal_ec_reg)`). The slot is filled iff the
-        // jitcode's `-live-` op at the resume PC lists `portal_ec_reg`.
-        // Similarly frame must remain alive across tracer-injected
-        // vable reads.
-        //
-        // Two parity options exist:
-        //   (a) emit every Python bytecode handler into the codewriter
-        //       SSA so `compute_liveness` sees ec/frame uses naturally —
-        //       a structural refactor on the scale of porting the entire
-        //       interpreter to RPython-style SSA;
-        //   (b) inject placeholder Register operands referencing
-        //       portal_ec_reg / portal_frame_reg into the SSA before
-        //       `compute_liveness` runs — semantically equivalent to
-        //       this explicit append, only more indirect.
-        //
-        // The explicit append below is option (c): document the
-        // adaptation at the single site that needs it. Portal-bridge
-        // installs sentinel-skip (`u16::MAX`).
-        if portal_frame_reg != u16::MAX && !live_r.contains(&portal_frame_reg) {
-            live_r.push(portal_frame_reg);
-        }
-        if portal_ec_reg != u16::MAX && !live_r.contains(&portal_ec_reg) {
-            live_r.push(portal_ec_reg);
         }
 
         existing.clear();
@@ -3830,7 +3804,43 @@ impl CodeWriter {
         // convergence path back to RPython orthodox emission.
         macro_rules! emit_live_placeholder {
             ($ssarepr:expr) => {{
-                $ssarepr.insns.push(Insn::live(Vec::new()));
+                // RPython force-alive mechanism (`liveness.py:11-12`):
+                //
+                //   You can also force extra variables to be alive by putting
+                //   them as args of the '-live-' operation in the first place.
+                //
+                // Use it to keep the portal red args (`pypy/module/pypyjit/
+                // interp_jit.py:67 reds = ['frame', 'ec']`) alive across every
+                // PC. RPython relies on natural SSA Register uses to keep ec
+                // alive because its JitCode encodes the full interpreter
+                // including the call-bytecode handlers that pass ec to
+                // `recursive_call_*`. Pyre's codewriter only encodes the
+                // dispatch-loop skeleton — the per-Python-bytecode handlers
+                // are emitted by the tracer (`pyre-jit-trace/src/trace_opcode
+                // .rs` CALL_ASSEMBLER paths) into the trace IR at trace time
+                // and never enter the codewriter's SSARepr. The compiled
+                // trace still reads ec from register slot `portal_ec_reg` at
+                // every CALL_ASSEMBLER. Forcing it alive at every PC's
+                // `-live-` op is the RPython-orthodox way to express this:
+                // `compute_liveness` (`liveness.py:46-48`,
+                // `liveness.rs:101-107`) adds Register args of `-live-` ops
+                // to the alive set during the backward walk, and the alive
+                // set propagates to all preceding labels / `-live-` ops.
+                //
+                // The pre-regalloc colors are used here; `apply_rename`
+                // (codewriter.rs:7776) translates them uniformly with every
+                // other use to post-regalloc colors.
+                let mut force_alive: Vec<Operand> = Vec::new();
+                if portal_frame_reg != u16::MAX {
+                    force_alive.push(Operand::Register(Register::new(
+                        Kind::Ref,
+                        portal_frame_reg,
+                    )));
+                }
+                if portal_ec_reg != u16::MAX {
+                    force_alive.push(Operand::Register(Register::new(Kind::Ref, portal_ec_reg)));
+                }
+                $ssarepr.insns.push(Insn::live(force_alive));
             }};
         }
 


### PR DESCRIPTION
Add portal_frame_reg and portal_ec_reg to every -live- op's R-bank list in filter_liveness_in_place. consume_one_section now fills both slots on bridge resume via the same setarg_r callback the locals/stack slots use, matching resume.py:1017 _prepare_next_section / 1077-1081 _callback_r.

Delete BlackholeInterpreter::fill_portal_registers (majit/majit-metainterp/src/blackhole.rs), the post-resume call in call_jit.rs root path, and the chain-fill loop in call_jit.rs bridge path. These had no RPython counterpart.

Encoder side: get_list_of_active_boxes substitutes sym.frame and sym.execution_context for the portal color positions when reading registers_r_bank, since pyre's PyreSym stores them on dedicated fields rather than as register-bank entries.

setup_bridge_sym: replace the pyre-only GetfieldGcR pyframe_execution_context_descr load with a read from sym.registers_r[portal_ec_reg], populated by the bank-fill loop on the preceding lines. Adds portal_red_regs_at helper for the lookup.

CALL_ASSEMBLER at trace_opcode.rs:5124: route through ensure_execution_context(ctx), matching the two sibling branches at 5262 and 5661.

JUMP arg fallback at state.rs pypyjit_collect_jump_args / _typed_jump_args: replace the [ec only] fallback with unreachable!(), since vable_collect_jump_args unconditionally pushes self.frame when frame_field is declared (derive.rs:381).

NUM_EXTRA_REDS gating: drop runtime "if NUM_EXTRA_REDS > 0" branches at state.rs:4565 and trace_opcode.rs:3062, and "if extra_reds == 1" branches at trace_opcode.rs:2805 and 2973. Add a pyre-jit-trace local const-assert NUM_EXTRA_REDS == 1 in lib.rs.

PyJitCode::skeleton: initialize portal_frame_reg and portal_ec_reg to u16::MAX (sentinel) instead of 0, matching canonical_bridge.rs:165-166. The 0 default aliased locals color 0 in the encoder's portal substitution.

Fix #38

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: gpt-5.5

Prompt: Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


• Static analysis result: I did not find a behavioral parity regression in git diff main. The patch moves frame/ec handling closer to PyPy’s
  model: PyPy declares reds = ['frame', 'ec'] in pypy/module/pypyjit/interp_jit.py:67, liveness can force variables via -live- args in rpython/
  jit/codewriter/liveness.py:10-12, and resume fills registers through _callback_r(register_index) in rpython/jit/metainterp/resume.py:1017-
  1038.

  1. Regressed Parity
  None found.

  The removed BlackholeInterpreter::fill_portal_registers and chain walk in majit/majit-metainterp/src/blackhole.rs:1269 / pyre/pyre-jit/src/
  call_jit.rs:1005 had no RPython counterpart. Routing these values through liveness and resume sections now matches resume.py:1381-1384 more
  closely.

  2. Other Introduced Mismatches
  No behavioral source-parity mismatch found, but two comments are now stale:

  - pyre/pyre-jit/src/jit/regalloc.rs:635 still says portal reds are pre-populated by BlackholeInterpreter::fill_portal_registers, which this
    patch deletes.
  - pyre/pyre-jit/src/jit/codewriter.rs:6725 says -live- markers are empty at regalloc time, but pyre/pyre-jit/src/jit/codewriter.rs:3747 now
    emits portal red registers into every placeholder before allocation.

  3. Pre-Existing Mismatches

  - pyre/pyre-jit/src/jit/codewriter.rs:2440 still applies the pyre-only LV∩SSA Ref liveness filter. RPython’s compute_liveness plus
    assembler.py:150-152 keeps all live registers by kind; it does not intersect with CPython frame-slot liveness. The patch preserves this
    mismatch but correctly exempts portal reds from being filtered out.
  - Pyre stores portal red register colors in pyre/pyre-jit-trace/src/pyjitcode.rs:84. RPython JitCode has no such fields; the red-arg shape
    comes from the jitdriver and graph inputargs.

  4. Structural Adaptations

  - pyre/pyre-jit-trace/src/trace_opcode.rs:1472 substitutes sym.frame / sym.execution_context when serializing portal red colors. RPython
    reads self.registers_r[index] directly in pyjitpl.py:223-226; pyre needs this because those two values live in named PyreSym fields.
  - pyre/pyre-jit-trace/src/state.rs:4991 copies the resumed portal_ec_reg bank slot back into sym.execution_context. RPython keeps the value
    in the frame register bank; pyre’s split symbolic state requires the extra assignment.
  - pyre/pyre-jit-trace/src/pyjitcode.rs:393 changing skeleton portal regs from 0 to u16::MAX is a pyre sentinel adaptation, consistent with
    canonical portal-bridge installs.

