### PR TITLE
Optimize list_reverse benchmark and enhance method tracing

### DIFF
--- a/pyre/bench/list_reverse.py
+++ b/pyre/bench/list_reverse.py
@@ -5,24 +5,22 @@
 # On this branch, reverse() stays in Integer strategy (no boxing overhead).
 # REPS=9 (odd): final list is reversed, so lst[0]=N-1, lst[-1]=0.
 #
-# NOTE: kept at module level intentionally — wrapping in def main() lets the
-# JIT fire and improves cranelift from ~18x to ~13x cpython, but the result
-# straddles the 10x cpython threshold and fails check.py flakily depending
-# on cpython measurement noise. Re-wrap when list oopspec lowering lands and
-# brings cranelift comfortably under threshold.
+def main():
+    N = 200000
+    REPS = 9
 
-N = 200000
-REPS = 9
+    lst = []
+    i = 0
+    while i < N:
+        lst.append(i)
+        i = i + 1
 
-lst = []
-i = 0
-while i < N:
-    lst.append(i)
-    i = i + 1
+    r = 0
+    while r < REPS:
+        lst.reverse()
+        r = r + 1
 
-r = 0
-while r < REPS:
-    lst.reverse()
-    r = r + 1
+    print(lst[0], lst[-1])
 
-print(lst[0], lst[-1])
+
+main()

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -402,6 +402,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::listobject::jit_list_reverse",
+        "pyre_object::jit_list_reverse",
+        pyre_object::jit_list_reverse as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::tupleobject::jit_tuple_getitem",
         "pyre_object::jit_tuple_getitem",
         pyre_object::jit_tuple_getitem as *const (),

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4753,6 +4753,33 @@ impl MIFrame {
         self.trace_call_callable(callable, &[])
     }
 
+    /// Direct trace path for `list.reverse()`.
+    ///
+    /// PyPy reaches `listobject.py`'s strategy `reverse` through the normal
+    /// rtyper/list helper path. Pyre does not have that full oopspec lowering
+    /// yet, so mirror the existing append/pop trace-time specialization and
+    /// emit a narrow helper call on the proven builtin list receiver.
+    pub(crate) fn list_reverse_value(
+        &mut self,
+        callable: OpRef,
+        list: OpRef,
+        concrete_list: PyObjectRef,
+    ) -> Result<OpRef, PyError> {
+        if concrete_list.is_null() || unsafe { !is_list(concrete_list) } {
+            return self.trace_call_callable(callable, &[]);
+        }
+        self.with_ctx(|this, ctx| {
+            this.guard_class(ctx, list, &LIST_TYPE as *const PyType);
+            crate::helpers::emit_trace_call_void_typed(
+                ctx,
+                pyre_object::listobject::jit_list_reverse as *const (),
+                &[list],
+                &[Type::Ref],
+            );
+            Ok(ctx.const_ref(pyre_object::w_none() as i64))
+        })
+    }
+
     pub(crate) fn concrete_iter_continues(
         &self,
         concrete_iter: PyObjectRef,
@@ -4977,6 +5004,10 @@ impl MIFrame {
                         return self.list_pop_value(callable, self_ref, inner_self, concrete_len);
                     }
                 }
+                if args.len() == 0 && canonical_list_method("reverse") == Some(inner_func) {
+                    let self_ref = recover_self(self);
+                    return self.list_reverse_value(callable, self_ref, inner_self);
+                }
             }
         }
 
@@ -4987,6 +5018,50 @@ impl MIFrame {
                 );
             if is_builtin {
                 let builtin_name = pyre_interpreter::function_get_name(concrete_callable);
+                let canonical_list_method = |name: &str| {
+                    let list_type = pyre_interpreter::typedef::gettypeobject(&LIST_TYPE);
+                    pyre_interpreter::lookup_in_type(list_type, name)
+                };
+                if args.len() == 2
+                    && canonical_list_method("append") == Some(concrete_callable)
+                    && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
+                    && is_list(concrete_args[0])
+                {
+                    self.with_ctx(|this, ctx| {
+                        this.implement_guard_value(ctx, callable, concrete_callable as i64)
+                    });
+                    let c_arg = concrete_args.get(1).copied().unwrap_or(PY_NULL);
+                    self.list_append_value(args[0], args[1], concrete_args[0], c_arg)?;
+                    return Ok(self.with_ctx(|_, ctx| ctx.const_ref(pyre_object::w_none() as i64)));
+                }
+                if args.len() == 1
+                    && canonical_list_method("pop") == Some(concrete_callable)
+                    && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
+                    && is_list(concrete_args[0])
+                {
+                    self.with_ctx(|this, ctx| {
+                        this.implement_guard_value(ctx, callable, concrete_callable as i64)
+                    });
+                    let concrete_len = w_list_len(concrete_args[0]);
+                    if concrete_len > 0 {
+                        return self.list_pop_value(
+                            callable,
+                            args[0],
+                            concrete_args[0],
+                            concrete_len,
+                        );
+                    }
+                }
+                if args.len() == 1
+                    && canonical_list_method("reverse") == Some(concrete_callable)
+                    && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
+                    && is_list(concrete_args[0])
+                {
+                    self.with_ctx(|this, ctx| {
+                        this.implement_guard_value(ctx, callable, concrete_callable as i64)
+                    });
+                    return self.list_reverse_value(callable, args[0], concrete_args[0]);
+                }
                 if args.len() == 1 {
                     let c_arg0 = concrete_args.first().copied().unwrap_or(PY_NULL);
                     self.with_ctx(|this, ctx| {

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1129,6 +1129,12 @@ pub extern "C" fn jit_list_setitem(list: i64, index: i64, value: i64) -> i64 {
     0
 }
 
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_list_reverse(list: i64) -> i64 {
+    unsafe { w_list_reverse(list as PyObjectRef) };
+    0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

This pull request adds JIT (Just-In-Time) specialization for the `list.reverse()` method in the Pyre Python interpreter, mirroring existing optimizations for `list.append()` and `list.pop()`. The changes enable the interpreter to emit a direct, efficient helper call when `list.reverse()` is invoked on a proven built-in list, improving performance for this operation. Additionally, the `list_reverse.py` benchmark is updated to wrap its logic in a `main()` function for consistency with other benchmarks.

**JIT Specialization for `list.reverse()`**

- Added a new external function `jit_list_reverse` in `listobject.rs` to perform the list reversal operation, marked with `dont_look_inside` for JIT optimization.
- Registered the new `jit_list_reverse` function and its alias in the JIT function address table in `jit_fnaddr.rs`.

**JIT Trace Integration**

- Implemented a new `list_reverse_value` trace path in `trace_opcode.rs` to directly emit the specialized helper call when a `list.reverse()` is detected on a built-in list.
- Integrated the new specialization into the method dispatch logic for both bound and unbound `list.reverse()` calls within the JIT trace opcode handler.

**Benchmark Update**

- Refactored the `list_reverse.py` benchmark to wrap its logic in a `main()` function, aligning it with other benchmarks and preparing for future oopspec lowering.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Cases Where Patch Regressed PyPy Parity Compared To Main

  None found.

  2. Other Mismatches Introduced By This Patch

  None found that should be classified as an incorrect port.

  The new list.reverse() trace path preserves PyPy-visible behavior for the list strategies Pyre currently implements: it guards an
  exact builtin list receiver, calls the existing w_list_reverse, and returns None, matching PyPy’s descr_reverse ->
  W_ListObject.reverse -> strategy.reverse.

  3. Mismatches That Already Existed Before This Patch

  - pyre/pyre-object/src/listobject.rs:822 implements only Pyre’s current list strategies: Empty, Integer, Float, and Object.
    PyPy’s pypy/objspace/std/listobject.py:1362 also has range-list behavior where reverse() switches to integer strategy and
    recurses, plus other strategies like bytes/ascii/int-or-float. This was already true on upstream/main; the patch only exposes the
    existing Rust helper to the JIT trace path.

  4. Structural Adaptations

  - pyre/pyre-jit-trace/src/trace_opcode.rs:4762 adds a direct trace-time specialization for list.reverse(). PyPy/RPython does not
    have this exact shape: PyPy goes through pypy/objspace/std/listobject.py:741, then RPython lowers reverse via rpython/rtyper/
    rlist.py:140 to rpython/rtyper/rlist.py:676.
  - pyre/pyre-object/src/listobject.rs:1133 adds jit_list_reverse as a dont_look_inside helper. RPython’s ll_reverse is
    look_inside_iff for virtual constant-length lists, so this is not structurally identical. Given Pyre’s current partial rtyper/
    codewriter lowering, this is a reasonable adaptation rather than a parity regression.
  - pyre/pyre-interpreter/src/jit_fnaddr.rs:405 registers the new helper address for Pyre’s JIT plumbing. There is no direct PyPy
    source equivalent.
  - pyre/bench/list_reverse.py:8 is a benchmark harness change, not a PyPy/RPython port surface.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved execution speed for `list.reverse()` operations through runtime optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/45)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->