### PR TITLE
Implement CallKw in JIT tracer for keyword argument resolution

### DIFF
--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1669,6 +1669,7 @@ pub(crate) fn instruction_needs_pre_opcode_snapshot(instruction: Instruction) ->
     matches!(
         instruction,
         Instruction::Call { .. }
+            | Instruction::CallKw { .. }
             | Instruction::StoreSubscr
             | Instruction::BinaryOp { .. }
             | Instruction::CompareOp { .. }
@@ -1693,6 +1694,7 @@ pub(crate) fn instruction_may_raise(instruction: Instruction) -> bool {
         // real lowering; otherwise the default "not implemented" error is
         // mis-recorded as a traced GUARD_EXCEPTION.
         Instruction::Call { .. }
+            | Instruction::CallKw { .. }
             | Instruction::StoreAttr { .. }
             | Instruction::StoreSubscr
             | Instruction::ImportFrom { .. } // RPython raise/reraise are dedicated opimpls, not generic
@@ -6372,8 +6374,8 @@ mod tests {
                 _ => None,
             })
             .expect("source should contain a Call instruction to reuse argc shape");
-        assert!(!instruction_may_raise(call_kw_instruction));
-        assert!(!instruction_needs_pre_opcode_snapshot(call_kw_instruction));
+        assert!(instruction_may_raise(call_kw_instruction));
+        assert!(instruction_needs_pre_opcode_snapshot(call_kw_instruction));
 
         assert!(!instruction_may_raise(Instruction::CallFunctionEx));
         assert!(!instruction_needs_pre_opcode_snapshot(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7639,11 +7639,17 @@ impl OpcodeStepExecutor for MIFrame {
                             "abort tracing CALL_KW with positional-only keyword",
                         ));
                     }
-                    if pi < n_pos.min(n_pos_params) || resolved[pi].is_some() {
+                    if pi < n_pos.min(n_pos_params) {
                         return Err(trace_abort_error(
                             "abort tracing CALL_KW with duplicate keyword value",
                         ));
                     }
+                    // PyPy argument.py:_match_keywords overwrites
+                    // kwds_mapping[j - input_argcount] for duplicate
+                    // keyword names in malformed bytecode; the last value
+                    // then wins when _match_signature fills scope_w. Only
+                    // conflicts with already-filled positional parameters
+                    // raise ArgErrMultipleValues.
                     resolved[pi] = Some(kw_val.clone());
                     matched = true;
                     break;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7552,9 +7552,16 @@ impl OpcodeStepExecutor for MIFrame {
         let code = unsafe { &*(code_ptr as *const CodeObject) };
         let total_params = (code.arg_count + code.kwonlyarg_count) as usize;
         let n_pos_params = code.arg_count as usize;
+        let n_posonly_params = code.posonlyarg_count as usize;
         let has_varargs = code.flags.contains(CodeFlags::VARARGS);
         let has_varkw = code.flags.contains(CodeFlags::VARKEYWORDS);
         let n_pos = args.len() - nkw;
+
+        if n_pos > n_pos_params && !has_varargs {
+            return Err(trace_abort_error(
+                "abort tracing CALL_KW with too many positional args",
+            ));
+        }
 
         let mut resolved: Vec<Option<FrontendOp>> = vec![None; total_params];
 
@@ -7570,12 +7577,30 @@ impl OpcodeStepExecutor for MIFrame {
             let kw_name_obj =
                 unsafe { pyre_object::w_tuple_getitem(concrete_kwnames, ki as i64) };
             let Some(kw_name_obj) = kw_name_obj else { continue };
+            if !unsafe { pyre_object::is_str(kw_name_obj) } {
+                return Err(trace_abort_error(
+                    "abort tracing CALL_KW with non-string keyword name",
+                ));
+            }
             let kw_str = unsafe { pyre_object::w_str_get_value(kw_name_obj) };
             let kw_val = args[n_pos + ki].clone();
 
             let mut matched = false;
             for pi in 0..total_params {
                 if &*code.varnames[pi] == kw_str {
+                    if pi < n_posonly_params {
+                        if has_varkw {
+                            break;
+                        }
+                        return Err(trace_abort_error(
+                            "abort tracing CALL_KW with positional-only keyword",
+                        ));
+                    }
+                    if pi < n_pos.min(n_pos_params) || resolved[pi].is_some() {
+                        return Err(trace_abort_error(
+                            "abort tracing CALL_KW with duplicate keyword value",
+                        ));
+                    }
                     resolved[pi] = Some(kw_val.clone());
                     matched = true;
                     break;
@@ -7584,6 +7609,10 @@ impl OpcodeStepExecutor for MIFrame {
             if !matched && has_varkw {
                 extra_kw_keys.push(kw_name_obj);
                 extra_kw_vals.push(kw_val);
+            } else if !matched {
+                return Err(trace_abort_error(
+                    "abort tracing CALL_KW with unknown keyword",
+                ));
             }
         }
 
@@ -7626,8 +7655,14 @@ impl OpcodeStepExecutor for MIFrame {
             }
         }
 
-        // Build final args vec. Any remaining None slots are PY_NULL
-        // (missing required args — the callee will raise TypeError).
+        if resolved.iter().any(Option::is_none) {
+            return Err(trace_abort_error(
+                "abort tracing CALL_KW with missing required arguments",
+            ));
+        }
+
+        // Build the resolved call scope. Missing required arguments were
+        // rejected above so no PY_NULL placeholder reaches the compiled call.
         let mut final_args: Vec<FrontendOp> = Vec::with_capacity(total_params + 2);
         for slot in resolved {
             match slot {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7487,6 +7487,191 @@ impl OpcodeStepExecutor for MIFrame {
         <Self as SharedOpcodeHandler>::push_value(self, result)
     }
 
+    fn call_kw(&mut self, nargs: usize) -> Result<(), Self::Error> {
+        use pyre_interpreter::bytecode::CodeFlags;
+
+        let kwarg_names_val = <Self as SharedOpcodeHandler>::pop_value(self)?;
+        let mut args = Vec::with_capacity(nargs);
+        for _ in 0..nargs {
+            args.push(<Self as SharedOpcodeHandler>::pop_value(self)?);
+        }
+        args.reverse();
+        let null_or_self = <Self as SharedOpcodeHandler>::pop_value(self)?;
+        let callable = <Self as SharedOpcodeHandler>::pop_value(self)?;
+
+        let concrete_kwnames = kwarg_names_val.concrete.to_pyobj();
+        let concrete_callable = callable.concrete.to_pyobj();
+
+        if null_or_self.concrete.to_pyobj() != PY_NULL
+            && !unsafe { pyre_object::is_none(null_or_self.concrete.to_pyobj()) }
+        {
+            args.insert(0, null_or_self);
+        }
+
+        // Unwrap bound method to get the underlying function for resolution.
+        let target_func = if unsafe { is_method(concrete_callable) } {
+            let func = unsafe { w_method_get_func(concrete_callable) };
+            let receiver = unsafe { w_method_get_self(concrete_callable) };
+            if !receiver.is_null() && !unsafe { pyre_object::is_none(receiver) } {
+                let receiver_opref = self.with_ctx(|this, ctx| {
+                    this.guard_class(ctx, callable.opref, &METHOD_TYPE as *const PyType);
+                    ctx.record_op_with_descr(
+                        OpCode::GetfieldGcR,
+                        &[callable.opref],
+                        crate::descr::method_w_self_descr(),
+                    )
+                });
+                let receiver_val = FrontendOp::new(
+                    receiver_opref,
+                    ConcreteValue::from_pyobj(receiver),
+                );
+                args.insert(0, receiver_val);
+            }
+            func
+        } else {
+            concrete_callable
+        };
+
+        // Determine nkw from concrete kwarg_names tuple.
+        let nkw = if !concrete_kwnames.is_null()
+            && unsafe { pyre_object::is_tuple(concrete_kwnames) }
+        {
+            unsafe { w_tuple_len(concrete_kwnames) }
+        } else {
+            0
+        };
+
+        if nkw == 0 || !unsafe { is_function(target_func) } {
+            // No kwargs or not a user function — fall through to plain call.
+            let result =
+                <Self as SharedOpcodeHandler>::call_callable(self, callable, &args)?;
+            return <Self as SharedOpcodeHandler>::push_value(self, result);
+        }
+
+        // Resolve kwargs to positional order at trace time.
+        let code_ptr = unsafe { pyre_interpreter::get_pycode(target_func) };
+        let code = unsafe { &*(code_ptr as *const CodeObject) };
+        let total_params = (code.arg_count + code.kwonlyarg_count) as usize;
+        let has_varargs = code.flags.contains(CodeFlags::VARARGS);
+        let has_varkw = code.flags.contains(CodeFlags::VARKEYWORDS);
+        let n_pos = args.len() - nkw;
+
+        let mut resolved: Vec<Option<FrontendOp>> = vec![None; total_params];
+
+        // Fill positional args.
+        for i in 0..n_pos.min(total_params) {
+            resolved[i] = Some(args[i].clone());
+        }
+
+        // Match keyword args to parameter positions.
+        let mut extra_kw_keys: Vec<PyObjectRef> = Vec::new();
+        let mut extra_kw_vals: Vec<FrontendOp> = Vec::new();
+        for ki in 0..nkw {
+            let kw_name_obj =
+                unsafe { pyre_object::w_tuple_getitem(concrete_kwnames, ki as i64) };
+            let Some(kw_name_obj) = kw_name_obj else { continue };
+            let kw_str = unsafe { pyre_object::w_str_get_value(kw_name_obj) };
+            let kw_val = args[n_pos + ki].clone();
+
+            let mut matched = false;
+            for pi in 0..total_params {
+                if &*code.varnames[pi] == kw_str {
+                    resolved[pi] = Some(kw_val.clone());
+                    matched = true;
+                    break;
+                }
+            }
+            if !matched && has_varkw {
+                extra_kw_keys.push(kw_name_obj);
+                extra_kw_vals.push(kw_val);
+            }
+        }
+
+        // Fill positional defaults.
+        let n_pos_params = code.arg_count as usize;
+        let defaults_obj = unsafe { function_get_defaults(target_func) };
+        if !defaults_obj.is_null() {
+            let defaults_obj = pyre_interpreter::baseobjspace::unwrap_cell(defaults_obj);
+            if unsafe { pyre_object::is_tuple(defaults_obj) } {
+                let ndefaults = unsafe { w_tuple_len(defaults_obj) };
+                let first_default = n_pos_params.saturating_sub(ndefaults);
+                for pi in first_default..n_pos_params {
+                    if resolved[pi].is_none() {
+                        if let Some(v) =
+                            unsafe { pyre_object::w_tuple_getitem(defaults_obj, (pi - first_default) as i64) }
+                        {
+                            let opref = self.with_ctx(|_this, ctx| ctx.const_ref(v as i64));
+                            resolved[pi] =
+                                Some(FrontendOp::new(opref, ConcreteValue::from_pyobj(v)));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fill keyword-only defaults.
+        let kwdefaults = unsafe { pyre_interpreter::function_get_kwdefaults(target_func) };
+        if !kwdefaults.is_null() && unsafe { pyre_object::is_dict(kwdefaults) } {
+            let nkwonly = code.kwonlyarg_count as usize;
+            for ki in 0..nkwonly {
+                let pi = n_pos_params + ki;
+                if resolved[pi].is_none() {
+                    let param_name = &code.varnames[pi];
+                    let key = pyre_object::w_str_new(param_name);
+                    if let Some(val) = unsafe { pyre_object::w_dict_lookup(kwdefaults, key) } {
+                        let opref = self.with_ctx(|_this, ctx| ctx.const_ref(val as i64));
+                        resolved[pi] =
+                            Some(FrontendOp::new(opref, ConcreteValue::from_pyobj(val)));
+                    }
+                }
+            }
+        }
+
+        // Build final args vec. Any remaining None slots are PY_NULL
+        // (missing required args — the callee will raise TypeError).
+        let mut final_args: Vec<FrontendOp> = Vec::with_capacity(total_params + 2);
+        for slot in resolved {
+            match slot {
+                Some(val) => final_args.push(val),
+                None => {
+                    let opref = self.with_ctx(|_this, ctx| ctx.const_ref(PY_NULL as i64));
+                    final_args.push(FrontendOp::new(opref, ConcreteValue::Null));
+                }
+            }
+        }
+
+        // Pack *args if needed.
+        if has_varargs {
+            let extra_pos: Vec<FrontendOp> = if n_pos > total_params {
+                args[total_params..n_pos].to_vec()
+            } else {
+                vec![]
+            };
+            let concrete_items: Vec<PyObjectRef> =
+                extra_pos.iter().map(|v| v.concrete.to_pyobj()).collect();
+            let tuple = pyre_interpreter::build_tuple_from_refs(&concrete_items);
+            let item_oprefs: Vec<OpRef> = extra_pos.iter().map(|v| v.opref).collect();
+            let opref = self.trace_build_tuple(&item_oprefs)?;
+            final_args.push(FrontendOp::new(opref, ConcreteValue::from_pyobj(tuple)));
+        }
+
+        // Pack **kwargs if needed.
+        if has_varkw {
+            let kw_dict = pyre_object::w_dict_new();
+            for (key, val) in extra_kw_keys.iter().zip(extra_kw_vals.iter()) {
+                unsafe {
+                    pyre_object::w_dict_store(kw_dict, *key, val.concrete.to_pyobj());
+                }
+            }
+            let opref = self.with_ctx(|_this, ctx| ctx.const_ref(kw_dict as i64));
+            final_args.push(FrontendOp::new(opref, ConcreteValue::from_pyobj(kw_dict)));
+        }
+
+        let result =
+            <Self as SharedOpcodeHandler>::call_callable(self, callable, &final_args)?;
+        <Self as SharedOpcodeHandler>::push_value(self, result)
+    }
+
     // RPython exception handler tracing (pyjitpl.py:2506 finishframe_exception):
     // handle_possible_exception emits GUARD_EXCEPTION and continues at the
     // handler PC. These three overrides trace the handler-entry bytecodes.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7516,13 +7516,16 @@ impl OpcodeStepExecutor for MIFrame {
                 0
             };
 
-        // Only trace the direct user-function keyword path here.  PyPy keeps
-        // kwargs inside `Arguments` and dispatches through `space.call_args`;
-        // pyre's trace side does not yet have an equivalent structured kwargs
-        // residual helper for methods, builtins, types, or arbitrary
-        // `__call__` objects.  Let those uncommon keyword-call shapes run in
-        // the interpreter instead of recording a call with the keyword-name
-        // tuple discarded or with a bound receiver inserted twice.
+        // Only trace the direct user-function keyword path here.  PyPy's
+        // `CALL_FUNCTION_KW` builds `Arguments(keyword_names_w, keywords_w)`
+        // and dispatches the same object through `space.call_args`
+        // (pyopcode.py:1386-1410), so methods, builtins, type calls, and
+        // arbitrary `__call__` objects all receive structured kwargs.
+        // Pyre's trace-side residual helpers still expose only flat
+        // positional slices for those callable shapes; forcing them through
+        // `call_callable` here would either discard the keyword-name tuple
+        // or re-bind receivers differently from PyPy.  Keep this as a
+        // structural adaptation until the trace ABI can carry `Arguments`.
         let target_func = if nkw == 0 {
             concrete_callable
         } else if unsafe { is_function(concrete_callable) }
@@ -7570,6 +7573,13 @@ impl OpcodeStepExecutor for MIFrame {
             ));
         }
 
+        // PyPy would raise the exact `ArgErr*` TypeError from
+        // `Arguments._match_signature` / `_match_keywords`
+        // (argument.py:259-321, 464-501).  The trace recorder cannot yet
+        // emit those exception paths with the right keyword metadata, and
+        // recording a partially resolved call would be worse than falling
+        // back to the interpreter.  Treat argument-mismatch keyword calls as
+        // structural aborts rather than residual calls.
         if n_pos > n_pos_params {
             return Err(trace_abort_error(
                 "abort tracing CALL_KW with too many positional args",

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -18,6 +18,17 @@ extern "C" fn trace_function_get_defaults(func: i64) -> i64 {
     unsafe { function_get_defaults(func as PyObjectRef) as i64 }
 }
 
+extern "C" fn trace_function_get_kwdefaults(func: i64) -> i64 {
+    unsafe { pyre_interpreter::function_get_kwdefaults(func as PyObjectRef) as i64 }
+}
+
+extern "C" fn trace_dict_lookup_jit(dict: i64, key: i64) -> i64 {
+    unsafe {
+        pyre_object::w_dict_lookup(dict as PyObjectRef, key as PyObjectRef).unwrap_or(PY_NULL)
+            as i64
+    }
+}
+
 /// floatobject.py:561 `descr_pow` → `_pow(space, x, y)` parity.
 ///
 /// `_pow` in floatobject.py:799-881 takes two raw floats and returns a
@@ -7648,6 +7659,15 @@ impl OpcodeStepExecutor for MIFrame {
         // Fill positional defaults.
         let defaults_obj = unsafe { function_get_defaults(target_func) };
         if !defaults_obj.is_null() {
+            self.with_ctx(|this, ctx| {
+                let defaults = ctx.call_ref_typed_with_effect(
+                    trace_function_get_defaults as *const (),
+                    &[callable.opref],
+                    &[Type::Ref],
+                    CANNOT_RAISE_NO_HEAP_EFFECT_INFO.clone(),
+                );
+                this.implement_guard_value(ctx, defaults, defaults_obj as i64);
+            });
             let defaults_obj = pyre_interpreter::baseobjspace::unwrap_cell(defaults_obj);
             if unsafe { pyre_object::is_tuple(defaults_obj) } {
                 let ndefaults = unsafe { w_tuple_len(defaults_obj) };
@@ -7669,6 +7689,16 @@ impl OpcodeStepExecutor for MIFrame {
         // Fill keyword-only defaults.
         let kwdefaults = unsafe { pyre_interpreter::function_get_kwdefaults(target_func) };
         if !kwdefaults.is_null() && unsafe { pyre_object::is_dict(kwdefaults) } {
+            let kwdefaults_opref = self.with_ctx(|this, ctx| {
+                let runtime_kwdefaults = ctx.call_ref_typed_with_effect(
+                    trace_function_get_kwdefaults as *const (),
+                    &[callable.opref],
+                    &[Type::Ref],
+                    CANNOT_RAISE_NO_HEAP_EFFECT_INFO.clone(),
+                );
+                this.implement_guard_value(ctx, runtime_kwdefaults, kwdefaults as i64);
+                runtime_kwdefaults
+            });
             let nkwonly = code.kwonlyarg_count as usize;
             for ki in 0..nkwonly {
                 let pi = n_pos_params + ki;
@@ -7676,7 +7706,17 @@ impl OpcodeStepExecutor for MIFrame {
                     let param_name = &code.varnames[pi];
                     let key = pyre_object::w_str_new(param_name);
                     if let Some(val) = unsafe { pyre_object::w_dict_lookup(kwdefaults, key) } {
-                        let opref = self.with_ctx(|_this, ctx| ctx.const_ref(val as i64));
+                        let opref = self.with_ctx(|this, ctx| {
+                            let key_opref = ctx.const_ref(key as i64);
+                            let val_opref = ctx.call_ref_typed_with_effect(
+                                trace_dict_lookup_jit as *const (),
+                                &[kwdefaults_opref, key_opref],
+                                &[Type::Ref, Type::Ref],
+                                CANNOT_RAISE_NO_HEAP_EFFECT_INFO.clone(),
+                            );
+                            this.implement_guard_value(ctx, val_opref, val as i64);
+                            val_opref
+                        });
                         resolved[pi] = Some(FrontendOp::new(opref, ConcreteValue::from_pyobj(val)));
                     }
                 }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7509,13 +7509,12 @@ impl OpcodeStepExecutor for MIFrame {
         }
 
         // Determine nkw from concrete kwarg_names tuple.
-        let nkw = if !concrete_kwnames.is_null()
-            && unsafe { pyre_object::is_tuple(concrete_kwnames) }
-        {
-            unsafe { w_tuple_len(concrete_kwnames) }
-        } else {
-            0
-        };
+        let nkw =
+            if !concrete_kwnames.is_null() && unsafe { pyre_object::is_tuple(concrete_kwnames) } {
+                unsafe { w_tuple_len(concrete_kwnames) }
+            } else {
+                0
+            };
 
         // Only trace the direct user-function keyword path here.  PyPy keeps
         // kwargs inside `Arguments` and dispatches through `space.call_args`;
@@ -7542,8 +7541,7 @@ impl OpcodeStepExecutor for MIFrame {
 
         if nkw == 0 {
             // No kwargs or not a user function — fall through to plain call.
-            let result =
-                <Self as SharedOpcodeHandler>::call_callable(self, callable, &args)?;
+            let result = <Self as SharedOpcodeHandler>::call_callable(self, callable, &args)?;
             return <Self as SharedOpcodeHandler>::push_value(self, result);
         }
 
@@ -7557,7 +7555,22 @@ impl OpcodeStepExecutor for MIFrame {
         let has_varkw = code.flags.contains(CodeFlags::VARKEYWORDS);
         let n_pos = args.len() - nkw;
 
-        if n_pos > n_pos_params && !has_varargs {
+        if has_varargs || has_varkw {
+            // PyPy's `Arguments._match_signature` writes a fully resolved
+            // frame scope for `*args` / `**kwargs` (argument.py:222-242).
+            // The trace-side residual helper below still calls the normal
+            // positional user-function path, whose `call_user_function`
+            // re-packs varargs/kwargs. Passing a pre-packed scope there
+            // double-packs `*args` and drops non-empty `**kwargs`. Until the
+            // JIT grows a resolved-scope helper matching
+            // `call_user_function_resolved`, keep this as a structural
+            // adaptation and let the interpreter handle these calls.
+            return Err(trace_abort_error(
+                "abort tracing CALL_KW for *args/**kwargs user function",
+            ));
+        }
+
+        if n_pos > n_pos_params {
             return Err(trace_abort_error(
                 "abort tracing CALL_KW with too many positional args",
             ));
@@ -7571,12 +7584,11 @@ impl OpcodeStepExecutor for MIFrame {
         }
 
         // Match keyword args to parameter positions.
-        let mut extra_kw_keys: Vec<PyObjectRef> = Vec::new();
-        let mut extra_kw_vals: Vec<FrontendOp> = Vec::new();
         for ki in 0..nkw {
-            let kw_name_obj =
-                unsafe { pyre_object::w_tuple_getitem(concrete_kwnames, ki as i64) };
-            let Some(kw_name_obj) = kw_name_obj else { continue };
+            let kw_name_obj = unsafe { pyre_object::w_tuple_getitem(concrete_kwnames, ki as i64) };
+            let Some(kw_name_obj) = kw_name_obj else {
+                continue;
+            };
             if !unsafe { pyre_object::is_str(kw_name_obj) } {
                 return Err(trace_abort_error(
                     "abort tracing CALL_KW with non-string keyword name",
@@ -7589,9 +7601,6 @@ impl OpcodeStepExecutor for MIFrame {
             for pi in 0..total_params {
                 if &*code.varnames[pi] == kw_str {
                     if pi < n_posonly_params {
-                        if has_varkw {
-                            break;
-                        }
                         return Err(trace_abort_error(
                             "abort tracing CALL_KW with positional-only keyword",
                         ));
@@ -7606,10 +7615,7 @@ impl OpcodeStepExecutor for MIFrame {
                     break;
                 }
             }
-            if !matched && has_varkw {
-                extra_kw_keys.push(kw_name_obj);
-                extra_kw_vals.push(kw_val);
-            } else if !matched {
+            if !matched {
                 return Err(trace_abort_error(
                     "abort tracing CALL_KW with unknown keyword",
                 ));
@@ -7625,9 +7631,9 @@ impl OpcodeStepExecutor for MIFrame {
                 let first_default = n_pos_params.saturating_sub(ndefaults);
                 for pi in first_default..n_pos_params {
                     if resolved[pi].is_none() {
-                        if let Some(v) =
-                            unsafe { pyre_object::w_tuple_getitem(defaults_obj, (pi - first_default) as i64) }
-                        {
+                        if let Some(v) = unsafe {
+                            pyre_object::w_tuple_getitem(defaults_obj, (pi - first_default) as i64)
+                        } {
                             let opref = self.with_ctx(|_this, ctx| ctx.const_ref(v as i64));
                             resolved[pi] =
                                 Some(FrontendOp::new(opref, ConcreteValue::from_pyobj(v)));
@@ -7648,8 +7654,7 @@ impl OpcodeStepExecutor for MIFrame {
                     let key = pyre_object::w_str_new(param_name);
                     if let Some(val) = unsafe { pyre_object::w_dict_lookup(kwdefaults, key) } {
                         let opref = self.with_ctx(|_this, ctx| ctx.const_ref(val as i64));
-                        resolved[pi] =
-                            Some(FrontendOp::new(opref, ConcreteValue::from_pyobj(val)));
+                        resolved[pi] = Some(FrontendOp::new(opref, ConcreteValue::from_pyobj(val)));
                     }
                 }
             }
@@ -7674,39 +7679,7 @@ impl OpcodeStepExecutor for MIFrame {
             }
         }
 
-        // Pack *args if needed.
-        if has_varargs {
-            let extra_pos: Vec<FrontendOp> = if n_pos > n_pos_params {
-                args[n_pos_params..n_pos].to_vec()
-            } else {
-                vec![]
-            };
-            let concrete_items: Vec<PyObjectRef> =
-                extra_pos.iter().map(|v| v.concrete.to_pyobj()).collect();
-            let tuple = pyre_interpreter::build_tuple_from_refs(&concrete_items);
-            let item_oprefs: Vec<OpRef> = extra_pos.iter().map(|v| v.opref).collect();
-            let opref = self.trace_build_tuple(&item_oprefs)?;
-            final_args.push(FrontendOp::new(opref, ConcreteValue::from_pyobj(tuple)));
-        }
-
-        // Pack **kwargs if needed.
-        if has_varkw {
-            let kw_dict = pyre_object::w_dict_new();
-            let mut item_oprefs = Vec::with_capacity(extra_kw_keys.len() * 2);
-            for (key, val) in extra_kw_keys.iter().zip(extra_kw_vals.iter()) {
-                unsafe {
-                    pyre_object::w_dict_store(kw_dict, *key, val.concrete.to_pyobj());
-                }
-                let key_opref = self.with_ctx(|_this, ctx| ctx.const_ref(*key as i64));
-                item_oprefs.push(key_opref);
-                item_oprefs.push(val.opref);
-            }
-            let opref = self.trace_build_map(&item_oprefs)?;
-            final_args.push(FrontendOp::new(opref, ConcreteValue::from_pyobj(kw_dict)));
-        }
-
-        let result =
-            <Self as SharedOpcodeHandler>::call_callable(self, callable, &final_args)?;
+        let result = <Self as SharedOpcodeHandler>::call_callable(self, callable, &final_args)?;
         <Self as SharedOpcodeHandler>::push_value(self, result)
     }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7508,30 +7508,6 @@ impl OpcodeStepExecutor for MIFrame {
             args.insert(0, null_or_self);
         }
 
-        // Unwrap bound method to get the underlying function for resolution.
-        let target_func = if unsafe { is_method(concrete_callable) } {
-            let func = unsafe { w_method_get_func(concrete_callable) };
-            let receiver = unsafe { w_method_get_self(concrete_callable) };
-            if !receiver.is_null() && !unsafe { pyre_object::is_none(receiver) } {
-                let receiver_opref = self.with_ctx(|this, ctx| {
-                    this.guard_class(ctx, callable.opref, &METHOD_TYPE as *const PyType);
-                    ctx.record_op_with_descr(
-                        OpCode::GetfieldGcR,
-                        &[callable.opref],
-                        crate::descr::method_w_self_descr(),
-                    )
-                });
-                let receiver_val = FrontendOp::new(
-                    receiver_opref,
-                    ConcreteValue::from_pyobj(receiver),
-                );
-                args.insert(0, receiver_val);
-            }
-            func
-        } else {
-            concrete_callable
-        };
-
         // Determine nkw from concrete kwarg_names tuple.
         let nkw = if !concrete_kwnames.is_null()
             && unsafe { pyre_object::is_tuple(concrete_kwnames) }
@@ -7541,7 +7517,30 @@ impl OpcodeStepExecutor for MIFrame {
             0
         };
 
-        if nkw == 0 || !unsafe { is_function(target_func) } {
+        // Only trace the direct user-function keyword path here.  PyPy keeps
+        // kwargs inside `Arguments` and dispatches through `space.call_args`;
+        // pyre's trace side does not yet have an equivalent structured kwargs
+        // residual helper for methods, builtins, types, or arbitrary
+        // `__call__` objects.  Let those uncommon keyword-call shapes run in
+        // the interpreter instead of recording a call with the keyword-name
+        // tuple discarded or with a bound receiver inserted twice.
+        let target_func = if nkw == 0 {
+            concrete_callable
+        } else if unsafe { is_function(concrete_callable) }
+            && unsafe {
+                !is_builtin_code(
+                    pyre_interpreter::getcode(concrete_callable) as pyre_object::PyObjectRef
+                )
+            }
+        {
+            concrete_callable
+        } else {
+            return Err(trace_abort_error(
+                "abort tracing CALL_KW for non-user-function callable",
+            ));
+        };
+
+        if nkw == 0 {
             // No kwargs or not a user function — fall through to plain call.
             let result =
                 <Self as SharedOpcodeHandler>::call_callable(self, callable, &args)?;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7508,13 +7508,22 @@ impl OpcodeStepExecutor for MIFrame {
             args.insert(0, null_or_self);
         }
 
-        // Determine nkw from concrete kwarg_names tuple.
-        let nkw =
-            if !concrete_kwnames.is_null() && unsafe { pyre_object::is_tuple(concrete_kwnames) } {
-                unsafe { w_tuple_len(concrete_kwnames) }
-            } else {
-                0
-            };
+        // Determine nkw from the concrete kwarg_names tuple. PyPy's
+        // `CALL_FUNCTION_KW` immediately `interp_w`s the stack value as a
+        // tuple (pyopcode.py:1391), so treating an unavailable/non-tuple
+        // concrete value as "no kwargs" would record a plain positional call
+        // that PyPy would never execute.
+        if concrete_kwnames.is_null() || unsafe { !pyre_object::is_tuple(concrete_kwnames) } {
+            return Err(trace_abort_error(
+                "abort tracing CALL_KW without concrete keyword tuple",
+            ));
+        }
+        let nkw = unsafe { w_tuple_len(concrete_kwnames) };
+        if nkw > args.len() {
+            return Err(trace_abort_error(
+                "abort tracing CALL_KW with malformed keyword tuple",
+            ));
+        }
 
         // Only trace the direct user-function keyword path here.  PyPy's
         // `CALL_FUNCTION_KW` builds `Arguments(keyword_names_w, keywords_w)`
@@ -7528,7 +7537,8 @@ impl OpcodeStepExecutor for MIFrame {
         // structural adaptation until the trace ABI can carry `Arguments`.
         let target_func = if nkw == 0 {
             concrete_callable
-        } else if unsafe { is_function(concrete_callable) }
+        } else if !concrete_callable.is_null()
+            && unsafe { is_function(concrete_callable) }
             && unsafe {
                 !is_builtin_code(
                     pyre_interpreter::getcode(concrete_callable) as pyre_object::PyObjectRef

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -19,7 +19,8 @@ extern "C" fn trace_function_get_defaults(func: i64) -> i64 {
 }
 
 extern "C" fn trace_function_get_kwdefaults(func: i64) -> i64 {
-    unsafe { pyre_interpreter::function_get_kwdefaults(func as PyObjectRef) as i64 }
+    let kwdefaults = unsafe { pyre_interpreter::function_get_kwdefaults(func as PyObjectRef) };
+    pyre_interpreter::baseobjspace::unwrap_cell(kwdefaults) as i64
 }
 
 extern "C" fn trace_dict_lookup_jit(dict: i64, key: i64) -> i64 {
@@ -7513,9 +7514,7 @@ impl OpcodeStepExecutor for MIFrame {
         let concrete_kwnames = kwarg_names_val.concrete.to_pyobj();
         let concrete_callable = callable.concrete.to_pyobj();
 
-        if null_or_self.concrete.to_pyobj() != PY_NULL
-            && !unsafe { pyre_object::is_none(null_or_self.concrete.to_pyobj()) }
-        {
+        if null_or_self.concrete.to_pyobj() != PY_NULL {
             args.insert(0, null_or_self);
         }
 
@@ -7693,7 +7692,9 @@ impl OpcodeStepExecutor for MIFrame {
         }
 
         // Fill keyword-only defaults.
-        let kwdefaults = unsafe { pyre_interpreter::function_get_kwdefaults(target_func) };
+        let kwdefaults = pyre_interpreter::baseobjspace::unwrap_cell(unsafe {
+            pyre_interpreter::function_get_kwdefaults(target_func)
+        });
         if !kwdefaults.is_null() && unsafe { pyre_object::is_dict(kwdefaults) } {
             let kwdefaults_opref = self.with_ctx(|this, ctx| {
                 let runtime_kwdefaults = ctx.call_ref_typed_with_effect(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7518,6 +7518,9 @@ impl OpcodeStepExecutor for MIFrame {
                 "abort tracing CALL_KW without concrete keyword tuple",
             ));
         }
+        self.with_ctx(|this, ctx| {
+            this.implement_guard_value(ctx, kwarg_names_val.opref, concrete_kwnames as i64);
+        });
         let nkw = unsafe { w_tuple_len(concrete_kwnames) };
         if nkw > args.len() {
             return Err(trace_abort_error(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7692,12 +7692,16 @@ impl OpcodeStepExecutor for MIFrame {
         // Pack **kwargs if needed.
         if has_varkw {
             let kw_dict = pyre_object::w_dict_new();
+            let mut item_oprefs = Vec::with_capacity(extra_kw_keys.len() * 2);
             for (key, val) in extra_kw_keys.iter().zip(extra_kw_vals.iter()) {
                 unsafe {
                     pyre_object::w_dict_store(kw_dict, *key, val.concrete.to_pyobj());
                 }
+                let key_opref = self.with_ctx(|_this, ctx| ctx.const_ref(*key as i64));
+                item_oprefs.push(key_opref);
+                item_oprefs.push(val.opref);
             }
-            let opref = self.with_ctx(|_this, ctx| ctx.const_ref(kw_dict as i64));
+            let opref = self.trace_build_map(&item_oprefs)?;
             final_args.push(FrontendOp::new(opref, ConcreteValue::from_pyobj(kw_dict)));
         }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7551,6 +7551,7 @@ impl OpcodeStepExecutor for MIFrame {
         let code_ptr = unsafe { pyre_interpreter::get_pycode(target_func) };
         let code = unsafe { &*(code_ptr as *const CodeObject) };
         let total_params = (code.arg_count + code.kwonlyarg_count) as usize;
+        let n_pos_params = code.arg_count as usize;
         let has_varargs = code.flags.contains(CodeFlags::VARARGS);
         let has_varkw = code.flags.contains(CodeFlags::VARKEYWORDS);
         let n_pos = args.len() - nkw;
@@ -7558,7 +7559,7 @@ impl OpcodeStepExecutor for MIFrame {
         let mut resolved: Vec<Option<FrontendOp>> = vec![None; total_params];
 
         // Fill positional args.
-        for i in 0..n_pos.min(total_params) {
+        for i in 0..n_pos.min(n_pos_params) {
             resolved[i] = Some(args[i].clone());
         }
 
@@ -7587,7 +7588,6 @@ impl OpcodeStepExecutor for MIFrame {
         }
 
         // Fill positional defaults.
-        let n_pos_params = code.arg_count as usize;
         let defaults_obj = unsafe { function_get_defaults(target_func) };
         if !defaults_obj.is_null() {
             let defaults_obj = pyre_interpreter::baseobjspace::unwrap_cell(defaults_obj);
@@ -7641,8 +7641,8 @@ impl OpcodeStepExecutor for MIFrame {
 
         // Pack *args if needed.
         if has_varargs {
-            let extra_pos: Vec<FrontendOp> = if n_pos > total_params {
-                args[total_params..n_pos].to_vec()
+            let extra_pos: Vec<FrontendOp> = if n_pos > n_pos_params {
+                args[n_pos_params..n_pos].to_vec()
             } else {
                 vec![]
             };


### PR DESCRIPTION
## Summary

This pull request adds support for tracing `CALL_KW` (function calls with keyword arguments) in the JIT trace engine, ensuring that keyword argument calls are handled correctly and consistently with user-defined Python functions. It introduces a new `call_kw` method, updates the instruction analysis logic, and adds supporting C-ABI functions for keyword defaults and dictionary lookup. The changes also update relevant tests to reflect the new behavior.

**Support for CALL_KW and Keyword Arguments:**

* Implements a new `call_kw` method in the `OpcodeStepExecutor` for handling `CALL_KW`, including argument resolution, default handling, and strict error checking for malformed calls. This ensures correct tracing of user function calls with keyword arguments, matching Python semantics.
* Adds C-ABI functions `trace_function_get_kwdefaults` and `trace_dict_lookup_jit` to support runtime access to keyword-only defaults and dictionary lookups during tracing.

**Instruction Analysis Updates:**

* Updates `instruction_needs_pre_opcode_snapshot` and `instruction_may_raise` to recognize `Instruction::CallKw` as requiring a snapshot and as a potentially raising instruction, aligning analysis with the new opcode support.

**Testing Updates:**

* Adjusts tests to assert the correct behavior for `Instruction::CallKw`, verifying that it is now recognized as possibly raising and requiring a pre-opcode snapshot.

Benchmark run:

```
$ python3 pyre/check.py --synthetic-only --synthetic-pattern default_keyword_args.py
[...]
Comparison
  benchmark                            cpython     pypy             dynasm          cranelift
  ──────────────────────────────────────────────────────────────────────────────────────────────────
  synth/default_keyword_args             0.38s    0.03s      0.55s   18.4x      0.71s   23.6x
```

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Cases Where Patch Regressed PyPy Parity Compared To Main

  None found. upstream/main had no trace-side CALL_KW implementation, so this patch improves coverage rather than regressing an existing equivalent
  path.

  2. Other Mismatches Introduced By Patch

  None found within the implemented subset: direct non-builtin user-function calls without *args / **kwargs. The manual resolution in pyre/pyre-jit-
  trace/src/trace_opcode.rs:7501 matches the relevant PyPy _match_signature flow for positional fill, keyword matching, positional defaults, kw-only
  defaults, duplicate keyword behavior, and missing-argument fallback-by-abort.

  The CallKw additions to instruction_may_raise and instruction_needs_pre_opcode_snapshot in pyre/pyre-jit-trace/src/state.rs:1661 are also consistent
  with PyPy: CALL_FUNCTION_KW goes through space.call_args, can invoke arbitrary Python code, and mutates the stack before the call/guard point.

  3. Mismatches That Already Existed Before This Patch

  The existing trace callable ABI is flat positional-only. SharedOpcodeHandler::call_callable builds concrete_args from a positional slice and calls
  call_user_function_plain_with_ctx for concrete execution in pyre/pyre-jit-trace/src/opcode_handler_impls_pre.template.rs:79. PyPy instead builds an
  Arguments object in CALL_FUNCTION_KW and passes that through space.call_args in pypy/interpreter/pyopcode.py:1386.

  This pre-existing ABI gap is why the new patch cannot faithfully residual-call arbitrary keyword calls yet.

  4. Structural Adaptations

  Several deliberate trace aborts are structural adaptations, not incorrect ports:

  - Non-user-function keyword calls abort in pyre/pyre-jit-trace/src/trace_opcode.rs:7542. PyPy supports methods, builtins, types, and __call__
    objects through Arguments; Pyre’s trace ABI currently cannot carry that structure.
  - User functions with *args / **kwargs abort in pyre/pyre-jit-trace/src/trace_opcode.rs:7585. PyPy packs these in _match_signature at pypy/
    interpreter/argument.py:222; Pyre would double-pack or drop kwargs if it reused the positional call helper.
  - Argument-error cases abort instead of tracing PyPy’s exact ArgErr* paths: too many positional args, positional-only keyword, duplicate positional/
    keyword, unknown keyword, missing required args. PyPy raises these via _match_signature / _match_keywords in pypy/interpreter/argument.py:259 and
    pypy/interpreter/argument.py:464.
  - The extra null_or_self pop is a CPython-compatible compiler stack-shape adaptation. PyPy’s CALL_FUNCTION_KW pops only w_function after positional
    args; Pyre’s interpreter has the same CPython-style shape in pyre/pyre-interpreter/src/eval.rs:2560.

  One notable coverage gap: PyPy has an explicit JIT regression test for method keyword calls in pypy/module/pypyjit/test_pypy_c/test_call.py:667.
  This patch still aborts those traces, but that is an existing trace-ABI limitation rather than a new parity regression.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tracing for calls with keyword arguments, including resolving keyword names, applying positional and kw-only defaults, runtime dict lookups for kw defaults, and stricter signature validation.

* **Bug Fixes**
  * Corrected bytecode handling so keyword-call instructions are treated like plain calls for exception detection and pre-opcode snapshotting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->