### PR TITLE
EC wiring + IR identity, regalloc, and HashMap retirement parity round

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -14,6 +14,20 @@ use crate::regalloc::{RegAlloc, RegAllocOp};
 use crate::regloc::{Loc, RegLoc};
 use majit_ir::{OpRef, Type};
 
+/// aarch64/regalloc.py:159 `DEFAULT_IMM_SIZE = 4096`.
+const DEFAULT_IMM_SIZE: i64 = 4096;
+
+/// aarch64/regalloc.py:169 `check_imm_box`. PyPy accepts only
+/// `ConstInt` values in the AArch64 immediate range; non-Int
+/// constants (ConstFloat/ConstPtr) and box references fall through
+/// to the register form.
+fn check_imm_box(arg: OpRef, val: i64) -> bool {
+    if !matches!(arg, OpRef::ConstInt(_)) {
+        return false;
+    }
+    val >= 0 && val < DEFAULT_IMM_SIZE
+}
+
 /// aarch64/registers.py:14
 ///   `all_regs = registers[:14] + [x19, x20] #, x21, x22]`
 pub fn all_core_regs() -> Vec<RegLoc> {
@@ -100,6 +114,9 @@ pub const MALLOC_NURSERY_RESULT: RegLoc = RegLoc {
 impl<'a> RegAlloc<'a> {
     /// aarch64/regalloc.py:362 `prepare_op_int_mul`. 3-operand form:
     /// both operands in registers, result allocated separately.
+    /// PyPy passes the full `boxes = op.getarglist()` as
+    /// `forbidden_vars` for both `make_sure_var_in_reg` calls
+    /// (regalloc.py:366-367), not just the opposite operand.
     pub(crate) fn consider_binop_j2(
         &mut self,
         dst: OpRef,
@@ -108,8 +125,9 @@ impl<'a> RegAlloc<'a> {
         i: usize,
         output: &mut Vec<RegAllocOp>,
     ) {
-        let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
-        let rhs_loc = self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false);
+        let boxes = [lhs, rhs];
+        let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
+        let rhs_loc = self.make_sure_var_in_reg(rhs, Type::Int, &boxes, None, false);
         self.possibly_free_var(lhs, Type::Int);
         self.possibly_free_var(rhs, Type::Int);
         let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);
@@ -146,10 +164,11 @@ impl<'a> RegAlloc<'a> {
         self.consider_int_ri_j2(dst, lhs, rhs, i, output);
     }
 
-    /// aarch64/regalloc.py:344 `prepare_op_int_sub`. `lhs` may be
-    /// constant only if it can be materialised into the scratch
-    /// register; the immediate path applies to `rhs` (encoded as
-    /// `sub Rd, Rn, #imm12`).
+    /// aarch64/regalloc.py:344 `prepare_op_int_sub`. `lhs` always
+    /// becomes Rn; `rhs` accepts the `sub Rd, Rn, #imm12` immediate
+    /// form only when it is a `ConstInt` in `[0, 4096)`
+    /// (`check_imm_box`). Other constants (ConstFloat/ConstPtr) and
+    /// out-of-range ints fall through to the register form.
     pub(crate) fn consider_int_sub_j2(
         &mut self,
         dst: OpRef,
@@ -158,17 +177,46 @@ impl<'a> RegAlloc<'a> {
         i: usize,
         output: &mut Vec<RegAllocOp>,
     ) {
-        // sub is asymmetric: lhs always becomes Rn.
-        let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
-        let rhs_loc = if rhs.is_constant() {
+        let boxes = [lhs, rhs];
+        let imm_rhs = check_imm_box(rhs, self.const_value(rhs));
+        let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
+        let rhs_loc = if imm_rhs {
             self.loc(rhs, Type::Int)
         } else {
-            self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false)
+            self.make_sure_var_in_reg(rhs, Type::Int, &boxes, None, false)
         };
         self.possibly_free_var(lhs, Type::Int);
         self.possibly_free_var(rhs, Type::Int);
         let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);
         self.perform(i, vec![lhs_loc, rhs_loc], Some(Loc::Reg(res)), output);
+    }
+
+    /// aarch64/regalloc.py:877 `prepare_comp_op_int_add_ovf =
+    /// prepare_int_ri`. The overflow form shares the immediate-friendly
+    /// preparation with `int_add` because `adds` accepts `#imm12`.
+    pub(crate) fn consider_int_add_ovf_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_int_ri_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// aarch64/regalloc.py:358 `prepare_comp_op_int_sub_ovf =
+    /// prepare_op_int_sub`. Shares preparation with `int_sub` since
+    /// `subs Rd, Rn, #imm12` accepts an immediate `rhs`.
+    pub(crate) fn consider_int_sub_ovf_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_int_sub_j2(dst, lhs, rhs, i, output);
     }
 
     /// aarch64/regalloc.py:362 — shifts piggy-back on `prepare_op_int_mul`.
@@ -213,9 +261,11 @@ impl<'a> RegAlloc<'a> {
         self.consider_binop_j2(dst, lhs, rhs, i, output);
     }
 
-    /// Internal helper for add: try the `add Rd, Rn, #imm12` immediate
-    /// form when one operand is a constant that fits, otherwise the
-    /// register form.  `lhs`/`rhs` are commutative for add.
+    /// aarch64/regalloc.py:321 `prepare_int_ri`. Either operand may
+    /// take the `add Rd, Rn, #imm12` immediate form when it is a
+    /// `ConstInt` in `[0, 4096)` (`check_imm_box`). Non-Int constants
+    /// (ConstFloat/ConstPtr) and out-of-range ints fall through to
+    /// the register form.
     fn consider_int_ri_j2(
         &mut self,
         dst: OpRef,
@@ -224,20 +274,22 @@ impl<'a> RegAlloc<'a> {
         i: usize,
         output: &mut Vec<RegAllocOp>,
     ) {
-        let imm_lhs = lhs.is_constant();
-        let imm_rhs = rhs.is_constant();
-        let (l0, l1) = if imm_lhs && !imm_rhs {
-            // add Rd, Rn, #imm — swap so the immediate stays on the RHS
-            let r0 = self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false);
-            let r1 = self.loc(lhs, Type::Int);
-            (r0, r1)
-        } else if !imm_lhs && imm_rhs {
-            let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
+        let boxes = [lhs, rhs];
+        let imm_lhs = check_imm_box(lhs, self.const_value(lhs));
+        let imm_rhs = check_imm_box(rhs, self.const_value(rhs));
+        let (l0, l1) = if !imm_lhs && imm_rhs {
+            let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
             let r1 = self.loc(rhs, Type::Int);
             (r0, r1)
+        } else if imm_lhs && !imm_rhs {
+            // PyPy regalloc.py:329-331 swaps so the immediate stays on
+            // the Rn slot; aarch64 `add` is commutative.
+            let r1 = self.loc(lhs, Type::Int);
+            let r0 = self.make_sure_var_in_reg(rhs, Type::Int, &boxes, None, false);
+            (r0, r1)
         } else {
-            let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
-            let r1 = self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false);
+            let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
+            let r1 = self.make_sure_var_in_reg(rhs, Type::Int, &boxes, None, false);
             (r0, r1)
         };
         self.possibly_free_var(lhs, Type::Int);

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -1,16 +1,18 @@
 //! Port of `rpython/jit/backend/aarch64/regalloc.py` — arch-specific
-//! register configuration that the shared
-//! `majit-backend-dynasm/src/regalloc.rs` (mirroring
-//! `rpython/jit/backend/llsupport/regalloc.py`) reads at construction
-//! time.
-//!
+//! register configuration plus the `prepare_op_int_*` family that
+//! depends on AAPCS64's 3-operand encoding (`ADD/SUB/MUL Rd, Rn, Rm`).
 //! Upstream splits per arch directory; pyre matches that split here.
-//! The aarch64 file is intentionally small — most of the `consider_*`
-//! and lifetime logic still lives in the shared base, just like
-//! upstream's RPython aarch64 inherits from llsupport.
+//!
+//! Methods that read/write the shared `RegAlloc` state are declared
+//! as a second `impl` block on `crate::regalloc::RegAlloc<'a>`, so
+//! Rust's name resolution picks up the right arch flavour at link
+//! time (the `aarch64` module is `#[cfg(target_arch = "aarch64")]`
+//! gated at `lib.rs:33`).
 
 use crate::aarch64::registers;
-use crate::regloc::RegLoc;
+use crate::regalloc::{RegAlloc, RegAllocOp};
+use crate::regloc::{Loc, RegLoc};
+use majit_ir::{OpRef, Type};
 
 /// aarch64/registers.py:14
 ///   `all_regs = registers[:14] + [x19, x20] #, x21, x22]`
@@ -86,3 +88,161 @@ pub const MALLOC_NURSERY_RESULT: RegLoc = RegLoc {
     value: 0,
     is_xmm: false,
 };
+
+/// `prepare_op_int_*` family — AArch64-side `consider_*_j2` entries.
+///
+/// AAPCS64's `ADD/SUB/MUL/AND/ORR/EOR/LSL/ASR/LSR Rd, Rn, Rm` accepts
+/// three distinct registers, so the result is always allocated via
+/// `force_allocate_reg` independently of the inputs.  RPython parity:
+/// `rpython/jit/backend/aarch64/regalloc.py:341 prepare_op_int_add`
+/// and `:362 prepare_op_int_mul` (the latter is reused for
+/// `and/or/xor/lshift/rshift/urshift/uint_mul_high`).
+impl<'a> RegAlloc<'a> {
+    /// aarch64/regalloc.py:362 `prepare_op_int_mul`. 3-operand form:
+    /// both operands in registers, result allocated separately.
+    pub(crate) fn consider_binop_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
+        let rhs_loc = self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false);
+        self.possibly_free_var(lhs, Type::Int);
+        self.possibly_free_var(rhs, Type::Int);
+        let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);
+        let res_loc = Loc::Reg(res);
+        self.perform(i, vec![lhs_loc, rhs_loc], Some(res_loc), output);
+    }
+
+    /// aarch64/regalloc.py:362 — `prepare_op_int_mul` is reused for
+    /// symmetric binops too; no x86-style swap optimisation is needed
+    /// because 3-operand encoding already lets `res` be distinct.
+    pub(crate) fn consider_binop_symm_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_binop_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// aarch64/regalloc.py:341 `prepare_op_int_add` → `prepare_int_ri`:
+    /// allows either operand to be an immediate that fits the AArch64
+    /// `add Rd, Rn, #imm12` (or shifted) encoding.  For non-immediate
+    /// or out-of-range constants, fall through to the register form.
+    pub(crate) fn consider_int_add_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_int_ri_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// aarch64/regalloc.py:344 `prepare_op_int_sub`. `lhs` may be
+    /// constant only if it can be materialised into the scratch
+    /// register; the immediate path applies to `rhs` (encoded as
+    /// `sub Rd, Rn, #imm12`).
+    pub(crate) fn consider_int_sub_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        // sub is asymmetric: lhs always becomes Rn.
+        let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
+        let rhs_loc = if rhs.is_constant() {
+            self.loc(rhs, Type::Int)
+        } else {
+            self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false)
+        };
+        self.possibly_free_var(lhs, Type::Int);
+        self.possibly_free_var(rhs, Type::Int);
+        let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);
+        self.perform(i, vec![lhs_loc, rhs_loc], Some(Loc::Reg(res)), output);
+    }
+
+    /// aarch64/regalloc.py:362 — shifts piggy-back on `prepare_op_int_mul`.
+    pub(crate) fn consider_int_lshift_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_binop_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// `prepare_op_int_neg` / `int_invert`. `neg X(d), X(s)` and
+    /// `mvn X(d), X(s)` are both 3-operand: result independent of
+    /// source.
+    pub(crate) fn consider_unary_int_j2(
+        &mut self,
+        dst: OpRef,
+        arg: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let arg_loc = self.make_sure_var_in_reg(arg, Type::Int, &[], None, false);
+        self.possibly_free_var(arg, Type::Int);
+        let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);
+        self.perform(i, vec![arg_loc], Some(Loc::Reg(res)), output);
+    }
+
+    /// aarch64/regalloc.py:397 `prepare_op_uint_mul_high = prepare_op_int_mul`.
+    /// `umulh Rd, Rn, Rm` is 3-operand; no scratch-pair constraints
+    /// (unlike x86 which forces EAX/EDX).
+    pub(crate) fn consider_uint_mul_high_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_binop_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// Internal helper for add: try the `add Rd, Rn, #imm12` immediate
+    /// form when one operand is a constant that fits, otherwise the
+    /// register form.  `lhs`/`rhs` are commutative for add.
+    fn consider_int_ri_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let imm_lhs = lhs.is_constant();
+        let imm_rhs = rhs.is_constant();
+        let (l0, l1) = if imm_lhs && !imm_rhs {
+            // add Rd, Rn, #imm — swap so the immediate stays on the RHS
+            let r0 = self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false);
+            let r1 = self.loc(lhs, Type::Int);
+            (r0, r1)
+        } else if !imm_lhs && imm_rhs {
+            let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
+            let r1 = self.loc(rhs, Type::Int);
+            (r0, r1)
+        } else {
+            let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &[rhs], None, false);
+            let r1 = self.make_sure_var_in_reg(rhs, Type::Int, &[lhs], None, false);
+            (r0, r1)
+        };
+        self.possibly_free_var(lhs, Type::Int);
+        self.possibly_free_var(rhs, Type::Int);
+        let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);
+        self.perform(i, vec![l0, l1], Some(Loc::Reg(res)), output);
+    }
+}

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -116,7 +116,9 @@ impl<'a> RegAlloc<'a> {
     /// both operands in registers, result allocated separately.
     /// PyPy passes the full `boxes = op.getarglist()` as
     /// `forbidden_vars` for both `make_sure_var_in_reg` calls
-    /// (regalloc.py:366-367), not just the opposite operand.
+    /// (regalloc.py:366-367), and after allocating the result also
+    /// calls `possibly_free_var(op)` (regalloc.py:372) so the result
+    /// register is reclaimable when the op is dead.
     pub(crate) fn consider_binop_j2(
         &mut self,
         dst: OpRef,
@@ -131,6 +133,7 @@ impl<'a> RegAlloc<'a> {
         self.possibly_free_var(lhs, Type::Int);
         self.possibly_free_var(rhs, Type::Int);
         let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);
+        self.possibly_free_var(dst, Type::Int);
         let res_loc = Loc::Reg(res);
         self.perform(i, vec![lhs_loc, rhs_loc], Some(res_loc), output);
     }
@@ -231,9 +234,13 @@ impl<'a> RegAlloc<'a> {
         self.consider_binop_j2(dst, lhs, rhs, i, output);
     }
 
-    /// `prepare_op_int_neg` / `int_invert`. `neg X(d), X(s)` and
-    /// `mvn X(d), X(s)` are both 3-operand: result independent of
-    /// source.
+    /// aarch64/regalloc.py:456 `prepare_unary` covers `int_neg`,
+    /// `int_invert`, `int_is_true`, `int_is_zero`. `neg X(d), X(s)`
+    /// and `mvn X(d), X(s)` are 3-operand: result independent of
+    /// source. PyPy asserts `not isinstance(a0, Const)`
+    /// (regalloc.py:458) since the optimizer is expected to have
+    /// folded any const-arg unary into a constant result before this
+    /// point.
     pub(crate) fn consider_unary_int_j2(
         &mut self,
         dst: OpRef,
@@ -241,6 +248,10 @@ impl<'a> RegAlloc<'a> {
         i: usize,
         output: &mut Vec<RegAllocOp>,
     ) {
+        debug_assert!(
+            !arg.is_constant(),
+            "prepare_unary expects a non-const arg; got constant OpRef {arg:?} (should have been folded earlier)"
+        );
         let arg_loc = self.make_sure_var_in_reg(arg, Type::Int, &[], None, false);
         self.possibly_free_var(arg, Type::Int);
         let res = self.force_allocate_reg(dst, Type::Int, &[], None, false);

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2559,13 +2559,18 @@ impl<'a> RegAlloc<'a> {
         match kind {
             IntBinKind::Add => self.consider_int_add_j2(dst, lhs, rhs, i, output),
             IntBinKind::Sub => self.consider_int_sub_j2(dst, lhs, rhs, i, output),
-            IntBinKind::AddOvf
-            | IntBinKind::Mul
+            // x86 routes AddOvf/SubOvf to _consider_binop{,_symm} because
+            // LEA can't set flags; aarch64 routes to prepare_int_ri /
+            // prepare_op_int_sub because adds/subs accept #imm12. Each
+            // backend implements consider_int_{add,sub}_ovf_j2 with the
+            // arch-correct semantics.
+            IntBinKind::AddOvf => self.consider_int_add_ovf_j2(dst, lhs, rhs, i, output),
+            IntBinKind::SubOvf => self.consider_int_sub_ovf_j2(dst, lhs, rhs, i, output),
+            IntBinKind::Mul
             | IntBinKind::MulOvf
             | IntBinKind::And
             | IntBinKind::Or
             | IntBinKind::Xor => self.consider_binop_symm_j2(dst, lhs, rhs, i, output),
-            IntBinKind::SubOvf => self.consider_binop_j2(dst, lhs, rhs, i, output),
             IntBinKind::LShift | IntBinKind::RShift | IntBinKind::URShift => {
                 self.consider_int_lshift_j2(dst, lhs, rhs, i, output)
             }

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -4924,9 +4924,10 @@ impl<'a> RegAlloc<'a> {
             arglocs.push(self.loc(arg, tp));
         }
 
+        let can_collect = calldescr.get_extra_info().check_can_collect();
         let save_regs = if save_all_regs {
             SAVE_ALL_REGS
-        } else if calldescr.get_extra_info().check_can_collect() {
+        } else if can_collect {
             SAVE_GCREF_REGS
         } else {
             SAVE_DEFAULT_REGS
@@ -4954,6 +4955,16 @@ impl<'a> RegAlloc<'a> {
             &type_index,
         );
 
+        // Same gcmap snapshot as `consider_call` above. The j2 dispatch
+        // handles the same Call*/CallMayForce*/CallReleaseGil* opcodes,
+        // so a collecting callee must record the live Ref slots that
+        // before_call just synced to the jitframe.
+        let gcmap = if can_collect {
+            Some(self.get_gcmap(&[], false) as usize)
+        } else {
+            None
+        };
+
         let result_tp = op.opcode.result_type();
         let result_loc = if result_tp != Type::Void {
             let dst = dst.unwrap_or(op.pos.get());
@@ -4968,7 +4979,11 @@ impl<'a> RegAlloc<'a> {
         };
         arglocs[0] = result_loc.unwrap_or(Loc::Immed(ImmedLoc::new(0)));
 
-        self.perform(i, arglocs, result_loc, output);
+        if let Some(gcmap) = gcmap {
+            self.perform_with_gcmap_ptr(i, arglocs, result_loc, gcmap, output);
+        } else {
+            self.perform(i, arglocs, result_loc, output);
+        }
     }
 
     /// llsupport/regalloc.py:894 locs_for_call_assembler parity.

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2097,7 +2097,7 @@ impl<'a> RegAlloc<'a> {
     }
 
     /// x86/regalloc.py:667 perform
-    fn perform(
+    pub(crate) fn perform(
         &mut self,
         op_index: usize,
         arglocs: Vec<Loc>,
@@ -2323,7 +2323,7 @@ impl<'a> RegAlloc<'a> {
     /// `majit-ir/src/op_type_index.rs:144-164` — the same cranelift
     /// caller seeding gap blocks fail-loud here. Convergence path
     /// closes both layers together.
-    fn tp(&self, v: OpRef) -> Type {
+    pub(crate) fn tp(&self, v: OpRef) -> Type {
         self.opref_type(v).unwrap_or(Type::Int)
     }
 
@@ -2333,7 +2333,7 @@ impl<'a> RegAlloc<'a> {
     /// CONST_BIT tag preserved) — see `convert_to_imm` at regalloc.rs
     /// line 1475 and the fail-args handling at line 2079. This helper
     /// must use the same key convention.
-    fn const_value(&self, v: OpRef) -> i64 {
+    pub(crate) fn const_value(&self, v: OpRef) -> i64 {
         self.constants.get(&v.raw()).copied().unwrap_or(0)
     }
 
@@ -3314,174 +3314,13 @@ impl<'a> RegAlloc<'a> {
 
     // ── consider_* methods ──
 
-    fn _consider_binop_part_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        symm: bool,
-    ) -> (Loc, Loc) {
-        let mut x = lhs;
-        let mut y = rhs;
-        let xloc = self.loc(x, self.tp(x));
-        let mut argloc = self.loc(y, self.tp(y));
-
-        if symm && !xloc.is_reg() && argloc.is_reg() {
-            let x_lives_longer = !self.longevity.contains(x)
-                || self.longevity.get(x).unwrap().last_usage > self.rm.position;
-            let y_dies = self
-                .longevity
-                .get(y)
-                .map(|lt| lt.last_usage == self.rm.position)
-                .unwrap_or(false);
-            if x_lives_longer && y_dies {
-                std::mem::swap(&mut x, &mut y);
-                argloc = self.loc(y, self.tp(y));
-            }
-        }
-
-        let tp = self.tp(x);
-        let args = [lhs, rhs];
-        let loc = self.rm.force_result_in_reg(
-            dst,
-            x,
-            tp,
-            &args,
-            &mut self.longevity,
-            &mut self.fm,
-            &self.constants,
-            &mut self.pending_moves,
-        );
-        (loc, argloc)
-    }
-
-    fn consider_binop_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        let (loc, argloc) = self._consider_binop_part_j2(dst, lhs, rhs, false);
-        self.perform(i, vec![loc, argloc], Some(loc), output);
-    }
-
-    fn consider_binop_symm_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        let (loc, argloc) = self._consider_binop_part_j2(dst, lhs, rhs, true);
-        self.perform(i, vec![loc, argloc], Some(loc), output);
-    }
-
-    fn _consider_lea_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        let loc = self.make_sure_var_in_reg(lhs, self.tp(lhs), &[], None, false);
-        self.possibly_free_var(lhs, self.tp(lhs));
-        let argloc = self.loc(rhs, self.tp(rhs));
-        let resloc = Loc::Reg(self.force_allocate_reg(dst, Type::Int, &[], None, false));
-        self.perform(i, vec![loc, argloc], Some(resloc), output);
-    }
-
-    fn consider_int_add_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        if rhs.is_constant() {
-            let val = self.const_value(rhs);
-            if fits_in_32bits(val) {
-                return self._consider_lea_j2(dst, lhs, rhs, i, output);
-            }
-        }
-        self.consider_binop_symm_j2(dst, lhs, rhs, i, output);
-    }
-
-    fn consider_int_sub_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        if rhs.is_constant() {
-            let val = self.const_value(rhs);
-            if fits_in_32bits(-val) {
-                return self._consider_lea_j2(dst, lhs, rhs, i, output);
-            }
-        }
-        self.consider_binop_j2(dst, lhs, rhs, i, output);
-    }
-
-    fn consider_int_lshift_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        #[cfg(target_arch = "aarch64")]
-        {
-            return self.consider_binop_j2(dst, lhs, rhs, i, output);
-        }
-        #[cfg(not(target_arch = "aarch64"))]
-        {
-            let loc2 = if rhs.is_constant() {
-                self.rm.convert_to_imm(rhs, &self.constants)
-            } else {
-                self.make_sure_var_in_reg(rhs, Type::Int, &[], Some(ECX), false)
-            };
-            let args = [lhs, rhs];
-            let loc1 = self.rm.force_result_in_reg(
-                dst,
-                lhs,
-                Type::Int,
-                &args,
-                &mut self.longevity,
-                &mut self.fm,
-                &self.constants,
-                &mut self.pending_moves,
-            );
-            self.perform(i, vec![loc1, loc2], Some(loc1), output);
-        }
-    }
-
-    fn consider_unary_int_j2(
-        &mut self,
-        dst: OpRef,
-        arg: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        let args = [arg];
-        let loc = self.rm.force_result_in_reg(
-            dst,
-            arg,
-            Type::Int,
-            &args,
-            &mut self.longevity,
-            &mut self.fm,
-            &self.constants,
-            &mut self.pending_moves,
-        );
-        self.perform(i, vec![loc], Some(loc), output);
-    }
+    // Integer binop / unary `consider_*_j2` methods live in the
+    // arch-specific modules (`crate::aarch64::regalloc` /
+    // `crate::x86::regalloc`) because the result-register coupling
+    // is encoding-dependent: x86 forces `dst = lhs` (2-operand form),
+    // AAPCS64 allocates the result independently (3-operand form).
+    // Mirrors the upstream `rpython/jit/backend/{aarch64,x86}/
+    // regalloc.py` split.
 
     fn consider_compop_j2(
         &mut self,
@@ -3502,53 +3341,9 @@ impl<'a> RegAlloc<'a> {
         self.perform(i, arglocs, Some(result_loc), output);
     }
 
-    fn consider_uint_mul_high_j2(
-        &mut self,
-        dst: OpRef,
-        lhs: OpRef,
-        rhs: OpRef,
-        i: usize,
-        output: &mut Vec<RegAllocOp>,
-    ) {
-        #[cfg(target_arch = "aarch64")]
-        {
-            return self.consider_binop_symm_j2(dst, lhs, rhs, i, output);
-        }
-        #[cfg(not(target_arch = "aarch64"))]
-        {
-            let mut arg1 = lhs;
-            let mut arg2 = rhs;
-            if arg1.is_constant() {
-                std::mem::swap(&mut arg1, &mut arg2);
-            }
-            self.make_sure_var_in_reg(arg2, Type::Int, &[], Some(EAX), false);
-            let l1 = self.loc(arg1, Type::Int);
-            self.possibly_free_var(arg2, Type::Int);
-            // x86/regalloc.py:605 tmpvar = TempVar()
-            let tmp = self.fresh_temp_var();
-            self.longevity
-                .set(tmp, Lifetime::new(self.rm.position, self.rm.position));
-            self.rm.force_allocate_reg(
-                tmp,
-                &[],
-                Some(EAX),
-                false,
-                &mut self.longevity,
-                &mut self.fm,
-            );
-            self.rm
-                .possibly_free_var(tmp, &mut self.longevity, &mut self.fm, Type::Int);
-            self.rm.force_allocate_reg(
-                dst,
-                &[],
-                Some(EDX),
-                false,
-                &mut self.longevity,
-                &mut self.fm,
-            );
-            self.perform(i, vec![l1], Some(Loc::Reg(EDX)), output);
-        }
-    }
+    // `consider_uint_mul_high_j2` is arch-specific: aarch64 uses the
+    // 3-operand `umulh`, x86 forces EAX/EDX pinning for `MUL`. See
+    // the arch-specific impl blocks.
 
     fn consider_int_signext_j2(
         &mut self,

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -1,15 +1,21 @@
 //! Port of `rpython/jit/backend/x86/regalloc.py` — arch-specific
-//! register configuration that the shared
-//! `majit-backend-dynasm/src/regalloc.rs` (mirroring
-//! `rpython/jit/backend/llsupport/regalloc.py`) reads at construction
-//! time.
-//!
+//! register configuration plus the `consider_int_*` family that
+//! depends on x86's 2-operand encoding (`OP dst, src` where dst
+//! must be the same as the first operand).
 //! Upstream splits per arch directory; pyre matches that split here.
+//!
+//! Methods that read/write the shared `RegAlloc` state are declared
+//! as a second `impl` block on `crate::regalloc::RegAlloc<'a>`. The
+//! `x86` module is `#[cfg(target_arch = "x86_64")]` gated at
+//! `lib.rs:35`, so these methods only compile on x86_64.
 
+use crate::regalloc::{RegAlloc, RegAllocOp, fits_in_32bits};
 use crate::regloc::{
     EAX, EBP, EBX, ECX, EDI, EDX, ESI, R8, R9, R10, R12, R13, R14, R15, RegLoc, XMM0, XMM1, XMM2,
     XMM3, XMM4, XMM5, XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14,
 };
+use crate::regloc::Loc;
+use majit_ir::{OpRef, Type};
 
 /// x86/regalloc.py X86_64_RegisterManager.all_regs — the GPR allocation
 /// pool.  Order chosen to prefer caller-save first (popped from end).
@@ -103,3 +109,238 @@ pub const MALLOC_NURSERY_CLOBBER: [RegLoc; 2] = [ECX, EDX];
 /// x86_64: result register after the nursery bump (ecx per
 /// regalloc.py:1021).
 pub const MALLOC_NURSERY_RESULT: RegLoc = ECX;
+
+/// `consider_int_*` family — x86-side `consider_*_j2` entries.
+///
+/// x86's two-operand encoding (`OP dst, src` with dst = first
+/// operand) means the result register is forced onto the lhs slot
+/// via `force_result_in_reg`.  RPython parity:
+/// `rpython/jit/backend/x86/regalloc.py:528 _consider_binop_part`
+/// and `:566 consider_int_add` (plus `_consider_lea` for the
+/// `add reg, imm32` LEA shortcut).
+impl<'a> RegAlloc<'a> {
+    /// x86/regalloc.py:528 `_consider_binop_part`. Sets up `dst =
+    /// lhs` register coupling; for symmetric ops, swaps `lhs`/`rhs`
+    /// when that lets us avoid a spill.
+    fn _consider_binop_part_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        symm: bool,
+    ) -> (Loc, Loc) {
+        let mut x = lhs;
+        let mut y = rhs;
+        let xloc = self.loc(x, self.tp(x));
+        let mut argloc = self.loc(y, self.tp(y));
+
+        if symm && !xloc.is_reg() && argloc.is_reg() {
+            let x_lives_longer = !self.longevity.contains(x)
+                || self.longevity.get(x).unwrap().last_usage > self.rm.position;
+            let y_dies = self
+                .longevity
+                .get(y)
+                .map(|lt| lt.last_usage == self.rm.position)
+                .unwrap_or(false);
+            if x_lives_longer && y_dies {
+                std::mem::swap(&mut x, &mut y);
+                argloc = self.loc(y, self.tp(y));
+            }
+        }
+
+        let tp = self.tp(x);
+        let args = [lhs, rhs];
+        let loc = self.rm.force_result_in_reg(
+            dst,
+            x,
+            tp,
+            &args,
+            &mut self.longevity,
+            &mut self.fm,
+            &self.constants,
+            &mut self.pending_moves,
+        );
+        (loc, argloc)
+    }
+
+    /// x86/regalloc.py:548 `_consider_binop` — asymmetric binop.
+    pub(crate) fn consider_binop_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let (loc, argloc) = self._consider_binop_part_j2(dst, lhs, rhs, false);
+        self.perform(i, vec![loc, argloc], Some(loc), output);
+    }
+
+    /// x86/regalloc.py:552 `_consider_binop_symm` — symmetric binop
+    /// with the swap heuristic.
+    pub(crate) fn consider_binop_symm_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let (loc, argloc) = self._consider_binop_part_j2(dst, lhs, rhs, true);
+        self.perform(i, vec![loc, argloc], Some(loc), output);
+    }
+
+    /// x86/regalloc.py:556 `_consider_lea` — emits `LEA dst, [lhs +
+    /// rhs]` so the result register can differ from `lhs`. Limited
+    /// to RHS constants that fit a 32-bit displacement.
+    fn _consider_lea_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let loc = self.make_sure_var_in_reg(lhs, self.tp(lhs), &[], None, false);
+        self.possibly_free_var(lhs, self.tp(lhs));
+        let argloc = self.loc(rhs, self.tp(rhs));
+        let resloc = Loc::Reg(self.force_allocate_reg(dst, Type::Int, &[], None, false));
+        self.perform(i, vec![loc, argloc], Some(resloc), output);
+    }
+
+    /// x86/regalloc.py:566 `consider_int_add` — LEA shortcut when
+    /// the RHS is a 32-bit-fitting immediate, otherwise symmetric
+    /// 2-operand `ADD dst, src`.
+    pub(crate) fn consider_int_add_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        if rhs.is_constant() {
+            let val = self.const_value(rhs);
+            if fits_in_32bits(val) {
+                return self._consider_lea_j2(dst, lhs, rhs, i, output);
+            }
+        }
+        self.consider_binop_symm_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// x86/regalloc.py:575 `consider_int_sub` — LEA shortcut with
+    /// negated immediate (`LEA dst, [lhs - imm]`).
+    pub(crate) fn consider_int_sub_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        if rhs.is_constant() {
+            let val = self.const_value(rhs);
+            if fits_in_32bits(-val) {
+                return self._consider_lea_j2(dst, lhs, rhs, i, output);
+            }
+        }
+        self.consider_binop_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// x86/regalloc.py:624 `consider_int_lshift` — shift count must
+    /// be in ECX (`SHL/SHR/SAR reg, CL`) unless it's an immediate.
+    pub(crate) fn consider_int_lshift_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let loc2 = if rhs.is_constant() {
+            self.rm.convert_to_imm(rhs, &self.constants)
+        } else {
+            self.make_sure_var_in_reg(rhs, Type::Int, &[], Some(ECX), false)
+        };
+        let args = [lhs, rhs];
+        let loc1 = self.rm.force_result_in_reg(
+            dst,
+            lhs,
+            Type::Int,
+            &args,
+            &mut self.longevity,
+            &mut self.fm,
+            &self.constants,
+            &mut self.pending_moves,
+        );
+        self.perform(i, vec![loc1, loc2], Some(loc1), output);
+    }
+
+    /// x86/regalloc.py:612 `consider_int_neg` / `consider_int_invert`
+    /// — `NEG dst` and `NOT dst` overwrite their argument register.
+    pub(crate) fn consider_unary_int_j2(
+        &mut self,
+        dst: OpRef,
+        arg: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let args = [arg];
+        let loc = self.rm.force_result_in_reg(
+            dst,
+            arg,
+            Type::Int,
+            &args,
+            &mut self.longevity,
+            &mut self.fm,
+            &self.constants,
+            &mut self.pending_moves,
+        );
+        self.perform(i, vec![loc], Some(loc), output);
+    }
+
+    /// x86/regalloc.py:591 `consider_uint_mul_high` — emits `MUL src`,
+    /// which clobbers EAX (low) and EDX (high), so EAX must be
+    /// pinned to one operand and EDX to the result.
+    pub(crate) fn consider_uint_mul_high_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let mut arg1 = lhs;
+        let mut arg2 = rhs;
+        if arg1.is_constant() {
+            std::mem::swap(&mut arg1, &mut arg2);
+        }
+        self.make_sure_var_in_reg(arg2, Type::Int, &[], Some(EAX), false);
+        let l1 = self.loc(arg1, Type::Int);
+        self.possibly_free_var(arg2, Type::Int);
+        let tmp = self.fresh_temp_var();
+        self.longevity.set(
+            tmp,
+            crate::regalloc::Lifetime::new(self.rm.position, self.rm.position),
+        );
+        self.rm.force_allocate_reg(
+            tmp,
+            &[],
+            Some(EAX),
+            false,
+            &mut self.longevity,
+            &mut self.fm,
+        );
+        self.rm
+            .possibly_free_var(tmp, &mut self.longevity, &mut self.fm, Type::Int);
+        self.rm.force_allocate_reg(
+            dst,
+            &[],
+            Some(EDX),
+            false,
+            &mut self.longevity,
+            &mut self.fm,
+        );
+        self.perform(i, vec![l1], Some(Loc::Reg(EDX)), output);
+    }
+}

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -240,8 +240,14 @@ impl<'a> RegAlloc<'a> {
     ) {
         if rhs.is_constant() {
             let val = self.const_value(rhs);
-            if fits_in_32bits(-val) {
-                return self._consider_lea_j2(dst, lhs, rhs, i, output);
+            // PyPy `rx86.fits_in_32bits(-y.value)` (regalloc.py:577) is safe
+            // because Python ints are arbitrary precision; Rust `-i64::MIN`
+            // overflows. `checked_neg` returns None for that single edge
+            // case and falls back to the normal SUB path.
+            if let Some(neg) = val.checked_neg() {
+                if fits_in_32bits(neg) {
+                    return self._consider_lea_j2(dst, lhs, rhs, i, output);
+                }
             }
         }
         self.consider_binop_j2(dst, lhs, rhs, i, output);

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -282,6 +282,35 @@ impl<'a> RegAlloc<'a> {
         self.perform(i, vec![loc1, loc2], Some(loc1), output);
     }
 
+    /// x86/regalloc.py:589 `consider_int_add_ovf = _consider_binop_symm`.
+    /// Distinct from `consider_int_add` because the LEA shortcut does
+    /// not set CPU flags and cannot be used when the trace needs the
+    /// overflow condition.
+    pub(crate) fn consider_int_add_ovf_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_binop_symm_j2(dst, lhs, rhs, i, output);
+    }
+
+    /// x86/regalloc.py:588 `consider_int_sub_ovf = _consider_binop`.
+    /// LEA cannot set flags, so SUB-via-LEA is unavailable for the
+    /// overflow form.
+    pub(crate) fn consider_int_sub_ovf_j2(
+        &mut self,
+        dst: OpRef,
+        lhs: OpRef,
+        rhs: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_binop_j2(dst, lhs, rhs, i, output);
+    }
+
     /// x86/regalloc.py:612 `consider_int_neg` / `consider_int_invert`
     /// — `NEG dst` and `NOT dst` overwrite their argument register.
     pub(crate) fn consider_unary_int_j2(

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -10,11 +10,11 @@
 //! `lib.rs:35`, so these methods only compile on x86_64.
 
 use crate::regalloc::{RegAlloc, RegAllocOp, fits_in_32bits};
+use crate::regloc::Loc;
 use crate::regloc::{
     EAX, EBP, EBX, ECX, EDI, EDX, ESI, R8, R9, R10, R12, R13, R14, R15, RegLoc, XMM0, XMM1, XMM2,
     XMM3, XMM4, XMM5, XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14,
 };
-use crate::regloc::Loc;
 use majit_ir::{OpRef, Type};
 
 /// x86/regalloc.py X86_64_RegisterManager.all_regs — the GPR allocation

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -506,13 +506,17 @@ pub trait GcRewriter: Send {
     /// Rewrite with access to the constant pool.
     /// Returns (rewritten ops, merged constants, type annotations for
     /// constants minted by the rewriter).
+    ///
+    /// The default impl forwards to `rewrite_for_gc` and preserves the
+    /// caller's constants verbatim. `rewrite_for_gc` may leave `Const*`
+    /// operands untouched, so returning an empty map would silently strand
+    /// downstream readers that resolve `ConstInt.raw()` against this table.
     fn rewrite_for_gc_with_constants(
         &self,
         ops: &[Op],
         constants: &VecAssoc<u32, i64>,
     ) -> (Vec<Op>, VecAssoc<u32, i64>, VecAssoc<u32, Type>) {
-        let _ = constants;
-        (self.rewrite_for_gc(ops), VecAssoc::new(), VecAssoc::new())
+        (self.rewrite_for_gc(ops), constants.clone(), VecAssoc::new())
     }
 }
 

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -23,7 +23,7 @@ use crate::value::{GcRef, Type};
 /// This keeps the disjoint RPython Box classes disjoint even when Pyre's
 /// flat encoding reuses the same raw position across InputArg / ResOp /
 /// Const namespaces.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum OpRef {
     /// Sentinel for missing/absent reference; `OpRef::NONE` aliases this.
     /// RPython has no equivalent — missing values are Python `None`.

--- a/majit/majit-metainterp/Cargo.toml
+++ b/majit/majit-metainterp/Cargo.toml
@@ -19,6 +19,7 @@ majit-gc = { workspace = true }
 majit-translate = { workspace = true }
 majit-backend-dynasm = { workspace = true, optional = true }
 smallvec = "1"
+vecset = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 majit-backend-cranelift = { workspace = true, optional = true }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -86,11 +86,13 @@ pub fn wire_clt_loop_token_wref(token: &Arc<JitCellToken>) {
 /// RPython resume.py:389-452 parity: guard metadata sees only the
 /// Box.type values available at the guard's numbering point, not later
 /// operations in the same trace. `value_types` is the incremental
-/// guard-point map maintained by `build_guard_metadata`.
-fn fail_arg_type(
-    opref: &OpRef,
-    value_types: &crate::optimizeopt::vec_assoc::VecAssoc<u32, Type>,
-) -> Type {
+/// guard-point map maintained by `build_guard_metadata`, stored as a
+/// `vecset::VecMap<u32, Type>` keyed by `OpRef::raw()` (no-HashMap rule;
+/// sparse OpRef keys made a dense `Vec<Option<Type>>` allocate and zero
+/// the full [0..max_opref) range per call — triggered macOS large-malloc
+/// mmap on every guard emission. VecMap allocates proportional to live
+/// entries only — see task #149 fannkuch sys-time).
+fn fail_arg_type(opref: &OpRef, value_types: &vecset::VecMap<u32, Type>) -> Type {
     if *opref == OpRef::NONE {
         return Type::Ref;
     }
@@ -409,13 +411,16 @@ pub(crate) fn build_guard_metadata(
     // Mirror main's incremental walk: maintain `value_types` seeded
     // from inputargs + constants, then insert each op's result type
     // before consulting it.
-    let mut value_types: crate::optimizeopt::vec_assoc::VecAssoc<u32, Type> =
-        crate::optimizeopt::vec_assoc::VecAssoc::new();
+    // `vecset::VecMap<u32, Type>` keyed by `OpRef::raw()` (no-HashMap rule).
+    // Sparse OpRef keys would make a dense `Vec<Option<Type>>` allocate
+    // and zero the full [0..max_opref) range per call (large traces hit
+    // macOS large-malloc mmap path — see task #149 fannkuch sys-time).
+    let mut value_types: vecset::VecMap<u32, Type> = vecset::VecMap::new();
     for arg in inputargs.iter() {
         value_types.insert(arg.index, arg.tp);
     }
     for (&idx, c) in constants.iter() {
-        if !value_types.contains_key(&idx) {
+        if value_types.get(&idx).is_none() {
             value_types.insert(idx, c.get_type());
         }
     }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1566,6 +1566,13 @@ pub(crate) fn infer_terminal_exit_layout(
         .getarglist()
         .iter()
         .map(|opref| {
+            // `OpRef::NONE` represents a null-ref placeholder per
+            // `fail_arg_type`; preserve `Type::Ref` so downstream
+            // `gc_ref_slots` + `decode_values_with_layout` see the same
+            // null-Ref typing the rest of the resume path uses.
+            if opref.is_none() {
+                return Type::Ref;
+            }
             type_index
                 .opref_type_at(*opref, op_index)
                 .unwrap_or(Type::Int)

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3696,28 +3696,35 @@ impl<S: JitState> JitDriver<S> {
         // bridge tracing runs synchronously within start_bridge_tracing's
         // caller scope, so self.meta outlives the callback.
         let meta_ptr = &self.meta as *const _ as *const ();
-        if let Some(ref mut ctx) = self.meta.tracing {
-            ctx.header_pc = resume_pc;
-            // pyjitpl.py:2978 `if not self.partial_trace:` — bridge
-            // entry sets the explicit flag so close-loop consumers
-            // can apply bridge-only behavior without overloading
-            // `has_compiled_targets_fn` presence.
-            ctx.is_bridge_trace = true;
-            ctx.has_compiled_targets_fn = Some(Box::new(move |gk: u64| -> bool {
-                let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };
-                meta.has_compiled_targets(gk)
-            }));
-            // pyjitpl.py:1551 first-iteration auto loop-header
-            // `if self.metainterp.portal_call_depth: return` parity —
-            // sample the live counter through the same self.meta
-            // pointer.  Same lifetime invariant as
-            // `has_compiled_targets_fn` (bridge tracing runs
-            // synchronously within `start_bridge_tracing`'s scope).
-            ctx.portal_call_depth_fn = Some(Box::new(move || -> i32 {
-                let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };
-                meta.portal_call_depth
-            }));
-        }
+        // `start_retrace_from_guard` above sets `self.meta.tracing = Some(..)`
+        // on success (pyjitpl.py:9415). Fail loud rather than skipping bridge
+        // header_pc / is_bridge_trace / has_compiled_targets_fn wiring
+        // silently.
+        let ctx = self
+            .meta
+            .tracing
+            .as_mut()
+            .expect("bridge: tracing context must be live after start_retrace_from_guard");
+        ctx.header_pc = resume_pc;
+        // pyjitpl.py:2978 `if not self.partial_trace:` — bridge
+        // entry sets the explicit flag so close-loop consumers
+        // can apply bridge-only behavior without overloading
+        // `has_compiled_targets_fn` presence.
+        ctx.is_bridge_trace = true;
+        ctx.has_compiled_targets_fn = Some(Box::new(move |gk: u64| -> bool {
+            let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };
+            meta.has_compiled_targets(gk)
+        }));
+        // pyjitpl.py:1551 first-iteration auto loop-header
+        // `if self.metainterp.portal_call_depth: return` parity —
+        // sample the live counter through the same self.meta
+        // pointer.  Same lifetime invariant as
+        // `has_compiled_targets_fn` (bridge tracing runs
+        // synchronously within `start_bridge_tracing`'s scope).
+        ctx.portal_call_depth_fn = Some(Box::new(move || -> i32 {
+            let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };
+            meta.portal_call_depth
+        }));
         // resume.py:1042 parity: map frame locals to bridge InputArg OpRefs
         // so bridge tracing sees locals as symbolic variables, not concrete values.
         // resume.py:945-956 getvirtual_ptr parity: when frame.values contains
@@ -3739,18 +3746,27 @@ impl<S: JitState> JitDriver<S> {
                 .pending_frontend_boxes_ref()
                 .map(|s| s.to_vec())
                 .unwrap_or_default();
-            if let (Some(ref mut sym), Some(ref mut ctx)) =
-                (self.sym.as_mut(), self.meta.tracing.as_mut())
-            {
-                S::setup_bridge_sym(
-                    sym,
-                    ctx,
-                    bfm,
-                    retrace.storage.as_deref().map(|s| s.rd_virtuals.as_slice()),
-                    &raw_values,
-                    &retrace.fail_types,
-                );
-            }
+            // Both `self.sym` (set above via `self.sym = Some(sym)`) and
+            // `self.meta.tracing` (set by `start_retrace_from_guard`) must be
+            // live by construction at this point. Skipping `setup_bridge_sym`
+            // silently would leave the bridge sym uninitialized.
+            let sym = self
+                .sym
+                .as_mut()
+                .expect("bridge: sym must be live after S::create_sym");
+            let ctx = self
+                .meta
+                .tracing
+                .as_mut()
+                .expect("bridge: tracing context must be live");
+            S::setup_bridge_sym(
+                sym,
+                ctx,
+                bfm,
+                retrace.storage.as_deref().map(|s| s.rd_virtuals.as_slice()),
+                &raw_values,
+                &retrace.fail_types,
+            );
         }
         self.meta.begin_trace_session(trace_meta);
         // resume.py:1047-1055 parity:
@@ -3794,9 +3810,12 @@ impl<S: JitState> JitDriver<S> {
             });
         // RPython pyjitpl.py:2908 — bridge traces start with empty
         // current_merge_points (no loop header to match against).
-        if let Some(ref mut ctx) = self.meta.tracing {
-            ctx.clear_merge_points();
-        }
+        let ctx = self
+            .meta
+            .tracing
+            .as_mut()
+            .expect("bridge: tracing context must be live");
+        ctx.clear_merge_points();
 
         // RPython pyjitpl.py:3101 _prepare_exception_resumption parity:
         // For exception guard bridges, the caller should emit

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -4918,4 +4918,77 @@ mod tests {
             );
         }
     }
+
+    /// `any_call_recorded_since` is the gate consulted by
+    /// `handle_possible_exception` to decide whether GUARD_NO_EXCEPTION
+    /// should fire. PyPy `pyjitpl.py:2082` only emits this guard inside
+    /// `do_residual_call`, so the gate returns false when no Call* op
+    /// has been recorded within the current opcode window.
+    #[test]
+    fn any_call_recorded_since_empty_recorder_is_false() {
+        let recorder = Trace::new();
+        let ctx = TraceCtx::new(
+            recorder,
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        );
+        assert!(!ctx.any_call_recorded_since(0));
+    }
+
+    #[test]
+    fn any_call_recorded_since_non_call_op_is_false() {
+        let mut recorder = Trace::new();
+        let a = recorder.record_input_arg(Type::Int);
+        let b = recorder.record_input_arg(Type::Int);
+        let mut ctx = TraceCtx::new(
+            recorder,
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        );
+        let start = ctx.num_ops() as u32;
+        ctx.record_op(OpCode::IntAdd, &[a, b]);
+        // A pure arithmetic op cannot raise, so the gate stays false.
+        assert!(!ctx.any_call_recorded_since(start));
+    }
+
+    #[test]
+    fn any_call_recorded_since_call_op_is_true() {
+        let mut recorder = Trace::new();
+        let a = recorder.record_input_arg(Type::Int);
+        let mut ctx = TraceCtx::new(
+            recorder,
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        );
+        let start = ctx.num_ops() as u32;
+        let descr = majit_ir::descr::make_call_descr(
+            vec![Type::Int],
+            Type::Int,
+            majit_ir::EffectInfo::default(),
+        );
+        ctx.record_op_with_descr(OpCode::CallI, &[a], descr);
+        // A CALL_* op was recorded after the snapshot — gate fires.
+        assert!(ctx.any_call_recorded_since(start));
+    }
+
+    #[test]
+    fn any_call_recorded_since_pre_start_call_is_false() {
+        let mut recorder = Trace::new();
+        let a = recorder.record_input_arg(Type::Int);
+        let mut ctx = TraceCtx::new(
+            recorder,
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        );
+        let descr = majit_ir::descr::make_call_descr(
+            vec![Type::Int],
+            Type::Int,
+            majit_ir::EffectInfo::default(),
+        );
+        ctx.record_op_with_descr(OpCode::CallI, &[a], descr);
+        let start = ctx.num_ops() as u32;
+        // start points past the recorded call; nothing has been recorded
+        // in the new window so the gate stays false.
+        assert!(!ctx.any_call_recorded_since(start));
+    }
 }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1312,6 +1312,21 @@ impl TraceCtx {
         self.recorder.num_ops()
     }
 
+    /// Whether the recorder contains any `Call*` family op at or after
+    /// position `start`. Used by `handle_possible_exception` to decide
+    /// if the current bytecode actually performed a residual call that
+    /// could have set the exception flag; absent any such call no
+    /// `GUARD_NO_EXCEPTION` need be recorded (PyPy parity: `do_residual_call`
+    /// pyjitpl.py:2082 is the only emit site).
+    pub fn any_call_recorded_since(&self, start: u32) -> bool {
+        let start = start as usize;
+        let ops = self.recorder.ops();
+        if start >= ops.len() {
+            return false;
+        }
+        ops[start..].iter().any(|op| op.opcode.is_call())
+    }
+
     /// The structured green key values, if provided.
     pub fn green_key_values(&self) -> Option<&GreenKey> {
         self.green_key_values.as_ref()

--- a/majit/majit-trace/Cargo.toml
+++ b/majit/majit-trace/Cargo.toml
@@ -11,3 +11,4 @@ majit-ir = { workspace = true }
 majit-backend = { workspace = true }
 majit-gc = { workspace = true }
 smallvec = "1"
+vecset = { workspace = true }

--- a/majit/majit-trace/src/heapcache.rs
+++ b/majit/majit-trace/src/heapcache.rs
@@ -7,7 +7,6 @@
 /// Translated from rpython/jit/metainterp/heapcache.py.
 use std::marker::PhantomData;
 
-use majit_ir::vec_assoc::VecAssoc;
 use majit_ir::vec_set::VecSet;
 
 // Vec<bool> helpers — RPython stores these as FrontendOp flags, not sets.
@@ -95,8 +94,8 @@ const _HF_VERSION_MAX: u32 = HF_VERSION_MAX;
 /// side-table indirection.
 #[derive(Debug, Default)]
 pub(crate) struct CacheEntry {
-    cache_anything: VecAssoc<OpRef, HeapBox>,
-    cache_seen_allocation: VecAssoc<OpRef, HeapBox>,
+    cache_anything: vecset::VecMap<OpRef, HeapBox>,
+    cache_seen_allocation: vecset::VecMap<OpRef, HeapBox>,
     quasiimmut_seen: Option<VecSet<OpRef>>,
     quasiimmut_seen_refs: Option<VecSet<usize>>,
     last_const_box: Option<OpRef>,
@@ -133,7 +132,7 @@ impl CacheEntry {
     }
 
     /// heapcache.py:84-88 _getdict
-    pub fn _getdict(&self, seen_alloc: bool) -> &VecAssoc<OpRef, HeapBox> {
+    pub fn _getdict(&self, seen_alloc: bool) -> &vecset::VecMap<OpRef, HeapBox> {
         if seen_alloc {
             &self.cache_seen_allocation
         } else {
@@ -143,7 +142,7 @@ impl CacheEntry {
 
     /// Pyre adapt: Python doesn't need a separate `_mut` accessor;
     /// Rust's borrow checker does.  Mirrors `_getdict`'s body.
-    pub fn _getdict_mut(&mut self, seen_alloc: bool) -> &mut VecAssoc<OpRef, HeapBox> {
+    pub fn _getdict_mut(&mut self, seen_alloc: bool) -> &mut vecset::VecMap<OpRef, HeapBox> {
         if seen_alloc {
             &mut self.cache_seen_allocation
         } else {
@@ -353,13 +352,18 @@ pub struct HeapCache {
     /// same `CacheEntry`, which owns the `cache_anything` /
     /// `cache_seen_allocation` dicts and the `last_const_box`
     /// `_unique_const_heuristic` LRU per heapcache.py:50-104.
-    heap_cache: VecAssoc<u32, CacheEntry>,
+    /// Backed by `vecset::VecMap` (sorted Vec + binary search) so the
+    /// hot per-descr lookup is O(log n) instead of linear scan when the
+    /// same descr is touched repeatedly across many frames.
+    heap_cache: vecset::VecMap<u32, CacheEntry>,
     /// heapcache.py: `cached_arrayitems` — nested map descr → ConstInt-index → CacheEntry.
     /// heapcache.py:557 `cache.get(index, None)` — array cache keyed by
     /// the `ConstInt.getint()` value, not the index Box's identity. Two
     /// distinct ConstInt boxes carrying the same `i64` index land in the
-    /// same slot, matching the upstream lookup semantics.
-    heap_array_cache: VecAssoc<u32, VecAssoc<i64, CacheEntry>>,
+    /// same slot, matching the upstream lookup semantics. `i64` indices
+    /// can be negative, so `vecset::VecMap` (sorted Vec + binary search)
+    /// is the natural no-HashMap substitute.
+    heap_array_cache: vecset::VecMap<u32, vecset::VecMap<i64, CacheEntry>>,
 
     /// Known class map: object_ref -> class pointer.
     /// RPython: CacheEntry 내부. Vec indexed by OpRef.0.
@@ -426,8 +430,8 @@ impl HeapCache {
     /// Create a new, empty heap cache.
     pub fn new() -> Self {
         HeapCache {
-            heap_cache: VecAssoc::new(),
-            heap_array_cache: VecAssoc::new(),
+            heap_cache: vecset::VecMap::new(),
+            heap_array_cache: vecset::VecMap::new(),
             known_class: Vec::new(),
             quasi_immut_known: VecSet::new(),
             is_unescaped: Vec::new(),
@@ -1517,8 +1521,8 @@ impl HeapCache {
                     let dst_index = dststart + i;
                     let entry = self
                         .heap_array_cache
-                        .entry_or_default(descr)
-                        .entry_or_insert_with(dst_index, CacheEntry::new);
+                        .entry(descr).or_default()
+                        .entry(dst_index).or_insert_with(CacheEntry::new);
                     // heapcache.py:90-94 `do_write_with_aliasing` —
                     // canonicalise dest, then `_clear_cache_on_write(seen_alloc)`
                     // BEFORE the insert so aliasing entries from prior
@@ -1689,8 +1693,8 @@ impl HeapCache {
         let seen_alloc = self.saw_allocation(array);
         let entry = self
             .heap_array_cache
-            .entry_or_default(descr)
-            .entry_or_insert_with(index_value, CacheEntry::new);
+            .entry(descr).or_default()
+            .entry(index_value).or_insert_with(CacheEntry::new);
         // CacheEntry.do_write_with_aliasing internally canonicalises
         // ConstPtr operands via `_unique_const_heuristic`, replicating
         // heapcache.py:577 `indexcache.do_write_with_aliasing(box, ...)`.
@@ -1715,8 +1719,8 @@ impl HeapCache {
         let seen_alloc = self.saw_allocation(array);
         let entry = self
             .heap_array_cache
-            .entry_or_default(descr)
-            .entry_or_insert_with(index_value, CacheEntry::new);
+            .entry(descr).or_default()
+            .entry(index_value).or_insert_with(CacheEntry::new);
         let array = entry._unique_const_heuristic(array, oracle);
         entry._getdict_mut(seen_alloc).insert(array, value);
     }

--- a/majit/majit-trace/src/heapcache.rs
+++ b/majit/majit-trace/src/heapcache.rs
@@ -1521,8 +1521,10 @@ impl HeapCache {
                     let dst_index = dststart + i;
                     let entry = self
                         .heap_array_cache
-                        .entry(descr).or_default()
-                        .entry(dst_index).or_insert_with(CacheEntry::new);
+                        .entry(descr)
+                        .or_default()
+                        .entry(dst_index)
+                        .or_insert_with(CacheEntry::new);
                     // heapcache.py:90-94 `do_write_with_aliasing` —
                     // canonicalise dest, then `_clear_cache_on_write(seen_alloc)`
                     // BEFORE the insert so aliasing entries from prior
@@ -1693,8 +1695,10 @@ impl HeapCache {
         let seen_alloc = self.saw_allocation(array);
         let entry = self
             .heap_array_cache
-            .entry(descr).or_default()
-            .entry(index_value).or_insert_with(CacheEntry::new);
+            .entry(descr)
+            .or_default()
+            .entry(index_value)
+            .or_insert_with(CacheEntry::new);
         // CacheEntry.do_write_with_aliasing internally canonicalises
         // ConstPtr operands via `_unique_const_heuristic`, replicating
         // heapcache.py:577 `indexcache.do_write_with_aliasing(box, ...)`.
@@ -1719,8 +1723,10 @@ impl HeapCache {
         let seen_alloc = self.saw_allocation(array);
         let entry = self
             .heap_array_cache
-            .entry(descr).or_default()
-            .entry(index_value).or_insert_with(CacheEntry::new);
+            .entry(descr)
+            .or_default()
+            .entry(index_value)
+            .or_insert_with(CacheEntry::new);
         let array = entry._unique_const_heuristic(array, oracle);
         entry._getdict_mut(seen_alloc).insert(array, value);
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11647,6 +11647,7 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+            pre_opcode_op_count: None,
         };
 
         let ret_byte = *insns_opname_to_byte()
@@ -11733,6 +11734,7 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+            pre_opcode_op_count: None,
         };
 
         let raise_byte = *insns_opname_to_byte()
@@ -11817,6 +11819,7 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+            pre_opcode_op_count: None,
         };
         let ret_byte = *insns_opname_to_byte()
             .get("ref_return/r")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4558,6 +4558,17 @@ fn handle(
                     });
                 }
             };
+            // pyjitpl.py:514 `assert switchcase == 1` — codewriter
+            // invariant: every condbox feeding GOTO_IF_NOT was produced
+            // by an int_is_* family op, so the only non-zero value
+            // possible is 1. Fail loud on any other truthy value rather
+            // than silently coercing.
+            assert!(
+                switchcase == 0 || switchcase == 1,
+                "opimpl_goto_if_not: switchcase must be 0 or 1, got {} (pc={})",
+                switchcase,
+                op.pc
+            );
             let (opcode, promoted) = if switchcase != 0 {
                 (OpCode::GuardTrue, ctx.trace_ctx.const_int(1))
             } else {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1647,6 +1647,16 @@ pub struct MIFrame {
     /// longer an `exc=True` residual call and must not emit the trailing
     /// GUARD_NO_EXCEPTION for this one step.
     pub(crate) suppress_guard_no_exception_for_opcode: bool,
+    /// Recorder op count snapshot at the start of the current bytecode.
+    /// Used by `handle_possible_exception` to detect whether a
+    /// `GUARD_NO_EXCEPTION` is required — mirrors PyPy's invariant that
+    /// `GUARD_NO_EXCEPTION` is recorded only by `do_residual_call`
+    /// (pyjitpl.py:2082), i.e. only when the bytecode actually emitted a
+    /// `CALL_*` family op. Pyre's `handle_possible_exception` runs at
+    /// every may-raise bytecode end regardless of what the inner dispatch
+    /// emitted, so the recording-time skip checks the bytecode's
+    /// recording window for a `Call*` op.
+    pub(crate) pre_opcode_op_count: Option<u32>,
     /// PyPy capture_resumedata: parent frame chain for multi-frame guards.
     /// Each entry points at one parent frame plus the resumepc that
     /// should be used when that parent is snapshotted. This stays much
@@ -6787,6 +6797,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let err = OpcodeStepExecutor::reraise(&mut state, 0).expect_err("reraise should raise");
@@ -6837,6 +6849,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let err = OpcodeStepExecutor::reraise(&mut state, 1).expect_err("reraise should raise");
@@ -6880,6 +6894,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let err = OpcodeStepExecutor::reraise(&mut state, 1).expect_err("reraise should raise");
@@ -6913,6 +6929,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let err =
@@ -6941,6 +6959,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         <MIFrame as SharedOpcodeHandler>::push_value(
@@ -6977,6 +6997,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         <MIFrame as SharedOpcodeHandler>::push_value(
@@ -7023,6 +7045,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         <MIFrame as SharedOpcodeHandler>::push_value(
@@ -7069,6 +7093,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         <MIFrame as SharedOpcodeHandler>::push_value(
@@ -7107,6 +7133,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         <MIFrame as SharedOpcodeHandler>::push_value(
@@ -7151,6 +7179,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         <MIFrame as SharedOpcodeHandler>::push_value(
@@ -7254,6 +7284,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         <MIFrame as SharedOpcodeHandler>::push_value(
@@ -7300,6 +7332,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         frame.push(caught_exc);
@@ -7573,6 +7607,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         state.with_ctx(|this, ctx| {
@@ -7613,6 +7649,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let _ = state.with_ctx(|this, ctx| this.trace_guarded_int_payload(ctx, int_obj));
@@ -7661,6 +7699,8 @@ mod tests {
                 pre_opcode_registers_r: None,
                 pre_opcode_semantic_depth: None,
                 suppress_guard_no_exception_for_opcode: false,
+
+                pre_opcode_op_count: None,
             };
             trace_unbox_int_with_resume(
                 &mut state,
@@ -7718,6 +7758,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let instance_ref = ctx.const_ref(instance as i64);
@@ -8093,6 +8135,8 @@ mod tests {
                 pre_opcode_registers_r: None,
                 pre_opcode_semantic_depth: None,
                 suppress_guard_no_exception_for_opcode: false,
+
+                pre_opcode_op_count: None,
             };
 
             let loaded =
@@ -8146,6 +8190,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         state
@@ -8182,6 +8228,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let _ = <MIFrame as TraceHelperAccess>::trace_binary_value(
@@ -8225,6 +8273,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let _ = state
@@ -8293,6 +8343,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let concrete_lhs = w_int_new(10);
@@ -8383,6 +8435,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let concrete_lhs = w_int_new(10);
@@ -8479,6 +8533,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         assert!(
@@ -8859,6 +8915,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let jump_args = state.with_ctx(|this, ctx| this.close_loop_args(ctx));
@@ -8943,6 +9001,8 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+
+            pre_opcode_op_count: None,
         };
 
         let jump_args = state.with_ctx(|this, ctx| this.close_loop_args(ctx));

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8265,6 +8265,7 @@ mod tests {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+            pre_opcode_op_count: None,
         };
 
         let active = frame.get_list_of_active_boxes(&mut ctx, false, false);
@@ -8341,6 +8342,7 @@ mod tests {
             pre_opcode_registers_r: Some(vec![local0, local1, stack0]),
             pre_opcode_semantic_depth: Some(3),
             suppress_guard_no_exception_for_opcode: false,
+            pre_opcode_op_count: None,
         };
 
         let active = frame.get_list_of_active_boxes(&mut ctx, false, false);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -770,6 +770,7 @@ impl MIFrame {
             pre_opcode_registers_r: None,
             pre_opcode_semantic_depth: None,
             suppress_guard_no_exception_for_opcode: false,
+            pre_opcode_op_count: None,
             parent_frames: Vec::new(),
             pending_result_stack_idx: None,
             pending_result_type: None,
@@ -6353,6 +6354,14 @@ impl MIFrame {
         self.set_orgpc(pc);
         self.prepare_fallthrough();
         self.suppress_guard_no_exception_for_opcode = false;
+        // Snapshot op count so handle_possible_exception can detect
+        // whether this bytecode emitted any CALL_* family op. PyPy
+        // records GUARD_NO_EXCEPTION only inside `do_residual_call`
+        // (pyjitpl.py:2082); pyre's end-of-bytecode emit must replicate
+        // that gating so inlined primitive bodies (int_*_ovf + boxing
+        // + guards) don't accrete orphan exception guards.
+        let pre_op_count = self.with_ctx(|_this, ctx| ctx.num_ops() as u32);
+        self.pre_opcode_op_count = Some(pre_op_count);
         // RPython pyjitpl.py captures resumedata at each guard site, not at
         // every opcode boundary. Pyre still needs an opcode-start snapshot
         // for stack-machine opcodes that can mutate stack/register state
@@ -6585,10 +6594,32 @@ impl MIFrame {
             // RERAISE-issuing site is the only producer of reraise_lasti.
             self.finishframe_exception(code, pc, -1)
         } else {
-            // pyjitpl.py:3397: GUARD_NO_EXCEPTION
-            self.with_ctx(|this, ctx| {
-                this.generate_guard(ctx, majit_ir::OpCode::GuardNoException, &[]);
-            });
+            // pyjitpl.py:3397: GUARD_NO_EXCEPTION.
+            //
+            // PyPy emits `GUARD_NO_EXCEPTION` only inside `do_residual_call`
+            // (pyjitpl.py:2082), so the guard exists only when the bytecode
+            // actually recorded a CALL_* family op that could have set the
+            // exception flag. Pyre's `handle_possible_exception` runs at
+            // every may-raise bytecode end regardless of the inner
+            // dispatch's structure, which leaves orphan exception guards
+            // after bytecodes whose body inlined entirely to primitives
+            // (e.g., `int_mul_ovf` + boxing/guards from `mul(x, x)`). Skip
+            // the emit when the bytecode's recording window contains no
+            // CALL_* op — mirrors PyPy's structural invariant at recording
+            // time, avoiding the post-opt `optimize_GUARD_NO_EXCEPTION`
+            // dependency on the `last_emitted_operation is REMOVED`
+            // sentinel (optimizeopt/heap.py:692) which pyre's per-pass
+            // `last_emitted_was_removed` flag cannot preserve across
+            // intermediate is_always_pure ops.
+            let skip = match self.pre_opcode_op_count {
+                Some(start) => self.with_ctx(|_this, ctx| !ctx.any_call_recorded_since(start)),
+                None => false,
+            };
+            if !skip {
+                self.with_ctx(|this, ctx| {
+                    this.generate_guard(ctx, majit_ir::OpCode::GuardNoException, &[]);
+                });
+            }
             TraceAction::Continue
         }
     }
@@ -6858,6 +6889,14 @@ impl MIFrame {
         self.set_orgpc(pc);
         self.prepare_fallthrough();
         self.suppress_guard_no_exception_for_opcode = false;
+        // Snapshot op count so handle_possible_exception can detect
+        // whether this bytecode emitted any CALL_* family op. PyPy
+        // records GUARD_NO_EXCEPTION only inside `do_residual_call`
+        // (pyjitpl.py:2082); pyre's end-of-bytecode emit must replicate
+        // that gating so inlined primitive bodies (int_*_ovf + boxing
+        // + guards) don't accrete orphan exception guards.
+        let pre_op_count = self.with_ctx(|_this, ctx| ctx.num_ops() as u32);
+        self.pre_opcode_op_count = Some(pre_op_count);
         // Keep inline-frame guard capture aligned with the root-frame path:
         // only opcodes that can actually reach a guard carry an opcode-start
         // snapshot, and specific guard paths may still suppress it.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1634,7 +1634,12 @@ impl MIFrame {
             let portal_frame_reg = jc.payload.metadata.portal_frame_reg as u32;
             let portal_ec_reg = jc.payload.metadata.portal_ec_reg as u32;
             let sym_frame = self.sym().frame;
-            let sym_ec = self.sym().execution_context;
+            // [frame, ec] portal-reds contract: `sym.execution_context`
+            // may be OpRef::NONE on adapter paths (CALL_ASSEMBLER bridge
+            // attach, bridge-from-guard). `ensure_execution_context`
+            // recovers it via GETFIELD_GC(frame, execution_context_descr)
+            // when needed; otherwise returns the seeded value.
+            let sym_ec = self.ensure_execution_context(ctx);
             let mut it = LivenessIterator::new(cursor, length_r, &all_liveness);
             while let Some(reg_idx) = it.next() {
                 let opref = if reg_idx == portal_frame_reg {
@@ -2872,6 +2877,10 @@ impl MIFrame {
         // current pc so `stack_only` reflects the actual JUMP-source
         // stack depth instead of the stale symbolic counter.
         let portal_vsd = self.portal_bridge_vable_vsd(self.orgpc).map(|d| d as usize);
+        // [frame, ec] portal-reds contract: recover ec before the sym()
+        // snapshot below so JUMP args never carry OpRef::NONE in the ec
+        // slot on adapter / bridge-from-guard paths.
+        let recovered_ec = self.ensure_execution_context(ctx);
         let (
             frame,
             execution_context,
@@ -2959,7 +2968,7 @@ impl MIFrame {
             stack_vec.resize(target_stack_capacity, OpRef::NONE);
             (
                 s.frame,
-                s.execution_context,
+                recovered_ec,
                 s.vable_last_instr,
                 s.vable_pycode,
                 s.vable_valuestackdepth,
@@ -3227,13 +3236,17 @@ impl MIFrame {
     pub(crate) fn current_fail_args(&mut self, ctx: &mut TraceCtx) -> Vec<OpRef> {
         self.flush_to_frame_for_guard(ctx);
         let active_boxes = self.get_list_of_active_boxes(ctx, false, false);
+        // [frame, ec] portal-reds contract. Recover ec before snapshotting
+        // sym fields so guard fail_args never carry OpRef::NONE in the ec
+        // slot (adapter/bridge-from-guard paths).
+        let ec = self.ensure_execution_context(ctx);
         let s = self.sym();
         let mut fa =
             Vec::with_capacity(crate::virtualizable_gen::NUM_SCALAR_INPUTARGS + active_boxes.len());
         fa.push(s.frame);
         // NUM_EXTRA_REDS == 1 (crate const-assert in `lib.rs`).
         // `interp_jit.py:67 reds = ['frame', 'ec']`.
-        fa.push(s.execution_context);
+        fa.push(ec);
         fa.extend_from_slice(&[
             s.vable_last_instr,
             s.vable_pycode,


### PR DESCRIPTION
Fix #38

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents stray exception guards after inlining; strengthens dispatcher validation.
  * Preserves caller-provided constant tables during GC rewriting to avoid missing constants.

* **New Features**
  * Enhanced register-allocation and immediate-handling optimizations for x86_64 and AArch64.

* **Refactor**
  * Replaced internal map structures for heap/trace caches for more efficient bookkeeping.
  * Added a helper to detect calls since a given op-count to enable smarter guard emission (with tests).

* **Chores**
  * Added shared vecset dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->