### PR TITLE
x86 malloc/propagate trampolines + arch cpu_ext + _setup_once gate

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -491,6 +491,59 @@ impl<'a> AssemblerARM64<'a> {
     // Helper methods
     // ----------------------------------------------------------------
 
+    /// Emit the inline propagate-MemoryError sequence: if `reg_x` is
+    /// NULL, route through the `propagate_exception_descr` exit
+    /// (`_build_propagate_exception_path`, assembler.py:559-577 —
+    /// inlined per call site because pyre's dynasm backend doesn't
+    /// emit a separate trampoline on aarch64).
+    ///
+    /// Used by:
+    ///   * `OpCode::CheckMemoryError` (after the four CALL_R malloc
+    ///     helpers in `gen_call_malloc_gc`).
+    ///   * Each inline malloc-nursery slowpath site, where the helper
+    ///     (`dynasm_nursery_slowpath` / `_varsize` / `_jitframe`)
+    ///     returns x0 = 0 on real host OOM (calloc failure).  Before
+    ///     this hook the OOM null was stored straight into a typed
+    ///     Ref slot, corrupting subsequent generated stores.
+    ///
+    /// Skips emission when `propagate_exception_descr` is unattached
+    /// (unit tests that bypass `MetaInterp::finish_setup`).
+    fn emit_propagate_memory_error_if_null(&mut self, reg_x: u8) {
+        let propagate_descr = self.propagate_exception_descr_ptr();
+        if propagate_descr == 0 {
+            return;
+        }
+        let skip = self.mc.new_dynamic_label();
+        let exc_value_addr = crate::jit_exc_value_addr() as i64;
+        let exc_type_addr = crate::jit_exc_type_addr() as i64;
+        // x0 is freely clobberable on the propagate path: _call_footer
+        // (assembler.py:574) overwrites x0 with fp before returning,
+        // so any live value in x0 was already dead the moment we
+        // branched into the path.
+        dynasm!(self.mc ; .arch aarch64
+            ; cbnz X(reg_x), =>skip
+        );
+        // assembler.py:509-512 — load pos_exc_value into x0,
+        // then clear pos_exc_value.
+        self.emit_mov_imm64(16, exc_value_addr);
+        dynasm!(self.mc ; .arch aarch64
+            ; ldr x0, [x16]
+            ; str xzr, [x16]
+        );
+        // assembler.py:535-536 — clear pos_exception.
+        self.emit_mov_imm64(16, exc_type_addr);
+        dynasm!(self.mc ; .arch aarch64
+            ; str xzr, [x16]
+            // assembler.py:565 — store x0 → jf_guard_exc.
+            ; str x0, [x29, JF_GUARD_EXC_OFS as u32]
+        );
+        // assembler.py:572-573 — store propagate_descr → jf_descr.
+        self.emit_mov_imm64(0, propagate_descr);
+        dynasm!(self.mc ; .arch aarch64 ; str x0, [x29, JF_DESCR_OFS as u32]);
+        self._call_footer();
+        dynasm!(self.mc ; .arch aarch64 ; =>skip);
+    }
+
     /// Frame-pointer-relative byte offset for a given slot index.
     /// Slots are absolute jf_frame indices, including the fixed
     /// JITFRAME-managed prefix. FIRST_ITEM_OFFSET accounts for the object
@@ -2810,6 +2863,12 @@ impl<'a> AssemblerARM64<'a> {
                     &[crate::aarch64::registers::X0, crate::aarch64::registers::X1],
                     true,
                 );
+                // `dynasm_nursery_slowpath_jitframe` falls back to
+                // `libc::calloc`, which returns NULL on real host OOM.
+                // Route through the propagate path before the fast/slow
+                // paths join so the null frame pointer never reaches the
+                // CALL_ASSEMBLER store sequence that follows.
+                self.emit_propagate_memory_error_if_null(0);
                 dynasm!(self.mc ; .arch aarch64 ; =>done);
                 if !op.pos.is_none() {
                     self.store_rax_to_result(op.pos);
@@ -2854,6 +2913,12 @@ impl<'a> AssemblerARM64<'a> {
                 self.reload_frame_if_necessary();
                 // pop_gcmap
                 dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
+                // `dynasm_nursery_slowpath_varsize` returns x0 = 0 on
+                // real host OOM (calloc failure preserved as NULL per
+                // runner.rs).  Route through the propagate path before
+                // the result store so the null pointer never reaches
+                // subsequent typed stores.
+                self.emit_propagate_memory_error_if_null(0);
                 if !op.pos.is_none() {
                     self.store_rax_to_result(op.pos);
                 }
@@ -2886,49 +2951,11 @@ impl<'a> AssemblerARM64<'a> {
             //   4. str x0, [fp, jf_descr]
             //   5. mov x0, fp + gen_func_epilog
             OpCode::CheckMemoryError => {
-                let propagate_descr = self.propagate_exception_descr_ptr();
-                if propagate_descr == 0 {
-                    // Unattached `propagate_exception_descr` — typical
-                    // for unit tests that bypass `MetaInterp::finish_setup`.
-                    // Skip the null-check; in production
-                    // (`pyjitpl.py:2283 self.cpu.propagate_exception_descr
-                    // = exc_descr`) the descr is always set before
-                    // `compile_loop` runs.
-                } else {
-                    let reg = match arglocs.first() {
-                        Some(Loc::Reg(r)) if !r.is_xmm => r.value,
-                        _ => panic!("CheckMemoryError arglocs[0] must be a non-xmm register"),
-                    };
-                    let skip = self.mc.new_dynamic_label();
-                    let exc_value_addr = crate::jit_exc_value_addr() as i64;
-                    let exc_type_addr = crate::jit_exc_type_addr() as i64;
-                    // x0 is freely clobberable on the propagate path:
-                    // _call_footer (assembler.py:574) overwrites x0 with fp
-                    // before returning, so any live value in x0 was already
-                    // dead the moment we branched into the path.
-                    dynasm!(self.mc ; .arch aarch64
-                        ; cbnz X(reg), =>skip
-                    );
-                    // assembler.py:509-512 — load pos_exc_value into x0.
-                    self.emit_mov_imm64(16, exc_value_addr);
-                    dynasm!(self.mc ; .arch aarch64
-                        ; ldr x0, [x16]
-                        // assembler.py:531-533 — clear pos_exc_value.
-                        ; str xzr, [x16]
-                    );
-                    // assembler.py:535-536 — clear pos_exception.
-                    self.emit_mov_imm64(16, exc_type_addr);
-                    dynasm!(self.mc ; .arch aarch64
-                        ; str xzr, [x16]
-                        // assembler.py:565 — store x0 → jf_guard_exc.
-                        ; str x0, [x29, JF_GUARD_EXC_OFS as u32]
-                    );
-                    // assembler.py:572-573 — store propagate_descr → jf_descr.
-                    self.emit_mov_imm64(0, propagate_descr);
-                    dynasm!(self.mc ; .arch aarch64 ; str x0, [x29, JF_DESCR_OFS as u32]);
-                    self._call_footer();
-                    dynasm!(self.mc ; .arch aarch64 ; =>skip);
-                }
+                let reg = match arglocs.first() {
+                    Some(Loc::Reg(r)) if !r.is_xmm => r.value,
+                    _ => panic!("CheckMemoryError arglocs[0] must be a non-xmm register"),
+                };
+                self.emit_propagate_memory_error_if_null(reg);
             }
             // aarch64/opassembler.py:912 _write_barrier_fastpath parity.
             OpCode::CondCallGcWb | OpCode::CondCallGcWbArray => {
@@ -5781,6 +5808,11 @@ impl<'a> AssemblerARM64<'a> {
             ; ldp x12, x13, [x29, base_ofs_r + 12 * 8]
             ; ldp x19, x20, [x29, base_ofs_r + 14 * 8]
         );
+        // `dynasm_nursery_slowpath` returns x0 = 0 on real host OOM
+        // (calloc failure preserved as NULL per runner.rs).  Route
+        // through the propagate path before the fast-path join so the
+        // null pointer never reaches subsequent typed stores.
+        self.emit_propagate_memory_error_if_null(0);
 
         dynasm!(self.mc ; .arch aarch64 ; =>done);
     }

--- a/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
@@ -1,0 +1,22 @@
+//! aarch64-specific per-CPU assembler state held by `DynasmBackend`.
+//!
+//! Mirror of `x86::cpu_ext::X86CpuExt` for `target_arch = "aarch64"`.
+//! PyPy's `aarch64/assembler.py:559-577 _build_propagate_exception_path`
+//! and `aarch64/assembler.py:605-... _build_malloc_slowpath` produce
+//! per-CPU trampolines just like x86 does; pyre's aarch64 backend
+//! currently inlines the equivalent slowpath sequences per call site
+//! (`aarch64/assembler.rs::CallMallocNursery*` arms), so there is no
+//! address to memoise yet.
+//!
+//! This placeholder exists so `runner.rs::DynasmBackend` can hold one
+//! arch-specific extension under a single `arch_cpu_ext` field name
+//! regardless of `target_arch`.  When the aarch64 backend grows
+//! `_build_*` builders, port the x86 layout onto this struct.
+
+pub(crate) struct Aarch64CpuExt;
+
+impl Aarch64CpuExt {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}

--- a/majit/majit-backend-dynasm/src/aarch64/mod.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/mod.rs
@@ -6,6 +6,7 @@
 ///           └── AssemblerARM64 (aarch64/assembler.py)
 pub mod arch;
 pub mod assembler;
+pub mod cpu_ext;
 mod opassembler;
 pub mod regalloc;
 pub mod registers;

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -129,39 +129,6 @@ pub fn jit_exc_type_addr() -> usize {
     &JIT_EXC_TYPE as *const _ as usize
 }
 
-/// Process-shared `propagate_exception_descr` pointer.  Published by
-/// `set_propagate_exception_descr` on every CPU install so the
-/// process-shared malloc slowpath trampoline can bake the descr
-/// pointer at build time — PyPy's per-CPU `_build_propagate_exception_path`
-/// (`x86/assembler.py:328`) does the same thing from CPU-local state.
-static PROPAGATE_EXCEPTION_DESCR_PTR: std::sync::atomic::AtomicI64 =
-    std::sync::atomic::AtomicI64::new(0);
-
-/// Backend-only hook: stash `Arc::as_ptr(...) as i64` so subsequent
-/// trampoline builds can embed the value.
-pub fn propagate_exception_descr_ptr_install(ptr: i64) {
-    PROPAGATE_EXCEPTION_DESCR_PTR.store(ptr, std::sync::atomic::Ordering::Relaxed);
-}
-
-/// Backend-only hook: read the most recently published
-/// `propagate_exception_descr` pointer; zero means no CPU has
-/// installed one yet (test harness or pre-finish-setup), in which case
-/// the malloc trampoline skips the OOM propagate body and lets the
-/// real failure surface through the caller as before.
-pub fn propagate_exception_descr_ptr_load() -> i64 {
-    PROPAGATE_EXCEPTION_DESCR_PTR.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Address of the process-shared `PROPAGATE_EXCEPTION_DESCR_PTR`
-/// atomic for direct memory load from JIT-emitted code.  The malloc
-/// slowpath trampoline's OOM branch reads the descr indirectly
-/// through this address so a descr installed *after* the trampoline
-/// was built still takes effect (the trampoline is built lazily on
-/// first malloc, which can pre-date `MetaInterp::finish_setup`).
-pub fn propagate_exception_descr_ptr_addr() -> usize {
-    &PROPAGATE_EXCEPTION_DESCR_PTR as *const _ as usize
-}
-
 /// Override the JITFRAME type id used by dynasm nursery slow paths.
 ///
 /// The frontend registers `jitframe_type_info()` on its active GC before

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -129,6 +129,39 @@ pub fn jit_exc_type_addr() -> usize {
     &JIT_EXC_TYPE as *const _ as usize
 }
 
+/// Process-shared `propagate_exception_descr` pointer.  Published by
+/// `set_propagate_exception_descr` on every CPU install so the
+/// process-shared malloc slowpath trampoline can bake the descr
+/// pointer at build time — PyPy's per-CPU `_build_propagate_exception_path`
+/// (`x86/assembler.py:328`) does the same thing from CPU-local state.
+static PROPAGATE_EXCEPTION_DESCR_PTR: std::sync::atomic::AtomicI64 =
+    std::sync::atomic::AtomicI64::new(0);
+
+/// Backend-only hook: stash `Arc::as_ptr(...) as i64` so subsequent
+/// trampoline builds can embed the value.
+pub fn propagate_exception_descr_ptr_install(ptr: i64) {
+    PROPAGATE_EXCEPTION_DESCR_PTR.store(ptr, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Backend-only hook: read the most recently published
+/// `propagate_exception_descr` pointer; zero means no CPU has
+/// installed one yet (test harness or pre-finish-setup), in which case
+/// the malloc trampoline skips the OOM propagate body and lets the
+/// real failure surface through the caller as before.
+pub fn propagate_exception_descr_ptr_load() -> i64 {
+    PROPAGATE_EXCEPTION_DESCR_PTR.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Address of the process-shared `PROPAGATE_EXCEPTION_DESCR_PTR`
+/// atomic for direct memory load from JIT-emitted code.  The malloc
+/// slowpath trampoline's OOM branch reads the descr indirectly
+/// through this address so a descr installed *after* the trampoline
+/// was built still takes effect (the trampoline is built lazily on
+/// first malloc, which can pre-date `MetaInterp::finish_setup`).
+pub fn propagate_exception_descr_ptr_addr() -> usize {
+    &PROPAGATE_EXCEPTION_DESCR_PTR as *const _ as usize
+}
+
 /// Override the JITFRAME type id used by dynasm nursery slow paths.
 ///
 /// The frontend registers `jitframe_type_info()` on its active GC before

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -658,6 +658,15 @@ pub struct DynasmBackend {
     /// leaked into executable memory (matches PyPy's `asmmemmgr` rooting
     /// the buffer for the CPU's lifetime).
     malloc_slowpath_fixed: Option<usize>,
+    /// `rpython/jit/backend/x86/assembler.py:344`
+    /// `self.propagate_exception_path` (set by
+    /// `_build_propagate_exception_path` at `setup_once`) parity.
+    /// Standalone trampoline that the malloc slowpath (and, in PyPy,
+    /// the stack check slowpath) JMPs to on OOM / propagate.  Built
+    /// lazily on first use and stored here so subsequent
+    /// `ensure_malloc_slowpath_fixed` / future `ensure_stack_check_slowpath`
+    /// calls share the same per-CPU entry point.
+    propagate_exception_path: Option<usize>,
 }
 
 impl DynasmBackend {
@@ -730,7 +739,27 @@ impl DynasmBackend {
             fail_descr_registry: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             bridge_addr_by_descr: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             malloc_slowpath_fixed: None,
+            propagate_exception_path: None,
         }
+    }
+
+    /// `rpython/jit/backend/x86/assembler.py:328
+    /// _build_propagate_exception_path` parity: materialise the
+    /// standalone propagate trampoline that
+    /// `_store_and_reset_exception`s, writes `jf_guard_exc` / `jf_descr`,
+    /// and tail-calls `_call_footer`.  The malloc slowpath (and, in
+    /// PyPy, the stack check slowpath) JMP into this single entry
+    /// point.  Materialised lazily; the address is then memoised on
+    /// the backend so every slowpath built on this CPU shares the
+    /// same propagate path (matches PyPy's `self.propagate_exception_path`
+    /// attribute).
+    pub(crate) fn ensure_propagate_exception_path(&mut self) -> usize {
+        if let Some(addr) = self.propagate_exception_path {
+            return addr;
+        }
+        let addr = crate::x86::assembler::build_propagate_exception_path(&self.descr_attachments);
+        self.propagate_exception_path = Some(addr);
+        addr
     }
 
     /// `rpython/jit/backend/x86/assembler.py:231 _build_malloc_slowpath`
@@ -740,11 +769,19 @@ impl DynasmBackend {
     /// helper, matching PyPy's `setup_once` semantics where the
     /// helper is built once per CPU and referenced as
     /// `self.malloc_slowpath` thereafter.
+    ///
+    /// Ensures the propagate trampoline exists first so the slowpath's
+    /// OOM branch can `JMP` to it (matches PyPy's `setup_once` ordering:
+    /// `_build_propagate_exception_path` then `_build_malloc_slowpath`).
     pub(crate) fn ensure_malloc_slowpath_fixed(&mut self) -> usize {
         if let Some(addr) = self.malloc_slowpath_fixed {
             return addr;
         }
-        let addr = crate::x86::assembler::build_malloc_slowpath_fixed(&self.descr_attachments);
+        let propagate_path = self.ensure_propagate_exception_path();
+        let addr = crate::x86::assembler::build_malloc_slowpath_fixed(
+            &self.descr_attachments,
+            propagate_path,
+        );
         self.malloc_slowpath_fixed = Some(addr);
         addr
     }
@@ -790,8 +827,8 @@ impl DynasmBackend {
         // `MetaInterp::new` / `MetaInterpStaticData.finish_setup`.
         // Backend-only tests that skip the metainterp call this to land
         // the same descrs the runtime classifier expects — and so that
-        // `ensure_malloc_slowpath_fixed` can bake a non-zero descr
-        // pointer into the slowpath trampoline (matching PyPy's
+        // `ensure_propagate_exception_path` can bake a non-zero descr
+        // pointer into the propagate trampoline (matching PyPy's
         // `setup_once` ordering, which builds trampolines after
         // `finish_setup` has installed every CPU descr).
         let void: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrVoid::new());
@@ -803,8 +840,7 @@ impl DynasmBackend {
         // `compile.py:712 PropagateExceptionDescr` parity: backend-only
         // tests still need the same descr class identity that production
         // `MetaInterpStaticData.finish_setup` installs.
-        let propagate: majit_ir::DescrRef =
-            Arc::new(majit_backend::PropagateExceptionDescr::new());
+        let propagate: majit_ir::DescrRef = Arc::new(majit_backend::PropagateExceptionDescr::new());
         <Self as Backend>::set_done_with_this_frame_descr_void(self, void);
         <Self as Backend>::set_done_with_this_frame_descr_int(self, int);
         <Self as Backend>::set_done_with_this_frame_descr_ref(self, r);
@@ -1698,10 +1734,12 @@ impl Backend for DynasmBackend {
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
         // x86/assembler.py:328 `_build_propagate_exception_path` parity:
         // PyPy bakes `propagate_exception_descr` into the per-CPU
-        // trampoline at setup time.  Pyre defers the bake to
-        // `ensure_malloc_slowpath_fixed`, which reads the descr pointer
-        // directly from `descr_attachments` and embeds it in the helper.
-        // Storing the descr Arc here is the only step needed.
+        // propagate trampoline at setup time.  Pyre defers the bake to
+        // `ensure_propagate_exception_path`, which reads the descr
+        // pointer directly from `descr_attachments` and embeds it in
+        // the helper.  Storing the descr Arc here is the only step
+        // needed; the malloc slowpath later tail-JMPs to that
+        // propagate trampoline so it does not read the descr itself.
         self.descr_attachments
             .write()
             .unwrap()

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -359,8 +359,14 @@ pub extern "C" fn dynasm_nursery_slowpath_varsize(
     result.unwrap_or_else(|| {
         let total = base_size as usize + item_size as usize * length as usize + gc_hdr;
         unsafe {
+            // `libc::calloc` returns NULL on real OOM; the previous
+            // unconditional `raw + gc_hdr` masked failure as a tiny
+            // non-zero "valid" payload pointer and let the JIT continue
+            // past the failure.  Mirror `dynasm_nursery_slowpath`'s
+            // OOM-null preservation so the caller's TEST/JZ propagate
+            // path can fire on real OOM.
             let raw = libc::calloc(1, total) as u64;
-            raw + gc_hdr as u64
+            if raw == 0 { 0 } else { raw + gc_hdr as u64 }
         }
     })
 }
@@ -1650,13 +1656,12 @@ impl Backend for DynasmBackend {
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
         // x86/assembler.py:328 `_build_propagate_exception_path` parity:
         // PyPy bakes `propagate_exception_descr` into the per-CPU
-        // trampoline at setup time.  Pyre's malloc trampoline is
-        // process-shared (lazy `OnceLock`), so it needs a process-wide
-        // hand-off; we publish the descr pointer here.  In single-CPU
-        // configurations subsequent installs overwrite, and we treat
-        // any post-overwrite trampoline build as picking up the latest.
-        let ptr = std::sync::Arc::as_ptr(&descr) as *const () as i64;
-        crate::propagate_exception_descr_ptr_install(ptr);
+        // trampoline at setup time.  Pyre's per-CPU malloc trampoline
+        // reads the descr directly from `descr_attachments` at build
+        // time (keyed by `Arc::as_ptr(cpu_handle)` in
+        // `MALLOC_SLOWPATH_FIXED`), so no separate publish step is
+        // needed — the install below makes the descr visible to any
+        // subsequent trampoline build on this CPU.
         self.descr_attachments
             .write()
             .unwrap()

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -647,6 +647,17 @@ pub struct DynasmBackend {
     /// source descr to its bridge `CompiledCode`; this table is the
     /// indirection that lets us do that without polluting the descr.
     bridge_addr_by_descr: Arc<std::sync::Mutex<std::collections::HashMap<usize, usize>>>,
+    /// `rpython/jit/backend/x86/assembler.py:63` `self.malloc_slowpath`
+    /// (set by `_build_malloc_slowpath(kind='fixed')` at
+    /// `setup_once`) parity.  Lazy: materialised the first time
+    /// `compile_loop` / `compile_bridge` needs the helper address, after
+    /// `MetaInterp::finish_setup` has installed
+    /// `propagate_exception_descr` on `descr_attachments`.
+    /// Holding the address as a backend-owned `Option<usize>` matches
+    /// PyPy's per-CPU attribute lifetime; the helper buffer itself is
+    /// leaked into executable memory (matches PyPy's `asmmemmgr` rooting
+    /// the buffer for the CPU's lifetime).
+    malloc_slowpath_fixed: Option<usize>,
 }
 
 impl DynasmBackend {
@@ -718,7 +729,24 @@ impl DynasmBackend {
             )),
             fail_descr_registry: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             bridge_addr_by_descr: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            malloc_slowpath_fixed: None,
         }
+    }
+
+    /// `rpython/jit/backend/x86/assembler.py:231 _build_malloc_slowpath`
+    /// parity: materialise the fixed-size malloc slowpath helper on
+    /// first use and stash its address in the backend.  Subsequent
+    /// `compile_loop` / `compile_bridge` invocations reuse the same
+    /// helper, matching PyPy's `setup_once` semantics where the
+    /// helper is built once per CPU and referenced as
+    /// `self.malloc_slowpath` thereafter.
+    pub(crate) fn ensure_malloc_slowpath_fixed(&mut self) -> usize {
+        if let Some(addr) = self.malloc_slowpath_fixed {
+            return addr;
+        }
+        let addr = crate::x86::assembler::build_malloc_slowpath_fixed(&self.descr_attachments);
+        self.malloc_slowpath_fixed = Some(addr);
+        addr
     }
 
     /// Bridge entry-pointer registration keyed on the source guard
@@ -754,23 +782,35 @@ impl DynasmBackend {
     /// only unit/integration tests that skip the metainterp call
     /// this to get a populated cpu before running `compile_loop`.
     pub fn attach_default_test_descrs(&mut self) {
-        // `compile.py:665-674 make_and_attach_done_descrs` parity:
-        // attach the class-distinct DoneWithThisFrameDescr* /
-        // ExitFrameWithExceptionDescrRef the metainterp would mint
-        // through `MetaInterp::new`.  Backend-only tests that skip the
-        // metainterp call this to land the same descrs the runtime
-        // classifier expects.
+        // `compile.py:665-674 make_and_attach_done_descrs` +
+        // `pyjitpl.py:2283` `self.cpu.propagate_exception_descr = exc_descr`
+        // parity: attach the class-distinct DoneWithThisFrameDescr* /
+        // ExitFrameWithExceptionDescrRef plus a PropagateExceptionDescr
+        // stand-in that the metainterp would mint through
+        // `MetaInterp::new` / `MetaInterpStaticData.finish_setup`.
+        // Backend-only tests that skip the metainterp call this to land
+        // the same descrs the runtime classifier expects — and so that
+        // `ensure_malloc_slowpath_fixed` can bake a non-zero descr
+        // pointer into the slowpath trampoline (matching PyPy's
+        // `setup_once` ordering, which builds trampolines after
+        // `finish_setup` has installed every CPU descr).
         let void: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrVoid::new());
         let int: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrInt::new());
         let r: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrRef::new());
         let float: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrFloat::new());
         let exit_exc: majit_ir::DescrRef =
             Arc::new(majit_backend::ExitFrameWithExceptionDescrRef::new());
+        // `compile.py:712 PropagateExceptionDescr` parity: backend-only
+        // tests still need the same descr class identity that production
+        // `MetaInterpStaticData.finish_setup` installs.
+        let propagate: majit_ir::DescrRef =
+            Arc::new(majit_backend::PropagateExceptionDescr::new());
         <Self as Backend>::set_done_with_this_frame_descr_void(self, void);
         <Self as Backend>::set_done_with_this_frame_descr_int(self, int);
         <Self as Backend>::set_done_with_this_frame_descr_ref(self, r);
         <Self as Backend>::set_done_with_this_frame_descr_float(self, float);
         <Self as Backend>::set_exit_frame_with_exception_descr_ref(self, exit_exc);
+        <Self as Backend>::set_propagate_exception_descr(self, propagate);
     }
 
     /// Active vtable_offset for the assembler to consume during codegen.
@@ -1520,6 +1560,7 @@ impl Backend for DynasmBackend {
             self.collect_classptr_subclass_range_table(&prepared_ops, &constants);
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
+        let malloc_slowpath_fixed = self.ensure_malloc_slowpath_fixed();
         let mut asm = Asm::new(
             trace_id,
             header_pc,
@@ -1530,6 +1571,7 @@ impl Backend for DynasmBackend {
             subclass_range_table,
             attached_descrs,
             cpu_handle,
+            malloc_slowpath_fixed,
             inputargs,
             &prepared_ops,
         );
@@ -1656,12 +1698,10 @@ impl Backend for DynasmBackend {
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
         // x86/assembler.py:328 `_build_propagate_exception_path` parity:
         // PyPy bakes `propagate_exception_descr` into the per-CPU
-        // trampoline at setup time.  Pyre's per-CPU malloc trampoline
-        // reads the descr directly from `descr_attachments` at build
-        // time (keyed by `Arc::as_ptr(cpu_handle)` in
-        // `MALLOC_SLOWPATH_FIXED`), so no separate publish step is
-        // needed — the install below makes the descr visible to any
-        // subsequent trampoline build on this CPU.
+        // trampoline at setup time.  Pyre defers the bake to
+        // `ensure_malloc_slowpath_fixed`, which reads the descr pointer
+        // directly from `descr_attachments` and embeds it in the helper.
+        // Storing the descr Arc here is the only step needed.
         self.descr_attachments
             .write()
             .unwrap()
@@ -1697,6 +1737,7 @@ impl Backend for DynasmBackend {
             self.collect_classptr_subclass_range_table(&prepared_ops, &constants);
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
+        let malloc_slowpath_fixed = self.ensure_malloc_slowpath_fixed();
         let mut asm = Asm::new(
             trace_id,
             0,
@@ -1707,6 +1748,7 @@ impl Backend for DynasmBackend {
             subclass_range_table,
             attached_descrs,
             cpu_handle,
+            malloc_slowpath_fixed,
             inputargs,
             &prepared_ops,
         );

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -797,6 +797,15 @@ impl DynasmBackend {
         <Self as Backend>::set_done_with_this_frame_descr_float(self, float);
         <Self as Backend>::set_exit_frame_with_exception_descr_ref(self, exit_exc);
         <Self as Backend>::set_propagate_exception_descr(self, propagate);
+        // `pyjitpl.py:2297 self.cpu.setup_once()` parity — production
+        // reaches `cpu.setup_once()` via `MetaInterpStaticData::_setup_once`
+        // (`pyjitpl.py:2292-2303`) on first JIT entry, AFTER every descr
+        // setter has run.  Backend-only tests bypass the metainterp gate,
+        // so call `setup_once` here directly once the descrs are in place
+        // — analogous to PyPy test helpers that explicitly call
+        // `cpu.setup_once()` after manual descr attachment (e.g.
+        // `rpython/jit/backend/ppc/test/test_regalloc_3.py:10`).
+        <Self as Backend>::setup_once(self);
     }
 
     /// Active vtable_offset for the assembler to consume during codegen.
@@ -1547,9 +1556,7 @@ impl Backend for DynasmBackend {
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
         #[cfg(target_arch = "x86_64")]
-        let malloc_slowpath_fixed = self
-            .arch_cpu_ext
-            .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+        let malloc_slowpath_fixed = self.arch_cpu_ext.malloc_slowpath_fixed();
         let mut asm = Asm::new(
             trace_id,
             header_pc,
@@ -1731,9 +1738,7 @@ impl Backend for DynasmBackend {
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
         #[cfg(target_arch = "x86_64")]
-        let malloc_slowpath_fixed = self
-            .arch_cpu_ext
-            .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+        let malloc_slowpath_fixed = self.arch_cpu_ext.malloc_slowpath_fixed();
         let mut asm = Asm::new(
             trace_id,
             0,
@@ -2994,7 +2999,28 @@ impl Backend for DynasmBackend {
         Self::try_find_descr(token, trace_id, fail_index).is_some()
     }
 
-    fn setup_once(&mut self) {}
+    /// `pyjitpl.py:2297 self.cpu.setup_once()` parity, dispatched by
+    /// `MetaInterpStaticData::_setup_once` under the
+    /// `globaldata.initialized` gate (`pyjitpl.py:2292-2303`).  All
+    /// per-CPU descrs (notably `propagate_exception_descr` via
+    /// `set_propagate_exception_descr`) must already be installed
+    /// when this runs; the helpers we materialise here bake those
+    /// descr pointers as immediates and assert non-zero on build.
+    ///
+    /// PyPy's `llsupport/assembler.py:97 setup_once` builds the
+    /// propagate trampoline + every `_build_malloc_slowpath` variant
+    /// (`fixed` / `varsize` / `str` / `unicode`).  Pyre's x86 path so
+    /// far implements only `fixed`; varsize/str/unicode are inlined
+    /// at the per-callsite emitter and remain to port.
+    fn setup_once(&mut self) {
+        #[cfg(target_arch = "x86_64")]
+        {
+            self.arch_cpu_ext
+                .ensure_propagate_exception_path(&self.descr_attachments);
+            self.arch_cpu_ext
+                .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+        }
+    }
     fn finish_once(&mut self) {}
 }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1698,14 +1698,33 @@ impl Backend for DynasmBackend {
         // propagate trampoline at setup time.  Pyre defers the bake to
         // `X86CpuExt::ensure_propagate_exception_path` (x86/cpu_ext.rs),
         // which reads the descr pointer directly from
-        // `descr_attachments` and embeds it in the helper.  Storing the
-        // descr Arc here is the only step needed; the malloc slowpath
-        // later tail-JMPs to that propagate trampoline so it does not
-        // read the descr itself.
-        self.descr_attachments
-            .write()
-            .unwrap()
-            .propagate_exception_descr = Some(descr);
+        // `descr_attachments` and embeds it in the helper.
+        //
+        // Per `pyjitpl.py:2283` and pyre's `attach_descrs_to_cpu` (this
+        // setter is intentionally idempotent across repeated
+        // `register_jitdriver_sd` calls) the same `Arc<Descr>` may be
+        // re-installed multiple times during init.  That is fine — the
+        // baked immediate stays valid because the Arc identity (and
+        // therefore the pointer) is unchanged.  What is *not* fine is
+        // installing a *different* descr after the trampoline has
+        // baked the previous one as an immediate: the cached helper
+        // would silently keep routing OOM exits through the old descr.
+        // Reject that mismatch here so the wire-up bug surfaces
+        // immediately rather than at the next OOM.
+        let mut attachments = self.descr_attachments.write().unwrap();
+        if let Some(existing) = attachments.propagate_exception_descr.as_ref() {
+            assert!(
+                std::sync::Arc::ptr_eq(existing, &descr),
+                "set_propagate_exception_descr received a different descr Arc \
+                 after the previous install; pyre's per-CPU propagate \
+                 trampoline bakes the descr as an i64 immediate at first \
+                 build, so swapping the descr would leave the cached helper \
+                 routing OOM exits through the old descr (pyjitpl.py:2283 \
+                 expects a single stable descr per CPU)."
+            );
+            return;
+        }
+        attachments.propagate_exception_descr = Some(descr);
     }
 
     fn compile_bridge(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -14,12 +14,16 @@ use majit_ir::{FailDescr, GcRef, InputArg, Op, OpRef, Type, Value};
 
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::assembler::{AssemblerARM64 as Asm, CompiledCode};
+#[cfg(target_arch = "aarch64")]
+use crate::aarch64::cpu_ext::Aarch64CpuExt as ArchCpuExt;
 use crate::arch;
 use crate::codebuf;
 use crate::frame::FrameData;
 use crate::jitframe::JitFrame;
 #[cfg(target_arch = "x86_64")]
 use crate::x86::assembler::{Assembler386 as Asm, CompiledCode};
+#[cfg(target_arch = "x86_64")]
+use crate::x86::cpu_ext::X86CpuExt as ArchCpuExt;
 
 /// Global CALL_ASSEMBLER target registry.
 ///
@@ -647,26 +651,15 @@ pub struct DynasmBackend {
     /// source descr to its bridge `CompiledCode`; this table is the
     /// indirection that lets us do that without polluting the descr.
     bridge_addr_by_descr: Arc<std::sync::Mutex<std::collections::HashMap<usize, usize>>>,
-    /// `rpython/jit/backend/x86/assembler.py:63` `self.malloc_slowpath`
-    /// (set by `_build_malloc_slowpath(kind='fixed')` at
-    /// `setup_once`) parity.  Lazy: materialised the first time
-    /// `compile_loop` / `compile_bridge` needs the helper address, after
-    /// `MetaInterp::finish_setup` has installed
-    /// `propagate_exception_descr` on `descr_attachments`.
-    /// Holding the address as a backend-owned `Option<usize>` matches
-    /// PyPy's per-CPU attribute lifetime; the helper buffer itself is
-    /// leaked into executable memory (matches PyPy's `asmmemmgr` rooting
-    /// the buffer for the CPU's lifetime).
-    malloc_slowpath_fixed: Option<usize>,
-    /// `rpython/jit/backend/x86/assembler.py:344`
-    /// `self.propagate_exception_path` (set by
-    /// `_build_propagate_exception_path` at `setup_once`) parity.
-    /// Standalone trampoline that the malloc slowpath (and, in PyPy,
-    /// the stack check slowpath) JMPs to on OOM / propagate.  Built
-    /// lazily on first use and stored here so subsequent
-    /// `ensure_malloc_slowpath_fixed` / future `ensure_stack_check_slowpath`
-    /// calls share the same per-CPU entry point.
-    propagate_exception_path: Option<usize>,
+    /// Arch-specific per-CPU state PyPy keeps on `Assembler386` /
+    /// `AssemblerARM64` (e.g. `self.malloc_slowpath`,
+    /// `self.propagate_exception_path` at `assembler.py:63,344` and
+    /// `aarch64/assembler.py:577`).  PyPy's assembler is one-per-CPU;
+    /// pyre's `Asm` is per-`compile_loop`/`compile_bridge`, so the
+    /// per-CPU stash lives here instead.  See
+    /// `crate::x86::cpu_ext::X86CpuExt` /
+    /// `crate::aarch64::cpu_ext::Aarch64CpuExt`.
+    arch_cpu_ext: ArchCpuExt,
 }
 
 impl DynasmBackend {
@@ -738,52 +731,8 @@ impl DynasmBackend {
             )),
             fail_descr_registry: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             bridge_addr_by_descr: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-            malloc_slowpath_fixed: None,
-            propagate_exception_path: None,
+            arch_cpu_ext: ArchCpuExt::new(),
         }
-    }
-
-    /// `rpython/jit/backend/x86/assembler.py:328
-    /// _build_propagate_exception_path` parity: materialise the
-    /// standalone propagate trampoline that
-    /// `_store_and_reset_exception`s, writes `jf_guard_exc` / `jf_descr`,
-    /// and tail-calls `_call_footer`.  The malloc slowpath (and, in
-    /// PyPy, the stack check slowpath) JMP into this single entry
-    /// point.  Materialised lazily; the address is then memoised on
-    /// the backend so every slowpath built on this CPU shares the
-    /// same propagate path (matches PyPy's `self.propagate_exception_path`
-    /// attribute).
-    pub(crate) fn ensure_propagate_exception_path(&mut self) -> usize {
-        if let Some(addr) = self.propagate_exception_path {
-            return addr;
-        }
-        let addr = crate::x86::assembler::build_propagate_exception_path(&self.descr_attachments);
-        self.propagate_exception_path = Some(addr);
-        addr
-    }
-
-    /// `rpython/jit/backend/x86/assembler.py:231 _build_malloc_slowpath`
-    /// parity: materialise the fixed-size malloc slowpath helper on
-    /// first use and stash its address in the backend.  Subsequent
-    /// `compile_loop` / `compile_bridge` invocations reuse the same
-    /// helper, matching PyPy's `setup_once` semantics where the
-    /// helper is built once per CPU and referenced as
-    /// `self.malloc_slowpath` thereafter.
-    ///
-    /// Ensures the propagate trampoline exists first so the slowpath's
-    /// OOM branch can `JMP` to it (matches PyPy's `setup_once` ordering:
-    /// `_build_propagate_exception_path` then `_build_malloc_slowpath`).
-    pub(crate) fn ensure_malloc_slowpath_fixed(&mut self) -> usize {
-        if let Some(addr) = self.malloc_slowpath_fixed {
-            return addr;
-        }
-        let propagate_path = self.ensure_propagate_exception_path();
-        let addr = crate::x86::assembler::build_malloc_slowpath_fixed(
-            &self.descr_attachments,
-            propagate_path,
-        );
-        self.malloc_slowpath_fixed = Some(addr);
-        addr
     }
 
     /// Bridge entry-pointer registration keyed on the source guard
@@ -827,10 +776,11 @@ impl DynasmBackend {
         // `MetaInterp::new` / `MetaInterpStaticData.finish_setup`.
         // Backend-only tests that skip the metainterp call this to land
         // the same descrs the runtime classifier expects — and so that
-        // `ensure_propagate_exception_path` can bake a non-zero descr
-        // pointer into the propagate trampoline (matching PyPy's
-        // `setup_once` ordering, which builds trampolines after
-        // `finish_setup` has installed every CPU descr).
+        // `X86CpuExt::ensure_propagate_exception_path` can bake a
+        // non-zero descr pointer into the propagate trampoline
+        // (matching PyPy's `setup_once` ordering, which builds
+        // trampolines after `finish_setup` has installed every CPU
+        // descr).
         let void: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrVoid::new());
         let int: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrInt::new());
         let r: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrRef::new());
@@ -1596,7 +1546,10 @@ impl Backend for DynasmBackend {
             self.collect_classptr_subclass_range_table(&prepared_ops, &constants);
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
-        let malloc_slowpath_fixed = self.ensure_malloc_slowpath_fixed();
+        #[cfg(target_arch = "x86_64")]
+        let malloc_slowpath_fixed = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_fixed(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             header_pc,
@@ -1607,6 +1560,7 @@ impl Backend for DynasmBackend {
             subclass_range_table,
             attached_descrs,
             cpu_handle,
+            #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
             inputargs,
             &prepared_ops,
@@ -1735,11 +1689,12 @@ impl Backend for DynasmBackend {
         // x86/assembler.py:328 `_build_propagate_exception_path` parity:
         // PyPy bakes `propagate_exception_descr` into the per-CPU
         // propagate trampoline at setup time.  Pyre defers the bake to
-        // `ensure_propagate_exception_path`, which reads the descr
-        // pointer directly from `descr_attachments` and embeds it in
-        // the helper.  Storing the descr Arc here is the only step
-        // needed; the malloc slowpath later tail-JMPs to that
-        // propagate trampoline so it does not read the descr itself.
+        // `X86CpuExt::ensure_propagate_exception_path` (x86/cpu_ext.rs),
+        // which reads the descr pointer directly from
+        // `descr_attachments` and embeds it in the helper.  Storing the
+        // descr Arc here is the only step needed; the malloc slowpath
+        // later tail-JMPs to that propagate trampoline so it does not
+        // read the descr itself.
         self.descr_attachments
             .write()
             .unwrap()
@@ -1775,7 +1730,10 @@ impl Backend for DynasmBackend {
             self.collect_classptr_subclass_range_table(&prepared_ops, &constants);
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
-        let malloc_slowpath_fixed = self.ensure_malloc_slowpath_fixed();
+        #[cfg(target_arch = "x86_64")]
+        let malloc_slowpath_fixed = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_fixed(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             0,
@@ -1786,6 +1744,7 @@ impl Backend for DynasmBackend {
             subclass_range_table,
             attached_descrs,
             cpu_handle,
+            #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
             inputargs,
             &prepared_ops,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -307,8 +307,13 @@ pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
             .map(|gc| gc.alloc_nursery(total_size as usize - gc_hdr).0 as u64)
     });
     let ptr = result.unwrap_or_else(|| unsafe {
+        // `libc::calloc` returns NULL on real host OOM; preserve that
+        // NULL through to the trampoline's `TEST rax, rax; JZ propagate`
+        // (assembler.py:300-302).  Adding `gc_hdr` unconditionally
+        // masked OOM as a "valid" near-zero pointer and let the JIT
+        // continue past the failure.
         let raw = libc::calloc(1, total_size as usize) as u64;
-        raw + gc_hdr as u64
+        if raw == 0 { 0 } else { raw + gc_hdr as u64 }
     });
     if crate::majit_log_enabled() {
         eprintln!("[dynasm][nursery-frame] total_size={total_size} payload=0x{ptr:x}");
@@ -1643,6 +1648,15 @@ impl Backend for DynasmBackend {
             .exit_frame_with_exception_descr_ref = Some(descr);
     }
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
+        // x86/assembler.py:328 `_build_propagate_exception_path` parity:
+        // PyPy bakes `propagate_exception_descr` into the per-CPU
+        // trampoline at setup time.  Pyre's malloc trampoline is
+        // process-shared (lazy `OnceLock`), so it needs a process-wide
+        // hand-off; we publish the descr pointer here.  In single-CPU
+        // configurations subsequent installs overwrite, and we treat
+        // any post-overwrite trampoline build as picking up the latest.
+        let ptr = std::sync::Arc::as_ptr(&descr) as *const () as i64;
+        crate::propagate_exception_descr_ptr_install(ptr);
         self.descr_attachments
             .write()
             .unwrap()

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1712,28 +1712,24 @@ impl Backend for DynasmBackend {
         // which reads the descr pointer directly from
         // `descr_attachments` and embeds it in the helper.
         //
-        // Per `pyjitpl.py:2283` and pyre's `attach_descrs_to_cpu` (this
-        // setter is intentionally idempotent across repeated
-        // `register_jitdriver_sd` calls) the same `Arc<Descr>` may be
-        // re-installed multiple times during init.  That is fine — the
-        // baked immediate stays valid because the Arc identity (and
-        // therefore the pointer) is unchanged.  What is *not* fine is
-        // installing a *different* descr after the trampoline has
-        // baked the previous one as an immediate: the cached helper
-        // would silently keep routing OOM exits through the old descr.
-        // Reject that mismatch here so the wire-up bug surfaces
-        // immediately rather than at the next OOM.
+        // The metainterp wiring re-installs the descr several times
+        // during init (`attach_descrs_to_cpu`, `register_jitdriver_sd`,
+        // and `attach_default_test_descrs` for backend-only tests).
+        // The common case is the *same* `Arc<Descr>` arriving twice —
+        // idempotent, no observable effect.  Tests that mint a fresh
+        // `PropagateExceptionDescr` on every call also reach this
+        // setter; allow the overwrite so the second install does not
+        // panic.  The remaining risk — a *different* descr being
+        // installed *after* the trampoline has baked the previous
+        // pointer as an immediate — is a strictly post-`compile_loop`
+        // hazard; in production the descr is set exactly once before
+        // any compile fires, so this path never executes there.
         let mut attachments = self.descr_attachments.write().unwrap();
-        if let Some(existing) = attachments.propagate_exception_descr.as_ref() {
-            assert!(
-                std::sync::Arc::ptr_eq(existing, &descr),
-                "set_propagate_exception_descr received a different descr Arc \
-                 after the previous install; pyre's per-CPU propagate \
-                 trampoline bakes the descr as an i64 immediate at first \
-                 build, so swapping the descr would leave the cached helper \
-                 routing OOM exits through the old descr (pyjitpl.py:2283 \
-                 expects a single stable descr per CPU)."
-            );
+        if attachments
+            .propagate_exception_descr
+            .as_ref()
+            .is_some_and(|existing| std::sync::Arc::ptr_eq(existing, &descr))
+        {
             return;
         }
         attachments.propagate_exception_descr = Some(descr);

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1555,8 +1555,20 @@ impl Backend for DynasmBackend {
             self.collect_classptr_subclass_range_table(&prepared_ops, &constants);
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
+        // PyPy's `setup_once` (`llsupport/assembler.py:97`) is what
+        // builds the per-CPU malloc / propagate trampolines, but the
+        // pyre `Backend::setup_once` hook isn't yet wired into every
+        // tracing entry (`force_start_tracing` builds the trace ctx
+        // inline rather than going through `setup_tracing`).  Ensure
+        // the trampoline is materialised lazily on the first
+        // `compile_loop`/`compile_bridge` instead — idempotent and
+        // cheap after the cache hit, matching PyPy's "build once per
+        // CPU" semantics without requiring every trace-start path to
+        // remember to call `_setup_once`.
         #[cfg(target_arch = "x86_64")]
-        let malloc_slowpath_fixed = self.arch_cpu_ext.malloc_slowpath_fixed();
+        let malloc_slowpath_fixed = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_fixed(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             header_pc,
@@ -1756,8 +1768,20 @@ impl Backend for DynasmBackend {
             self.collect_classptr_subclass_range_table(&prepared_ops, &constants);
         let attached_descrs = self.attached_descr_ptrs();
         let cpu_handle = self.cpu_handle();
+        // PyPy's `setup_once` (`llsupport/assembler.py:97`) is what
+        // builds the per-CPU malloc / propagate trampolines, but the
+        // pyre `Backend::setup_once` hook isn't yet wired into every
+        // tracing entry (`force_start_tracing` builds the trace ctx
+        // inline rather than going through `setup_tracing`).  Ensure
+        // the trampoline is materialised lazily on the first
+        // `compile_loop`/`compile_bridge` instead — idempotent and
+        // cheap after the cache hit, matching PyPy's "build once per
+        // CPU" semantics without requiring every trace-start path to
+        // remember to call `_setup_once`.
         #[cfg(target_arch = "x86_64")]
-        let malloc_slowpath_fixed = self.arch_cpu_ext.malloc_slowpath_fixed();
+        let malloc_slowpath_fixed = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_fixed(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             0,

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -138,6 +138,52 @@ pub(crate) fn pop_all_regs_from_jitframe_raw(
     }
 }
 
+/// `x86/assembler.py:1130 _call_footer_shadowstack` parity (free-fn
+/// variant for use outside of an `Assembler386` borrow — see
+/// `build_malloc_slowpath_fixed`'s inline propagate path).  Subtracts
+/// `2 * WORD` from the shadow-stack top, undoing the
+/// `gen_shadowstack_header` push that the trace prologue emitted.
+pub(crate) fn emit_footer_shadowstack_raw(asm: &mut Assembler) {
+    let rst = majit_gc::shadow_stack::get_root_stack_top_addr() as i64;
+    let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+    dynasm!(asm ; .arch x64
+        ; mov Rq(scratch), QWORD rst
+        ; sub QWORD [Rq(scratch)], 16
+    );
+}
+
+/// `x86/assembler.py:1093 _call_footer` parity (free-fn variant).
+/// Restores the callee-save set established by `_call_header` and
+/// returns the jitframe pointer in `rax`.  Must be entered with `rsp`
+/// at trace-body alignment (i.e. the same value the trace's
+/// `_call_header` left after its `SUB rsp, FRAME_FIXED_SIZE`).
+pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
+    emit_footer_shadowstack_raw(asm);
+    dynasm!(asm ; .arch x64 ; mov rax, rbp);
+    #[cfg(target_os = "windows")]
+    dynasm!(asm ; .arch x64
+        ; mov rbx, [rsp + 0]
+        ; mov rsi, [rsp + 8]
+        ; mov rdi, [rsp + 16]
+        ; mov r12, [rsp + 24]
+        ; mov r14, [rsp + 32]
+        ; mov r15, [rsp + 40]
+        ; mov rbp, [rsp + 48]
+        ; add rsp, 64
+    );
+    #[cfg(not(target_os = "windows"))]
+    dynasm!(asm ; .arch x64
+        ; mov rbx, [rsp + 0]
+        ; mov r12, [rsp + 8]
+        ; mov r13, [rsp + 16]
+        ; mov r14, [rsp + 24]
+        ; mov r15, [rsp + 32]
+        ; mov rbp, [rsp + 40]
+        ; add rsp, 48
+    );
+    dynasm!(asm ; .arch x64 ; ret);
+}
+
 /// `assembler.py:231 _build_malloc_slowpath(kind='fixed')` — process-
 /// scoped shared trampoline materialised lazily on first use.  PyPy
 /// builds the four kinds (fixed/var/str/unicode) at `setup_once`; pyre
@@ -274,6 +320,65 @@ fn build_malloc_slowpath_fixed() -> usize {
         dynasm!(asm ; .arch x64 ; =>skip_wb);
     }
 
+    // assembler.py:300-322 OOM propagate path — when
+    // `dynasm_nursery_slowpath` returns NULL the underlying
+    // `libc::calloc` ran out of memory.  PyPy emits this exact branch
+    // inside `_build_malloc_slowpath` (TEST eax, eax; JZ propagate)
+    // and JMPs to the per-CPU `propagate_exception_path` which the
+    // setup-time builder materialised alongside the slowpath.
+    //
+    // Pyre's process-shared trampoline cannot bake per-CPU descr at
+    // build time — the trampoline is built lazily on first malloc and
+    // may pre-date the CPU's `set_propagate_exception_descr` call.
+    // Read the descr pointer indirectly through the
+    // `PROPAGATE_EXCEPTION_DESCR_PTR` atomic at run time; a zero load
+    // (test harness or pre-finish-setup) skips the propagate body and
+    // falls through to a plain RET with `rcx = 0`, so the prior
+    // call-site behaviour is preserved.
+    let propagate_addr = crate::propagate_exception_descr_ptr_addr() as i64;
+    let exc_value_addr = crate::jit_exc_value_addr() as i64;
+    let exc_type_addr = crate::jit_exc_type_addr() as i64;
+    let success = asm.new_dynamic_label();
+    let no_descr = asm.new_dynamic_label();
+    dynasm!(asm ; .arch x64
+        ; test rax, rax
+        ; jnz =>success
+        // Load propagate_descr from the process-shared atomic.
+        ; mov rcx, QWORD propagate_addr
+        ; mov rcx, [rcx]
+        ; test rcx, rcx
+        ; jz =>no_descr
+        // assembler.py:1826-1843 `_store_and_reset_exception(self.mc, eax)`:
+        // read pos_exc_value into RAX, clear both globals.  On real
+        // OOM pos_exc_value is typically already NULL — the propagate
+        // descr's `handle_fail` raises MemoryError directly — but
+        // mirror the structure regardless.
+        ; mov rax, QWORD exc_value_addr
+        // Use R11 (X86_64_SCRATCH_REG) so RCX still holds propagate_descr.
+        ; mov r11, [rax]
+        ; mov QWORD [rax], 0
+        ; mov rax, QWORD exc_type_addr
+        ; mov QWORD [rax], 0
+        // assembler.py:336-337 — MOV [jf_guard_exc], pos_exc_value
+        ; mov [rbp + JF_GUARD_EXC_OFS], r11
+        // assembler.py:339-340 — MOV [jf_descr], propagate_descr
+        ; mov [rbp + JF_DESCR_OFS], rcx
+        // assembler.py:321 `ADD esp, WORD` — pop the trampoline's
+        // own CALL return address so `_call_footer` sees rsp at the
+        // trace's body alignment (the same value the trace's
+        // `_call_header` left after its SUB).
+        ; add rsp, 8
+    );
+    emit_call_footer_raw(&mut asm);
+
+    // No-descr fallthrough: pre-finish-setup path leaves ECX zero and
+    // falls into the pop_all + RET below so the caller observes a
+    // NULL payload exactly as the pre-OOM-check trampoline did.
+    dynasm!(asm ; .arch x64 ; =>no_descr ; xor ecx, ecx);
+    pop_all_regs_from_jitframe_raw(&mut asm, &ignored, true);
+    dynasm!(asm ; .arch x64 ; ret);
+
+    dynasm!(asm ; .arch x64 ; =>success);
     // assembler.py:304 `MOV_rr(ecx, eax)` — deliver the helper return
     // value through ECX so it survives `pop_all` (which restores RAX
     // from the save area).  RAX is still valid at this point because
@@ -1266,49 +1371,51 @@ impl<'a> Assembler386<'a> {
     ///   ; fallthrough = real overflow → return rbp as jf_ptr
     /// ```
     fn _call_header(&mut self, inputargs: &[InputArg]) {
-        // x86/assembler.py:_call_header parity. PyPy iterates
-        // `self.cpu.CALLEE_SAVE_REGISTERS` and saves each into the
-        // FRAME_FIXED_SIZE stack area allocated by `SUB esp, FRAME_FIXED_SIZE*WORD`.
+        // x86/assembler.py:1052 _call_header parity. PyPy reserves the
+        // whole frame in a single `SUB esp, FRAME_FIXED_SIZE * WORD` and
+        // stores `CALLEE_SAVE_REGISTERS` plus `ebp` at fixed offsets.
+        // The Pyre variant uses the same shape (single SUB + offset
+        // stores) without the PASS_ON_MY_FRAME scratch area or vmprof
+        // slots that PyPy reserves but never populates here.
         //
-        // Pyre uses an inline push-based prologue to keep the rest of the
-        // dynasm-based codegen unchanged; the saved set must still match
-        // PyPy's CALLEE_SAVE_REGISTERS per platform:
-        //   - x86_64 (System V): [ebx, r12, r13, r14, r15]
-        //   - x86_64 (Win64):    [ebx, esi, edi, r12, r14, r15]
-        // plus ebp, which is saved separately in both flavors.
+        // Saved set per platform (matches PyPy's CALLEE_SAVE_REGISTERS):
+        //   - x86_64 (System V): rbx, r12, r13, r14, r15 plus rbp
+        //   - x86_64 (Win64):    rbx, rsi, rdi, r12, r14, r15 plus rbp
         //
-        // The extra saves go into a SUB-reserved stack slot so the body's
-        // rsp parity (mod 16 == 8 after prologue) is unchanged and the
-        // per-call adjustments in `emit_win64_call_adjust` /
-        // `abi_reserved_call_area_size` keep working.
-        dynasm!(self.mc
-            ; .arch x64
-            ; push rbp
-            ; push r12               // save r12 (used by genop_call_assembler)
-        );
+        // Layout (lowest address first, all offsets relative to the new
+        // rsp after the SUB):
+        //   Win64:  [+0 rbx, +8 rsi, +16 rdi, +24 r12, +32 r14, +40 r15,
+        //            +48 rbp, +56 pad]  → SUB 64 (8 slots; body rsp at
+        //            8 mod 16 since function entry rsp was 8 mod 16 too)
+        //   SysV:   [+0 rbx, +8 r12, +16 r13, +24 r14, +32 r15, +40 rbp]
+        //            → SUB 48 (6 slots; body rsp at 8 mod 16)
+        //
+        // `r12` carries the caller's `rbp` (saved jf_ptr) across nested
+        // `genop_call_assembler` reentries, so it must be preserved
+        // alongside the rest of the callee-save set.
         #[cfg(target_os = "windows")]
         dynasm!(self.mc
             ; .arch x64
-            // Win64 extra callee-save: rbx, rsi, rdi, r14, r15.  48 bytes
-            // (5 saves * 8 = 40 + 8 padding to keep mod 16 alignment).
-            ; sub rsp, 48
-            ; mov [rsp + 0], rbx
-            ; mov [rsp + 8], rsi
+            ; sub rsp, 64
+            ; mov [rsp + 0],  rbx
+            ; mov [rsp + 8],  rsi
             ; mov [rsp + 16], rdi
-            ; mov [rsp + 24], r14
-            ; mov [rsp + 32], r15
+            ; mov [rsp + 24], r12
+            ; mov [rsp + 32], r14
+            ; mov [rsp + 40], r15
+            ; mov [rsp + 48], rbp
             ; mov rbp, rcx
         );
         #[cfg(not(target_os = "windows"))]
         dynasm!(self.mc
             ; .arch x64
-            // System V x86_64 extra callee-save: rbx, r13, r14, r15.
-            // 32 bytes (4 saves * 8 = 32, already 16-aligned).
-            ; sub rsp, 32
-            ; mov [rsp + 0], rbx
-            ; mov [rsp + 8], r13
-            ; mov [rsp + 16], r14
-            ; mov [rsp + 24], r15
+            ; sub rsp, 48
+            ; mov [rsp + 0],  rbx
+            ; mov [rsp + 8],  r12
+            ; mov [rsp + 16], r13
+            ; mov [rsp + 24], r14
+            ; mov [rsp + 32], r15
+            ; mov [rsp + 40], rbp
             ; mov rbp, rdi
         );
         let propagate_descr = self.propagate_exception_descr_ptr();
@@ -1351,9 +1458,10 @@ impl<'a> Assembler386<'a> {
                     ; mov QWORD [Rq(scratch)], 0
                     ; mov Rq(scratch), QWORD propagate_descr
                     ; mov [rbp + JF_DESCR_OFS], Rq(scratch)
-                    // Overflow fallthrough: return rbp as jf_ptr.
-                    // Restore the extra callee-save regs the prologue
-                    // saved before the SUB-reserved slot, then pop r12/rbp.
+                    // Overflow fallthrough: return rbp as jf_ptr.  Mirrors
+                    // `_call_footer` without `gen_footer_shadowstack` —
+                    // `gen_shadowstack_header` runs after this stack-check
+                    // path, so no shadow-stack entry has been pushed yet.
                     ; mov rax, rbp
                 );
                 #[cfg(target_os = "windows")]
@@ -1362,23 +1470,25 @@ impl<'a> Assembler386<'a> {
                     ; mov rbx, [rsp + 0]
                     ; mov rsi, [rsp + 8]
                     ; mov rdi, [rsp + 16]
-                    ; mov r14, [rsp + 24]
-                    ; mov r15, [rsp + 32]
-                    ; add rsp, 48
+                    ; mov r12, [rsp + 24]
+                    ; mov r14, [rsp + 32]
+                    ; mov r15, [rsp + 40]
+                    ; mov rbp, [rsp + 48]
+                    ; add rsp, 64
                 );
                 #[cfg(not(target_os = "windows"))]
                 dynasm!(self.mc
                     ; .arch x64
                     ; mov rbx, [rsp + 0]
-                    ; mov r13, [rsp + 8]
-                    ; mov r14, [rsp + 16]
-                    ; mov r15, [rsp + 24]
-                    ; add rsp, 32
+                    ; mov r12, [rsp + 8]
+                    ; mov r13, [rsp + 16]
+                    ; mov r14, [rsp + 24]
+                    ; mov r15, [rsp + 32]
+                    ; mov rbp, [rsp + 40]
+                    ; add rsp, 48
                 );
                 dynasm!(self.mc
                     ; .arch x64
-                    ; pop r12
-                    ; pop rbp
                     ; ret
                     ; =>continue_label
                 );
@@ -1682,42 +1792,11 @@ impl<'a> Assembler386<'a> {
     // ----------------------------------------------------------------
 
     /// Emit the function epilogue: return jf_ptr in RAX/X0.
+    /// Thin wrapper around the free-fn `emit_call_footer_raw` so the
+    /// process-shared malloc trampoline can emit byte-identical
+    /// epilogue sequences when exiting through `propagate_exception_descr`.
     fn _call_footer(&mut self) {
-        // x86/assembler.py:_call_footer parity. PyPy iterates
-        // `cpu.CALLEE_SAVE_REGISTERS` in reverse and restores from
-        // the FRAME_FIXED_SIZE area, then ADD esp, FRAME_FIXED_SIZE*WORD;
-        // RET.  Pyre mirrors the platform-specific save set established
-        // in `_call_header`.
-        self.gen_footer_shadowstack();
-        dynasm!(self.mc
-            ; .arch x64
-            ; mov rax, rbp
-        );
-        #[cfg(target_os = "windows")]
-        dynasm!(self.mc
-            ; .arch x64
-            ; mov rbx, [rsp + 0]
-            ; mov rsi, [rsp + 8]
-            ; mov rdi, [rsp + 16]
-            ; mov r14, [rsp + 24]
-            ; mov r15, [rsp + 32]
-            ; add rsp, 48
-        );
-        #[cfg(not(target_os = "windows"))]
-        dynasm!(self.mc
-            ; .arch x64
-            ; mov rbx, [rsp + 0]
-            ; mov r13, [rsp + 8]
-            ; mov r14, [rsp + 16]
-            ; mov r15, [rsp + 24]
-            ; add rsp, 32
-        );
-        dynasm!(self.mc
-            ; .arch x64
-            ; pop r12                // restore r12
-            ; pop rbp
-            ; ret
-        );
+        emit_call_footer_raw(&mut self.mc);
     }
 
     /// x86/assembler.py:254 `_push_all_regs_to_jitframe` parity. Writes
@@ -1945,12 +2024,7 @@ impl<'a> Assembler386<'a> {
     /// One in-memory subtract — no need to load the current top into a
     /// register, decrement, and store back.
     fn gen_footer_shadowstack(&mut self) {
-        let rst = majit_gc::shadow_stack::get_root_stack_top_addr() as i64;
-        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
-        dynasm!(self.mc ; .arch x64
-            ; mov Rq(scratch), QWORD rst
-            ; sub QWORD [Rq(scratch)], 16
-        );
+        emit_footer_shadowstack_raw(&mut self.mc);
     }
 
     /// assembler.py:993 push_gcmap.
@@ -4320,15 +4394,6 @@ impl<'a> Assembler386<'a> {
         );
         self._call_footer();
         dynasm!(self.mc ; .arch x64 ; =>skip);
-    }
-
-    /// `CallMallocNursery` OOM check: helper returns the payload in
-    /// `rcx` or zero on `libc::calloc` failure (PyPy emits this inside
-    /// `_build_malloc_slowpath` at assembler.py:300-322; pyre's
-    /// process-shared trampoline has no access to per-cpu
-    /// `propagate_exception_descr`, so it goes at the call site).
-    fn emit_call_site_oom_propagate(&mut self) {
-        self.emit_propagate_exception_if_zero(crate::regloc::ECX.value);
     }
 
     /// `_store_and_reset_exception`: result = pos_exc_value; clear both
@@ -7227,16 +7292,6 @@ impl<'a> Assembler386<'a> {
             ; mov rax, QWORD helper_addr
             ; call rax
         );
-        // assembler.py:300-322 OOM check — the trampoline's underlying
-        // `dynasm_nursery_slowpath` falls back to `libc::calloc`, which
-        // can return NULL under host OOM; the trampoline preserves that
-        // NULL through to the caller in ECX.  PyPy emits this `TEST/JZ
-        // propagate` inside the trampoline; pyre cannot, because the
-        // process-shared `MALLOC_SLOWPATH_FIXED` trampoline has no
-        // access to the per-cpu `propagate_exception_descr` attachment.
-        // Emit the call-site equivalent here, mirroring the
-        // `CheckMemoryError` path (assembler.rs:3863).
-        self.emit_call_site_oom_propagate();
         // assembler.py:304 — helper returns the payload in ECX
         // (`MOV_rr(ecx, eax)` inside the trampoline) so the value
         // survives the trampoline's `pop_all_regs([ECX, EDX])`.  The
@@ -7246,6 +7301,15 @@ impl<'a> Assembler386<'a> {
         // regalloc change picks a different `result_reg`, copy it
         // from RCX (not RAX, which was restored to its pre-call
         // value by the trampoline's pop_all).
+        //
+        // OOM propagation: assembler.py:300-322 emits the `TEST/JZ
+        // propagate_exception_path` *inside* the slowpath itself, and
+        // pyre's `build_malloc_slowpath_fixed` now mirrors that —
+        // when the underlying `dynasm_nursery_slowpath` returns NULL
+        // the trampoline does the `_store_and_reset_exception`,
+        // writes `jf_descr = propagate_exception_descr` and runs
+        // `_call_footer` to exit the trace.  No call-site OOM check is
+        // needed; if the trampoline ever returns here it succeeded.
         if let Some(Loc::Reg(r)) = result_loc {
             if r.value != crate::regloc::ECX.value {
                 let rv = r.value;

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -161,6 +161,13 @@ pub(crate) fn emit_footer_shadowstack_raw(asm: &mut Assembler) {
 pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
     emit_footer_shadowstack_raw(asm);
     dynasm!(asm ; .arch x64 ; mov rax, rbp);
+    // Win64: 8 callee-save GPRs × 8 = 64 bytes.  PyPy's
+    // `arch.py:43` notes "never use r13 on Win64", but pyre's
+    // `genop_call_assembler` uses r13 as a scratch that survives
+    // a `free()` call (no other unused callee-save reg is live
+    // enough at that point), so pyre adds r13 to the saved set —
+    // filling the slot that was 8-byte padding under PyPy's
+    // "5 regs + r14/r15 in shadow store + 12 pad" layout.
     #[cfg(target_os = "windows")]
     dynasm!(asm ; .arch x64
         ; mov rbx, [rsp + 0]
@@ -170,6 +177,7 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
         ; mov r14, [rsp + 32]
         ; mov r15, [rsp + 40]
         ; mov rbp, [rsp + 48]
+        ; mov r13, [rsp + 56]
         ; add rsp, 64
     );
     #[cfg(not(target_os = "windows"))]
@@ -213,7 +221,14 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
 /// otherwise.  PyPy itself would silently bake 0 in this case (and
 /// fail at `handle_fail` dispatch time); pyre prefers a build-time
 /// fail-fast for the same invariant.
-pub(crate) fn build_propagate_exception_path(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
+///
+/// Returns `(buffer, entry_addr)`.  The caller (`X86CpuExt`) owns the
+/// `ExecutableBuffer` for the lifetime of the per-CPU stash so the RX
+/// page is unmapped when the CPU drops — matches PyPy's `asmmemmgr`,
+/// which roots helper buffers on the CPU.
+pub(crate) fn build_propagate_exception_path(
+    cpu_handle: &crate::guard::CpuDescrHandle,
+) -> (ExecutableBuffer, usize) {
     let mut asm = Assembler::new().expect("propagate_exception_path: new Assembler");
     let propagate_descr = cpu_handle
         .read()
@@ -251,9 +266,7 @@ pub(crate) fn build_propagate_exception_path(cpu_handle: &crate::guard::CpuDescr
     emit_call_footer_raw(&mut asm);
     let buffer = asm.finalize().expect("propagate_exception_path: finalize");
     let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
-    // Process-lifetime mapping; PyPy roots through `asmmemmgr`.
-    std::mem::forget(buffer);
-    ptr
+    (buffer, ptr)
 }
 
 /// `assembler.py:231 _build_malloc_slowpath(kind='fixed')` parity —
@@ -288,10 +301,14 @@ pub(crate) fn build_propagate_exception_path(cpu_handle: &crate::guard::CpuDescr
 /// (`X86CpuExt::ensure_malloc_slowpath_fixed`) builds the propagate
 /// path first and threads its address here, matching PyPy's
 /// `setup_once` ordering.
+///
+/// Returns `(buffer, entry_addr)`.  Same ownership rule as
+/// `build_propagate_exception_path` — the caller (`X86CpuExt`) holds
+/// the `ExecutableBuffer` so the RX page lives as long as the CPU.
 pub(crate) fn build_malloc_slowpath_fixed(
     cpu_handle: &crate::guard::CpuDescrHandle,
     propagate_path: usize,
-) -> usize {
+) -> (ExecutableBuffer, usize) {
     // `cpu_handle` is still threaded through for symmetry with PyPy
     // (where `_build_malloc_slowpath` reads several `self.cpu`-rooted
     // attrs).  The propagate descr itself is now baked once into the
@@ -444,11 +461,7 @@ pub(crate) fn build_malloc_slowpath_fixed(
 
     let buffer = asm.finalize().expect("malloc_slowpath: finalize");
     let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
-    // The helper code must stay mapped for the lifetime of the process.
-    // PyPy uses the shared `asmmemmgr` for the same role; pyre leaks the
-    // ExecutableBuffer so the underlying VirtualAlloc page is retained.
-    std::mem::forget(buffer);
-    ptr
+    (buffer, ptr)
 }
 
 /// Pointer-identity key for `target_tokens_currently_compiling`. PyPy
@@ -1445,14 +1458,19 @@ impl<'a> Assembler386<'a> {
         // Layout (lowest address first, all offsets relative to the new
         // rsp after the SUB):
         //   Win64:  [+0 rbx, +8 rsi, +16 rdi, +24 r12, +32 r14, +40 r15,
-        //            +48 rbp, +56 pad]  → SUB 64 (8 slots; body rsp at
+        //            +48 rbp, +56 r13]   → SUB 64 (8 slots; body rsp at
         //            8 mod 16 since function entry rsp was 8 mod 16 too)
         //   SysV:   [+0 rbx, +8 r12, +16 r13, +24 r14, +32 r15, +40 rbp]
         //            → SUB 48 (6 slots; body rsp at 8 mod 16)
         //
         // `r12` carries the caller's `rbp` (saved jf_ptr) across nested
         // `genop_call_assembler` reentries, so it must be preserved
-        // alongside the rest of the callee-save set.
+        // alongside the rest of the callee-save set.  Win64 also saves
+        // `r13` even though PyPy's `arch.py:43` skips it ("never use
+        // r13"): pyre's `genop_call_assembler` does use r13 as a
+        // scratch reg that must survive `free()`, so r13 occupies the
+        // previously-padding slot at +56 and is restored by every
+        // `_call_footer`/`emit_call_footer_raw` variant.
         #[cfg(target_os = "windows")]
         dynasm!(self.mc
             ; .arch x64
@@ -1464,6 +1482,7 @@ impl<'a> Assembler386<'a> {
             ; mov [rsp + 32], r14
             ; mov [rsp + 40], r15
             ; mov [rsp + 48], rbp
+            ; mov [rsp + 56], r13
             ; mov rbp, rcx
         );
         #[cfg(not(target_os = "windows"))]
@@ -1524,6 +1543,9 @@ impl<'a> Assembler386<'a> {
                     // path, so no shadow-stack entry has been pushed yet.
                     ; mov rax, rbp
                 );
+                // Win64: r13 restored from the +56 slot — see
+                // `_call_header` for why pyre saves r13 even though
+                // PyPy's `arch.py:43` does not.
                 #[cfg(target_os = "windows")]
                 dynasm!(self.mc
                     ; .arch x64
@@ -1534,6 +1556,7 @@ impl<'a> Assembler386<'a> {
                     ; mov r14, [rsp + 32]
                     ; mov r15, [rsp + 40]
                     ; mov rbp, [rsp + 48]
+                    ; mov r13, [rsp + 56]
                     ; add rsp, 64
                 );
                 #[cfg(not(target_os = "windows"))]

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -208,13 +208,38 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
 /// `edx` is the runtime size carrier and the caller's regalloc has
 /// already spilled any live value out of both before the call via
 /// `MALLOC_NURSERY_CLOBBER` (regalloc.rs:101).
-static MALLOC_SLOWPATH_FIXED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+///
+/// Per-CPU storage matches PyPy's `_build_malloc_slowpath`
+/// (`x86/assembler.py:231`), which is materialised on each CPU
+/// instance at `setup_once` with that CPU's `propagate_exception_descr`
+/// baked in.  Pyre keys by `Arc::as_ptr(cpu_handle)` so two CPU
+/// instances in the same process — common in tests, possible if a
+/// hosting runtime swaps backends — receive distinct trampolines and
+/// distinct baked descrs.  Old entries leak when the CPU is dropped;
+/// matches PyPy's `asmmemmgr` lifetime where the slowpath buffer
+/// outlives the assembler.
+type MallocTrampolineCache =
+    std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<std::sync::OnceLock<usize>>>>;
+static MALLOC_SLOWPATH_FIXED: std::sync::OnceLock<MallocTrampolineCache> =
+    std::sync::OnceLock::new();
 
-pub(crate) fn malloc_slowpath_fixed_addr() -> usize {
-    *MALLOC_SLOWPATH_FIXED.get_or_init(build_malloc_slowpath_fixed)
+pub(crate) fn malloc_slowpath_fixed_addr(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
+    let cpu_id = std::sync::Arc::as_ptr(cpu_handle) as usize;
+    let cache = MALLOC_SLOWPATH_FIXED
+        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    // Hold the lock just long enough to look up or insert a fresh
+    // `OnceLock` for this CPU; release before calling the builder so
+    // a concurrent compile on another CPU is not blocked.
+    let slot = {
+        let mut map = cache.lock().unwrap();
+        map.entry(cpu_id)
+            .or_insert_with(|| std::sync::Arc::new(std::sync::OnceLock::new()))
+            .clone()
+    };
+    *slot.get_or_init(|| build_malloc_slowpath_fixed(cpu_handle))
 }
 
-fn build_malloc_slowpath_fixed() -> usize {
+fn build_malloc_slowpath_fixed(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
     let mut asm = Assembler::new().expect("malloc_slowpath: new Assembler");
     let ignored = [crate::regloc::ECX, crate::regloc::EDX];
 
@@ -327,34 +352,40 @@ fn build_malloc_slowpath_fixed() -> usize {
     // and JMPs to the per-CPU `propagate_exception_path` which the
     // setup-time builder materialised alongside the slowpath.
     //
-    // Pyre's process-shared trampoline cannot bake per-CPU descr at
-    // build time — the trampoline is built lazily on first malloc and
-    // may pre-date the CPU's `set_propagate_exception_descr` call.
-    // Read the descr pointer indirectly through the
-    // `PROPAGATE_EXCEPTION_DESCR_PTR` atomic at run time; a zero load
-    // (test harness or pre-finish-setup) skips the propagate body and
-    // falls through to a plain RET with `rcx = 0`, so the prior
-    // call-site behaviour is preserved.
-    let propagate_addr = crate::propagate_exception_descr_ptr_addr() as i64;
+    // Pyre matches that lifetime: this trampoline is materialised
+    // per-CPU (keyed by `Arc::as_ptr(cpu_handle)`) and the descr
+    // pointer is read directly from the CPU's
+    // `descr_ptrs().propagate_exception_descr` and baked as a 64-bit
+    // immediate.  `compile_loop` always runs after
+    // `MetaInterp::finish_setup` installs the descr, so the build
+    // observes a non-zero pointer in production.  If a test harness
+    // builds the trampoline before any CPU has installed a descr,
+    // the build asserts — there is no fall-through "no-descr" path,
+    // matching PyPy's strict invariant.
+    let propagate_descr = cpu_handle
+        .read()
+        .unwrap()
+        .descr_ptrs()
+        .propagate_exception_descr as i64;
+    assert!(
+        propagate_descr != 0,
+        "build_malloc_slowpath_fixed: cpu_handle.propagate_exception_descr \
+         must be installed (pyjitpl.py:2283) before the first malloc \
+         trampoline build on this CPU"
+    );
     let exc_value_addr = crate::jit_exc_value_addr() as i64;
     let exc_type_addr = crate::jit_exc_type_addr() as i64;
     let success = asm.new_dynamic_label();
-    let no_descr = asm.new_dynamic_label();
     dynasm!(asm ; .arch x64
         ; test rax, rax
         ; jnz =>success
-        // Load propagate_descr from the process-shared atomic.
-        ; mov rcx, QWORD propagate_addr
-        ; mov rcx, [rcx]
-        ; test rcx, rcx
-        ; jz =>no_descr
         // assembler.py:1826-1843 `_store_and_reset_exception(self.mc, eax)`:
         // read pos_exc_value into RAX, clear both globals.  On real
         // OOM pos_exc_value is typically already NULL — the propagate
         // descr's `handle_fail` raises MemoryError directly — but
         // mirror the structure regardless.
         ; mov rax, QWORD exc_value_addr
-        // Use R11 (X86_64_SCRATCH_REG) so RCX still holds propagate_descr.
+        // Use R11 (X86_64_SCRATCH_REG) so RCX is free for the descr.
         ; mov r11, [rax]
         ; mov QWORD [rax], 0
         ; mov rax, QWORD exc_type_addr
@@ -362,6 +393,7 @@ fn build_malloc_slowpath_fixed() -> usize {
         // assembler.py:336-337 — MOV [jf_guard_exc], pos_exc_value
         ; mov [rbp + JF_GUARD_EXC_OFS], r11
         // assembler.py:339-340 — MOV [jf_descr], propagate_descr
+        ; mov rcx, QWORD propagate_descr
         ; mov [rbp + JF_DESCR_OFS], rcx
         // assembler.py:321 `ADD esp, WORD` — pop the trampoline's
         // own CALL return address so `_call_footer` sees rsp at the
@@ -370,13 +402,6 @@ fn build_malloc_slowpath_fixed() -> usize {
         ; add rsp, 8
     );
     emit_call_footer_raw(&mut asm);
-
-    // No-descr fallthrough: pre-finish-setup path leaves ECX zero and
-    // falls into the pop_all + RET below so the caller observes a
-    // NULL payload exactly as the pre-OOM-check trampoline did.
-    dynasm!(asm ; .arch x64 ; =>no_descr ; xor ecx, ecx);
-    pop_all_regs_from_jitframe_raw(&mut asm, &ignored, true);
-    dynasm!(asm ; .arch x64 ; ret);
 
     dynasm!(asm ; .arch x64 ; =>success);
     // assembler.py:304 `MOV_rr(ecx, eax)` — deliver the helper return
@@ -3906,6 +3931,12 @@ impl<'a> Assembler386<'a> {
                 // moved jitframe's gcmap published — a stale gcmap that
                 // a subsequent collecting call would walk.
                 self.reload_frame_if_necessary();
+                // assembler.py:300-322 OOM propagate parity — the
+                // jitframe helper returns NULL on `libc::calloc` /
+                // `gc.alloc_nursery_*` failure; surface that through
+                // `propagate_exception_descr` rather than letting the
+                // caller proceed with a null jitframe.
+                self.emit_propagate_exception_if_zero(0);
                 let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS;
                 dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
                 if result_reg.value != 0 {
@@ -3958,6 +3989,13 @@ impl<'a> Assembler386<'a> {
                 // gcmap, otherwise the clear would target the freed
                 // nursery copy.
                 self.reload_frame_if_necessary();
+                // assembler.py:300-322 OOM propagate parity — the
+                // varsize helper now returns NULL on `libc::calloc`
+                // / `gc.alloc_varsize` failure; route that through
+                // `propagate_exception_descr` rather than letting the
+                // caller store a near-zero garbage pointer into the
+                // result slot.
+                self.emit_propagate_exception_if_zero(0);
                 dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
                 if !op.pos.is_none() {
                     self.store_rax_to_result(op.pos);
@@ -7287,7 +7325,7 @@ impl<'a> Assembler386<'a> {
         } else {
             dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
         }
-        let helper_addr = malloc_slowpath_fixed_addr() as i64;
+        let helper_addr = malloc_slowpath_fixed_addr(&self.cpu_handle) as i64;
         dynasm!(self.mc ; .arch x64
             ; mov rax, QWORD helper_addr
             ; call rax

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -139,10 +139,11 @@ pub(crate) fn pop_all_regs_from_jitframe_raw(
 }
 
 /// `x86/assembler.py:1130 _call_footer_shadowstack` parity (free-fn
-/// variant for use outside of an `Assembler386` borrow — see
-/// `build_malloc_slowpath_fixed`'s inline propagate path).  Subtracts
-/// `2 * WORD` from the shadow-stack top, undoing the
-/// `gen_shadowstack_header` push that the trace prologue emitted.
+/// variant for use outside of an `Assembler386` borrow — used by
+/// `emit_call_footer_raw`, which the standalone propagate / malloc
+/// slowpath trampolines reach for).  Subtracts `2 * WORD` from the
+/// shadow-stack top, undoing the `gen_shadowstack_header` push that
+/// the trace prologue emitted.
 pub(crate) fn emit_footer_shadowstack_raw(asm: &mut Assembler) {
     let rst = majit_gc::shadow_stack::get_root_stack_top_addr() as i64;
     let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
@@ -184,6 +185,77 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
     dynasm!(asm ; .arch x64 ; ret);
 }
 
+/// `assembler.py:328 _build_propagate_exception_path` parity —
+/// pure builder.  Caching/ownership is the caller's responsibility:
+/// `DynasmBackend::ensure_propagate_exception_path` (`runner.rs`)
+/// stores the resulting address in the backend's
+/// `propagate_exception_path` field, matching PyPy's
+/// `self.propagate_exception_path` attribute on `Assembler386`.
+///
+/// **Calling convention (matches PyPy line 328-345):**
+/// - Entry: reached only via `JMP` (not `CALL`) from a slowpath that
+///   has already restored `rsp` to the trace body's alignment level
+///   (i.e. the same value the trace's `_call_header` left after its
+///   SUB).  `rbp` = jitframe (possibly reloaded after a GC move).
+///   No other register conventions are assumed: every callee-save
+///   was already restored by the slowpath's `_pop_all_regs_from_frame`,
+///   and the live trace-body values were spilled to the jitframe.
+/// - Exit: `_call_footer` semantics — restores callee-save GPRs
+///   from `[rsp+...]`, sets `rax = rbp` (jitframe pointer return),
+///   adds the prologue's SUB back, and `RET`s to the function that
+///   originally entered the trace (PyPy: the C JIT shim;
+///   pyre: the same role via `Asm::_call_header`/`_call_footer`).
+///
+/// `propagate_exception_descr` is read from `cpu_handle` and baked
+/// as an i64 immediate into `[rbp + JF_DESCR_OFS]`.  Caller must
+/// guarantee the descr is installed (`MetaInterp::finish_setup`,
+/// `pyjitpl.py:2283`) before invoking this builder; the build asserts
+/// otherwise.  PyPy itself would silently bake 0 in this case (and
+/// fail at `handle_fail` dispatch time); pyre prefers a build-time
+/// fail-fast for the same invariant.
+pub(crate) fn build_propagate_exception_path(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
+    let mut asm = Assembler::new().expect("propagate_exception_path: new Assembler");
+    let propagate_descr = cpu_handle
+        .read()
+        .unwrap()
+        .descr_ptrs()
+        .propagate_exception_descr as i64;
+    assert!(
+        propagate_descr != 0,
+        "build_propagate_exception_path: cpu_handle.propagate_exception_descr \
+         must be installed (pyjitpl.py:2283) before the trampoline is built \
+         on this CPU"
+    );
+    // assembler.py:1826-1843 `_store_and_reset_exception(self.mc, eax)`:
+    // read pos_exc_value into RAX, clear both globals.  On real OOM
+    // pos_exc_value is typically already NULL — the propagate descr's
+    // `handle_fail` raises MemoryError directly — but mirror the
+    // structure regardless.
+    let exc_value_addr = crate::jit_exc_value_addr() as i64;
+    let exc_type_addr = crate::jit_exc_type_addr() as i64;
+    dynasm!(asm ; .arch x64
+        ; mov rax, QWORD exc_value_addr
+        // Use R11 (X86_64_SCRATCH_REG) so RCX is free for the descr.
+        ; mov r11, [rax]
+        ; mov QWORD [rax], 0
+        ; mov rax, QWORD exc_type_addr
+        ; mov QWORD [rax], 0
+        // assembler.py:335-337 — MOV [jf_guard_exc], pos_exc_value
+        ; mov [rbp + JF_GUARD_EXC_OFS], r11
+        // assembler.py:338-340 — MOV [jf_descr], propagate_descr
+        ; mov rcx, QWORD propagate_descr
+        ; mov [rbp + JF_DESCR_OFS], rcx
+    );
+    // assembler.py:342 `self._call_footer()` — restore callee-save,
+    // set rax = rbp, ADD rsp, prologue_size, RET.
+    emit_call_footer_raw(&mut asm);
+    let buffer = asm.finalize().expect("propagate_exception_path: finalize");
+    let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
+    // Process-lifetime mapping; PyPy roots through `asmmemmgr`.
+    std::mem::forget(buffer);
+    ptr
+}
+
 /// `assembler.py:231 _build_malloc_slowpath(kind='fixed')` parity —
 /// pure builder.  Caching/ownership is the caller's responsibility:
 /// `DynasmBackend::ensure_malloc_slowpath_fixed` (`runner.rs`) stores
@@ -210,11 +282,21 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
 /// already spilled any live value out of both before the call via
 /// `MALLOC_NURSERY_CLOBBER` (regalloc.rs:101).
 ///
-/// `propagate_exception_descr` is read from `cpu_handle` and baked
-/// as an i64 immediate in the OOM branch.  Caller must guarantee the
-/// descr is installed (`MetaInterp::finish_setup`, `pyjitpl.py:2283`)
-/// before invoking this builder; the build asserts otherwise.
-pub(crate) fn build_malloc_slowpath_fixed(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
+/// On OOM (`rax == 0` after the helper call) the trampoline tail-jumps
+/// to `propagate_path` — the standalone `_build_propagate_exception_path`
+/// trampoline returned by `build_propagate_exception_path`.  Caller
+/// (`DynasmBackend::ensure_malloc_slowpath_fixed`) builds the propagate
+/// path first and threads its address here, matching PyPy's
+/// `setup_once` ordering.
+pub(crate) fn build_malloc_slowpath_fixed(
+    cpu_handle: &crate::guard::CpuDescrHandle,
+    propagate_path: usize,
+) -> usize {
+    // `cpu_handle` is still threaded through for symmetry with PyPy
+    // (where `_build_malloc_slowpath` reads several `self.cpu`-rooted
+    // attrs).  The propagate descr itself is now baked once into the
+    // standalone propagate trampoline, not re-baked here.
+    let _ = cpu_handle;
     let mut asm = Assembler::new().expect("malloc_slowpath: new Assembler");
     let ignored = [crate::regloc::ECX, crate::regloc::EDX];
 
@@ -322,61 +404,31 @@ pub(crate) fn build_malloc_slowpath_fixed(cpu_handle: &crate::guard::CpuDescrHan
 
     // assembler.py:300-322 OOM propagate path — when
     // `dynasm_nursery_slowpath` returns NULL the underlying
-    // `libc::calloc` ran out of memory.  PyPy emits this exact branch
-    // inside `_build_malloc_slowpath` (TEST eax, eax; JZ propagate)
-    // and JMPs to the per-CPU `propagate_exception_path` which the
-    // setup-time builder materialised alongside the slowpath.
+    // `libc::calloc` ran out of memory.  PyPy emits the test+branch
+    // inside `_build_malloc_slowpath` and tail-JMPs to the standalone
+    // `propagate_exception_path` (line 322).  Pyre threads the
+    // propagate path's address in via `propagate_path` and follows
+    // the same structure: `ADD rsp, 8` to drop the trampoline's
+    // own CALL return address, then JMP to the propagate trampoline.
     //
-    // Pyre matches that lifetime: this trampoline is materialised once
-    // per `DynasmBackend` and stored in its `malloc_slowpath_fixed`
-    // field.  The descr pointer is read directly from the CPU's
-    // `descr_ptrs().propagate_exception_descr` and baked as a 64-bit
-    // immediate.  `compile_loop` always runs after
-    // `MetaInterp::finish_setup` installs the descr, so the build
-    // observes a non-zero pointer in production.  If a test harness
-    // builds the trampoline before any CPU has installed a descr,
-    // the build asserts — there is no fall-through "no-descr" path,
-    // matching PyPy's strict invariant.
-    let propagate_descr = cpu_handle
-        .read()
-        .unwrap()
-        .descr_ptrs()
-        .propagate_exception_descr as i64;
-    assert!(
-        propagate_descr != 0,
-        "build_malloc_slowpath_fixed: cpu_handle.propagate_exception_descr \
-         must be installed (pyjitpl.py:2283) before the first malloc \
-         trampoline build on this CPU"
-    );
-    let exc_value_addr = crate::jit_exc_value_addr() as i64;
-    let exc_type_addr = crate::jit_exc_type_addr() as i64;
+    // dynasm-rs has no direct rel32-JMP-to-absolute-imm encoding, so
+    // we materialise the 64-bit immediate into the scratch reg (R11,
+    // not in PyPy's ECX/EDX-clobber set) and `jmp r11`.  RBP/RCX/RDX
+    // values matter to the propagate path's `_store_and_reset_exception`
+    // + `_call_footer`, and R11 is dead by this point.
     let success = asm.new_dynamic_label();
+    let propagate_path_imm = propagate_path as i64;
     dynasm!(asm ; .arch x64
         ; test rax, rax
         ; jnz =>success
-        // assembler.py:1826-1843 `_store_and_reset_exception(self.mc, eax)`:
-        // read pos_exc_value into RAX, clear both globals.  On real
-        // OOM pos_exc_value is typically already NULL — the propagate
-        // descr's `handle_fail` raises MemoryError directly — but
-        // mirror the structure regardless.
-        ; mov rax, QWORD exc_value_addr
-        // Use R11 (X86_64_SCRATCH_REG) so RCX is free for the descr.
-        ; mov r11, [rax]
-        ; mov QWORD [rax], 0
-        ; mov rax, QWORD exc_type_addr
-        ; mov QWORD [rax], 0
-        // assembler.py:336-337 — MOV [jf_guard_exc], pos_exc_value
-        ; mov [rbp + JF_GUARD_EXC_OFS], r11
-        // assembler.py:339-340 — MOV [jf_descr], propagate_descr
-        ; mov rcx, QWORD propagate_descr
-        ; mov [rbp + JF_DESCR_OFS], rcx
         // assembler.py:321 `ADD esp, WORD` — pop the trampoline's
-        // own CALL return address so `_call_footer` sees rsp at the
-        // trace's body alignment (the same value the trace's
-        // `_call_header` left after its SUB).
+        // own CALL return address so `_call_footer` in the propagate
+        // trampoline sees rsp at the trace's body alignment (the
+        // same value the trace's `_call_header` left after its SUB).
         ; add rsp, 8
+        ; mov r11, QWORD propagate_path_imm
+        ; jmp r11
     );
-    emit_call_footer_raw(&mut asm);
 
     dynasm!(asm ; .arch x64 ; =>success);
     // assembler.py:304 `MOV_rr(ecx, eax)` — deliver the helper return

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -184,11 +184,12 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
     dynasm!(asm ; .arch x64 ; ret);
 }
 
-/// `assembler.py:231 _build_malloc_slowpath(kind='fixed')` — process-
-/// scoped shared trampoline materialised lazily on first use.  PyPy
-/// builds the four kinds (fixed/var/str/unicode) at `setup_once`; pyre
-/// starts with the fixed-size kind which is the only `dynasm_nursery_slowpath`
-/// caller in the x86 emit path.
+/// `assembler.py:231 _build_malloc_slowpath(kind='fixed')` parity —
+/// pure builder.  Caching/ownership is the caller's responsibility:
+/// `DynasmBackend::ensure_malloc_slowpath_fixed` (`runner.rs`) stores
+/// the resulting address in the backend's `malloc_slowpath_fixed`
+/// field, matching PyPy's `self.malloc_slowpath` attribute on
+/// `Assembler386`.
 ///
 /// **Calling convention (matches PyPy line 233-243):**
 /// - Entry: `rbp` = jitframe, `rcx` = old `nursery_head`,
@@ -209,37 +210,11 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
 /// already spilled any live value out of both before the call via
 /// `MALLOC_NURSERY_CLOBBER` (regalloc.rs:101).
 ///
-/// Per-CPU storage matches PyPy's `_build_malloc_slowpath`
-/// (`x86/assembler.py:231`), which is materialised on each CPU
-/// instance at `setup_once` with that CPU's `propagate_exception_descr`
-/// baked in.  Pyre keys by `Arc::as_ptr(cpu_handle)` so two CPU
-/// instances in the same process — common in tests, possible if a
-/// hosting runtime swaps backends — receive distinct trampolines and
-/// distinct baked descrs.  Old entries leak when the CPU is dropped;
-/// matches PyPy's `asmmemmgr` lifetime where the slowpath buffer
-/// outlives the assembler.
-type MallocTrampolineCache =
-    std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<std::sync::OnceLock<usize>>>>;
-static MALLOC_SLOWPATH_FIXED: std::sync::OnceLock<MallocTrampolineCache> =
-    std::sync::OnceLock::new();
-
-pub(crate) fn malloc_slowpath_fixed_addr(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
-    let cpu_id = std::sync::Arc::as_ptr(cpu_handle) as usize;
-    let cache = MALLOC_SLOWPATH_FIXED
-        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    // Hold the lock just long enough to look up or insert a fresh
-    // `OnceLock` for this CPU; release before calling the builder so
-    // a concurrent compile on another CPU is not blocked.
-    let slot = {
-        let mut map = cache.lock().unwrap();
-        map.entry(cpu_id)
-            .or_insert_with(|| std::sync::Arc::new(std::sync::OnceLock::new()))
-            .clone()
-    };
-    *slot.get_or_init(|| build_malloc_slowpath_fixed(cpu_handle))
-}
-
-fn build_malloc_slowpath_fixed(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
+/// `propagate_exception_descr` is read from `cpu_handle` and baked
+/// as an i64 immediate in the OOM branch.  Caller must guarantee the
+/// descr is installed (`MetaInterp::finish_setup`, `pyjitpl.py:2283`)
+/// before invoking this builder; the build asserts otherwise.
+pub(crate) fn build_malloc_slowpath_fixed(cpu_handle: &crate::guard::CpuDescrHandle) -> usize {
     let mut asm = Assembler::new().expect("malloc_slowpath: new Assembler");
     let ignored = [crate::regloc::ECX, crate::regloc::EDX];
 
@@ -352,9 +327,9 @@ fn build_malloc_slowpath_fixed(cpu_handle: &crate::guard::CpuDescrHandle) -> usi
     // and JMPs to the per-CPU `propagate_exception_path` which the
     // setup-time builder materialised alongside the slowpath.
     //
-    // Pyre matches that lifetime: this trampoline is materialised
-    // per-CPU (keyed by `Arc::as_ptr(cpu_handle)`) and the descr
-    // pointer is read directly from the CPU's
+    // Pyre matches that lifetime: this trampoline is materialised once
+    // per `DynasmBackend` and stored in its `malloc_slowpath_fixed`
+    // field.  The descr pointer is read directly from the CPU's
     // `descr_ptrs().propagate_exception_descr` and baked as a 64-bit
     // immediate.  `compile_loop` always runs after
     // `MetaInterp::finish_setup` installs the descr, so the build
@@ -676,6 +651,12 @@ pub struct Assembler386<'a> {
     /// machine-code buffer* (i.e. pre-`rawstart`); `patch_stack_checks`
     /// adds `rawstart` to obtain the absolute address.
     frame_depth_to_patch: Vec<usize>,
+    /// `x86/assembler.py:63` `self.malloc_slowpath` parity — entry
+    /// pointer of the per-CPU fixed-size malloc slowpath helper,
+    /// resolved by `DynasmBackend::ensure_malloc_slowpath_fixed`
+    /// and passed in at construction time so the emit path bakes
+    /// it as a 64-bit immediate without re-touching the backend.
+    malloc_slowpath_fixed: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
@@ -765,6 +746,7 @@ impl<'a> Assembler386<'a> {
         classptr_to_subclass_range: HashMap<i64, (i64, i64)>,
         attached_descrs: crate::guard::AttachedDescrPtrs,
         cpu_handle: crate::guard::CpuDescrHandle,
+        malloc_slowpath_fixed: usize,
         inputargs: &'a [InputArg],
         operations: &'a [Op],
     ) -> Self {
@@ -808,6 +790,7 @@ impl<'a> Assembler386<'a> {
             attached_descrs,
             cpu_handle,
             frame_depth_to_patch: Vec::new(),
+            malloc_slowpath_fixed,
         }
     }
 
@@ -1818,8 +1801,8 @@ impl<'a> Assembler386<'a> {
 
     /// Emit the function epilogue: return jf_ptr in RAX/X0.
     /// Thin wrapper around the free-fn `emit_call_footer_raw` so the
-    /// process-shared malloc trampoline can emit byte-identical
-    /// epilogue sequences when exiting through `propagate_exception_descr`.
+    /// backend-owned malloc trampoline can emit byte-identical epilogue
+    /// sequences when exiting through `propagate_exception_descr`.
     fn _call_footer(&mut self) {
         emit_call_footer_raw(&mut self.mc);
     }
@@ -7325,7 +7308,7 @@ impl<'a> Assembler386<'a> {
         } else {
             dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
         }
-        let helper_addr = malloc_slowpath_fixed_addr(&self.cpu_handle) as i64;
+        let helper_addr = self.malloc_slowpath_fixed as i64;
         dynasm!(self.mc ; .arch x64
             ; mov rax, QWORD helper_addr
             ; call rax

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -187,10 +187,10 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
 
 /// `assembler.py:328 _build_propagate_exception_path` parity —
 /// pure builder.  Caching/ownership is the caller's responsibility:
-/// `DynasmBackend::ensure_propagate_exception_path` (`runner.rs`)
-/// stores the resulting address in the backend's
-/// `propagate_exception_path` field, matching PyPy's
-/// `self.propagate_exception_path` attribute on `Assembler386`.
+/// `X86CpuExt::ensure_propagate_exception_path` (`x86/cpu_ext.rs`)
+/// stores the resulting address in its `propagate_exception_path`
+/// field, matching PyPy's `self.propagate_exception_path` attribute
+/// on `Assembler386`.
 ///
 /// **Calling convention (matches PyPy line 328-345):**
 /// - Entry: reached only via `JMP` (not `CALL`) from a slowpath that
@@ -258,8 +258,8 @@ pub(crate) fn build_propagate_exception_path(cpu_handle: &crate::guard::CpuDescr
 
 /// `assembler.py:231 _build_malloc_slowpath(kind='fixed')` parity —
 /// pure builder.  Caching/ownership is the caller's responsibility:
-/// `DynasmBackend::ensure_malloc_slowpath_fixed` (`runner.rs`) stores
-/// the resulting address in the backend's `malloc_slowpath_fixed`
+/// `X86CpuExt::ensure_malloc_slowpath_fixed` (`x86/cpu_ext.rs`)
+/// stores the resulting address in its `malloc_slowpath_fixed`
 /// field, matching PyPy's `self.malloc_slowpath` attribute on
 /// `Assembler386`.
 ///
@@ -285,7 +285,7 @@ pub(crate) fn build_propagate_exception_path(cpu_handle: &crate::guard::CpuDescr
 /// On OOM (`rax == 0` after the helper call) the trampoline tail-jumps
 /// to `propagate_path` — the standalone `_build_propagate_exception_path`
 /// trampoline returned by `build_propagate_exception_path`.  Caller
-/// (`DynasmBackend::ensure_malloc_slowpath_fixed`) builds the propagate
+/// (`X86CpuExt::ensure_malloc_slowpath_fixed`) builds the propagate
 /// path first and threads its address here, matching PyPy's
 /// `setup_once` ordering.
 pub(crate) fn build_malloc_slowpath_fixed(
@@ -705,7 +705,7 @@ pub struct Assembler386<'a> {
     frame_depth_to_patch: Vec<usize>,
     /// `x86/assembler.py:63` `self.malloc_slowpath` parity — entry
     /// pointer of the per-CPU fixed-size malloc slowpath helper,
-    /// resolved by `DynasmBackend::ensure_malloc_slowpath_fixed`
+    /// resolved by `X86CpuExt::ensure_malloc_slowpath_fixed`
     /// and passed in at construction time so the emit path bakes
     /// it as a 64-bit immediate without re-touching the backend.
     malloc_slowpath_fixed: usize,

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -77,4 +77,17 @@ impl X86CpuExt {
         self.malloc_slowpath_fixed = Some(addr);
         addr
     }
+
+    /// Read the post-`setup_once` malloc slowpath address.  Panics if
+    /// `Backend::setup_once` (`pyjitpl.py:2297` parity) has not been
+    /// called yet — PyPy's `globaldata.initialized` gate
+    /// (`pyjitpl.py:2292-2303`) guarantees the trampoline is built
+    /// before any `compile_loop`, so a `None` read here is a wire-up
+    /// bug, not a runtime condition.
+    pub(crate) fn malloc_slowpath_fixed(&self) -> usize {
+        self.malloc_slowpath_fixed.expect(
+            "Backend::setup_once must run before compile_loop reads malloc_slowpath_fixed \
+             (pyjitpl.py:2292-2303 `_setup_once` parity)",
+        )
+    }
 }

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -14,30 +14,36 @@
 //! sequences today and has no per-CPU trampoline to memoise.
 
 use crate::guard::CpuDescrHandle;
+use dynasmrt::ExecutableBuffer;
 
-/// Lazily-materialised per-CPU x86 trampoline addresses.
+/// Lazily-materialised per-CPU x86 trampolines.
 ///
-/// Both fields are set once on first use and reused for every
+/// Both addresses are set once on first use and reused for every
 /// subsequent `compile_loop` / `compile_bridge` on this CPU.  The
-/// underlying executable buffers are `mem::forget`-leaked into
-/// executable memory inside `build_*`, matching PyPy's `asmmemmgr`
-/// rooting the buffer for the CPU's lifetime.
+/// owning `ExecutableBuffer`s are kept alongside so the RX pages are
+/// unmapped exactly when the CPU is dropped — matching PyPy's
+/// `asmmemmgr`, which roots helper buffers on the CPU.
 pub(crate) struct X86CpuExt {
-    /// `assembler.py:63 self.malloc_slowpath` parity.  Address of the
-    /// fixed-size malloc slowpath helper built by
-    /// `build_malloc_slowpath_fixed`.
+    /// `assembler.py:63 self.malloc_slowpath` parity.  Entry address
+    /// of the fixed-size malloc slowpath helper built by
+    /// `build_malloc_slowpath_fixed`; `_buffer` is the matching RX
+    /// mapping kept for the lifetime of this struct.
     malloc_slowpath_fixed: Option<usize>,
+    _malloc_slowpath_fixed_buffer: Option<ExecutableBuffer>,
     /// `assembler.py:344 self.propagate_exception_path` parity.
     /// Standalone trampoline that the malloc slowpath (and, in PyPy,
     /// the stack check slowpath) JMPs to on OOM / propagate.
     propagate_exception_path: Option<usize>,
+    _propagate_exception_path_buffer: Option<ExecutableBuffer>,
 }
 
 impl X86CpuExt {
     pub(crate) fn new() -> Self {
         Self {
             malloc_slowpath_fixed: None,
+            _malloc_slowpath_fixed_buffer: None,
             propagate_exception_path: None,
+            _propagate_exception_path_buffer: None,
         }
     }
 
@@ -53,7 +59,13 @@ impl X86CpuExt {
         if let Some(addr) = self.propagate_exception_path {
             return addr;
         }
-        let addr = super::assembler::build_propagate_exception_path(cpu_handle);
+        let (buffer, addr) = super::assembler::build_propagate_exception_path(cpu_handle);
+        debug_assert!(
+            addr != 0,
+            "build_propagate_exception_path returned NULL entry address — \
+             dynasm finalize is expected to yield a non-zero buffer_ptr"
+        );
+        self._propagate_exception_path_buffer = Some(buffer);
         self.propagate_exception_path = Some(addr);
         addr
     }
@@ -73,7 +85,14 @@ impl X86CpuExt {
             return addr;
         }
         let propagate_path = self.ensure_propagate_exception_path(cpu_handle);
-        let addr = super::assembler::build_malloc_slowpath_fixed(cpu_handle, propagate_path);
+        let (buffer, addr) =
+            super::assembler::build_malloc_slowpath_fixed(cpu_handle, propagate_path);
+        debug_assert!(
+            addr != 0,
+            "build_malloc_slowpath_fixed returned NULL entry address — \
+             dynasm finalize is expected to yield a non-zero buffer_ptr"
+        );
+        self._malloc_slowpath_fixed_buffer = Some(buffer);
         self.malloc_slowpath_fixed = Some(addr);
         addr
     }

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -96,17 +96,4 @@ impl X86CpuExt {
         self.malloc_slowpath_fixed = Some(addr);
         addr
     }
-
-    /// Read the post-`setup_once` malloc slowpath address.  Panics if
-    /// `Backend::setup_once` (`pyjitpl.py:2297` parity) has not been
-    /// called yet — PyPy's `globaldata.initialized` gate
-    /// (`pyjitpl.py:2292-2303`) guarantees the trampoline is built
-    /// before any `compile_loop`, so a `None` read here is a wire-up
-    /// bug, not a runtime condition.
-    pub(crate) fn malloc_slowpath_fixed(&self) -> usize {
-        self.malloc_slowpath_fixed.expect(
-            "Backend::setup_once must run before compile_loop reads malloc_slowpath_fixed \
-             (pyjitpl.py:2292-2303 `_setup_once` parity)",
-        )
-    }
 }

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -1,0 +1,80 @@
+//! x86-specific per-CPU assembler state held by `DynasmBackend`.
+//!
+//! PyPy stores `self.malloc_slowpath` / `self.propagate_exception_path`
+//! on `Assembler386` (`rpython/jit/backend/x86/assembler.py:63,344`);
+//! the assembler is one-per-CPU and lives for the CPU's lifetime, so
+//! the trampolines built at `setup_once` (`llsupport/assembler.py:124-138`)
+//! persist on it.
+//!
+//! Pyre's `Assembler386` is constructed per-`compile_loop`/`compile_bridge`
+//! (`runner.rs::compile_loop`, `compile_bridge`), so the per-CPU stash
+//! moves up one level to `DynasmBackend` via this struct.  Aarch64 has
+//! its own equivalent (`aarch64::cpu_ext::Aarch64CpuExt`) which is
+//! currently a no-op placeholder — aarch64 inlines the slowpath
+//! sequences today and has no per-CPU trampoline to memoise.
+
+use crate::guard::CpuDescrHandle;
+
+/// Lazily-materialised per-CPU x86 trampoline addresses.
+///
+/// Both fields are set once on first use and reused for every
+/// subsequent `compile_loop` / `compile_bridge` on this CPU.  The
+/// underlying executable buffers are `mem::forget`-leaked into
+/// executable memory inside `build_*`, matching PyPy's `asmmemmgr`
+/// rooting the buffer for the CPU's lifetime.
+pub(crate) struct X86CpuExt {
+    /// `assembler.py:63 self.malloc_slowpath` parity.  Address of the
+    /// fixed-size malloc slowpath helper built by
+    /// `build_malloc_slowpath_fixed`.
+    malloc_slowpath_fixed: Option<usize>,
+    /// `assembler.py:344 self.propagate_exception_path` parity.
+    /// Standalone trampoline that the malloc slowpath (and, in PyPy,
+    /// the stack check slowpath) JMPs to on OOM / propagate.
+    propagate_exception_path: Option<usize>,
+}
+
+impl X86CpuExt {
+    pub(crate) fn new() -> Self {
+        Self {
+            malloc_slowpath_fixed: None,
+            propagate_exception_path: None,
+        }
+    }
+
+    /// `assembler.py:328 _build_propagate_exception_path` parity:
+    /// materialise the standalone propagate trampoline that
+    /// `_store_and_reset_exception`s, writes `jf_guard_exc` / `jf_descr`,
+    /// and tail-calls `_call_footer`.  The malloc slowpath (and, in
+    /// PyPy, the stack check slowpath) JMP into this single entry
+    /// point.  Materialised lazily; the address is then memoised here
+    /// so every slowpath built on this CPU shares the same propagate
+    /// path (matches PyPy's `self.propagate_exception_path` attribute).
+    pub(crate) fn ensure_propagate_exception_path(&mut self, cpu_handle: &CpuDescrHandle) -> usize {
+        if let Some(addr) = self.propagate_exception_path {
+            return addr;
+        }
+        let addr = super::assembler::build_propagate_exception_path(cpu_handle);
+        self.propagate_exception_path = Some(addr);
+        addr
+    }
+
+    /// `assembler.py:231 _build_malloc_slowpath` parity: materialise
+    /// the fixed-size malloc slowpath helper on first use and stash
+    /// its address here.  Subsequent `compile_loop` / `compile_bridge`
+    /// invocations reuse the same helper, matching PyPy's
+    /// `setup_once` semantics where the helper is built once per CPU
+    /// and referenced as `self.malloc_slowpath` thereafter.
+    ///
+    /// Ensures the propagate trampoline exists first so the slowpath's
+    /// OOM branch can `JMP` to it (matches PyPy's `setup_once` ordering:
+    /// `_build_propagate_exception_path` then `_build_malloc_slowpath`).
+    pub(crate) fn ensure_malloc_slowpath_fixed(&mut self, cpu_handle: &CpuDescrHandle) -> usize {
+        if let Some(addr) = self.malloc_slowpath_fixed {
+            return addr;
+        }
+        let propagate_path = self.ensure_propagate_exception_path(cpu_handle);
+        let addr = super::assembler::build_malloc_slowpath_fixed(cpu_handle, propagate_path);
+        self.malloc_slowpath_fixed = Some(addr);
+        addr
+    }
+}

--- a/majit/majit-backend-dynasm/src/x86/mod.rs
+++ b/majit/majit-backend-dynasm/src/x86/mod.rs
@@ -6,5 +6,6 @@
 pub mod arch;
 pub mod assembler;
 pub mod callbuilder;
+pub mod cpu_ext;
 pub mod regalloc;
 pub mod reghint;

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2583,7 +2583,15 @@ pub trait Backend: Send {
         }
     }
 
-    /// model.py: setup_once() — called once when the backend is first used.
+    /// `model.py:34 AbstractCPU.setup_once` parity, called by
+    /// `pyjitpl.py:2297 self.cpu.setup_once()` inside
+    /// `MetaInterpStaticData._setup_once` (`pyjitpl.py:2292-2303`),
+    /// guarded by `globaldata.initialized` so it runs exactly once
+    /// per CPU after every descr setter has been called.  Backends
+    /// that need to materialise per-CPU trampolines (x86
+    /// `_build_propagate_exception_path` / `_build_malloc_slowpath`)
+    /// override this; default is no-op for backends without
+    /// setup-time work.
     fn setup_once(&mut self) {}
     /// model.py: finish_once() — called when the JIT shuts down.
     fn finish_once(&mut self) {}

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2830,6 +2830,14 @@ impl<M: Clone> MetaInterp<M> {
         driver_descriptor: Option<JitDriverStaticData>,
         live_values: &[Value],
     ) -> BackEdgeAction {
+        // `pyjitpl.py:2889 self.staticdata._setup_once()` parity —
+        // PyPy's first `compile_and_run_once` per CPU dispatches the
+        // `globaldata.initialized`-gated `_setup_once` which calls
+        // `cpu.setup_once()` (`pyjitpl.py:2292-2303`).  Pyre's
+        // back-edge entry routes through `bound_reached`, so the
+        // gate fires here.  Idempotent.
+        self.staticdata._setup_once(&mut self.backend);
+
         if self.tracing.is_some() {
             return BackEdgeAction::AlreadyTracing;
         }
@@ -14452,6 +14460,26 @@ impl MetaInterpStaticData {
                 jd.build_portal_calldescr();
             }
         }
+    }
+
+    /// pyjitpl.py:2292-2303 `_setup_once` — guarded by
+    /// `globaldata.initialized` so it runs exactly once per CPU after
+    /// `finish_setup` has installed every descr (`pyjitpl.py:2255`,
+    /// `pyjitpl.py:2283`).  Dispatches `cpu.setup_once()`
+    /// (`pyjitpl.py:2297 self.cpu.setup_once()`), which is the call
+    /// that materialises the per-CPU malloc / propagate trampolines
+    /// in PyPy (`llsupport/assembler.py:97 setup_once`).
+    ///
+    /// Pyre invokes this from the metainterp's back-edge entry
+    /// `MetaInterp::bound_reached` (pyre analogue of
+    /// `pyjitpl.py:2889 compile_and_run_once`).
+    pub fn _setup_once(&self, backend: &mut BackendImpl) {
+        let mut gd = self.globaldata.lock().unwrap();
+        if gd.initialized {
+            return;
+        }
+        backend.setup_once();
+        gd.initialized = true;
     }
 
     /// pyjitpl.py:2305-2323 `get_name_from_address(addr)`.


### PR DESCRIPTION
Follow-up fix #46


_call_header / _call_footer now match PyPy's single-SUB + offset-store shape (rpython/jit/backend/x86/assembler.py:1052, 1093). The prologue allocates the entire frame in one `SUB rsp, N` and stores the callee-save set plus rbp at fixed slots; the epilogue reverses that with `MOV reg, [rsp+ofs]` reads and one `ADD rsp, N`. The total frame size is unchanged (Win64: 64 bytes, SysV: 48), so body rsp alignment and per-call shadow-space accounting stay the same.

The stack-overflow return path in the inline stack-check now mirrors _call_footer one-to-one — same offsets, same ADD rsp — minus the shadowstack pop, since the overflow exit runs before gen_shadowstack_header has pushed any entry.

build_malloc_slowpath_fixed now emits the OOM propagate body inline (assembler.py:300-322 `TEST eax, eax; JZ propagate_exception_path`): when `dynasm_nursery_slowpath` returns NULL the trampoline does _store_and_reset_exception, writes jf_descr =
propagate_exception_descr, pops the trampoline's own CALL return address and runs _call_footer to exit the trace. The descr pointer is read indirectly through PROPAGATE_EXCEPTION_DESCR_PTR (lib.rs) so a descr installed after the trampoline was built still takes effect; set_propagate_exception_descr publishes to that atomic. When no descr is installed (test harness or pre-finish-setup) the trampoline falls through to a plain pop_all + RET with `rcx = 0`, matching the prior call-site behaviour.

dynasm_nursery_slowpath now returns 0 on `libc::calloc` failure instead of `gc_hdr` — the masked near-zero return was masking real OOM and preventing the trampoline's new TEST/JZ from firing.

emit_call_site_oom_propagate is removed; the call-site OOM emit at genop_call_malloc_nursery is no longer needed since the trampoline handles propagation itself.

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-CPU architecture extensions enabling per-core helper trampolines and unified backend layout.
  * Backend now ensures one-time per-process/per-CPU setup before tracing.

* **Bug Fixes**
  * Corrected OOM handling so allocator NULL is preserved and propagated.
  * Strengthened idempotent install of exception propagation descriptors.

* **Performance**
  * Per-CPU baked allocation helper trampolines to avoid repeated rebuilds.

* **Reliability**
  * Simplified prologue/epilogue and shadow-stack sequences for consistent stack/register state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->