### PR TITLE
X86 fannkuch

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -13938,6 +13938,10 @@ fn collect_terminal_exit_layouts(
 // ---------------------------------------------------------------------------
 
 impl majit_backend::Backend for CraneliftBackend {
+    fn backend_name(&self) -> &'static str {
+        "cranelift"
+    }
+
     fn compile_loop(
         &mut self,
         inputargs: &[InputArg],

--- a/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
@@ -20,10 +20,13 @@ impl Aarch64CpuExt {
         Self
     }
 
-    /// Cross-arch stub matching `X86CpuExt::invalidate_propagate_dependent`.
+    /// Cross-arch stub matching `X86CpuExt::has_propagate_dependent_caches`.
     /// aarch64 doesn't cache propagate / malloc trampolines yet (the
-    /// sequences are inlined per call site), so there is nothing to
-    /// drop here.  When aarch64 grows per-CPU trampolines, mirror the
-    /// x86 invalidation.
-    pub(crate) fn invalidate_propagate_dependent(&mut self) {}
+    /// sequences are inlined per call site), so no baked immediate
+    /// can go stale.  When aarch64 grows per-CPU trampolines, mirror
+    /// the x86 query so `set_propagate_exception_descr` can enforce
+    /// the same attach-once invariant.
+    pub(crate) fn has_propagate_dependent_caches(&self) -> bool {
+        false
+    }
 }

--- a/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
@@ -19,4 +19,11 @@ impl Aarch64CpuExt {
     pub(crate) fn new() -> Self {
         Self
     }
+
+    /// Cross-arch stub matching `X86CpuExt::invalidate_propagate_dependent`.
+    /// aarch64 doesn't cache propagate / malloc trampolines yet (the
+    /// sequences are inlined per call site), so there is nothing to
+    /// drop here.  When aarch64 grows per-CPU trampolines, mirror the
+    /// x86 invalidation.
+    pub(crate) fn invalidate_propagate_dependent(&mut self) {}
 }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3126,6 +3126,24 @@ impl Backend for DynasmBackend {
                 .ensure_malloc_slowpath_fixed(&self.descr_attachments);
         }
     }
+
+    /// `backend/<arch>/__init__.py` parity — pyre's dynasm backend
+    /// spans x86 and aarch64; the active target_arch picks the name.
+    fn backend_name(&self) -> &'static str {
+        #[cfg(target_arch = "x86_64")]
+        {
+            "x86"
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            "aarch64"
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            "dynasm"
+        }
+    }
+
     fn finish_once(&mut self) {}
 }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1787,21 +1787,30 @@ impl Backend for DynasmBackend {
         // The common case is the *same* `Arc<Descr>` arriving twice —
         // idempotent, no observable effect.  Tests that mint a fresh
         // `PropagateExceptionDescr` on every call also reach this
-        // setter; allow the overwrite so the second install does not
-        // panic.  The remaining risk — a *different* descr being
-        // installed *after* the trampoline has baked the previous
-        // pointer as an immediate — is a strictly post-`compile_loop`
-        // hazard; in production the descr is set exactly once before
-        // any compile fires, so this path never executes there.
-        let mut attachments = self.descr_attachments.write().unwrap();
-        if attachments
-            .propagate_exception_descr
-            .as_ref()
-            .is_some_and(|existing| std::sync::Arc::ptr_eq(existing, &descr))
+        // setter, so a non-identical `Arc` is allowed to overwrite the
+        // previous attachment.
+        //
+        // When the `Arc` actually changes after the per-CPU propagate
+        // / malloc trampolines have been built, those trampolines
+        // still carry the *previous* descr pointer baked as an
+        // immediate; OOM exits would write the stale pointer into
+        // `jf_descr` and miss the propagate-exception dispatch.
+        // Invalidate the dependent caches so the next
+        // `ensure_propagate_exception_path` /
+        // `ensure_malloc_slowpath_fixed` rebuilds against the new
+        // descr pointer.
         {
-            return;
+            let mut attachments = self.descr_attachments.write().unwrap();
+            if attachments
+                .propagate_exception_descr
+                .as_ref()
+                .is_some_and(|existing| std::sync::Arc::ptr_eq(existing, &descr))
+            {
+                return;
+            }
+            attachments.propagate_exception_descr = Some(descr);
         }
-        attachments.propagate_exception_descr = Some(descr);
+        self.arch_cpu_ext.invalidate_propagate_dependent();
     }
 
     fn compile_bridge(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1785,32 +1785,37 @@ impl Backend for DynasmBackend {
         // during init (`attach_descrs_to_cpu`, `register_jitdriver_sd`,
         // and `attach_default_test_descrs` for backend-only tests).
         // The common case is the *same* `Arc<Descr>` arriving twice —
-        // idempotent, no observable effect.  Tests that mint a fresh
-        // `PropagateExceptionDescr` on every call also reach this
-        // setter, so a non-identical `Arc` is allowed to overwrite the
-        // previous attachment.
+        // idempotent, no observable effect — so a pointer-equal
+        // `Arc` returns immediately.
         //
-        // When the `Arc` actually changes after the per-CPU propagate
-        // / malloc trampolines have been built, those trampolines
-        // still carry the *previous* descr pointer baked as an
-        // immediate; OOM exits would write the stale pointer into
-        // `jf_descr` and miss the propagate-exception dispatch.
-        // Invalidate the dependent caches so the next
-        // `ensure_propagate_exception_path` /
-        // `ensure_malloc_slowpath_fixed` rebuilds against the new
-        // descr pointer.
+        // PyPy's lifecycle binds `propagate_exception_descr` before
+        // `cpu.setup_once()` (`pyjitpl.py:2273-2283` precedes
+        // `pyjitpl.py:2292-2303`) and never swaps it afterwards.
+        // Pyre upholds the same invariant: a *different* `Arc`
+        // arriving after the propagate / malloc trampolines have
+        // already baked the previous descr pointer would leave
+        // already-compiled loops/bridges writing the orphaned pointer
+        // into `jf_descr` on OOM, missing the propagate-exception
+        // dispatch.  Rather than patch the baked immediates (PyPy
+        // never does so), refuse the swap with a clear assert.  The
+        // pre-bake path (no trampoline yet) keeps overwriting freely
+        // — the next `ensure_*_path` will bake the fresh pointer.
+        let mut attachments = self.descr_attachments.write().unwrap();
+        if attachments
+            .propagate_exception_descr
+            .as_ref()
+            .is_some_and(|existing| std::sync::Arc::ptr_eq(existing, &descr))
         {
-            let mut attachments = self.descr_attachments.write().unwrap();
-            if attachments
-                .propagate_exception_descr
-                .as_ref()
-                .is_some_and(|existing| std::sync::Arc::ptr_eq(existing, &descr))
-            {
-                return;
-            }
-            attachments.propagate_exception_descr = Some(descr);
+            return;
         }
-        self.arch_cpu_ext.invalidate_propagate_dependent();
+        assert!(
+            !self.arch_cpu_ext.has_propagate_dependent_caches(),
+            "set_propagate_exception_descr called with a fresh Arc after \
+             per-CPU propagate/malloc trampolines have already baked the \
+             previous descr pointer; bind propagate_exception_descr once \
+             before backend.setup_once() (pyjitpl.py:2273-2283 ordering)"
+        );
+        attachments.propagate_exception_descr = Some(descr);
     }
 
     fn compile_bridge(

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2697,7 +2697,42 @@ impl<'a> Assembler386<'a> {
                     }
                 }
             }
-            OpCode::IntSub | OpCode::IntMul | OpCode::IntAnd | OpCode::IntOr | OpCode::IntXor => {
+            // x86/assembler.py:1268-1284 `_binaryop_or_lea(asmop='SUB',
+            // is_add=False)`: when `result_loc is arglocs[0]` emit
+            // `SUB dst, src` in place; otherwise the regalloc routed
+            // through `_consider_lea` (consider_int_sub at
+            // x86/regalloc.py:575) and produced a fresh result register,
+            // and we must emit `LEA result_loc, [arglocs[0] - delta]`
+            // — never `SUB dst, src`, which would corrupt `dst`'s stale
+            // value (the bug seen in fannkuch as `q.int_items.ptr - 1`
+            // landing in a fresh result register that previously held
+            // the base pointer).  IntMul / IntAnd / IntOr / IntXor never
+            // take the LEA path (regalloc.rs:2960 routes them through
+            // `consider_binop_symm` which keeps result==arglocs[0]), so
+            // a plain in-place op is correct for them.
+            OpCode::IntSub => {
+                if let (Some(Loc::Reg(dst)), Some(a0), Some(src)) =
+                    (result_loc, arglocs.first(), arglocs.get(1))
+                {
+                    let same_as_lhs = matches!(a0, Loc::Reg(a) if a.value == dst.value);
+                    if same_as_lhs {
+                        self.emit_binop_reg_loc(op.opcode, dst.value, src);
+                    } else {
+                        match (a0, src) {
+                            (Loc::Reg(a), Loc::Immed(i)) => {
+                                let v = -(i.value as i32);
+                                dynasm!(self.mc ; .arch x64
+                                    ; lea Rq(dst.value), [Rq(a.value) + v])
+                            }
+                            _ => panic!(
+                                "IntSub: result_loc != arglocs[0] requires LEA form \
+                                 (arglocs[0]=Reg, arglocs[1]=Immed); got a0={a0:?} src={src:?}",
+                            ),
+                        }
+                    }
+                }
+            }
+            OpCode::IntMul | OpCode::IntAnd | OpCode::IntOr | OpCode::IntXor => {
                 if let (Some(Loc::Reg(dst)), Some(src)) = (result_loc, arglocs.get(1)) {
                     self.emit_binop_reg_loc(op.opcode, dst.value, src);
                 }
@@ -7280,42 +7315,46 @@ impl<'a> Assembler386<'a> {
 
         let nf = nf_addr as i64;
         let nt = nt_addr as i64;
+        // assembler.py:2556 `malloc_cond` clobbers only ECX/EDX (the pair
+        // regalloc spilled via MALLOC_NURSERY_CLOBBER) because PyPy's
+        // encoder supports `MOV [imm64], reg` directly.  dynasm-rs has no
+        // such encoding so we need a third register to stage the absolute
+        // nursery slot addresses; use R11 (X86_64_SCRATCH_REG, outside
+        // ALL_CORE_REGS) instead of RAX — RAX is in the regalloc pool and
+        // clobbering it would silently destroy any live Box the regalloc
+        // bound to it.  The slow path preserves RAX via push_all_regs.
+        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
 
         // ecx = nursery_free, edx = new nursery_free
         dynasm!(self.mc ; .arch x64
-            ; mov rcx, QWORD nf
-            ; mov rcx, [rcx]
+            ; mov Rq(scratch), QWORD nf
+            ; mov rcx, [Rq(scratch)]
             ; lea rdx, [rcx + total_size as i32]
-            ; mov rax, QWORD nt
-            ; cmp rdx, [rax]
+            ; mov Rq(scratch), QWORD nt
+            ; cmp rdx, [Rq(scratch)]
         );
 
         let slow_path = self.mc.new_dynamic_label();
         let done = self.mc.new_dynamic_label();
         dynasm!(self.mc ; .arch x64 ; ja =>slow_path);
 
-        // Fast path: update nursery_free, zero header, compute obj ptr
+        // Fast path: update nursery_free, zero header, compute obj ptr.
+        // Stage the `*nf = new_free` store through R11; materialise the
+        // payload pointer directly into `result_reg` (regalloc forces it
+        // to ECX, MALLOC_NURSERY_RESULT) so both paths converge with the
+        // payload in the same register.
         dynasm!(self.mc ; .arch x64
-            ; mov rax, QWORD nf
-            ; mov [rax], rdx
+            ; mov Rq(scratch), QWORD nf
+            ; mov [Rq(scratch)], rdx
             ; mov QWORD [rcx], 0       // zero GcHeader
-            ; lea rax, [rcx + gc_header_size as i32]
         );
-        // Mirror the slow-path's copy of `rax` into the result register
-        // so the post-`done` read at the join (`mov rax, Rq(result_reg)`)
-        // observes the past-header payload pointer from both paths.
-        // Without this, the fast path leaves only `rax` updated and the
-        // join read reverts `rax` to the stale `result_reg`, causing
-        // subsequent `mov [result + (-WORD)], type_id` writes (which use
-        // the result-register-relative addressing for the GcHeader slot)
-        // to land outside the nursery — corrupting the heap-manager's
-        // HEAP_ENTRY metadata for the nursery block.
-        if let Some(Loc::Reg(r)) = result_loc {
-            if r.value != 0 {
-                let rv = r.value;
-                dynasm!(self.mc ; .arch x64 ; mov Rq(rv), rax);
-            }
-        }
+        let result_reg_for_payload = match result_loc {
+            Some(Loc::Reg(r)) => r.value,
+            _ => crate::regloc::ECX.value,
+        };
+        dynasm!(self.mc ; .arch x64
+            ; lea Rq(result_reg_for_payload), [rcx + gc_header_size as i32]
+        );
         dynasm!(self.mc ; .arch x64 ; jmp =>done);
 
         // Slow path: helper extraction (PyPy assembler.py:295 `mc.CALL`).
@@ -7326,10 +7365,19 @@ impl<'a> Assembler386<'a> {
         } else {
             dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
         }
+        // Stage the trampoline address through R11 so RAX still holds
+        // the caller's pre-call value at the trampoline entry — its
+        // `push_all_regs_to_frame([ECX, EDX])` then saves the real RAX,
+        // and the matching pop restores it after the helper call.
+        // Loading `helper_addr` into RAX here (the previous shape) would
+        // clobber the caller's RAX, and the trampoline would save+restore
+        // that already-clobbered value, silently dropping any live Box
+        // the regalloc kept in RAX across this op.
         let helper_addr = self.malloc_slowpath_fixed as i64;
+        let call_scratch = crate::regloc::X86_64_SCRATCH_REG.value;
         dynasm!(self.mc ; .arch x64
-            ; mov rax, QWORD helper_addr
-            ; call rax
+            ; mov Rq(call_scratch), QWORD helper_addr
+            ; call Rq(call_scratch)
         );
         // assembler.py:304 — helper returns the payload in ECX
         // (`MOV_rr(ecx, eax)` inside the trampoline) so the value
@@ -7338,8 +7386,8 @@ impl<'a> Assembler386<'a> {
         // (regalloc.rs:105), so the value already lives in the right
         // register and no caller-side copy is needed.  If a future
         // regalloc change picks a different `result_reg`, copy it
-        // from RCX (not RAX, which was restored to its pre-call
-        // value by the trampoline's pop_all).
+        // from RCX (not RAX, which is now the caller's preserved
+        // pre-call value, not the helper return).
         //
         // OOM propagation: assembler.py:300-322 emits the `TEST/JZ
         // propagate_exception_path` *inside* the slowpath itself, and
@@ -7358,13 +7406,24 @@ impl<'a> Assembler386<'a> {
         dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
 
         dynasm!(self.mc ; .arch x64 ; =>done);
-        if !op.pos.get().is_none() {
-            if let Some(Loc::Reg(r)) = result_loc {
-                if r.value != 0 {
-                    dynasm!(self.mc ; .arch x64 ; mov rax, Rq(r.value));
+        // Spill the result to the regalloc-assigned jitframe slot.  Stage
+        // it directly from `result_reg`; routing through RAX (the previous
+        // shape) silently clobbered any live Box the regalloc bound to
+        // RAX across this op, since the malloc-nursery clobber set is
+        // only ECX/EDX.
+        let pos = op.pos.get();
+        if !pos.is_none() {
+            let slot = self.allocate_slot(pos);
+            let offset = Self::slot_offset(slot);
+            match result_loc {
+                Some(Loc::Reg(r)) => {
+                    let rv = r.value;
+                    dynasm!(self.mc ; .arch x64 ; mov [rbp + offset], Rq(rv));
+                }
+                _ => {
+                    dynasm!(self.mc ; .arch x64 ; mov [rbp + offset], rax);
                 }
             }
-            self.store_rax_to_result(op.pos.get());
         }
     }
 

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -6514,6 +6514,15 @@ impl<'a> Assembler386<'a> {
     /// aarch64/opassembler.py:1036 _emit_call.
     /// arglocs = [resloc, size, sign, func, args...] for normal CALLs and
     /// [resloc, size, sign, saveerr, func, args...] for CALL_RELEASE_GIL.
+    ///
+    /// Register-bound arg moves go through `remap_frame_layout_mixed`
+    /// (a parallel-move algorithm) mirroring x86/callbuilder.py:584
+    /// `prepare_arguments` → `remap_frame_layout`.  Emitting them naively
+    /// in source order broke Win64 where two args could map to the same
+    /// dst-then-src register (e.g. arg0 → rcx clobbering Reg(rcx) before
+    /// arg1 reads it as Gpr(rdx)).  Linux SysV escaped the same code
+    /// path because its rdi/rsi placement happened not to collide with
+    /// regalloc-chosen rcx/rdx for these traces.
     fn emit_call_from_arglocs(&mut self, op: &Op, arglocs: &[Loc], func_index: usize) {
         let arg_count = arglocs.len();
         let call_arg_count = arg_count.saturating_sub(func_index + 1);
@@ -6529,48 +6538,79 @@ impl<'a> Assembler386<'a> {
         dynasm!(self.mc ; .arch x64 ; push rbp);
         let call_area_adjust = self.emit_reserve_abi_call_area(1, stack_slots);
 
+        // Pass 1: emit stack-dst args first.  Their sources may be
+        // registers the parallel move below will overwrite, but stack
+        // writes never disturb registers, so doing them up front keeps
+        // every register source live for Pass 2.
         for i in (func_index + 1)..arg_count {
             let abi_idx = i - func_index - 1;
             let placement = placements[abi_idx];
+            if !matches!(placement, AbiArgPlacement::Stack(_)) {
+                continue;
+            }
             let arg_type = arg_types[abi_idx];
             let arg = &arglocs[i];
             match arg {
-                Loc::Frame(f) => {
-                    let offset = f.ebp_loc.value;
-                    self.emit_abi_arg_from_mem(placement, offset, arg_type);
-                }
+                Loc::Frame(f) => self.emit_abi_arg_from_mem(placement, f.ebp_loc.value, arg_type),
                 Loc::Reg(r) => self.emit_abi_arg_from_reg(placement, *r, arg_type),
-                Loc::Immed(i) => {
-                    let val = i.value;
-                    self.emit_abi_arg_from_imm(placement, val, arg_type);
-                }
+                Loc::Immed(i) => self.emit_abi_arg_from_imm(placement, i.value, arg_type),
                 _ => {}
             }
         }
 
-        match arglocs.get(func_index) {
-            Some(Loc::Frame(f)) => {
-                let offset = f.ebp_loc.value;
-                dynasm!(self.mc ; .arch x64
-                    ; mov rax, [rbp + offset]
-                    ; call rax
-                );
+        // Pass 2: parallel-move register-bound args (GPR and XMM groups
+        // separately).  If the call target itself is a register, append
+        // it to the int group with rax as the dst so the move algorithm
+        // sees the dependency — otherwise loading the target after the
+        // move could read a register whose old value has just been
+        // overwritten by Gpr(reg)-placed args.
+        let mut int_src: Vec<Loc> = Vec::new();
+        let mut int_dst: Vec<Loc> = Vec::new();
+        let mut xmm_src: Vec<Loc> = Vec::new();
+        let mut xmm_dst: Vec<Loc> = Vec::new();
+        for i in (func_index + 1)..arg_count {
+            let abi_idx = i - func_index - 1;
+            let placement = placements[abi_idx];
+            let arg = arglocs[i];
+            match placement {
+                AbiArgPlacement::Gpr(dst_reg) => {
+                    int_src.push(arg);
+                    int_dst.push(Loc::Reg(crate::regloc::RegLoc::new(dst_reg, false)));
+                }
+                AbiArgPlacement::Xmm(dst_reg) => {
+                    xmm_src.push(arg);
+                    xmm_dst.push(Loc::Reg(crate::regloc::RegLoc::new(dst_reg, true)));
+                }
+                AbiArgPlacement::Stack(_) => {}
             }
-            Some(Loc::Reg(r)) => {
-                dynasm!(self.mc ; .arch x64
-                    ; mov rax, Rq(r.value)
-                    ; call rax
-                );
-            }
-            Some(Loc::Immed(i)) => {
-                let val = i.value;
-                dynasm!(self.mc ; .arch x64
-                    ; mov rax, QWORD val
-                    ; call rax
-                );
-            }
-            _ => {}
         }
+        let func_in_rax_after_move = matches!(arglocs.get(func_index), Some(Loc::Reg(_)));
+        if let Some(Loc::Reg(r)) = arglocs.get(func_index) {
+            int_src.push(Loc::Reg(*r));
+            int_dst.push(Loc::Reg(crate::regloc::RegLoc::new(0, false))); // rax
+        }
+        let tmpreg1 = Loc::Reg(crate::regloc::X86_64_SCRATCH_REG);
+        let tmpreg2 = Loc::Reg(crate::regloc::XMM15);
+        self.remap_frame_layout_mixed(&int_src, &int_dst, tmpreg1, &xmm_src, &xmm_dst, tmpreg2);
+
+        // Call.  For Immed/Frame targets, load rax now (parallel move
+        // never touches rax or rbp, so this is safe).  For Reg targets,
+        // the parallel move above already left the function pointer in
+        // rax.
+        if !func_in_rax_after_move {
+            match arglocs.get(func_index) {
+                Some(Loc::Frame(f)) => {
+                    let offset = f.ebp_loc.value;
+                    dynasm!(self.mc ; .arch x64 ; mov rax, [rbp + offset]);
+                }
+                Some(Loc::Immed(i)) => {
+                    let val = i.value;
+                    dynasm!(self.mc ; .arch x64 ; mov rax, QWORD val);
+                }
+                _ => {}
+            }
+        }
+        dynasm!(self.mc ; .arch x64 ; call rax);
 
         self.emit_release_abi_call_area(call_area_adjust);
         dynasm!(self.mc ; .arch x64 ; pop rbp);

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -96,4 +96,23 @@ impl X86CpuExt {
         self.malloc_slowpath_fixed = Some(addr);
         addr
     }
+
+    /// Drop cached trampolines that bake `propagate_exception_descr`
+    /// as an immediate.  Called from
+    /// `DynasmBackend::set_propagate_exception_descr` whenever the
+    /// attached descr `Arc` is replaced (test harnesses that re-mint
+    /// the descr per setup), so the next
+    /// `ensure_propagate_exception_path` / `ensure_malloc_slowpath_fixed`
+    /// rebuilds against the new pointer instead of routing OOM exits
+    /// through a stale baked descr.
+    ///
+    /// Both addresses must clear together: `build_malloc_slowpath_fixed`
+    /// bakes the propagate-path entry as an immediate, so a fresh
+    /// propagate path requires a fresh malloc slowpath too.
+    pub(crate) fn invalidate_propagate_dependent(&mut self) {
+        self.malloc_slowpath_fixed = None;
+        self._malloc_slowpath_fixed_buffer = None;
+        self.propagate_exception_path = None;
+        self._propagate_exception_path_buffer = None;
+    }
 }

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -97,22 +97,19 @@ impl X86CpuExt {
         addr
     }
 
-    /// Drop cached trampolines that bake `propagate_exception_descr`
-    /// as an immediate.  Called from
-    /// `DynasmBackend::set_propagate_exception_descr` whenever the
-    /// attached descr `Arc` is replaced (test harnesses that re-mint
-    /// the descr per setup), so the next
-    /// `ensure_propagate_exception_path` / `ensure_malloc_slowpath_fixed`
-    /// rebuilds against the new pointer instead of routing OOM exits
-    /// through a stale baked descr.
-    ///
-    /// Both addresses must clear together: `build_malloc_slowpath_fixed`
-    /// bakes the propagate-path entry as an immediate, so a fresh
-    /// propagate path requires a fresh malloc slowpath too.
-    pub(crate) fn invalidate_propagate_dependent(&mut self) {
-        self.malloc_slowpath_fixed = None;
-        self._malloc_slowpath_fixed_buffer = None;
-        self.propagate_exception_path = None;
-        self._propagate_exception_path_buffer = None;
+    /// Whether either trampoline that bakes `propagate_exception_descr`
+    /// as an immediate has already been materialised.  Used by
+    /// `DynasmBackend::set_propagate_exception_descr` to refuse a
+    /// non-identical `Arc` swap after the bake: such a swap would
+    /// leave previously-compiled loops/bridges (whose `JMP` immediates
+    /// point at this buffer's RX pages and whose helpers carry the
+    /// old descr pointer) referencing a now-orphaned descr.  PyPy
+    /// attaches `propagate_exception_descr` once before
+    /// `cpu.setup_once()` and never replaces it
+    /// (`pyjitpl.py:2273-2283` precedes `pyjitpl.py:2292-2303`); pyre
+    /// upholds the same invariant by panicking instead of dropping
+    /// the buffer.
+    pub(crate) fn has_propagate_dependent_caches(&self) -> bool {
+        self.malloc_slowpath_fixed.is_some() || self.propagate_exception_path.is_some()
     }
 }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -291,6 +291,10 @@ impl WasmBackend {
 unsafe impl Send for WasmBackend {}
 
 impl majit_backend::Backend for WasmBackend {
+    fn backend_name(&self) -> &'static str {
+        "wasm"
+    }
+
     fn compile_loop(
         &mut self,
         inputargs: &[InputArg],

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2581,6 +2581,28 @@ pub trait Backend: Send {
     /// override this; default is no-op for backends without
     /// setup-time work.
     fn setup_once(&mut self) {}
+
+    /// `backend/x86/vector_ext.py:55 setup_once(asm)` parity, called
+    /// by `pyjitpl.py:2298-2299
+    /// `if self.cpu.vector_ext: self.cpu.vector_ext.setup_once(...)`
+    /// inside `MetaInterpStaticData._setup_once`.  Backends with a
+    /// vector extension override this; pyre's x86 / aarch64 / wasm /
+    /// cranelift backends have no vector_ext today (the optimizeopt
+    /// vector pass has no runtime setup hook yet), so the default
+    /// no-op is the honest port.
+    fn vector_ext_setup_once(&mut self) {}
+
+    /// pyjitpl.py:2215-2217 `backendmodule = self.cpu.__module__
+    /// .split('.')[-2]` parity — backend identifier used in
+    /// `self.jit_starting_line = 'JIT starting (%s)' % backendmodule`
+    /// (`pyjitpl.py:2296` `debug_print(self.jit_starting_line)`).
+    /// RPython derives it by reflection on the CPU module path;
+    /// pyre returns a literal because the backend struct already
+    /// knows its own name at compile time.
+    fn backend_name(&self) -> &'static str {
+        "unknown"
+    }
+
     /// model.py: finish_once() — called when the JIT shuts down.
     fn finish_once(&mut self) {}
 

--- a/majit/majit-backend/src/synthetic_cpu.rs
+++ b/majit/majit-backend/src/synthetic_cpu.rs
@@ -84,6 +84,10 @@ impl SyntheticCpu {
 }
 
 impl crate::Backend for SyntheticCpu {
+    fn backend_name(&self) -> &'static str {
+        "synthetic"
+    }
+
     /// `rpython/jit/backend/model.py:79-91` declares `compile_loop` on every
     /// `AbstractCPU`.  SyntheticCpu does not produce native code; this method
     /// must never be reached.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -936,6 +936,18 @@ impl<S: JitState> JitDriver<S> {
 
     pub fn with_descriptor(threshold: u32, descriptor: JitDriverStaticData) -> Self {
         let mut driver = Self::new(threshold);
+        // `pyjitpl.py:2273-2283 finish_setup_descrs_for_jitdrivers` —
+        // production `JitDriver` consumers reach this via
+        // `register_descriptor` (called from the macro-emitted
+        // `__JitMeta::install_canonical_liveness`).  `with_descriptor`
+        // skips registration on purpose (it is a "pre-built descriptor"
+        // shortcut used by integration tests and `with_declarative`),
+        // so the propagate-exception descr would otherwise stay
+        // unattached and the first `backend.compile_loop` would build
+        // a per-CPU trampoline against a NULL descr pointer
+        // (`x86/assembler.rs:238`).  The call is idempotent — a later
+        // `register_descriptor` re-uses the same `Arc` by identity.
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         // warmstate.py:564 `_green_args_spec` carries lltype TYPE per
         // green arg, including `Ptr(rstr.STR)` / `Ptr(rstr.UNICODE)`
         // distinct from generic Ptr.  `JitDriverVar.green_type` is the

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -936,18 +936,6 @@ impl<S: JitState> JitDriver<S> {
 
     pub fn with_descriptor(threshold: u32, descriptor: JitDriverStaticData) -> Self {
         let mut driver = Self::new(threshold);
-        // `pyjitpl.py:2273-2283 finish_setup_descrs_for_jitdrivers` —
-        // production `JitDriver` consumers reach this via
-        // `register_descriptor` (called from the macro-emitted
-        // `__JitMeta::install_canonical_liveness`).  `with_descriptor`
-        // skips registration on purpose (it is a "pre-built descriptor"
-        // shortcut used by integration tests and `with_declarative`),
-        // so the propagate-exception descr would otherwise stay
-        // unattached and the first `backend.compile_loop` would build
-        // a per-CPU trampoline against a NULL descr pointer
-        // (`x86/assembler.rs:238`).  The call is idempotent — a later
-        // `register_descriptor` re-uses the same `Arc` by identity.
-        driver.meta.finish_setup_descrs_for_jitdrivers();
         // warmstate.py:564 `_green_args_spec` carries lltype TYPE per
         // green arg, including `Ptr(rstr.STR)` / `Ptr(rstr.UNICODE)`
         // distinct from generic Ptr.  `JitDriverVar.green_type` is the
@@ -968,6 +956,15 @@ impl<S: JitState> JitDriver<S> {
             name: "primary".to_string(),
             schema: greens,
         });
+        // PyPy's `finish_setup` (`pyjitpl.py:2273-2283`) wires
+        // `portal_finishtoken` / `propagate_exc_descr` after the driver
+        // is present in `metainterp_sd.jitdrivers_sd`.  Register the
+        // pre-built descriptor now so the existing
+        // `register_jitdriver_sd` tail call performs that wiring on the
+        // actual jitdriver slot, not just on the CPU-global propagate
+        // descr.  Later macro-emitted `ensure_descriptor_registered`
+        // calls are idempotent because the descriptor now has an index.
+        driver.ensure_descriptor_registered();
         driver
     }
 
@@ -4223,6 +4220,7 @@ mod tests {
     #[test]
     fn jit_merge_point_only_drives_active_trace() {
         let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let key = 123u64;
         let mut state = TypedRestoreState {
             live_values: vec![1],
@@ -4267,6 +4265,7 @@ mod tests {
     #[test]
     fn blackhole_jump_reports_via_blackhole_even_with_typed_restore_values() {
         let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let key = 9u64;
 
         assert!(matches!(
@@ -4311,6 +4310,7 @@ mod tests {
     #[test]
     fn run_compiled_detailed_keyed_uses_typed_live_inputs() {
         let mut driver = JitDriver::<TypedInputState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let key = 11u64;
         // Input 0 is Int (used as GuardFalse condition); inputs 1/2 are
         // Ref/Float so the typed restore path still exercises mixed types.
@@ -4371,6 +4371,7 @@ mod tests {
     #[test]
     fn blackhole_fallback_uses_typed_live_inputs() {
         let mut driver = JitDriver::<TypedInputState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let key = 12u64;
         // Input 0 is Int (used as GuardFalse condition); inputs 1/2 are
         // Ref/Float so the typed restore path still exercises mixed types.
@@ -4438,6 +4439,7 @@ mod tests {
         // counter.py: compute_threshold(1) = 1.0/(1-0.001) ≈ 1.001
         // First tick adds ≈1.001 to 0.0, reaching ≥1.0 immediately.
         let mut driver = JitDriver::<TypedRestoreState>::new(1);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let key = 500u64;
         assert!(matches!(
             driver.meta.on_back_edge(key, &[]),
@@ -4448,6 +4450,7 @@ mod tests {
     #[test]
     fn test_set_param_threshold() {
         let mut driver = JitDriver::<TypedRestoreState>::new(10);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         // Initially threshold is 10 — not hot after 2 ticks.
         let key = 100u64;
         assert!(matches!(
@@ -4476,6 +4479,7 @@ mod tests {
     #[test]
     fn test_get_stats_after_compile() {
         let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let key = 300u64;
 
         // Stats should be zero initially.
@@ -4520,6 +4524,7 @@ mod tests {
     #[test]
     fn test_set_param_unknown_ignored() {
         let mut driver = JitDriver::<TypedRestoreState>::new(5);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         // Unknown params should not panic or cause any side effects.
         driver.set_param("nonexistent_param", 999);
         driver.set_param("", 0);
@@ -4593,6 +4598,7 @@ mod tests {
         use std::sync::{Arc, Mutex};
 
         let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let compile_events: Arc<Mutex<Vec<(u64, usize, usize)>>> = Arc::new(Mutex::new(Vec::new()));
         let events = compile_events.clone();
         driver.set_on_compile_loop(move |green_key, ops_before, ops_after| {
@@ -4641,6 +4647,7 @@ mod tests {
     #[test]
     fn test_hook_get_stats_matches_real_compile_count() {
         let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
 
         // Initially zero.
         let stats = driver.get_stats();
@@ -4680,6 +4687,7 @@ mod tests {
         use std::sync::{Arc, Mutex};
 
         let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let bridge_events: Arc<Mutex<Vec<(u64, u32, usize)>>> = Arc::new(Mutex::new(Vec::new()));
         let ev = bridge_events.clone();
         driver.meta.set_on_compile_bridge(move |gk, fi, nops| {
@@ -4762,6 +4770,7 @@ mod tests {
     #[test]
     fn test_start_bridge_tracing_skips_non_traceable_state() {
         let mut driver = JitDriver::<NonTraceableState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 404u64;
         assert!(matches!(
             driver.meta.on_back_edge(green_key, &[0]),
@@ -4803,6 +4812,7 @@ mod tests {
     #[test]
     fn test_multi_entry_point_registration() {
         let mut driver = JitDriver::<TypedRestoreState>::new(1);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
 
         // Initially no entry points.
         assert!(driver.entry_points().is_empty());
@@ -4838,6 +4848,7 @@ mod tests {
         // from any entry point, since they share the same MetaInterp and
         // compiled loop table (keyed by green_key, not by entry point name).
         let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         driver.register_entry_point("func_a", &[Type::Int]);
         driver.register_entry_point("func_b", &[Type::Int]);
 
@@ -4927,6 +4938,7 @@ mod tests {
         let expected = asm.all_liveness().to_vec();
 
         let mut driver = JitDriver::<TypedRestoreState>::new(0);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
         driver.install_canonical_liveness(&asm);
 
         assert_eq!(driver.meta.staticdata.liveness_info, expected);

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -108,14 +108,45 @@ impl JitProfiler {
     /// signal (pyjitpl.py:2300-2302).
     ///
     /// Returns whether `start()` actually ran the initialisation
-    /// (`false` if `initialized` was already set).  Counters / calls
-    /// are not reset here — pyre creates the profiler via
-    /// `Default::default()` which already zeros every slot, and
-    /// post-`start()` resets would discard counts accumulated by
-    /// out-of-band callers (eg. tests that count_ops before
-    /// `_setup_once`).
+    /// (`false` if `initialized` was already set).  On the first
+    /// real call every counter is zeroed to match upstream's
+    /// `self.counters = [0] * ncounters; self.calls = 0` reset
+    /// (jitprof.py:63-64).  Out-of-band counts accumulated before
+    /// `_setup_once` (e.g. fixture-driven `count_ops` calls) are
+    /// discarded by design — the canonical "session start" moment
+    /// is when `_setup_once` flips `initialized`.
     pub fn start(&self) -> bool {
-        !self.initialized.swap(true, Ordering::AcqRel)
+        if self.initialized.swap(true, Ordering::AcqRel) {
+            return false;
+        }
+        for field in [
+            &self.tracing,
+            &self.backend,
+            &self.ops,
+            &self.heapcached_ops,
+            &self.recorded_ops,
+            &self.guards,
+            &self.opt_ops,
+            &self.opt_guards,
+            &self.opt_guards_shared,
+            &self.opt_forcings,
+            &self.opt_vectorize_try,
+            &self.opt_vectorized,
+            &self.abort_too_long,
+            &self.abort_bridge,
+            &self.abort_bad_loop,
+            &self.abort_escape,
+            &self.abort_force_quasiimmut,
+            &self.abort_segmented_trace,
+            &self.force_virtualizables,
+            &self.nvirtuals,
+            &self.nvholes,
+            &self.nvreused,
+            &self.calls,
+        ] {
+            field.store(0, Ordering::Relaxed);
+        }
+        true
     }
 
     /// jitprof.py:118-122 `Profiler.count_ops(opnum, kind=Counters.OPS)`.

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -95,30 +95,21 @@ pub struct JitProfiler {
     pub calls: AtomicUsize,
     /// pyjitpl.py:2300-2302 `_setup_once` guard — `if not
     /// self.profiler.initialized: self.profiler.start(); ...
-    /// initialized = True`.  Pyre carries the flag on the profiler
-    /// itself (instead of on `MetaInterpStaticData.globaldata`) so
-    /// `start()` is self-contained and idempotent without needing the
-    /// staticdata mutex.
+    /// initialized = True`.  RPython keeps this flag separate from
+    /// `Profiler.start()`: `start()` always resets counters, while
+    /// `_setup_once` decides whether to call it.
     pub initialized: AtomicBool,
 }
 
 impl JitProfiler {
-    /// jitprof.py:55-61 `Profiler.start`.  Idempotent because the
-    /// `initialized` flag is the canonical "has start ever run?"
-    /// signal (pyjitpl.py:2300-2302).
+    /// jitprof.py:55-61 `Profiler.start`.
     ///
-    /// Returns whether `start()` actually ran the initialisation
-    /// (`false` if `initialized` was already set).  On the first
-    /// real call every counter is zeroed to match upstream's
-    /// `self.counters = [0] * ncounters; self.calls = 0` reset
-    /// (jitprof.py:63-64).  Out-of-band counts accumulated before
-    /// `_setup_once` (e.g. fixture-driven `count_ops` calls) are
-    /// discarded by design — the canonical "session start" moment
-    /// is when `_setup_once` flips `initialized`.
-    pub fn start(&self) -> bool {
-        if self.initialized.swap(true, Ordering::AcqRel) {
-            return false;
-        }
+    /// Not idempotent by design: upstream `Profiler.start()` resets
+    /// `self.counters` and `self.calls` every time it is called.  The
+    /// one-shot guard lives at the caller (`pyjitpl.py:2300-2302`
+    /// `_setup_once`: `if not self.profiler.initialized: ...`), not
+    /// inside `start()`.
+    pub fn start(&self) {
         for field in [
             &self.tracing,
             &self.backend,
@@ -146,7 +137,6 @@ impl JitProfiler {
         ] {
             field.store(0, Ordering::Relaxed);
         }
-        true
     }
 
     /// jitprof.py:118-122 `Profiler.count_ops(opnum, kind=Counters.OPS)`.

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -12,7 +12,7 @@
 //! relationship between any two counter updates, and we only ever publish
 //! totals via [`JitProfiler::snapshot`] which itself is `Relaxed`.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use majit_ir::OpCode;
 
@@ -93,9 +93,31 @@ pub struct JitProfiler {
     /// jitprof.Profiler.calls — `count_ops` increments this when the op
     /// is a CALL_* and `kind == RECORDED_OPS` (jitprof.py:121-122).
     pub calls: AtomicUsize,
+    /// pyjitpl.py:2300-2302 `_setup_once` guard — `if not
+    /// self.profiler.initialized: self.profiler.start(); ...
+    /// initialized = True`.  Pyre carries the flag on the profiler
+    /// itself (instead of on `MetaInterpStaticData.globaldata`) so
+    /// `start()` is self-contained and idempotent without needing the
+    /// staticdata mutex.
+    pub initialized: AtomicBool,
 }
 
 impl JitProfiler {
+    /// jitprof.py:55-61 `Profiler.start`.  Idempotent because the
+    /// `initialized` flag is the canonical "has start ever run?"
+    /// signal (pyjitpl.py:2300-2302).
+    ///
+    /// Returns whether `start()` actually ran the initialisation
+    /// (`false` if `initialized` was already set).  Counters / calls
+    /// are not reset here — pyre creates the profiler via
+    /// `Default::default()` which already zeros every slot, and
+    /// post-`start()` resets would discard counts accumulated by
+    /// out-of-band callers (eg. tests that count_ops before
+    /// `_setup_once`).
+    pub fn start(&self) -> bool {
+        !self.initialized.swap(true, Ordering::AcqRel)
+    }
+
     /// jitprof.py:118-122 `Profiler.count_ops(opnum, kind=Counters.OPS)`.
     ///
     /// ```python

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2890,7 +2890,8 @@ impl<M: Clone> MetaInterp<M> {
         // `cpu.setup_once()` (`pyjitpl.py:2292-2303`).  Pyre's
         // back-edge entry routes through `bound_reached`, so the
         // gate fires here.  Idempotent.
-        self.staticdata._setup_once(&mut self.backend);
+        self.staticdata
+            ._setup_once(&mut self.backend, &mut self.warm_state);
 
         if self.tracing.is_some() {
             return BackEdgeAction::AlreadyTracing;
@@ -13806,6 +13807,14 @@ pub struct MetaInterpStaticData {
     /// bump.  Each fetch_add is `Relaxed` — counters have no causal
     /// dependency on each other.
     pub profiler: crate::jitprof::JitProfiler,
+    /// pyjitpl.py:2217 `self.jit_starting_line = 'JIT starting (%s)' %
+    /// backendmodule`.  RPython captures the backend module name (eg.
+    /// `'x86'`, `'aarch64'`) at MetaInterp construction and
+    /// `_setup_once` `debug_print`s it once on the first warmup.
+    /// Pyre fills this in `register_backend_name` (called by
+    /// whichever crate brings up the backend) so it travels with the
+    /// staticdata Arc.
+    pub jit_starting_line: String,
 }
 
 /// pyjitpl.py:2357-2373 `class MetaInterpGlobalData`.
@@ -14478,34 +14487,82 @@ impl MetaInterpStaticData {
         }
     }
 
-    /// pyjitpl.py:2292-2303 `_setup_once` — narrow port.
+    /// pyjitpl.py:2292-2303 `_setup_once`.
     ///
-    /// Guarded by `globaldata.initialized` so the body runs exactly
-    /// once per CPU after `finish_setup` has installed every descr
-    /// (`pyjitpl.py:2255`, `pyjitpl.py:2283`).
+    /// PyPy:
+    /// ```python
+    /// def _setup_once(self):
+    ///     if not self.globaldata.initialized:
+    ///         self.jitlog.setup_once()
+    ///         debug_print(self.jit_starting_line)
+    ///         self.cpu.setup_once()
+    ///         if self.cpu.vector_ext:
+    ///             self.cpu.vector_ext.setup_once(self.cpu.assembler)
+    ///         if not self.profiler.initialized:
+    ///             self.profiler.start()
+    ///             self.profiler.initialized = True
+    ///         self.globaldata.initialized = True
+    /// ```
     ///
-    /// PRE-EXISTING-ADAPTATION: PyPy's `_setup_once` invokes four
-    /// lifecycle hooks in sequence — `profiler.start()`,
-    /// `cpu.setup_once()`, `jitlog.setup_once()`, and
-    /// `vector_ext.setup_once()` (with `debug_print` interleaved).
-    /// Pyre only dispatches `cpu.setup_once()` here because the
-    /// profiler / jitlog / vector_ext subsystems are not yet wired
-    /// in pyre; the other three hooks will be added as those
-    /// subsystems land.  `cpu.setup_once()`
-    /// (`pyjitpl.py:2297 self.cpu.setup_once()`) is the call that
-    /// materialises the per-CPU malloc / propagate trampolines in
-    /// PyPy (`llsupport/assembler.py:97 setup_once`).
+    /// Each hook is dispatched in the same order:
+    ///
+    /// 1. `jitlog.setup_once()` — `setup_once_jitlog` walks the
+    ///    registered jitdrivers and forces each `WarmEnterState`'s
+    ///    `Logger::from_env` to materialise (pyre adapts PyPy's
+    ///    single staticdata-owned `JitLogger` into a per-jitdriver
+    ///    `Logger`).
+    /// 2. `debug_print(self.jit_starting_line)` — prints to stderr
+    ///    when `MAJIT_LOG` is set, matching PyPy's `PYPYLOG`-gated
+    ///    `debug_print`.  `jit_starting_line` is filled in here
+    ///    from `backend.backend_name()` if `register_backend_name`
+    ///    has not been called explicitly.
+    /// 3. `cpu.setup_once()` — backends materialise per-CPU
+    ///    trampolines (x86 `_build_propagate_exception_path` /
+    ///    `_build_malloc_slowpath`).
+    /// 4. `cpu.vector_ext.setup_once(cpu.assembler)` — pyre dispatches
+    ///    through the `Backend::vector_ext_setup_once` trait hook;
+    ///    every current backend is a no-op (no `vector_ext`), but
+    ///    the call site is in place for when a backend grows one.
+    /// 5. `profiler.start()` — flips the profiler `initialized` flag.
     ///
     /// Pyre invokes this from the metainterp's back-edge entry
     /// `MetaInterp::bound_reached` (pyre analogue of
     /// `pyjitpl.py:2889 compile_and_run_once`).
-    pub fn _setup_once(&self, backend: &mut BackendImpl) {
+    pub fn _setup_once(
+        &self,
+        backend: &mut BackendImpl,
+        warm_state: &mut crate::warmstate::WarmEnterState,
+    ) {
         let mut gd = self.globaldata.lock().unwrap();
         if gd.initialized {
             return;
         }
+        warm_state.ensure_jitlog_initialised();
+        self.debug_print_jit_starting_line(backend.backend_name());
         backend.setup_once();
+        backend.vector_ext_setup_once();
+        self.profiler.start();
         gd.initialized = true;
+    }
+
+    /// pyjitpl.py:2296 `debug_print(self.jit_starting_line)` parity.
+    ///
+    /// RPython's `debug_print` fires only when `PYPYLOG` is set; the
+    /// pyre equivalent gates on `MAJIT_LOG` (the env var the rest of
+    /// the backend already reads).  Caller passes `backend_name()`
+    /// so the line reads `JIT starting (x86)` etc. on first
+    /// `_setup_once` — matches PyPy's `'JIT starting (%s)' %
+    /// backendmodule` (pyjitpl.py:2217).
+    fn debug_print_jit_starting_line(&self, backend_name: &'static str) {
+        if !crate::majit_log_enabled() {
+            return;
+        }
+        let line = if self.jit_starting_line.is_empty() {
+            format!("JIT starting ({backend_name})")
+        } else {
+            self.jit_starting_line.clone()
+        };
+        eprintln!("[majit] {line}");
     }
 
     /// pyjitpl.py:2305-2323 `get_name_from_address(addr)`.

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1843,11 +1843,30 @@ impl<M: Clone> MetaInterp<M> {
         // onto the backend so FINISH fast-path pointer identity works
         // against the same `Arc` the metainterp reads back.
         let MetaInterp {
-            ref staticdata,
+            ref mut staticdata,
             ref mut backend,
             ..
         } = this;
         staticdata.attach_descrs_to_cpu(backend);
+        // `pyjitpl.py:2273` `exc_descr = compile.PropagateExceptionDescr()`
+        // — PyPy creates this in `finish_setup_descrs_for_jitdrivers`
+        // (which runs from `warmspot.py:289`), before any
+        // `cpu.setup_once()`.  Pyre's back-edge / function-entry trace
+        // starts both gate through `_setup_once`, which materialises
+        // the per-CPU propagate trampoline; the trampoline reads
+        // `propagate_exception_descr` from the CPU.  Eagerly create
+        // and attach the descr here so the lifecycle holds for
+        // callers that construct a `MetaInterp` without running the
+        // full `register_jitdriver_sd` path (notably the test
+        // harness).  `finish_setup_descrs_for_jitdrivers` re-uses the
+        // existing `Arc` by identity, so a later
+        // `register_jitdriver_sd` call sees the same descr — no
+        // duplicate, no swap.
+        let sd_mut = std::sync::Arc::get_mut(staticdata).expect(
+            "MetaInterp::new: staticdata Arc must still have refcount 1 \
+             at construction time",
+        );
+        sd_mut.finish_setup_descrs_for_jitdrivers(backend);
         this
     }
 
@@ -2757,6 +2776,17 @@ impl<M: Clone> MetaInterp<M> {
         driver_descriptor: Option<JitDriverStaticData>,
         live_values: &[Value],
     ) -> BackEdgeAction {
+        // pyjitpl.py:2884 `compile_and_run_once` invokes `_setup_once`
+        // before every trace start.  pyre routes back-edge traces
+        // through `bound_reached`, but function-entry traces enter
+        // here, so the same gate must fire to materialise per-CPU
+        // trampolines (`cpu.setup_once`), profiler `start`, and the
+        // jitlog header before the first trace records anything.
+        // Idempotent — `globaldata.initialized` short-circuits after
+        // the first call.
+        self.staticdata
+            ._setup_once(&mut self.backend, &mut self.warm_state);
+
         if self.tracing.is_some() {
             return BackEdgeAction::AlreadyTracing;
         }
@@ -13811,9 +13841,14 @@ pub struct MetaInterpStaticData {
     /// backendmodule`.  RPython captures the backend module name (eg.
     /// `'x86'`, `'aarch64'`) at MetaInterp construction and
     /// `_setup_once` `debug_print`s it once on the first warmup.
-    /// Pyre fills this in `register_backend_name` (called by
-    /// whichever crate brings up the backend) so it travels with the
-    /// staticdata Arc.
+    ///
+    /// Pyre defaults this to the empty string; the first `_setup_once`
+    /// then formats `'JIT starting ({backend_name})'` from
+    /// `Backend::backend_name()` via `debug_print_jit_starting_line`.
+    /// Embedders that want a host-specific banner can assign a
+    /// non-empty string to this field before `_setup_once` fires;
+    /// `debug_print_jit_starting_line` prefers the stored line over
+    /// the backend-name fallback.
     pub jit_starting_line: String,
 }
 
@@ -14513,9 +14548,10 @@ impl MetaInterpStaticData {
     ///    `Logger`).
     /// 2. `debug_print(self.jit_starting_line)` — prints to stderr
     ///    when `MAJIT_LOG` is set, matching PyPy's `PYPYLOG`-gated
-    ///    `debug_print`.  `jit_starting_line` is filled in here
-    ///    from `backend.backend_name()` if `register_backend_name`
-    ///    has not been called explicitly.
+    ///    `debug_print`.  When `jit_starting_line` is empty (the
+    ///    default), `debug_print_jit_starting_line` formats one from
+    ///    `backend.backend_name()`; embedders may pre-assign a custom
+    ///    banner string instead.
     /// 3. `cpu.setup_once()` — backends materialise per-CPU
     ///    trampolines (x86 `_build_propagate_exception_path` /
     ///    `_build_malloc_slowpath`).

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1847,31 +1847,10 @@ impl<M: Clone> MetaInterp<M> {
             ref mut backend,
             ..
         } = this;
+        std::sync::Arc::get_mut(staticdata)
+            .expect("MetaInterpStaticData must be uniquely owned during MetaInterp::new")
+            .jit_starting_line = format!("JIT starting ({})", backend.backend_name());
         staticdata.attach_descrs_to_cpu(backend);
-        // `pyjitpl.py:2273-2283` `finish_setup_descrs_for_jitdrivers`
-        // runs as part of `finish_setup` (`warmspot.py:289`) before any
-        // `MetaInterp` is constructed.  Pyre's production entry point
-        // (`JitDriver::register_descriptor`, `mod.rs:2023
-        // set_result_type`, …) calls `finish_setup_descrs_for_jitdrivers`
-        // on each driver registration, so by the time the back-edge or
-        // function-entry trace start hits `_setup_once` the
-        // `propagate_exception_descr` is already on the cpu.
-        //
-        // Inline `#[test]` modules that build a `MetaInterp` directly
-        // skip the registration path (no portal runner, no macro-emitted
-        // `install_canonical_liveness`) but still drive
-        // `force_start_tracing` / `bound_reached` / `compile_loop`.
-        // Running the descr setup here under `cfg(test)` keeps those
-        // fixtures working without leaking the shortcut into production
-        // — the call is idempotent (`finish_setup_descrs_for_jitdrivers`
-        // re-uses the existing `Arc` by identity) so the later real
-        // registration sees the same descr, no duplicate, no swap.
-        #[cfg(test)]
-        {
-            let sd_mut = std::sync::Arc::get_mut(staticdata)
-                .expect("staticdata Arc must still have refcount 1 at construction");
-            sd_mut.finish_setup_descrs_for_jitdrivers(backend);
-        }
         this
     }
 
@@ -2471,6 +2450,17 @@ impl<M: Clone> MetaInterp<M> {
                 .expect("ensure_default_driver_sd: staticdata has other owners")
                 .jitdrivers_sd
                 .push(crate::jitdriver::JitDriverStaticData::new(vec![], vec![]));
+            // `pyjitpl.py:2273-2283` `finish_setup_descrs_for_jitdrivers`
+            // — `register_jitdriver_sd` runs this tail step on every
+            // jitdriver insertion (mod.rs:14418).  The default driver
+            // pushed above bypasses `register_jitdriver_sd`, so wire up
+            // `portal_finishtoken` / `propagate_exc_descr` /
+            // `portal_calldescr` here for the assert in `_setup_once`
+            // that demands populated jitdriver slots before tracing.
+            // Idempotent — any previously-attached descrs (if a test
+            // also called `finish_setup_descrs_for_jitdrivers` itself)
+            // are re-used by `Arc` identity.
+            self.finish_setup_descrs_for_jitdrivers();
         }
         0
     }
@@ -13884,13 +13874,9 @@ pub struct MetaInterpStaticData {
     /// `'x86'`, `'aarch64'`) at MetaInterp construction and
     /// `_setup_once` `debug_print`s it once on the first warmup.
     ///
-    /// Pyre defaults this to the empty string; the first `_setup_once`
-    /// then formats `'JIT starting ({backend_name})'` from
-    /// `Backend::backend_name()` via `debug_print_jit_starting_line`.
-    /// Embedders that want a host-specific banner can assign a
-    /// non-empty string to this field before `_setup_once` fires;
-    /// `debug_print_jit_starting_line` prefers the stored line over
-    /// the backend-name fallback.
+    /// Pyre stores the formatted line during `MetaInterp::new`, after
+    /// the backend exists, instead of deriving it by Python module
+    /// reflection.
     pub jit_starting_line: String,
 }
 
@@ -14597,12 +14583,9 @@ impl MetaInterpStaticData {
     ///
     /// Each remaining hook is dispatched in the same order as upstream:
     ///
-    /// 1. `debug_print(self.jit_starting_line)` — prints to stderr
-    ///    when `MAJIT_LOG` is set, matching PyPy's `PYPYLOG`-gated
-    ///    `debug_print`.  When `jit_starting_line` is empty (the
-    ///    default), `debug_print_jit_starting_line` formats one from
-    ///    `backend.backend_name()`; embedders may pre-assign a custom
-    ///    banner string instead.
+    /// 1. `debug_print(self.jit_starting_line)` — prints the stored
+    ///    line when `MAJIT_LOG` is set, matching PyPy's `PYPYLOG`-gated
+    ///    `debug_print`.
     /// 2. `cpu.setup_once()` — backends materialise per-CPU
     ///    trampolines (x86 `_build_propagate_exception_path` /
     ///    `_build_malloc_slowpath`).
@@ -14610,8 +14593,9 @@ impl MetaInterpStaticData {
     ///    through the `Backend::vector_ext_setup_once` trait hook;
     ///    every current backend is a no-op (no `vector_ext`), but
     ///    the call site is in place for when a backend grows one.
-    /// 4. `profiler.start()` — flips the profiler `initialized` flag
-    ///    and zeroes every counter (`jitprof.py:55-64`).
+    /// 4. `if not profiler.initialized: profiler.start(); initialized
+    ///    = True` — `_setup_once` owns the one-shot guard; `start()`
+    ///    itself always resets counters (`jitprof.py:55-64`).
     ///
     /// Pyre invokes this from `MetaInterp::bound_reached` (analogue
     /// of `pyjitpl.py:2889 compile_and_run_once`) and from
@@ -14642,10 +14626,30 @@ impl MetaInterpStaticData {
              before the first trace start (pyjitpl.py:2273-2283 \
              precedes pyjitpl.py:2292-2303)"
         );
-        self.debug_print_jit_starting_line(backend.backend_name());
+        assert!(
+            self.jitdrivers_sd.iter().all(|jd| {
+                jd.portal_finishtoken.is_some()
+                    && jd.propagate_exc_descr.is_some()
+                    && jd.portal_calldescr.is_some()
+            }),
+            "_setup_once: every registered jitdriver must have \
+             portal_finishtoken, propagate_exc_descr, and portal_calldescr \
+             before the first trace start (pyjitpl.py:2274-2281; \
+             warmspot.py:1013-1017)"
+        );
+        self.debug_print_jit_starting_line();
         backend.setup_once();
         backend.vector_ext_setup_once();
-        self.profiler.start();
+        if !self
+            .profiler
+            .initialized
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            self.profiler.start();
+            self.profiler
+                .initialized
+                .store(true, std::sync::atomic::Ordering::Release);
+        }
         gd.initialized = true;
     }
 
@@ -14653,20 +14657,14 @@ impl MetaInterpStaticData {
     ///
     /// RPython's `debug_print` fires only when `PYPYLOG` is set; the
     /// pyre equivalent gates on `MAJIT_LOG` (the env var the rest of
-    /// the backend already reads).  Caller passes `backend_name()`
-    /// so the line reads `JIT starting (x86)` etc. on first
-    /// `_setup_once` — matches PyPy's `'JIT starting (%s)' %
-    /// backendmodule` (pyjitpl.py:2217).
-    fn debug_print_jit_starting_line(&self, backend_name: &'static str) {
+    /// the backend already reads).  The stored line is populated at
+    /// construction time to match PyPy's `jit_starting_line` attribute
+    /// (`pyjitpl.py:2217`).
+    fn debug_print_jit_starting_line(&self) {
         if !crate::majit_log_enabled() {
             return;
         }
-        let line = if self.jit_starting_line.is_empty() {
-            format!("JIT starting ({backend_name})")
-        } else {
-            self.jit_starting_line.clone()
-        };
-        eprintln!("[majit] {line}");
+        eprintln!("{}", self.jit_starting_line);
     }
 
     /// pyjitpl.py:2305-2323 `get_name_from_address(addr)`.
@@ -14867,6 +14865,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let fnaddr = execute_varargs_void_helper as *const () as i64;
         let action = meta.force_start_tracing(
             0,
@@ -14902,6 +14901,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let fnaddr = execute_varargs_void_helper as *const () as i64 as usize;
         std::sync::Arc::get_mut(&mut meta.staticdata)
             .unwrap()
@@ -14935,6 +14935,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let fnaddr = execute_varargs_void_helper as *const () as i64 as usize;
         std::sync::Arc::get_mut(&mut meta.staticdata)
             .unwrap()
@@ -14955,6 +14956,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:2493-2496: result_type == VOID + resultbox is None
         // → raise DoneWithThisFrameVoid().
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let result = meta.finishframe(None, true);
         assert!(matches!(
             result,
@@ -14973,6 +14975,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         let resultbox_ref = meta.trace_ctx().expect("active trace").const_int(0xc0ffee);
@@ -14988,6 +14991,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:2499-2500.
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let result = meta.finishframe(Some((JitArgKind::Ref, 0, OpRef::ref_op(101), 0xfeed)), true);
         assert!(matches!(
             result,
@@ -15000,6 +15004,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:2501-2502.
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let bits = f64::to_bits(2.5) as i64;
         let result = meta.finishframe(
             Some((JitArgKind::Float, 0, OpRef::float_op(102), bits)),
@@ -15025,6 +15030,7 @@ mod metainterp_static_data_tests {
         let jitcode = builder.finish();
         jitcode.set_jitdriver_sd(0);
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let driver = crate::jitdriver::JitDriverStaticData {
             index: None,
             vars: vec![],
@@ -15077,6 +15083,7 @@ mod metainterp_static_data_tests {
         builder.load_const_f_value(0, 0);
         let jitcode = std::sync::Arc::new(builder.finish());
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let result = meta.perform_call(
             jitcode,
             &[
@@ -15132,6 +15139,7 @@ mod metainterp_static_data_tests {
         let callee = std::sync::Arc::new(builder_callee.finish());
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         // Push caller, then advance caller.pc to the post-call
         // position the way the bytecode dispatch loop would (the
         // opimpl reads operand bytes and bumps `pc` past the entire
@@ -15165,6 +15173,7 @@ mod metainterp_static_data_tests {
         let callee = std::sync::Arc::new(JitCodeBuilder::new().finish());
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.perform_call(caller, &[], None).unwrap_err();
         // Mutate the caller's register 0 so we can detect any
         // accidental write triggered by the void return.
@@ -15196,6 +15205,7 @@ mod metainterp_static_data_tests {
         let mainjitcode = std::sync::Arc::new(mainjitcode);
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         // Pre-populate framestack with a stale frame to verify reset.
         meta.perform_call(mainjitcode.clone(), &[], None)
             .unwrap_err();
@@ -15225,6 +15235,7 @@ mod metainterp_static_data_tests {
         let jitcode = std::sync::Arc::new(JitCodeBuilder::new().finish());
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -15256,6 +15267,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let initial = meta.portal_call_depth;
 
         // Push a non-portal frame: counter unchanged.
@@ -15311,6 +15323,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         let descr = StubCallDescr {
@@ -15341,6 +15354,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         let descr = StubCallDescr {
@@ -15372,6 +15386,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         // descr declares [Int, Ref, Int, Ref] (declaration order).
@@ -15418,6 +15433,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         let descr = StubCallDescr {
@@ -15493,6 +15509,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -15544,6 +15561,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -15630,6 +15648,7 @@ mod metainterp_static_data_tests {
         use crate::executor;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let descr = StubCallDescr {
             arg_types: vec![majit_ir::Type::Int],
             result_type: majit_ir::Type::Float,
@@ -15668,6 +15687,7 @@ mod metainterp_static_data_tests {
         use crate::executor;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         // Pre-set a stale class-const flag and a stale TLS value: the
         // executor must overwrite both.
         meta.class_of_last_exc_is_const = true;
@@ -15774,6 +15794,7 @@ mod metainterp_static_data_tests {
         // after the count_ops call, so we still observe both bumps.
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let descr_view = StubCallDescr {
             arg_types: vec![majit_ir::Type::Int, majit_ir::Type::Int],
             result_type: majit_ir::Type::Int,
@@ -15807,6 +15828,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -15858,6 +15880,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:2745-2755 — last_exc_value = llexception;
         //                       class_of_last_exc_is_const = constant.
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         assert_eq!(meta.last_exc_value, 0);
         assert!(!meta.class_of_last_exc_is_const);
 
@@ -15875,6 +15898,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:2739-2743 — pyre callers pass the lowered
         // exception pointer directly; execute_raised forwards.
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.execute_raised(0xc0ffee, false);
         assert_eq!(meta.last_exc_value, 0xc0ffee);
         assert!(!meta.class_of_last_exc_is_const);
@@ -15886,6 +15910,7 @@ mod metainterp_static_data_tests {
         // pyre's `count` routes every Counters.ABORT_* into
         // `loops_aborted` (reason-keyed split is a future expansion).
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let stats_before = meta.get_stats();
         meta.aborted_tracing(counters::ABORT_ESCAPE);
         let stats_after = meta.get_stats();
@@ -15898,6 +15923,7 @@ mod metainterp_static_data_tests {
         // pre-set the abort fires the trace-too-long hook and
         // clears both fields.
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.aborted_tracing_jitdriver = Some(7);
         meta.aborted_tracing_greenkey = Some(0xfeed);
         meta.aborted_tracing(0);
@@ -15908,6 +15934,7 @@ mod metainterp_static_data_tests {
     #[test]
     fn aborted_tracing_does_not_touch_jitdriver_when_unset() {
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         assert!(meta.aborted_tracing_jitdriver.is_none());
         meta.aborted_tracing(0);
         assert!(meta.aborted_tracing_jitdriver.is_none());
@@ -15923,6 +15950,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitCodeBuilder;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -15944,6 +15972,7 @@ mod metainterp_static_data_tests {
         // remove.  Single-frame stack short-circuits.
         use crate::jitcode::JitCodeBuilder;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.force_start_tracing(0, (0, 0), None, &[]);
 
         let jitcode = std::sync::Arc::new(JitCodeBuilder::new().finish());
@@ -15965,6 +15994,7 @@ mod metainterp_static_data_tests {
         // ConstInt(resvalue) is returned in place of the op.
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16041,6 +16071,7 @@ mod metainterp_static_data_tests {
     fn do_recursive_call_panics_when_portal_runner_adr_is_zero() {
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         let descr_view = StubCallDescr {
@@ -16071,6 +16102,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         let descr_view = StubCallDescr {
@@ -16108,6 +16140,7 @@ mod metainterp_static_data_tests {
         // assembler_call).
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16154,6 +16187,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16202,6 +16236,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let fnaddr = execute_varargs_int_helper as *const () as i64;
         let action = meta.force_start_tracing(
             0,
@@ -16256,6 +16291,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16299,6 +16335,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16344,6 +16381,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16391,6 +16429,7 @@ mod metainterp_static_data_tests {
         use crate::BackEdgeAction;
         use crate::jitcode::JitArgKind;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16425,6 +16464,7 @@ mod metainterp_static_data_tests {
     fn clear_exception_resets_last_exc_value_to_zero() {
         // pyjitpl.py:2757-2758 — `self.last_exc_value = lltype.nullptr(...)`
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.last_exc_value = 0xbeef;
         meta.clear_exception();
         assert_eq!(meta.last_exc_value, 0);
@@ -16434,6 +16474,7 @@ mod metainterp_static_data_tests {
     fn finishframe_clears_last_exc_value_per_pyjitpl_2481() {
         // pyjitpl.py:2481 — `self.last_exc_value = lltype.nullptr(...)`.
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.last_exc_value = 0xc0ffee;
         let _ = meta.finishframe(None, true);
         assert_eq!(meta.last_exc_value, 0);
@@ -16444,6 +16485,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:1882-1886 — ovf_flag → GUARD_OVERFLOW + pc=label, return None
         use crate::jitcode::JitCodeBuilder;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.force_start_tracing(0, (0, 0), None, &[]);
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         // Already tracing returns AlreadyTracing — that's fine, the
@@ -16475,6 +16517,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:1888-1890 — !ovf_flag → GUARD_NO_OVERFLOW, return resbox
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16497,6 +16540,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:3394-3395 — last_exc_value == 0 → GUARD_NO_EXCEPTION.
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.last_exc_value = 0;
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
@@ -16519,6 +16563,7 @@ mod metainterp_static_data_tests {
         // followed by finishframe_exception().
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         // Override cls_of_box so we can inject a known typeptr without
         // dereferencing a raw pointer.
         meta.cls_of_box = Some(|_| 0xc1a55);
@@ -16569,6 +16614,7 @@ mod metainterp_static_data_tests {
         // ConstPtr equivalent (trace_ctx.rs:583).
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.cls_of_box = Some(|_| 0xc1a55);
         meta.last_exc_value = 0xfeed;
         meta.class_of_last_exc_is_const = true;
@@ -16617,6 +16663,7 @@ mod metainterp_static_data_tests {
     fn finishframe_exception_jumps_to_current_frame_catch_handler() {
         let (jitcode, target) = make_catch_exception_jitcode();
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         {
             let sd = std::sync::Arc::get_mut(&mut meta.staticdata).unwrap();
             sd.op_live = crate::jitcode::insns::BC_LIVE as i32;
@@ -16642,6 +16689,7 @@ mod metainterp_static_data_tests {
         let callee = std::sync::Arc::new(crate::jitcode::JitCodeBuilder::new().finish());
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         {
             let sd = std::sync::Arc::get_mut(&mut meta.staticdata).unwrap();
             sd.op_live = crate::jitcode::insns::BC_LIVE as i32;
@@ -16667,6 +16715,7 @@ mod metainterp_static_data_tests {
     #[test]
     fn finishframe_exception_jumps_to_catch_handler() {
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let mut jitcode = crate::jitcode::JitCodeBuilder::new().finish();
         jitcode.body_mut().code = vec![crate::jitcode::insns::BC_CATCH_EXCEPTION, 3, 0];
         let jitcode = std::sync::Arc::new(jitcode);
@@ -16686,6 +16735,7 @@ mod metainterp_static_data_tests {
     #[test]
     fn finishframe_exception_skips_live_prefix_before_catch_handler() {
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let mut jitcode = crate::jitcode::JitCodeBuilder::new().finish();
         jitcode.body_mut().code = vec![
             crate::jitcode::insns::BC_LIVE,
@@ -16719,6 +16769,7 @@ mod metainterp_static_data_tests {
         // surfaces the same shape via the `ExitFrameWithExceptionRef`
         // signal variant.
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.last_exc_value = 0xfeed;
         let jitcode = std::sync::Arc::new(crate::jitcode::JitCodeBuilder::new().finish());
         meta.framestack
@@ -16750,6 +16801,7 @@ mod metainterp_static_data_tests {
         let callee_jitcode = std::sync::Arc::new(callee_jitcode);
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.framestack
             .push(crate::pyjitpl::MIFrame::new(caller_jitcode, 0));
         meta.framestack
@@ -16791,6 +16843,7 @@ mod metainterp_static_data_tests {
         let callee_jitcode = std::sync::Arc::new(callee_jitcode);
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.cls_of_box = Some(|_| 0xcafef00d);
         meta.last_exc_value = 0xbeef;
 
@@ -16840,6 +16893,7 @@ mod metainterp_static_data_tests {
     #[should_panic(expected = "MetaInterp.assert_no_exception")]
     fn assert_no_exception_panics_when_value_set() {
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.last_exc_value = 0xdead;
         meta.assert_no_exception();
     }
@@ -16852,6 +16906,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let mut portal = JitCodeBuilder::new().finish();
         portal.replace_jitdriver_sd(Some(0));
         let portal = std::sync::Arc::new(portal);
@@ -16881,6 +16936,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let plain = std::sync::Arc::new(JitCodeBuilder::new().finish());
 
         meta.perform_call(plain.clone(), &[], None).unwrap_err();
@@ -16902,6 +16958,7 @@ mod metainterp_static_data_tests {
         let mainjitcode = std::sync::Arc::new(mainjitcode);
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         // Pre-pollute the counter to verify the reset.
         meta.portal_call_depth = 42;
         meta.initialize_state_from_start(mainjitcode, &[]);
@@ -16911,6 +16968,7 @@ mod metainterp_static_data_tests {
     #[test]
     fn is_main_jitcode_returns_false_for_non_portal_jitcode() {
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let mut jc = crate::jitcode::JitCodeBuilder::new().finish();
         jc.replace_jitdriver_sd(None);
         assert!(!meta.is_main_jitcode(&jc));
@@ -16938,6 +16996,7 @@ mod metainterp_static_data_tests {
     #[test]
     fn is_main_jitcode_returns_true_for_recursive_portal_jitcode() {
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let mut jd = crate::jitdriver::JitDriverStaticData::new(vec![], vec![]);
         jd.is_recursive = true;
         let idx = {
@@ -16962,6 +17021,7 @@ mod metainterp_static_data_tests {
         // ConstInt(jd_no), ConstInt(unique_id), None)
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -16989,6 +17049,7 @@ mod metainterp_static_data_tests {
         // pyjitpl.py:2459 — history.record1(rop.LEAVE_PORTAL_FRAME, ConstInt(jd_no), None)
         use crate::BackEdgeAction;
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -17016,6 +17077,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -17063,6 +17125,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let mut jd = crate::jitdriver::JitDriverStaticData::new(vec![], vec![]);
         jd.is_recursive = true;
         let idx = {
@@ -17113,6 +17176,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let mut jd = crate::jitdriver::JitDriverStaticData::new(vec![], vec![]);
         jd.is_recursive = false;
         let idx = {
@@ -17148,6 +17212,7 @@ mod metainterp_static_data_tests {
         // Without an active TraceCtx the named entry must not panic and
         // must not record anything.
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.enter_portal_frame(0, 0);
         meta.leave_portal_frame(0);
     }
@@ -17159,6 +17224,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
         let jitcode = std::sync::Arc::new(JitCodeBuilder::new().finish());
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.perform_call(jitcode, &[], None).unwrap_err();
         assert_eq!(meta.framestack.len(), 1);
         meta.reset_framestack_for_failure();
@@ -17174,6 +17240,7 @@ mod metainterp_static_data_tests {
         use crate::jitcode::JitCodeBuilder;
         let jitcode = std::sync::Arc::new(JitCodeBuilder::new().finish());
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.perform_call(jitcode, &[], None).unwrap_err();
         assert_eq!(meta.framestack.len(), 1);
         meta.popframe(true);
@@ -17320,6 +17387,7 @@ mod metainterp_static_data_tests {
 
         let callcontrol = CallControl::new();
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.finish_setup(&codewriter, &callcontrol);
 
         assert_eq!(meta.staticdata.liveness_info, expected);
@@ -17337,6 +17405,7 @@ mod metainterp_static_data_tests {
         use majit_translate::jit_codewriter::codewriter::CodeWriter;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let _share: std::sync::Arc<MetaInterpStaticData> = meta.staticdata.clone();
         meta.finish_setup(&CodeWriter::new(), &CallControl::new());
     }
@@ -17378,6 +17447,7 @@ mod metainterp_static_data_tests {
         let expected = asm.all_liveness().to_vec();
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.install_canonical_liveness(&asm);
 
         assert_eq!(meta.staticdata.liveness_info, expected);
@@ -17421,6 +17491,7 @@ mod metainterp_static_data_tests {
         use majit_translate::jit_codewriter::assembler::Assembler;
 
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let _share: std::sync::Arc<MetaInterpStaticData> = meta.staticdata.clone();
         meta.install_canonical_liveness(&Assembler::new());
     }
@@ -17430,6 +17501,7 @@ mod metainterp_static_data_tests {
         // call.py:46-47 `jd.index = idx` — index written back into the
         // descriptor at registration time, not left None.
         let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
         let jd = crate::jitdriver::JitDriverStaticData::new(vec![], vec![]);
         let idx = {
             let MetaInterp {
@@ -17675,6 +17747,7 @@ mod tests {
     #[test]
     fn test_front_target_inputarg_types_uses_saved_front_label_contract() {
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 7;
         let trace_id = 11;
         let token = std::sync::Arc::new(JitCellToken::new(3));
@@ -17833,6 +17906,7 @@ mod tests {
     #[test]
     fn test_guard_resume_getters_return_stored_exit_layout_metadata() {
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 19;
         let trace_id = 23;
         let fail_index = 5;
@@ -17931,6 +18005,7 @@ mod tests {
     #[test]
     fn test_handle_async_forcing_prepares_rd_virtuals_from_exit_layout() {
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 29;
         let trace_id = 31;
         let fail_index = 7;
@@ -18068,6 +18143,7 @@ mod tests {
     #[test]
     fn test_handle_async_forcing_falls_back_to_previous_token_backend_exit_layout() {
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 30;
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(
@@ -18314,6 +18390,7 @@ mod tests {
     #[test]
     fn guard_exit_getters_fall_back_to_previous_token_backend_layouts() {
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 77;
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(
@@ -18398,6 +18475,7 @@ mod tests {
     #[test]
     fn guard_failure_recovery_uses_previous_token_backend_exit_layout() {
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 88;
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(
@@ -18495,6 +18573,7 @@ mod tests {
     #[test]
     fn test_start_retrace_from_guard_uses_previous_token_backend_resume_data() {
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = 89;
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(
@@ -18702,6 +18781,7 @@ mod tests {
 
     fn finish_trace_for_parity_preserves_captured_snapshots() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let action = meta.force_start_tracing(777, (0, 0), None, &[Value::Int(17)]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
@@ -18757,6 +18837,7 @@ mod tests {
         let obj = TraceEntryObj { arr: &array };
 
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         meta.set_virtualizable_info(std::sync::Arc::new(info.clone()));
         meta.set_vable_ptr((&obj as *const TraceEntryObj).cast());
         // Even if the interpreter cache claims a different length, the heap
@@ -18769,6 +18850,7 @@ mod tests {
     #[test]
     fn initialize_virtualizable_appends_read_boxes_to_red_only_trace_entry() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = std::sync::Arc::new(test_vable_info_static_only());
         meta.set_virtualizable_info(info.clone());
 
@@ -18802,6 +18884,7 @@ mod tests {
     #[test]
     fn opimpl_getfield_vable_int_reads_standard_box_without_heap_op() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_static_only();
         let fd8 = info.static_field_descr(0);
         start_tracing_with_virtualizable(
@@ -18821,6 +18904,7 @@ mod tests {
     #[test]
     fn opimpl_setfield_vable_int_synchronizes_standard_virtualizable() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_static_only();
         let fd8 = info.static_field_descr(0);
         start_tracing_with_virtualizable(
@@ -18851,6 +18935,7 @@ mod tests {
     #[test]
     fn opimpl_getarrayitem_vable_int_reads_standard_box_without_heap_op() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_with_array();
         let fd24 = info.array_pointer_field_descr(0);
         let adesc = info.array_item_descr(0);
@@ -18876,6 +18961,7 @@ mod tests {
     #[test]
     fn opimpl_arraylen_vable_returns_cached_standard_length() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_with_array();
         let fd24 = info.array_pointer_field_descr(0);
         let adesc = info.array_item_descr(0);
@@ -18895,6 +18981,7 @@ mod tests {
     #[test]
     fn opimpl_getfield_vable_int_nonstandard_falls_back_to_heap_op() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         start_tracing_with_virtualizable(
             &mut meta,
             test_vable_info_static_only(),
@@ -18931,6 +19018,7 @@ mod tests {
     #[test]
     fn opimpl_getarrayitem_vable_int_nonstandard_falls_back_to_heap_ops() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         start_tracing_with_virtualizable(
             &mut meta,
             test_vable_info_with_array(),
@@ -18968,6 +19056,7 @@ mod tests {
     #[test]
     fn opimpl_hint_force_virtualizable_standard_emits_store_back_only_once() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         start_tracing_with_virtualizable(
             &mut meta,
             test_vable_info_static_only(),
@@ -18987,6 +19076,7 @@ mod tests {
     #[test]
     fn opimpl_hint_force_virtualizable_ignores_nonstandard_virtualizable() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         start_tracing_with_virtualizable(
             &mut meta,
             test_vable_info_static_only(),
@@ -19007,6 +19097,7 @@ mod tests {
     #[test]
     fn do_jit_force_virtual_preserves_standard_concrete_value() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         start_tracing_with_virtualizable(
             &mut meta,
             test_vable_info_static_only(),
@@ -19047,6 +19138,7 @@ mod tests {
     #[test]
     fn load_fields_from_virtualizable_reloads_heap_values_into_boxes() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         start_tracing_with_virtualizable(
             &mut meta,
             test_vable_info_static_only(),
@@ -19067,6 +19159,7 @@ mod tests {
     #[test]
     fn direct_assembler_call_uses_greenkey_token_in_descr() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         std::sync::Arc::get_mut(&mut meta.staticdata)
             .unwrap()
             .jitdrivers_sd
@@ -19074,6 +19167,11 @@ mod tests {
                 vec![("code", Type::Int)],
                 vec![("frame", Type::Int)],
             ));
+        // Wire portal_finishtoken/propagate_exc_descr/portal_calldescr
+        // onto the manually-pushed driver — `register_jitdriver_sd`
+        // does this for the regular path; idempotent on the
+        // already-attached cpu-side descrs.
+        meta.finish_setup_descrs_for_jitdrivers();
         let green_key = crate::green_key_hash(&[55]);
         let mut token = majit_backend::JitCellToken::new(4242);
         token.virtualizable_arg_index = None;
@@ -19143,6 +19241,7 @@ mod tests {
         }
 
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         {
             let staticdata = std::sync::Arc::get_mut(&mut meta.staticdata).unwrap();
             let mut jd =
@@ -19211,6 +19310,7 @@ mod tests {
     #[test]
     fn hint_force_virtualizable_state_is_reset_between_traces() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         start_tracing_with_virtualizable(
             &mut meta,
             test_vable_info_static_only(),
@@ -19237,6 +19337,7 @@ mod tests {
     #[test]
     fn standard_vable_access_consumes_forced_virtualizable_state() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_static_only();
         let fd8 = info.static_field_descr(0);
         start_tracing_with_virtualizable(
@@ -19261,6 +19362,7 @@ mod tests {
     #[test]
     fn compiled_virtualizable_trace_does_not_use_raw_heap_ops() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_with_array();
         let fd24 = info.array_pointer_field_descr(0);
         let adesc = info.array_item_descr(0);
@@ -19343,6 +19445,7 @@ mod tests {
     #[test]
     fn optimizer_vable_config_requires_standard_virtualizable_boxes() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_with_array();
         meta.set_virtualizable_info(std::sync::Arc::new(info.clone()));
         assert!(
@@ -19361,6 +19464,7 @@ mod tests {
     #[test]
     fn optimizer_vable_config_matches_registered_virtualizable_when_boxes_active() {
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let info = test_vable_info_with_array();
         start_tracing_with_virtualizable(
             &mut meta,
@@ -19398,6 +19502,7 @@ mod tests {
         // Parity with test_on_compile: after_compile hook fires with green_key,
         // num_ops_before, num_ops_after.
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let compile_events: Arc<Mutex<Vec<(u64, usize, usize)>>> = Arc::new(Mutex::new(Vec::new()));
         let events = compile_events.clone();
         meta.set_on_compile_loop(move |green_key, ops_before, ops_after| {
@@ -19437,6 +19542,7 @@ mod tests {
         // Parity with test_on_abort: on_compile_error fires when compilation fails.
         // We can test this by installing a hook and verifying it captures the error.
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let error_events: Arc<Mutex<Vec<(u64, String)>>> = Arc::new(Mutex::new(Vec::new()));
         let events = error_events.clone();
         meta.set_on_compile_error(move |green_key, msg| {
@@ -19460,6 +19566,7 @@ mod tests {
         // Parity with JitHookInterface: multiple different hooks can be registered
         // independently and all fire for their respective events.
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
 
         let compile_count = Arc::new(Mutex::new(0u32));
         let trace_start_count = Arc::new(Mutex::new(0u32));
@@ -19537,6 +19644,7 @@ mod tests {
         // Parity with test_on_compile: verify that the hook receives the correct
         // green key and that op counts reflect the actual trace.
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let events: Arc<Mutex<Vec<(u64, usize, usize)>>> = Arc::new(Mutex::new(Vec::new()));
         let ev = events.clone();
         meta.set_on_compile_loop(move |gk, before, after| {
@@ -19578,6 +19686,7 @@ mod tests {
         // Parity with test_on_compile_bridge: after_compile_bridge hook fires
         // when a bridge is compiled.
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let bridge_events: Arc<Mutex<Vec<(u64, u32, usize)>>> = Arc::new(Mutex::new(Vec::new()));
         let ev = bridge_events.clone();
         meta.set_on_compile_bridge(move |gk, fi, nops| {
@@ -19645,6 +19754,7 @@ mod tests {
     fn test_on_guard_failure_hook() {
         // Parity with test_get_stats: guard failure hook fires with correct args.
         let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
         let failure_events: Arc<Mutex<Vec<(u64, u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
         let ev = failure_events.clone();
         meta.set_on_guard_failure(move |gk, fi, fc| {
@@ -19754,6 +19864,7 @@ mod tests {
     fn test_on_trace_abort_hook_with_permanent_flag() {
         // Parity with test_abort_quasi_immut: on_abort receives the permanent flag.
         let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
         let abort_events: Arc<Mutex<Vec<(u64, bool)>>> = Arc::new(Mutex::new(Vec::new()));
         let ev = abort_events.clone();
         meta.set_on_trace_abort(move |gk, permanent| {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1848,25 +1848,30 @@ impl<M: Clone> MetaInterp<M> {
             ..
         } = this;
         staticdata.attach_descrs_to_cpu(backend);
-        // `pyjitpl.py:2273` `exc_descr = compile.PropagateExceptionDescr()`
-        // — PyPy creates this in `finish_setup_descrs_for_jitdrivers`
-        // (which runs from `warmspot.py:289`), before any
-        // `cpu.setup_once()`.  Pyre's back-edge / function-entry trace
-        // starts both gate through `_setup_once`, which materialises
-        // the per-CPU propagate trampoline; the trampoline reads
-        // `propagate_exception_descr` from the CPU.  Eagerly create
-        // and attach the descr here so the lifecycle holds for
-        // callers that construct a `MetaInterp` without running the
-        // full `register_jitdriver_sd` path (notably the test
-        // harness).  `finish_setup_descrs_for_jitdrivers` re-uses the
-        // existing `Arc` by identity, so a later
-        // `register_jitdriver_sd` call sees the same descr — no
-        // duplicate, no swap.
-        let sd_mut = std::sync::Arc::get_mut(staticdata).expect(
-            "MetaInterp::new: staticdata Arc must still have refcount 1 \
-             at construction time",
-        );
-        sd_mut.finish_setup_descrs_for_jitdrivers(backend);
+        // `pyjitpl.py:2273-2283` `finish_setup_descrs_for_jitdrivers`
+        // runs as part of `finish_setup` (`warmspot.py:289`) before any
+        // `MetaInterp` is constructed.  Pyre's production entry point
+        // (`JitDriver::register_descriptor`, `mod.rs:2023
+        // set_result_type`, …) calls `finish_setup_descrs_for_jitdrivers`
+        // on each driver registration, so by the time the back-edge or
+        // function-entry trace start hits `_setup_once` the
+        // `propagate_exception_descr` is already on the cpu.
+        //
+        // Inline `#[test]` modules that build a `MetaInterp` directly
+        // skip the registration path (no portal runner, no macro-emitted
+        // `install_canonical_liveness`) but still drive
+        // `force_start_tracing` / `bound_reached` / `compile_loop`.
+        // Running the descr setup here under `cfg(test)` keeps those
+        // fixtures working without leaking the shortcut into production
+        // — the call is idempotent (`finish_setup_descrs_for_jitdrivers`
+        // re-uses the existing `Arc` by identity) so the later real
+        // registration sees the same descr, no duplicate, no swap.
+        #[cfg(test)]
+        {
+            let sd_mut = std::sync::Arc::get_mut(staticdata)
+                .expect("staticdata Arc must still have refcount 1 at construction");
+            sd_mut.finish_setup_descrs_for_jitdrivers(backend);
+        }
         this
     }
 
@@ -1931,6 +1936,31 @@ impl<M: Clone> MetaInterp<M> {
     /// thread it explicitly.
     pub fn finish_setup_descrs(&self) {
         self.staticdata.finish_setup_descrs();
+    }
+
+    /// `pyjitpl.py:2273-2283 finish_setup_descrs_for_jitdrivers` —
+    /// create the shared `PropagateExceptionDescr`, attach it to the
+    /// cpu, and bind `propagate_exc_descr` / `portal_finishtoken` /
+    /// `portal_calldescr` on every registered jitdriver.
+    ///
+    /// Real entry points (`JitDriver::register_descriptor`,
+    /// `MetaInterpStaticData::set_result_type`) call the underlying
+    /// staticdata method themselves; this wrapper is the public
+    /// surface for integration-test fixtures that build a
+    /// `MetaInterp` without the registration plumbing.  Idempotent —
+    /// re-running picks the same `Arc` by identity.
+    pub fn finish_setup_descrs_for_jitdrivers(&mut self) {
+        let MetaInterp {
+            staticdata,
+            backend,
+            ..
+        } = self;
+        let sd_mut = std::sync::Arc::get_mut(staticdata).expect(
+            "MetaInterp::finish_setup_descrs_for_jitdrivers: staticdata Arc \
+             must still have refcount 1; call before any tracing session \
+             clones it",
+        );
+        sd_mut.finish_setup_descrs_for_jitdrivers(backend);
     }
 
     /// Narrow lifecycle hook for state-field JIT: install the canonical
@@ -2784,8 +2814,15 @@ impl<M: Clone> MetaInterp<M> {
         // jitlog header before the first trace records anything.
         // Idempotent — `globaldata.initialized` short-circuits after
         // the first call.
-        self.staticdata
-            ._setup_once(&mut self.backend, &mut self.warm_state);
+        //
+        // PRE-EXISTING-ADAPTATION: pyre's jitlog `Logger` lives on
+        // `WarmEnterState` rather than `MetaInterpStaticData`, so the
+        // `pyjitpl.py:2295 self.jitlog.setup_once()` step is driven
+        // here against this MetaInterp's own warmstate.  Idempotent
+        // — `ensure_jitlog_initialised` only fills the slot when it
+        // is still `None`.
+        self.warm_state.ensure_jitlog_initialised();
+        self.staticdata._setup_once(&mut self.backend);
 
         if self.tracing.is_some() {
             return BackEdgeAction::AlreadyTracing;
@@ -2920,8 +2957,13 @@ impl<M: Clone> MetaInterp<M> {
         // `cpu.setup_once()` (`pyjitpl.py:2292-2303`).  Pyre's
         // back-edge entry routes through `bound_reached`, so the
         // gate fires here.  Idempotent.
-        self.staticdata
-            ._setup_once(&mut self.backend, &mut self.warm_state);
+        //
+        // PRE-EXISTING-ADAPTATION: pyre's jitlog `Logger` lives on
+        // `WarmEnterState`, not on `MetaInterpStaticData`; drive the
+        // per-warmstate `setup_once` step here before the staticdata
+        // hook runs (matches PyPy's `jitlog → ...` order).
+        self.warm_state.ensure_jitlog_initialised();
+        self.staticdata._setup_once(&mut self.backend);
 
         if self.tracing.is_some() {
             return BackEdgeAction::AlreadyTracing;
@@ -14539,41 +14581,67 @@ impl MetaInterpStaticData {
     ///         self.globaldata.initialized = True
     /// ```
     ///
-    /// Each hook is dispatched in the same order:
+    /// PRE-EXISTING-ADAPTATION: pyre owns the jitlog `Logger` on
+    /// `WarmEnterState`, not on `MetaInterpStaticData` as PyPy does
+    /// on `self.jitlog`.  The PyPy `setup_once` step `self.jitlog
+    /// .setup_once()` therefore cannot run from here — it would need
+    /// a list of registered warmstates that pyre doesn't keep, and
+    /// the per-warmstate `Option<Logger>` is initialised eagerly by
+    /// `WarmEnterState::new` / `with_jitlog` constructors anyway.
+    /// Callers that wrap `_setup_once` (`force_start_tracing`,
+    /// `bound_reached`) drive `WarmEnterState::ensure_jitlog_initialised`
+    /// against their own warmstate just before invoking this hook,
+    /// which preserves the lifecycle ordering (jitlog → debug_print
+    /// → cpu.setup_once → vector_ext → profiler) for the single
+    /// warmstate they own.
     ///
-    /// 1. `jitlog.setup_once()` — `setup_once_jitlog` walks the
-    ///    registered jitdrivers and forces each `WarmEnterState`'s
-    ///    `Logger::from_env` to materialise (pyre adapts PyPy's
-    ///    single staticdata-owned `JitLogger` into a per-jitdriver
-    ///    `Logger`).
-    /// 2. `debug_print(self.jit_starting_line)` — prints to stderr
+    /// Each remaining hook is dispatched in the same order as upstream:
+    ///
+    /// 1. `debug_print(self.jit_starting_line)` — prints to stderr
     ///    when `MAJIT_LOG` is set, matching PyPy's `PYPYLOG`-gated
     ///    `debug_print`.  When `jit_starting_line` is empty (the
     ///    default), `debug_print_jit_starting_line` formats one from
     ///    `backend.backend_name()`; embedders may pre-assign a custom
     ///    banner string instead.
-    /// 3. `cpu.setup_once()` — backends materialise per-CPU
+    /// 2. `cpu.setup_once()` — backends materialise per-CPU
     ///    trampolines (x86 `_build_propagate_exception_path` /
     ///    `_build_malloc_slowpath`).
-    /// 4. `cpu.vector_ext.setup_once(cpu.assembler)` — pyre dispatches
+    /// 3. `cpu.vector_ext.setup_once(cpu.assembler)` — pyre dispatches
     ///    through the `Backend::vector_ext_setup_once` trait hook;
     ///    every current backend is a no-op (no `vector_ext`), but
     ///    the call site is in place for when a backend grows one.
-    /// 5. `profiler.start()` — flips the profiler `initialized` flag.
+    /// 4. `profiler.start()` — flips the profiler `initialized` flag
+    ///    and zeroes every counter (`jitprof.py:55-64`).
     ///
-    /// Pyre invokes this from the metainterp's back-edge entry
-    /// `MetaInterp::bound_reached` (pyre analogue of
-    /// `pyjitpl.py:2889 compile_and_run_once`).
-    pub fn _setup_once(
-        &self,
-        backend: &mut BackendImpl,
-        warm_state: &mut crate::warmstate::WarmEnterState,
-    ) {
+    /// Pyre invokes this from `MetaInterp::bound_reached` (analogue
+    /// of `pyjitpl.py:2889 compile_and_run_once`) and from
+    /// `MetaInterp::force_start_tracing` for the function-entry trace
+    /// path.
+    pub fn _setup_once(&self, backend: &mut BackendImpl) {
         let mut gd = self.globaldata.lock().unwrap();
         if gd.initialized {
             return;
         }
-        warm_state.ensure_jitlog_initialised();
+        // `pyjitpl.py:2273-2283` `finish_setup_descrs_for_jitdrivers`
+        // runs before `_setup_once` — in PyPy the call sits earlier in
+        // `finish_setup` so by the time `pyjitpl.py:2884
+        // compile_and_run_once` triggers the `globaldata.initialized`
+        // dispatch, `propagate_exception_descr` is already on the cpu
+        // and every jitdriver has its `propagate_exc_descr`/`portal_*`
+        // slots populated.  Pyre keeps the same invariant: real entry
+        // points (`MetaInterpStaticData::register_jitdriver_sd_*`,
+        // `set_result_type`) drive that method, and test fixtures that
+        // construct a `MetaInterp` without going through registration
+        // must call `finish_setup_descrs_for_jitdrivers` explicitly
+        // before tracing starts.  Panicking here exposes the missing
+        // setup at the call site instead of letting the per-CPU
+        // propagate trampoline bake a NULL descr immediate.
+        assert!(
+            self.propagate_exception_descr.is_some(),
+            "_setup_once: finish_setup_descrs_for_jitdrivers must run \
+             before the first trace start (pyjitpl.py:2273-2283 \
+             precedes pyjitpl.py:2292-2303)"
+        );
         self.debug_print_jit_starting_line(backend.backend_name());
         backend.setup_once();
         backend.vector_ext_setup_once();

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -14478,13 +14478,23 @@ impl MetaInterpStaticData {
         }
     }
 
-    /// pyjitpl.py:2292-2303 `_setup_once` — guarded by
-    /// `globaldata.initialized` so it runs exactly once per CPU after
-    /// `finish_setup` has installed every descr (`pyjitpl.py:2255`,
-    /// `pyjitpl.py:2283`).  Dispatches `cpu.setup_once()`
-    /// (`pyjitpl.py:2297 self.cpu.setup_once()`), which is the call
-    /// that materialises the per-CPU malloc / propagate trampolines
-    /// in PyPy (`llsupport/assembler.py:97 setup_once`).
+    /// pyjitpl.py:2292-2303 `_setup_once` — narrow port.
+    ///
+    /// Guarded by `globaldata.initialized` so the body runs exactly
+    /// once per CPU after `finish_setup` has installed every descr
+    /// (`pyjitpl.py:2255`, `pyjitpl.py:2283`).
+    ///
+    /// PRE-EXISTING-ADAPTATION: PyPy's `_setup_once` invokes four
+    /// lifecycle hooks in sequence — `profiler.start()`,
+    /// `cpu.setup_once()`, `jitlog.setup_once()`, and
+    /// `vector_ext.setup_once()` (with `debug_print` interleaved).
+    /// Pyre only dispatches `cpu.setup_once()` here because the
+    /// profiler / jitlog / vector_ext subsystems are not yet wired
+    /// in pyre; the other three hooks will be added as those
+    /// subsystems land.  `cpu.setup_once()`
+    /// (`pyjitpl.py:2297 self.cpu.setup_once()`) is the call that
+    /// materialises the per-CPU malloc / propagate trampolines in
+    /// PyPy (`llsupport/assembler.py:97 setup_once`).
     ///
     /// Pyre invokes this from the metainterp's back-edge entry
     /// `MetaInterp::bound_reached` (pyre analogue of

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1017,20 +1017,26 @@ impl WarmEnterState {
         self.jitlog.as_ref()
     }
 
-    /// pyjitpl.py:2295 `self.jitlog.setup_once()` parity.
+    /// pyjitpl.py:2295 `self.jitlog.setup_once()` parity (per-warmstate
+    /// adaptation).
     ///
-    /// PyPy owns one `JitLogger` on `MetaInterpStaticData` and its
-    /// `setup_once` (`rlib/rjitlog/rjitlog.py:347-354`) re-reads
-    /// `PYPYLOG` and writes a header.  Pyre's `Logger` is owned
-    /// per-`WarmEnterState`; `Logger::from_env` already runs at
-    /// construction (the `new` / `with_jitlog` constructors above),
-    /// so this hook is the late opportunity to install one if the
-    /// warmstate was built before the env was set.  Idempotent —
-    /// only fills the slot when it is still `None`.
+    /// PRE-EXISTING-ADAPTATION: PyPy owns one `JitLogger` on
+    /// `MetaInterpStaticData` (`rlib/rjitlog/rjitlog.py:347-354`) and
+    /// `setup_once` re-reads `PYPYLOG` and writes a header.  Pyre's
+    /// `Logger` is owned per-`WarmEnterState` instead, so the global
+    /// jitlog hook is decomposed into a per-warmstate call that the
+    /// `MetaInterp` driving this warmstate runs just before
+    /// `MetaInterpStaticData::_setup_once`.  `Logger::from_env`
+    /// already runs at construction (the `new` / `with_jitlog`
+    /// constructors above), so this hook is the late opportunity to
+    /// install one if the warmstate was built before the env was
+    /// set.  Idempotent — only fills the slot when it is still
+    /// `None`.
     ///
-    /// Called from `MetaInterpStaticData::_setup_once` so the
-    /// lifecycle order (jitlog → debug_print → cpu.setup_once →
-    /// vector_ext → profiler) matches PyPy.
+    /// Called from `MetaInterp::bound_reached` /
+    /// `MetaInterp::force_start_tracing` so the lifecycle order
+    /// (jitlog → debug_print → cpu.setup_once → vector_ext →
+    /// profiler) matches PyPy for this warmstate.
     pub fn ensure_jitlog_initialised(&mut self) {
         if self.jitlog.is_none() {
             self.jitlog = Logger::from_env();

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1017,6 +1017,26 @@ impl WarmEnterState {
         self.jitlog.as_ref()
     }
 
+    /// pyjitpl.py:2295 `self.jitlog.setup_once()` parity.
+    ///
+    /// PyPy owns one `JitLogger` on `MetaInterpStaticData` and its
+    /// `setup_once` (`rlib/rjitlog/rjitlog.py:347-354`) re-reads
+    /// `PYPYLOG` and writes a header.  Pyre's `Logger` is owned
+    /// per-`WarmEnterState`; `Logger::from_env` already runs at
+    /// construction (the `new` / `with_jitlog` constructors above),
+    /// so this hook is the late opportunity to install one if the
+    /// warmstate was built before the env was set.  Idempotent —
+    /// only fills the slot when it is still `None`.
+    ///
+    /// Called from `MetaInterpStaticData::_setup_once` so the
+    /// lifecycle order (jitlog → debug_print → cpu.setup_once →
+    /// vector_ext → profiler) matches PyPy.
+    pub fn ensure_jitlog_initialised(&mut self) {
+        if self.jitlog.is_none() {
+            self.jitlog = Logger::from_env();
+        }
+    }
+
     /// warmstate.py: trace_eagerness parameter (integer).
     pub fn trace_eagerness(&self) -> u32 {
         self.trace_eagerness

--- a/majit/majit-metainterp/tests/elidable_canary_test.rs
+++ b/majit/majit-metainterp/tests/elidable_canary_test.rs
@@ -56,6 +56,9 @@ fn elidable_canary_traces_to_call_pure_i_when_args_not_all_const() {
     // all_const=false → cut from patch_pos and re-emit CALL → CALL_PURE.
 
     let mut meta = MetaInterp::<()>::new(0);
+    // pyjitpl.py:2273-2283 — fixtures that bypass JitDriver::register_descriptor
+    // must seed propagate_exception_descr before the first trace start.
+    meta.finish_setup_descrs_for_jitdrivers();
     let live_x: i64 = 7;
     let action = meta.force_start_tracing(0, (0, 0), None, &[Value::Int(live_x)]);
     assert!(matches!(action, BackEdgeAction::StartedTracing));
@@ -124,6 +127,7 @@ fn elidable_canary_all_const_args_fold_to_const_and_cut_call() {
     // ConstInt(resvalue) returned.
 
     let mut meta = MetaInterp::<()>::new(0);
+    meta.finish_setup_descrs_for_jitdrivers();
     let action = meta.force_start_tracing(0, (0, 0), None, &[]);
     assert!(matches!(action, BackEdgeAction::StartedTracing));
 

--- a/pyre/bench/list_pop_append.py
+++ b/pyre/bench/list_pop_append.py
@@ -4,7 +4,7 @@
 # On main, first pop() called items_to_vec() → Object strategy;
 # on this branch, stays Integer throughout (no boxing overhead).
 
-N = 300000
+N = 700000
 
 
 def main():

--- a/pyre/bench/list_reverse.py
+++ b/pyre/bench/list_reverse.py
@@ -3,11 +3,11 @@
 # PYPYLOG confirms: guard_class(IntegerListStrategy) + setarrayitem(ArrayS 8) swaps.
 # On main, reverse() called items_to_vec() → Object strategy first.
 # On this branch, reverse() stays in Integer strategy (no boxing overhead).
-# REPS=9 (odd): final list is reversed, so lst[0]=N-1, lst[-1]=0.
+# REPS=15 (odd): final list is reversed, so lst[0]=N-1, lst[-1]=0.
 #
 def main():
-    N = 200000
-    REPS = 9
+    N = 700000
+    REPS = 15
 
     lst = []
     i = 0

--- a/pyre/bench/list_setslice.py
+++ b/pyre/bench/list_setslice.py
@@ -4,7 +4,7 @@
 # On main, there was no setslice op (Object-only fallback).
 # On this branch, setslice stays in Integer strategy when new items are plain ints.
 #
-N = 200000
+N = 500000
 
 def main():
     lst = [0] * 10

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -817,8 +817,8 @@ def main():
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       10,       10,      None,    20,      None)
         chk.run_bench("nbody",          f"{B}/nbody_50k.py",           10,       5,       None,    30,      None)
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       2,       10,      40,      None)
-        chk.run_bench("list_reverse",   f"{B}/list_reverse.py",         5,       10,      None,    10,      None)
-        chk.run_bench("list_pop_append",f"{B}/list_pop_append.py",      5,       15,      None,    15,      None)
+        chk.run_bench("list_reverse",   f"{B}/list_reverse.py",         5,       15,      None,    15,      None)
+        chk.run_bench("list_pop_append",f"{B}/list_pop_append.py",      5,       20,      None,    20,      None)
         chk.run_bench("list_insert",    f"{B}/list_insert.py",          5,       None,    2,       None,    2)
         chk.run_bench("list_setslice",  f"{B}/list_setslice.py",        5,       10,      None,    10,      None)
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -812,7 +812,7 @@ def main():
         chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       None,    3,     3,     None)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       1.5,     10,      1.5,     10)
-        chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    2)
+        chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    1.5,     None,    3)
         chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     6,       None,    None,    None,    None)
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       10,       10,      None,    20,      None)
         chk.run_bench("nbody",          f"{B}/nbody_50k.py",           10,       5,       None,    30,      None)

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -812,7 +812,7 @@ def main():
         chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       None,    3,     3,     None)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       1.5,     10,      1.5,     10)
-        chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    1.5,     None,    3)
+        chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)
         chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     6,       None,    None,    None,    None)
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       10,       10,      None,    20,      None)
         chk.run_bench("nbody",          f"{B}/nbody_50k.py",           10,       5,       None,    30,      None)

--- a/pyre/pyre-jit-trace/tests/elidable_helper_canary_test.rs
+++ b/pyre/pyre-jit-trace/tests/elidable_helper_canary_test.rs
@@ -53,6 +53,7 @@ fn elidable_helper_traces_to_call_pure_i_when_args_not_all_const() {
     // the live wire.
 
     let mut meta = MetaInterp::<()>::new(0);
+    meta.finish_setup_descrs_for_jitdrivers();
     let live_x: i64 = 7;
     let action = meta.force_start_tracing(0, (0, 0), None, &[Value::Int(live_x)]);
     assert!(matches!(action, BackEdgeAction::StartedTracing));
@@ -109,6 +110,7 @@ fn elidable_helper_traces_to_call_pure_i_when_args_not_all_const() {
 #[test]
 fn emit_trace_call_int_typed_elidable_cannot_raise_routes_to_call_pure_i() {
     let mut meta = MetaInterp::<()>::new(0);
+    meta.finish_setup_descrs_for_jitdrivers();
     let live_x: i64 = 0x_dead_beef;
     let action = meta.force_start_tracing(0, (0, 0), None, &[Value::Int(live_x)]);
     assert!(matches!(action, BackEdgeAction::StartedTracing));
@@ -159,6 +161,7 @@ fn elidable_int_bit_count_macro_advertises_extern_c_trampoline_and_traces_call_p
     assert_eq!(trace_target, __majit_call_target_int_bit_count as *const (),);
 
     let mut meta = MetaInterp::<()>::new(0);
+    meta.finish_setup_descrs_for_jitdrivers();
     let live_x: i64 = 0x_0bad_cafe_dead_beef;
     let action = meta.force_start_tracing(0, (0, 0), None, &[Value::Int(live_x)]);
     assert!(matches!(action, BackEdgeAction::StartedTracing));
@@ -199,6 +202,7 @@ fn elidable_int_bit_count_macro_advertises_extern_c_trampoline_and_traces_call_p
 #[test]
 fn elidable_helper_all_const_args_fold_to_const_and_cut_call() {
     let mut meta = MetaInterp::<()>::new(0);
+    meta.finish_setup_descrs_for_jitdrivers();
     let action = meta.force_start_tracing(0, (0, 0), None, &[]);
     assert!(matches!(action, BackEdgeAction::StartedTracing));
 


### PR DESCRIPTION
Fix #69

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer


  1. PyPy parity regressions vs main
  I do not see a clear regression relative to main.
  The changes around jitprof.start(),
  jit_starting_line, x86 int_sub LEA handling, malloc
  slowpath clobbers, and call argument remapping all
  move closer to the RPython shape.

  2. Other mismatch introduced by our patch
  majit/majit-metainterp/src/pyjitpl/mod.rs:2976
  still lets the on_back_edge_typed path start
  tracing without calling _setup_once().

  In RPython, compile_and_run_once() always calls
  self.staticdata._setup_once() before tracing. The
  Rust port now does this for force_start_tracing and
  bound_reached, but not for:

  on_back_edge_typed -> maybe_compile -> StartTracing
  -> setup_tracing

  The parity-correct fix is to call setup after the
  hotness decision, not on every cold back-edge tick:

  HotResult::StartTracing => {
      self.warm_state.ensure_jitlog_initialised();
      self.staticdata._setup_once(&mut self.backend);
      self.setup_tracing(...);
  }

  That matches RPython’s timing: setup runs after the
  loop is considered hot, immediately before actual
  tracing starts.

  3. Pre-existing mismatches
  majit/majit-metainterp/src/pyjitpl/mod.rs:2450
  still has ensure_default_driver_sd directly pushing
  JitDriverStaticData::new(...). RPython’s
  CallControl consistently assigns jd.index while
  building jitdrivers. This looks pre-existing, not
  introduced by the latest patch.

  The x86 backend setup path also still appears
  incomplete versus RPython: RPython builds fixed,
  varsize, str, and unicode malloc slowpaths, while
  this port mainly has the fixed slowpath wired.

  4. Structural adaptations
  backend_name() is a Rust trait adaptation of
  RPython’s cpu.__module__ backend-name derivation.

  WarmEnterState::ensure_jitlog_initialised() is also
  an adaptation: RPython owns jitlog setup from
  MetaInterpStaticData, while this Rust port routes
  it through warmstate ownership.

  .claude/skills, benchmark tuning, and pyre/check.py
  changes are not RPython/PyPy parity surfaces.

  Verification: static analysis plus cargo check -p
  majit-metainterp --features dynasm, which passed.


<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added backend identification system for JIT logging and diagnostics
  * Enhanced profiler with initialization tracking and reset capability

* **Bug Fixes**
  * Fixed register corruption in x86 arithmetic operations
  * Fixed call argument handling on Windows x64 platform
  * Improved register preservation in memory allocation paths

* **Chores**
  * Updated benchmark parameters for more comprehensive performance testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->