### PR TITLE
Fix blackhole exception handling and align LOAD_GLOBAL behavior

### DIFF
--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3331,21 +3331,49 @@ pub extern "C" fn bh_load_global_fn(namespace_ptr: i64, w_code_ptr: i64, namei: 
         return 0;
     }
 
-    let name = code.names[idx].as_ref();
-    let ns = unsafe { &*(namespace_ptr as *const pyre_interpreter::DictStorage) };
-    match ns.get(name) {
-        Some(&value) => value as i64,
-        None => {
-            // NameError: set exception object in TLS.
-            let err = pyre_interpreter::PyError::new(
-                pyre_interpreter::PyErrorKind::NameError,
-                format!("name '{}' is not defined", name),
-            );
-            let exc_obj = err.to_exc_object();
-            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
-            0
+    let varname = code.names[idx].as_ref();
+    let w_globals = unsafe { &*(namespace_ptr as *const pyre_interpreter::DictStorage) };
+    // pypy/interpreter/pyopcode.py:958-969 `_load_global`:
+    //   w_value = self.space.finditem_str(self.get_w_globals(), varname)
+    //   if w_value is None:
+    //       w_value = self.get_builtin().getdictvalue(self.space, varname)
+    //       if w_value is None:
+    //           self._load_global_failed(w_varname)
+    if let Some(&w_value) = pyre_interpreter::dict_storage_get(w_globals, varname).as_ref() {
+        return w_value as i64;
+    }
+
+    // Blackhole helper adaptation: `self` is the virtualizable frame currently
+    // pinned in BH_VABLE_PTR, so `self.get_builtin()` maps to PyFrame::get_builtin().
+    let parent_frame_ptr =
+        majit_metainterp::blackhole::BH_VABLE_PTR.with(|c| c.get()) as *const PyFrame;
+    if !parent_frame_ptr.is_null() {
+        let w_builtin = unsafe { (*parent_frame_ptr).get_builtin() };
+        if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {
+            let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
+            if !w_dict.is_null() {
+                match pyre_interpreter::baseobjspace::finditem_str(w_dict, varname) {
+                    Ok(Some(w_value)) => return w_value as i64,
+                    Ok(None) => {}
+                    Err(err) => {
+                        let exc_obj = err.to_exc_object();
+                        majit_metainterp::blackhole::BH_LAST_EXC_VALUE
+                            .with(|c| c.set(exc_obj as i64));
+                        return 0;
+                    }
+                }
+            }
         }
     }
+
+    // pyopcode.py:970 `_load_global_failed`: raise NameError.
+    let err = pyre_interpreter::PyError::new(
+        pyre_interpreter::PyErrorKind::NameError,
+        format!("name '{}' is not defined", varname),
+    );
+    let exc_obj = err.to_exc_object();
+    majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+    0
 }
 
 /// Load a constant from the code object.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3316,10 +3316,17 @@ fn bh_call_fn_impl(callable: PyObjectRef, args: &[PyObjectRef]) -> i64 {
     }
 }
 
-/// jtransform.py parity: namespace and code come from getfield_vable_r.
+/// jtransform.py parity: namespace and code come from getfield_vable_r; the
+/// live frame is passed explicitly so `_load_global` can mirror
+/// `self.get_builtin()` in compiled residual-call paths as well as blackhole.
 /// namespace = getfield_vable_r(frame, w_globals), code = getfield_vable_r(frame, pycode).
 /// namei is the raw oparg from LOAD_GLOBAL: name_idx = namei >> 1.
-pub extern "C" fn bh_load_global_fn(namespace_ptr: i64, w_code_ptr: i64, namei: i64) -> i64 {
+pub extern "C" fn bh_load_global_fn(
+    namespace_ptr: i64,
+    w_code_ptr: i64,
+    frame_ptr: i64,
+    namei: i64,
+) -> i64 {
     let code = unsafe {
         &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
             as *const pyre_interpreter::CodeObject)
@@ -3343,10 +3350,10 @@ pub extern "C" fn bh_load_global_fn(namespace_ptr: i64, w_code_ptr: i64, namei: 
         return w_value as i64;
     }
 
-    // Blackhole helper adaptation: `self` is the virtualizable frame currently
-    // pinned in BH_VABLE_PTR, so `self.get_builtin()` maps to PyFrame::get_builtin().
-    let parent_frame_ptr =
-        majit_metainterp::blackhole::BH_VABLE_PTR.with(|c| c.get()) as *const PyFrame;
+    // Residual helper adaptation: `self` is the live portal frame passed as
+    // an explicit Ref argument, so `self.get_builtin()` maps to
+    // PyFrame::get_builtin() without relying on blackhole-only TLS.
+    let parent_frame_ptr = frame_ptr as *const PyFrame;
     if !parent_frame_ptr.is_null() {
         let w_builtin = unsafe { (*parent_frame_ptr).get_builtin() };
         if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2187,9 +2187,9 @@ fn register_helper_fn_pointers(
         HelperHandle { idx, flavor }
     };
     let call_fn = bind(assembler, cpu.call_fn as *const (), CallFlavor::MayForce);
-    // `bh_load_global_fn` is a flat `DictStorage::get(name)` lookup
-    // followed by `NameError` synthesis on miss — no
-    // `__getattr__`-style user dispatch (`call_jit.rs:3215-3242`).
+    // `bh_load_global_fn` mirrors pyopcode.py `_load_global`: globals
+    // lookup, then the current frame's picked builtins module, then
+    // `NameError` synthesis on miss.
     // Matches `EF_CAN_RAISE` (`call.py:301` `elif self._canraise(op)`):
     // can raise but does not force virtuals.
     let load_global_fn = bind(
@@ -5540,10 +5540,10 @@ impl CodeWriter {
                         // load_global_fn_idx, ...)` call is replaced by
                         // a single direct push of
                         // `build_load_global_fn_residual_call_ir_r_insn`,
-                        // which produces the same `residual_call_ir_r(
+                        // which produces the matching `residual_call_ir_r(
                         // ConstInt(fn_idx), ListI([ConstInt(namei)]),
-                        // ListR([Reg(ns), Reg(code)]), Descr) →
-                        // Reg(scratch_ns)` Insn shape
+                        // ListR([Reg(ns), Reg(code), Reg(frame)]), Descr)
+                        // → Reg(scratch_ns)` Insn shape
                         // `emit_residual_call_shape` would have
                         // produced.  LoadGlobal has no frontend HLOp
                         // (no `lower_load_global_hlop_to_insn` arm);
@@ -5559,15 +5559,17 @@ impl CodeWriter {
                                 raw_namei,
                                 scratch_ns,
                                 scratch_code,
+                                portal_frame_reg,
                                 scratch_ns,
                             ),
                         );
                         // Task #46 micro-slice 6: graph-side residual_call
                         // dual-write for load_global_fn(ns:Ref, code:Ref,
-                        // namei:Int) → Ref.  Both ns and code Variables
-                        // come from the preceding emit_vable_getfield_ref!
-                        // graph dual-writes — thread them so def-use stays
-                        // intact.  Shape: residual_call_ir_r.
+                        // frame:Ref, namei:Int) → Ref.  ns and code
+                        // Variables come from the preceding
+                        // emit_vable_getfield_ref! graph dual-writes; frame
+                        // is the portal red variable, matching PyPy's
+                        // `_load_global(self, ...)` receiver.
                         // Match helper bind-site flavor at
                         // codewriter.rs:2186 (`load_global_fn`
                         // is `EF_CAN_RAISE`, not virtual-forcing)
@@ -5587,9 +5589,9 @@ impl CodeWriter {
                                 load_global_fn_idx,
                                 CallFlavor::Plain,
                                 vec![super::flow::Constant::signed(raw_namei).into()],
-                                vec![ns_var.into(), code_var.into()],
+                                vec![ns_var.into(), code_var.into(), frame_var.into()],
                                 vec![],
-                                vec![Kind::Ref, Kind::Ref, Kind::Int],
+                                vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
                                 ResKind::Ref,
                                 py_pc as i64,
                             )

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6114,13 +6114,14 @@ impl CodeWriter {
                             .stack
                             .pop()
                             .unwrap_or_else(|| fresh_ref_value(&mut graph));
-                        // D2-1: input-side staging retire — exc_reg's SSA
-                        // register slot still holds the popped value (the
-                        // popvalue macro only NULL-clears the portal vable
-                        // mirror), so set_current_exception can read it
-                        // directly and the trailing push can use it as the
-                        // src register. Pattern matches Sessions 1-3
-                        // input-side retirements.
+                        // pyopcode.py:786 keeps `exc` in a local after
+                        // `popvalue()`.  Mirror that with a scratch register:
+                        // the following `push(prev)` writes to the popped
+                        // stack slot, so reusing `exc_reg` for the trailing
+                        // `push(exc)` would read back `prev` instead of the
+                        // caught exception.
+                        let scratch_exc = ssarepr.fresh_var(Kind::Ref, scratch_ref_base).0;
+                        emit_ref_copy!(ssarepr, scratch_exc, exc_reg);
                         let scratch_prev = ssarepr.fresh_var(Kind::Ref, scratch_ref_base).0;
                         // get_current_exception / set_current_exception are TLS read/write —
                         // EF_CANNOT_RAISE per `effectinfo.py:19` (matching call.py:296
@@ -6141,7 +6142,7 @@ impl CodeWriter {
                         ssarepr.insns.push(
                             super::flatten::build_set_current_exception_fn_residual_call_r_v_insn(
                                 set_current_exception_fn_idx,
-                                exc_reg,
+                                scratch_exc,
                             ),
                         );
                         // Task #46 micro-slice 7: graph dual-writes for
@@ -6188,7 +6189,7 @@ impl CodeWriter {
                         current_state.stack.push(prev_value.clone());
                         emit_pushvalue_ref!(ssarepr, current_depth, scratch_prev, prev_value);
                         current_state.stack.push(exc_value.clone());
-                        emit_pushvalue_ref!(ssarepr, current_depth, exc_reg, exc_value);
+                        emit_pushvalue_ref!(ssarepr, current_depth, scratch_exc, exc_value);
                     }
 
                     Instruction::CheckExcMatch => {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2910,6 +2910,12 @@ impl CodeWriter {
         // tests stay stable.
         let portal_frame_reg = (nlocals + max_stackdepth + 11) as u16;
         let portal_ec_reg = (nlocals + max_stackdepth + 12) as u16;
+        // Trace inputarg 0 is the live PyFrame pointer for both portal
+        // and non-portal dispatch (virtualizable_gen.rs:25).  Portal red
+        // register slots are only the codewriter/BH register-bank carrier,
+        // so residual helpers that need the actual frame receiver must use
+        // this canonical frame input slot.
+        let caller_frame_reg = 0_u16;
         // Per-arm fresh ref scratch slots — Phase 2 Commit 2.2 first slice
         // (Tasks #158/#159/#122 plan).  Each opcode handler arm that needs
         // a transient ref-typed register allocates one or more fresh slots
@@ -5559,7 +5565,7 @@ impl CodeWriter {
                                 raw_namei,
                                 scratch_ns,
                                 scratch_code,
-                                portal_frame_reg,
+                                caller_frame_reg,
                                 scratch_ns,
                             ),
                         );

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2910,12 +2910,6 @@ impl CodeWriter {
         // tests stay stable.
         let portal_frame_reg = (nlocals + max_stackdepth + 11) as u16;
         let portal_ec_reg = (nlocals + max_stackdepth + 12) as u16;
-        // Trace inputarg 0 is the live PyFrame pointer for both portal
-        // and non-portal dispatch (virtualizable_gen.rs:25).  Portal red
-        // register slots are only the codewriter/BH register-bank carrier,
-        // so residual helpers that need the actual frame receiver must use
-        // this canonical frame input slot.
-        let caller_frame_reg = 0_u16;
         // Per-arm fresh ref scratch slots — Phase 2 Commit 2.2 first slice
         // (Tasks #158/#159/#122 plan).  Each opcode handler arm that needs
         // a transient ref-typed register allocates one or more fresh slots
@@ -5565,7 +5559,7 @@ impl CodeWriter {
                                 raw_namei,
                                 scratch_ns,
                                 scratch_code,
-                                caller_frame_reg,
+                                portal_frame_reg,
                                 scratch_ns,
                             ),
                         );

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -37,8 +37,8 @@ pub struct Cpu {
     pub call_fn_6: extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64,
     pub call_fn_7: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
     pub call_fn_8: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
-    /// `bhimpl_load_global` — namespace + code from getfield_vable_r.
-    pub load_global_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bhimpl_load_global` — namespace/code from getfield_vable_r plus live frame.
+    pub load_global_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// `bhimpl_compare_op` — RPython compare_op opcodes.
     pub compare_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// `bhimpl_binary_op` — RPython binary_op opcodes.

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -5761,7 +5761,7 @@ mod tests {
         // `_load_global(self, ...)` receiver.
         let insn = build_load_global_fn_residual_call_ir_r_insn(
             /* load_global_fn_idx */ 12, /* namei */ 5, /* ns_reg */ 3,
-            /* code_reg */ 4, /* frame_reg */ 6, /* dst_reg */ 3,
+            /* code_reg */ 4, /* frame_reg */ 6, /* dst_reg */ 7,
         );
         match insn {
             Insn::Op {
@@ -5770,7 +5770,7 @@ mod tests {
                 result: Some(reg),
             } => {
                 assert_eq!(opname, "residual_call_ir_r");
-                assert_eq!(reg, Register::new(Kind::Ref, 3));
+                assert_eq!(reg, Register::new(Kind::Ref, 7));
                 assert_eq!(args.len(), 4);
                 match &args[0] {
                     Operand::ConstInt(v) => assert_eq!(*v, 12),
@@ -5851,7 +5851,7 @@ mod tests {
         let ns_var = Variable::new(VariableId(3), Kind::Ref);
         let code_var = Variable::new(VariableId(4), Kind::Ref);
         let frame_var = Variable::new(VariableId(6), Kind::Ref);
-        let dst_var = Variable::new(VariableId(3), Kind::Ref);
+        let dst_var = Variable::new(VariableId(7), Kind::Ref);
         let descr = intern_call_descr_stub(
             effect_info_for_call_flavor(CallFlavor::Plain),
             vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
@@ -5876,7 +5876,7 @@ mod tests {
         let mut lower_constant = probe_constant_lowering();
         let dual = flatten_op_to_insn(&dual_op, &mut get_register)
             .expect("residual_call SpaceOperation must lower");
-        let prod = build_load_global_fn_residual_call_ir_r_insn(12, 5, 3, 4, 6, 3);
+        let prod = build_load_global_fn_residual_call_ir_r_insn(12, 5, 3, 4, 6, 7);
         assert_eq!(format!("{prod:?}"), format!("{dual:?}"));
     }
 

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2693,8 +2693,8 @@ pub fn build_binary_op_residual_call_ir_r_insn(
 /// `(Ref, Ref, Int) → Ref` HLOp / helper families that lower to a
 /// uniform `residual_call_ir_r` Insn shape.  Today: BINARY_OP
 /// (`binary_op_fn`, MayForce), COMPARE_OP (`compare_fn`, MayForce),
-/// and LOAD_GLOBAL (`load_global_fn`, Plain — `(ns, code, namei)`
-/// per codewriter.rs:5598-5615).  All share `arg_kinds = [Ref,
+/// and two-Ref residual helper families.  BINARY_OP and COMPARE_OP share
+/// `arg_kinds = [Ref,
 /// Ref, Int]`, ResKind Ref → kinds `"ir"` + reskind `'r'` → opname
 /// `"residual_call_ir_r"`.  They differ in the leading `fn_idx`
 /// literal, the per-family `op_val` (or callee-arg integer), and
@@ -2838,12 +2838,11 @@ pub fn build_compare_op_residual_call_ir_r_insn(
 /// graph dual-write at codewriter.rs:5622-5635 stays in place — this
 /// slice is incremental factor refactor, not retirement.
 ///
-/// `load_global_fn` has signature `(ns: Ref, code: Ref, namei: Int)
+/// `load_global_fn` has signature `(ns: Ref, code: Ref, frame: Ref, namei: Int)
 /// → Ref` with `CallFlavor::Plain` (per codewriter.rs:2176-2185 —
-/// `bh_load_global_fn` is a flat namespace lookup that can `NameError`
-/// but cannot force virtuals; matches `EF_CAN_RAISE`).  Same
-/// `(Ref, Ref, Int) → Ref` arity as BINARY_OP/COMPARE_OP — only the
-/// CallFlavor on the EffectInfo descr differs.
+/// `bh_load_global_fn` can `NameError` but cannot force virtuals; matches
+/// `EF_CAN_RAISE`).  The explicit frame Ref is the Rust residual-helper
+/// adaptation for PyPy's `_load_global(self, ...)` receiver.
 ///
 /// The matching graph dual-write at codewriter.rs (LoadGlobal arm)
 /// records `CallFlavor::Plain` so the SSA helper, the inline
@@ -2853,14 +2852,30 @@ pub fn build_load_global_fn_residual_call_ir_r_insn(
     namei: i64,
     ns_reg: u16,
     code_reg: u16,
+    frame_reg: u16,
     dst_reg: u16,
 ) -> Insn {
-    build_residual_call_ir_r_insn_from_operands(
-        load_global_fn_idx,
-        namei,
-        Operand::Register(Register::new(Kind::Ref, ns_reg)),
-        Operand::Register(Register::new(Kind::Ref, code_reg)),
-        CallFlavor::Plain,
+    let effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(load_global_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(namei)])),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Ref,
+                vec![
+                    Operand::Register(Register::new(Kind::Ref, ns_reg)),
+                    Operand::Register(Register::new(Kind::Ref, code_reg)),
+                    Operand::Register(Register::new(Kind::Ref, frame_reg)),
+                ],
+            )),
+            descr_operand,
+        ],
         Register::new(Kind::Ref, dst_reg),
     )
 }
@@ -5740,15 +5755,13 @@ mod tests {
         // that `emit_residual_call_shape` produced inline at
         // codewriter.rs:5598-5615 before the refactor: `[ConstInt(
         // fn_idx), ListI([ConstInt(namei)]), ListR([Reg(ns), Reg(
-        // code)]), Descr(CallDescrStub{Plain, [Ref, Ref, Int]})] →
-        // Reg(Ref, dst)`.  Same `(Ref, Ref, Int) → Ref` arity as
-        // BINARY_OP/COMPARE_OP — distinguished only by the `Plain`
-        // CallFlavor on the EffectInfo descr (per
-        // codewriter.rs:2176-2185 — `bh_load_global_fn` cannot force
-        // virtuals, matches `EF_CAN_RAISE`).
+        // code), Reg(frame)]), Descr(CallDescrStub{Plain,
+        // [Ref, Ref, Ref, Int]})] → Reg(Ref, dst)`.  The explicit
+        // frame Ref is the helper-level stand-in for PyPy's
+        // `_load_global(self, ...)` receiver.
         let insn = build_load_global_fn_residual_call_ir_r_insn(
             /* load_global_fn_idx */ 12, /* namei */ 5, /* ns_reg */ 3,
-            /* code_reg */ 4, /* dst_reg */ 3,
+            /* code_reg */ 4, /* frame_reg */ 6, /* dst_reg */ 3,
         );
         match insn {
             Insn::Op {
@@ -5775,11 +5788,11 @@ mod tests {
                     }
                     other => panic!("expected ListOfKind(Int, 1), got {other:?}"),
                 }
-                // args[2] = ListR([Reg(Ref, ns_reg), Reg(Ref, code_reg)]).
+                // args[2] = ListR([Reg(Ref, ns_reg), Reg(Ref, code_reg), Reg(Ref, frame_reg)]).
                 match &args[2] {
                     Operand::ListOfKind(list) => {
                         assert_eq!(list.kind, Kind::Ref);
-                        assert_eq!(list.content.len(), 2);
+                        assert_eq!(list.content.len(), 3);
                         assert!(matches!(
                             &list.content[0],
                             Operand::Register(Register {
@@ -5794,13 +5807,23 @@ mod tests {
                                 index: 4
                             })
                         ));
+                        assert!(matches!(
+                            &list.content[2],
+                            Operand::Register(Register {
+                                kind: Kind::Ref,
+                                index: 6
+                            })
+                        ));
                     }
-                    other => panic!("expected ListOfKind(Ref, 2), got {other:?}"),
+                    other => panic!("expected ListOfKind(Ref, 3), got {other:?}"),
                 }
                 match &args[3] {
                     Operand::Descr(rc) => match &**rc {
                         DescrOperand::CallDescrStub(stub) => {
-                            assert_eq!(stub.arg_kinds, vec![Kind::Ref, Kind::Ref, Kind::Int]);
+                            assert_eq!(
+                                stub.arg_kinds,
+                                vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int]
+                            );
                             assert_eq!(
                                 stub.effect_info,
                                 effect_info_for_call_flavor(CallFlavor::Plain),
@@ -5827,10 +5850,11 @@ mod tests {
         // path.
         let ns_var = Variable::new(VariableId(3), Kind::Ref);
         let code_var = Variable::new(VariableId(4), Kind::Ref);
+        let frame_var = Variable::new(VariableId(6), Kind::Ref);
         let dst_var = Variable::new(VariableId(3), Kind::Ref);
         let descr = intern_call_descr_stub(
             effect_info_for_call_flavor(CallFlavor::Plain),
-            vec![Kind::Ref, Kind::Ref, Kind::Int],
+            vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
             Some(Kind::Ref),
         );
         let dual_op = SpaceOperation::new(
@@ -5838,7 +5862,11 @@ mod tests {
             vec![
                 Constant::signed(12).into(),
                 FlowListOfKind::new(Kind::Int, vec![Constant::signed(5).into()]).into(),
-                FlowListOfKind::new(Kind::Ref, vec![ns_var.into(), code_var.into()]).into(),
+                FlowListOfKind::new(
+                    Kind::Ref,
+                    vec![ns_var.into(), code_var.into(), frame_var.into()],
+                )
+                .into(),
                 descr.into(),
             ],
             Some(dst_var.into()),
@@ -5848,7 +5876,7 @@ mod tests {
         let mut lower_constant = probe_constant_lowering();
         let dual = flatten_op_to_insn(&dual_op, &mut get_register)
             .expect("residual_call SpaceOperation must lower");
-        let prod = build_load_global_fn_residual_call_ir_r_insn(12, 5, 3, 4, 3);
+        let prod = build_load_global_fn_residual_call_ir_r_insn(12, 5, 3, 4, 6, 3);
         assert_eq!(format!("{prod:?}"), format!("{dual:?}"));
     }
 
@@ -5868,7 +5896,7 @@ mod tests {
         // (`:293-299`). Both EIs therefore carry distinct shapes and
         // round-trip through `dispatch_kind_for_effect_info`.
         let bin = build_binary_op_residual_call_ir_r_insn(7, 0, 1, 2, 3);
-        let glob = build_load_global_fn_residual_call_ir_r_insn(7, 0, 1, 2, 3);
+        let glob = build_load_global_fn_residual_call_ir_r_insn(7, 0, 1, 2, 4, 3);
         let bin_descr = match &bin {
             Insn::Op { args, .. } => match &args[3] {
                 Operand::Descr(rc) => match &**rc {


### PR DESCRIPTION
## Summary

This pull request refactors the JIT's handling of Python's LOAD_GLOBAL opcode to more closely mirror PyPy's semantics by explicitly passing the live frame object to the residual helper. This allows the global lookup to fall back to the frame's builtins module, not just the globals dict, matching Python's runtime behavior. The change also updates the relevant IR building, code generation, and tests to handle the new function signature and argument shape.

Key changes:

### LOAD_GLOBAL helper refactor

* The `bh_load_global_fn` helper now takes an explicit `frame` argument in addition to `namespace` and `code`, allowing it to access builtins via the live frame, not just the globals dict. The lookup logic now matches PyPy's `_load_global`, first checking globals, then builtins, and raising `NameError` if not found.

* The CPU struct's `load_global_fn` signature is updated to accept four arguments (`namespace`, `code`, `frame`, `namei`).

### IR and codewriter updates

* The IR builder and codewriter are updated so that all residual calls to `load_global_fn` now pass the frame as an additional argument, and the IR shape reflects this (`[ns, code, frame, namei]`).

### Test and documentation updates

* All related tests are updated to expect the new argument shape and verify the correct IR and call signatures.

### Exception handling improvement

* Exception stack handling in the codewriter is improved to use a scratch register for the exception object, preventing accidental overwrites when reusing registers.

These changes ensure that LOAD_GLOBAL in the JIT now matches Python's semantics more closely, especially in cases involving custom builtins, and that the IR and tests are consistent with the new calling convention.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Regressed PyPy Parity Compared To Main

  None found.

  The patch improves parity in the two changed behavioral areas:

  - LOAD_GLOBAL now checks frame-picked builtins after globals, matching PyPy _load_global() in pypy/interpreter/pyopcode.py:958.
  - PUSH_EXC_INFO now preserves the popped exception in a scratch register before pushing prev, matching PyPy’s local w_exc lifetime
    in pypy/interpreter/pyopcode.py:819.

  2. Other Mismatches Introduced By This Patch

  None found.

  The changed helper signature is internally consistent across:

  - pyre/pyre-jit/src/call_jit.rs:3324: bh_load_global_fn(ns, code, frame, namei)
  - pyre/pyre-jit/src/jit/cpu.rs:41: extern fn type updated to 4 args
  - pyre/pyre-jit/src/jit/codewriter.rs:5557: SSA residual call passes ns, code, frame
  - pyre/pyre-jit/src/jit/flatten.rs:2850: call descr uses [Ref, Ref, Ref, Int]

  3. Mismatches That Already Existed Before This Patch

  PUSH_EXC_INFO still models current exception state as a raw exception object in TLS, while PyPy stores/restores an OperationError
  and distinguishes hidden applevel frames. PyPy branches on self.hide() and uses hidden_operationerr in pypy/interpreter/
  pyopcode.py:823, then restores via _restore_exc_info() in pypy/interpreter/pyframe.py:185. The Rust JIT helper path uses
  get_current_exception / set_current_exception object helpers in pyre/pyre-jit/src/call_jit.rs:3652. This was already the shape on
  upstream/main; the patch only fixes register lifetime.

  LOAD_GLOBAL still uses Pyre’s split DictStorage globals representation instead of PyPy’s direct object-space
  finditem_str(self.get_w_globals(), varname) object path. The direct globals lookup existed before this patch in the helper; the new
  builtins fallback brings it closer to PyPy rather than introducing the mismatch.

  4. Structural Adaptations

  LOAD_GLOBAL passes the live frame explicitly as a residual helper argument. PyPy has self._load_global(varname) and can call
  self.get_builtin() directly; the Rust C-style helper has no implicit receiver, so pyre/pyre-jit/src/jit/codewriter.rs:5592 adds
  frame_var to the ref args.

  namei >> 1 in pyre/pyre-jit/src/call_jit.rs:3335 is a CPython-compatible bytecode adaptation for LOAD_GLOBAL’s low-bit NULL marker.
  PyPy’s local source uses nameindex directly, but this falls under the opcode/compiler mismatch exception.

  The PUSH_EXC_INFO scratch copy in pyre/pyre-jit/src/jit/codewriter.rs:6125 is a Rust SSA/register adaptation. PyPy keeps w_exc as a
  Python local while mutating the value stack; Rust needs ref_copy so the later push(exc) does not reread the stack slot overwritten
  by push(prev).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exception value handling in JIT compilation to prevent stack slot corruption.

* **Refactor**
  * Improved global variable lookup to support frame-aware builtin resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/48)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->