### PR TITLE
Implement RawBuffer module and maintain RawBufferPtrInfo parity

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1111,7 +1111,7 @@ impl PtrInfo {
             PtrInfo::VirtualArray(v) => v.items.len(),
             PtrInfo::VirtualStruct(v) => v.fields.len(),
             PtrInfo::VirtualArrayStruct(v) => v.element_fields.len(),
-            PtrInfo::VirtualRawBuffer(v) => v.buffer.offsets.len(),
+            PtrInfo::VirtualRawBuffer(v) => v.buffer.len(),
             _ => 0,
         }
     }
@@ -1131,7 +1131,7 @@ impl PtrInfo {
                 .iter()
                 .flat_map(|fields| fields.iter().map(|(_, r)| *r))
                 .collect(),
-            PtrInfo::VirtualRawBuffer(v) => v.buffer.values.clone(),
+            PtrInfo::VirtualRawBuffer(v) => v.buffer.values().to_vec(),
             // info.py:478-482 `RawSlicePtrInfo._visitor_walk_recursive`:
             //
             // ```python
@@ -1289,8 +1289,8 @@ impl PtrInfo {
             PtrInfo::VirtualRawBuffer(info) => Some(visitor.visit_vrawbuffer(
                 info.func,
                 info.size,
-                &info.buffer.offsets,
-                &info.buffer.descrs,
+                info.buffer.offsets(),
+                info.buffer.descrs(),
             )),
             // info.py:485-486 RawSlicePtrInfo.visitor_dispatch_virtual_type
             PtrInfo::VirtualRawSlice(info) => Some(visitor.visit_vrawslice(info.offset)),
@@ -1611,9 +1611,7 @@ impl PtrInfo {
             PtrInfo::VirtualRawBuffer(vinfo) => {
                 // info.py:420-436: RawBufferPtrInfo._force_elements()
                 // info.py:421: self.size = -1 (mark as no longer virtual)
-                let offsets = std::mem::take(&mut vinfo.buffer.offsets);
-                let descrs = std::mem::take(&mut vinfo.buffer.descrs);
-                let values = std::mem::take(&mut vinfo.buffer.values);
+                let entries = vinfo.buffer.drain_entries();
                 let func = vinfo.func;
                 let size = vinfo.size;
                 let calldescr = vinfo.calldescr.take();
@@ -1639,12 +1637,12 @@ impl PtrInfo {
                 emit_op(ctx, check_op);
 
                 // info.py:429-436: emit RAW_STORE for each buffered write
-                for i in 0..offsets.len() {
-                    let value_ref = force_child(values[i], ctx);
-                    let offset_ref = ctx.emit_constant_int(offsets[i] as i64);
+                for (offset, _length, descr, value) in entries {
+                    let value_ref = force_child(value, ctx);
+                    let offset_ref = ctx.emit_constant_int(offset);
                     let mut store_op =
                         Op::new(OpCode::RawStore, &[alloc_ref, offset_ref, value_ref]);
-                    store_op.descr = Some(descrs[i].clone());
+                    store_op.descr = Some(descr);
                     emit_op(ctx, store_op);
                 }
 

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1,4 +1,5 @@
 use crate::optimizeopt::intutils::IntBound;
+pub use crate::optimizeopt::rawbuffer::{RawBuffer, RawBufferError};
 /// Abstract information attached to operations during optimization.
 ///
 /// Translated from rpython/jit/metainterp/optimizeopt/info.py.
@@ -1110,7 +1111,7 @@ impl PtrInfo {
             PtrInfo::VirtualArray(v) => v.items.len(),
             PtrInfo::VirtualStruct(v) => v.fields.len(),
             PtrInfo::VirtualArrayStruct(v) => v.element_fields.len(),
-            PtrInfo::VirtualRawBuffer(v) => v.offsets.len(),
+            PtrInfo::VirtualRawBuffer(v) => v.buffer.offsets.len(),
             _ => 0,
         }
     }
@@ -1130,7 +1131,7 @@ impl PtrInfo {
                 .iter()
                 .flat_map(|fields| fields.iter().map(|(_, r)| *r))
                 .collect(),
-            PtrInfo::VirtualRawBuffer(v) => v.values.clone(),
+            PtrInfo::VirtualRawBuffer(v) => v.buffer.values.clone(),
             // info.py:478-482 `RawSlicePtrInfo._visitor_walk_recursive`:
             //
             // ```python
@@ -1285,9 +1286,12 @@ impl PtrInfo {
                 ))
             }
             // info.py:445-450 RawBufferPtrInfo.visitor_dispatch_virtual_type
-            PtrInfo::VirtualRawBuffer(info) => {
-                Some(visitor.visit_vrawbuffer(info.func, info.size, &info.offsets, &info.descrs))
-            }
+            PtrInfo::VirtualRawBuffer(info) => Some(visitor.visit_vrawbuffer(
+                info.func,
+                info.size,
+                &info.buffer.offsets,
+                &info.buffer.descrs,
+            )),
             // info.py:485-486 RawSlicePtrInfo.visitor_dispatch_virtual_type
             PtrInfo::VirtualRawSlice(info) => Some(visitor.visit_vrawslice(info.offset)),
             // vstring.py:211-212 / 263-264 / 333-334 per-variant dispatch
@@ -1607,9 +1611,9 @@ impl PtrInfo {
             PtrInfo::VirtualRawBuffer(vinfo) => {
                 // info.py:420-436: RawBufferPtrInfo._force_elements()
                 // info.py:421: self.size = -1 (mark as no longer virtual)
-                let offsets = std::mem::take(&mut vinfo.offsets);
-                let descrs = std::mem::take(&mut vinfo.descrs);
-                let values = std::mem::take(&mut vinfo.values);
+                let offsets = std::mem::take(&mut vinfo.buffer.offsets);
+                let descrs = std::mem::take(&mut vinfo.buffer.descrs);
+                let values = std::mem::take(&mut vinfo.buffer.values);
                 let func = vinfo.func;
                 let size = vinfo.size;
                 let calldescr = vinfo.calldescr.take();
@@ -2703,28 +2707,20 @@ pub struct VirtualRawSliceInfo {
     pub cached_vinfo: std::cell::RefCell<Option<std::rc::Rc<majit_ir::RdVirtualInfo>>>,
 }
 
-/// A virtual raw memory buffer.
+/// info.py:386 RawBufferPtrInfo — pointer info for virtual raw memory.
 ///
-/// rawbuffer.py:13 RawBuffer — 4 parallel lists: offsets, lengths, descrs, values.
-/// Sorted by offset. Invariant: offsets[i]+lengths[i] <= offsets[i+1].
+/// RPython stores the byte-write tracking in a separate `RawBuffer` object
+/// (`self.buffer = RawBuffer(cpu, None)` in info.py:392-393). Rust mirrors
+/// that by keeping the rawbuffer.py parallel-list state in `buffer`, while
+/// this struct owns the RawBufferPtrInfo metadata.
 #[derive(Clone, Debug)]
 pub struct VirtualRawBufferInfo {
-    /// resume.py:695: self.func — raw malloc function pointer.
+    /// info.py:390 self.func — raw malloc function pointer.
     pub func: i64,
-    /// Size of the buffer in bytes.
+    /// info.py:391 self.size — size of the virtual raw buffer.
     pub size: usize,
-    /// rawbuffer.py:14: self.offsets — signed because RPython's
-    /// unbounded int allows `basesize + itemsize*index` to be negative
-    /// when `index < 0`. `write_value` keeps the list sorted using
-    /// signed comparison (rawbuffer.py:104 `self.offsets[i] > offset`).
-    pub offsets: Vec<i64>,
-    /// rawbuffer.py:15: self.lengths — always non-negative (unsigned
-    /// upstream itemsize from `unpack_arraydescr_size`).
-    pub lengths: Vec<usize>,
-    /// rawbuffer.py:16: self.descrs — per-entry ArrayDescr.
-    pub descrs: Vec<DescrRef>,
-    /// rawbuffer.py:17: self.values
-    pub values: Vec<OpRef>,
+    /// info.py:387/392 self.buffer — rawbuffer.py RawBuffer.
+    pub buffer: RawBuffer,
     /// info.py:91-92
     pub last_guard_pos: i32,
     /// info.py:420: calldescr for CALL_I(func, size) raw malloc.
@@ -2734,42 +2730,31 @@ pub struct VirtualRawBufferInfo {
     pub cached_vinfo: std::cell::RefCell<Option<std::rc::Rc<majit_ir::RdVirtualInfo>>>,
 }
 
-/// Error returned when a raw buffer operation violates invariants.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RawBufferError {
-    /// A write overlaps with an existing write.
-    OverlappingWrite {
-        new_offset: i64,
-        new_length: usize,
-        existing_offset: i64,
-        existing_length: usize,
-    },
-    /// A read from an offset that was never written.
-    UninitializedRead { offset: i64, length: usize },
-    /// A read whose length/offset doesn't match the write at that offset.
-    IncompatibleRead {
-        offset: i64,
-        read_length: usize,
-        write_length: usize,
-    },
-}
-
 impl VirtualRawBufferInfo {
-    /// rawbuffer.py:83: _descrs_are_compatible(d1, d2)
-    /// Two arraydescrs are compatible if they have the same basesize,
-    /// itemsize and sign.
-    fn descrs_are_compatible(d1: &DescrRef, d2: &DescrRef) -> bool {
-        let (Some(a1), Some(a2)) = (d1.as_array_descr(), d2.as_array_descr()) else {
-            return false;
-        };
-        a1.base_size() == a2.base_size()
-            && a1.item_size() == a2.item_size()
-            && a1.is_item_signed() == a2.is_item_signed()
+    /// virtualize.py:52-58 creates RawBufferPtrInfo(cpu, func, size),
+    /// whose constructor initializes `self.buffer = RawBuffer(cpu, None)`.
+    pub fn new(func: i64, size: usize, calldescr: Option<DescrRef>) -> Self {
+        Self {
+            func,
+            size,
+            buffer: RawBuffer::new(),
+            last_guard_pos: -1,
+            calldescr,
+            cached_vinfo: std::cell::RefCell::new(None),
+        }
     }
 
-    /// rawbuffer.py:89: write_value(offset, length, descr, value).
-    /// Maintains sorted order by offset. Same-offset update only
-    /// replaces value (rawbuffer.py:102), never descr.
+    /// info.py:403-410 RawBufferPtrInfo.getitem_raw delegates to RawBuffer.
+    pub fn read_value(
+        &self,
+        offset: i64,
+        length: usize,
+        descr: &DescrRef,
+    ) -> Result<OpRef, RawBufferError> {
+        self.buffer.read_value(offset, length, descr)
+    }
+
+    /// info.py:412-415 RawBufferPtrInfo.setitem_raw delegates to RawBuffer.
     pub fn write_value(
         &mut self,
         offset: i64,
@@ -2777,109 +2762,7 @@ impl VirtualRawBufferInfo {
         descr: DescrRef,
         value: OpRef,
     ) -> Result<(), RawBufferError> {
-        // RPython rawbuffer.py uses unbounded-int `length`. The pyre
-        // length is `usize`; on 64-bit platforms `usize > i64::MAX`
-        // would wrap to a negative i64 and break the signed overlap
-        // checks. Realistically itemsize never approaches 2^63, but
-        // bail conservatively for spec-strict parity. Treat the
-        // failure as `InvalidRawWrite` (OverlappingWrite is the
-        // closest existing error variant).
-        let Ok(length_i) = i64::try_from(length) else {
-            return Err(RawBufferError::OverlappingWrite {
-                new_offset: offset,
-                new_length: length,
-                existing_offset: offset,
-                existing_length: length,
-            });
-        };
-        let mut insert_pos = 0;
-        for i in 0..self.offsets.len() {
-            let wo = self.offsets[i];
-            let wl = self.lengths[i];
-            if wo == offset {
-                // rawbuffer.py:94-95: length and descr must be compatible.
-                if wl != length || !Self::descrs_are_compatible(&descr, &self.descrs[i]) {
-                    return Err(RawBufferError::OverlappingWrite {
-                        new_offset: offset,
-                        new_length: length,
-                        existing_offset: wo,
-                        existing_length: wl,
-                    });
-                }
-                // rawbuffer.py:102: only replace value, keep existing descr.
-                self.values[i] = value;
-                return Ok(());
-            } else if wo > offset {
-                break;
-            }
-            insert_pos = i + 1;
-        }
-        // rawbuffer.py:108: `if i < len(self.offsets) and offset+length
-        // > self.offsets[i]: _invalid_write("overlap with next bytes")`.
-        // RPython int is unbounded; in Rust an i64 overflow on
-        // `offset + length` (length is non-negative usize) means the
-        // write extends past i64::MAX, which by signed compare is
-        // greater than every legitimate next_off — i.e. an overlap.
-        // checked_add returns None on overflow → treat as overlap.
-        if insert_pos < self.offsets.len() {
-            let next_off = self.offsets[insert_pos];
-            let end = offset.checked_add(length_i);
-            if end.map_or(true, |e| e > next_off) {
-                return Err(RawBufferError::OverlappingWrite {
-                    new_offset: offset,
-                    new_length: length,
-                    existing_offset: next_off,
-                    existing_length: self.lengths[insert_pos],
-                });
-            }
-        }
-        // rawbuffer.py:111: `if i > 0 and self.offsets[i-1]+self.lengths[i-1]
-        // > offset: _invalid_write("overlap with previous bytes")`.
-        // Same overflow argument: a saturated/overflowed `prev_off+prev_len`
-        // is unbounded-greater-than `offset` in RPython, so checked_add
-        // None → treat as overlap.
-        if insert_pos > 0 {
-            let prev_off = self.offsets[insert_pos - 1];
-            let prev_len = self.lengths[insert_pos - 1];
-            let prev_end = prev_off.checked_add(prev_len as i64);
-            if prev_end.map_or(true, |e| e > offset) {
-                return Err(RawBufferError::OverlappingWrite {
-                    new_offset: offset,
-                    new_length: length,
-                    existing_offset: prev_off,
-                    existing_length: prev_len,
-                });
-            }
-        }
-        // rawbuffer.py:115-118: insert new entry.
-        self.offsets.insert(insert_pos, offset);
-        self.lengths.insert(insert_pos, length);
-        self.descrs.insert(insert_pos, descr);
-        self.values.insert(insert_pos, value);
-        Ok(())
-    }
-
-    /// rawbuffer.py:120: read_value(offset, length, descr).
-    pub fn read_value(
-        &self,
-        offset: i64,
-        length: usize,
-        descr: &DescrRef,
-    ) -> Result<OpRef, RawBufferError> {
-        for i in 0..self.offsets.len() {
-            if self.offsets[i] == offset {
-                if self.lengths[i] != length || !Self::descrs_are_compatible(descr, &self.descrs[i])
-                {
-                    return Err(RawBufferError::IncompatibleRead {
-                        offset,
-                        read_length: length,
-                        write_length: self.lengths[i],
-                    });
-                }
-                return Ok(self.values[i]);
-            }
-        }
-        Err(RawBufferError::UninitializedRead { offset, length })
+        self.buffer.write_value(offset, length, descr, value)
     }
 }
 
@@ -2917,204 +2800,6 @@ mod tests {
     #[derive(Debug)]
     struct TestDescr;
     impl Descr for TestDescr {}
-
-    /// Create an int ArrayDescr for tests (base_size=0, item_size=8, Int).
-    fn int_descr() -> DescrRef {
-        majit_ir::descr::make_array_descr(0, 8, majit_ir::Type::Int)
-    }
-
-    /// Create an int ArrayDescr with specified item_size for tests.
-    fn int_descr_sz(item_size: usize) -> DescrRef {
-        majit_ir::descr::make_array_descr(0, item_size, majit_ir::Type::Int)
-    }
-
-    fn make_buf(size: usize) -> VirtualRawBufferInfo {
-        VirtualRawBufferInfo {
-            func: 0,
-            size,
-            offsets: Vec::new(),
-            lengths: Vec::new(),
-            descrs: Vec::new(),
-            values: Vec::new(),
-            last_guard_pos: -1,
-            calldescr: None,
-            cached_vinfo: std::cell::RefCell::new(None),
-        }
-    }
-
-    #[test]
-    fn rawbuffer_write_and_read() {
-        let mut buf = make_buf(32);
-        let d = int_descr();
-        let d4 = int_descr_sz(4);
-        buf.write_value(0, 8, d.clone(), OpRef::int_op(10)).unwrap();
-        buf.write_value(8, 4, d4.clone(), OpRef::int_op(20))
-            .unwrap();
-        buf.write_value(16, 8, d.clone(), OpRef::int_op(30))
-            .unwrap();
-
-        assert_eq!(buf.read_value(0, 8, &d).unwrap(), OpRef::int_op(10));
-        assert_eq!(buf.read_value(8, 4, &d4).unwrap(), OpRef::int_op(20));
-        assert_eq!(buf.read_value(16, 8, &d).unwrap(), OpRef::int_op(30));
-    }
-
-    #[test]
-    fn rawbuffer_update_same_offset() {
-        let mut buf = make_buf(16);
-        let d = int_descr();
-        buf.write_value(0, 8, d.clone(), OpRef::int_op(10)).unwrap();
-        buf.write_value(0, 8, d.clone(), OpRef::int_op(99)).unwrap();
-
-        assert_eq!(buf.read_value(0, 8, &d).unwrap(), OpRef::int_op(99));
-        assert_eq!(buf.offsets.len(), 1);
-    }
-
-    #[test]
-    fn rawbuffer_overlap_next() {
-        let mut buf = make_buf(32);
-        let d = int_descr();
-        buf.write_value(8, 8, d.clone(), OpRef::int_op(10)).unwrap();
-        // Write at offset 4 with length 8 overlaps [8, 16)
-        let err = buf
-            .write_value(4, 8, d.clone(), OpRef::int_op(20))
-            .unwrap_err();
-        assert!(matches!(err, RawBufferError::OverlappingWrite { .. }));
-    }
-
-    #[test]
-    fn rawbuffer_overlap_prev() {
-        let mut buf = make_buf(32);
-        let d = int_descr();
-        let d4 = int_descr_sz(4);
-        buf.write_value(0, 8, d.clone(), OpRef::int_op(10)).unwrap();
-        // Write at offset 4 overlaps with [0, 8)
-        let err = buf.write_value(4, 4, d4, OpRef::int_op(20)).unwrap_err();
-        assert!(matches!(err, RawBufferError::OverlappingWrite { .. }));
-    }
-
-    #[test]
-    fn rawbuffer_incompatible_length_at_same_offset() {
-        let mut buf = make_buf(16);
-        let d = int_descr();
-        let d4 = int_descr_sz(4);
-        buf.write_value(0, 8, d, OpRef::int_op(10)).unwrap();
-        let err = buf.write_value(0, 4, d4, OpRef::int_op(20)).unwrap_err();
-        assert!(matches!(err, RawBufferError::OverlappingWrite { .. }));
-    }
-
-    #[test]
-    fn rawbuffer_uninitialized_read() {
-        let buf = make_buf(16);
-        let d = int_descr();
-        let err = buf.read_value(0, 8, &d).unwrap_err();
-        assert_eq!(
-            err,
-            RawBufferError::UninitializedRead {
-                offset: 0,
-                length: 8
-            }
-        );
-    }
-
-    #[test]
-    fn rawbuffer_incompatible_read_length() {
-        let mut buf = make_buf(16);
-        let d = int_descr();
-        let d4 = int_descr_sz(4);
-        buf.write_value(0, 8, d, OpRef::int_op(10)).unwrap();
-        let err = buf.read_value(0, 4, &d4).unwrap_err();
-        assert_eq!(
-            err,
-            RawBufferError::IncompatibleRead {
-                offset: 0,
-                read_length: 4,
-                write_length: 8,
-            }
-        );
-    }
-
-    #[test]
-    fn rawbuffer_sorted_insertion() {
-        let mut buf = make_buf(32);
-        let d4 = int_descr_sz(4);
-        buf.write_value(16, 4, d4.clone(), OpRef::int_op(30))
-            .unwrap();
-        buf.write_value(0, 4, d4.clone(), OpRef::int_op(10))
-            .unwrap();
-        buf.write_value(8, 4, d4.clone(), OpRef::int_op(20))
-            .unwrap();
-
-        // Entries should be sorted by offset
-        assert_eq!(buf.offsets[0], 0);
-        assert_eq!(buf.offsets[1], 8);
-        assert_eq!(buf.offsets[2], 16);
-    }
-
-    /// test_rawbuffer.py:66 test_unpack_descrs
-    /// Two different descr objects with same (basesize, itemsize, signed)
-    /// must be compatible. Different signed-ness must be incompatible.
-    #[test]
-    fn test_unpack_descrs() {
-        use majit_ir::descr::SimpleArrayDescr;
-
-        // ArrayS_8_1 and ArrayS_8_2: same (base=0, item=8, signed=true)
-        let array_s_8_1: DescrRef = std::sync::Arc::new(SimpleArrayDescr::with_flag(
-            0,
-            0,
-            8,
-            0,
-            majit_ir::Type::Int,
-            majit_ir::descr::ArrayFlag::Signed,
-        ));
-        let array_s_8_2: DescrRef = std::sync::Arc::new(SimpleArrayDescr::with_flag(
-            1,
-            0,
-            8,
-            0,
-            majit_ir::Type::Int,
-            majit_ir::descr::ArrayFlag::Signed,
-        ));
-        // ArrayU_8: same size but unsigned
-        let array_u_8: DescrRef = std::sync::Arc::new(SimpleArrayDescr::with_flag(
-            2,
-            0,
-            8,
-            0,
-            majit_ir::Type::Int,
-            majit_ir::descr::ArrayFlag::Unsigned,
-        ));
-
-        assert!(!std::sync::Arc::ptr_eq(&array_s_8_1, &array_s_8_2));
-
-        let mut buf = make_buf(16);
-
-        // Write with ArrayS_8_1
-        buf.write_value(0, 4, array_s_8_1.clone(), OpRef::int_op(10))
-            .unwrap();
-
-        // Read with same descr
-        assert_eq!(
-            buf.read_value(0, 4, &array_s_8_1).unwrap(),
-            OpRef::int_op(10)
-        );
-        // Read with non-identical but compatible descr
-        assert_eq!(
-            buf.read_value(0, 4, &array_s_8_2).unwrap(),
-            OpRef::int_op(10)
-        );
-
-        // Overwrite with non-identical compatible descr
-        buf.write_value(0, 4, array_s_8_2.clone(), OpRef::int_op(20))
-            .unwrap();
-        assert_eq!(
-            buf.read_value(0, 4, &array_s_8_1).unwrap(),
-            OpRef::int_op(20)
-        );
-
-        // Incompatible descr (unsigned) must fail
-        assert!(buf.read_value(0, 4, &array_u_8).is_err());
-        assert!(buf.write_value(0, 4, array_u_8, OpRef::int_op(30)).is_err());
-    }
 
     #[test]
     fn test_ptr_info_factories() {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -17,6 +17,7 @@ pub mod intutils;
 // optimize module is at crate::optimize (RPython: metainterp/optimize.py)
 pub mod optimizer;
 pub mod pure;
+pub mod rawbuffer;
 pub mod renamer;
 pub mod rewrite;
 pub mod schedule;
@@ -714,6 +715,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 descr: None,
                 known_class: None,
                 field_oprefs: vi
+                    .buffer
                     .values
                     .iter()
                     .map(|vref| self.ctx.get_box_replacement(*vref))
@@ -2622,7 +2624,7 @@ impl OptContext {
                         .iter()
                         .flat_map(|row| row.iter().map(|(_, r)| *r))
                         .collect(),
-                    PtrInfo::VirtualRawBuffer(r) => r.values.clone(),
+                    PtrInfo::VirtualRawBuffer(r) => r.buffer.values.clone(),
                     _ => Vec::new(),
                 };
                 self.setinfo_from_preamble_list(&items, infos);
@@ -7224,17 +7226,7 @@ mod constant_ptr_info_tests {
             .expect("body-namespace OpRef must have a BoxRef slot");
         ctx.set_ptr_info(
             &parent_box,
-            PtrInfo::VirtualRawBuffer(VirtualRawBufferInfo {
-                func: 0,
-                size: 32,
-                offsets: Vec::new(),
-                lengths: Vec::new(),
-                descrs: Vec::new(),
-                values: Vec::new(),
-                last_guard_pos: -1,
-                calldescr: None,
-                cached_vinfo: std::cell::RefCell::new(None),
-            }),
+            PtrInfo::VirtualRawBuffer(VirtualRawBufferInfo::new(0, 32, None)),
         );
         ctx.set_ptr_info(
             &slice_box,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -716,7 +716,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 known_class: None,
                 field_oprefs: vi
                     .buffer
-                    .values
+                    .values()
                     .iter()
                     .map(|vref| self.ctx.get_box_replacement(*vref))
                     .collect(),
@@ -2624,7 +2624,7 @@ impl OptContext {
                         .iter()
                         .flat_map(|row| row.iter().map(|(_, r)| *r))
                         .collect(),
-                    PtrInfo::VirtualRawBuffer(r) => r.buffer.values.clone(),
+                    PtrInfo::VirtualRawBuffer(r) => r.buffer.values().to_vec(),
                     _ => Vec::new(),
                 };
                 self.setinfo_from_preamble_list(&items, infos);

--- a/majit/majit-metainterp/src/optimizeopt/rawbuffer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rawbuffer.rs
@@ -13,14 +13,14 @@ pub struct RawBuffer {
     /// unbounded int allows `basesize + itemsize*index` to be negative
     /// when `index < 0`. `write_value` keeps the list sorted using
     /// signed comparison (rawbuffer.py:104 `self.offsets[i] > offset`).
-    pub offsets: Vec<i64>,
+    offsets: Vec<i64>,
     /// rawbuffer.py:15: self.lengths — always non-negative (unsigned
     /// upstream itemsize from `unpack_arraydescr_size`).
-    pub lengths: Vec<usize>,
+    lengths: Vec<usize>,
     /// rawbuffer.py:16: self.descrs — per-entry ArrayDescr.
-    pub descrs: Vec<DescrRef>,
+    descrs: Vec<DescrRef>,
     /// rawbuffer.py:17: self.values
-    pub values: Vec<OpRef>,
+    values: Vec<OpRef>,
 }
 
 /// Error returned when a raw buffer operation violates invariants.
@@ -57,6 +57,53 @@ impl RawBuffer {
             descrs: Vec::new(),
             values: Vec::new(),
         }
+    }
+
+    pub fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    pub fn offsets(&self) -> &[i64] {
+        &self.offsets
+    }
+
+    pub fn lengths(&self) -> &[usize] {
+        &self.lengths
+    }
+
+    pub fn descrs(&self) -> &[DescrRef] {
+        &self.descrs
+    }
+
+    pub fn values(&self) -> &[OpRef] {
+        &self.values
+    }
+
+    pub fn iter_entries(&self) -> impl Iterator<Item = (i64, usize, &DescrRef, OpRef)> + '_ {
+        self.offsets
+            .iter()
+            .copied()
+            .zip(self.lengths.iter().copied())
+            .zip(self.descrs.iter())
+            .zip(self.values.iter().copied())
+            .map(|(((offset, length), descr), value)| (offset, length, descr, value))
+    }
+
+    pub(crate) fn drain_entries(&mut self) -> Vec<(i64, usize, DescrRef, OpRef)> {
+        let offsets = std::mem::take(&mut self.offsets);
+        let lengths = std::mem::take(&mut self.lengths);
+        let descrs = std::mem::take(&mut self.descrs);
+        let values = std::mem::take(&mut self.values);
+        debug_assert_eq!(offsets.len(), lengths.len());
+        debug_assert_eq!(offsets.len(), descrs.len());
+        debug_assert_eq!(offsets.len(), values.len());
+        offsets
+            .into_iter()
+            .zip(lengths)
+            .zip(descrs)
+            .zip(values)
+            .map(|(((offset, length), descr), value)| (offset, length, descr, value))
+            .collect()
     }
 
     /// rawbuffer.py:83: _descrs_are_compatible(d1, d2)
@@ -231,7 +278,7 @@ mod tests {
         buf.write_value(0, 8, d.clone(), OpRef::int_op(99)).unwrap();
 
         assert_eq!(buf.read_value(0, 8, &d).unwrap(), OpRef::int_op(99));
-        assert_eq!(buf.offsets.len(), 1);
+        assert_eq!(buf.offsets().len(), 1);
     }
 
     #[test]
@@ -310,9 +357,9 @@ mod tests {
             .unwrap();
 
         // Entries should be sorted by offset
-        assert_eq!(buf.offsets[0], 0);
-        assert_eq!(buf.offsets[1], 8);
-        assert_eq!(buf.offsets[2], 16);
+        assert_eq!(buf.offsets()[0], 0);
+        assert_eq!(buf.offsets()[1], 8);
+        assert_eq!(buf.offsets()[2], 16);
     }
 
     /// test_rawbuffer.py:66 test_unpack_descrs

--- a/majit/majit-metainterp/src/optimizeopt/rawbuffer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rawbuffer.rs
@@ -1,0 +1,383 @@
+//! Raw buffer write tracking.
+//!
+//! RPython parity target:
+//! `rpython/jit/metainterp/optimizeopt/rawbuffer.py`.
+
+use majit_ir::{DescrRef, OpRef};
+
+/// rawbuffer.py:13 RawBuffer — 4 parallel lists: offsets, lengths, descrs, values.
+/// Sorted by offset. Invariant: offsets[i]+lengths[i] <= offsets[i+1].
+#[derive(Clone, Debug)]
+pub struct RawBuffer {
+    /// rawbuffer.py:14: self.offsets — signed because RPython's
+    /// unbounded int allows `basesize + itemsize*index` to be negative
+    /// when `index < 0`. `write_value` keeps the list sorted using
+    /// signed comparison (rawbuffer.py:104 `self.offsets[i] > offset`).
+    pub offsets: Vec<i64>,
+    /// rawbuffer.py:15: self.lengths — always non-negative (unsigned
+    /// upstream itemsize from `unpack_arraydescr_size`).
+    pub lengths: Vec<usize>,
+    /// rawbuffer.py:16: self.descrs — per-entry ArrayDescr.
+    pub descrs: Vec<DescrRef>,
+    /// rawbuffer.py:17: self.values
+    pub values: Vec<OpRef>,
+}
+
+/// Error returned when a raw buffer operation violates invariants.
+///
+/// RPython raises `InvalidRawWrite` / `InvalidRawRead`. The Rust optimizer
+/// only needs the category to give up the optimization, but tests inspect the
+/// details to keep the port honest.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RawBufferError {
+    /// A write overlaps with an existing write, or a same-offset write has
+    /// incompatible length/descr. Both are `InvalidRawWrite` upstream.
+    OverlappingWrite {
+        new_offset: i64,
+        new_length: usize,
+        existing_offset: i64,
+        existing_length: usize,
+    },
+    /// A read from an offset that was never written.
+    UninitializedRead { offset: i64, length: usize },
+    /// A read whose length/offset doesn't match the write at that offset.
+    IncompatibleRead {
+        offset: i64,
+        read_length: usize,
+        write_length: usize,
+    },
+}
+
+impl RawBuffer {
+    /// Construct the empty rawbuffer.py parallel-list state.
+    pub fn new() -> Self {
+        Self {
+            offsets: Vec::new(),
+            lengths: Vec::new(),
+            descrs: Vec::new(),
+            values: Vec::new(),
+        }
+    }
+
+    /// rawbuffer.py:83: _descrs_are_compatible(d1, d2)
+    /// Two arraydescrs are compatible if they have the same basesize,
+    /// itemsize and sign.
+    fn descrs_are_compatible(d1: &DescrRef, d2: &DescrRef) -> bool {
+        let (Some(a1), Some(a2)) = (d1.as_array_descr(), d2.as_array_descr()) else {
+            return false;
+        };
+        a1.base_size() == a2.base_size()
+            && a1.item_size() == a2.item_size()
+            && a1.is_item_signed() == a2.is_item_signed()
+    }
+
+    /// rawbuffer.py:89: write_value(offset, length, descr, value).
+    ///
+    /// Maintains sorted order by offset. Same-offset update only
+    /// replaces value (rawbuffer.py:102), never descr.
+    pub fn write_value(
+        &mut self,
+        offset: i64,
+        length: usize,
+        descr: DescrRef,
+        value: OpRef,
+    ) -> Result<(), RawBufferError> {
+        // RPython rawbuffer.py uses unbounded-int `length`. The pyre
+        // length is `usize`; on 64-bit platforms `usize > i64::MAX`
+        // would wrap to a negative i64 and break the signed overlap
+        // checks. Realistically itemsize never approaches 2^63, but
+        // bail conservatively for spec-strict parity. Treat the
+        // failure as `InvalidRawWrite` (OverlappingWrite is the
+        // closest existing error variant).
+        let Ok(length_i) = i64::try_from(length) else {
+            return Err(RawBufferError::OverlappingWrite {
+                new_offset: offset,
+                new_length: length,
+                existing_offset: offset,
+                existing_length: length,
+            });
+        };
+        let mut insert_pos = 0;
+        for i in 0..self.offsets.len() {
+            let wo = self.offsets[i];
+            let wl = self.lengths[i];
+            if wo == offset {
+                // rawbuffer.py:94-95: length and descr must be compatible.
+                if wl != length || !Self::descrs_are_compatible(&descr, &self.descrs[i]) {
+                    return Err(RawBufferError::OverlappingWrite {
+                        new_offset: offset,
+                        new_length: length,
+                        existing_offset: wo,
+                        existing_length: wl,
+                    });
+                }
+                // rawbuffer.py:102: only replace value, keep existing descr.
+                self.values[i] = value;
+                return Ok(());
+            } else if wo > offset {
+                break;
+            }
+            insert_pos = i + 1;
+        }
+        // rawbuffer.py:108: `if i < len(self.offsets) and offset+length
+        // > self.offsets[i]: _invalid_write("overlap with next bytes")`.
+        // RPython int is unbounded; in Rust an i64 overflow on
+        // `offset + length` (length is non-negative usize) means the
+        // write extends past i64::MAX, which by signed compare is
+        // greater than every legitimate next_off — i.e. an overlap.
+        // checked_add returns None on overflow → treat as overlap.
+        if insert_pos < self.offsets.len() {
+            let next_off = self.offsets[insert_pos];
+            let end = offset.checked_add(length_i);
+            if end.map_or(true, |e| e > next_off) {
+                return Err(RawBufferError::OverlappingWrite {
+                    new_offset: offset,
+                    new_length: length,
+                    existing_offset: next_off,
+                    existing_length: self.lengths[insert_pos],
+                });
+            }
+        }
+        // rawbuffer.py:111: `if i > 0 and self.offsets[i-1]+self.lengths[i-1]
+        // > offset: _invalid_write("overlap with previous bytes")`.
+        // Same overflow argument: a saturated/overflowed `prev_off+prev_len`
+        // is unbounded-greater-than `offset` in RPython, so checked_add
+        // None → treat as overlap.
+        if insert_pos > 0 {
+            let prev_off = self.offsets[insert_pos - 1];
+            let prev_len = self.lengths[insert_pos - 1];
+            let prev_len_i = i64::try_from(prev_len).ok();
+            let prev_end = prev_len_i.and_then(|l| prev_off.checked_add(l));
+            if prev_end.map_or(true, |e| e > offset) {
+                return Err(RawBufferError::OverlappingWrite {
+                    new_offset: offset,
+                    new_length: length,
+                    existing_offset: prev_off,
+                    existing_length: prev_len,
+                });
+            }
+        }
+        // rawbuffer.py:115-118: insert new entry.
+        self.offsets.insert(insert_pos, offset);
+        self.lengths.insert(insert_pos, length);
+        self.descrs.insert(insert_pos, descr);
+        self.values.insert(insert_pos, value);
+        Ok(())
+    }
+
+    /// rawbuffer.py:120: read_value(offset, length, descr).
+    pub fn read_value(
+        &self,
+        offset: i64,
+        length: usize,
+        descr: &DescrRef,
+    ) -> Result<OpRef, RawBufferError> {
+        for i in 0..self.offsets.len() {
+            if self.offsets[i] == offset {
+                if self.lengths[i] != length || !Self::descrs_are_compatible(descr, &self.descrs[i])
+                {
+                    return Err(RawBufferError::IncompatibleRead {
+                        offset,
+                        read_length: length,
+                        write_length: self.lengths[i],
+                    });
+                }
+                return Ok(self.values[i]);
+            }
+        }
+        Err(RawBufferError::UninitializedRead { offset, length })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create an int ArrayDescr for tests (base_size=0, item_size=8, Int).
+    fn int_descr() -> DescrRef {
+        majit_ir::descr::make_array_descr(0, 8, majit_ir::Type::Int)
+    }
+
+    /// Create an int ArrayDescr with specified item_size for tests.
+    fn int_descr_sz(item_size: usize) -> DescrRef {
+        majit_ir::descr::make_array_descr(0, item_size, majit_ir::Type::Int)
+    }
+
+    fn make_buf(_size: usize) -> RawBuffer {
+        RawBuffer::new()
+    }
+
+    #[test]
+    fn rawbuffer_write_and_read() {
+        let mut buf = make_buf(32);
+        let d = int_descr();
+        let d4 = int_descr_sz(4);
+        buf.write_value(0, 8, d.clone(), OpRef::int_op(10)).unwrap();
+        buf.write_value(8, 4, d4.clone(), OpRef::int_op(20))
+            .unwrap();
+        buf.write_value(16, 8, d.clone(), OpRef::int_op(30))
+            .unwrap();
+
+        assert_eq!(buf.read_value(0, 8, &d).unwrap(), OpRef::int_op(10));
+        assert_eq!(buf.read_value(8, 4, &d4).unwrap(), OpRef::int_op(20));
+        assert_eq!(buf.read_value(16, 8, &d).unwrap(), OpRef::int_op(30));
+    }
+
+    #[test]
+    fn rawbuffer_update_same_offset() {
+        let mut buf = make_buf(16);
+        let d = int_descr();
+        buf.write_value(0, 8, d.clone(), OpRef::int_op(10)).unwrap();
+        buf.write_value(0, 8, d.clone(), OpRef::int_op(99)).unwrap();
+
+        assert_eq!(buf.read_value(0, 8, &d).unwrap(), OpRef::int_op(99));
+        assert_eq!(buf.offsets.len(), 1);
+    }
+
+    #[test]
+    fn rawbuffer_overlap_next() {
+        let mut buf = make_buf(32);
+        let d = int_descr();
+        buf.write_value(8, 8, d.clone(), OpRef::int_op(10)).unwrap();
+        // Write at offset 4 with length 8 overlaps [8, 16)
+        let err = buf
+            .write_value(4, 8, d.clone(), OpRef::int_op(20))
+            .unwrap_err();
+        assert!(matches!(err, RawBufferError::OverlappingWrite { .. }));
+    }
+
+    #[test]
+    fn rawbuffer_overlap_prev() {
+        let mut buf = make_buf(32);
+        let d = int_descr();
+        let d4 = int_descr_sz(4);
+        buf.write_value(0, 8, d.clone(), OpRef::int_op(10)).unwrap();
+        // Write at offset 4 overlaps with [0, 8)
+        let err = buf.write_value(4, 4, d4, OpRef::int_op(20)).unwrap_err();
+        assert!(matches!(err, RawBufferError::OverlappingWrite { .. }));
+    }
+
+    #[test]
+    fn rawbuffer_incompatible_length_at_same_offset() {
+        let mut buf = make_buf(16);
+        let d = int_descr();
+        let d4 = int_descr_sz(4);
+        buf.write_value(0, 8, d, OpRef::int_op(10)).unwrap();
+        let err = buf.write_value(0, 4, d4, OpRef::int_op(20)).unwrap_err();
+        assert!(matches!(err, RawBufferError::OverlappingWrite { .. }));
+    }
+
+    #[test]
+    fn rawbuffer_uninitialized_read() {
+        let buf = make_buf(16);
+        let d = int_descr();
+        let err = buf.read_value(0, 8, &d).unwrap_err();
+        assert_eq!(
+            err,
+            RawBufferError::UninitializedRead {
+                offset: 0,
+                length: 8
+            }
+        );
+    }
+
+    #[test]
+    fn rawbuffer_incompatible_read_length() {
+        let mut buf = make_buf(16);
+        let d = int_descr();
+        let d4 = int_descr_sz(4);
+        buf.write_value(0, 8, d, OpRef::int_op(10)).unwrap();
+        let err = buf.read_value(0, 4, &d4).unwrap_err();
+        assert_eq!(
+            err,
+            RawBufferError::IncompatibleRead {
+                offset: 0,
+                read_length: 4,
+                write_length: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn rawbuffer_sorted_insertion() {
+        let mut buf = make_buf(32);
+        let d4 = int_descr_sz(4);
+        buf.write_value(16, 4, d4.clone(), OpRef::int_op(30))
+            .unwrap();
+        buf.write_value(0, 4, d4.clone(), OpRef::int_op(10))
+            .unwrap();
+        buf.write_value(8, 4, d4.clone(), OpRef::int_op(20))
+            .unwrap();
+
+        // Entries should be sorted by offset
+        assert_eq!(buf.offsets[0], 0);
+        assert_eq!(buf.offsets[1], 8);
+        assert_eq!(buf.offsets[2], 16);
+    }
+
+    /// test_rawbuffer.py:66 test_unpack_descrs
+    /// Two different descr objects with same (basesize, itemsize, signed)
+    /// must be compatible. Different signed-ness must be incompatible.
+    #[test]
+    fn test_unpack_descrs() {
+        use majit_ir::descr::SimpleArrayDescr;
+
+        // ArrayS_8_1 and ArrayS_8_2: same (base=0, item=8, signed=true)
+        let array_s_8_1: DescrRef = std::sync::Arc::new(SimpleArrayDescr::with_flag(
+            0,
+            0,
+            8,
+            0,
+            majit_ir::Type::Int,
+            majit_ir::descr::ArrayFlag::Signed,
+        ));
+        let array_s_8_2: DescrRef = std::sync::Arc::new(SimpleArrayDescr::with_flag(
+            1,
+            0,
+            8,
+            0,
+            majit_ir::Type::Int,
+            majit_ir::descr::ArrayFlag::Signed,
+        ));
+        // ArrayU_8: same size but unsigned
+        let array_u_8: DescrRef = std::sync::Arc::new(SimpleArrayDescr::with_flag(
+            2,
+            0,
+            8,
+            0,
+            majit_ir::Type::Int,
+            majit_ir::descr::ArrayFlag::Unsigned,
+        ));
+
+        assert!(!std::sync::Arc::ptr_eq(&array_s_8_1, &array_s_8_2));
+
+        let mut buf = make_buf(16);
+
+        // Write with ArrayS_8_1
+        buf.write_value(0, 4, array_s_8_1.clone(), OpRef::int_op(10))
+            .unwrap();
+
+        // Read with same descr
+        assert_eq!(
+            buf.read_value(0, 4, &array_s_8_1).unwrap(),
+            OpRef::int_op(10)
+        );
+        // Read with non-identical but compatible descr
+        assert_eq!(
+            buf.read_value(0, 4, &array_s_8_2).unwrap(),
+            OpRef::int_op(10)
+        );
+
+        // Overwrite with non-identical compatible descr
+        buf.write_value(0, 4, array_s_8_2.clone(), OpRef::int_op(20))
+            .unwrap();
+        assert_eq!(
+            buf.read_value(0, 4, &array_s_8_1).unwrap(),
+            OpRef::int_op(20)
+        );
+
+        // Incompatible descr (unsigned) must fail
+        assert!(buf.read_value(0, 4, &array_u_8).is_err());
+        assert!(buf.write_value(0, 4, array_u_8, OpRef::int_op(30)).is_err());
+    }
+}

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -370,17 +370,11 @@ impl OptVirtualize {
         source_op: &Op,
         ctx: &mut OptContext,
     ) {
-        let opinfo = crate::optimizeopt::info::VirtualRawBufferInfo {
+        let opinfo = crate::optimizeopt::info::VirtualRawBufferInfo::new(
             func,
             size,
-            offsets: Vec::new(),
-            lengths: Vec::new(),
-            descrs: Vec::new(),
-            values: Vec::new(),
-            last_guard_pos: -1,
-            calldescr: source_op.descr.clone(),
-            cached_vinfo: std::cell::RefCell::new(None),
-        };
+            source_op.descr.clone(),
+        );
         let b = ctx
             .ensure_box(source_op.pos)
             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -3883,17 +3877,7 @@ mod tests {
                 .expect("body-namespace OpRef must have a BoxRef slot");
             ctx.set_ptr_info(
                 &b,
-                PtrInfo::VirtualRawBuffer(VirtualRawBufferInfo {
-                    func: 0,
-                    size,
-                    offsets: Vec::new(),
-                    lengths: Vec::new(),
-                    descrs: Vec::new(),
-                    values: Vec::new(),
-                    last_guard_pos: -1,
-                    calldescr: None,
-                    cached_vinfo: std::cell::RefCell::new(None),
-                }),
+                PtrInfo::VirtualRawBuffer(VirtualRawBufferInfo::new(0, size, None)),
             );
         }
 


### PR DESCRIPTION
## Summary

This pull request adds a new raw buffer write-tracking module to the optimizer, refactors how virtual raw buffer information is managed, and updates related code to use the new structure. The main goal is to improve the handling and tracking of raw buffer writes in the optimizer, closely matching the RPython implementation. Key changes include the introduction of the `rawbuffer` module, updating the `VirtualRawBufferInfo` structure, and refactoring code to use these new abstractions.

**Raw buffer tracking improvements:**

- Added a new `rawbuffer` module (`rawbuffer.rs`) implementing raw buffer write tracking, including the `RawBuffer` struct, error handling, and comprehensive tests to ensure correct behavior and RPython parity.
- Updated the `VirtualRawBufferInfo` structure and its usage to encapsulate a `RawBuffer` instance instead of managing parallel lists directly, simplifying state management and improving code clarity.

**Integration and refactoring:**

- Modified the optimizer and related code to use the new `buffer` field of `VirtualRawBufferInfo` for accessing values, replacing direct access to parallel lists.
- Registered the new `rawbuffer` module in the optimizer's module tree for proper integration.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Cases Where This Patch Regressed PyPy Parity Compared To Main

  None found.

  The extraction of RawBuffer into majit/majit-metainterp/src/optimizeopt/rawbuffer.rs:11 improves structural parity: RPython has a
  separate RawBuffer object stored on RawBufferPtrInfo.buffer, and the patch now mirrors that shape via majit/majit-metainterp/src/
  optimizeopt/info.rs:2723.

  2. Other Mismatches Introduced By This Patch

  None found.

  The changed call sites appear mechanically equivalent: offsets, descrs, and values now route through vinfo.buffer, matching
  RPython’s self._get_buffer() usage in RawBufferPtrInfo.

  3. Mismatches That Already Existed Before This Patch

  RawBufferPtrInfo.is_virtual() sentinel is still not represented for raw buffers. RPython sets self.size = -1 when forcing, and
  is_virtual() returns self.size != -1 in rpython/jit/metainterp/optimizeopt/info.py:417-421. Rust still treats every
  PtrInfo::VirtualRawBuffer(_) as virtual in majit/majit-metainterp/src/optimizeopt/info.rs:780, and forcing drains buffer state
  without changing size to a non-virtual sentinel in majit/majit-metainterp/src/optimizeopt/info.rs:1611. This existed on upstream/
  main; the patch did not introduce it.

  Rust cannot represent RPython’s non-virtual RawBufferPtrInfo(size=-1) shape because majit/majit-metainterp/src/optimizeopt/
  info.rs:2721 is usize. That was also already true before this patch.

  4. Structural Adaptations

  RawBuffer omits RPython’s cpu and logops fields. RPython uses cpu.unpack_arraydescr_size() for descriptor compatibility in
  rawbuffer.py:83-87; Rust uses DescrRef::as_array_descr() and compares base size, item size, and signedness in majit/majit-
  metainterp/src/optimizeopt/rawbuffer.rs:65. This is an implementation-language adaptation, not a parity regression.

  Rust returns RawBufferError instead of raising InvalidRawWrite / InvalidRawRead. The optimizer callers still treat failures the
  same way as RPython’s except InvalidRawOperation: pass, so this is a Rust error-handling adaptation.

  Rust keeps calldescr on VirtualRawBufferInfo so force_box_impl can reconstruct the raw malloc call. RPython keeps the original
  operation object and does not need this extra field. This is a structural adaptation to Rust’s representation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated raw buffer management logic into a shared module with unified error handling and validation for write and read operations, including overlap detection and invariant checking.
  * Refactored internal data structures to centralize buffer state using a composable component architecture instead of separate vector fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/51)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->