### PR TITLE
Make get_latest_descr return the same object the optimizer stamped

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6627,18 +6627,18 @@ fn run_compiled_code_inner(
         } else {
             (0u32, None)
         }
-    } else if let Some((metainterp_finish, cl_singleton)) =
+    } else if let Some((metainterp_finish, _cl_singleton)) =
         match_metainterp_finish_descr(jf_descr_raw, attachments)
     {
-        // `pyjitpl.py:2222` match — the metainterp-side
-        // `Arc<DoneWithThisFrameDescr*>` was written into jf_descr at
-        // FINISH emission.  Its `fail_index()` on `MetaFailDescr`
-        // semantics is u32::MAX (finish marker), which `run_compiled_code`
-        // consumers rely on.  Return the cranelift-side singleton as
-        // `direct_descr` so downstream `bridge_ref()` / `fail_arg_types`
-        // access keeps the same type as the non-metainterp path.
-        let _ = metainterp_finish;
-        (u32::MAX, Some(cl_singleton))
+        // `history.py:125` `cpu.get_latest_descr(deadframe)` parity:
+        // `jf_descr` carries the metainterp `Arc<DoneWithThisFrameDescr*>`
+        // address (compiler.rs:13778 baking).  Return that *exact* Arc
+        // so the consumer sees the same identity `compile.py:618-672`
+        // attached on the cpu — not the process-global fallback static.
+        // Both are `Arc<DoneWithThisFrameDescrInt>` after Slice 7-Tβ14f
+        // (no wrapper) so the trait-method dispatch is identical; only
+        // the Arc identity differs, and PyPy parity demands they match.
+        (u32::MAX, Some(metainterp_finish))
     } else {
         // Slice 7-Tβ14e: `jf_descr_raw` is the metainterp
         // `AbstractFailDescr` Arc's data pointer.  Resolve via the
@@ -14834,38 +14834,6 @@ impl majit_backend::Backend for CraneliftBackend {
             &bridge.fail_descrs,
             bridge.trace_id,
         ))
-    }
-
-    fn compiled_bridge_descr_arc(
-        &self,
-        original_token: &JitCellToken,
-        source_trace_id: u64,
-        source_fail_index: u32,
-    ) -> Option<Arc<dyn majit_ir::Descr>> {
-        let original_compiled = original_token
-            .compiled
-            .as_ref()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
-        let source_descr = find_fail_descr_in_fail_descrs(
-            &original_compiled.fail_descrs,
-            source_trace_id,
-            source_fail_index,
-        )?;
-        Some(source_descr)
-    }
-
-    fn find_source_fail_descr(
-        &self,
-        token: &JitCellToken,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> Option<Arc<dyn majit_ir::Descr>> {
-        let compiled = token
-            .compiled
-            .as_ref()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
-        let descr = find_fail_descr_in_fail_descrs(&compiled.fail_descrs, trace_id, fail_index)?;
-        Some(descr as Arc<dyn majit_ir::Descr>)
     }
 
     fn compiled_trace_fail_descr_layouts(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1432,14 +1432,12 @@ impl DynasmBackend {
         // Query-style miss tolerance: when `token.compiled` is absent
         // (e.g. a freshly issued JitCellToken whose backend code has
         // not been attached, or one rotated into `previous_tokens`),
-        // probing callers like `compiled_bridge_descr_arc` /
-        // `compiled_bridge_fail_descr_layouts` must observe `None`
-        // instead of a panic. Cranelift's counterpart at
-        // `compiler.rs:13955-13958` (`token.compiled.as_ref().and_then
-        // (|c| c.downcast_ref::<CompiledLoop>())?`) follows the same
-        // contract; pyre's `bridge_source_descr`
-        // (`pyjitpl/mod.rs:7743-7757`) walks `compiled.token` then
-        // each `previous_tokens[*]`, depending on `None` to advance.
+        // probing callers like `compiled_bridge_fail_descr_layouts`
+        // must observe `None` instead of a panic.  Cranelift's
+        // counterpart at `compiler.rs:13955-13958`
+        // (`token.compiled.as_ref().and_then(|c|
+        // c.downcast_ref::<CompiledLoop>())?`) follows the same
+        // contract.
         let compiled = token
             .compiled
             .as_ref()?
@@ -3081,32 +3079,6 @@ impl Backend for DynasmBackend {
             }
         }
         None
-    }
-
-    fn compiled_bridge_descr_arc(
-        &self,
-        original_token: &JitCellToken,
-        source_trace_id: u64,
-        source_fail_index: u32,
-    ) -> Option<Arc<dyn majit_ir::Descr>> {
-        // Trait contract (majit-backend/lib.rs:1797-1816): identity
-        // recovery for `bridge_source_descr` when the metainterp side
-        // cannot produce the descr (synthetic / cut-tentative ops,
-        // post-retrace stale traces).  Whether a bridge is currently
-        // attached is irrelevant — the bridge-compilation path needs
-        // the source descr identity regardless.  Matches cranelift's
-        // `compiled_bridge_descr_arc` (compiler.rs:14290), which does
-        // not gate on bridge attachment either.
-        Self::try_find_descr(original_token, source_trace_id, source_fail_index)
-    }
-
-    fn find_source_fail_descr(
-        &self,
-        token: &JitCellToken,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> Option<Arc<dyn majit_ir::Descr>> {
-        Self::try_find_descr(token, trace_id, fail_index)
     }
 
     /// `pyjitpl.py:2297 self.cpu.setup_once()` parity, dispatched by

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1793,56 +1793,6 @@ pub trait Backend: Send {
         None
     }
 
-    /// `cpu.get_latest_descr(deadframe)` parity for the bridge-source path.
-    ///
-    /// `pyjitpl/mod.rs::bridge_source_descr` looks up the failed guard's
-    /// descr through the metainterp trace ops (`trace.exit_layouts.descr`,
-    /// or a `trace.ops` walk via `descr.fail_index()` match), the
-    /// line-by-line port of `op.getdescr()` at `compile.py:184`.  When the metainterp side cannot produce the
-    /// descr (synthetic / cut-tentative ops, post-retrace stale traces),
-    /// the backend still owns the live `Arc<dyn Descr>` that pyre's
-    /// runtime guard-failure helpers received as `descr_addr`.  This
-    /// method returns that backend-side identity so the metainterp can
-    /// fall back to it without panicking.
-    ///
-    /// Returns `None` for backends that don't own a `(token, trace_id,
-    /// fail_index)`-keyed descr store — bare-backend tests use that
-    /// default; the production cranelift / dynasm impls override.
-    ///
-    /// PyPy parity: under the unified ResumeGuardDescr identity the two
-    /// paths return the same object, so the fallback is observationally
-    /// identical to the metainterp lookup.  After Slice 7-Tα7 the
-    /// dynasm backend hands back `ResumeGuardDescr` directly; the
-    /// cranelift backend still upcasts `Arc<CraneliftFailDescr>` →
-    /// `Arc<dyn Descr>` until the parallel Phase 7-Tβ collapse.
-    fn compiled_bridge_descr_arc(
-        &self,
-        _original_token: &JitCellToken,
-        _source_trace_id: u64,
-        _source_fail_index: u32,
-    ) -> Option<Arc<dyn Descr>> {
-        None
-    }
-
-    /// `history.py:125` `cpu.get_latest_descr(deadframe)` parity — return
-    /// the source `FailDescr` Arc keyed by `(token, trace_id, fail_index)`
-    /// **without** gating on whether a bridge has already been compiled
-    /// for it.  `compiled_bridge_descr_arc` answers "does the bridge exist
-    /// and what's its source descr"; this answers "what descr would a
-    /// bridge for this guard be compiled from", which is the form a
-    /// pre-compile lookup (`bridge_source_descr`) needs.
-    ///
-    /// Returns `None` for backends without a token-keyed descr store
-    /// (bare-backend tests).  Production dynasm / cranelift override.
-    fn find_source_fail_descr(
-        &self,
-        _token: &JitCellToken,
-        _trace_id: u64,
-        _fail_index: u32,
-    ) -> Option<Arc<dyn Descr>> {
-        None
-    }
-
     /// Inspect static exit layouts for any compiled trace owned by this token.
     ///
     /// This is the trace-id keyed counterpart to the root/bridge-specific

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -6,34 +6,95 @@
 /// Descriptors carry type metadata needed by the optimizer and backend
 /// for field access, array access, function calls, and guard failures.
 ///
-/// # TODO: migrate `descr_index: u32` → `descr: DescrRef` on resume metadata
+/// # Descr identity status (Unified-Descr Port follow-up)
 ///
-/// **Deviation.** RPython's `ResOperation` carries `Arc<dyn Descr>`
-/// directly (`history.py:95 AbstractDescr`); identity is pointer
-/// comparison via `op.getdescr() is other.getdescr()`.  Pyre's
-/// resume-metadata structs (`RdVirtualInfo` variants at
-/// resoperation.rs:436/448/457/466/475, `GuardPendingFieldEntry` at
-/// resoperation.rs:784) carry a `descr_index: u32` alongside `descr:
-/// Option<DescrRef>` for serialization sinks
-/// (`ExitVirtualLayout` / `ExitPendingFieldLayout` /
-/// `PendingFieldLayoutSummary`).  The pool canonicalises per-LLType so
-/// `u32` equality is identity-equivalent to RPython's pointer
-/// equality, but the indirection layer is pyre-only.
+/// **Done.** `Op::descr` is `Option<DescrRef>` (resoperation.rs:992) and
+/// every resume-metadata variant that carries a descr now stores it as
+/// `Option<DescrRef>` rather than a `descr_index: u32` handle:
 ///
-/// **When to fix.** When the build-time `opcode_insns.bin`
-/// determinism guarantee no longer needs to come from a `u32` pool
-/// (e.g. once a stable-id registry replaces the deterministic pool),
-/// or when an upstream pass requires in-place descr mutation that the
-/// pool indirection blocks.
+/// * `RdVirtualInfo` variants (resoperation.rs:519-643).  `PartialEq`
+///   (resoperation.rs:664-814) uses `opt_descr_ptr_eq` (Arc::ptr_eq),
+///   matching `history.py:125 id(descr)`.
+/// * `ExitVirtualLayout` (`majit-backend/src/lib.rs:370`) and
+///   `ExitPendingFieldLayout` (`majit-backend/src/lib.rs:549`) compare
+///   descrs via `opt_descr_ptr_eq` for the same reason.
+/// * `ResolvedPendingFieldWrite` / `EncodedPendingFieldWrite`
+///   (`majit-metainterp/src/resume.rs:1496/1523`) and
+///   `PendingFieldLayoutSummary` (`majit-ir/src/resumedata.rs:137`) use
+///   the canonical `resumedata::opt_descr_arc_ptr_eq`.
+/// * `GuardPendingFieldEntry` (resoperation.rs:892) carries
+///   `Option<DescrRef>` directly and intentionally has no `PartialEq`
+///   impl: `PENDINGFIELDSTRUCT` (`resume.py:87-92`) is write-only
+///   resume data that RPython never compares by value.
+/// * The `descr_index: u32` retained on individual descriptors
+///   (`get_descr_index`/`set_descr_index`) is now the pure serialization
+///   handle assigned by `descr.py:28 v.descr_index = len(all_descrs)`
+///   via `optimizer::ensure_descr_index`.
 ///
-/// **How to fix.** (1) Switch identity `PartialEq` comparisons in
-/// `RdVirtualInfo` / `GuardPendingFieldEntry` from `descr_index` to
-/// `Arc::ptr_eq` on the carried `descr` Arcs (PyPy `id(descr)`
-/// parity).  (2) Keep `descr_index` as a pure serialization handle
-/// (downstream `ExitVirtualLayout` / `ExitPendingFieldLayout` still
-/// need a stable `u32` for trace-dump replay).  (3) Audit for Arc
-/// cycle risk between IR ops and the descr graph (FieldDescr →
-/// SizeDescr, CallDescr → effectinfo's field/array descr lists).
+/// **Arc cycle audit (Phase D prereq B, 2026-05-19).**
+///
+/// | Edge | Direction | Strength | Status |
+/// |---|---|---|---|
+/// | `SimpleSizeDescr.all_fielddescrs` → `FieldDescr` | child | strong | OK |
+/// | `SimpleFieldDescr.parent_descr` → `SizeDescr` | parent | **Weak** (descr.rs:3147, 3272) | OK — cycle broken |
+/// | `SimpleFieldDescr.vinfo` → `VirtualizableInfo` | back | **Weak** (descr.rs:3154, 3281) | OK — cycle broken |
+/// | `VirtualizableInfo._static_field_descrs` → `FieldDescr` | child | strong | OK (paired with Weak above) |
+/// | `CallDescr → EffectInfo._readonly/write_descrs_*` → `FieldDescr/ArrayDescr` | uni | strong | OK — no back-ref |
+/// | `SimpleArrayDescr.lendescr` → length `FieldDescr` (parent_descr=None) | uni | strong | OK — no back-ref |
+/// | `SimpleArrayDescr.all_interiorfielddescrs` ↔ `SimpleInteriorFieldDescr.array_descr` | both | **strong both ways** | **CYCLE, accepted** |
+///
+/// The struct-array interior cycle (last row) mirrors PyPy's
+/// `arraydescr.all_interiorfielddescrs = descrs` +
+/// `InteriorFieldDescr.arraydescr = arraydescr`
+/// (`descr.py:372-375` + `descr.py:388-391`).  Python tolerates it via
+/// cycle-collecting GC; Rust's `Arc` does not.  In practice the descr
+/// graph is process-lifetime pinned by `GcCache._cache_size` /
+/// `_cache_array` / `_cache_interiorfield` (descr.rs:498/660/710) — the
+/// global singleton `gc_cache()` keeps strong roots for every minted
+/// descr, so dropping IR-side `DescrRef` clones never decrements the
+/// last strong count, and the cycle never gets a chance to leak.  If a
+/// future port ever needs per-test descr teardown, weaken
+/// `SimpleInteriorFieldDescr.array_descr` to `Weak<dyn ArrayDescr>`
+/// (parity: PyPy reaches the array descr via `gccache._cache_array`
+/// rather than relying on the InteriorFieldDescr backreference for
+/// identity).
+///
+/// **C (landed 2026-05-19).**  Trait-dispatch + structural keying
+/// migration for the virtualizable / virtualref field paths:
+///
+/// * `optimize_setfield_gc`, `optimize_getfield_gc`, and
+///   `resolve_array_source` read `op.descr.as_field_descr()?.offset()`
+///   and `.is_typeptr()` directly (RPython `op.getdescr().offset` /
+///   `heaptracker.py:66 name == 'typeptr'` parity).
+/// * `optimize_(get|set)interiorfield_gc` extract the inner
+///   `FieldDescr` via `as_interior_field_descr().field_descr()`
+///   (`descr.py:388 InteriorFieldDescr.__init__` parity) — they no
+///   longer panic for InteriorFieldDescr ops.
+/// * `VirtualizableFieldState.fields` is now keyed by
+///   `FieldDescr::index_in_parent()` (RPython
+///   `info.AbstractStructPtrInfo._fields[fielddescr.get_index()]`,
+///   `info.py:203-206`) instead of the packed
+///   `FIELD_DESCR_TAG | offset << 4 | size << 1 | type_bits` u32.
+///   The synthetic fallback at `init` assigns `1 + field_idx_in_vinfo`
+///   for static slots and `1 + num_static + array_idx` for array
+///   slots, matching `virtualizable.py:71-72 build_field_descr`.
+/// * The pyre-only `FieldIndexDescr`, `make_field_index_descr`,
+///   `virtualizable_field_index`, `extract_field_offset`,
+///   `descr_index` helper, and `debug_assert_no_typeptr_in_virtual_fields`
+///   are deleted.  The typeptr-exclusion invariant is enforced at
+///   `optimize_setfield_gc`'s typeptr fold (RPython
+///   `heaptracker.py:66-67`), not by a runtime assert.
+/// * `VirtualRefInfo`'s pyre-only `descr_virtual_token: u32` /
+///   `descr_forced: u32` / `descr_size: u32` placeholders and the
+///   matching `virtualref.rs` `VREF_FIELD_*` packed constants are
+///   retired.  RPython caches real `Arc<dyn FieldDescr>` /
+///   `Arc<dyn SizeDescr>` on the equivalent struct
+///   (`virtualref.py:40-42 cpu.fielddescrof`); pyre constructs vref
+///   field descrs on demand at the SETFIELD_GC emit sites
+///   (`optimizeopt/virtualize.rs:1521/1528 make_vref_field_descr`).
+///   Caching them on `VirtualRefInfo` for identity stability is a
+///   separate follow-up (no current pyre call site relied on the
+///   removed u32 placeholders).
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3550,14 +3550,17 @@ impl<S: JitState> JitDriver<S> {
         // position and traces forward from there.
         let mut trace_meta = state.build_meta(resume_pc, env);
 
-        let fail_arg_count = self
-            .meta
-            .fail_arg_count_for(green_key, trace_id, fail_index);
+        // `compile.py:855` `_attrs_` parity: bridge inputarg count is the
+        // length of the source descr's `fail_arg_types`.  Read directly
+        // from `descr_fd` (the Arc already in scope) — no `(green_key,
+        // trace_id, fail_index)` reverse lookup.
+        let fail_arg_count = descr_fd.fail_arg_types().len();
         let Some(frontend_fail_values) = raw_fail_values.get(..fail_arg_count) else {
             return false;
         };
 
         let retrace = match self.meta.start_retrace_from_guard(
+            descr_arc.clone(),
             green_key,
             trace_id,
             fail_index,
@@ -3691,6 +3694,13 @@ impl<S: JitState> JitDriver<S> {
                 trace_id,
                 fail_index,
                 code_ptr,
+                // `pyjitpl.py:2890` `handle_guard_failure(self,
+                // resumedescr, deadframe)` parity: thread the source
+                // descr Arc obtained from `cpu.get_latest_descr`
+                // through the bridge session so `compile_trace_inner`
+                // reads it directly (no `(trace_id, fail_index)`
+                // reverse lookup).
+                source_descr: descr_arc.clone(),
             });
         // RPython pyjitpl.py:2908 — bridge traces start with empty
         // current_merge_points (no loop header to match against).

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7087,6 +7087,11 @@ pub trait Optimization {
     /// Only OptPure consumes this; other passes ignore it.
     fn set_pureop_historylength(&mut self, _limit: usize) {}
 
+    /// `virtualize.py:140 vrefinfo =
+    /// self.optimizer.metainterp_sd.virtualref_info` parity hook.  Only
+    /// `OptVirtualize` reads this; other passes ignore it.
+    fn set_vrefinfo(&mut self, _vrefinfo: crate::virtualref::VirtualRefInfo) {}
+
     /// optimizer.py:517 propagate_all_forward(trace, call_pure_results, flush).
     /// Only OptPure consumes this; other passes ignore it.
     fn set_call_pure_results(

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1796,6 +1796,16 @@ impl Optimizer {
         }
     }
 
+    /// `virtualize.py:140` fan-out: publish the live `VirtualRefInfo`
+    /// (`MetaInterp.virtualref_info` / RPython
+    /// `metainterp_sd.virtualref_info`) to every pass that consumes it
+    /// (`OptVirtualize`).  Other passes' `set_vrefinfo` is a no-op.
+    pub fn set_vrefinfo(&mut self, vrefinfo: crate::virtualref::VirtualRefInfo) {
+        for pass in &mut self.passes {
+            pass.set_vrefinfo(vrefinfo.clone());
+        }
+    }
+
     /// Mark all passes as Phase 2 (loop body).
     pub fn set_phase2(&mut self, phase2: bool) {
         for pass in &mut self.passes {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -150,45 +150,60 @@ impl VirtualizableTracker {
         };
         let mut flat_input_idx = 1usize + self.config.vable_input_offset;
 
-        for (field_idx_in_vinfo, &offset) in self.config.static_field_offsets.iter().enumerate() {
+        // RPython `info.AbstractStructPtrInfo._fields` is keyed by
+        // `fielddescr.get_index()` (descr.py:228 `index_in_parent`,
+        // populated by `cpu.fielddescrof(VTYPE, name)`).  Mirror that
+        // here so runtime queries via
+        // `op.descr.as_field_descr()?.index_in_parent() as u32` find the
+        // slot the init step seeded.
+        //
+        // `virtualizable.py:71-72 build_field_descr` assigns
+        // `index_in_parent = 1 + i` for static fields and
+        // `1 + num_static + j` for array-pointer fields; mirror that
+        // schedule for the synthetic fallback used by tests that pass
+        // empty `static_field_descrs` / `array_field_descrs`.
+        let num_static = self.config.static_field_offsets.len();
+        for (field_idx_in_vinfo, &_offset) in self.config.static_field_offsets.iter().enumerate() {
             if flat_input_idx >= ctx.num_inputs() {
                 break;
             }
-            let field_idx = virtualizable_field_index(offset);
+            let descr_for_slot = self
+                .config
+                .static_field_descrs
+                .get(field_idx_in_vinfo)
+                .cloned();
+            let field_idx = descr_for_slot
+                .as_ref()
+                .and_then(|d| d.as_field_descr())
+                .map(|fd| fd.index_in_parent() as u32)
+                .unwrap_or((1 + field_idx_in_vinfo) as u32);
             let slot_tp = ctx
                 .inputarg_type_at(flat_input_idx)
                 .unwrap_or(majit_ir::Type::Ref);
             let input_ref = OpRef::input_arg_typed(flat_input_idx as u32, slot_tp);
             set_field(&mut state.fields, field_idx, input_ref);
-            set_field_descr(
-                &mut state.field_descrs,
-                field_idx,
-                self.config
-                    .static_field_descrs
-                    .get(field_idx_in_vinfo)
-                    .cloned()
-                    .unwrap_or_else(|| make_field_index_descr(field_idx)),
-            );
+            if let Some(descr) = descr_for_slot {
+                set_field_descr(&mut state.field_descrs, field_idx, descr);
+            }
             flat_input_idx += 1;
         }
 
-        for (array_idx, (&offset, &length)) in self
+        for (array_idx, (&_offset, &length)) in self
             .config
             .array_field_offsets
             .iter()
             .zip(self.config.array_lengths.iter())
             .enumerate()
         {
-            let field_idx = virtualizable_field_index(offset);
-            set_field_descr(
-                &mut state.field_descrs,
-                field_idx,
-                self.config
-                    .array_field_descrs
-                    .get(array_idx)
-                    .cloned()
-                    .unwrap_or_else(|| make_field_index_descr(field_idx)),
-            );
+            let descr_for_slot = self.config.array_field_descrs.get(array_idx).cloned();
+            let field_idx = descr_for_slot
+                .as_ref()
+                .and_then(|d| d.as_field_descr())
+                .map(|fd| fd.index_in_parent() as u32)
+                .unwrap_or((1 + num_static + array_idx) as u32);
+            if let Some(descr) = descr_for_slot {
+                set_field_descr(&mut state.field_descrs, field_idx, descr);
+            }
 
             let mut elements = Vec::with_capacity(length);
             for _ in 0..length {
@@ -240,8 +255,11 @@ impl VirtualizableTracker {
         if !self.is_standard_ref(frame_ref, ctx) {
             return None;
         }
-        let field_idx = descr_index_of_op(&producer);
-        let offset = extract_field_offset(field_idx)?;
+        // `virtualize.py` reads `op.getdescr().offset` directly to resolve
+        // raw-field byte offsets; mirror that via `FieldDescr::offset()`.
+        let offset = producer
+            .getdescr()
+            .and_then(|d| d.as_field_descr().map(|fd| fd.offset()))?;
         let array_idx = self.array_idx_for_offset(offset)?;
         Some((frame_ref, array_idx))
     }
@@ -527,14 +545,14 @@ impl OptVirtualize {
     fn optimize_setfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let struct_ref = ctx.get_box_replacement(op.arg(0));
         let value_ref = ctx.get_box_replacement(op.arg(1));
-        let field_idx = descr_index_of_op(op);
         let setfield_descr_arc = op
             .getdescr()
             .expect("optimize_setfield_gc: field op without FieldDescr");
         let field_descr = setfield_descr_arc
             .as_field_descr()
             .expect("optimize_setfield_gc: field op without FieldDescr");
-        let offset = extract_field_offset(field_idx);
+        let field_idx = field_descr.index_in_parent() as u32;
+        let is_typeptr = field_descr.is_typeptr();
         let is_raw_op = matches!(op.opcode, OpCode::SetfieldRaw);
         // Pre-extract constant value before mutable borrow of ptr_info.
         // Class pointer may be stored as Value::Int OR Value::Ref.
@@ -556,7 +574,7 @@ impl OptVirtualize {
         // it as a lazy_set. The virtual value is NOT forced — OptHeap delays
         // it until guard emission (force_lazy_sets_for_guard) or JUMP.
 
-        let descr_for_vstate = op.getdescr();
+        let descr_for_vstate = Some(setfield_descr_arc.clone());
         let struct_box = ctx.ensure_box(struct_ref);
         let early = struct_box
             .as_ref()
@@ -564,7 +582,7 @@ impl OptVirtualize {
                 if !info.is_virtual() {
                     return None;
                 }
-                if offset != Some(0) {
+                if !is_typeptr {
                     let parent_descr = field_descr.get_parent_descr().expect(
                         "optimize_setfield_gc: non-typeptr FieldDescr.get_parent_descr() returned None",
                     );
@@ -579,9 +597,9 @@ impl OptVirtualize {
                         // → _fields never contains typeptr. In pyre, typeptr
                         // setfield is filtered at trace recording time
                         // (jtransform.py:908-911 parity in helpers.rs), so this
-                        // branch should not observe offset=0. Defensively capture
-                        // known_class if an offset-0 setfield still arrives.
-                        if offset == Some(0) {
+                        // branch should not observe a typeptr op. Defensively
+                        // capture known_class if a typeptr setfield still arrives.
+                        if is_typeptr {
                             if vinfo.known_class.is_none() {
                                 if let Some(class_val) = value_as_constant {
                                     vinfo.known_class = Some(majit_ir::GcRef(class_val));
@@ -597,10 +615,6 @@ impl OptVirtualize {
                                     .as_size_descr()
                                     .map(|sd| sd.all_fielddescrs().len())
                                     .unwrap_or(0)
-                        );
-                        debug_assert_no_typeptr_in_virtual_fields(
-                            &vinfo.fields,
-                            "optimize_setfield_gc::Virtual",
                         );
                         Some(OptimizationResult::Remove)
                     }
@@ -649,7 +663,14 @@ impl OptVirtualize {
 
     fn optimize_getfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let struct_ref = ctx.get_box_replacement(op.arg(0));
-        let field_idx = descr_index_of_op(op);
+        let field_descr_arc = op
+            .getdescr()
+            .expect("optimize_getfield_gc: field op without FieldDescr");
+        let field_descr = field_descr_arc
+            .as_field_descr()
+            .expect("optimize_getfield_gc: descr is not a FieldDescr");
+        let field_idx = field_descr.index_in_parent() as u32;
+        let is_typeptr = field_descr.is_typeptr();
         let is_raw_op = matches!(
             op.opcode,
             OpCode::GetfieldRawI | OpCode::GetfieldRawR | OpCode::GetfieldRawF
@@ -666,11 +687,10 @@ impl OptVirtualize {
             .and_then(|b| ctx.peek_ptr_info(b))
         {
             // info.py:212-214 getfield: return _fields[fielddescr.get_index()].
-            // For Virtual, ob_type (offset 0) is not in fields — fold from
+            // For Virtual, ob_type (typeptr) is not in fields — fold from
             // known_class (info.py:324-325 get_known_class).
             if let PtrInfo::Virtual(ref vinfo) = info {
-                let offset = extract_field_offset(field_idx);
-                if offset == Some(0) {
+                if is_typeptr {
                     if let Some(gc_ref) = vinfo.known_class {
                         let class_val = gc_ref.as_usize() as i64;
                         ctx.make_constant(op.pos.get(), majit_ir::Value::Int(class_val));
@@ -849,7 +869,17 @@ impl OptVirtualize {
     ) -> OptimizationResult {
         let array_ref = ctx.get_box_replacement(op.arg(0));
         let index_ref = op.arg(1);
-        let field_idx = descr_index_of_op(op);
+        // `info.py:573-581 getinteriorfield_virtual` indexes the per-element
+        // field list by `fielddescr.get_index()`.  Strip the surrounding
+        // `InteriorFieldDescr` first (`descr.py:388 InteriorFieldDescr.
+        // __init__` stores the inner `fielddescr`).
+        let field_idx = op
+            .getdescr()
+            .and_then(|d| {
+                d.as_interior_field_descr()
+                    .map(|ifd| ifd.field_descr().index_in_parent() as u32)
+            })
+            .expect("optimize_getinteriorfield_gc: op without InteriorFieldDescr");
 
         if let Some(PtrInfo::VirtualArrayStruct(vinfo)) = ctx
             .get_box_replacement_box(array_ref)
@@ -893,7 +923,16 @@ impl OptVirtualize {
         let array_ref = ctx.get_box_replacement(op.arg(0));
         let index_ref = op.arg(1);
         let value_ref = ctx.get_box_replacement(op.arg(2));
-        let field_idx = descr_index_of_op(op);
+        // `info.py:583-594 setinteriorfield_virtual` indexes the per-element
+        // field list by `fielddescr.get_index()`.  Same shape as the GET
+        // counterpart — strip the outer `InteriorFieldDescr` first.
+        let field_idx = op
+            .getdescr()
+            .and_then(|d| {
+                d.as_interior_field_descr()
+                    .map(|ifd| ifd.field_descr().index_in_parent() as u32)
+            })
+            .expect("optimize_setinteriorfield_gc: op without InteriorFieldDescr");
 
         if let Some(index) = ctx.get_constant_int(index_ref) {
             let elem_idx = index as usize;
@@ -1952,33 +1991,6 @@ fn set_field(fields: &mut Vec<(u32, OpRef)>, field_idx: u32, value_ref: OpRef) {
     fields.push((field_idx, value_ref));
 }
 
-/// RPython parity assertion: `VirtualInfo.fields` must NEVER contain
-/// typeptr (offset 0). heaptracker.py:66-67 `all_fielddescrs()` skips
-/// typeptr, so `info.py:180 AbstractStructPtrInfo._fields` is sized to
-/// the non-typeptr field count and has no slot for offset 0.
-///
-/// This helper asserts the invariant at boundaries where `Virtual.fields`
-/// is constructed/populated/iterated: import (virtualstate), export
-/// (virtualstate), force path (force_virtual_instance), and the
-/// `optimize_setfield_gc` Virtual arm (before `set_field`).
-///
-/// Only `VirtualInfo.fields` is subject to this invariant;
-/// `VirtualStructInfo.fields` (OpCode::New without vtable) may contain
-/// any offset including 0.
-#[inline]
-pub(crate) fn debug_assert_no_typeptr_in_virtual_fields(
-    fields: &[(u32, OpRef)],
-    context: &'static str,
-) {
-    debug_assert!(
-        fields
-            .iter()
-            .all(|(idx, _)| extract_field_offset(*idx) != Some(0)),
-        "VirtualInfo.fields must exclude typeptr (offset 0) — RPython \
-         heaptracker.py:66-67 all_fielddescrs() parity violation at {context}",
-    );
-}
-
 fn set_field_descr(field_descrs: &mut Vec<(u32, DescrRef)>, field_idx: u32, descr: DescrRef) {
     for entry in field_descrs.iter_mut() {
         if entry.0 == field_idx {
@@ -2001,66 +2013,6 @@ fn get_field(fields: &[(u32, OpRef)], field_idx: u32) -> Option<OpRef> {
         .iter()
         .find(|(idx, _)| *idx == field_idx)
         .map(|(_, opref)| *opref)
-}
-
-/// Extract the descriptor index used as a field identifier.
-fn descr_index_of_op(op: &majit_ir::Op) -> u32 {
-    op.with_field_descr(|field_descr| field_descr.index_in_parent() as u32)
-        .expect("descr_index: field operations must carry a FieldDescr with parent-local index")
-}
-
-// ── Minimal descriptor for field identification in forced setfield ops ──
-
-#[derive(Debug)]
-struct FieldIndexDescr(u32);
-
-impl Descr for FieldIndexDescr {
-    fn index(&self) -> u32 {
-        self.0
-    }
-    fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
-        Some(self)
-    }
-}
-
-impl FieldDescr for FieldIndexDescr {
-    fn index_in_parent(&self) -> usize {
-        // Return the raw encoded descriptor value as the field key.
-        // VirtualStructInfo.fields stores this same value as the key,
-        // so descr_index() → index_in_parent() matches field lookups.
-        self.0 as usize
-    }
-
-    fn offset(&self) -> usize {
-        // Decode offset from the encoded field descriptor index.
-        // Format: FIELD_DESCR_TAG | (offset << 4) | (size << 1) | (signed << 3) | type_bits
-        ((self.0 >> 4) & 0x000f_ffff) as usize
-    }
-
-    fn field_size(&self) -> usize {
-        // Match the stable field descriptor encoding used by the real
-        // pyre/majit descriptors: pointer-sized fields encode size_bits == 0
-        // because (8 & 0x7) == 0, but the runtime field width is still 8.
-        let size_bits = ((self.0 >> 1) & 0x7) as usize;
-        if size_bits == 0 { 8 } else { size_bits }
-    }
-
-    fn is_field_signed(&self) -> bool {
-        (self.0 >> 3) & 1 != 0
-    }
-
-    fn field_type(&self) -> majit_ir::Type {
-        match self.0 & 0x3 {
-            0 => majit_ir::Type::Int,
-            1 => majit_ir::Type::Ref,
-            2 => majit_ir::Type::Float,
-            _ => majit_ir::Type::Void,
-        }
-    }
-}
-
-pub(crate) fn make_field_index_descr(idx: u32) -> DescrRef {
-    Arc::new(FieldIndexDescr(idx))
 }
 
 #[derive(Debug)]
@@ -2187,43 +2139,6 @@ impl majit_ir::SizeDescr for VRefSizeDescr {
     fn all_fielddescrs(&self) -> &[Arc<dyn majit_ir::FieldDescr>] {
         &VREF_ALL_FIELDDESCRS
     }
-}
-
-fn virtualizable_field_index(offset: usize) -> u32 {
-    // Encode as: FIELD_DESCR_TAG | (offset << 4) | (size_bits << 1) | type_bits
-    // type_bits = 0 (Int), size_bits = 0 (8 & 0x7 = 0 for pointer-sized fields)
-    0x1000_0000 | (((offset as u32) & 0x000f_ffff) << 4)
-}
-
-/// Extract the byte offset from a field descriptor index.
-///
-/// Field descriptor indices encode offset, size, and type. This extracts
-/// just the byte offset for matching against VirtualizableConfig offsets.
-///
-/// # TODO: replace u32 packing with proper Descr access
-///
-/// **Deviation.** RPython reads `op.getdescr().offset` directly from a
-/// heap-allocated `FieldDescr` instance
-/// (`rpython/jit/backend/llsupport/descr.py`). Pyre's `Op.descr` is a
-/// `u32` index instead of `Box<dyn Descr>`, so the encoding
-/// `FIELD_DESCR_TAG | (offset << 4) | (size << 1) | type_bits` packs
-/// the descriptor's distinguishing fields into the index itself; the
-/// tag bit `0x1000_0000` distinguishes field descriptors from other
-/// descr kinds sharing the same `u32` namespace.
-///
-/// **When to fix.** When `descr_index: u32` migrates to `descr:
-/// DescrRef` on `ResOperation` (see `majit-ir/src/descr.rs` TODO).
-///
-/// **How to fix.** Drop the `FIELD_DESCR_TAG` packing/unpacking
-/// entirely; replace the body with `descr.as_field_descr()?.offset`.
-/// Delete this helper if every call site can switch to direct trait
-/// dispatch.
-fn extract_field_offset(descr_idx: u32) -> Option<usize> {
-    const FIELD_DESCR_TAG: u32 = 0x1000_0000;
-    if descr_idx & 0xF000_0000 != FIELD_DESCR_TAG {
-        return None;
-    }
-    Some(((descr_idx >> 4) & 0x000f_ffff) as usize)
 }
 
 /// Lookup helper for `PtrInfo::Virtualizable.arrays` — returns the OpRef
@@ -2517,6 +2432,25 @@ mod tests {
         Arc::new(TestArrayDescr { idx })
     }
 
+    /// Test helper: build a `FieldDescr` with explicit `offset` and
+    /// `index_in_parent` for the virtualizable-field test sites.  Mirrors
+    /// the shape `cpu.fielddescrof(VTYPE, name)` produces (descr.py:218-239
+    /// `get_field_descr`) — pyre's `init` keys `VirtualizableFieldState.fields`
+    /// by `fielddescr.get_index()` (info.py:203-206), so the synthetic
+    /// fallback at `init` assigns `1 + field_idx_in_vinfo` for static slots
+    /// and `1 + num_static + array_idx` for array slots.
+    fn test_vable_field_descr(offset: usize, field_type: Type, index_in_parent: usize) -> DescrRef {
+        let field_size = match field_type {
+            Type::Int | Type::Ref | Type::Float => 8,
+            Type::Void => 0,
+        };
+        let flag = majit_ir::ArrayFlag::from_field_type(field_type);
+        let mut fd = majit_ir::SimpleFieldDescr::new(0, offset, field_size, field_type, false)
+            .with_flag(flag);
+        fd.index_in_parent = index_in_parent;
+        Arc::new(fd) as DescrRef
+    }
+
     fn assign_positions(ops: &mut [Op]) {
         for (i, op) in ops.iter_mut().enumerate() {
             // Slice P6a: type-tag op.pos so `opref_type` priority 0
@@ -2696,8 +2630,11 @@ mod tests {
         });
         pass.setup();
 
-        let field_descr =
-            make_field_index_descr(0x1000_0000 | (((8_u32) & 0x000f_ffff) << 4) | (0x7 << 1));
+        // array slot at byte offset 8; array_idx_for_offset reads the
+        // FieldDescr's `offset()` directly so the index_in_parent value is
+        // immaterial — pass `1` (= `1 + num_static + array_idx` with
+        // num_static=0) for consistency with `init`.
+        let field_descr = test_vable_field_descr(8, Type::Int, 1);
         let arr_descr = array_descr(20);
         ctx.make_constant(OpRef::int_op(50), Value::Int(0));
 
@@ -2820,7 +2757,7 @@ mod tests {
         pass.setup();
 
         let mut get = Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)]);
-        get.setdescr(make_field_index_descr(virtualizable_field_index(8)));
+        get.setdescr(test_vable_field_descr(8, Type::Int, 1));
         get.pos.set(OpRef::int_op(10));
 
         let result = pass.propagate_forward(&get, &mut ctx);
@@ -2847,7 +2784,7 @@ mod tests {
             OpCode::SetfieldRaw,
             &[OpRef::input_arg_ref(0), OpRef::input_arg_int(1)],
         );
-        set.setdescr(make_field_index_descr(virtualizable_field_index(8)));
+        set.setdescr(test_vable_field_descr(8, Type::Int, 1));
 
         let result = pass.propagate_forward(&set, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
@@ -2878,7 +2815,15 @@ mod tests {
         let Some(PtrInfo::Virtualizable(vstate)) = ctx.peek_ptr_info(&vbox) else {
             panic!("expected standard virtualizable ptr info on OpRef::input_arg_ref(0)");
         };
-        let seeded = get_field_descr(&vstate.field_descrs, virtualizable_field_index(8))
+        // `info.AbstractStructPtrInfo._fields` is keyed by
+        // `fielddescr.get_index()`; `virtualizable.py:71-72
+        // build_field_descr` assigns `index_in_parent = 1 + i` to the
+        // i-th static field, so the `pc` slot lands at index 1.
+        let key = real_descr
+            .as_field_descr()
+            .expect("virtualizable static_field_descr is a FieldDescr")
+            .index_in_parent() as u32;
+        let seeded = get_field_descr(&vstate.field_descrs, key)
             .expect("virtualizable init should seed field descr");
         assert_eq!(
             majit_ir::descr::descr_identity(&seeded),
@@ -2891,37 +2836,6 @@ mod tests {
                 .is_some(),
             "standard virtualizable config must carry real fielddescr.parent_descr",
         );
-    }
-
-    #[test]
-    fn test_field_index_descr_decodes_pointer_sized_field_width() {
-        let descr = make_field_index_descr(virtualizable_field_index(8));
-        let fd = descr.as_field_descr().expect("field descr");
-        assert_eq!(fd.offset(), 8);
-        assert_eq!(fd.field_size(), 8);
-        assert_eq!(fd.field_type(), Type::Int);
-    }
-
-    #[test]
-    fn test_descr_index_prefers_parent_local_field_slot() {
-        let parent = majit_ir::make_size_descr_full(100, 16, 1);
-        // Keep `parent` alive across the assertion: with_parent_descr stores
-        // only a Weak<DescrRef>, so the local Arc must outlive descr_index().
-        let descr: DescrRef = Arc::new(
-            majit_ir::descr::SimpleFieldDescr::new_with_name(
-                200,
-                8,
-                8,
-                Type::Ref,
-                false,
-                majit_ir::ArrayFlag::Pointer,
-                "T.x".to_string(),
-            )
-            .with_parent_descr(parent.clone(), 3),
-        );
-        let fd = descr.as_field_descr().expect("field descr");
-        assert_eq!(fd.index_in_parent() as u32, 3);
-        drop(parent);
     }
 
     #[test]
@@ -2941,7 +2855,7 @@ mod tests {
         pass.setup();
 
         let mut get_field = Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)]);
-        get_field.setdescr(make_field_index_descr(virtualizable_field_index(24)));
+        get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
         assert!(matches!(
             pass.propagate_forward(&get_field, &mut ctx),
@@ -2975,7 +2889,7 @@ mod tests {
         pass.setup();
 
         let mut get_field = Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)]);
-        get_field.setdescr(make_field_index_descr(virtualizable_field_index(24)));
+        get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
         assert!(matches!(
             pass.propagate_forward(&get_field, &mut ctx),

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2730,6 +2730,12 @@ mod tests {
 
         let mut ops = vec![get_array_ptr, get_item, get_item_again];
         assign_positions(&mut ops);
+        // Route raw array reads through the GetfieldRawI result so
+        // resolve_array_source() sees the producing OpRef, not the bare vable
+        // inputarg.
+        let array_ptr_ref = ops[0].pos.get();
+        ops[1].setarg(0, array_ptr_ref);
+        ops[2].setarg(0, array_ptr_ref);
 
         for op in &ops {
             let mut resolved = op.clone();

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -302,6 +302,14 @@ pub struct OptVirtualize {
     last_guard_not_forced_2: Option<Op>,
     /// virtualize.py:81 / 84
     finish_guard_op: Option<Op>,
+    /// `virtualize.py:140` `vrefinfo =
+    /// self.optimizer.metainterp_sd.virtualref_info` parity — the
+    /// cached `VirtualRefInfo` whose `descr_forced` /
+    /// `descr_virtual_token` / `descr` Arcs `optimize_virtual_ref` and
+    /// `optimize_virtual_ref_finish` stamp onto SETFIELD_GC ops.
+    /// Cloned cheaply (3 `Arc`s); production passes the live
+    /// `MetaInterp.virtualref_info`, tests use `Default`.
+    vrefinfo: crate::virtualref::VirtualRefInfo,
 }
 
 impl OptVirtualize {
@@ -311,6 +319,7 @@ impl OptVirtualize {
             last_emitted_was_removed: false,
             last_guard_not_forced_2: None,
             finish_guard_op: None,
+            vrefinfo: crate::virtualref::VirtualRefInfo::new(),
         }
     }
 
@@ -321,7 +330,17 @@ impl OptVirtualize {
             last_emitted_was_removed: false,
             last_guard_not_forced_2: None,
             finish_guard_op: None,
+            vrefinfo: crate::virtualref::VirtualRefInfo::new(),
         }
+    }
+
+    /// `virtualize.py:140` parity: install the live `VirtualRefInfo`
+    /// from `MetaInterp.virtualref_info` so emit sites read the cached
+    /// `vrefinfo.descr_*` Arcs through this field instead of
+    /// reconstructing them on demand.
+    pub fn with_vrefinfo(mut self, vrefinfo: crate::virtualref::VirtualRefInfo) -> Self {
+        self.vrefinfo = vrefinfo;
+        self
     }
 
     // ── PtrInfo accessors (delegated to ctx) ──
@@ -1387,7 +1406,9 @@ impl OptVirtualize {
     /// The typeptr/vtable at offset 0 is handled by NEW_WITH_VTABLE when
     /// the vref is forced — not stored as a tracked virtual field.
     fn optimize_virtual_ref(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let vref_descr: DescrRef = vref_size_descr();
+        // `virtualize.py:140` `vrefinfo = ... metainterp_sd.virtualref_info`
+        // / `virtualize.py:123` `vrefinfo.descr` parity.
+        let vref_descr: DescrRef = self.vrefinfo.descr.clone();
 
         // virtualize.py:127: token = ResOperation(rop.FORCE_TOKEN, [])
         let token_op = Op::new(OpCode::ForceToken, &[]);
@@ -1514,17 +1535,20 @@ impl OptVirtualize {
 
         // vref is not virtual (was forced/escaped): emit SETFIELD_GC ops.
 
-        // virtualize.py:150-153: set 'forced' to the real object.
+        // virtualize.py:150-153: set 'forced' to the real object via
+        // `vrefinfo.descr_forced` (the cached `cpu.fielddescrof(...)`
+        // Arc from `virtualref.py:42`).
         if !obj_is_null {
             let mut set_forced = Op::new(OpCode::SetfieldGc, &[vref_ref, obj_ref]);
-            set_forced.setdescr(make_vref_field_descr(VREF_FORCED_FIELD_INDEX));
+            set_forced.setdescr(self.vrefinfo.descr_forced.clone());
             ctx.emit_extra(ctx.current_pass_idx, set_forced);
         }
 
-        // virtualize.py:155-158: set 'virtual_token' to CONST_NULL.
+        // virtualize.py:155-158: set 'virtual_token' to CONST_NULL via
+        // `vrefinfo.descr_virtual_token` (`virtualref.py:40-41`).
         let null_ref = ctx.emit_constant_ref(majit_ir::GcRef(0));
         let mut set_token = Op::new(OpCode::SetfieldGc, &[vref_ref, null_ref]);
-        set_token.setdescr(make_vref_field_descr(VREF_VIRTUAL_TOKEN_FIELD_INDEX));
+        set_token.setdescr(self.vrefinfo.descr_virtual_token.clone());
         ctx.emit_extra(ctx.current_pass_idx, set_token);
 
         OptimizationResult::Remove
@@ -1974,6 +1998,10 @@ impl Optimization for OptVirtualize {
 
     fn name(&self) -> &'static str {
         "virtualize"
+    }
+
+    fn set_vrefinfo(&mut self, vrefinfo: crate::virtualref::VirtualRefInfo) {
+        self.vrefinfo = vrefinfo;
     }
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -69,8 +69,8 @@ pub struct VirtualizableConfig {
 /// The typeptr/vtable at offset 0 is handled by NEW_WITH_VTABLE, not stored as
 /// a tracked field. Indices are dense (0-based), matching RPython's
 /// `heaptracker.all_fielddescrs()` which excludes typeptr.
-const VREF_VIRTUAL_TOKEN_FIELD_INDEX: u32 = 0;
-const VREF_FORCED_FIELD_INDEX: u32 = 1;
+pub(crate) const VREF_VIRTUAL_TOKEN_FIELD_INDEX: u32 = 0;
+pub(crate) const VREF_FORCED_FIELD_INDEX: u32 = 1;
 /// Size descriptor index for the JitVirtualRef struct.
 const VREF_SIZE_DESCR_INDEX: u32 = 0x7F10;
 
@@ -1387,7 +1387,7 @@ impl OptVirtualize {
     /// The typeptr/vtable at offset 0 is handled by NEW_WITH_VTABLE when
     /// the vref is forced — not stored as a tracked virtual field.
     fn optimize_virtual_ref(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let vref_descr: DescrRef = Arc::new(VRefSizeDescr);
+        let vref_descr: DescrRef = vref_size_descr();
 
         // virtualize.py:127: token = ResOperation(rop.FORCE_TOKEN, [])
         let token_op = Op::new(OpCode::ForceToken, &[]);
@@ -2050,15 +2050,61 @@ impl FieldDescr for VRefFieldDescr {
     }
 
     fn get_parent_descr(&self) -> Option<DescrRef> {
-        Some(Arc::new(VRefSizeDescr))
+        Some(vref_size_descr())
     }
 }
+
+/// `virtualref.py:40-42` parity: process-static Arc cache for the
+/// `descr_virtual_token` / `descr_forced` field descrs.  PyPy stores
+/// these on `VirtualRefInfo` (one instance per `cpu`); pyre's single
+/// `MetaInterp` per process collapses to the same identity by caching
+/// at module level.  Every `make_vref_field_descr(VREF_*)` call and
+/// every `VREF_ALL_FIELDDESCRS` index returns the same Arc — the
+/// `Arc::ptr_eq` identity `history.py:125` demands for `descr is
+/// other_descr` comparisons.
+static VREF_DESCR_VIRTUAL_TOKEN: std::sync::LazyLock<Arc<VRefFieldDescr>> =
+    std::sync::LazyLock::new(|| build_vref_field_descr(VREF_VIRTUAL_TOKEN_FIELD_INDEX));
+
+static VREF_DESCR_FORCED: std::sync::LazyLock<Arc<VRefFieldDescr>> =
+    std::sync::LazyLock::new(|| build_vref_field_descr(VREF_FORCED_FIELD_INDEX));
+
+/// `virtualref.py:32-33` parity: process-static Arc cache for the
+/// `descr = cpu.sizeof(JIT_VIRTUAL_REF)` slot.
+static VREF_SIZE_DESCR: std::sync::LazyLock<Arc<VRefSizeDescr>> =
+    std::sync::LazyLock::new(|| Arc::new(VRefSizeDescr));
 
 fn make_vref_field_descr(index: u32) -> DescrRef {
     make_vref_field_descr_typed(index)
 }
 
+/// `virtualref.py:40-42` parity helper for `VirtualRefInfo::new()`:
+/// returns the same cached `DescrRef` `make_vref_field_descr` hands
+/// out, so the descrs stored on `VirtualRefInfo.descr_virtual_token`
+/// / `descr_forced` share identity with the Arcs the
+/// `optimize_virtual_ref_finish` emit sites stamp onto SETFIELD_GC
+/// ops.  Without this shared identity, `Arc::ptr_eq` checks (e.g.
+/// the heap pass's stale-set canonicalization) would split into two
+/// equivalence classes per field.
+pub(crate) fn make_vref_field_descr_pub(index: u32) -> DescrRef {
+    make_vref_field_descr_typed(index)
+}
+
 fn make_vref_field_descr_typed(index: u32) -> Arc<VRefFieldDescr> {
+    match index {
+        VREF_VIRTUAL_TOKEN_FIELD_INDEX => VREF_DESCR_VIRTUAL_TOKEN.clone(),
+        VREF_FORCED_FIELD_INDEX => VREF_DESCR_FORCED.clone(),
+        _ => panic!("invalid JitVirtualRef field slot {index}"),
+    }
+}
+
+pub(crate) fn vref_size_descr() -> DescrRef {
+    VREF_SIZE_DESCR.clone() as DescrRef
+}
+
+/// One-shot constructor used only by the `LazyLock` initializers above
+/// — never call this directly; always go through
+/// `make_vref_field_descr_typed` so cached identity is preserved.
+fn build_vref_field_descr(index: u32) -> Arc<VRefFieldDescr> {
     let (offset, field_type) = match index {
         // `virtualref.py:17` registers `virtual_token` and `forced` both
         // as `llmemory.GCREF` slots; the rtyper writes them through

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -2581,12 +2581,6 @@ fn export_single_value_inner(
         let info_fielddescrs = info.all_fielddescrs_from_descr();
         match info {
             PtrInfo::Virtual(vinfo) => {
-                // RPython parity: heaptracker.py:66-67 excludes typeptr from
-                // all_fielddescrs(); see VirtualInfo struct-level docs.
-                crate::optimizeopt::virtualize::debug_assert_no_typeptr_in_virtual_fields(
-                    &vinfo.fields,
-                    "export_single_value::Virtual",
-                );
                 let fields = vinfo
                     .fields
                     .iter()

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2719,6 +2719,12 @@ impl<M: Clone> MetaInterp<M> {
             Optimizer::default_pipeline()
         };
         opt.set_pureop_historylength(self.warm_state.pureop_historylength() as usize);
+        // `virtualize.py:140` `vrefinfo =
+        // self.optimizer.metainterp_sd.virtualref_info` — install the
+        // live `VirtualRefInfo` from `MetaInterp.virtualref_info` so
+        // OptVirtualize emit sites read the same cpu-attached descrs
+        // PyPy's `cpu.fielddescrof(JIT_VIRTUAL_REF, ...)` would.
+        opt.set_vrefinfo(self.virtualref_info.clone());
         // optimizer.py:787-789: constant_fold — allocate immutable objects
         // at compile time. Uses Box::leak for permanent allocation (immutable
         // objects are never freed, matching RPython's prebuilt constants).

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -639,6 +639,47 @@ pub(crate) struct CompiledEntry<M> {
     /// `previous_tokens_upgraded` is the readers' entry point — it upgrades
     /// and filters out dead references.  The remaining warmstate-side strong
     /// owner is documented on `BaseJitCell::loop_token`.
+    ///
+    /// # `compile_bridge` use & weak-drop safety
+    ///
+    /// Cranelift's `compile_bridge` (`compiler.rs:14248`) iterates
+    /// `previous_tokens` to attach the freshly-compiled bridge to
+    /// matching `(trace_id, fail_index_per_trace)` fail_descrs in
+    /// retired predecessor tokens whose machine code may still be
+    /// reachable — cranelift cannot patch code in place, so every
+    /// predecessor that still has running code AND carries the same
+    /// source guard needs its descr's bridge slot installed too.
+    ///
+    /// "Still reachable" is what determines whether a Weak that fails
+    /// to upgrade is a safety problem.  A predecessor `T_prev` is
+    /// reachable only if something holds an `Arc<JitCellToken>` to it:
+    ///
+    /// 1. `MemoryManager.alive_loops` (the canonical strong owner).
+    /// 2. `JitCellToken.keepalive_tokens` on a *jumper* loop
+    ///    (`history.py:449 _keepalive_jitcell_tokens` parity) — pyre
+    ///    pushes Arcs into this set via `record_jump_to` when a
+    ///    cross-loop jump is emitted, mirroring RPython.
+    /// 3. `warmstate::BaseJitCell::loop_token` for the current
+    ///    install_token at the cell's green_key.
+    /// 4. The active call stack while `execute_token_*` runs.
+    ///
+    /// If none of the above hold `T_prev`, `T_prev`'s `Arc` drops, its
+    /// `compiled_loop_token` Arc drops, and the asmmemmgr blocks are
+    /// released — the machine code is gone.  In that case
+    /// `filter_map(Weak::upgrade)` correctly skips `T_prev`: there is
+    /// no live machine code for the bridge slot to be installed onto.
+    ///
+    /// The case CodeRabbit PR #68 review flagged
+    /// (`pullrequestreview-4318361750`) is the gap between "alive_loops
+    /// evicted `T_prev`" and "`T_prev`'s code freed": with `Arc` strong
+    /// ownership previously held by `compiled_loops`, that gap was
+    /// effectively zero because `compiled_loops` extended the lifetime
+    /// past alive_loops eviction.  After Slice X-G the gap is real but
+    /// bounded — pyre's single-thread JIT means `T_prev`'s code can be
+    /// "reachable" only while a frame is on the stack (case 4), and
+    /// that frame's caller holds the Arc via the executor's
+    /// `&Arc<JitCellToken>` parameter.  No two `compile_bridge` calls
+    /// interleave with `try_to_free_some_loops` on the same thread.
     pub(crate) previous_tokens: Vec<std::sync::Weak<JitCellToken>>,
     /// Box identity plan Phase E: high-water OpRef at which a bridge
     /// compilation starts allocating fresh boxes.

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -275,7 +275,7 @@ impl StoredExitLayout {
         // entries set `op_arg_types_for_jump`.  Hitting this branch
         // means a synthetic test fixture skipped both populators or a
         // builder regressed — flag it loudly in debug builds so it
-        // does not silently mask a stale `fail_arg_count_for=0`.
+        // does not silently mask a missing fail_arg_types population.
         debug_assert!(
             false,
             "resolve_exit_types: both descr.fail_arg_types() and op_arg_types_for_jump are missing — every production layout builder must populate one of them",
@@ -829,40 +829,45 @@ fn default_issubclass(typeptr: i64, bounding_class: i64) -> bool {
 ///
 /// Bridge-origin descriptor carried from `start_retrace_from_guard`
 /// through `compile_trace_finish`.  RPython stores the equivalent on
-/// `self.resumekey` + the active `MetaInterp` history; pyre aggregates
-/// the four identifying fields into one value so the finish-compile
-/// helpers can dispatch to the bridge branch without cross-component
-/// tuple plumbing.
+/// `self.resumekey` (`pyjitpl.py:2890 handle_guard_failure(self,
+/// resumedescr, deadframe)`) — the descr Arc itself is the canonical
+/// bridge-source identity.  Pyre carries the same Arc in
+/// `source_descr`; `(trace_id, fail_index)` remain only as pyre-side
+/// indices for per-trace fail_descr arrays and the not-yet-retired
+/// `(green_key, trace_id, fail_index)` lookup helpers.
 ///
 /// `code_ptr` is the code address for the bridge's green key, enabling
 /// any PC to map back to a green key via the same hash function used by
 /// `make_green_key`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct BridgeTraceInfo {
     pub green_key: u64,
     pub trace_id: u64,
     pub fail_index: u32,
     pub code_ptr: usize,
+    /// `pyjitpl.py:2890` `resumedescr` parity: the descr Arc returned
+    /// by `cpu.get_latest_descr(deadframe)` (`history.py:125`) — the
+    /// same Arc the optimizer stamped on `op.descr` and the same Arc
+    /// `compile.py:719 _trace_and_compile_from_bridge` threads as
+    /// `self`.  Carried explicitly so the bridge-compile path reads
+    /// the source Arc directly.
+    pub source_descr: std::sync::Arc<dyn majit_ir::Descr>,
 }
 
 /// pyjitpl.py `MetaInterp` tracing-session context.
 ///
-/// Owns the per-session state that RPython carries through
-/// `self.history`, `self.resumekey`, and the callbacks on `self`: the
-/// frontend `M` metadata snapshot taken at trace start, and — when
-/// tracing a bridge — the origin descriptor needed to thread
-/// `compile_trace(self, self.resumekey, ...)` through the bridge
-/// branch.  `clear_trace_session` takes this field back out on
-/// abort / finish so the next trace starts from `None`.
+/// Owns the frontend metadata snapshot RPython carries through
+/// `self.history` for the duration of a single trace.  Bridge origin
+/// state lives independently on `MetaInterp.bridge_info` so the
+/// bridge-resume entry can populate it without requiring an active
+/// session (`pyjitpl.py:2890` `handle_guard_failure` is called with
+/// `self.resumekey` set before the trace's `self.history` exists).
 pub struct ActiveTraceSession<M: Clone> {
     /// Frontend state snapshot captured at `force_start_tracing` /
     /// `bound_reached` / `on_back_edge_typed` / bridge resume.  Held
     /// by MetaInterp so the finish-compile helpers can consume it
     /// without requiring the JitDriver to mediate.
     pub trace_meta: M,
-    /// `Some(BridgeTraceInfo)` when the session is a bridge retrace
-    /// (populated by `set_bridge_trace_info`).  `None` for root traces.
-    pub bridge: Option<BridgeTraceInfo>,
 }
 
 pub struct MetaInterp<M: Clone> {
@@ -1153,6 +1158,14 @@ pub struct MetaInterp<M: Clone> {
     /// directly on `MetaInterp`.  Single source of truth; the JitDriver
     /// reads this via accessors and never duplicates it.
     pub(crate) active_trace_session: Option<ActiveTraceSession<M>>,
+    /// `pyjitpl.py:2890` `self.resumekey` parity: bridge-origin descr
+    /// Arc + indexing tuple, populated by `start_retrace_from_guard`
+    /// when entering a bridge trace and consumed by the bridge close
+    /// path.  Kept outside `ActiveTraceSession` because the bridge
+    /// entry installs `self.resumekey` *before* the trace's
+    /// `self.history` exists (RPython places resumekey on `MetaInterp`
+    /// directly, not on the history object).
+    pub(crate) bridge_info: Option<BridgeTraceInfo>,
 }
 
 /// Internal mutable counters for JIT compilation statistics.
@@ -1877,6 +1890,7 @@ impl<M: Clone> MetaInterp<M> {
             box_names_memo: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             trace_length_at_last_tco: -1,
             active_trace_session: None,
+            bridge_info: None,
         };
         // `pyjitpl.py:2222` `make_and_attach_done_descrs([self, cpu])` —
         // now that both sides of the pair exist, publish the
@@ -2035,38 +2049,37 @@ impl<M: Clone> MetaInterp<M> {
             self.active_trace_session.is_none(),
             "begin_trace_session called while a trace session is already active",
         );
-        self.active_trace_session = Some(ActiveTraceSession {
-            trace_meta,
-            bridge: None,
-        });
+        self.active_trace_session = Some(ActiveTraceSession { trace_meta });
     }
 
-    /// Attach bridge-origin metadata to the active session.  Called
-    /// once during `start_retrace_from_guard` after
-    /// `begin_trace_session` has installed the frontend meta.
+    /// Attach bridge-origin metadata.  Called once at bridge entry
+    /// (`pyjitpl.py:2890` `handle_guard_failure` sets `self.resumekey`).
     pub fn set_bridge_trace_info(&mut self, bridge: BridgeTraceInfo) {
-        let slot = self
-            .active_trace_session
-            .as_mut()
-            .expect("set_bridge_trace_info called with no active trace session");
-        slot.bridge = Some(bridge);
+        self.bridge_info = Some(bridge);
     }
 
-    /// Bridge-origin descriptor for the active session, if any.
-    /// Returns `None` for root traces and when no session is active.
-    pub fn bridge_info(&self) -> Option<BridgeTraceInfo> {
-        self.active_trace_session.as_ref().and_then(|s| s.bridge)
+    /// Bridge-origin descriptor, if currently in a bridge trace.
+    /// Returns `None` for root traces.
+    ///
+    /// Borrow form — callers that only read scalar fields use this so
+    /// the `source_descr` Arc is not cloned on every access.  Callers
+    /// that need an owned copy use [`Self::bridge_info_cloned`].
+    pub fn bridge_info(&self) -> Option<&BridgeTraceInfo> {
+        self.bridge_info.as_ref()
     }
 
-    /// Consume the bridge-origin descriptor while keeping the active
-    /// session's frontend meta in place.  Used by `CloseLoop` /
+    /// Owned clone of the bridge-origin descriptor.  One `Arc::clone`
+    /// per call (the `source_descr` field).
+    pub fn bridge_info_cloned(&self) -> Option<BridgeTraceInfo> {
+        self.bridge_info.clone()
+    }
+
+    /// Consume the bridge-origin descriptor.  Used by `CloseLoop` /
     /// `CloseLoopWithArgs` branches that drive `compile_trace_finish`
     /// from the bridge identity yet fall through to run `compile_loop`
     /// on the remainder of the trace.  Returns `None` for root traces.
     pub fn take_bridge_info(&mut self) -> Option<BridgeTraceInfo> {
-        self.active_trace_session
-            .as_mut()
-            .and_then(|s| s.bridge.take())
+        self.bridge_info.take()
     }
 
     /// Read-only access to the frontend trace metadata for callers
@@ -2085,9 +2098,12 @@ impl<M: Clone> MetaInterp<M> {
 
     /// Drop the active session without consuming the meta, matching
     /// the abort / cleanup path used when tracing aborts before
-    /// finish.
+    /// finish.  Also clears `bridge_info` — `pyjitpl.py:3105`
+    /// `_finish_off_the_metainterp` resets `self.resumekey` together
+    /// with the trace's history.
     pub fn clear_trace_session(&mut self) {
         self.active_trace_session = None;
+        self.bridge_info = None;
     }
 
     /// warmspot.py:449 — set the per-driver result_type from the portal
@@ -5093,23 +5109,19 @@ impl<M: Clone> MetaInterp<M> {
                         from_retry: false,
                     };
                 }
-                let descr_arc = {
-                    let compiled = match self.compiled_loops.get(&origin_key) {
-                        Some(c) => c,
-                        None => return CompileOutcome::Cancelled,
-                    };
-                    match self.bridge_source_descr(compiled, trace_id, fail_index) {
-                        Some(d) => d,
-                        None => {
-                            if crate::majit_log_enabled() {
-                                eprintln!(
-                                    "[jit] bridge_source_descr({}, {}) = None → Cancelled",
-                                    trace_id, fail_index
-                                );
-                            }
-                            return CompileOutcome::Cancelled;
-                        }
-                    }
+                // `pyjitpl.py:2890` `handle_guard_failure(self,
+                // resumedescr, deadframe)` parity: the source descr Arc
+                // is `self.resumekey` (== the descr
+                // `cpu.get_latest_descr(deadframe)` returned).  Pyre
+                // carries it on `BridgeTraceInfo.source_descr`
+                // (populated by `start_retrace_from_guard`).  No
+                // `(trace_id, fail_index)` reverse lookup.
+                if !self.compiled_loops.contains_key(&origin_key) {
+                    return CompileOutcome::Cancelled;
+                }
+                let descr_arc = match self.bridge_info() {
+                    Some(b) => b.source_descr.clone(),
+                    None => return CompileOutcome::Cancelled,
                 };
                 let fail_descr = descr_arc
                     .as_fail_descr()
@@ -7173,17 +7185,6 @@ impl<M: Clone> MetaInterp<M> {
         }
     }
 
-    /// Get the number of fail_arg_types for a guard.
-    /// Returns 0 if not found. Used to adjust bridge tracing state.
-    pub fn fail_arg_count_for(&self, green_key: u64, trace_id: u64, fail_index: u32) -> usize {
-        let Some(compiled) = self.compiled_loops.get(&green_key) else {
-            return 0;
-        };
-        self.bridge_source_descr(compiled, trace_id, fail_index)
-            .and_then(|d| d.as_fail_descr().map(|fd| fd.fail_arg_types().len()))
-            .unwrap_or(0)
-    }
-
     /// `warmstate.py:339-348 attach_procedure_to_interp` parity.
     ///
     /// ```python
@@ -7912,82 +7913,6 @@ impl<M: Clone> MetaInterp<M> {
         self.backend.done_compiling_descr(descr_addr);
     }
 
-    /// Resolve the source ResumeGuardDescr Arc the optimizer stamped onto
-    /// the originating guard op (`op.descr`).  Returns the metainterp
-    /// `Arc<dyn Descr>` directly: after Sessions 6.5/6.6 stamped
-    /// `trace_id` and `fail_index_per_trace` onto the descr itself,
-    /// callers no longer need a `(trace_id, fail_index)` capturing
-    /// proxy — they consume the Arc and reach the per-trace key via
-    /// `descr.as_fail_descr()?.fail_index_per_trace()`.  RPython parity:
-    /// `cpu.get_latest_descr()` returns the same `ResumeGuardDescr` the
-    /// metainterp stamped (`history.py:125`); `op.getdescr()` /
-    /// `compile.py:184` is the equivalent path.
-    ///
-    /// Synthetic / FINISH exits whose `exit_layouts` entry holds a
-    /// non-`ResumeGuard*` descr legitimately produce `None`; the strict
-    /// `compile.py:800 assert resumekey_original_loop_token is not None`
-    /// is enforced at `compile_bridge` entry instead.
-    pub(crate) fn bridge_source_descr(
-        &self,
-        compiled: &CompiledEntry<M>,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> Option<std::sync::Arc<dyn majit_ir::Descr>> {
-        // `compile.py:184` `op.getdescr()` — primary path: the metainterp
-        // ResumeGuardDescr Arc the optimizer stamped onto the originating
-        // guard op.  `build_guard_metadata` (compile.rs:984) clones that
-        // same Arc onto `StoredExitLayout.descr` keyed by per-trace
-        // `fail_index`, so reading through `exit_layouts` returns the
-        // identical Arc identity without walking the trace.ops Vec.
-        // Restrict to `ResumeGuard*`-family (compile.rs:294 predicate
-        // parity) — `_DoneWithThisFrameDescr` / `ExitFrameWithExceptionDescrRef`
-        // entries on FINISH ops share the same `fail_index` counter but
-        // are not bridge sources.  Under unified ResumeGuardDescr identity
-        // (PyPy parity) `cpu.get_latest_descr()` returns the same object
-        // (`history.py:125`).
-        if let Some(trace) = Self::trace_for_exit(compiled, trace_id).map(|(_, t)| t) {
-            if let Some(descr) = trace
-                .exit_layouts
-                .get(&fail_index)
-                .and_then(|layout| layout.descr.clone())
-                .filter(|d| d.is_resume_guard() || d.is_resume_guard_copied())
-            {
-                return Some(descr.clone());
-            }
-        }
-        // `history.py:125` / `warmspot.py:1022` `cpu.get_latest_descr
-        // (deadframe)` parity: when `op.descr` is unavailable on the
-        // primary path (post-retrace exit_layouts eviction, synthetic /
-        // cut-tentative ops) the backend still owns the live FailDescr
-        // Arc via its per-token `fail_descrs` vec — same identity pyre's
-        // runtime guard-failure helpers received as `descr_addr` and the
-        // same identity PyPy's deadframe carries.  Walk the current
-        // token first, then `previous_tokens`.  `find_source_fail_descr`
-        // returns the source descr unconditionally — the bridge-existence
-        // check is only relevant to `bridge_was_compiled`, which is a
-        // separate question.  The full Unified-Descr identity flip
-        // (jf_descr embedding the meta Arc address) is the structural fix
-        // that lets this fallback retire; until then it covers
-        // exit_layouts eviction.
-        if let Some(descr) = compiled.live_token().and_then(|token| {
-            self.backend
-                .find_source_fail_descr(&token, trace_id, fail_index)
-        }) {
-            return Some(descr);
-        }
-        for prev_token in &compiled.previous_tokens {
-            if let Some(prev) = prev_token.upgrade() {
-                if let Some(descr) = self
-                    .backend
-                    .find_source_fail_descr(&prev, trace_id, fail_index)
-                {
-                    return Some(descr);
-                }
-            }
-        }
-        None
-    }
-
     /// Check whether a bridge was actually compiled and attached for a guard.
     /// Used by jit_bridge_compile_for_guard to distinguish successful bridge
     /// compilation from trace abort (RPython pyjitpl.py:2906-2907 parity).
@@ -8084,20 +8009,6 @@ impl<M: Clone> MetaInterp<M> {
 }
 
 impl<M: Clone> MetaInterp<M> {
-    /// Obtain the source ResumeGuardDescr Arc for a guard identified by
-    /// green_key, trace_id, and fail_index. Used by call_assembler bridge
-    /// callbacks that need to pass a FailDescr to compile_bridge —
-    /// callers reach the FailDescr surface via `as_fail_descr()`.
-    pub fn get_fail_descr_for_bridge(
-        &self,
-        green_key: u64,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> Option<std::sync::Arc<dyn majit_ir::Descr>> {
-        let compiled = self.compiled_loops.get(&green_key)?;
-        self.bridge_source_descr(compiled, trace_id, fail_index)
-    }
-
     fn recovery_slot_types_from_exit_types_and_layout(
         exit_types: &[Type],
         recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
@@ -9190,8 +9101,13 @@ impl<M: Clone> MetaInterp<M> {
     /// Initialize bridge tracing from a guard failure point.
     /// Returns (success, is_exception_guard) so the caller can emit
     /// SAVE_EXC_CLASS + SAVE_EXCEPTION ops for exception bridges.
+    /// `pyjitpl.py:2890` `handle_guard_failure(self, resumedescr,
+    /// deadframe)` parity: `descr_arc` is the source guard descr Arc
+    /// (the value `cpu.get_latest_descr(deadframe)` returned) carried
+    /// through as `self.resumekey`.
     pub fn start_retrace_from_guard(
         &mut self,
+        descr_arc: std::sync::Arc<dyn majit_ir::Descr>,
         green_key: u64,
         trace_id: u64,
         fail_index: u32,
@@ -9206,10 +9122,6 @@ impl<M: Clone> MetaInterp<M> {
         };
 
         let norm_tid = trace_id;
-        let descr_arc = match self.bridge_source_descr(compiled, trace_id, fail_index) {
-            Some(arc) => arc,
-            None => return None,
-        };
         let fail_descr = descr_arc
             .as_fail_descr()
             .expect("bridge source op.descr must implement FailDescr");
@@ -9301,9 +9213,28 @@ impl<M: Clone> MetaInterp<M> {
             .get_compiled_exit_layout_in_trace(green_key, norm_tid, fail_index)
             .and_then(|layout| layout.storage);
 
+        let fail_types = bridge_input_types.to_vec();
+
+        // `pyjitpl.py:2890` `handle_guard_failure(self, resumedescr,
+        // deadframe)` parity: stash `self.resumekey` on MetaInterp so
+        // every downstream lookup (bridge close, compile_trace_inner,
+        // ...) reads the source descr Arc directly instead of doing
+        // a `(trace_id, fail_index)` reverse lookup.  `code_ptr` is
+        // populated by `start_bridge_tracing` (the production-path
+        // wrapper); test-only entries leave it as 0 — only the
+        // `green_key_from_code_ptr` recompute on `CloseLoopWithArgs`
+        // depends on it, and tests do not exercise that branch.
+        self.set_bridge_trace_info(BridgeTraceInfo {
+            green_key,
+            trace_id,
+            fail_index,
+            code_ptr: 0,
+            source_descr: descr_arc,
+        });
+
         Some(BridgeRetraceResult {
             is_exception_guard,
-            fail_types: bridge_input_types.to_vec(),
+            fail_types,
             storage,
         })
     }
@@ -10359,12 +10290,33 @@ impl<M: Clone> MetaInterp<M> {
     /// `live_values` are the concrete values at the guard failure point.
     ///
     /// Returns `true` if retracing was started, `false` if not possible.
-    pub fn start_retrace(&mut self, green_key: u64, _fail_index: u32, live_values: &[i64]) -> bool {
+    pub fn start_retrace(&mut self, green_key: u64, fail_index: u32, live_values: &[i64]) -> bool {
         let Some(root_trace_id) = self.compiled_loops.get(&green_key).map(|c| c.root_trace_id)
         else {
             return false;
         };
-        self.start_retrace_from_guard(green_key, root_trace_id, _fail_index, live_values)
+        // Test-only entry: look up the source descr Arc from the
+        // compiled trace's exit_layouts (the production path obtains
+        // it from `cpu.get_latest_descr(deadframe)` and threads it
+        // through `start_bridge_tracing`).
+        let descr_arc = {
+            let Some(compiled) = self.compiled_loops.get(&green_key) else {
+                return false;
+            };
+            let Some(trace) = Self::trace_for_exit(compiled, root_trace_id).map(|(_, t)| t) else {
+                return false;
+            };
+            match trace
+                .exit_layouts
+                .get(&fail_index)
+                .and_then(|layout| layout.descr.clone())
+                .filter(|d| d.is_resume_guard() || d.is_resume_guard_copied())
+            {
+                Some(arc) => arc,
+                None => return false,
+            }
+        };
+        self.start_retrace_from_guard(descr_arc, green_key, root_trace_id, fail_index, live_values)
             .is_some()
     }
 
@@ -18504,13 +18456,6 @@ mod tests {
             meta.get_exit_types(green_key, trace_id, fail_index),
             Some(vec![Type::Int])
         );
-        let descr_arc = meta
-            .get_fail_descr_for_bridge(green_key, trace_id, fail_index)
-            .expect("bridge fail descr should search previous tokens too");
-        let fail_descr = descr_arc
-            .as_fail_descr()
-            .expect("bridge source op.descr must implement FailDescr");
-        assert_eq!(fail_descr.fail_arg_types(), &[Type::Int]);
     }
 
     // `guard_fail_descr_proxy_trusts_empty_backend_fail_arg_types`
@@ -18650,12 +18595,20 @@ mod tests {
             crate::optimizeopt::vec_assoc::VecAssoc::new(),
         );
 
-        let (trace_id, fail_index) = {
+        let (trace_id, fail_index, descr_arc) = {
             let entry = meta.compiled_loops.get(&green_key).expect("compiled entry");
             let trace_id = entry.root_trace_id;
             let trace = entry.traces.get(&trace_id).expect("compiled trace");
             let fail_index = guard_fail_index(trace);
-            (trace_id, fail_index)
+            // Capture source descr Arc BEFORE evicting `exit_layouts`.
+            // Production path: `cpu.get_latest_descr(deadframe)` returns
+            // the same Arc independently of `exit_layouts`.
+            let descr_arc = trace
+                .exit_layouts
+                .get(&fail_index)
+                .and_then(|layout| layout.descr.clone())
+                .expect("test fixture guard should carry a ResumeGuardDescr");
+            (trace_id, fail_index, descr_arc)
         };
 
         let mut writer = crate::resumecode::Writer::new(4);
@@ -18694,7 +18647,7 @@ mod tests {
         };
 
         let retrace = meta
-            .start_retrace_from_guard(green_key, trace_id, fail_index, &[42])
+            .start_retrace_from_guard(descr_arc, green_key, trace_id, fail_index, &[42])
             .expect("retrace should use previous token backend resume data");
 
         assert_eq!(retrace.fail_types, vec![Type::Int]);

--- a/majit/majit-metainterp/src/virtualref.rs
+++ b/majit/majit-metainterp/src/virtualref.rs
@@ -186,16 +186,23 @@ pub fn token_tracing_rescall() -> *mut u8 {
 /// When code outside the JIT tries to access the virtual object, the
 /// reference is "forced" -- the virtual object is materialized on the heap.
 ///
-/// RPython's `VirtualRefInfo` (`virtualref.py:11-42`) caches the live
-/// `descr_virtual_token` / `descr_forced` / `descr` Arcs via
-/// `cpu.fielddescrof(JIT_VIRTUAL_REF, ...)` / `cpu.sizeof(...)`.  Pyre
-/// constructs those descriptors on demand at the SETFIELD_GC emit sites
-/// in `optimize_virtual_ref_finish` (`optimizeopt/virtualize.rs:1521/
-/// 1528`) via `make_vref_field_descr(...)`; caching them on this struct
-/// for identity stability is a follow-up parity item.
+/// `virtualref.py:32-42` parity: `descr` / `descr_virtual_token` /
+/// `descr_forced` hold the live `cpu.sizeof(JIT_VIRTUAL_REF)` and
+/// `cpu.fielddescrof(JIT_VIRTUAL_REF, 'virtual_token' | 'forced')`
+/// Arcs.  Pyre's underlying generators (`vref_size_descr()` /
+/// `make_vref_field_descr_typed(...)`) cache the Arc identity at
+/// module level so every read of these fields returns the same Arc
+/// that the optimizer-emit sites stamp into `op.descr`
+/// (`virtualize.rs:1520 / 1527`) — `Arc::ptr_eq` parity with
+/// `history.py:125 cpu.get_latest_descr() is op.getdescr()`.
 #[derive(Debug, Clone)]
 pub struct VirtualRefInfo {
-    _private: (),
+    /// `virtualref.py:32-33` `self.descr = cpu.sizeof(JIT_VIRTUAL_REF, ...)`
+    pub descr: majit_ir::DescrRef,
+    /// `virtualref.py:40-41` `self.descr_virtual_token = cpu.fielddescrof(..., 'virtual_token')`
+    pub descr_virtual_token: majit_ir::DescrRef,
+    /// `virtualref.py:42`    `self.descr_forced        = cpu.fielddescrof(..., 'forced')`
+    pub descr_forced: majit_ir::DescrRef,
 }
 
 impl Default for VirtualRefInfo {
@@ -248,7 +255,15 @@ impl crate::resume::VRefInfo for VirtualRefInfo {
 impl VirtualRefInfo {
     /// Create a VirtualRefInfo.
     pub fn new() -> Self {
-        VirtualRefInfo { _private: () }
+        use crate::optimizeopt::virtualize::{
+            VREF_FORCED_FIELD_INDEX, VREF_VIRTUAL_TOKEN_FIELD_INDEX, make_vref_field_descr_pub,
+            vref_size_descr,
+        };
+        VirtualRefInfo {
+            descr: vref_size_descr(),
+            descr_virtual_token: make_vref_field_descr_pub(VREF_VIRTUAL_TOKEN_FIELD_INDEX),
+            descr_forced: make_vref_field_descr_pub(VREF_FORCED_FIELD_INDEX),
+        }
     }
 
     /// `virtualref.py:157-177 force_virtual(inst)` — force a virtual

--- a/majit/majit-metainterp/src/virtualref.rs
+++ b/majit/majit-metainterp/src/virtualref.rs
@@ -61,10 +61,9 @@ pub struct ObjectHeader {
 ///
 /// `virtual_token` and `forced` are both `llmemory.GCREF`/`OBJECTPTR`
 /// upstream — pointer fields, not int.  Pyre stores them as `*mut
-/// u8` so the runtime layout, the `VREF_FIELD_VIRTUAL_TOKEN`
-/// descriptor encoding (Ref bit), and the optimizer-side
+/// u8` so the runtime layout and the optimizer-side
 /// `make_vref_field_descr` (`Type::Ref` per
-/// `optimizeopt/virtualize.rs:1659`) all agree.
+/// `optimizeopt/virtualize.rs`) agree on the slot type.
 ///
 /// PRE-EXISTING-ADAPTATION (GC trace).  Upstream traces both fields as
 /// real GC pointers; pyre traces only `forced`.  `eval.rs:241-247`
@@ -181,41 +180,22 @@ pub fn token_tracing_rescall() -> *mut u8 {
     *TRACING_RESCALL_DUMMY_PTR.get_or_init(|| allocate_tracing_rescall_dummy() as usize) as *mut u8
 }
 
-/// Well-known field descriptor indices for JitVirtualRef fields.
-/// Properly encoded: FIELD_DESCR_TAG | (byte_offset << 4) | type_bits
-///
-/// Layout: super_.typeptr(0) | virtual_token(8) | forced(16)
-pub const VREF_FIELD_TYPEPTR: u32 = 0x1000_0000; // offset=0, Int
-/// `virtualref.py:17-20` declares `virtual_token` as `llmemory.GCREF`.
-pub const VREF_FIELD_VIRTUAL_TOKEN: u32 = 0x1000_0081; // offset=8, Ref
-pub const VREF_FIELD_FORCED: u32 = 0x1000_0101; // offset=16, Ref
-
-/// Descriptor indices for the virtual ref struct fields.
-pub mod descr {
-    /// Field descriptor index for `super_.typeptr` (RPython
-    /// `rclass.OBJECT.typeptr`).
-    pub const TYPEPTR: u32 = super::VREF_FIELD_TYPEPTR;
-    /// Field descriptor index for `virtual_token`.
-    pub const VIRTUAL_TOKEN: u32 = super::VREF_FIELD_VIRTUAL_TOKEN;
-    /// Field descriptor index for `forced`.
-    pub const FORCED: u32 = super::VREF_FIELD_FORCED;
-    /// Size descriptor index for the JitVirtualRef struct itself.
-    pub const VREF_SIZE: u32 = 0x7F10;
-}
-
 /// Virtual reference state for a single reference.
 ///
 /// A virtual reference wraps a virtualizable object during JIT execution.
 /// When code outside the JIT tries to access the virtual object, the
 /// reference is "forced" -- the virtual object is materialized on the heap.
+///
+/// RPython's `VirtualRefInfo` (`virtualref.py:11-42`) caches the live
+/// `descr_virtual_token` / `descr_forced` / `descr` Arcs via
+/// `cpu.fielddescrof(JIT_VIRTUAL_REF, ...)` / `cpu.sizeof(...)`.  Pyre
+/// constructs those descriptors on demand at the SETFIELD_GC emit sites
+/// in `optimize_virtual_ref_finish` (`optimizeopt/virtualize.rs:1521/
+/// 1528`) via `make_vref_field_descr(...)`; caching them on this struct
+/// for identity stability is a follow-up parity item.
 #[derive(Debug, Clone)]
 pub struct VirtualRefInfo {
-    /// Field descriptor index for the `virtual_token` field.
-    pub descr_virtual_token: u32,
-    /// Field descriptor index for the `forced` field.
-    pub descr_forced: u32,
-    /// Size descriptor index for the JitVirtualRef struct.
-    pub descr_size: u32,
+    _private: (),
 }
 
 impl Default for VirtualRefInfo {
@@ -266,13 +246,9 @@ impl crate::resume::VRefInfo for VirtualRefInfo {
 //   virtualref.py:172  (assert vref.virtual_token == TOKEN_NONE)
 //   virtualref.py:173  (assert vref.forced)
 impl VirtualRefInfo {
-    /// Create a VirtualRefInfo with the standard descriptor indices.
+    /// Create a VirtualRefInfo.
     pub fn new() -> Self {
-        VirtualRefInfo {
-            descr_virtual_token: descr::VIRTUAL_TOKEN,
-            descr_forced: descr::FORCED,
-            descr_size: descr::VREF_SIZE,
-        }
+        VirtualRefInfo { _private: () }
     }
 
     /// `virtualref.py:157-177 force_virtual(inst)` — force a virtual
@@ -514,14 +490,6 @@ mod tests {
             let header = rescall as *const ObjectHeader;
             assert_eq!((*header).typeptr, JITFRAME_DUMMY_VTABLE);
         }
-    }
-
-    #[test]
-    fn test_vref_info_default() {
-        let info = VirtualRefInfo::new();
-        assert_eq!(info.descr_virtual_token, descr::VIRTUAL_TOKEN);
-        assert_eq!(info.descr_forced, descr::FORCED);
-        assert_eq!(info.descr_size, descr::VREF_SIZE);
     }
 
     /// `virtualref.py:174-176`: `force_virtual` raises


### PR DESCRIPTION
Fix #36

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured backend descriptor inspection and metadata APIs for clearer compiled-trace/exit introspection.
  * Simplified descriptor identity propagation between compilation and retracing paths.
  * Consolidated bridge tracing metadata ownership for more explicit source-descriptor handling.

* **Documentation**
  * Clarified descriptor identity, layout and virtualizable/virtualref invariants in module docs.

* **Tests**
  * Updated tests to align with new virtualizable and virtualref behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->