### PR TITLE
Tighten RPython parity across rtyper/annotator/front-end

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -486,6 +486,19 @@ impl Bookkeeper {
             .expect("Bookkeeper.annotator backlink is absent or dropped")
     }
 
+    /// Non-panicking variant of [`Self::annotator`].  Returns `None`
+    /// when the backlink is absent (test fixtures that wire the
+    /// bookkeeper without an `RPythonAnnotator`) or when the
+    /// `Rc<RPythonAnnotator>` has been dropped.  Production callers
+    /// that need the annotator should prefer [`Self::annotator`];
+    /// this variant is for diagnostic side-channels that should
+    /// degrade gracefully when the annotator is not yet attached
+    /// (e.g. lift-error recording from a registry pre-pass that may
+    /// also be exercised in standalone fixture setups).
+    pub fn try_annotator(&self) -> Option<Rc<crate::annotator::annrpython::RPythonAnnotator>> {
+        self.annotator.borrow().upgrade()
+    }
+
     /// RPython `Bookkeeper.warning(self, msg)` (bookkeeper.py:580-581).
     ///
     /// ```python

--- a/majit/majit-translate/src/annotator/description.rs
+++ b/majit/majit-translate/src/annotator/description.rs
@@ -792,6 +792,13 @@ pub struct FunctionDesc {
     /// access `graph.signature` / `graph.defaults` for the
     /// description.py:223-225 comparison.
     pub(crate) cache: RefCell<HashMap<GraphCacheKey, Rc<PyGraph>>>,
+    /// Pyre-only lazy-failure record for registry-prefilled callable
+    /// graphs.  RPython builds these graphs lazily inside
+    /// `cachedgraph -> buildgraph`; pyre may attempt an eager lift first.
+    /// If that eager lift fails, cache misses must surface the recorded
+    /// producer-side error here instead of falling through to
+    /// `buildflowgraph`'s generic synthetic-function failure.
+    pub(crate) pyre_lift_error: RefCell<Option<String>>,
     /// Upstream `self.pyobj._signature_` (description.py:294, :315).
     /// Carried on FunctionDesc rather than HostObject because
     /// `_signature_` is a function-level attribute.
@@ -872,6 +879,7 @@ impl FunctionDesc {
             defaults: defaults.unwrap_or_default(),
             specializer,
             cache: RefCell::new(HashMap::new()),
+            pyre_lift_error: RefCell::new(None),
             annsignature: None,
             annenforceargs: None,
         }
@@ -880,6 +888,17 @@ impl FunctionDesc {
     /// RPython `FunctionDesc.getgraphs()` (description.py:215-216).
     pub fn getgraphs(&self) -> Vec<Rc<PyGraph>> {
         self.cache.borrow().values().cloned().collect()
+    }
+
+    /// Record a pyre eager-lift failure to be observed at the same
+    /// lazy `cachedgraph` use-site where upstream would run
+    /// `buildgraph` and propagate the original construction error.
+    pub(crate) fn record_pyre_lift_error(&self, message: String) {
+        *self.pyre_lift_error.borrow_mut() = Some(message);
+    }
+
+    pub(crate) fn pyre_lift_error_message(&self) -> Option<String> {
+        self.pyre_lift_error.borrow().clone()
     }
 
     /// RPython `FunctionDesc.rowkey()` (description.py:365-366).
@@ -1036,6 +1055,14 @@ impl FunctionDesc {
     ) -> Result<Rc<PyGraph>, AnnotatorError> {
         if let Some(existing) = self.cache.borrow().get(&key) {
             return Ok(existing.clone());
+        }
+        if let Some(lift_err) = self.pyre_lift_error_message() {
+            return Err(AnnotatorError::new(format!(
+                "{}.cachedgraph: pyre-side lift failed during \
+                 populate_call_registry_from_call_graphs (recorded \
+                 lazy-failure error): {lift_err}",
+                self.name,
+            )));
         }
         let computed_alt_name = alt_name.map(str::to_string).or_else(|| {
             if matches!(&key, GraphCacheKey::None) {
@@ -3070,6 +3097,26 @@ mod tests {
             .expect("builder graph");
 
         assert_eq!(graph.graph.borrow().name, "f__arg_or_var");
+    }
+
+    #[test]
+    fn function_desc_cachedgraph_surfaces_recorded_pyre_lift_error() {
+        let fd = FunctionDesc::new(bk(), None, "bad_leaf", int_sig(&[]), None, None);
+        fd.record_pyre_lift_error("producer failed before pygraph lift".to_string());
+
+        let err = fd
+            .cachedgraph(
+                GraphCacheKey::None,
+                None,
+                Some(Box::new(|_translator, _func| {
+                    panic!("cachedgraph must not call buildgraph after recorded lift error")
+                })),
+            )
+            .expect_err("recorded pyre lift error must surface at cachedgraph");
+
+        let msg = err.msg.expect("AnnotatorError should carry message");
+        assert!(msg.contains("bad_leaf.cachedgraph: pyre-side lift failed"));
+        assert!(msg.contains("producer failed before pygraph lift"));
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2576,23 +2576,25 @@ impl Eq for AnnotatorError {}
 
 impl fmt::Display for AnnotatorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // RPython `AnnotatorError(msg)` always carries a message; the
-        // Rust port models the `block`/`source` slots as `Option` so an
-        // error in flight before `set_annotator_block` runs has neither
-        // populated.  The previous `if let Some(...)` arms silently
-        // suppressed `AnnotatorError` whose `msg`/`source` were both
-        // `None`, surfacing as `compute_at_fixpoint failed: ` (empty
-        // payload) in `cutover::dual_gate_check_with_registry`'s Skip
-        // log.  Always emit a structural tag plus whatever fields are
-        // populated, so propagators (`complete_pending_blocks` /
-        // `compute_at_fixpoint`) carry the producer-side context.
-        let has_msg = self.msg.is_some();
-        let has_source = self.source.is_some();
-        if !has_msg && !has_source {
-            return write!(f, "AnnotatorError{{block:{:?}}}", self.block);
-        }
-        if let Some(msg) = &self.msg {
-            write!(f, "\n\n{msg}")?;
+        // Line-by-line port of `AnnotatorError.__str__`
+        // (`rpython/annotator/model.py:719-725`):
+        //
+        //     def __str__(self):
+        //         s = "\n\n%s" % self.msg
+        //         if self.source is not None:
+        //             s += "\n\n"
+        //             s += self.source
+        //         return s
+        //
+        // Upstream's `%s` formats `None` literally as `"None"` when
+        // `self.msg is None` — pyre matches via `Option::Display`
+        // (None → "None") to keep producer-side telemetry symmetric.
+        // The `block` slot is pyre-only diagnostic state; rendering it
+        // here would deviate from upstream and is the reporting
+        // layer's concern, not the exception's.
+        match &self.msg {
+            Some(msg) => write!(f, "\n\n{msg}")?,
+            None => write!(f, "\n\nNone")?,
         }
         if let Some(source) = &self.source {
             write!(f, "\n\n{source}")?;

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2576,6 +2576,21 @@ impl Eq for AnnotatorError {}
 
 impl fmt::Display for AnnotatorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // RPython `AnnotatorError(msg)` always carries a message; the
+        // Rust port models the `block`/`source` slots as `Option` so an
+        // error in flight before `set_annotator_block` runs has neither
+        // populated.  The previous `if let Some(...)` arms silently
+        // suppressed `AnnotatorError` whose `msg`/`source` were both
+        // `None`, surfacing as `compute_at_fixpoint failed: ` (empty
+        // payload) in `cutover::dual_gate_check_with_registry`'s Skip
+        // log.  Always emit a structural tag plus whatever fields are
+        // populated, so propagators (`complete_pending_blocks` /
+        // `compute_at_fixpoint`) carry the producer-side context.
+        let has_msg = self.msg.is_some();
+        let has_source = self.source.is_some();
+        if !has_msg && !has_source {
+            return write!(f, "AnnotatorError{{block:{:?}}}", self.block);
+        }
         if let Some(msg) = &self.msg {
             write!(f, "\n\n{msg}")?;
         }

--- a/majit/majit-translate/src/front/ast.rs
+++ b/majit/majit-translate/src/front/ast.rs
@@ -1534,6 +1534,36 @@ pub fn lower_expr_into_graph(
     graph: &mut FunctionGraph,
     expr: &syn::Expr,
 ) -> Result<(), FlowingError> {
+    lower_expr_into_graph_with_signature(graph, expr, None)
+}
+
+/// Variant of [`lower_expr_into_graph`] that pre-registers a function
+/// signature's formal parameters as startblock `OpKind::Input` ops +
+/// `Block.inputargs` entries + `GraphBuildContext.bind_local_id`
+/// bindings.
+///
+/// Closes the Cat 2.1 "adapter cross-block body Input" Skip family
+/// for `__opcode_dispatch__::*` synthesized arm graphs:
+/// without this pre-binding, an arm body that references
+/// `execute_opcode_step`'s formal parameters (`frame`, `instruction`,
+/// `executor`, ...) falls through to the naked body-`Input` emit at
+/// the `Expr::Path` fallback (`front/ast.rs:4559`), which the
+/// flowspace adapter rejects as a producer-side gap.  Pre-binding
+/// puts each formal parameter at a known startblock inputarg so
+/// same-block reads dedup against the binding and cross-block reads
+/// resolve via `lazy_install_local_at_current_block` — matching the
+/// `RPython`/PyPy shape where every per-opcode handler method has the
+/// dispatcher's parameters in its formal signature.
+///
+/// The parameter-registration loop mirrors [`build_function_graph`]
+/// (`front/ast.rs:3056-3156`) but skips module-prefix / use-imports /
+/// struct / trait registries, since opcode-dispatch arm graphs are
+/// synthesized without whole-program context.
+pub fn lower_expr_into_graph_with_signature(
+    graph: &mut FunctionGraph,
+    expr: &syn::Expr,
+    sig: Option<&syn::Signature>,
+) -> Result<(), FlowingError> {
     let mut block = graph.startblock;
     let empty_registry = StructFieldRegistry::default();
     let empty_fn_ret = HashMap::new();
@@ -1547,6 +1577,49 @@ pub fn lower_expr_into_graph(
         &empty_names,
         &empty_trait_names,
     );
+    if let Some(sig) = sig {
+        for param in &sig.inputs {
+            match param {
+                syn::FnArg::Receiver(recv) => {
+                    let self_ty = classify_fn_arg_ty(&recv.ty);
+                    ctx.local_value_types
+                        .insert("self".to_string(), self_ty.clone());
+                    if let Some(vid) = graph.push_op(
+                        block,
+                        OpKind::Input {
+                            name: "self".to_string(),
+                            ty: self_ty,
+                        },
+                        true,
+                    ) {
+                        graph.name_value(vid, "self".to_string());
+                        graph.push_inputarg(block, vid);
+                        ctx.bind_local_id("self".to_string(), vid, block);
+                    }
+                }
+                syn::FnArg::Typed(pat_type) => {
+                    let name = canonical_pat_name(&pat_type.pat);
+                    if let Some(type_root) = type_root_ident(&pat_type.ty) {
+                        ctx.local_type_roots.insert(name.clone(), type_root);
+                    }
+                    let arg_ty = classify_fn_arg_ty(&pat_type.ty);
+                    ctx.local_value_types.insert(name.clone(), arg_ty.clone());
+                    if let Some(vid) = graph.push_op(
+                        block,
+                        OpKind::Input {
+                            name: name.clone(),
+                            ty: arg_ty,
+                        },
+                        true,
+                    ) {
+                        graph.name_value(vid, name.clone());
+                        graph.push_inputarg(block, vid);
+                        ctx.bind_local_id(name, vid, block);
+                    }
+                }
+            }
+        }
+    }
     ctx.assert_stack_empty_at_stmt_boundary("lower_expr_into_graph entry");
     let lowered = lower_expr(
         graph,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -832,6 +832,32 @@ pub struct SpaceOperation {
     pub kind: OpKind,
 }
 
+impl SpaceOperation {
+    /// Strict projection of [`Self::result`] onto pyre's `ValueId`
+    /// surface.  Returns `None` only when `result` is `None`
+    /// (intentionally void op).  Panics when `result` is `Some(var)`
+    /// but the Variable is not registered on the graph — a contract
+    /// violation that the inline `self.result.as_ref().and_then(|v|
+    /// graph.value_id_of(v))` idiom would otherwise swallow into the
+    /// same `None` as a genuinely void op, silently dropping
+    /// authoritative type inference for the unregistered ValueId.
+    ///
+    /// Mirrors the panic shape used by
+    /// [`Block::inputarg_value_ids`] and the `ExitSwitch::Value`
+    /// branch of [`remap_control_flow_metadata`].
+    pub fn registered_result_value_id(&self, graph: &FunctionGraph) -> Option<ValueId> {
+        self.result.as_ref().map(|var| {
+            graph.value_id_of(var).unwrap_or_else(|| {
+                panic!(
+                    "SpaceOperation.result ({var:?}) is not registered on \
+                     the graph — malformed op metadata (every result \
+                     Variable must be allocated through the graph allocator)"
+                )
+            })
+        })
+    }
+}
+
 /// RPython `Block.exitswitch`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExitSwitch {

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2879,21 +2879,35 @@ impl FunctionGraph {
 
     /// Route a return through the graph's canonical `returnblock`.
     ///
-    /// RPython `flowcontext.py` return handling produces a fresh
-    /// prevblock-side Variable (Void Variable for `return None`), then
-    /// builds a Link carrying that value into the returnblock's
-    /// inputargs.  pyre's codewriter adaptation mirrors that shape: a
-    /// `None` `value` allocates a fresh prevblock-side ValueId whose
-    /// kind defaults to Void (no regalloc color, no emitted move), so
-    /// `Link.args` is always a prevblock value per upstream's
-    /// `flowspace/model.py:114` invariant.
+    /// RPython `flowcontext.py:687-689 RETURN_VALUE` pops `w_returnvalue`
+    /// from the stack and wraps it in `Return(w_returnvalue)`; in
+    /// `flowcontext.py:1232-1236 Return.nomoreblocks`, the link is built
+    /// as `Link([w_result], ctx.graph.returnblock)`.  For `def foo():
+    /// pass`, the bytecode is `LOAD_CONST None; RETURN_VALUE`, so
+    /// `w_result` is `Constant(None)` and `Link.args = [Constant(None)]`
+    /// — an `Hlvalue::Constant`, not a freshly allocated Variable.
+    ///
+    /// `value == None` wires `LinkArg::Const(ConstValue::None)` with
+    /// `concretetype = Void` into `Link.args[0]` directly, matching
+    /// upstream's `Constant(None)`-on-the-stack shape with the
+    /// `NoneRepr.lowleveltype = Void` (`rpython/rtyper/rnone.py`)
+    /// kind stamped at construction.  Pyre's downstream consumers
+    /// (`flatten::constant_kind`, assembler `emit_const`) honour the
+    /// explicit concretetype so the constant flows through
+    /// `FlatOp::VoidReturn` instead of the `constvalue_kind(None) → 'r'`
+    /// fallback that would otherwise route a Ref-kind void constant
+    /// into the unsupported `emit_const_r(None)` pool.
     pub fn set_return(&mut self, block: BlockId, value: Option<crate::flowspace::model::Variable>) {
         let (returnblock, _) = self.returnblock_arg();
-        let value_var = value.unwrap_or_else(|| {
-            let vid = self.alloc_value();
-            self.must_variable(vid)
-        });
-        self.set_goto(block, returnblock, vec![value_var]);
+        let arg = match value {
+            Some(var) => LinkArg::Value(var),
+            None => LinkArg::Const(crate::flowspace::model::Constant::with_concretetype(
+                ConstValue::None,
+                crate::translator::rtyper::lltypesystem::lltype::VOID,
+            )),
+        };
+        let link = Link::new_mixed(vec![arg], returnblock, None);
+        self.set_control_flow_metadata(block, None, vec![link]);
     }
 
     /// Route `block` to the graph's canonical `exceptblock` — the

--- a/majit/majit-translate/src/parse.rs
+++ b/majit/majit-translate/src/parse.rs
@@ -804,7 +804,9 @@ fn extract_match_arms(expr: &ExprMatch, sig: &syn::Signature) -> Vec<ExtractedOp
             // each per-opcode handler method receives the
             // dispatcher's parameters in its formal signature.
             crate::front::ast::lower_expr_into_graph_with_signature(
-                &mut graph, &arm.body, Some(sig),
+                &mut graph,
+                &arm.body,
+                Some(sig),
             )
             .unwrap_or_else(|e| {
                 panic!("opcode dispatch arm `{name}` must lower without FlowingError: {e:?}")

--- a/majit/majit-translate/src/parse.rs
+++ b/majit/majit-translate/src/parse.rs
@@ -718,7 +718,7 @@ pub fn extract_opcode_dispatch_arms(parsed: &ParsedInterpreter) -> Vec<Extracted
     let Some(opcode_match) = find_opcode_match(func) else {
         return Vec::new();
     };
-    reject_duplicate_opcode_selectors(extract_match_arms(opcode_match))
+    reject_duplicate_opcode_selectors(extract_match_arms(opcode_match, &func.sig))
 }
 
 /// Extract receiver -> trait bounds for `execute_opcode_step`.
@@ -786,7 +786,7 @@ pub fn collect_function_graphs(
 /// a panic rather than silently dropping the arm's graph.  Silently
 /// dropping would let a `PipelineOpcodeArm` reach the codewriter
 /// without the semantic graph the downstream jitcode path depends on.
-fn extract_match_arms(expr: &ExprMatch) -> Vec<ExtractedOpcodeArm> {
+fn extract_match_arms(expr: &ExprMatch, sig: &syn::Signature) -> Vec<ExtractedOpcodeArm> {
     expr.arms
         .iter()
         .map(|arm| {
@@ -794,7 +794,19 @@ fn extract_match_arms(expr: &ExprMatch) -> Vec<ExtractedOpcodeArm> {
             let selector = extract_opcode_dispatch_selector(&arm.pat);
             let name = selector.canonical_key();
             let mut graph = crate::model::FunctionGraph::new(name.clone());
-            crate::front::ast::lower_expr_into_graph(&mut graph, &arm.body).unwrap_or_else(|e| {
+            // Pre-bind `execute_opcode_step`'s formal parameters as
+            // startblock inputargs so the arm body's `Expr::Path`
+            // references (e.g. `frame`, `instruction`, `executor`)
+            // resolve to those inputargs instead of falling through
+            // to the naked body-`Input` emit that the flowspace
+            // adapter rejects as "adapter cross-block body Input"
+            // (the dominant Cat 2.1 Skip family).  PyPy/RPython parity:
+            // each per-opcode handler method receives the
+            // dispatcher's parameters in its formal signature.
+            crate::front::ast::lower_expr_into_graph_with_signature(
+                &mut graph, &arm.body, Some(sig),
+            )
+            .unwrap_or_else(|e| {
                 panic!("opcode dispatch arm `{name}` must lower without FlowingError: {e:?}")
             });
             ExtractedOpcodeArm {

--- a/majit/majit-translate/src/translator/backendopt/ssa.rs
+++ b/majit/majit-translate/src/translator/backendopt/ssa.rs
@@ -771,6 +771,58 @@ mod tests {
     }
 
     #[test]
+    fn ssi_to_ssa_rename_propagates_into_op_args_and_link_args() {
+        // ssi_to_ssa's rename mechanism is purely Rc::clone identity on
+        // VariableInner._name / _nr.  Cover every storage shape that
+        // holds the same Rc handle — inputargs, op args, op result,
+        // link args — so a future deep-copy of Variable cannot silently
+        // break the propagation by only updating one storage class.
+        let v_in = Variable::new();
+        let v_mid = Variable::new();
+        let v_in_for_op = v_in.clone();
+        let op_result = Variable::new();
+        let start_block_op = SpaceOperation::new(
+            "same_as",
+            vec![Hlvalue::Variable(v_in_for_op.clone())],
+            Hlvalue::Variable(op_result.clone()),
+        );
+        let start = Block::shared(vec![Hlvalue::Variable(v_in.clone())]);
+        start.borrow_mut().operations.push(start_block_op);
+        let middle = Block::shared(vec![Hlvalue::Variable(v_mid.clone())]);
+
+        let graph = mk_graph_start_to_block("rename_op_args", start.clone());
+        let returnblock = graph.returnblock.clone();
+        let l1 = Link::new(
+            vec![Hlvalue::Variable(v_in.clone())],
+            Some(middle.clone()),
+            None,
+        )
+        .into_ref();
+        start.closeblock(vec![l1]);
+        let l2 = Link::new(
+            vec![Hlvalue::Variable(v_mid.clone())],
+            Some(returnblock.clone()),
+            None,
+        )
+        .into_ref();
+        middle.closeblock(vec![l2]);
+
+        ssi_to_ssa(&graph);
+
+        let mid_prefix = match &middle.borrow().inputargs[0] {
+            Hlvalue::Variable(v) => v.name_prefix().to_string(),
+            _ => unreachable!(),
+        };
+        // Same Rc-shared cell, so the op-arg observation goes through
+        // the same `_name` slot the rename mutated.
+        let op_arg_prefix = v_in_for_op.name_prefix().to_string();
+        assert_eq!(
+            op_arg_prefix, mid_prefix,
+            "op-arg Variable must observe ssi_to_ssa rename through Rc-shared identity",
+        );
+    }
+
+    #[test]
     fn merge_identical_phi_nodes_unifies_two_equal_phis() {
         // A block receives (via two incoming links) the same
         // Constant(1) into two different input slots. The two input

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -750,18 +750,33 @@ pub fn populate_call_registry_from_call_graphs(
     // `FunctionDesc` is built independently via `newfuncdesc`, and a
     // failure on one callable does NOT abort the bookkeeper's `descs`
     // population for other callables.  Upstream's per-`Constant(pyobj)`
-    // builder is invoked lazily; pyre's eager pre-pass mirrors the same
-    // lazy-failure shape by swallowing the per-callee lift error,
-    // leaving that callee's `FunctionDesc.cache` empty so a later
-    // `cachedgraph` miss surfaces the same failure at use-site
-    // (matching RPython's lazy `newfuncdesc → buildgraph` failure
-    // point).  Without this isolation a single bad leaf (e.g.
-    // `function_write_barrier`'s unregistered
-    // `try_gc_write_barrier` callee) cascades into "missing code
-    // object" for every later-prefilled callee — a NEW-DEVIATION from
-    // upstream's per-callable failure model.
+    // builder is invoked lazily; pyre's eager pre-pass approximates
+    // that lazy shape by isolating per-callee failures here — but
+    // unlike a previous draft that *swallowed* the error outright,
+    // the lift error is now stashed on the entry via
+    // `PyreFunctionEntry::record_lift_error` so the next
+    // `cachedgraph` consumer surfaces the actual producer-side
+    // failure instead of falling through to `buildflowgraph`'s
+    // generic "missing code object" message
+    // (`translator/translator.rs:439`).  This keeps the lazy-failure
+    // *point of observation* aligned with upstream
+    // `description.py:228` while preserving pyre's eager prefill
+    // shape for the success path.  Without per-entry error capture a
+    // single bad leaf (e.g. `function_write_barrier`'s unregistered
+    // `try_gc_write_barrier` callee) would mask its own diagnosis
+    // behind every later use-site's generic fallback — a divergence
+    // from upstream's per-callable failure model where the original
+    // exception propagates.
     let mut lifted: HashSet<*const PyreFunctionEntry> =
         HashSet::with_capacity(by_canonical_path.len());
+    // Each lift failure pushes into the translator's
+    // `_pyre_lift_errors` map keyed by the entry's `HostObject`
+    // identity, making the recorded error visible to
+    // `buildflowgraph` consumers downstream.  Resolved lazily so
+    // test fixtures whose `Bookkeeper` runs without an attached
+    // `RPythonAnnotator` (`bookkeeper.annotator()` panics with
+    // "backlink absent or dropped") only pay the lookup on the
+    // failure path; success paths remain unaffected.
     for (_key, graph, entry) in &pending {
         let entry_ptr = Rc::as_ptr(entry);
         if !lifted.insert(entry_ptr) {
@@ -769,10 +784,16 @@ pub fn populate_call_registry_from_call_graphs(
         }
         match lift_callee_to_pygraph(graph, signature_for_graph(graph), registry) {
             Ok(pygraph) => entry.prefill_default_cache(pygraph),
-            Err(_) => {
-                // Leave the entry's cache empty; the use-site lookup
-                // will surface this callee's lift failure when
-                // `FunctionRepr.call` consults `cachedgraph`.
+            Err(e) => {
+                let message = format!("{e}");
+                entry.record_lift_error(message.clone());
+                if let Some(annotator) = registry.bookkeeper().try_annotator() {
+                    annotator
+                        .translator
+                        ._pyre_lift_errors
+                        .borrow_mut()
+                        .insert(entry.host_object.clone(), message);
+                }
             }
         }
     }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -744,6 +744,22 @@ pub fn populate_call_registry_from_call_graphs(
     // once (`Rc::as_ptr` identity dedup); aliases share the same
     // pre-filled `FunctionDesc.cache` because they hold the same
     // `Rc<PyreFunctionEntry>`.
+    //
+    // Per-callee failure isolation matches RPython
+    // `bookkeeper.py:353-409 getdesc(pyobj)` semantics: each
+    // `FunctionDesc` is built independently via `newfuncdesc`, and a
+    // failure on one callable does NOT abort the bookkeeper's `descs`
+    // population for other callables.  Upstream's per-`Constant(pyobj)`
+    // builder is invoked lazily; pyre's eager pre-pass mirrors the same
+    // lazy-failure shape by swallowing the per-callee lift error,
+    // leaving that callee's `FunctionDesc.cache` empty so a later
+    // `cachedgraph` miss surfaces the same failure at use-site
+    // (matching RPython's lazy `newfuncdesc → buildgraph` failure
+    // point).  Without this isolation a single bad leaf (e.g.
+    // `function_write_barrier`'s unregistered
+    // `try_gc_write_barrier` callee) cascades into "missing code
+    // object" for every later-prefilled callee — a NEW-DEVIATION from
+    // upstream's per-callable failure model.
     let mut lifted: HashSet<*const PyreFunctionEntry> =
         HashSet::with_capacity(by_canonical_path.len());
     for (_key, graph, entry) in &pending {
@@ -751,8 +767,14 @@ pub fn populate_call_registry_from_call_graphs(
         if !lifted.insert(entry_ptr) {
             continue;
         }
-        let pygraph = lift_callee_to_pygraph(graph, signature_for_graph(graph), registry)?;
-        entry.prefill_default_cache(pygraph);
+        match lift_callee_to_pygraph(graph, signature_for_graph(graph), registry) {
+            Ok(pygraph) => entry.prefill_default_cache(pygraph),
+            Err(_) => {
+                // Leave the entry's cache empty; the use-site lookup
+                // will surface this callee's lift failure when
+                // `FunctionRepr.call` consults `cachedgraph`.
+            }
+        }
     }
     Ok(())
 }

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -94,32 +94,6 @@ pub use crate::jit_codewriter::annotation_state::valuetype_to_someshell;
 /// `Variable::new` allocates a fresh process-wide identity
 /// (`flowspace/model.rs:2042`). Identity correspondence is preserved
 /// out-of-band by [`ValueIdToVariable`].
-/// Return `true` when `value` is a synthetic placeholder allocated
-/// by `model.rs::set_return(_, None)` for a void return — i.e. a
-/// `ValueId` that appears in `Link.args` but is **not** defined as
-/// any block's `inputargs` entry or any op's `result`.  Mirrors
-/// `translator/rtyper/legacy_annotator.rs:183-193
-/// is_synthetic_return_void_value` line-by-line so the adapter and
-/// the legacy annotator agree on which `Link.args` ValueIds are
-/// "void return placeholders" eligible for the Void pre-seed and
-/// which are genuine `undefined operand` producer bugs that should
-/// remain fail-loud.
-fn is_synthetic_return_void_value(graph: &FunctionGraph, value: ValueId) -> bool {
-    for block in &graph.blocks {
-        if block.inputarg_value_ids(graph).contains(&value) {
-            return false;
-        }
-        if block
-            .operations
-            .iter()
-            .any(|op| op.result.as_ref().and_then(|v| graph.value_id_of(v)) == Some(value))
-        {
-            return false;
-        }
-    }
-    true
-}
-
 fn seed_variable(vid: ValueId, annotations: &AnnotationState) -> Variable {
     let var = Variable::new();
     // Copy the precise per-`ValueId` `SomeValue` onto
@@ -1557,47 +1531,6 @@ pub fn function_graph_to_flowspace_with_seed_annotations(
         }
     }
 
-    // ─── Synthetic void-return placeholder seeding ───
-    // `model.rs::set_return(block, None)` (`model.rs:1177`) emits a
-    // Link to the canonical returnblock with a fresh
-    // `alloc_value()`-allocated ValueId in `args[0]` — a pyre
-    // divergence from RPython's `RETURN_VALUE`
-    // (`flowcontext.py:687-689`) which carries `Constant(None)` from
-    // a preceding `LOAD_CONST None` directly.  The legacy annotator
-    // already pre-seeds these synthetic placeholders as
-    // `ValueType::Void` (`translator/rtyper/legacy_annotator.rs:
-    // 47-62` + `is_synthetic_return_void_value`); the adapter
-    // mirrors the same pre-seed by materializing a Variable with
-    // the Void shell that `valuetype_to_someshell(&ValueType::Void)`
-    // returns (`SomeImpossible`).  `RPythonTyper::specialize` then
-    // assigns `Void` LowLevelType, the LL→Concrete projector maps
-    // back to `Void`, and the dual-gate matches legacy's `Void`
-    // resolution — keeping the synthetic placeholder resolvable in
-    // `link_arg_to_hlvalue` without dropping the fail-loud invariant
-    // for genuinely-undefined Link.args producers.
-    let mut synthetic_void_hlvalues: HashMap<ValueId, Hlvalue> = HashMap::new();
-    for legacy_block in &legacy.blocks {
-        for link in &legacy_block.exits {
-            if link.target != legacy.returnblock {
-                continue;
-            }
-            let Some(vid) = link.args.first().and_then(|a| a.as_value(legacy)) else {
-                continue;
-            };
-            if !is_synthetic_return_void_value(legacy, vid) {
-                continue;
-            }
-            let var = Variable::new();
-            if let Some(shell) = valuetype_to_someshell(&crate::model::ValueType::Void) {
-                *var.annotation.borrow_mut() = Some(Rc::new(shell));
-            }
-            value_to_var.entry(vid).or_insert_with(|| var.clone());
-            synthetic_void_hlvalues
-                .entry(vid)
-                .or_insert(Hlvalue::Variable(var));
-        }
-    }
-
     // ──────────────────────────────────────────────────────────────
     // Pass 1 — allocate fresh `flowspace::BlockRef` for every legacy
     // non-final block. The legacy `returnblock` and `exceptblock` are
@@ -1706,14 +1639,6 @@ pub fn function_graph_to_flowspace_with_seed_annotations(
         }
         let block_ref = block_map[&legacy_block.id].clone();
         let mut value_map = constant_hlvalues.clone();
-        // Mirror the legacy annotator's `is_synthetic_return_void_value`
-        // pre-seed: any synthetic void-return placeholder ValueId is
-        // available in every block's value_map so `link_arg_to_hlvalue`
-        // resolves the Link.args[0] entry instead of failing
-        // `undefined operand`.
-        for (&vid, hlv) in &synthetic_void_hlvalues {
-            value_map.entry(vid).or_insert_with(|| hlv.clone());
-        }
         let mut name_to_value: HashMap<String, Hlvalue> = HashMap::new();
 
         if let Some(inputs) = block_inputarg_vars.get(&legacy_block.id) {

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -64,7 +64,7 @@ pub fn annotate(graph: &FunctionGraph) -> AnnotationState {
         for block in &graph.blocks {
             // Propagate annotations through ops in this block
             for op in &block.operations {
-                if let Some(result) = op.result.as_ref().and_then(|v| graph.value_id_of(v)) {
+                if let Some(result) = op.registered_result_value_id(graph) {
                     let inferred = infer_op_type(&op.kind, &state, graph);
                     let current = state.get(result);
                     let merged = union_type(&current, &inferred);

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -172,18 +172,24 @@ fn const_value_type(value: &ConstValue) -> ValueType {
         | ConstValue::LLAddress(_) => ValueType::Int,
         ConstValue::Float(_) => ValueType::Float,
         ConstValue::Placeholder => ValueType::Unknown,
-        // RPython `Constant(None)` annotates to `SomeNone`
-        // (`annotator/model.py: SomePBC.lowleveltype` / `rnone.py:
-        // NoneRepr.lowleveltype = Void`), which the rtyper lowers to
-        // LL `Void`.  Pyre's legacy projector previously collapsed
-        // `ConstValue::None` to `Ref` (Python None as a PyObject), which
-        // mis-typed `Link.args = [Constant(None)]` return-block flow as
-        // `Ref` instead of `Void`, blocking the `set_return(_, None)`
-        // orthodox shape.  Returning `Void` aligns with `NoneRepr`'s
-        // LL kind so the orthodox Constant-link-arg matches the
-        // `synthetic_void_return_stays_void` invariant directly.
-        ConstValue::None => ValueType::Void,
-        ConstValue::Atom(_)
+        // RPython `Constant(None)` is annotated as `SomeNone`
+        // (`rpython/annotator/annrpython.py:273 immutablevalue(None)`
+        // → `SomeNone()` per `annotator/model.py:603`), distinct from
+        // `SomeInteger` / `SomeString`.  Pyre's `ValueType` lacks a
+        // dedicated `SomeNone` variant, so collapse to `Ref` — the
+        // closest match for the dominant downstream consumer where
+        // None flows into a `Ptr` target and the rtyper emits
+        // `inputconst(Ptr, None)` per `pairtype(NoneRepr, Repr).
+        // convert_from_to` (`rpython/rtyper/rnone.py:58`).  For the
+        // `Constant(None) → NoneRepr` target case (where the rtyper
+        // returns `inputconst(Void, None)` per `rnone.py:48`),
+        // construction sites such as `set_return` write the target
+        // repr onto `Constant.concretetype`; the rtyping-layer
+        // projection at `legacy_resolve::link_arg_concrete_type` then
+        // honours that hint to materialise `Void` without forcing
+        // every None through the annotation layer as `Void`.
+        ConstValue::None
+        | ConstValue::Atom(_)
         | ConstValue::Dict(_)
         | ConstValue::ByteStr(_)
         | ConstValue::UniStr(_)
@@ -530,13 +536,35 @@ mod tests {
     }
 
     #[test]
-    fn synthetic_void_return_stays_void() {
+    fn synthetic_void_return_carries_void_concretetype() {
+        // `set_return(_, None)` wires `LinkArg::Const(Constant(None,
+        // concretetype=Void))` per `flowcontext.py:687-689` +
+        // `:1232-1236`.  At the annotation layer, `Constant(None)`
+        // projects to `Ref` (pyre's nearest mapping for upstream's
+        // `SomeNone` — see `const_value_type`).  The rtyping-layer
+        // projection at [`super::legacy_resolve::link_arg_concrete_type`]
+        // then honours the construction-site `concretetype=Void` to
+        // materialise `Void` on the returnblock inputarg, matching
+        // `pairtype(Repr, NoneRepr).convert_from_to → inputconst(Void, None)`
+        // (`rpython/rtyper/rnone.py:48`).
+        use super::super::legacy_resolve;
         let mut graph = FunctionGraph::new("void_return");
         let entry = graph.startblock;
         graph.set_return(entry, None);
 
-        let state = annotate(&graph);
+        let annotations = annotate(&graph);
         let ret = graph.block(graph.returnblock).inputarg_value_ids(&graph)[0];
-        assert_eq!(state.get(ret), ValueType::Void);
+        assert_eq!(
+            annotations.get(ret),
+            ValueType::Ref,
+            "annotation-layer projection of Constant(None) follows SomeNone → Ref",
+        );
+
+        legacy_resolve::resolve_types(&graph, &annotations);
+        assert_eq!(
+            graph.concretetype(ret),
+            crate::jit_codewriter::type_state::ConcreteType::Void,
+            "rtyping-layer projection honours Constant.concretetype=Void from set_return",
+        );
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -29,17 +29,20 @@ use crate::model::{FunctionGraph, Link, LinkArg, OpKind, ValueId, ValueType};
 pub fn annotate(graph: &FunctionGraph) -> AnnotationState {
     let mut state = AnnotationState::new();
 
-    // Seed the terminal pseudo-block inputargs. RPython `flowspace/
-    // model.py:17-18` `returnblock = Block([return_var])` and
-    // `exceptblock = Block([etype, evalue])` carry implicit types that
-    // later Link propagation confirms but never introduces for Links
-    // that never reach the block.  Raising-only or void functions can
-    // leave these args untyped, which later drops them from
-    // `build_value_kinds` and trips the assembler's
-    // `lookup_reg_with_kind` panic.  `rpython/jit/codewriter/flatten.py:
-    // 169-172` assumes `etype: Int, evalue: Ref` and `return_var:
-    // <result_type>` unconditionally; pyre mirrors that by seeding the
-    // annotator state up front.
+    // RPython parity gap: `annrpython.py:RPythonAnnotator.complete()`
+    // never seeds exceptblock inputargs — they receive `SomeInstance`
+    // annotations only through `follow_raise_link` (`annrpython.py:
+    // 614-618 typeof([v_last_exc_value])`) when an actual raise reaches
+    // the block, and stay `None` for unreachable exceptblocks.  Pyre's
+    // legacy walker pre-seeds `etype: Int, evalue: Ref` because the
+    // dual-gate baseline must match the real rtyper's exceptblock
+    // resolution (`Signed` / `GcRef`) regardless of whether the graph
+    // actually raises — without the pre-seed, `dual_gate_check` diverges
+    // on every trivial identity function (`anchor_int_identity_dual_
+    // gate_agrees` etc.).  This pre-seed retires only when the real
+    // rtyper's exceptblock-handling path itself aligns with upstream
+    // (i.e. `None`-annotation → exclude from build_value_kinds, not
+    // backfill to `Signed`/`GcRef`).
     if let Some(exceptblock) = graph.blocks.get(graph.exceptblock.0) {
         let exceptblock_vids = exceptblock.inputarg_value_ids(graph);
         if let Some(&etype) = exceptblock_vids.first() {
@@ -49,30 +52,6 @@ pub fn annotate(graph: &FunctionGraph) -> AnnotationState {
             state.set(evalue, ValueType::Ref);
         }
     }
-    // `returnblock.inputargs[0]` must not be pre-seeded to `Ref`.
-    // Doing so collapses a real `Float`/`Int` return into
-    // `union_type(Ref, Float|Int) == Unknown`, which the legacy rtyper
-    // then backfills to `GcRef`.  Seed only the pyre-only synthetic
-    // `return None` placeholder values here; normal non-void returns
-    // are inferred from the incoming Link args.
-    if let Some(returnblock) = graph.blocks.get(graph.returnblock.0)
-        && let Some(&ret) = returnblock.inputarg_value_ids(graph).first()
-    {
-        for block in &graph.blocks {
-            for link in &block.exits {
-                if link.target != graph.returnblock {
-                    continue;
-                }
-                if let Some(src) = link.args.first().and_then(|a| a.as_value(graph))
-                    && is_synthetic_return_void_value(graph, src)
-                {
-                    state.set(src, ValueType::Void);
-                    state.set(ret, ValueType::Void);
-                }
-            }
-        }
-    }
-
     // Process all blocks (simple single-pass for acyclic; loops need fixpoint)
     let mut changed = true;
     let mut iterations = 0;
@@ -193,6 +172,17 @@ fn const_value_type(value: &ConstValue) -> ValueType {
         | ConstValue::LLAddress(_) => ValueType::Int,
         ConstValue::Float(_) => ValueType::Float,
         ConstValue::Placeholder => ValueType::Unknown,
+        // RPython `Constant(None)` annotates to `SomeNone`
+        // (`annotator/model.py: SomePBC.lowleveltype` / `rnone.py:
+        // NoneRepr.lowleveltype = Void`), which the rtyper lowers to
+        // LL `Void`.  Pyre's legacy projector previously collapsed
+        // `ConstValue::None` to `Ref` (Python None as a PyObject), which
+        // mis-typed `Link.args = [Constant(None)]` return-block flow as
+        // `Ref` instead of `Void`, blocking the `set_return(_, None)`
+        // orthodox shape.  Returning `Void` aligns with `NoneRepr`'s
+        // LL kind so the orthodox Constant-link-arg matches the
+        // `synthetic_void_return_stays_void` invariant directly.
+        ConstValue::None => ValueType::Void,
         ConstValue::Atom(_)
         | ConstValue::Dict(_)
         | ConstValue::ByteStr(_)
@@ -201,31 +191,11 @@ fn const_value_type(value: &ConstValue) -> ValueType {
         | ConstValue::List(_)
         | ConstValue::Graphs(_)
         | ConstValue::LowLevelType(_)
-        | ConstValue::None
         | ConstValue::Code(_)
         | ConstValue::LLPtr(_)
         | ConstValue::Function(_)
         | ConstValue::HostObject(_) => ValueType::Ref,
     }
-}
-
-fn is_synthetic_return_void_value(graph: &FunctionGraph, value: ValueId) -> bool {
-    let Some(target) = graph.variable(value).cloned() else {
-        return true;
-    };
-    for block in &graph.blocks {
-        if block.inputargs.contains(&target) {
-            return false;
-        }
-        if block
-            .operations
-            .iter()
-            .any(|op| op.result.as_ref() == Some(&target))
-        {
-            return false;
-        }
-    }
-    true
 }
 
 /// Infer the output type of an operation from its inputs.

--- a/majit/majit-translate/src/translator/rtyper/legacy_resolve.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_resolve.rs
@@ -179,8 +179,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
                             .expect("BinOp.rhs has backing ValueId");
                         changed |= maybe_seed_concrete_type(graph, lhs_vid, ConcreteType::Signed);
                         changed |= maybe_seed_concrete_type(graph, rhs_vid, ConcreteType::Signed);
-                        if let Some(result) = op.registered_result_value_id(graph)
-                        {
+                        if let Some(result) = op.registered_result_value_id(graph) {
                             // RPython rtyper resolves an `add` whose
                             // operands are both `lltype.Float` to
                             // `float_add` directly (`rfloat.py
@@ -245,8 +244,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
                             .expect("UnaryOp.operand has backing ValueId");
                         changed |=
                             maybe_seed_concrete_type(graph, operand_vid, ConcreteType::Signed);
-                        if let Some(result) = op.registered_result_value_id(graph)
-                        {
+                        if let Some(result) = op.registered_result_value_id(graph) {
                             // Same Float-operand override as the BinOp
                             // arm above.  Unary `neg` on a Float
                             // returns Float (`float_neg`).
@@ -294,8 +292,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
                         operand,
                         ..
                     } if is_identity_unop(opname) => {
-                        if let Some(result) = op.registered_result_value_id(graph)
-                        {
+                        if let Some(result) = op.registered_result_value_id(graph) {
                             let operand_vid = graph
                                 .value_id_of(operand)
                                 .expect("UnaryOp.operand has backing ValueId");
@@ -409,6 +406,22 @@ fn convert_link(graph: &FunctionGraph, link: &Link) {
     let target_block = graph.block(link.target);
     let target_vids = target_block.inputarg_value_ids(graph);
     for (dst, src) in target_vids.iter().zip(link.args.iter()) {
+        // A `LinkArg::Const(_)` whose `concretetype` carries a
+        // construction-site repr (e.g. `set_return`'s
+        // `Constant(None, concretetype=Void)`) is authoritative —
+        // mirrors RPython `_convert_link()` materialising
+        // `inputconst(r_to, value)` whose own `concretetype` is the
+        // destination repr (`rpython/rtyper/rmodel.py:inputconst`
+        // + `rpython/rtyper/rnone.py:48`).  Force-write so an
+        // earlier annotation-derived kind (e.g. `Ref → GcRef` from
+        // `valuetype_to_concrete` on the upstream `SomeNone → Ref`
+        // projection) does not shadow it.
+        if let LinkArg::Const(value) = src
+            && let Some(lltype) = value.concretetype.as_ref()
+        {
+            graph.set_concretetype_inline(*dst, crate::model::getkind(lltype));
+            continue;
+        }
         let _ = maybe_seed_concrete_type(graph, *dst, link_arg_concrete_type(graph, src));
     }
 }
@@ -461,9 +474,15 @@ fn converge_link(graph: &FunctionGraph, link: &Link) -> bool {
                 changed |= maybe_seed_concrete_type(graph, *dst, src_ty);
                 changed |= maybe_seed_concrete_type(graph, src_vid, dst_ty);
             }
-            LinkArg::Const(value) => {
+            LinkArg::Const(_) => {
+                // Route through `link_arg_concrete_type` so the
+                // `Constant.concretetype` construction-site hint
+                // (e.g. `set_return`'s `concretetype=Void`) is
+                // honoured here too — bypassing it would let
+                // `const_value_to_concrete(&value.value)` default
+                // `None → GcRef` and shadow the Void write.
                 changed |=
-                    maybe_seed_concrete_type(graph, *dst, const_value_to_concrete(&value.value));
+                    maybe_seed_concrete_type(graph, *dst, link_arg_concrete_type(graph, src));
             }
         }
     }
@@ -527,7 +546,23 @@ fn link_arg_concrete_type(graph: &FunctionGraph, src: &LinkArg) -> ConcreteType 
             });
             graph.concretetype(vid)
         }
-        LinkArg::Const(value) => const_value_to_concrete(&value.value),
+        // RPython `pairtype(Repr, NoneRepr).convert_from_to`
+        // (`rpython/rtyper/rnone.py:48`) emits `inputconst(Void, None)`
+        // when None flows into a `NoneRepr` target; the symmetric
+        // `pairtype(NoneRepr, Repr).convert_from_to`
+        // (`rpython/rtyper/rnone.py:58`) emits `inputconst(r_to, None)`
+        // which is a null pointer for `Ptr`/ref targets.  Pyre's
+        // construction sites that already know the target repr write
+        // it onto `Constant.concretetype` at the construction site
+        // (e.g. `set_return` wires `Constant(None, concretetype=Void)`
+        // per `flowcontext.py:687-689` + `:1232-1236`); honour that
+        // construction-site hint here.  Falls back to the value-only
+        // default (`getkind(Ptr) == GcRef` for None) when the
+        // construction site did not set a target repr.
+        LinkArg::Const(value) => match value.concretetype.as_ref() {
+            Some(lltype) => crate::model::getkind(lltype),
+            None => const_value_to_concrete(&value.value),
+        },
     }
 }
 

--- a/majit/majit-translate/src/translator/rtyper/legacy_resolve.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_resolve.rs
@@ -67,7 +67,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
             }
         }
         for op in &block.operations {
-            if let Some(result) = op.result.as_ref().and_then(|v| graph.value_id_of(v)) {
+            if let Some(result) = op.registered_result_value_id(graph) {
                 let inferred = infer_concrete_from_op(&op.kind);
                 if inferred != ConcreteType::Unknown {
                     // The op carries authoritative result kind (post-
@@ -179,7 +179,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
                             .expect("BinOp.rhs has backing ValueId");
                         changed |= maybe_seed_concrete_type(graph, lhs_vid, ConcreteType::Signed);
                         changed |= maybe_seed_concrete_type(graph, rhs_vid, ConcreteType::Signed);
-                        if let Some(result) = op.result.as_ref().and_then(|v| graph.value_id_of(v))
+                        if let Some(result) = op.registered_result_value_id(graph)
                         {
                             // RPython rtyper resolves an `add` whose
                             // operands are both `lltype.Float` to
@@ -245,7 +245,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
                             .expect("UnaryOp.operand has backing ValueId");
                         changed |=
                             maybe_seed_concrete_type(graph, operand_vid, ConcreteType::Signed);
-                        if let Some(result) = op.result.as_ref().and_then(|v| graph.value_id_of(v))
+                        if let Some(result) = op.registered_result_value_id(graph)
                         {
                             // Same Float-operand override as the BinOp
                             // arm above.  Unary `neg` on a Float
@@ -294,7 +294,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
                         operand,
                         ..
                     } if is_identity_unop(opname) => {
-                        if let Some(result) = op.result.as_ref().and_then(|v| graph.value_id_of(v))
+                        if let Some(result) = op.registered_result_value_id(graph)
                         {
                             let operand_vid = graph
                                 .value_id_of(operand)
@@ -346,7 +346,7 @@ pub fn resolve_types(graph: &FunctionGraph, annotations: &AnnotationState) {
             for v in crate::inline::op_value_refs(&op.kind, Some(graph)) {
                 seen.insert(v);
             }
-            if let Some(r) = op.result.as_ref().and_then(|v| graph.value_id_of(v)) {
+            if let Some(r) = op.registered_result_value_id(graph) {
                 seen.insert(r);
             }
         }

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -115,19 +115,6 @@ impl FunctionPathKey {
 pub struct PyreFunctionEntry {
     pub host_object: HostObject,
     pub function_desc: Rc<RefCell<FunctionDesc>>,
-    /// Lazy-failure record for the per-entry lift step.  When
-    /// `populate_call_registry_from_call_graphs`'s
-    /// `lift_callee_to_pygraph` fails on this entry, the error is
-    /// stashed here instead of being swallowed — mirrors the upstream
-    /// `Bookkeeper.getdesc` semantics
-    /// (`rpython/annotator/bookkeeper.py:353-409`) where construction
-    /// failures are *not* cached and *not* silently dropped: the
-    /// next consumer that consults the entry must observe the failure.
-    /// Pyre's eager pre-pass differs from upstream's lazy `getdesc`
-    /// only in timing; surfacing the recorded error at `cachedgraph`
-    /// (`description.rs:1029-1051`) keeps the failure point
-    /// observable at the same use-site as upstream's lazy chain.
-    pub lift_error: RefCell<Option<String>>,
 }
 
 impl PyreFunctionEntry {
@@ -161,12 +148,12 @@ impl PyreFunctionEntry {
     /// from `cutover::populate_call_registry_from_call_graphs`'s Pass
     /// 2 when `lift_callee_to_pygraph` returns Err.
     pub fn record_lift_error(&self, message: String) {
-        *self.lift_error.borrow_mut() = Some(message);
+        self.function_desc.borrow().record_pyre_lift_error(message);
     }
 
     /// Read the recorded per-entry lift error, if any.
     pub fn lift_error_message(&self) -> Option<String> {
-        self.lift_error.borrow().clone()
+        self.function_desc.borrow().pyre_lift_error_message()
     }
 }
 
@@ -393,7 +380,6 @@ impl PyreCallRegistry {
         let entry = Rc::new(PyreFunctionEntry {
             host_object,
             function_desc,
-            lift_error: RefCell::new(None),
         });
         self.entries.borrow_mut().insert(key, entry.clone());
         entry

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -115,6 +115,19 @@ impl FunctionPathKey {
 pub struct PyreFunctionEntry {
     pub host_object: HostObject,
     pub function_desc: Rc<RefCell<FunctionDesc>>,
+    /// Lazy-failure record for the per-entry lift step.  When
+    /// `populate_call_registry_from_call_graphs`'s
+    /// `lift_callee_to_pygraph` fails on this entry, the error is
+    /// stashed here instead of being swallowed — mirrors the upstream
+    /// `Bookkeeper.getdesc` semantics
+    /// (`rpython/annotator/bookkeeper.py:353-409`) where construction
+    /// failures are *not* cached and *not* silently dropped: the
+    /// next consumer that consults the entry must observe the failure.
+    /// Pyre's eager pre-pass differs from upstream's lazy `getdesc`
+    /// only in timing; surfacing the recorded error at `cachedgraph`
+    /// (`description.rs:1029-1051`) keeps the failure point
+    /// observable at the same use-site as upstream's lazy chain.
+    pub lift_error: RefCell<Option<String>>,
 }
 
 impl PyreFunctionEntry {
@@ -140,6 +153,20 @@ impl PyreFunctionEntry {
             .cache
             .borrow_mut()
             .insert(GraphCacheKey::None, pygraph);
+    }
+
+    /// Record a per-entry lift failure so consumers surfacing through
+    /// `cachedgraph` see the producer-side error instead of the
+    /// generic `buildflowgraph: missing code object` fallback.  Called
+    /// from `cutover::populate_call_registry_from_call_graphs`'s Pass
+    /// 2 when `lift_callee_to_pygraph` returns Err.
+    pub fn record_lift_error(&self, message: String) {
+        *self.lift_error.borrow_mut() = Some(message);
+    }
+
+    /// Read the recorded per-entry lift error, if any.
+    pub fn lift_error_message(&self) -> Option<String> {
+        self.lift_error.borrow().clone()
     }
 }
 
@@ -366,6 +393,7 @@ impl PyreCallRegistry {
         let entry = Rc::new(PyreFunctionEntry {
             host_object,
             function_desc,
+            lift_error: RefCell::new(None),
         });
         self.entries.borrow_mut().insert(key, entry.clone());
         entry

--- a/majit/majit-translate/src/translator/translator.rs
+++ b/majit/majit-translate/src/translator/translator.rs
@@ -278,6 +278,19 @@ pub struct TranslationContext {
     /// role of upstream `flowcontext.py:847 FlowingError.value`'s
     /// preserved cause channel.
     pub _walker_errors: RefCell<HashMap<HostObject, String>>,
+    /// Per-`HostObject` lift-failure record drained from
+    /// `cutover::populate_call_registry_from_call_graphs`'s Pass 2
+    /// failure arm.  When the eager pre-pass cannot lift a callee
+    /// into a `PyGraph`, the error is stashed here (keyed by the
+    /// callee's `HostObject` identity) so a later `buildflowgraph`
+    /// fallback surfaces the actual lift error instead of the
+    /// generic "missing code object" message.  Mirrors
+    /// [`Self::_walker_errors`]'s role for the rust-source walker —
+    /// preserves the producer-side failure point analogous to
+    /// upstream's lazy `getdesc → newfuncdesc → buildgraph` chain
+    /// (`rpython/annotator/bookkeeper.py:353-409`) where the
+    /// original exception propagates.
+    pub _pyre_lift_errors: RefCell<HashMap<HostObject, String>>,
     /// RPython `self.entry_point_graph`. Set by
     /// `RPythonAnnotator.build_types(main_entry_point=True)`.
     pub entry_point_graph: RefCell<Option<GraphRef>>,
@@ -318,6 +331,7 @@ impl TranslationContext {
             _prebuilt_graphs: RefCell::new(HashMap::new()),
             _walker_pygraphs: RefCell::new(HashMap::new()),
             _walker_errors: RefCell::new(HashMap::new()),
+            _pyre_lift_errors: RefCell::new(HashMap::new()),
             entry_point_graph: RefCell::new(None),
         }
     }
@@ -431,6 +445,23 @@ impl TranslationContext {
             }
             drop(graphs);
             return Ok(pygraph);
+        }
+
+        // If the eager pre-pass at
+        // `cutover::populate_call_registry_from_call_graphs` recorded
+        // a lift failure for this host, surface that error instead of
+        // the generic "missing code object" fallback below.  Mirrors
+        // upstream `bookkeeper.getdesc → newfuncdesc → buildgraph`
+        // where the original construction error propagates from the
+        // lazy `cachedgraph` consumer
+        // (`rpython/annotator/description.py:228`).
+        if let Some(lift_err) = self._pyre_lift_errors.borrow().get(&func).cloned() {
+            return Err(format!(
+                "buildflowgraph({}): pyre-side lift failed during \
+                 populate_call_registry_from_call_graphs (recorded \
+                 lazy-failure error): {lift_err}",
+                graph_func.name,
+            ));
         }
 
         let code = graph_func


### PR DESCRIPTION
Fix #37

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

  1. PyPy Parity Regressions Compared To Main
  None found.

  The previous issue I reported is now fixed: lift errors are no longer recorded only on an entry-local dead field. They are stored on majit/
  majit-translate/src/annotator/description.rs:801, and majit/majit-translate/src/annotator/description.rs:1059 now surfaces them on cache
  miss.

  2. Other Mismatches Introduced By This Patch
  None found in the current patch.

  The lift-error path now matches the intended lazy observation point: majit/majit-translate/src/translator/rtyper/cutover.rs:789 records the
  error, majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs:150 writes it to the FunctionDesc, and cachedgraph returns it before
  falling through to generic synthetic-function build failure.

  3. Mismatches That Already Existed Before This Patch
  Two existing structural gaps remain:

  - majit/majit-translate/src/translator/rtyper/legacy_annotator.rs:175 still maps ConstValue::None to Ref because pyre ValueType has no
    dedicated SomeNone. RPython keeps Constant(None) as SomeNone.
  - exceptblock inputargs are still preseeded as Int/Ref in the legacy path. RPython normally binds them through follow_raise_link only when a
    raise edge reaches the exceptblock.

  4. Structural Adaptations
  These look intentional rather than incorrect:

  - FunctionDesc.pyre_lift_error preserves RPython’s lazy cachedgraph -> buildgraph failure surface while pyre does eager lift work.
  - TranslationContext._pyre_lift_errors keeps the same producer-side error visible through buildflowgraph fallback.
  - lower_expr_into_graph_with_signature prebinds opcode-dispatch formal parameters for synthesized arm graphs.
  - registered_result_value_id makes Rust graph registry violations fail loudly instead of silently treating malformed op results like void
    ops.


<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lift failures are isolated per entry and recorded so other items continue to populate; recorded lift errors are surfaced earlier when building graphs.

* **Refactor**
  * Unified handling of void returns and result value resolution across typing/annotation passes.
  * Error formatting now consistently includes message content.

* **New Features**
  * Non-panicking annotator accessor for safer access in tests/runtime.
  * Improved expression lowering to respect function signatures and dispatcher signatures.

* **Tests**
  * Added SSI→SSA rename-propagation test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->