### PR TITLE
Fix stack-effect accounting for unhandled bytecodes and related ops

### DIFF
--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -610,7 +610,11 @@ fn stack_effects(
         // is_method=true  → push 2 (func, self_or_null). Net -1.
         Instruction::LoadSuperAttr { .. } => {
             let is_method = (u32::from(op_arg) & 1) != 0;
-            if is_method { (d - 1, d - 1) } else { (d - 2, d - 2) }
+            if is_method {
+                (d - 1, d - 1)
+            } else {
+                (d - 2, d - 2)
+            }
         }
         // CheckExcMatch: codewriter pops match_type, peeks the caught
         // exception, then pushes the bool result. Net 0.

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -571,8 +571,8 @@ fn stack_effects(
         // PopExcept: codewriter pops the saved previous exception object
         // from the value stack and restores TLS from it. Net -1.
         Instruction::PopExcept => (d - 1, d - 1),
-        // Pop one; pyre splits the CPython END_FOR into EndFor (-1) + PopIter (-1).
-        Instruction::EndFor => (d - 1, d - 1),
+        // No-op; pyre's end_for() is a no-op (pyopcode.rs:999). PopIter handles the pop.
+        Instruction::EndFor => (d, d),
         // Pop 0, push 0 (identity stack effect)
         Instruction::DeleteFast { .. }
         | Instruction::DeleteName { .. }

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -571,8 +571,8 @@ fn stack_effects(
         // PopExcept: codewriter pops the saved previous exception object
         // from the value stack and restores TLS from it. Net -1.
         Instruction::PopExcept => (d - 1, d - 1),
-        // Pop two
-        Instruction::EndFor => (d - 2, d - 2),
+        // Pop one; pyre splits the CPython END_FOR into EndFor (-1) + PopIter (-1).
+        Instruction::EndFor => (d - 1, d - 1),
         // Pop 0, push 0 (identity stack effect)
         Instruction::DeleteFast { .. }
         | Instruction::DeleteName { .. }
@@ -605,8 +605,13 @@ fn stack_effects(
         | Instruction::ImportFrom { .. } => (d + 1, d + 1),
         // ImportName: pop 2 (fromlist + level), push 1 (module). Net -1.
         Instruction::ImportName { .. } => (d - 1, d - 1),
-        // LoadSuperAttr: pop 3 (global_super, cls, self), push 1. Net -2.
-        Instruction::LoadSuperAttr { .. } => (d - 2, d - 2),
+        // LoadSuperAttr: pop 3 (global_super, cls, self).
+        // is_method=false → push 1 (result). Net -2.
+        // is_method=true  → push 2 (func, self_or_null). Net -1.
+        Instruction::LoadSuperAttr { .. } => {
+            let is_method = (u32::from(op_arg) & 1) != 0;
+            if is_method { (d - 1, d - 1) } else { (d - 2, d - 2) }
+        }
         // CheckExcMatch: codewriter pops match_type, peeks the caught
         // exception, then pushes the bool result. Net 0.
         Instruction::CheckExcMatch => (d, d),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6554,7 +6554,10 @@ impl CodeWriter {
                     }
 
                     Instruction::Reraise { .. } => {
-                        // Exception path: abort_permanent.
+                        // Pops the exception. Net: -1.
+                        // pypy/interpreter/pyopcode.py:1364, assemble.py:1608.
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
                         emit_abort_permanent!();
                     }
 
@@ -6580,9 +6583,16 @@ impl CodeWriter {
                                 duplicated
                             );
                         } else {
-                            // COPY(d>1): exception handler pattern only.
-                            // Use abort_permanent (BC_ABORT_PERMANENT=14) so it
-                            // doesn't trigger the has_abort(BC_ABORT=13) check.
+                            // COPY(d>1): duplicates stack[d] onto TOS. Net: +1.
+                            // assemble.py:1482.
+                            let stack_len = current_state.stack.len();
+                            let duplicated = if d > 0 && d <= stack_len {
+                                current_state.stack[stack_len - d].clone()
+                            } else {
+                                fresh_ref_value(&mut graph)
+                            };
+                            current_state.stack.push(duplicated);
+                            current_depth += 1;
                             emit_abort_permanent!();
                         }
                     }
@@ -7176,10 +7186,10 @@ impl CodeWriter {
                     // StoreName pops 1 value from the stack.
                     // (This is separate from the above because pyopcode.rs pops.)
 
-                    // YieldValue: pops 1. Net: -1. (Re-push happens on SEND/resume.)
+                    // YieldValue: pops yielded value, pushes placeholder back. Net: 0.
+                    // rpython/flowspace/flowcontext.py:721, liveness.rs:569,
+                    // assemble.py:1543.
                     Instruction::YieldValue { .. } => {
-                        let _ = current_state.stack.pop();
-                        current_depth = current_depth.saturating_sub(1);
                         emit_abort_permanent!();
                     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7230,11 +7230,10 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // ExitInitCheck: pops __init__ return value. Net: -1.
-                    // RustPython instructions.rs:1202 (0 pushed, 1 popped).
+                    // ExitInitCheck: no-op in pyre (pyopcode.rs:2069). Net: 0.
+                    // RustPython pops the __init__ return value, but pyre's
+                    // dispatch is a plain Ok(StepResult::Continue).
                     Instruction::ExitInitCheck => {
-                        let _ = current_state.stack.pop();
-                        current_depth = current_depth.saturating_sub(1);
                         emit_abort_permanent!();
                     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7141,13 +7141,18 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
+                    // LoadFromDictOrDeref: pops 1 (dict), pushes 1 (result). Net: 0.
+                    // Same shape as LoadFromDictOrGlobals.
+                    Instruction::LoadFromDictOrDeref { .. } => {
+                        emit_abort_permanent!();
+                    }
+
                     // Loads that push +1.
                     Instruction::LoadDeref { .. }
                     | Instruction::LoadFastCheck { .. }
                     | Instruction::LoadCommonConstant { .. }
                     | Instruction::LoadLocals
-                    | Instruction::LoadBuildClass
-                    | Instruction::LoadFromDictOrDeref { .. } => {
+                    | Instruction::LoadBuildClass => {
                         current_state.stack.push(fresh_ref_value(&mut graph));
                         current_depth += 1;
                         emit_abort_permanent!();

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7027,15 +7027,22 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // LoadSuperAttr: pops 3 (super, cls, self), pushes 1 or 2. Net: -2 or -1.
-                    // Conservative: treat as pops 3, pushes 1.
+                    // LoadSuperAttr: pops 3 (super, cls, self).
+                    // is_method=false → pushes 1 (result). Net: -2.
+                    // is_method=true  → pushes 2 (func, self_or_null). Net: -1.
+                    // pyopcode.rs:1926-1932, eval.rs:2331-2360.
                     Instruction::LoadSuperAttr { .. } => {
+                        let is_method = (u32::from(op_arg) & 1) != 0;
                         for _ in 0..3 {
                             let _ = current_state.stack.pop();
                             current_depth = current_depth.saturating_sub(1);
                         }
                         current_state.stack.push(fresh_ref_value(&mut graph));
                         current_depth += 1;
+                        if is_method {
+                            current_state.stack.push(fresh_ref_value(&mut graph));
+                            current_depth += 1;
+                        }
                         emit_abort_permanent!();
                     }
 
@@ -7053,8 +7060,17 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // BuildInterpolation: pops 1-2 depending on format spec, pushes 1. Net: 0 or -1.
-                    Instruction::BuildInterpolation { .. } => {
+                    // BuildInterpolation: conditionally pops format_spec when (oparg & 1) != 0,
+                    // then pops 2 (value, expression_str) via build_tuple, pushes 1.
+                    // No spec: pops 2, pushes 1. Net: -1.
+                    // With spec: pops 3, pushes 1. Net: -2.
+                    // pyopcode.rs:1798-1806.
+                    Instruction::BuildInterpolation { format } => {
+                        let has_format_spec = (u32::from(format.get(op_arg)) & 1) != 0;
+                        if has_format_spec {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
                         for _ in 0..2 {
                             let _ = current_state.stack.pop();
                             current_depth = current_depth.saturating_sub(1);
@@ -7098,8 +7114,15 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // LoadSpecial: pops 1 (obj), pushes 1 (bound method). Net: 0.
+                    // LoadSpecial: pops 1 (obj), pushes 2 (callable, self_or_null). Net: +1.
+                    // pyopcode.rs:2059 delegates to load_method; eval.rs:2365 pops 1 pushes 2.
                     Instruction::LoadSpecial { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
                         emit_abort_permanent!();
                     }
 
@@ -7181,6 +7204,9 @@ impl CodeWriter {
                     }
 
                     // EndAsyncFor: pops 2. Net: -2.
+                    // CPython 3.12/3.13 semantics; PyPy pops 3 (w_exc, w_prev, aiter)
+                    // on the StopAsyncIteration path (assemble.py:1578). Structural
+                    // adaptation: pyre targets CPython opcode shape here.
                     Instruction::EndAsyncFor => {
                         for _ in 0..2 {
                             let _ = current_state.stack.pop();
@@ -7200,8 +7226,11 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // MatchSequence: pops 1, pushes 1. Net: 0.
+                    // MatchSequence: peeks TOS (subject), pushes bool. Net: +1.
+                    // assemble.py:1614, liveness.rs:601.
                     Instruction::MatchSequence => {
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
                         emit_abort_permanent!();
                     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6721,21 +6721,26 @@ impl CodeWriter {
                     // adjust current_depth so subsequent instructions don't
                     // underflow.
                     Instruction::UnpackSequence { count } => {
-                        let n = count.get(op_arg) as u16;
-                        emit_abort_permanent!();
-                        // Stack effect: pop 1 + push n = net (n - 1)
-                        if current_depth > 0 {
-                            current_depth -= 1;
-                            emit_vsd!(current_depth);
+                        let n = count.get(op_arg) as usize;
+                        // Pop iterable, push n unpacked items.
+                        // pypy/interpreter/pyopcode.py:872.
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        for _ in 0..n {
+                            current_state.stack.push(fresh_ref_value(&mut graph));
+                            current_depth += 1;
                         }
-                        current_depth += n;
+                        emit_abort_permanent!();
                     }
 
                     // CPython 3.13 iterator protocol — emit abort_permanent
                     // with correct depth tracking so subsequent instructions
                     // don't underflow.
                     Instruction::GetIter => {
-                        // pop iterable, push iterator: net 0
+                        // Pop iterable, push iterator. Net: 0. Replace shadow value.
+                        // pypy/interpreter/pyopcode.py:1281.
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
                     }
 
@@ -6977,24 +6982,29 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // SetFunctionAttribute: pops attr+func, pushes func. Net: -1.
+                    // SetFunctionAttribute: pops attr (TOS), pops func (TOS1),
+                    // pushes same func back. Net: -1. Preserve func identity.
+                    // eval.rs:1897.
                     Instruction::SetFunctionAttribute { .. } => {
-                        for _ in 0..2 {
-                            let _ = current_state.stack.pop();
-                            current_depth = current_depth.saturating_sub(1);
-                        }
-                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        let _ = current_state.stack.pop(); // attr
+                        current_depth = current_depth.saturating_sub(1);
+                        let func = current_state.stack.pop()
+                            .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                        current_depth = current_depth.saturating_sub(1);
+                        current_state.stack.push(func);
                         current_depth += 1;
                         emit_abort_permanent!();
                     }
 
-                    // EndSend: pops 2 (result, iter), pushes 1. Net: -1.
+                    // EndSend: pops result (TOS), pops iter (TOS1), pushes result back.
+                    // Net: -1. Preserve result identity. eval.rs:2305-2309.
                     Instruction::EndSend => {
-                        for _ in 0..2 {
-                            let _ = current_state.stack.pop();
-                            current_depth = current_depth.saturating_sub(1);
-                        }
-                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        let result = current_state.stack.pop()
+                            .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                        current_depth = current_depth.saturating_sub(1);
+                        let _ = current_state.stack.pop(); // iter
+                        current_depth = current_depth.saturating_sub(1);
+                        current_state.stack.push(result);
                         current_depth += 1;
                         emit_abort_permanent!();
                     }
@@ -7101,19 +7111,18 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // CallIntrinsic1: pops 1, pushes 1. Net: 0.
+                    // CallIntrinsic1: pops 1, pushes 1 (result may differ). Net: 0.
                     Instruction::CallIntrinsic1 { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
                     }
 
-                    // CallIntrinsic2: pops 2, pushes 1. Net: -1.
+                    // CallIntrinsic2: pops type_params, preserves func (TOS1). Net: -1.
+                    // eval.rs SetFunctionTypeParams pops only type_params.
                     Instruction::CallIntrinsic2 { .. } => {
-                        for _ in 0..2 {
-                            let _ = current_state.stack.pop();
-                            current_depth = current_depth.saturating_sub(1);
-                        }
-                        current_state.stack.push(fresh_ref_value(&mut graph));
-                        current_depth += 1;
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
                         emit_abort_permanent!();
                     }
 
@@ -7137,13 +7146,11 @@ impl CodeWriter {
                     }
 
                     // LoadFromDictOrGlobals: pops 1 (dict), pushes 1 (result). Net: 0.
-                    Instruction::LoadFromDictOrGlobals { .. } => {
-                        emit_abort_permanent!();
-                    }
-
-                    // LoadFromDictOrDeref: pops 1 (dict), pushes 1 (result). Net: 0.
-                    // Same shape as LoadFromDictOrGlobals.
-                    Instruction::LoadFromDictOrDeref { .. } => {
+                    // Replace shadow value. eval.rs:2028.
+                    Instruction::LoadFromDictOrGlobals { .. }
+                    | Instruction::LoadFromDictOrDeref { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
                     }
 
@@ -7158,7 +7165,7 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // Pops 1, pushes 1 (net 0).
+                    // Pops 1, pushes 1 (net 0). Replace shadow value.
                     Instruction::ConvertValue { .. }
                     | Instruction::FormatSimple
                     | Instruction::UnaryNot
@@ -7166,6 +7173,8 @@ impl CodeWriter {
                     | Instruction::GetAiter
                     | Instruction::GetAwaitable { .. }
                     | Instruction::GetYieldFromIter => {
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
                     }
 
@@ -7192,9 +7201,11 @@ impl CodeWriter {
                     // (This is separate from the above because pyopcode.rs pops.)
 
                     // YieldValue: pops yielded value, pushes placeholder back. Net: 0.
-                    // rpython/flowspace/flowcontext.py:721, liveness.rs:569,
-                    // assemble.py:1543.
+                    // Replace shadow value. rpython/flowspace/flowcontext.py:721,
+                    // liveness.rs:569, assemble.py:1543.
                     Instruction::YieldValue { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
                     }
 
@@ -7205,8 +7216,11 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // Send: pops 1, peeks iter, pushes 1. Net: 0.
+                    // Send: pops sent value, peeks iter, pushes next result. Net: 0.
+                    // Replace shadow value.
                     Instruction::Send { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
                     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6988,7 +6988,9 @@ impl CodeWriter {
                     // pushes same func back. Net: -1. Preserve func identity.
                     // eval.rs:1907-1908: func = pop(), attr = pop().
                     Instruction::SetFunctionAttribute { .. } => {
-                        let func = current_state.stack.pop()
+                        let func = current_state
+                            .stack
+                            .pop()
                             .unwrap_or_else(|| fresh_ref_value(&mut graph));
                         current_depth = current_depth.saturating_sub(1);
                         let _ = current_state.stack.pop(); // attr
@@ -7001,7 +7003,9 @@ impl CodeWriter {
                     // EndSend: pops result (TOS), pops iter (TOS1), pushes result back.
                     // Net: -1. Preserve result identity. eval.rs:2305-2309.
                     Instruction::EndSend => {
-                        let result = current_state.stack.pop()
+                        let result = current_state
+                            .stack
+                            .pop()
                             .unwrap_or_else(|| fresh_ref_value(&mut graph));
                         current_depth = current_depth.saturating_sub(1);
                         let _ = current_state.stack.pop(); // iter
@@ -7205,8 +7209,7 @@ impl CodeWriter {
                     // Structural adaptation: async opcodes. Pyre's dispatcher
                     // errors immediately (pyopcode.rs:2027) without stack mutation.
                     // Stack effects model intended CPython shape for convergence.
-                    Instruction::GetAiter
-                    | Instruction::GetAwaitable { .. } => {
+                    Instruction::GetAiter | Instruction::GetAwaitable { .. } => {
                         let _ = current_state.stack.pop();
                         current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
@@ -7307,7 +7310,9 @@ impl CodeWriter {
                     }
 
                     // Catch-all: unknown instruction.
-                    _other => { emit_abort_permanent!(); }
+                    _other => {
+                        emit_abort_permanent!();
+                    }
                 }
                 sync_stack_state(&mut graph, &mut current_state, current_depth);
                 current_state.next_offset = py_pc + 1;

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6756,15 +6756,9 @@ impl CodeWriter {
                     }
 
                     Instruction::EndFor => {
-                        // Pyre's end_for() is a no-op (pyopcode.rs:999).
-                        // The actual pop is handled by the subsequent PopIter.
-                        // RustPython instructions.rs:1200 (0 pushed, 1 popped)
-                        // covers combined semantics; pyre splits it.
-                        let _ = current_state.stack.pop();
-                        current_depth = current_depth.saturating_sub(1);
+                        // Pyre's end_for() is a no-op (pyopcode.rs:999). Net: 0.
+                        // The actual pop is handled by the subsequent PopIter (-1).
                         emit_abort_permanent!();
-                        // No emit_vsd: after abort_permanent, depth is
-                        // simulation-only for subsequent compile-time tracking.
                     }
 
                     Instruction::PopIter => {
@@ -7126,15 +7120,26 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // CallIntrinsic2: pops 2, pushes 1. Net: -1.
-                    // RustPython instructions.rs:1248 stack effect (1 pushed, 2 popped).
-                    Instruction::CallIntrinsic2 { .. } => {
-                        for _ in 0..2 {
-                            let _ = current_state.stack.pop();
-                            current_depth = current_depth.saturating_sub(1);
+                    // CallIntrinsic2: variant-dependent stack effect.
+                    // SetFunctionTypeParams: pops type_params (TOS), leaves func. Net: -1.
+                    // Other variants: general pop 2, push 1. Net: -1.
+                    // pyopcode.rs:1302-1316.
+                    Instruction::CallIntrinsic2 { func } => {
+                        use pyre_interpreter::bytecode::IntrinsicFunction2;
+                        match func.get(op_arg) {
+                            IntrinsicFunction2::SetFunctionTypeParams => {
+                                let _ = current_state.stack.pop(); // type_params only
+                                current_depth = current_depth.saturating_sub(1);
+                            }
+                            _ => {
+                                for _ in 0..2 {
+                                    let _ = current_state.stack.pop();
+                                    current_depth = current_depth.saturating_sub(1);
+                                }
+                                current_state.stack.push(fresh_ref_value(&mut graph));
+                                current_depth += 1;
+                            }
                         }
-                        current_state.stack.push(fresh_ref_value(&mut graph));
-                        current_depth += 1;
                         emit_abort_permanent!();
                     }
 
@@ -7159,8 +7164,17 @@ impl CodeWriter {
 
                     // LoadFromDictOrGlobals: pops 1 (dict), pushes 1 (result). Net: 0.
                     // Replace shadow value. eval.rs:2028.
-                    Instruction::LoadFromDictOrGlobals { .. }
-                    | Instruction::LoadFromDictOrDeref { .. } => {
+                    Instruction::LoadFromDictOrGlobals { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        emit_abort_permanent!();
+                    }
+
+                    // LoadFromDictOrDeref: structural adaptation — CPython pops dict,
+                    // pushes result (net 0). Pyre's trait default raises before stack
+                    // mutation (pyopcode.rs:1247), so this models the intended CPython
+                    // shape, not current pyre runtime behavior.
+                    Instruction::LoadFromDictOrDeref { .. } => {
                         let _ = current_state.stack.pop();
                         current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
@@ -7182,9 +7196,17 @@ impl CodeWriter {
                     | Instruction::FormatSimple
                     | Instruction::UnaryNot
                     | Instruction::UnaryInvert
-                    | Instruction::GetAiter
-                    | Instruction::GetAwaitable { .. }
                     | Instruction::GetYieldFromIter => {
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        emit_abort_permanent!();
+                    }
+
+                    // Structural adaptation: async opcodes. Pyre's dispatcher
+                    // errors immediately (pyopcode.rs:2027) without stack mutation.
+                    // Stack effects model intended CPython shape for convergence.
+                    Instruction::GetAiter
+                    | Instruction::GetAwaitable { .. } => {
                         let _ = current_state.stack.pop();
                         current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
@@ -7243,7 +7265,10 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // Async instructions: not implemented, but account for stack.
+                    // Structural adaptation: async opcodes below. Pyre's dispatcher
+                    // errors immediately (pyopcode.rs:2027) without stack mutation.
+                    // Stack effects model intended CPython shape for convergence.
+
                     // GetAnext: pushes 1. Net: +1.
                     Instruction::GetAnext => {
                         current_state.stack.push(fresh_ref_value(&mut graph));

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6619,7 +6619,11 @@ impl CodeWriter {
                         emit_vsd!(current_depth);
                     }
                     Instruction::MakeFunction { .. } => {
-                        // Module-level only: abort_permanent (won't block blackhole).
+                        // Pops code object (TOS), pushes function. Net: 0.
+                        // Replace shadow value so SET_FUNCTION_ATTRIBUTE sees func.
+                        // RustPython: (1 pushed, 1 popped).
+                        let _ = current_state.stack.pop();
+                        current_state.stack.push(fresh_ref_value(&mut graph));
                         emit_abort_permanent!();
                     }
                     Instruction::StoreAttr { namei } => {
@@ -6752,9 +6756,13 @@ impl CodeWriter {
                     }
 
                     Instruction::EndFor => {
-                        // pop iterator + last value: net -2
+                        // Pyre's end_for() is a no-op (pyopcode.rs:999).
+                        // The actual pop is handled by the subsequent PopIter.
+                        // RustPython instructions.rs:1200 (0 pushed, 1 popped)
+                        // covers combined semantics; pyre splits it.
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
                         emit_abort_permanent!();
-                        current_depth = current_depth.saturating_sub(2);
                         // No emit_vsd: after abort_permanent, depth is
                         // simulation-only for subsequent compile-time tracking.
                     }
@@ -6982,14 +6990,14 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // SetFunctionAttribute: pops attr (TOS), pops func (TOS1),
+                    // SetFunctionAttribute: pops func (TOS), pops attr (TOS1),
                     // pushes same func back. Net: -1. Preserve func identity.
-                    // eval.rs:1897.
+                    // eval.rs:1907-1908: func = pop(), attr = pop().
                     Instruction::SetFunctionAttribute { .. } => {
-                        let _ = current_state.stack.pop(); // attr
-                        current_depth = current_depth.saturating_sub(1);
                         let func = current_state.stack.pop()
                             .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                        current_depth = current_depth.saturating_sub(1);
+                        let _ = current_state.stack.pop(); // attr
                         current_depth = current_depth.saturating_sub(1);
                         current_state.stack.push(func);
                         current_depth += 1;
@@ -7118,11 +7126,15 @@ impl CodeWriter {
                         emit_abort_permanent!();
                     }
 
-                    // CallIntrinsic2: pops type_params, preserves func (TOS1). Net: -1.
-                    // eval.rs SetFunctionTypeParams pops only type_params.
+                    // CallIntrinsic2: pops 2, pushes 1. Net: -1.
+                    // RustPython instructions.rs:1248 stack effect (1 pushed, 2 popped).
                     Instruction::CallIntrinsic2 { .. } => {
-                        let _ = current_state.stack.pop();
-                        current_depth = current_depth.saturating_sub(1);
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
                         emit_abort_permanent!();
                     }
 
@@ -7192,8 +7204,15 @@ impl CodeWriter {
                     | Instruction::DeleteName { .. }
                     | Instruction::CopyFreeVars { .. }
                     | Instruction::MakeCell { .. }
-                    | Instruction::SetupAnnotations
-                    | Instruction::ExitInitCheck => {
+                    | Instruction::SetupAnnotations => {
+                        emit_abort_permanent!();
+                    }
+
+                    // ExitInitCheck: pops __init__ return value. Net: -1.
+                    // RustPython instructions.rs:1202 (0 pushed, 1 popped).
+                    Instruction::ExitInitCheck => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
                         emit_abort_permanent!();
                     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6750,12 +6750,463 @@ impl CodeWriter {
                         emit_vsd!(current_depth);
                     }
 
-                    // Unsupported instruction: abort_permanent.
-                    // BC_ABORT_PERMANENT(14) so has_abort_opcode doesn't
-                    // false-positive on functions with only module-level paths.
-                    _other => {
+                    // BinarySlice: obj[start:stop] — pops 3 (stop, start, obj), pushes 1 (result).
+                    // Net stack effect: -2.
+                    // pyopcode.py BINARY_SLICE / eval.rs:2857-2935.
+                    Instruction::BinarySlice => {
+                        for _ in 0..3 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
                         emit_abort_permanent!();
                     }
+
+                    // ContainsOp: item in container — pops 2, pushes 1 (bool).
+                    // Net stack effect: -1.
+                    // pyopcode.py CONTAINS_OP / eval.rs:1784-1798.
+                    Instruction::ContainsOp { .. } => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // CallKw: like Call but with extra kwnames tuple.
+                    // Pops: kwnames + argc args + null_or_self + callable = argc + 3.
+                    // Pushes: result. Net stack effect: -(argc + 2).
+                    // pyopcode.py CALL_FUNCTION_KW / CALL_KW / eval.rs:2570-2726.
+                    Instruction::CallKw { argc } => {
+                        let nargs = argc.get(op_arg) as usize;
+                        // Pop kwnames + nargs args + null_or_self + callable.
+                        for _ in 0..nargs + 3 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // Swap: swap TOS with TOS[i]. No net stack effect.
+                    // pyopcode.py SWAP / eval.rs:1029-1034.
+                    Instruction::Swap { i } => {
+                        let depth = i.get(op_arg) as usize;
+                        let stack_len = current_state.stack.len();
+                        if depth > 0 && depth <= stack_len {
+                            current_state.stack.swap(stack_len - 1, stack_len - depth);
+                        }
+                        emit_abort_permanent!();
+                    }
+
+                    // LoadFastAndClear: push local, clear it. Net: +1.
+                    // pyopcode.py LOAD_FAST_AND_CLEAR / eval.rs:2052-2058.
+                    Instruction::LoadFastAndClear { var_num } => {
+                        let idx = var_num.get(op_arg).as_usize();
+                        let value = if idx < current_state.locals_w.len() {
+                            current_state.locals_w[idx]
+                                .clone()
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph))
+                        } else {
+                            fresh_ref_value(&mut graph)
+                        };
+                        if idx < current_state.locals_w.len() {
+                            current_state.locals_w[idx] = None;
+                        }
+                        current_state.stack.push(value);
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // ListAppend(i): peek list at stack[i], pop value. Net: -1.
+                    // shared_opcode.rs opcode_list_append.
+                    Instruction::ListAppend { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // BuildMap(count): pop 2*count key-value pairs, push dict. Net: -(2*count - 1).
+                    // shared_opcode.rs opcode_build_map.
+                    Instruction::BuildMap { count } => {
+                        let n = count.get(op_arg) as usize;
+                        for _ in 0..n * 2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // MapAdd(i): peek dict at stack[i], pop value + key. Net: -2.
+                    // eval.rs map_add.
+                    Instruction::MapAdd { .. } => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        emit_abort_permanent!();
+                    }
+
+                    // ── Remaining instructions: stack-effect-only accounting ──
+                    // Each arm adjusts current_depth / current_state.stack to
+                    // match the interpreter's stack effect, then aborts so the
+                    // codewriter's mergeblock/pendingblocks converge.
+
+                    // IsOp: pops 2, pushes 1 bool. Net: -1.
+                    Instruction::IsOp { .. } => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // BuildTuple(count): pops count items, pushes 1 tuple. Net: -(count-1).
+                    Instruction::BuildTuple { count } => {
+                        let n = count.get(op_arg) as usize;
+                        for _ in 0..n {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // BuildSet(count): pops count items, pushes 1 set. Net: -(count-1).
+                    Instruction::BuildSet { count } => {
+                        let n = count.get(op_arg) as usize;
+                        for _ in 0..n {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // BuildString(count): pops count strings, pushes 1. Net: -(count-1).
+                    Instruction::BuildString { count } => {
+                        let n = count.get(op_arg) as usize;
+                        for _ in 0..n {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // CallFunctionEx: pops callable+null+args+kwargs_or_null (4), pushes 1. Net: -3.
+                    Instruction::CallFunctionEx => {
+                        for _ in 0..4 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // DeleteSubscr: pops 2 (key, obj). Net: -2.
+                    Instruction::DeleteSubscr => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        emit_abort_permanent!();
+                    }
+
+                    // DeleteAttr: pops 1 (obj). Net: -1.
+                    Instruction::DeleteAttr { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // PopJumpIfNone / PopJumpIfNotNone: pops 1. Net: -1.
+                    Instruction::PopJumpIfNone { .. } | Instruction::PopJumpIfNotNone { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // SetAdd(i): peek set, pop value. Net: -1.
+                    Instruction::SetAdd { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // ListExtend(i): peek list, pop iterable. Net: -1.
+                    Instruction::ListExtend { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // SetUpdate(i): peek set, pop iterable. Net: -1.
+                    Instruction::SetUpdate { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // DictUpdate(i) / DictMerge(i): peek dict, pop source. Net: -1.
+                    Instruction::DictUpdate { .. } | Instruction::DictMerge { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // SetFunctionAttribute: pops attr+func, pushes func. Net: -1.
+                    Instruction::SetFunctionAttribute { .. } => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // EndSend: pops 2 (result, iter), pushes 1. Net: -1.
+                    Instruction::EndSend => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // ImportName: pops 2 (level, fromlist), pushes 1 module. Net: -1.
+                    Instruction::ImportName { .. } => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // ImportFrom: peek module, push attr. Net: +1.
+                    Instruction::ImportFrom { .. } => {
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // StoreSlice: pops 4 (stop, start, obj, value). Net: -4.
+                    Instruction::StoreSlice => {
+                        for _ in 0..4 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        emit_abort_permanent!();
+                    }
+
+                    // FormatWithSpec: pops 2 (spec, value), pushes 1 string. Net: -1.
+                    Instruction::FormatWithSpec => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // LoadSuperAttr: pops 3 (super, cls, self), pushes 1 or 2. Net: -2 or -1.
+                    // Conservative: treat as pops 3, pushes 1.
+                    Instruction::LoadSuperAttr { .. } => {
+                        for _ in 0..3 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // UnpackEx: pops 1, pushes before+1+after items. Net: before+after.
+                    Instruction::UnpackEx { counts } => {
+                        let args = counts.get(op_arg);
+                        let before = args.before as usize;
+                        let after = args.after as usize;
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        for _ in 0..before + 1 + after {
+                            current_state.stack.push(fresh_ref_value(&mut graph));
+                            current_depth += 1;
+                        }
+                        emit_abort_permanent!();
+                    }
+
+                    // BuildInterpolation: pops 1-2 depending on format spec, pushes 1. Net: 0 or -1.
+                    Instruction::BuildInterpolation { .. } => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // BuildTemplate: pops 2, pushes 1. Net: -1.
+                    Instruction::BuildTemplate => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // CallIntrinsic1: pops 1, pushes 1. Net: 0.
+                    Instruction::CallIntrinsic1 { .. } => {
+                        emit_abort_permanent!();
+                    }
+
+                    // CallIntrinsic2: pops 2, pushes 1. Net: -1.
+                    Instruction::CallIntrinsic2 { .. } => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // GetLen: peeks obj, pushes len. Net: +1.
+                    Instruction::GetLen => {
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // LoadSpecial: pops 1 (obj), pushes 1 (bound method). Net: 0.
+                    Instruction::LoadSpecial { .. } => {
+                        emit_abort_permanent!();
+                    }
+
+                    // LoadFromDictOrGlobals: pops 1 (dict), pushes 1 (result). Net: 0.
+                    Instruction::LoadFromDictOrGlobals { .. } => {
+                        emit_abort_permanent!();
+                    }
+
+                    // Loads that push +1.
+                    Instruction::LoadDeref { .. }
+                    | Instruction::LoadFastCheck { .. }
+                    | Instruction::LoadCommonConstant { .. }
+                    | Instruction::LoadLocals
+                    | Instruction::LoadBuildClass
+                    | Instruction::LoadFromDictOrDeref { .. } => {
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // Pops 1, pushes 1 (net 0).
+                    Instruction::ConvertValue { .. }
+                    | Instruction::FormatSimple
+                    | Instruction::UnaryNot
+                    | Instruction::UnaryInvert
+                    | Instruction::GetAiter
+                    | Instruction::GetAwaitable { .. }
+                    | Instruction::GetYieldFromIter => {
+                        emit_abort_permanent!();
+                    }
+
+                    // StoreDeref: pops 1 value. Net: -1.
+                    Instruction::StoreDeref { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // Instructions that don't touch the operand stack (locals/cells only).
+                    Instruction::DeleteFast { .. }
+                    | Instruction::DeleteDeref { .. }
+                    | Instruction::DeleteGlobal { .. }
+                    | Instruction::DeleteName { .. }
+                    | Instruction::CopyFreeVars { .. }
+                    | Instruction::MakeCell { .. }
+                    | Instruction::SetupAnnotations
+                    | Instruction::ExitInitCheck => {
+                        emit_abort_permanent!();
+                    }
+
+                    // StoreName pops 1 value from the stack.
+                    // (This is separate from the above because pyopcode.rs pops.)
+
+                    // YieldValue: pops 1. Net: -1. (Re-push happens on SEND/resume.)
+                    Instruction::YieldValue { .. } => {
+                        let _ = current_state.stack.pop();
+                        current_depth = current_depth.saturating_sub(1);
+                        emit_abort_permanent!();
+                    }
+
+                    // ReturnGenerator: pushes 1. Net: +1.
+                    Instruction::ReturnGenerator => {
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // Send: pops 1, peeks iter, pushes 1. Net: 0.
+                    Instruction::Send { .. } => {
+                        emit_abort_permanent!();
+                    }
+
+                    // Async instructions: not implemented, but account for stack.
+                    // GetAnext: pushes 1. Net: +1.
+                    Instruction::GetAnext => {
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // EndAsyncFor: pops 2. Net: -2.
+                    Instruction::EndAsyncFor => {
+                        for _ in 0..2 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        emit_abort_permanent!();
+                    }
+
+                    // CleanupThrow: pops 3, pushes 1. Net: -2.
+                    Instruction::CleanupThrow => {
+                        for _ in 0..3 {
+                            let _ = current_state.stack.pop();
+                            current_depth = current_depth.saturating_sub(1);
+                        }
+                        current_state.stack.push(fresh_ref_value(&mut graph));
+                        current_depth += 1;
+                        emit_abort_permanent!();
+                    }
+
+                    // MatchSequence: pops 1, pushes 1. Net: 0.
+                    Instruction::MatchSequence => {
+                        emit_abort_permanent!();
+                    }
+
+                    // Catch-all: unknown instruction.
+                    _other => { emit_abort_permanent!(); }
                 }
                 sync_stack_state(&mut graph, &mut current_state, current_depth);
                 current_state.next_offset = py_pc + 1;


### PR DESCRIPTION
## Summary

This pull request updates the stack effect calculations for certain instructions in the `stack_effects` function in `liveness.rs` to more accurately reflect their runtime behavior, especially for `EndFor` and `LoadSuperAttr`. The changes improve correctness and alignment with the underlying interpreter logic.

**Stack effect calculation fixes:**

* Updated `Instruction::EndFor` to be a no-op for stack effects, aligning with `pyre`'s implementation where stack changes are handled by `PopIter` instead.
* Refined `Instruction::LoadSuperAttr` to account for the `is_method` flag, so the stack effect is now conditional: it pops three and pushes either one or two, depending on whether `is_method` is true or false.

This PR unbreaks bytes_ops, comprehensions, default_keyword_args and set_membership synthetic tests which were timed out due to the miscalculated net stack effect.

## Self-review

### Prompt & Model

Model: gpt-5.5

Prompt:
```
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
```

### Answer

```
  1. Regressed Parity
  No definite cases where this patch regressed PyPy parity compared to upstream/main.

  The changed EndFor and LoadSuperAttr stack effects look like intentional CPython/Pyre opcode-shape adaptations, not PyPy regressions.

  2. Other Introduced Mismatches
  No non-structural incorrect ports found in the changed hunks.

  For opcodes that exist in local PyPy sources, the new stack effects match PyPy’s interpreter or assembler stack effects: RERAISE, COPY,
  UNPACK_SEQUENCE, GET_ITER, collection builders, import ops, YIELD_VALUE, END_SEND, MATCH_SEQUENCE, etc.

  3. Pre-Existing Mismatches
  No newly relevant non-structural mismatch found that already existed before this patch in the reviewed area.

  4. Structural Adaptations
  These are not 1:1 PyPy ports because Pyre is modeling CPython/Pyre bytecode shapes:

  - pyre/pyre-jit-trace/src/liveness.rs:574, pyre/pyre-jit/src/jit/codewriter.rs:6758: EndFor is no-op and PopIter does the pop. PyPy has FOR_ITER pop
    the iterator on exhaustion and no matching END_FOR opcode in the local source.
  - pyre/pyre-jit-trace/src/liveness.rs:608, pyre/pyre-jit/src/jit/codewriter.rs:7052: LoadSuperAttr method form pushes two values. PyPy has no
    corresponding opcode; this follows Pyre’s CPython-style LOAD_SUPER_ATTR.
  - pyre/pyre-jit/src/jit/codewriter.rs:6621: MakeFunction net effect is 0; PyPy MAKE_FUNCTION consumes flag-dependent attribute operands. Pyre uses
    separate SET_FUNCTION_ATTRIBUTE.
  - pyre/pyre-jit/src/jit/codewriter.rs:6796, pyre/pyre-jit/src/jit/codewriter.rs:6925: CALL_KW / CALL_FUNCTION_EX include Pyre’s CPython-style null/
    self and kwargs vehicle shape, unlike PyPy’s CALL_FUNCTION_KW / CALL_FUNCTION_EX stack effects.
  - pyre/pyre-jit/src/jit/codewriter.rs:7279: EndAsyncFor uses CPython-style -2; local PyPy assembler says END_ASYNC_FOR: -3.
  - Several opcodes added in the catch-all accounting have no PyPy equivalent and are structural Pyre/CPython adaptations: BuildTemplate,
    BuildInterpolation, LoadFromDictOrGlobals, LoadFromDictOrDeref, SetFunctionAttribute, LoadFastAndClear, LoadSpecial, ReturnGenerator,
    CleanupThrow, and intrinsic calls.

  Bottom line: I found structural CPython/Pyre adaptations, but no clear incorrect RPython/PyPy port introduced by this diff.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bytecode stack-effect modeling to better match interpreter behavior and ensure consistent state tracking.
  * Enhanced support for previously under-handled or unsupported Python operations, enabling more reliable JIT compilation.
  * Fixed stack synchronization issues between interpreted and compiled bytecode execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->