### PR TITLE
Introduce CompileData parity markers and align with RPython

### DIFF
--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -234,15 +234,11 @@ pub struct DeadFrameArtifacts {
 /// state that RPython would store on the corresponding object.
 pub struct CompileData<'a> {
     pub trace: &'a TreeLoop,
-    pub call_pure_results: &'a HashMap<Vec<Value>, Value>,
 }
 
 impl<'a> CompileData<'a> {
-    pub fn new(trace: &'a TreeLoop, call_pure_results: &'a HashMap<Vec<Value>, Value>) -> Self {
-        Self {
-            trace,
-            call_pure_results,
-        }
+    pub fn new(trace: &'a TreeLoop) -> Self {
+        Self { trace }
     }
 
     pub fn inputargs(&self) -> &'a [InputArg] {
@@ -262,6 +258,7 @@ impl<'a> CompileData<'a> {
 pub struct PreambleCompileData<'a> {
     pub base: CompileData<'a>,
     pub runtime_boxes: &'a [OpRef],
+    pub call_pure_results: &'a HashMap<Vec<Value>, Value>,
     pub enable_opts: &'a [String],
 }
 
@@ -273,8 +270,9 @@ impl<'a> PreambleCompileData<'a> {
         enable_opts: &'a [String],
     ) -> Self {
         Self {
-            base: CompileData::new(trace, call_pure_results),
+            base: CompileData::new(trace),
             runtime_boxes,
+            call_pure_results,
             enable_opts,
         }
     }
@@ -284,6 +282,7 @@ impl<'a> PreambleCompileData<'a> {
 pub struct SimpleCompileData<'a> {
     pub base: CompileData<'a>,
     pub resumestorage: Option<&'a ResumeStorage>,
+    pub call_pure_results: &'a HashMap<Vec<Value>, Value>,
     pub enable_opts: &'a [String],
 }
 
@@ -295,8 +294,9 @@ impl<'a> SimpleCompileData<'a> {
         enable_opts: &'a [String],
     ) -> Self {
         Self {
-            base: CompileData::new(trace, call_pure_results),
+            base: CompileData::new(trace),
             resumestorage,
+            call_pure_results,
             enable_opts,
         }
     }
@@ -307,6 +307,7 @@ pub struct BridgeCompileData<'a> {
     pub base: CompileData<'a>,
     pub runtime_boxes: &'a [OpRef],
     pub resumestorage: Option<&'a ResumeStorage>,
+    pub call_pure_results: &'a HashMap<Vec<Value>, Value>,
     pub inline_short_preamble: bool,
     pub enable_opts: &'a [String],
 }
@@ -321,9 +322,10 @@ impl<'a> BridgeCompileData<'a> {
         enable_opts: &'a [String],
     ) -> Self {
         Self {
-            base: CompileData::new(trace, call_pure_results),
+            base: CompileData::new(trace),
             runtime_boxes,
             resumestorage,
+            call_pure_results,
             inline_short_preamble,
             enable_opts,
         }
@@ -335,6 +337,7 @@ pub struct UnrolledLoopData<'a> {
     pub base: CompileData<'a>,
     pub celltoken: &'a Arc<JitCellToken>,
     pub state: &'a crate::optimizeopt::unroll::ExportedState,
+    pub call_pure_results: &'a HashMap<Vec<Value>, Value>,
     pub enable_opts: &'a [String],
 }
 
@@ -347,9 +350,10 @@ impl<'a> UnrolledLoopData<'a> {
         enable_opts: &'a [String],
     ) -> Self {
         Self {
-            base: CompileData::new(trace, call_pure_results),
+            base: CompileData::new(trace),
             celltoken,
             state,
+            call_pure_results,
             enable_opts,
         }
     }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -30,10 +30,11 @@ use majit_ir::{
 };
 
 use crate::blackhole::ExceptionState;
+use crate::history::TreeLoop;
 use crate::pyjitpl::{CompiledTrace, StoredExitLayout};
 use crate::resume::{
     ResumeData, ResumeDataLoopMemo, ResumeDataVirtualAdder, ResumeFrameLayoutSummary,
-    ResumeLayoutSummary, ResumeValueSource,
+    ResumeLayoutSummary, ResumeStorage, ResumeValueSource,
 };
 use crate::trace_ctx::{MergePoint, TraceCtx};
 
@@ -217,6 +218,128 @@ pub struct DeadFrameArtifacts {
     pub exit_layout: CompiledExitLayout,
     pub savedata: Option<GcRef>,
     pub exception: ExceptionState,
+}
+
+// ── CompileData class hierarchy markers (compile.py:31-139) ─────────────
+
+/// `compile.py:31` `class CompileData(object)`.
+///
+/// This is intentionally only the shared input bundle for now.  RPython
+/// stores optimization-path state on subclasses, and pyre's larger compile
+/// flow is still flattened in `pyjitpl/mod.rs`; the named Rust structs below
+/// give each path the same boundary without changing backend behavior.
+pub struct CompileData<'a> {
+    pub trace: &'a TreeLoop,
+    pub call_pure_results: &'a HashMap<Vec<Value>, Value>,
+}
+
+impl<'a> CompileData<'a> {
+    pub fn new(trace: &'a TreeLoop, call_pure_results: &'a HashMap<Vec<Value>, Value>) -> Self {
+        Self {
+            trace,
+            call_pure_results,
+        }
+    }
+
+    pub fn inputargs(&self) -> &'a [InputArg] {
+        &self.trace.inputargs
+    }
+
+    pub fn operations(&self) -> &'a [Op] {
+        &self.trace.ops
+    }
+
+    pub fn snapshots(&self) -> &'a [crate::recorder::Snapshot] {
+        &self.trace.snapshots
+    }
+}
+
+/// `compile.py:62` `class PreambleCompileData(CompileData)`.
+pub struct PreambleCompileData<'a> {
+    pub base: CompileData<'a>,
+    pub runtime_boxes: &'a [OpRef],
+}
+
+impl<'a> PreambleCompileData<'a> {
+    pub fn new(
+        trace: &'a TreeLoop,
+        runtime_boxes: &'a [OpRef],
+        call_pure_results: &'a HashMap<Vec<Value>, Value>,
+    ) -> Self {
+        Self {
+            base: CompileData::new(trace, call_pure_results),
+            runtime_boxes,
+        }
+    }
+}
+
+/// `compile.py:81` `class SimpleCompileData(CompileData)`.
+pub struct SimpleCompileData<'a> {
+    pub base: CompileData<'a>,
+    pub resumestorage: Option<&'a ResumeStorage>,
+}
+
+impl<'a> SimpleCompileData<'a> {
+    pub fn new(
+        trace: &'a TreeLoop,
+        resumestorage: Option<&'a ResumeStorage>,
+        call_pure_results: &'a HashMap<Vec<Value>, Value>,
+    ) -> Self {
+        Self {
+            base: CompileData::new(trace, call_pure_results),
+            resumestorage,
+        }
+    }
+}
+
+/// `compile.py:98` `class BridgeCompileData(CompileData)`.
+pub struct BridgeCompileData<'a> {
+    pub base: CompileData<'a>,
+    pub runtime_boxes: &'a [OpRef],
+    pub resumestorage: Option<&'a ResumeStorage>,
+    pub inline_short_preamble: bool,
+}
+
+impl<'a> BridgeCompileData<'a> {
+    pub fn new(
+        trace: &'a TreeLoop,
+        runtime_boxes: &'a [OpRef],
+        resumestorage: Option<&'a ResumeStorage>,
+        call_pure_results: &'a HashMap<Vec<Value>, Value>,
+        inline_short_preamble: bool,
+    ) -> Self {
+        Self {
+            base: CompileData::new(trace, call_pure_results),
+            runtime_boxes,
+            resumestorage,
+            inline_short_preamble,
+        }
+    }
+}
+
+/// `compile.py:122` `class UnrolledLoopData(CompileData)`.
+pub struct UnrolledLoopData<'a> {
+    pub base: CompileData<'a>,
+    /// RPython has this at construction time. Some pyre paths allocate the
+    /// `JitCellToken` after optimization for backend bookkeeping, so the
+    /// marker accepts `None` until that larger flow is refactored.
+    pub celltoken: Option<&'a Arc<JitCellToken>>,
+    pub state: Option<&'a crate::optimizeopt::unroll::ExportedState>,
+}
+
+impl<'a> UnrolledLoopData<'a> {
+    pub fn new(
+        trace: &'a TreeLoop,
+        celltoken: Option<&'a Arc<JitCellToken>>,
+        state: Option<&'a crate::optimizeopt::unroll::ExportedState>,
+        call_pure_results: &'a HashMap<Vec<Value>, Value>,
+    ) -> Self {
+        Self {
+            base: CompileData::new(trace, call_pure_results),
+            celltoken,
+            state,
+        }
+    }
 }
 
 // ── Compilation helper functions ────────────────────────────────────────

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -220,14 +220,18 @@ pub struct DeadFrameArtifacts {
     pub exception: ExceptionState,
 }
 
-// ── CompileData class hierarchy markers (compile.py:31-139) ─────────────
+// ── CompileData input bundles (compile.py:31-139) ───────────────────────
 
 /// `compile.py:31` `class CompileData(object)`.
 ///
-/// This is intentionally only the shared input bundle for now.  RPython
-/// stores optimization-path state on subclasses, and pyre's larger compile
-/// flow is still flattened in `pyjitpl/mod.rs`; the named Rust structs below
-/// give each path the same boundary without changing backend behavior.
+/// PYRE-ADAPTATION: RPython's `CompileData.optimize_trace()` builds the
+/// optimizer chain, logs, dispatches to the subclass `optimize()`, and clears
+/// forwarded boxes in one Python method. Pyre's optimizer entry points borrow
+/// `MetaInterp`, backend state, constant pools, and snapshot side tables
+/// directly in `pyjitpl/mod.rs`, so that dispatch remains flattened there.
+/// These structs intentionally model the RPython constructor payloads only;
+/// call sites must still pass the same trace/runtime/resume/call-pure/opts
+/// state that RPython would store on the corresponding object.
 pub struct CompileData<'a> {
     pub trace: &'a TreeLoop,
     pub call_pure_results: &'a HashMap<Vec<Value>, Value>,
@@ -258,6 +262,7 @@ impl<'a> CompileData<'a> {
 pub struct PreambleCompileData<'a> {
     pub base: CompileData<'a>,
     pub runtime_boxes: &'a [OpRef],
+    pub enable_opts: &'a [String],
 }
 
 impl<'a> PreambleCompileData<'a> {
@@ -265,10 +270,12 @@ impl<'a> PreambleCompileData<'a> {
         trace: &'a TreeLoop,
         runtime_boxes: &'a [OpRef],
         call_pure_results: &'a HashMap<Vec<Value>, Value>,
+        enable_opts: &'a [String],
     ) -> Self {
         Self {
             base: CompileData::new(trace, call_pure_results),
             runtime_boxes,
+            enable_opts,
         }
     }
 }
@@ -277,6 +284,7 @@ impl<'a> PreambleCompileData<'a> {
 pub struct SimpleCompileData<'a> {
     pub base: CompileData<'a>,
     pub resumestorage: Option<&'a ResumeStorage>,
+    pub enable_opts: &'a [String],
 }
 
 impl<'a> SimpleCompileData<'a> {
@@ -284,10 +292,12 @@ impl<'a> SimpleCompileData<'a> {
         trace: &'a TreeLoop,
         resumestorage: Option<&'a ResumeStorage>,
         call_pure_results: &'a HashMap<Vec<Value>, Value>,
+        enable_opts: &'a [String],
     ) -> Self {
         Self {
             base: CompileData::new(trace, call_pure_results),
             resumestorage,
+            enable_opts,
         }
     }
 }
@@ -298,6 +308,7 @@ pub struct BridgeCompileData<'a> {
     pub runtime_boxes: &'a [OpRef],
     pub resumestorage: Option<&'a ResumeStorage>,
     pub inline_short_preamble: bool,
+    pub enable_opts: &'a [String],
 }
 
 impl<'a> BridgeCompileData<'a> {
@@ -307,12 +318,14 @@ impl<'a> BridgeCompileData<'a> {
         resumestorage: Option<&'a ResumeStorage>,
         call_pure_results: &'a HashMap<Vec<Value>, Value>,
         inline_short_preamble: bool,
+        enable_opts: &'a [String],
     ) -> Self {
         Self {
             base: CompileData::new(trace, call_pure_results),
             runtime_boxes,
             resumestorage,
             inline_short_preamble,
+            enable_opts,
         }
     }
 }
@@ -320,24 +333,24 @@ impl<'a> BridgeCompileData<'a> {
 /// `compile.py:122` `class UnrolledLoopData(CompileData)`.
 pub struct UnrolledLoopData<'a> {
     pub base: CompileData<'a>,
-    /// RPython has this at construction time. Some pyre paths allocate the
-    /// `JitCellToken` after optimization for backend bookkeeping, so the
-    /// marker accepts `None` until that larger flow is refactored.
-    pub celltoken: Option<&'a Arc<JitCellToken>>,
-    pub state: Option<&'a crate::optimizeopt::unroll::ExportedState>,
+    pub celltoken: &'a Arc<JitCellToken>,
+    pub state: &'a crate::optimizeopt::unroll::ExportedState,
+    pub enable_opts: &'a [String],
 }
 
 impl<'a> UnrolledLoopData<'a> {
     pub fn new(
         trace: &'a TreeLoop,
-        celltoken: Option<&'a Arc<JitCellToken>>,
-        state: Option<&'a crate::optimizeopt::unroll::ExportedState>,
+        celltoken: &'a Arc<JitCellToken>,
+        state: &'a crate::optimizeopt::unroll::ExportedState,
         call_pure_results: &'a HashMap<Vec<Value>, Value>,
+        enable_opts: &'a [String],
     ) -> Self {
         Self {
             base: CompileData::new(trace, call_pure_results),
             celltoken,
             state,
+            enable_opts,
         }
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3032,6 +3032,7 @@ impl Optimizer {
         constants: &mut std::collections::HashMap<u32, i64>,
         num_inputs: usize,
         front_target_tokens: &mut Vec<crate::optimizeopt::unroll::TargetToken>,
+        runtime_boxes: &[OpRef],
         inline_short_preamble: bool,
         retraced_count: u32,
         retrace_limit: u32,
@@ -3055,9 +3056,10 @@ impl Optimizer {
         // Store as pending — setup() inside optimize_with_constants_and_inputs
         // clears pass state, so we apply AFTER setup.
         self.pending_bridge_rd = pending_bridge_rd;
-        // unroll.py:183 parity: save pre-optimization JUMP args as
-        // runtime_boxes. RPython passes the original live_arg_boxes from
-        // compile_trace / guard failure, not the optimized jump args.
+        // The prepared trace's pre-optimization JUMP args are used when
+        // emitting a fallback jump through send_extra_operation.  RPython's
+        // separate `runtime_boxes` argument is threaded below into
+        // jump_to_existing_trace for virtual-state guard generation.
         let pre_opt_jump_args: Vec<OpRef> = ops
             .last()
             .filter(|op| op.opcode == OpCode::Jump)
@@ -3189,7 +3191,7 @@ impl Optimizer {
             self,
             &mut ctx,
             false,
-            &pre_opt_jump_args,
+            runtime_boxes,
             None,
         ) {
             Ok(vs) => vs,
@@ -3246,7 +3248,7 @@ impl Optimizer {
             self,
             &mut ctx,
             true,
-            &pre_opt_jump_args,
+            runtime_boxes,
             None,
         ) {
             Ok(vs) => vs,

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -8463,10 +8463,17 @@ impl<M: Clone> MetaInterp<M> {
             pending_bridge_rd,
             bridge_inputarg_base,
         );
+        // compile.py:1056-1060 / unroll.py:183-184 parity:
+        // BridgeCompileData.runtime_boxes is the original live box list
+        // passed to compile_trace, i.e. the bridge's closing JUMP args before
+        // trace.get_iter() allocates fresh input boxes for optimization.
+        let bridge_runtime_boxes: Vec<OpRef> = bridge_ops
+            .last()
+            .filter(|op| op.opcode == OpCode::Jump)
+            .map(|op| op.args.to_vec())
+            .unwrap_or_default();
         let bridge_trace_data =
             TreeLoop::with_snapshots(prepared.inputargs.clone(), prepared.ops.clone(), Vec::new());
-        let bridge_runtime_boxes: Vec<OpRef> =
-            prepared.inputargs.iter().map(|ia| ia.opref()).collect();
         let bridge_resumestorage = prepared
             .pending_bridge_rd
             .as_ref()

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -3965,8 +3965,9 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             trace
         };
+        let enable_opts = self.warm_state.get_enable_opts();
         let preamble_data =
-            compile::PreambleCompileData::new(&trace, jump_args, &call_pure_results);
+            compile::PreambleCompileData::new(&trace, jump_args, &call_pure_results, enable_opts);
         let trace_snapshots = preamble_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
@@ -4043,12 +4044,11 @@ impl<M: Clone> MetaInterp<M> {
         // Phase 2 InvalidLoop. Phase 1 writes to phase1_out on the caller's
         // stack BEFORE Phase 2 starts. If Phase 2 panics, phase1_out still
         // holds the Phase 1 results.
-        let loop_data = compile::UnrolledLoopData::new(&trace, None, None, &call_pure_results);
         let mut phase1_out: Option<(Vec<Op>, crate::optimizeopt::unroll::ExportedState)> = None;
         let mut updated_constant_types = constant_types.clone();
         let optimize_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let result = unroll_opt.optimize_trace_with_constants_and_inputs_vable_out(
-                loop_data.base.operations(),
+                &trace_ops,
                 &mut constants,
                 num_trace_inputargs,
                 vable_config.clone(),
@@ -4730,6 +4730,7 @@ impl<M: Clone> MetaInterp<M> {
             .collect();
         let mut constants = ctx.constants.snapshot();
         let mut constant_types = ctx.constants.constant_types_snapshot();
+        let call_pure_results = ctx.call_pure_results.clone();
         let trace_snapshots = ctx.snapshots().to_vec();
         let (
             snapshot_boxes,
@@ -4820,6 +4821,7 @@ impl<M: Clone> MetaInterp<M> {
                     snapshot_vable_boxes,
                     snapshot_vref_boxes,
                     snapshot_frame_pcs,
+                    call_pure_results,
                 );
                 if success {
                     CompileOutcome::Compiled {
@@ -4933,6 +4935,7 @@ impl<M: Clone> MetaInterp<M> {
             mut constants,
             mut constant_types,
             trace,
+            call_pure_results,
         ) = {
             let green_key = ctx.green_key;
             let header_pc = ctx.header_pc;
@@ -4953,6 +4956,7 @@ impl<M: Clone> MetaInterp<M> {
             let constants = ctx.constants.snapshot();
             let constant_types = ctx.constants.constant_types_snapshot();
             let initial_inputarg_consts = ctx.initial_inputarg_consts.clone();
+            let call_pure_results = ctx.take_call_pure_results();
 
             // compile.py:358-362 records the closing JUMP on the same history
             // that `cut_trace_from` views. Rust materializes TreeLoop eagerly,
@@ -4987,16 +4991,24 @@ impl<M: Clone> MetaInterp<M> {
                 constants,
                 constant_types,
                 trace,
+                call_pure_results,
             )
         };
 
-        let call_pure_results = HashMap::new();
+        let Some(loop_jitcell_token) = self
+            .compiled_loops
+            .get(&green_key)
+            .map(|compiled| Arc::clone(&compiled.token))
+        else {
+            return false;
+        };
         let trace_ops = {
             let loop_data = compile::UnrolledLoopData::new(
                 &trace,
-                None,
-                Some(&start_state),
+                &loop_jitcell_token,
+                &start_state,
                 &call_pure_results,
+                self.warm_state.get_enable_opts(),
             );
             loop_data.base.operations().to_vec()
         };
@@ -5025,6 +5037,7 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.max_retrace_guards = self.warm_state.max_retrace_guards();
         unroll_opt.constant_types = constant_types.clone();
         unroll_opt.callinfocollection = self.callinfocollection.clone();
+        unroll_opt.call_pure_results = call_pure_results.clone();
         let (
             retrace_snapshot_boxes,
             retrace_snapshot_frame_sizes,
@@ -5490,7 +5503,12 @@ impl<M: Clone> MetaInterp<M> {
         // returns a snapshot-less TreeLoop post-Task #70.
         let mut trace = recorder.get_trace();
         trace.snapshots = std::mem::take(&mut ctx.snapshots);
-        let simple_data = compile::SimpleCompileData::new(&trace, None, &call_pure_results);
+        let simple_data = compile::SimpleCompileData::new(
+            &trace,
+            None,
+            &call_pure_results,
+            self.warm_state.get_enable_opts(),
+        );
         let trace_snapshots = simple_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
@@ -5898,7 +5916,12 @@ impl<M: Clone> MetaInterp<M> {
         // returns a snapshot-less TreeLoop post-Task #70.
         let mut trace = recorder.get_trace();
         trace.snapshots = std::mem::take(&mut ctx.snapshots);
-        let simple_data = compile::SimpleCompileData::new(&trace, None, &call_pure_results);
+        let simple_data = compile::SimpleCompileData::new(
+            &trace,
+            None,
+            &call_pure_results,
+            self.warm_state.get_enable_opts(),
+        );
         let trace_snapshots = simple_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
@@ -8286,6 +8309,7 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_vable_boxes: SnapshotBoxes,
         snapshot_vref_boxes: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
+        call_pure_results: HashMap<Vec<Value>, Value>,
     ) -> bool {
         if !self.compiled_loops.contains_key(&green_key) {
             return false;
@@ -8439,16 +8463,34 @@ impl<M: Clone> MetaInterp<M> {
             pending_bridge_rd,
             bridge_inputarg_base,
         );
-        let call_pure_results = HashMap::new();
         let bridge_trace_data =
             TreeLoop::with_snapshots(prepared.inputargs.clone(), prepared.ops.clone(), Vec::new());
-        let bridge_data = compile::BridgeCompileData::new(
-            &bridge_trace_data,
-            &[],
-            None,
-            &call_pure_results,
-            inline_short_preamble,
-        );
+        let bridge_runtime_boxes: Vec<OpRef> =
+            prepared.inputargs.iter().map(|ia| ia.opref()).collect();
+        let bridge_resumestorage = prepared
+            .pending_bridge_rd
+            .as_ref()
+            .map(|pending| pending.storage.as_ref());
+        let (bridge_inputarg_types, bridge_inline_short_preamble, bridge_call_pure_results) = {
+            let bridge_data = compile::BridgeCompileData::new(
+                &bridge_trace_data,
+                &bridge_runtime_boxes,
+                bridge_resumestorage,
+                &call_pure_results,
+                inline_short_preamble,
+                self.warm_state.get_enable_opts(),
+            );
+            (
+                bridge_data
+                    .base
+                    .inputargs()
+                    .iter()
+                    .map(|ia| ia.tp)
+                    .collect::<Vec<_>>(),
+                bridge_data.inline_short_preamble,
+                bridge_data.base.call_pure_results.clone(),
+            )
+        };
         let bridge_inputargs = prepared.inputargs.as_slice();
         let bridge_ops = prepared.ops.as_slice();
         let pending_bridge_rd = prepared.pending_bridge_rd;
@@ -8461,6 +8503,7 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.set_pending_box_pool(prepared.box_pool);
         let mut constants = constants;
         optimizer.constant_types = constant_types.clone();
+        optimizer.call_pure_results = bridge_call_pure_results;
         // history.py InputArg.type parity: each `InputArg` carries its type
         // in the typed OpRef variant tag (`OpRef::input_arg_typed`); the
         // legacy `constant_types.insert(arg.index, arg.tp)` writes were
@@ -8472,12 +8515,7 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
         // Store bridge inputarg types so export_state can propagate them
         // to ExportedState.renamed_inputarg_types (RPython Box type parity).
-        optimizer.trace_inputarg_types = bridge_data
-            .base
-            .inputargs()
-            .iter()
-            .map(|ia| ia.tp)
-            .collect();
+        optimizer.trace_inputarg_types = bridge_inputarg_types;
 
         // RPython-orthodox: no source→bridge constant_types merge.
         // bridgeopt.py / unroll.py do not copy the source loop's constant
@@ -8511,7 +8549,7 @@ impl<M: Clone> MetaInterp<M> {
                     &mut constants,
                     bridge_inputargs.len(),
                     &mut compiled.front_target_tokens,
-                    bridge_data.inline_short_preamble,
+                    bridge_inline_short_preamble,
                     retraced_count,
                     retrace_limit,
                     pending_bridge_rd,

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -3965,7 +3965,9 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             trace
         };
-        let trace_snapshots = trace.snapshots.clone();
+        let preamble_data =
+            compile::PreambleCompileData::new(&trace, jump_args, &call_pure_results);
+        let trace_snapshots = preamble_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
         // sees the post-GC addresses for any object that moved since the last
@@ -3973,7 +3975,7 @@ impl<M: Clone> MetaInterp<M> {
         ctx.constants.refresh_from_gc();
         let (mut constants, mut constant_types) = ctx.constants.into_inner_with_types();
 
-        let trace_ops = trace.ops.clone();
+        let trace_ops = preamble_data.base.operations().to_vec();
         if crate::majit_log_enabled() {
             eprintln!("--- trace (before opt) ---");
             eprint!("{}", majit_ir::format_trace(&trace_ops, &constants));
@@ -4008,10 +4010,15 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.max_retrace_guards = self.warm_state.max_retrace_guards();
         unroll_opt.constant_types = constant_types.clone();
         unroll_opt.callinfocollection = self.callinfocollection.clone();
-        unroll_opt.call_pure_results = call_pure_results.clone();
+        unroll_opt.call_pure_results = preamble_data.base.call_pure_results.clone();
         // RPython Box type parity: each InputArg carries its type from
         // tracing. Propagate to optimizer so value_types covers inputargs.
-        unroll_opt.trace_inputarg_types = trace.inputargs.iter().map(|ia| ia.tp).collect();
+        unroll_opt.trace_inputarg_types = preamble_data
+            .base
+            .inputargs()
+            .iter()
+            .map(|ia| ia.tp)
+            .collect();
         // resume.py parity: convert tracing-time snapshots to flat OpRef
         // vectors so the optimizer can rebuild fail_args from snapshot in
         // store_final_boxes_in_guard (RPython ResumeDataVirtualAdder.finish).
@@ -4036,11 +4043,12 @@ impl<M: Clone> MetaInterp<M> {
         // Phase 2 InvalidLoop. Phase 1 writes to phase1_out on the caller's
         // stack BEFORE Phase 2 starts. If Phase 2 panics, phase1_out still
         // holds the Phase 1 results.
+        let loop_data = compile::UnrolledLoopData::new(&trace, None, None, &call_pure_results);
         let mut phase1_out: Option<(Vec<Op>, crate::optimizeopt::unroll::ExportedState)> = None;
         let mut updated_constant_types = constant_types.clone();
         let optimize_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let result = unroll_opt.optimize_trace_with_constants_and_inputs_vable_out(
-                &trace_ops,
+                loop_data.base.operations(),
                 &mut constants,
                 num_trace_inputargs,
                 vable_config.clone(),
@@ -4982,7 +4990,16 @@ impl<M: Clone> MetaInterp<M> {
             )
         };
 
-        let trace_ops = trace.ops.clone();
+        let call_pure_results = HashMap::new();
+        let trace_ops = {
+            let loop_data = compile::UnrolledLoopData::new(
+                &trace,
+                None,
+                Some(&start_state),
+                &call_pure_results,
+            );
+            loop_data.base.operations().to_vec()
+        };
 
         if crate::majit_log_enabled() {
             eprintln!("--- retrace body (before opt) ---");
@@ -5446,6 +5463,7 @@ impl<M: Clone> MetaInterp<M> {
         // `MIFrame::generate_guard` path.
         let green_key = ctx.green_key;
 
+        let call_pure_results = ctx.take_call_pure_results();
         let mut recorder = ctx.recorder;
         // `pyjitpl.py:3216-3217` / `pyjitpl.py:3241`:
         //   `token = sd.done_with_this_frame_descr_<type>` (normal) or
@@ -5472,14 +5490,15 @@ impl<M: Clone> MetaInterp<M> {
         // returns a snapshot-less TreeLoop post-Task #70.
         let mut trace = recorder.get_trace();
         trace.snapshots = std::mem::take(&mut ctx.snapshots);
-        let trace_snapshots = trace.snapshots.clone();
+        let simple_data = compile::SimpleCompileData::new(&trace, None, &call_pure_results);
+        let trace_snapshots = simple_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
         // sees the post-GC addresses for any object that moved.
         ctx.constants.refresh_from_gc();
         let (mut constants, mut constant_types) = ctx.constants.into_inner_with_types();
 
-        let trace_ops = trace.ops.clone();
+        let trace_ops = simple_data.base.operations().to_vec();
 
         let num_ops_before = trace_ops.len();
         let mut optimizer = if let Some(config) = vable_config {
@@ -5489,6 +5508,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         optimizer.all_descrs = std::mem::take(&mut *self.staticdata.all_descrs.lock().unwrap());
         optimizer.constant_types = constant_types.clone();
+        optimizer.call_pure_results = simple_data.base.call_pure_results.clone();
         // history.py:_make_op parity: every InputArg carries its type
         // from the recorder. Propagate those raw recorder types to the
         // optimizer without further reconciliation.
@@ -5870,6 +5890,7 @@ impl<M: Clone> MetaInterp<M> {
         let orig_vable_ptr_simple =
             self.orig_vable_ptr_from_trace_ctx(&ctx, driver_descriptor.as_ref());
 
+        let call_pure_results = ctx.take_call_pure_results();
         let recorder = ctx.recorder;
         // Task #70: snapshots live on TraceCtx; rebuild the TreeLoop with
         // them so downstream consumers (`trace.snapshots`) still observe
@@ -5877,14 +5898,15 @@ impl<M: Clone> MetaInterp<M> {
         // returns a snapshot-less TreeLoop post-Task #70.
         let mut trace = recorder.get_trace();
         trace.snapshots = std::mem::take(&mut ctx.snapshots);
-        let trace_snapshots = trace.snapshots.clone();
+        let simple_data = compile::SimpleCompileData::new(&trace, None, &call_pure_results);
+        let trace_snapshots = simple_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
         // sees the post-GC addresses for any object that moved.
         ctx.constants.refresh_from_gc();
         let (mut constants, mut constant_types) = ctx.constants.into_inner_with_types();
 
-        let trace_ops = trace.ops.clone();
+        let trace_ops = simple_data.base.operations().to_vec();
 
         if crate::majit_log_enabled() {
             eprintln!("--- simple loop trace (before opt) ---");
@@ -5892,7 +5914,7 @@ impl<M: Clone> MetaInterp<M> {
         }
 
         let num_ops_before = trace_ops.len();
-        let num_trace_inputargs = trace.inputargs.len();
+        let num_trace_inputargs = simple_data.base.inputargs().len();
 
         // Simple optimizer — no unrolling (compile.py:222-226 SimpleCompileData).
         let mut optimizer = if let Some(config) = vable_config {
@@ -5902,6 +5924,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         optimizer.all_descrs = std::mem::take(&mut *self.staticdata.all_descrs.lock().unwrap());
         optimizer.constant_types = constant_types.clone();
+        optimizer.call_pure_results = simple_data.base.call_pure_results.clone();
         // history.py InputArg.type parity: each `InputArg` already carries
         // its type in the typed OpRef variant tag (`InputArg::opref()` calls
         // `OpRef::input_arg_typed(idx, tp)` in majit-ir/src/value.rs:253).
@@ -8416,6 +8439,16 @@ impl<M: Clone> MetaInterp<M> {
             pending_bridge_rd,
             bridge_inputarg_base,
         );
+        let call_pure_results = HashMap::new();
+        let bridge_trace_data =
+            TreeLoop::with_snapshots(prepared.inputargs.clone(), prepared.ops.clone(), Vec::new());
+        let bridge_data = compile::BridgeCompileData::new(
+            &bridge_trace_data,
+            &[],
+            None,
+            &call_pure_results,
+            inline_short_preamble,
+        );
         let bridge_inputargs = prepared.inputargs.as_slice();
         let bridge_ops = prepared.ops.as_slice();
         let pending_bridge_rd = prepared.pending_bridge_rd;
@@ -8439,7 +8472,12 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
         // Store bridge inputarg types so export_state can propagate them
         // to ExportedState.renamed_inputarg_types (RPython Box type parity).
-        optimizer.trace_inputarg_types = bridge_inputargs.iter().map(|ia| ia.tp).collect();
+        optimizer.trace_inputarg_types = bridge_data
+            .base
+            .inputargs()
+            .iter()
+            .map(|ia| ia.tp)
+            .collect();
 
         // RPython-orthodox: no source→bridge constant_types merge.
         // bridgeopt.py / unroll.py do not copy the source loop's constant
@@ -8473,7 +8511,7 @@ impl<M: Clone> MetaInterp<M> {
                     &mut constants,
                     bridge_inputargs.len(),
                     &mut compiled.front_target_tokens,
-                    inline_short_preamble,
+                    bridge_data.inline_short_preamble,
                     retraced_count,
                     retrace_limit,
                     pending_bridge_rd,

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -7995,6 +7995,14 @@ impl<M: Clone> MetaInterp<M> {
         // Optimizer::optimize_bridge docstring for the RPython identity
         // model this mirrors (opencoder.py:249-273).
         let bridge_inputarg_base = parent_next_global_opref.max(bridge_inputargs.len() as u32);
+        // compile.py:1056 / unroll.py:183 parity: runtime_boxes are passed
+        // separately from the trace iterator and stay as the original live
+        // boxes from the closing JUMP.
+        let bridge_runtime_boxes: Vec<OpRef> = bridge_ops
+            .last()
+            .filter(|op| op.opcode == OpCode::Jump)
+            .map(|op| op.args.to_vec())
+            .unwrap_or_default();
         // unroll.py:187 `trace = trace.get_iter()`: mint fresh InputArg /
         // ResOperation objects in a disjoint OpRef namespace
         // (`opencoder.py:259-262 self.inputargs = [rop.inputarg_from_tp(...)]`).
@@ -8045,6 +8053,7 @@ impl<M: Clone> MetaInterp<M> {
                     &mut constants,
                     bridge_inputargs.len(),
                     &mut compiled.front_target_tokens,
+                    &bridge_runtime_boxes,
                     true,
                     retraced_count,
                     retrace_limit,
@@ -8475,7 +8484,7 @@ impl<M: Clone> MetaInterp<M> {
         let bridge_resumestorage = pending_bridge_rd
             .as_ref()
             .map(|pending| pending.storage.as_ref());
-        let (bridge_inline_short_preamble, bridge_call_pure_results) = {
+        let (bridge_inline_short_preamble, bridge_call_pure_results, bridge_runtime_boxes) = {
             let bridge_data = compile::BridgeCompileData::new(
                 &bridge_trace_data,
                 &bridge_runtime_boxes,
@@ -8487,6 +8496,7 @@ impl<M: Clone> MetaInterp<M> {
             (
                 bridge_data.inline_short_preamble,
                 bridge_data.call_pure_results.clone(),
+                bridge_data.runtime_boxes.to_vec(),
             )
         };
         // unroll.py:187 `trace = trace.get_iter()`: mint fresh InputArg /
@@ -8562,6 +8572,7 @@ impl<M: Clone> MetaInterp<M> {
                     &mut constants,
                     bridge_inputargs.len(),
                     &mut compiled.front_target_tokens,
+                    &bridge_runtime_boxes,
                     bridge_inline_short_preamble,
                     retraced_count,
                     retrace_limit,

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -123,6 +123,27 @@ pub enum CompileOutcome {
     Aborted,
 }
 
+struct SimpleCompileViews<'a> {
+    data: compile::SimpleCompileData<'a>,
+    trace_snapshots: Vec<crate::recorder::Snapshot>,
+    trace_ops: Vec<Op>,
+}
+
+fn make_simple_compile_views<'a>(
+    trace: &'a TreeLoop,
+    call_pure_results: &'a HashMap<Vec<Value>, Value>,
+    enable_opts: &'a [String],
+) -> SimpleCompileViews<'a> {
+    let data = compile::SimpleCompileData::new(trace, None, call_pure_results, enable_opts);
+    let trace_snapshots = data.base.snapshots().to_vec();
+    let trace_ops = data.base.operations().to_vec();
+    SimpleCompileViews {
+        data,
+        trace_snapshots,
+        trace_ops,
+    }
+}
+
 pub(crate) struct CompiledTrace {
     /// Inputargs for this trace, used to recover typed exit layouts during blackhole replay.
     pub(crate) inputargs: Vec<InputArg>,
@@ -5515,20 +5536,20 @@ impl<M: Clone> MetaInterp<M> {
         // returns a snapshot-less TreeLoop post-Task #70.
         let mut trace = recorder.get_trace();
         trace.snapshots = std::mem::take(&mut ctx.snapshots);
-        let simple_data = compile::SimpleCompileData::new(
+        let SimpleCompileViews {
+            data: simple_data,
+            trace_snapshots,
+            trace_ops,
+        } = make_simple_compile_views(
             &trace,
-            None,
             &call_pure_results,
             self.warm_state.get_enable_opts(),
         );
-        let trace_snapshots = simple_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
         // sees the post-GC addresses for any object that moved.
         ctx.constants.refresh_from_gc();
         let (mut constants, mut constant_types) = ctx.constants.into_inner_with_types();
-
-        let trace_ops = simple_data.base.operations().to_vec();
 
         let num_ops_before = trace_ops.len();
         let mut optimizer = if let Some(config) = vable_config {
@@ -5928,20 +5949,20 @@ impl<M: Clone> MetaInterp<M> {
         // returns a snapshot-less TreeLoop post-Task #70.
         let mut trace = recorder.get_trace();
         trace.snapshots = std::mem::take(&mut ctx.snapshots);
-        let simple_data = compile::SimpleCompileData::new(
+        let SimpleCompileViews {
+            data: simple_data,
+            trace_snapshots,
+            trace_ops,
+        } = make_simple_compile_views(
             &trace,
-            None,
             &call_pure_results,
             self.warm_state.get_enable_opts(),
         );
-        let trace_snapshots = simple_data.base.snapshots().to_vec();
 
         // Refresh shadow-stack-rooted Ref constants so `into_inner_with_types`
         // sees the post-GC addresses for any object that moved.
         ctx.constants.refresh_from_gc();
         let (mut constants, mut constant_types) = ctx.constants.into_inner_with_types();
-
-        let trace_ops = simple_data.base.operations().to_vec();
 
         if crate::majit_log_enabled() {
             eprintln!("--- simple loop trace (before opt) ---");

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4011,7 +4011,7 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.max_retrace_guards = self.warm_state.max_retrace_guards();
         unroll_opt.constant_types = constant_types.clone();
         unroll_opt.callinfocollection = self.callinfocollection.clone();
-        unroll_opt.call_pure_results = preamble_data.base.call_pure_results.clone();
+        unroll_opt.call_pure_results = preamble_data.call_pure_results.clone();
         // RPython Box type parity: each InputArg carries its type from
         // tracing. Propagate to optimizer so value_types covers inputargs.
         unroll_opt.trace_inputarg_types = preamble_data
@@ -4932,6 +4932,7 @@ impl<M: Clone> MetaInterp<M> {
             green_key,
             driver_descriptor,
             orig_vable_ptr_retrace,
+            loop_jitcell_token,
             mut constants,
             mut constant_types,
             trace,
@@ -4940,6 +4941,13 @@ impl<M: Clone> MetaInterp<M> {
             let green_key = ctx.green_key;
             let header_pc = ctx.header_pc;
             let driver_descriptor = ctx.driver_descriptor().cloned();
+            let Some(loop_jitcell_token) = self
+                .compiled_loops
+                .get(&green_key)
+                .map(|compiled| Arc::clone(&compiled.token))
+            else {
+                return false;
+            };
             let retrace_cut = retracing_from.and_then(|retrace_pos| {
                 ctx.get_merge_point_at(green_key, header_pc)
                     .filter(|mp| mp.position == retrace_pos && mp.position._pos > 0)
@@ -4988,6 +4996,7 @@ impl<M: Clone> MetaInterp<M> {
                 green_key,
                 driver_descriptor,
                 orig_vable_ptr_retrace,
+                loop_jitcell_token,
                 constants,
                 constant_types,
                 trace,
@@ -4995,13 +5004,6 @@ impl<M: Clone> MetaInterp<M> {
             )
         };
 
-        let Some(loop_jitcell_token) = self
-            .compiled_loops
-            .get(&green_key)
-            .map(|compiled| Arc::clone(&compiled.token))
-        else {
-            return false;
-        };
         let trace_ops = {
             let loop_data = compile::UnrolledLoopData::new(
                 &trace,
@@ -5526,7 +5528,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         optimizer.all_descrs = std::mem::take(&mut *self.staticdata.all_descrs.lock().unwrap());
         optimizer.constant_types = constant_types.clone();
-        optimizer.call_pure_results = simple_data.base.call_pure_results.clone();
+        optimizer.call_pure_results = simple_data.call_pure_results.clone();
         // history.py:_make_op parity: every InputArg carries its type
         // from the recorder. Propagate those raw recorder types to the
         // optimizer without further reconciliation.
@@ -5947,7 +5949,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         optimizer.all_descrs = std::mem::take(&mut *self.staticdata.all_descrs.lock().unwrap());
         optimizer.constant_types = constant_types.clone();
-        optimizer.call_pure_results = simple_data.base.call_pure_results.clone();
+        optimizer.call_pure_results = simple_data.call_pure_results.clone();
         // history.py InputArg.type parity: each `InputArg` already carries
         // its type in the typed OpRef variant tag (`InputArg::opref()` calls
         // `OpRef::input_arg_typed(idx, tp)` in majit-ir/src/value.rs:253).
@@ -8449,6 +8451,34 @@ impl<M: Clone> MetaInterp<M> {
         // Optimizer::optimize_bridge docstring for the RPython identity
         // model this mirrors (opencoder.py:249-273).
         let bridge_inputarg_base = parent_next_global_opref.max(bridge_inputargs.len() as u32);
+        // compile.py:1056-1060: BridgeCompileData is built from the original
+        // history trace/runtime boxes. The explicit Rust TraceIterator
+        // preparation below mirrors unroll.py:187 `trace = trace.get_iter()`
+        // and must happen after this payload is formed.
+        let bridge_runtime_boxes: Vec<OpRef> = bridge_ops
+            .last()
+            .filter(|op| op.opcode == OpCode::Jump)
+            .map(|op| op.args.to_vec())
+            .unwrap_or_default();
+        let bridge_trace_data =
+            TreeLoop::with_snapshots(bridge_inputargs.to_vec(), bridge_ops.to_vec(), Vec::new());
+        let bridge_resumestorage = pending_bridge_rd
+            .as_ref()
+            .map(|pending| pending.storage.as_ref());
+        let (bridge_inline_short_preamble, bridge_call_pure_results) = {
+            let bridge_data = compile::BridgeCompileData::new(
+                &bridge_trace_data,
+                &bridge_runtime_boxes,
+                bridge_resumestorage,
+                &call_pure_results,
+                inline_short_preamble,
+                self.warm_state.get_enable_opts(),
+            );
+            (
+                bridge_data.inline_short_preamble,
+                bridge_data.call_pure_results.clone(),
+            )
+        };
         // unroll.py:187 `trace = trace.get_iter()`: mint fresh InputArg /
         // ResOperation objects in a disjoint OpRef namespace
         // (`opencoder.py:259-262 self.inputargs = [rop.inputarg_from_tp(...)]`).
@@ -8463,41 +8493,7 @@ impl<M: Clone> MetaInterp<M> {
             pending_bridge_rd,
             bridge_inputarg_base,
         );
-        // compile.py:1056-1060 / unroll.py:183-184 parity:
-        // BridgeCompileData.runtime_boxes is the original live box list
-        // passed to compile_trace, i.e. the bridge's closing JUMP args before
-        // trace.get_iter() allocates fresh input boxes for optimization.
-        let bridge_runtime_boxes: Vec<OpRef> = bridge_ops
-            .last()
-            .filter(|op| op.opcode == OpCode::Jump)
-            .map(|op| op.args.to_vec())
-            .unwrap_or_default();
-        let bridge_trace_data =
-            TreeLoop::with_snapshots(prepared.inputargs.clone(), prepared.ops.clone(), Vec::new());
-        let bridge_resumestorage = prepared
-            .pending_bridge_rd
-            .as_ref()
-            .map(|pending| pending.storage.as_ref());
-        let (bridge_inputarg_types, bridge_inline_short_preamble, bridge_call_pure_results) = {
-            let bridge_data = compile::BridgeCompileData::new(
-                &bridge_trace_data,
-                &bridge_runtime_boxes,
-                bridge_resumestorage,
-                &call_pure_results,
-                inline_short_preamble,
-                self.warm_state.get_enable_opts(),
-            );
-            (
-                bridge_data
-                    .base
-                    .inputargs()
-                    .iter()
-                    .map(|ia| ia.tp)
-                    .collect::<Vec<_>>(),
-                bridge_data.inline_short_preamble,
-                bridge_data.base.call_pure_results.clone(),
-            )
-        };
+        let bridge_inputarg_types = prepared.inputargs.iter().map(|ia| ia.tp).collect();
         let bridge_inputargs = prepared.inputargs.as_slice();
         let bridge_ops = prepared.ops.as_slice();
         let pending_bridge_rd = prepared.pending_bridge_rd;

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4909,6 +4909,23 @@ impl<M: Clone> MetaInterp<M> {
     ///
     /// Returns true if compilation succeeded.
     pub fn compile_retrace(&mut self, jump_args: &[OpRef], meta: M) -> bool {
+        // compile.py:355-359: resolve `loop_jitcell_token` before recording
+        // the closing JUMP.  Keep this lookup before any state is consumed so
+        // the rare missing-token path does not drain the active retrace.
+        let loop_jitcell_token = {
+            let green_key = match self.tracing.as_ref() {
+                Some(ctx) => ctx.green_key,
+                None => return false,
+            };
+            let Some(token) = self
+                .compiled_loops
+                .get(&green_key)
+                .map(|compiled| Arc::clone(&compiled.token))
+            else {
+                return false;
+            };
+            token
+        };
         let partial = match self.partial_trace.take() {
             Some(p) => p,
             None => return false,
@@ -4941,13 +4958,6 @@ impl<M: Clone> MetaInterp<M> {
             let green_key = ctx.green_key;
             let header_pc = ctx.header_pc;
             let driver_descriptor = ctx.driver_descriptor().cloned();
-            let Some(loop_jitcell_token) = self
-                .compiled_loops
-                .get(&green_key)
-                .map(|compiled| Arc::clone(&compiled.token))
-            else {
-                return false;
-            };
             let retrace_cut = retracing_from.and_then(|retrace_pos| {
                 ctx.get_merge_point_at(green_key, header_pc)
                     .filter(|mp| mp.position == retrace_pos && mp.position._pos > 0)


### PR DESCRIPTION
## Summary

This pull request introduces a set of new data structures to standardize and clarify the data passed into the JIT compilation pipeline, closely modeling RPython's `CompileData` and its subclasses. It refactors how trace and runtime information (such as snapshots, input arguments, and optimization options) are bundled and passed throughout the compilation and optimization process. The changes improve maintainability and parity with the original RPython design, and ensure that all relevant context is consistently available to downstream consumers.

Key changes include:

**Introduction of CompileData Bundles:**

- Added new structs (`CompileData`, `PreambleCompileData`, `SimpleCompileData`, `BridgeCompileData`, and `UnrolledLoopData`) in `compile.rs` to encapsulate trace, runtime, and optimization state, mirroring RPython's object model for JIT compilation inputs. These bundles are now used to pass data to optimizers and other compilation stages, replacing ad-hoc argument lists.

**Refactoring Compilation Call Sites:**

- Updated all major compilation entry points in `pyjitpl/mod.rs` to construct and use the new `CompileData` bundles, ensuring that trace operations, snapshots, input arguments, and optimization options are accessed via these unified interfaces. This includes retrace, simple compilation, and bridge compilation paths.
- All optimizer invocations now receive `call_pure_results` and other relevant state from the appropriate `CompileData` bundle, ensuring consistency.

**Runtime Boxes and Bridge Compilation:**

- Ensured that `runtime_boxes` (the original live argument boxes from the closing JUMP) are passed separately and consistently into optimizer and bridge compilation routines, matching RPython's model and fixing previous inconsistencies.
- Clarified documentation and comments to explain the parity with RPython and the purpose of these changes.

**Miscellaneous Improvements:**

- Ensured that all relevant state (such as `call_pure_results`, `enable_opts`, and `snapshots`) is cloned or moved from the context at the correct time to avoid accidental mutation or loss of data.

These changes bring the codebase closer to RPython's design, reduce code duplication, and make the flow of compilation data more explicit and maintainable.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Cases Where Our Patch Regressed PyPy Parity Compared To Main
  None found.

  The main behavioral change in majit/majit-metainterp/src/optimizeopt/optimizer.rs:3035 improves parity: runtime_boxes is now
  threaded separately into jump_to_existing_trace, matching RPython unroll.py:183-207, where runtime_boxes is distinct from the fresh
  trace iterator boxes.

  2. Other Mismatches Introduced By Our Patch
  None found.

  The new CompileData structs in majit/majit-metainterp/src/compile.rs:223 are constructor-payload mirrors only. They do not fully
  port CompileData.optimize_trace, but the file documents this as a Pyre adaptation, and the existing Rust optimizer dispatch remains
  flattened in pyjitpl/mod.rs.

  3. Mismatches That Already Existed Before This Patch
  Entry bridges still do not receive call_pure_results.

  RPython compile.py:1048-1060 passes metainterp.call_pure_results into both BridgeCompileData and SimpleCompileData; then
  unroll.py:193-194 passes it to propagate_all_forward. Current Rust captures call_pure_results in majit/majit-metainterp/src/
  pyjitpl/mod.rs:4733, and this patch now passes it into guard bridges via majit/majit-metainterp/src/pyjitpl/mod.rs:8333. But the
  interpreter entry bridge path still calls majit/majit-metainterp/src/pyjitpl/mod.rs:4842 without call_pure_results, and majit/
  majit-metainterp/src/pyjitpl/mod.rs:7963 never sets optimizer.call_pure_results.

  This mismatch was already present on upstream/main; the patch fixes the guard-bridge half but not entry bridges.

  4. Structural Adaptations
  CompileData is not ported as a polymorphic optimizer driver. RPython CompileData.optimize_trace builds the optimization chain,
  logs, dispatches to subclass optimize, and clears forwarded boxes. Pyre keeps that flow flattened in pyjitpl/mod.rs, with the new
  structs used as typed payload bundles.

  Rust uses HashMap<Vec<Value>, Value> for call_pure_results; this is acceptable parity because RPython stores it in an args-dict-
  like mapping, not on box forwarding state.

  Bridge trace preparation still uses a Rust-specific fresh OpRef namespace before optimization. That is the existing adaptation for
  RPython trace.get_iter() creating fresh InputArg / ResOperation object identities. The patch correctly takes runtime_boxes from the
  original pre-prepared JUMP args before that transformation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal compilation infrastructure refactored to improve data handling and pipeline efficiency across preamble, simple, and bridge compilation stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/52)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->