### PR TITLE
x86 layout: malloc slowpath, profiler counters, debug API

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7981,7 +7981,8 @@ impl CraneliftBackend {
         // ops actually reference.
         for ia in inputargs {
             if debug_declares {
-                majit_ir::debug::log_one("jit-backend", &format!("declare input var{}", ia.index));
+                // Independent debug toggle — not gated by MAJIT_LOG.
+                eprintln!("[jit][declare] input var{}", ia.index);
             }
             var_types.insert(ia.index, cl_types::I64);
             declared_vars.insert(ia.index);
@@ -8004,10 +8005,8 @@ impl CraneliftBackend {
                     cl_types::I64
                 };
                 if debug_declares {
-                    majit_ir::debug::log_one(
-                        "jit-backend",
-                        &format!("declare op-result var{vi} opcode={:?}", op.opcode),
-                    );
+                    // Independent debug toggle — not gated by MAJIT_LOG.
+                    eprintln!("[jit][declare] op-result var{vi} opcode={:?}", op.opcode);
                 }
                 var_types.insert(vi as u32, cl_type);
             }
@@ -8049,10 +8048,8 @@ impl CraneliftBackend {
                 }
                 declared_vars.insert(arg.raw());
                 if debug_declares {
-                    majit_ir::debug::log_one(
-                        "jit-backend",
-                        &format!("declare label-arg var{}", arg.raw()),
-                    );
+                    // Independent debug toggle — not gated by MAJIT_LOG.
+                    eprintln!("[jit][declare] label-arg var{}", arg.raw());
                 }
                 var_types.insert(arg.raw(), cl_types::I64);
             }
@@ -12857,15 +12854,13 @@ impl CraneliftBackend {
         // Compile
         let mut ctx = Context::for_function(func);
         if std::env::var_os("MAJIT_DUMP_CLIF").is_some() {
-            let _s = majit_ir::debug::scope("jit-backend-dump");
-            majit_ir::debug::debug_print(&format!(
-                "clif-dump trace_id={trace_id} header_pc={header_pc} num_inputs={} num_ops={}",
+            // Independent debug toggle — not gated by MAJIT_LOG.
+            eprintln!(
+                "[jit][clif-dump] trace_id={trace_id} header_pc={header_pc} num_inputs={} num_ops={}\n{}",
                 inputargs.len(),
                 ops.len(),
-            ));
-            for line in ctx.func.display().to_string().lines() {
-                majit_ir::debug::debug_print(line);
-            }
+                ctx.func.display()
+            );
         }
         if let Err(e) = self.module.define_function(func_id, &mut ctx) {
             if majit_ir::debug::have_debug_prints() {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3600,8 +3600,11 @@ pub unsafe extern "C" fn cranelift_realloc_frame(old_jf: *mut i64, new_depth: us
         *((old_base + JF_FORWARD_OFS as usize) as *mut *mut i64) = new_jf;
     }
 
-    if majit_log_enabled() {
-        eprintln!("[cranelift][realloc-frame] old={old_jf:p} new={new_jf:p} new_depth={new_depth}");
+    if majit_ir::debug::have_debug_prints() {
+        majit_ir::debug::log_one(
+            "jit-backend",
+            &format!("cranelift realloc-frame old={old_jf:p} new={new_jf:p} new_depth={new_depth}"),
+        );
     }
 
     new_jf
@@ -4623,8 +4626,11 @@ fn build_ref_root_slots(
             && used_inputargs.contains(&input.index)
             && seen.insert(input.index)
         {
-            if std::env::var_os("MAJIT_LOG").is_some() {
-                eprintln!("[ref-root] inputarg idx={} tp={:?}", input.index, input.tp);
+            if majit_ir::debug::have_debug_prints() {
+                majit_ir::debug::log_one(
+                    "jit-backend",
+                    &format!("ref-root inputarg idx={} tp={:?}", input.index, input.tp),
+                );
             }
             slots.push((input.index, slots.len()));
         } else if input.tp == Type::Ref
@@ -6512,15 +6518,18 @@ fn run_compiled_code_inner(
     for (i, &val) in inputs.iter().enumerate() {
         unsafe { *jf_ptr.add(header_words + i) = val };
     }
-    if majit_log_enabled() {
+    if majit_ir::debug::have_debug_prints() {
         let preview: Vec<i64> = inputs.iter().copied().take(10).collect();
-        eprintln!("[pre-call-inputs] {:?}", preview);
+        majit_ir::debug::log_one("jit-running", &format!("pre-call-inputs {preview:?}"));
     }
     // Debug: verify first input (frame ptr) is valid
     if majit_verify_enabled() && !inputs.is_empty() {
         let frame_ptr = inputs[0];
         if frame_ptr != 0 && (frame_ptr < 0x1000 || (frame_ptr as usize & 0x7) != 0) {
-            eprintln!("[VERIFY] BAD frame_ptr input[0]={:#x}", frame_ptr);
+            majit_ir::debug::log_one(
+                "jit-backend",
+                &format!("VERIFY BAD frame_ptr input[0]={frame_ptr:#x}"),
+            );
         }
     }
 
@@ -6538,19 +6547,18 @@ fn run_compiled_code_inner(
     // _call_footer_shadowstack are emitted as inline MOVs in compiled
     // code's prologue/epilogue. The caller does NOT touch root_stack_top.
 
-    if majit_log_enabled() {
-        eprintln!(
-            "[pre-call] code_ptr={:p} jf_ptr={:p} inputs.len={} ref_roots={} max_output={}",
-            code_ptr,
-            jf_ptr,
-            inputs.len(),
-            num_ref_roots,
-            max_output_slots
+    if majit_ir::debug::have_debug_prints() {
+        majit_ir::debug::log_one(
+            "jit-running",
+            &format!(
+                "pre-call code_ptr={code_ptr:p} jf_ptr={jf_ptr:p} inputs.len={} ref_roots={num_ref_roots} max_output={max_output_slots}",
+                inputs.len(),
+            ),
         );
     }
     let result_jf = unsafe { func(jf_ptr) };
-    if majit_log_enabled() {
-        eprintln!("[post-call] result_jf={:p}", result_jf);
+    if majit_ir::debug::have_debug_prints() {
+        majit_ir::debug::log_one("jit-running", &format!("post-call result_jf={result_jf:p}"));
     }
 
     // jitframe_resolve (jitframe.py:54-57):
@@ -7973,7 +7981,7 @@ impl CraneliftBackend {
         // ops actually reference.
         for ia in inputargs {
             if debug_declares {
-                eprintln!("[jit][declare] input var{}", ia.index);
+                majit_ir::debug::log_one("jit-backend", &format!("declare input var{}", ia.index));
             }
             var_types.insert(ia.index, cl_types::I64);
             declared_vars.insert(ia.index);
@@ -7996,7 +8004,10 @@ impl CraneliftBackend {
                     cl_types::I64
                 };
                 if debug_declares {
-                    eprintln!("[jit][declare] op-result var{} opcode={:?}", vi, op.opcode);
+                    majit_ir::debug::log_one(
+                        "jit-backend",
+                        &format!("declare op-result var{vi} opcode={:?}", op.opcode),
+                    );
                 }
                 var_types.insert(vi as u32, cl_type);
             }
@@ -8038,7 +8049,10 @@ impl CraneliftBackend {
                 }
                 declared_vars.insert(arg.raw());
                 if debug_declares {
-                    eprintln!("[jit][declare] label-arg var{}", arg.raw());
+                    majit_ir::debug::log_one(
+                        "jit-backend",
+                        &format!("declare label-arg var{}", arg.raw()),
+                    );
                 }
                 var_types.insert(arg.raw(), cl_types::I64);
             }
@@ -12843,18 +12857,24 @@ impl CraneliftBackend {
         // Compile
         let mut ctx = Context::for_function(func);
         if std::env::var_os("MAJIT_DUMP_CLIF").is_some() {
-            eprintln!(
-                "[jit][clif-dump] trace_id={} header_pc={} num_inputs={} num_ops={}\n{}",
-                trace_id,
-                header_pc,
+            let _s = majit_ir::debug::scope("jit-backend-dump");
+            majit_ir::debug::debug_print(&format!(
+                "clif-dump trace_id={trace_id} header_pc={header_pc} num_inputs={} num_ops={}",
                 inputargs.len(),
                 ops.len(),
-                ctx.func.display()
-            );
+            ));
+            for line in ctx.func.display().to_string().lines() {
+                majit_ir::debug::debug_print(line);
+            }
         }
         if let Err(e) = self.module.define_function(func_id, &mut ctx) {
-            if std::env::var_os("MAJIT_LOG").is_some() {
-                eprintln!("[jit][clif-error] {e}\nCLIF IR:\n{}", ctx.func.display());
+            if majit_ir::debug::have_debug_prints() {
+                let _s = majit_ir::debug::scope("jit-backend");
+                majit_ir::debug::debug_print(&format!("clif-error {e}"));
+                majit_ir::debug::debug_print("CLIF IR:");
+                for line in ctx.func.display().to_string().lines() {
+                    majit_ir::debug::debug_print(line);
+                }
             }
             self.module.clear_context(&mut ctx);
             return Err(BackendError::CompilationFailed(format!("{e}\n{e:?}")));

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -1599,7 +1599,8 @@ impl<'a> AssemblerARM64<'a> {
         // assembler.py:537 prepare_loop / assembler.py:638 prepare_bridge
         if std::env::var_os("MAJIT_J2PLAN_LOG").is_some() {
             let plan = crate::j2plan::TracePlan::build(inputargs, ops);
-            majit_ir::debug::log_one("jit-backend", &format!("j2plan: {}", plan.summary()));
+            // Independent debug toggle — not gated by MAJIT_LOG.
+            eprintln!("[dynasm:j2plan] {}", plan.summary());
         }
 
         let mut ra = RegAlloc::new(

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -582,8 +582,8 @@ impl<'a> AssemblerARM64<'a> {
     /// assembler.py:1145 regalloc_mov(from_loc, to_loc).
     /// Emit a move between any two locations: reg↔reg, reg↔frame, imm→reg, imm→frame.
     pub(crate) fn regalloc_mov(&mut self, src: &Loc, dst: &Loc) {
-        if crate::majit_log_enabled() {
-            eprintln!("[dynasm] remap-mov: {:?} -> {:?}", src, dst);
+        if majit_ir::debug::have_debug_prints() {
+            majit_ir::debug::log_one("jit-backend", &format!("remap-mov: {src:?} -> {dst:?}"));
         }
         match (src, dst) {
             (Loc::Reg(s), Loc::Reg(d)) if s == d => {}
@@ -1599,7 +1599,7 @@ impl<'a> AssemblerARM64<'a> {
         // assembler.py:537 prepare_loop / assembler.py:638 prepare_bridge
         if std::env::var_os("MAJIT_J2PLAN_LOG").is_some() {
             let plan = crate::j2plan::TracePlan::build(inputargs, ops);
-            eprintln!("[dynasm:j2plan] {}", plan.summary());
+            majit_ir::debug::log_one("jit-backend", &format!("j2plan: {}", plan.summary()));
         }
 
         let mut ra = RegAlloc::new(
@@ -1661,8 +1661,11 @@ impl<'a> AssemblerARM64<'a> {
                     continue;
                 }
                 RegAllocOp::Move { src, dst } => {
-                    if crate::majit_log_enabled() {
-                        eprintln!("[dynasm] move: {:?} → {:?}", src, dst);
+                    if majit_ir::debug::have_debug_prints() {
+                        majit_ir::debug::log_one(
+                            "jit-backend",
+                            &format!("move: {src:?} → {dst:?}"),
+                        );
                     }
                     self.regalloc_mov(src, dst);
                     continue;
@@ -2660,8 +2663,11 @@ impl<'a> AssemblerARM64<'a> {
                         .copied()
                         .map(target_argloc_from_loc)
                         .collect::<Vec<_>>();
-                    if crate::majit_log_enabled() {
-                        eprintln!("[dynasm] LABEL target_arglocs={:?}", stored_arglocs);
+                    if majit_ir::debug::have_debug_prints() {
+                        majit_ir::debug::log_one(
+                            "jit-backend",
+                            &format!("LABEL target_arglocs={stored_arglocs:?}"),
+                        );
                     }
                     descr.set_target_arglocs(stored_arglocs);
                     descr.set_ll_loop_code(self.mc.offset().0);
@@ -3508,8 +3514,11 @@ impl<'a> AssemblerARM64<'a> {
         let stub_start = self.mc.offset();
 
         let fail_label = guard_token.fail_label;
-        if crate::majit_log_enabled() {
-            eprintln!("[dynasm] recovery stub: binding {:?}", fail_label);
+        if majit_ir::debug::have_debug_prints() {
+            majit_ir::debug::log_one(
+                "jit-backend",
+                &format!("recovery stub: binding {fail_label:?}"),
+            );
         }
         dynasm!(self.mc ; .arch aarch64 ; =>fail_label);
 
@@ -3563,8 +3572,11 @@ impl<'a> AssemblerARM64<'a> {
         for guard_token in std::mem::take(&mut self.pending_guard_tokens) {
             stub_offsets.push(self.generate_quick_failure(guard_token, save_regs_label));
         }
-        if crate::majit_log_enabled() {
-            eprintln!("[dynasm] write_pending done: {} stubs", stub_offsets.len());
+        if majit_ir::debug::have_debug_prints() {
+            majit_ir::debug::log_one(
+                "jit-backend",
+                &format!("write_pending done: {} stubs", stub_offsets.len()),
+            );
         }
         stub_offsets
     }

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -368,8 +368,11 @@ pub extern "C" fn call_assembler_helper_trampoline(
     green_key: u64,
 ) -> i64 {
     if callee_jf_ptr.is_null() {
-        if majit_log_enabled() {
-            eprintln!("[dynasm][ca-helper] null callee_jf_ptr green_key={green_key}");
+        if majit_ir::debug::have_debug_prints() {
+            majit_ir::debug::log_one(
+                "jit-backend",
+                &format!("ca-helper null callee_jf_ptr green_key={green_key}"),
+            );
         }
         return 0;
     }
@@ -724,8 +727,8 @@ pub extern "C" fn call_assembler_execute_trampoline(
     let func: unsafe extern "C" fn(*mut jitframe::JitFrame) -> *mut jitframe::JitFrame =
         unsafe { std::mem::transmute(callee_addr) };
     let result = unsafe { func(jf_ptr) };
-    if majit_log_enabled() {
-        eprintln!("[dynasm][ca-exec] leave jf={result:p}");
+    if majit_ir::debug::have_debug_prints() {
+        majit_ir::debug::log_one("jit-backend", &format!("ca-exec leave jf={result:p}"));
     }
     result
 }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1655,10 +1655,6 @@ impl Backend for DynasmBackend {
         let malloc_slowpath_fixed = self
             .arch_cpu_ext
             .ensure_malloc_slowpath_fixed(&self.descr_attachments);
-        #[cfg(target_arch = "x86_64")]
-        let malloc_slowpath_varsize_frame = self
-            .arch_cpu_ext
-            .ensure_malloc_slowpath_varsize_frame(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             header_pc,
@@ -1671,8 +1667,6 @@ impl Backend for DynasmBackend {
             cpu_handle,
             #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
-            #[cfg(target_arch = "x86_64")]
-            malloc_slowpath_varsize_frame,
             inputargs,
             &prepared_ops,
         );
@@ -1885,10 +1879,6 @@ impl Backend for DynasmBackend {
         let malloc_slowpath_fixed = self
             .arch_cpu_ext
             .ensure_malloc_slowpath_fixed(&self.descr_attachments);
-        #[cfg(target_arch = "x86_64")]
-        let malloc_slowpath_varsize_frame = self
-            .arch_cpu_ext
-            .ensure_malloc_slowpath_varsize_frame(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             0,
@@ -1901,8 +1891,6 @@ impl Backend for DynasmBackend {
             cpu_handle,
             #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
-            #[cfg(target_arch = "x86_64")]
-            malloc_slowpath_varsize_frame,
             inputargs,
             &prepared_ops,
         );
@@ -3130,8 +3118,6 @@ impl Backend for DynasmBackend {
                 .ensure_propagate_exception_path(&self.descr_attachments);
             self.arch_cpu_ext
                 .ensure_malloc_slowpath_fixed(&self.descr_attachments);
-            self.arch_cpu_ext
-                .ensure_malloc_slowpath_varsize_frame(&self.descr_attachments);
         }
     }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2054,14 +2054,12 @@ impl Backend for DynasmBackend {
         }
 
         if crate::majit_dump_enabled() {
+            // Independent debug toggle — MAJIT_DUMP must produce output
+            // regardless of whether MAJIT_LOG is set, so emit via plain
+            // eprintln (debug_print would silently no-op without
+            // MAJIT_LOG and lose the dump).
             let code = unsafe { std::slice::from_raw_parts(entry, compiled.buffer.len()) };
-            let _s = majit_ir::debug::scope("jit-backend-dump");
-            majit_ir::debug::debug_print(&format!(
-                "CODE DUMP ({} bytes at {:?}):",
-                code.len(),
-                entry
-            ));
-            let mut line = String::new();
+            eprintln!("[dynasm] CODE DUMP ({} bytes at {:?}):", code.len(), entry);
             for (i, chunk) in code.chunks(4).enumerate() {
                 let word = u32::from_le_bytes([
                     chunk.first().copied().unwrap_or(0),
@@ -2069,15 +2067,12 @@ impl Backend for DynasmBackend {
                     chunk.get(2).copied().unwrap_or(0),
                     chunk.get(3).copied().unwrap_or(0),
                 ]);
-                line.push_str(&format!("{word:08x} "));
+                eprint!("{word:08x} ");
                 if (i + 1) % 8 == 0 {
-                    majit_ir::debug::debug_print(&line);
-                    line.clear();
+                    eprintln!();
                 }
             }
-            if !line.is_empty() {
-                majit_ir::debug::debug_print(&line);
-            }
+            eprintln!();
         }
 
         // Debug: verify bridge patches are visible

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1655,6 +1655,10 @@ impl Backend for DynasmBackend {
         let malloc_slowpath_fixed = self
             .arch_cpu_ext
             .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+        #[cfg(target_arch = "x86_64")]
+        let malloc_slowpath_varsize_frame = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_varsize_frame(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             header_pc,
@@ -1667,6 +1671,8 @@ impl Backend for DynasmBackend {
             cpu_handle,
             #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
+            #[cfg(target_arch = "x86_64")]
+            malloc_slowpath_varsize_frame,
             inputargs,
             &prepared_ops,
         );
@@ -1879,6 +1885,10 @@ impl Backend for DynasmBackend {
         let malloc_slowpath_fixed = self
             .arch_cpu_ext
             .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+        #[cfg(target_arch = "x86_64")]
+        let malloc_slowpath_varsize_frame = self
+            .arch_cpu_ext
+            .ensure_malloc_slowpath_varsize_frame(&self.descr_attachments);
         let mut asm = Asm::new(
             trace_id,
             0,
@@ -1891,6 +1901,8 @@ impl Backend for DynasmBackend {
             cpu_handle,
             #[cfg(target_arch = "x86_64")]
             malloc_slowpath_fixed,
+            #[cfg(target_arch = "x86_64")]
+            malloc_slowpath_varsize_frame,
             inputargs,
             &prepared_ops,
         );
@@ -3118,6 +3130,8 @@ impl Backend for DynasmBackend {
                 .ensure_propagate_exception_path(&self.descr_attachments);
             self.arch_cpu_ext
                 .ensure_malloc_slowpath_fixed(&self.descr_attachments);
+            self.arch_cpu_ext
+                .ensure_malloc_slowpath_varsize_frame(&self.descr_attachments);
         }
     }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -371,8 +371,11 @@ pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
         let raw = libc::calloc(1, total_size as usize) as u64;
         if raw == 0 { 0 } else { raw + gc_hdr as u64 }
     });
-    if crate::majit_log_enabled() {
-        eprintln!("[dynasm][nursery-frame] total_size={total_size} payload=0x{ptr:x}");
+    if majit_ir::debug::have_debug_prints() {
+        majit_ir::debug::log_one(
+            "jit-backend",
+            &format!("nursery-frame total_size={total_size} payload=0x{ptr:x}"),
+        );
     }
     ptr
 }
@@ -1958,8 +1961,11 @@ impl Backend for DynasmBackend {
         if ajo != 0 {
             Asm::patch_jump_for_descr(guard_fd, bridge_addr);
             self.register_bridge_addr(Arc::as_ptr(&guard_descr) as *const () as usize, bridge_addr);
-        } else if crate::majit_log_enabled() {
-            eprintln!("[dynasm-bridge] WARNING: adr_jump_offset=0, bridge NOT patched!");
+        } else {
+            majit_ir::debug::log_one(
+                "jit-backend",
+                "dynasm-bridge WARNING: adr_jump_offset=0, bridge NOT patched!",
+            );
         }
 
         // llmodel.py:252 asmmemmgr_blocks parity: store the entire
@@ -2029,39 +2035,49 @@ impl Backend for DynasmBackend {
             unsafe { crate::llmodel::set_int_value(jf_ptr, Self::input_slot(i), raw as isize) };
         }
 
-        if crate::majit_log_enabled() {
+        if majit_ir::debug::have_debug_prints() {
+            let _s = majit_ir::debug::scope("jit-running");
             for (i, arg) in args.iter().enumerate() {
                 let raw = unsafe {
                     crate::llmodel::get_int_value_direct(jf_ptr, Self::input_slot(i)) as i64
                 };
-                eprintln!("[dynasm]   arg[{}] = {:#018x} ({:?})", i, raw as u64, arg);
+                majit_ir::debug::debug_print(&format!(
+                    "  arg[{i}] = {:#018x} ({arg:?})",
+                    raw as u64
+                ));
             }
-            eprintln!(
-                "[dynasm] execute_token: entry={:?} jf_ptr={:?} num_args={} num_slots={} code_len={}",
-                entry,
-                jf_ptr,
+            majit_ir::debug::debug_print(&format!(
+                "execute_token: entry={entry:?} jf_ptr={jf_ptr:?} num_args={} num_slots={num_slots} code_len={}",
                 args.len(),
-                num_slots,
                 compiled.buffer.len()
-            );
+            ));
         }
 
         if crate::majit_dump_enabled() {
             let code = unsafe { std::slice::from_raw_parts(entry, compiled.buffer.len()) };
-            eprintln!("[dynasm] CODE DUMP ({} bytes at {:?}):", code.len(), entry);
+            let _s = majit_ir::debug::scope("jit-backend-dump");
+            majit_ir::debug::debug_print(&format!(
+                "CODE DUMP ({} bytes at {:?}):",
+                code.len(),
+                entry
+            ));
+            let mut line = String::new();
             for (i, chunk) in code.chunks(4).enumerate() {
                 let word = u32::from_le_bytes([
-                    chunk.get(0).copied().unwrap_or(0),
+                    chunk.first().copied().unwrap_or(0),
                     chunk.get(1).copied().unwrap_or(0),
                     chunk.get(2).copied().unwrap_or(0),
                     chunk.get(3).copied().unwrap_or(0),
                 ]);
-                eprint!("{:08x} ", word);
+                line.push_str(&format!("{word:08x} "));
                 if (i + 1) % 8 == 0 {
-                    eprintln!();
+                    majit_ir::debug::debug_print(&line);
+                    line.clear();
                 }
             }
-            eprintln!();
+            if !line.is_empty() {
+                majit_ir::debug::debug_print(&line);
+            }
         }
 
         // Debug: verify bridge patches are visible

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -170,7 +170,7 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
         ; mov r15, [rsp + 40]
         ; mov rbp, [rsp + 48]
         ; mov r13, [rsp + 56]
-        ; add rsp, 64
+        ; add rsp, 72
     );
     #[cfg(not(target_os = "windows"))]
     dynasm!(asm ; .arch x64
@@ -180,7 +180,7 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
         ; mov r14, [rsp + 24]
         ; mov r15, [rsp + 32]
         ; mov rbp, [rsp + 40]
-        ; add rsp, 48
+        ; add rsp, 56
     );
     dynasm!(asm ; .arch x64 ; ret);
 }
@@ -308,10 +308,12 @@ pub(crate) fn build_malloc_slowpath_fixed(
     let _ = cpu_handle;
     let mut asm = Assembler::new().expect("malloc_slowpath: new Assembler");
 
-    // assembler.py:264 `SUB_rr(edx, ecx)` — recover total_size at runtime.
-    // Only the `kind == 'fixed'` arm preprocesses the size; varsize_frame
-    // receives the frame size in RDX directly from the caller (see
-    // `build_malloc_slowpath_varsize_frame`).
+    // assembler.py:264 `SUB_rr(edx, ecx)` — recover total_size at
+    // runtime.  Both `malloc_cond` and `malloc_cond_varsize_frame`
+    // hand off `ecx = old_nursery_free` / `edx = old_nursery_free +
+    // total_bytes`, so the same `SUB` recovers the byte count for
+    // either caller (PyPy line 2554 / 2578 both route through this
+    // shared `malloc_slowpath`).
     dynasm!(asm ; .arch x64 ; sub rdx, rcx);
 
     let slowpath_fn = crate::runner::dynasm_nursery_slowpath as *const () as i64;
@@ -322,68 +324,21 @@ pub(crate) fn build_malloc_slowpath_fixed(
     (buffer, ptr)
 }
 
-/// `assembler.py:231 _build_malloc_slowpath` `kind='var'` analog for
-/// pyre's `CallMallocNurseryVarsizeFrame`.  Same helper trampoline
-/// shape as [`build_malloc_slowpath_fixed`], differing only in the
-/// size-prep step: the caller stages `frame_size` directly into RDX
-/// (no `nursery_free` recovery), so the trampoline skips the
-/// `sub rdx, rcx` and dispatches straight to
-/// `dynasm_nursery_slowpath_jitframe`.
-///
-/// **Calling convention:**
-/// - Entry: `rbp` = jitframe, `rdx` = frame_size (the same value
-///   the caller's fast path computed for the bump-allocator probe).
-///   Caller has published the gcmap to `[rbp + JF_GCMAP_OFS]`.
-/// - Exit: `rcx` = jitframe payload pointer (or `propagate_exception_path`
-///   tail-call on OOM); every other GPR/XMM restored from the
-///   jitframe save area; `rbp` reloaded from the shadow stack top.
-///
-/// Save mask `[ECX, EDX]` is identical to the fixed variant — the
-/// caller's `MALLOC_NURSERY_CLOBBER` (regalloc.rs:101) is the same set
-/// for both variants, so `_pop_all_regs_from_frame` restores the same
-/// register snapshot in both.
-///
-/// Ownership: caller (`X86CpuExt::ensure_malloc_slowpath_varsize_frame`)
-/// owns the returned `ExecutableBuffer` and the entry address is
-/// memoised on the per-CPU `X86CpuExt`, matching PyPy's per-CPU
-/// `self.malloc_slowpath` cache.
-pub(crate) fn build_malloc_slowpath_varsize_frame(
-    cpu_handle: &crate::guard::CpuDescrHandle,
-    propagate_path: usize,
-) -> (ExecutableBuffer, usize) {
-    let _ = cpu_handle;
-    let mut asm = Assembler::new().expect("malloc_slowpath_varsize_frame: new Assembler");
-
-    let slowpath_fn =
-        crate::runner::dynasm_nursery_slowpath_jitframe as *const () as i64;
-    build_malloc_slowpath_body(&mut asm, slowpath_fn, propagate_path);
-
-    let buffer = asm
-        .finalize()
-        .expect("malloc_slowpath_varsize_frame: finalize");
-    let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
-    (buffer, ptr)
-}
-
-/// Shared body of [`build_malloc_slowpath_fixed`] and
-/// [`build_malloc_slowpath_varsize_frame`].  Emits the
+/// Body of the single PyPy `malloc_slowpath` trampoline used by both
+/// `CallMallocNursery` (fixed-size object alloc) and
+/// `CallMallocNurseryVarsizeFrame` (JITFRAME alloc).  Emits the
 /// `_push_all_regs_to_frame([ecx, edx])` → CALL helper → reload_frame
 /// → inline WB → OOM check → `MOV ecx, eax` → `_pop_all_regs_from_frame`
-/// → RET sequence shared by both `kind='fixed'` and `kind='var'`
-/// slowpath trampolines.
-///
-/// The caller emits the kind-specific size-prep step (the `SUB rdx, rcx`
-/// for fixed; nothing for varsize_frame, which receives `frame_size`
-/// directly in RDX) and then defers to this helper.
+/// → RET sequence.  The caller emits the `SUB rdx, rcx` size recovery
+/// just above this helper (the only line that differs between fixed
+/// and varsize_frame in the trampoline header, and PyPy emits it for
+/// both kinds via the same `_build_malloc_slowpath('fixed')` arm —
+/// PyPy line 264).
 ///
 /// `slowpath_fn` is the absolute address of the GC helper called by
 /// `MOV rax, imm64; CALL rax`.  ABI: size in ARG0 (RCX on Win64, RDI
 /// on SysV).  Result in RAX.
-fn build_malloc_slowpath_body(
-    asm: &mut Assembler,
-    slowpath_fn: i64,
-    propagate_path: usize,
-) {
+fn build_malloc_slowpath_body(asm: &mut Assembler, slowpath_fn: i64, propagate_path: usize) {
     let ignored = [crate::regloc::ECX, crate::regloc::EDX];
 
     // assembler.py:247 `_push_all_regs_to_frame(mc, [ecx, edx], floats)`.
@@ -394,16 +349,16 @@ fn build_malloc_slowpath_body(
     // promises ECX/EDX clobber to the caller.
     push_all_regs_to_jitframe_raw(asm, &ignored, true);
 
-    // assembler.py:258-261 — reserve Win64 shadow space (if any).  The
-    // caller's `call rax` arrives with rsp at 0-mod-16: pyre's JIT
-    // prologue leaves rsp at 8-mod-16, and the `call` push of the
-    // return address subtracts another 8 (→ 0-mod-16).  No extra
-    // alignment SUB is needed before the inner CALL on either ABI;
-    // Win64 still needs the 32-byte shadow space.
+    // assembler.py:258-261 `add_to_esp = 16 - WORD` plus Win64 shadow
+    // space.  pyre's JIT body is 0-mod-16 (per `_call_header`'s
+    // padding-slot SUB) and the outer `call rax` pushes the return
+    // address, leaving rsp 8-mod-16 inside the trampoline.  The SUB
+    // below brings rsp back to 0-mod-16 before the inner CALL — `8`
+    // alignment alone on SysV, `8 + 32` shadow on Win64.
     #[cfg(target_os = "windows")]
-    let align: i32 = 32;
+    let align: i32 = 40;
     #[cfg(not(target_os = "windows"))]
-    let align: i32 = 0;
+    let align: i32 = 8;
 
     // assembler.py:270 `MOV_rr(ARG0, edx)` — size argument.
     #[cfg(target_os = "windows")]
@@ -454,66 +409,45 @@ fn build_malloc_slowpath_body(
             ; jz =>skip_wb
         );
         // Inline WB helper call: rbp -> ARG0, save/restore rax across.
-        // Stack accounting at this point: helper entry rsp was
-        // 0-mod-16 (the caller's pre-CALL rsp was the JIT
-        // prologue-aligned 8-mod-16 and the CALL push of the return
-        // address subtracted another 8).  Push rax → 8-mod-16; for
-        // the inner CALL we need rsp 0-mod-16, so SUB rsp, 8 (Linux)
-        // or SUB rsp, 40 (Win64: 8 align + 32 shadow).
+        // Stack accounting at this point: the trampoline's pre-call
+        // alignment SUB has been fully reversed by the matching ADD,
+        // so rsp is back at the trampoline-entry value of 8-mod-16
+        // (pyre JIT body 0-mod-16 + outer-CALL push).  `push rax`
+        // brings rsp to 0-mod-16 — already aligned for the inner CALL
+        // on SysV, while Win64 still needs its 32-byte shadow space.
         let wb_fn = crate::runner::dynasm_write_barrier as *const () as i64;
         #[cfg(target_os = "windows")]
         dynasm!(asm ; .arch x64
             ; push rax
-            ; sub rsp, 40           // 8 align (push rax broke alignment) + 32 shadow
+            ; sub rsp, 32           // 32 shadow (push rax already aligned)
             ; mov rcx, rbp
             ; mov rax, QWORD wb_fn
             ; call rax
-            ; add rsp, 40
+            ; add rsp, 32
             ; pop rax
         );
         #[cfg(not(target_os = "windows"))]
         dynasm!(asm ; .arch x64
             ; push rax
-            ; sub rsp, 8            // alignment after push rax
             ; mov rdi, rbp
             ; mov rax, QWORD wb_fn
             ; call rax
-            ; add rsp, 8
             ; pop rax
         );
         dynasm!(asm ; .arch x64 ; =>skip_wb);
     }
 
-    // assembler.py:300-322 OOM propagate path — when the slowpath
-    // helper returns NULL the underlying `libc::calloc` /
-    // `gc.alloc_nursery_*` ran out of memory.  PyPy emits the
-    // test+branch inside `_build_malloc_slowpath` and tail-JMPs to
-    // the standalone `propagate_exception_path` (line 322).  Pyre
-    // threads the propagate path's address in via `propagate_path`
-    // and follows the same structure: `ADD rsp, 8` to drop the
-    // trampoline's own CALL return address, then JMP to the propagate
-    // trampoline.
-    //
-    // dynasm-rs has no direct rel32-JMP-to-absolute-imm encoding, so
-    // we materialise the 64-bit immediate into the scratch reg (R11,
-    // not in PyPy's ECX/EDX-clobber set) and `jmp r11`.  RBP/RCX/RDX
-    // values matter to the propagate path's `_store_and_reset_exception`
-    // + `_call_footer`, and R11 is dead by this point.
-    let success = asm.new_dynamic_label();
-    let propagate_path_imm = propagate_path as i64;
+    // assembler.py:298-322 — TEST/JZ-to-OOM-tail with the common (success)
+    // case as fall-through, matching PyPy's branch layout exactly.  The
+    // `JZ` lands on the OOM tail emitted after RET; the fall-through path
+    // does `MOV ecx, eax` → `_pop_all_regs_from_frame` → `pop_gcmap` →
+    // `RET`.
+    let oom_tail = asm.new_dynamic_label();
     dynasm!(asm ; .arch x64
         ; test rax, rax
-        ; jnz =>success
-        // assembler.py:321 `ADD esp, WORD` — pop the trampoline's
-        // own CALL return address so `_call_footer` in the propagate
-        // trampoline sees rsp at the trace's body alignment (the
-        // same value the trace's `_call_header` left after its SUB).
-        ; add rsp, 8
-        ; mov r11, QWORD propagate_path_imm
-        ; jmp r11
+        ; jz =>oom_tail
     );
 
-    dynasm!(asm ; .arch x64 ; =>success);
     // assembler.py:304 `MOV_rr(ecx, eax)` — deliver the helper return
     // value through ECX so it survives `pop_all` (which restores RAX
     // from the save area).  RAX is still valid at this point because
@@ -523,7 +457,36 @@ fn build_malloc_slowpath_body(
 
     // assembler.py:307 `_pop_all_regs_from_frame(mc, [ecx, edx], floats)`.
     pop_all_regs_from_jitframe_raw(asm, &ignored, true);
-    dynasm!(asm ; .arch x64 ; ret);
+    // assembler.py:308 `self.pop_gcmap(mc)` — clear `JF_GCMAP_OFS`
+    // before RET so the caller's regalloc layout (which never sees the
+    // trampoline's saved-reg slots) is the only gcmap the next
+    // collecting call walks.  Matches PyPy "trampoline owns the
+    // gcmap-clear before RET" structure exactly.
+    dynasm!(asm ; .arch x64
+        ; mov QWORD [rbp + crate::jitframe::JF_GCMAP_OFS], 0
+        ; ret
+    );
+
+    // assembler.py:309-322 OOM tail — patched JZ target above.  When the
+    // slowpath helper returns NULL (`libc::calloc` / `gc.alloc_nursery_*`
+    // OOM) PyPy tail-JMPs to the standalone `propagate_exception_path`
+    // (line 322).  `jmp extern propagate_path` lowers via dynasm-rs's
+    // `value_reloc` to `E9 + rel32`, matching PyPy line-by-line: the
+    // rel32 is computed at `finalize` time from the propagate buffer's
+    // runtime address (the buffer was finalised by the caller before
+    // this trampoline is built, so its address is known).  Requires
+    // the two ExecutableBuffers to land within ±2GB; if not, finalize
+    // returns `ImpossibleRelocation` and the `expect` in the caller
+    // surfaces a clear diagnostic.
+    dynasm!(asm ; .arch x64
+        ; =>oom_tail
+        // assembler.py:321 `ADD esp, WORD` — pop the trampoline's own
+        // CALL return address so `_call_footer` in the propagate
+        // trampoline sees rsp at the trace's body alignment (the same
+        // value the trace's `_call_header` left after its SUB).
+        ; add rsp, 8
+        ; jmp extern propagate_path
+    );
 }
 
 /// Pointer-identity key for `target_tokens_currently_compiling`. PyPy
@@ -779,19 +742,13 @@ pub struct Assembler386<'a> {
     /// adds `rawstart` to obtain the absolute address.
     frame_depth_to_patch: Vec<usize>,
     /// `x86/assembler.py:63` `self.malloc_slowpath` parity — entry
-    /// pointer of the per-CPU fixed-size malloc slowpath helper,
-    /// resolved by `X86CpuExt::ensure_malloc_slowpath_fixed`
-    /// and passed in at construction time so the emit path bakes
-    /// it as a 64-bit immediate without re-touching the backend.
+    /// pointer of the per-CPU malloc slowpath trampoline used by both
+    /// `CallMallocNursery` and `CallMallocNurseryVarsizeFrame` (PyPy
+    /// line 2554 / 2578 both route through the same `malloc_slowpath`).
+    /// Resolved by `X86CpuExt::ensure_malloc_slowpath_fixed` and
+    /// passed in at construction time so the emit path bakes it as a
+    /// 64-bit immediate without re-touching the backend.
     malloc_slowpath_fixed: usize,
-    /// `x86/assembler.py:64 self.malloc_slowpath_varsize` analog —
-    /// entry pointer of the per-CPU jitframe-sized malloc slowpath
-    /// trampoline, resolved by
-    /// `X86CpuExt::ensure_malloc_slowpath_varsize_frame`.  Used by
-    /// `CallMallocNurseryVarsizeFrame` so the inline save/restore
-    /// machinery lives inside the trampoline (PyPy parity), not at
-    /// the call site.
-    malloc_slowpath_varsize_frame: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
@@ -881,7 +838,6 @@ impl<'a> Assembler386<'a> {
         attached_descrs: crate::guard::AttachedDescrPtrs,
         cpu_handle: crate::guard::CpuDescrHandle,
         malloc_slowpath_fixed: usize,
-        malloc_slowpath_varsize_frame: usize,
         inputargs: &'a [InputArg],
         operations: &'a [Op],
     ) -> Self {
@@ -926,7 +882,6 @@ impl<'a> Assembler386<'a> {
             cpu_handle,
             frame_depth_to_patch: Vec::new(),
             malloc_slowpath_fixed,
-            malloc_slowpath_varsize_frame,
         }
     }
 
@@ -1529,10 +1484,20 @@ impl<'a> Assembler386<'a> {
         // Layout (lowest address first, all offsets relative to the new
         // rsp after the SUB):
         //   Win64:  [+0 rbx, +8 rsi, +16 rdi, +24 r12, +32 r14, +40 r15,
-        //            +48 rbp, +56 r13]   → SUB 64 (8 slots; body rsp at
-        //            8 mod 16 since function entry rsp was 8 mod 16 too)
-        //   SysV:   [+0 rbx, +8 r12, +16 r13, +24 r14, +32 r15, +40 rbp]
-        //            → SUB 48 (6 slots; body rsp at 8 mod 16)
+        //            +48 rbp, +56 r13, +64 pad]   → SUB 72 (8 slots +
+        //            1 padding; body rsp at 0 mod 16 since function
+        //            entry rsp was 8 mod 16)
+        //   SysV:   [+0 rbx, +8 r12, +16 r13, +24 r14, +32 r15, +40 rbp,
+        //            +48 pad]   → SUB 56 (6 slots + 1 padding; body rsp
+        //            at 0 mod 16)
+        //
+        // The trailing padding slot (`+64` Win64, `+48` SysV) brings the
+        // body rsp from the function-entry 8-mod-16 down to 0-mod-16,
+        // matching PyPy's body alignment convention.  This lets every
+        // inner CALL omit the per-call `SUB rsp, 8` alignment fixup
+        // (PyPy `_build_malloc_slowpath` `add_to_esp = 16 - WORD = 8`
+        // accounts for the dual: PyPy trampoline body is 8-mod-16
+        // because PyPy JIT body is 0-mod-16 + CALL push).
         //
         // `r12` carries the caller's `rbp` (saved jf_ptr) across nested
         // `genop_call_assembler` reentries, so it must be preserved
@@ -1545,7 +1510,7 @@ impl<'a> Assembler386<'a> {
         #[cfg(target_os = "windows")]
         dynasm!(self.mc
             ; .arch x64
-            ; sub rsp, 64
+            ; sub rsp, 72
             ; mov [rsp + 0],  rbx
             ; mov [rsp + 8],  rsi
             ; mov [rsp + 16], rdi
@@ -1559,7 +1524,7 @@ impl<'a> Assembler386<'a> {
         #[cfg(not(target_os = "windows"))]
         dynasm!(self.mc
             ; .arch x64
-            ; sub rsp, 48
+            ; sub rsp, 56
             ; mov [rsp + 0],  rbx
             ; mov [rsp + 8],  r12
             ; mov [rsp + 16], r13
@@ -1628,7 +1593,7 @@ impl<'a> Assembler386<'a> {
                     ; mov r15, [rsp + 40]
                     ; mov rbp, [rsp + 48]
                     ; mov r13, [rsp + 56]
-                    ; add rsp, 64
+                    ; add rsp, 72
                 );
                 #[cfg(not(target_os = "windows"))]
                 dynasm!(self.mc
@@ -1639,7 +1604,7 @@ impl<'a> Assembler386<'a> {
                     ; mov r14, [rsp + 24]
                     ; mov r15, [rsp + 32]
                     ; mov rbp, [rsp + 40]
-                    ; add rsp, 48
+                    ; add rsp, 56
                 );
                 dynasm!(self.mc
                     ; .arch x64
@@ -1830,17 +1795,25 @@ impl<'a> Assembler386<'a> {
     }
 
     fn emit_win64_call_adjust(extra_pushes: usize) -> i32 {
-        if extra_pushes & 1 == 0 { 40 } else { 32 }
+        // Body rsp is 0-mod-16 (per `_call_header`'s padding-slot SUB).
+        // With 0 extra pushes, only the 32-byte shadow space is needed
+        // (rsp already aligned).  With 1 extra push, rsp is at 8-mod-16
+        // so an extra 8 bytes of alignment pad is required before the
+        // 32-byte shadow space → 40.
+        if extra_pushes & 1 == 0 { 32 } else { 40 }
     }
 
     fn abi_reserved_call_area_size(extra_pushes: usize, stack_slots: usize) -> i32 {
+        // Body rsp is 0-mod-16; the inversion in `needs_pad` accounts
+        // for that vs the previous 8-mod-16 layout (see `_call_header`
+        // comment for the alignment rationale).
         #[cfg(target_os = "windows")]
         {
             let base = 32 + (stack_slots * WORD) as i32;
             let needs_pad = if extra_pushes & 1 == 0 {
-                base % 16 == 0
-            } else {
                 base % 16 != 0
+            } else {
+                base % 16 == 0
             };
             base + if needs_pad { WORD as i32 } else { 0 }
         }
@@ -1848,9 +1821,9 @@ impl<'a> Assembler386<'a> {
         {
             let base = (stack_slots * WORD) as i32;
             let needs_pad = if extra_pushes & 1 == 0 {
-                base % 16 == 0
-            } else {
                 base % 16 != 0
+            } else {
+                base % 16 == 0
             };
             base + if needs_pad { WORD as i32 } else { 0 }
         }
@@ -1899,14 +1872,13 @@ impl<'a> Assembler386<'a> {
     }
 
     fn emit_abi_call_rax_aligned(&mut self) {
+        // Body rsp is 0-mod-16 (see `_call_header`), so no alignment
+        // SUB is needed before the inner CALL on either ABI; Win64
+        // still needs the 32-byte shadow space.
         #[cfg(target_os = "windows")]
         self.emit_abi_call_rax_with_extra_pushes(0);
         #[cfg(not(target_os = "windows"))]
-        dynasm!(self.mc ; .arch x64
-            ; sub rsp, 8
-            ; call rax
-            ; add rsp, 8
-        );
+        dynasm!(self.mc ; .arch x64 ; call rax);
     }
 
     fn emit_abi_call_rax_after_one_push(&mut self) {
@@ -3975,34 +3947,19 @@ impl<'a> Assembler386<'a> {
             OpCode::CallMallocNursery => {
                 self.genop_call_malloc_nursery(op, result_loc);
             }
-            // assembler.py:715 malloc_cond_varsize_frame parity.
-            // The JITFRAME allocation goes through a collecting slowpath:
-            // 1. publish `pending_malloc_nursery_gcmap` into JF_GCMAP_OFS
-            //    so a minor GC during the call can trace live frame-
-            //    resident Refs (previously unconditionally cleared,
-            //    which left ref roots invisible and corrupted live
-            //    boxes after a collect — fib_recursive crashed on the
-            //    first nursery overflow that triggered a minor GC).
-            // 2. invoke `dynasm_nursery_slowpath_jitframe`, which uses
-            //    the JITFRAME type_id rather than the generic nursery
-            //    slowpath.
-            // 3. clear gcmap after.
-            // 4. copy RAX into the regalloc-assigned `result_loc`
-            //    register; the regalloc may pick something other than
-            //    RAX and downstream ops read that register directly.
+            // assembler.py:2567 malloc_cond_varsize_frame parity.
+            // The varsize_frame call site shares the entire slowpath
+            // structure with the fixed-size variant: PyPy's
+            // `MallocCondSlowPath` (line 2551) does `CALL malloc_slowpath`
+            // regardless of which caller pushed it, and the slowpath
+            // recovers `total_size = edx - ecx` either way.  Pyre
+            // mirrors that — both arms emit the ECX/EDX bump-allocator
+            // probe and `JA` into the same `malloc_slowpath_fixed`
+            // trampoline.  The trampoline's gcmap-aware save/restore
+            // preserves every regalloc-resident Ref across a minor
+            // collection fired by the slowpath (fib_recursive on x86
+            // exercised this path).
             OpCode::CallMallocNurseryVarsizeFrame => {
-                // x86/assembler.py:715 malloc_cond_varsize_frame parity:
-                // an inline bump-allocator fast path keeps the common
-                // path off the helper (which may trigger a minor GC).
-                // The slowpath is bracketed with push_all_regs /
-                // pop_all_regs so any Ref the regalloc left in a
-                // register survives a minor collection (the gcmap
-                // describes the saved-reg slots, and the visitor
-                // rewrites them in place). Without the push/pop and
-                // reload_frame_if_necessary, fib_recursive on x86 read
-                // stale parent-frame pointers out of call-clobbered
-                // registers after the first minor GC fired by a
-                // recursive JITFRAME alloc.
                 let sizeloc = match arglocs.first() {
                     Some(Loc::Reg(r)) => *r,
                     other => panic!(
@@ -4018,16 +3975,10 @@ impl<'a> Assembler386<'a> {
                 let sv = sizeloc.value;
                 let rv = result_reg.value;
                 // `MALLOC_NURSERY_CLOBBER` spills any live variable
-                // out of RCX/RDX before this op, so `sizeloc` is never
-                // in those registers and is guaranteed disjoint from
-                // `result_reg = MALLOC_NURSERY_RESULT = RCX`. R11
-                // (scratch) loads address constants and is not the
-                // sizeloc. RAX is used only AFTER the last read of
-                // sizeloc, so a sv==RAX overlap is benign.
-                assert!(
-                    rv != sv,
-                    "CallMallocNurseryVarsizeFrame: sizeloc must differ from result_reg",
-                );
+                // out of RCX/RDX before this op, so `sizeloc` is
+                // never in those registers and is disjoint from the
+                // ECX/EDX probe pair.  R11 (X86_64_SCRATCH_REG) loads
+                // the absolute nursery_free/nursery_top addresses.
                 let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
                 let slow_path = self.mc.new_dynamic_label();
                 let done = self.mc.new_dynamic_label();
@@ -4036,86 +3987,67 @@ impl<'a> Assembler386<'a> {
                 if nf_addr == 0 || nt_addr == 0 {
                     dynasm!(self.mc ; .arch x64 ; jmp =>slow_path);
                 } else {
-                    // Fast path. Use `result_reg` as scratch for the
-                    // proposed new free pointer; on success it ends
-                    // holding the allocated object's payload address.
-                    // RAX is loaded with the old nursery_free AFTER
-                    // the `ja slow_path` so sizeloc remains intact on
-                    // the slow-path fall-through even when sv == RAX.
+                    // assembler.py:2572-2581 line-by-line — `MOV ecx,
+                    // [nf]; LEA edx, [ecx + sizeloc + gc_hdr]; CMP edx,
+                    // [nt]; JA slow; MOV [nf], edx`.  PyPy's LEA omits
+                    // `gc_hdr` because its allocator accounts for the
+                    // header inside the helper; pyre adds it here so
+                    // the trampoline's `SUB rdx, rcx` recovers the
+                    // exact byte count `dynasm_nursery_slowpath`
+                    // expects (total bytes including header).
                     dynasm!(self.mc ; .arch x64
                         ; mov Rq(scratch), QWORD nf_addr as i64
-                        ; mov Rq(rv), [Rq(scratch)]
-                        ; add Rq(rv), Rq(sv)
-                        ; add Rq(rv), gc_header_size
+                        ; mov rcx, [Rq(scratch)]
+                        ; lea rdx, [rcx + Rq(sv) + gc_header_size]
                         ; mov Rq(scratch), QWORD nt_addr as i64
-                        ; cmp Rq(rv), [Rq(scratch)]
+                        ; cmp rdx, [Rq(scratch)]
                         ; ja =>slow_path
                         ; mov Rq(scratch), QWORD nf_addr as i64
-                        ; mov rax, [Rq(scratch)]            // rax = old nf
-                        ; mov [Rq(scratch)], Rq(rv)         // *nf = new_nf
-                        ; mov QWORD [rax], 0                // zero GC header
-                        ; lea Rq(rv), [rax + gc_header_size] // payload ptr
+                        ; mov [Rq(scratch)], rdx
+                        ; mov QWORD [rcx], 0
+                        ; lea Rq(rv), [rcx + gc_header_size]
                         ; jmp =>done
                     );
                 }
                 dynasm!(self.mc ; .arch x64 ; =>slow_path);
-                // Trampoline entry convention: frame_size in RDX
-                // (matches PyPy `_build_malloc_slowpath(kind='var')`
-                // which carries the size through EDX).
-                // `MALLOC_NURSERY_CLOBBER` guarantees
-                // `sizeloc ∉ {RCX, RDX}`, so `mov rdx, sizeloc` is
-                // safe; the guard skips the MOV if the regalloc
-                // pre-placed sizeloc in RDX (currently unreachable
-                // but harmless if the clobber set ever flips).
-                if sizeloc.value != crate::regloc::EDX.value {
-                    dynasm!(self.mc ; .arch x64 ; mov rdx, Rq(sv));
+                // Trampoline entry contract (assembler.py:264
+                // `SUB_rr(edx, ecx)` → total size): caller must hand
+                // off `rcx = old_nf` and `rdx = old_nf + total`, just
+                // like `malloc_cond` does.  The `nf_addr == 0` guard
+                // path above skipped the probe, so re-stage the
+                // operands here.  `gc_header_size` is added so the
+                // slowpath's `dynasm_nursery_slowpath(total)` sees the
+                // same byte count the fast path proposed.
+                if nf_addr == 0 || nt_addr == 0 {
+                    dynasm!(self.mc ; .arch x64
+                        ; mov Rq(scratch), QWORD nf_addr as i64
+                        ; mov rcx, [Rq(scratch)]
+                        ; lea rdx, [rcx + Rq(sv) + gc_header_size]
+                    );
                 }
-                // Publish the gcmap before entering the trampoline
-                // (PyPy: "the caller already did push_gcmap(store=True)" —
-                // `_build_malloc_slowpath` reads it via the saved-reg
-                // slot layout encoded in the gcmap).  The trampoline
-                // saves every GPR/XMM except ECX/EDX, so any live Box
-                // the regalloc left in a register survives a minor
-                // collection via the gcmap-described save slots.
                 if let Some(gcmap) = self.pending_malloc_nursery_gcmap {
                     self.push_gcmap(gcmap as *mut usize);
                 } else {
                     let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS;
                     dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
                 }
-                // Stage the trampoline entry through R11
-                // (X86_64_SCRATCH_REG) so RAX stays caller-live
-                // across the call.  The trampoline's
-                // `push_all_regs_to_jitframe_raw([ECX, EDX], true)`
-                // saves the caller's RAX into the jitframe save area
-                // and the matching pop restores it — loading the
-                // helper address into RAX here would clobber that
-                // value before the save (same fix the fixed-size
-                // variant applied in commit daf25bd5874e).
-                let helper_addr = self.malloc_slowpath_varsize_frame as i64;
+                // Stage the trampoline address through R11 so RAX
+                // stays caller-live across the call (the trampoline
+                // saves+restores it via the `[ECX, EDX]`-ignored
+                // push_all_regs).
+                let helper_addr = self.malloc_slowpath_fixed as i64;
                 let call_scratch = crate::regloc::X86_64_SCRATCH_REG.value;
                 dynasm!(self.mc ; .arch x64
                     ; mov Rq(call_scratch), QWORD helper_addr
                     ; call Rq(call_scratch)
                 );
-                // Trampoline returns the jitframe payload in RCX
-                // (PyPy line 304 `MOV_rr(ecx, eax)` ahead of
-                // `_pop_all_regs_from_frame([ecx, edx])`).  The
-                // regalloc forces
-                // `result_reg = MALLOC_NURSERY_RESULT = RCX`
-                // (regalloc.rs:105), so the MOV is elided in the
-                // common case.  OOM cases never return here — the
-                // trampoline tail-JMPs to `propagate_exception_path`.
+                // assembler.py:304 — helper returns the payload in
+                // ECX (`MOV_rr(ecx, eax)` inside the trampoline).
+                // regalloc forces `result_reg = MALLOC_NURSERY_RESULT
+                // = ECX`, so the MOV is elided in the common case.
                 if result_reg.value != crate::regloc::ECX.value {
                     dynasm!(self.mc ; .arch x64 ; mov Rq(rv), rcx);
                 }
-                // Clear gcmap slot.  The trampoline already ran
-                // `_reload_frame_if_necessary` (PyPy assembler.py:1375),
-                // so RBP points at the live (possibly moved) frame
-                // and this write targets the live `JF_GCMAP_OFS`,
-                // not the freed nursery copy.
-                let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS;
-                dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
                 dynasm!(self.mc ; .arch x64 ; =>done);
                 if !op.pos.get().is_none() {
                     if result_reg.value != 0 {
@@ -7561,7 +7493,11 @@ impl<'a> Assembler386<'a> {
                 dynasm!(self.mc ; .arch x64 ; mov Rq(rv), rcx);
             }
         }
-        dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
+        // gcmap was cleared by `pop_gcmap(mc)` inside the trampoline
+        // before RET (PyPy assembler.py:308); no caller-side clear is
+        // needed here.  Matches the PyPy contract where the trampoline
+        // owns the `JF_GCMAP_OFS` reset.
+        let _ = gcmap_ofs;
 
         dynasm!(self.mc ; .arch x64 ; =>done);
         // Spill the result to the regalloc-assigned jitframe slot.  Stage

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2516,7 +2516,8 @@ impl<'a> Assembler386<'a> {
         // assembler.py:537 prepare_loop / assembler.py:638 prepare_bridge
         if crate::majit_j2plan_log_enabled() {
             let plan = crate::j2plan::TracePlan::build(inputargs, ops);
-            majit_ir::debug::log_one("jit-backend", &format!("j2plan: {}", plan.summary()));
+            // Independent debug toggle — not gated by MAJIT_LOG.
+            eprintln!("[dynasm:j2plan] {}", plan.summary());
         }
 
         let mut ra = RegAlloc::new(

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2516,7 +2516,7 @@ impl<'a> Assembler386<'a> {
         // assembler.py:537 prepare_loop / assembler.py:638 prepare_bridge
         if crate::majit_j2plan_log_enabled() {
             let plan = crate::j2plan::TracePlan::build(inputargs, ops);
-            eprintln!("[dynasm:j2plan] {}", plan.summary());
+            majit_ir::debug::log_one("jit-backend", &format!("j2plan: {}", plan.summary()));
         }
 
         let mut ra = RegAlloc::new(
@@ -2588,8 +2588,11 @@ impl<'a> Assembler386<'a> {
                     continue;
                 }
                 RegAllocOp::Move { src, dst } => {
-                    if crate::majit_log_enabled() {
-                        eprintln!("[dynasm] move: {:?} → {:?}", src, dst);
+                    if majit_ir::debug::have_debug_prints() {
+                        majit_ir::debug::log_one(
+                            "jit-backend",
+                            &format!("move: {src:?} → {dst:?}"),
+                        );
                     }
                     self.regalloc_mov(src, dst);
                     continue;
@@ -3740,15 +3743,16 @@ impl<'a> Assembler386<'a> {
                 }
                 let tmpreg1 = Loc::Reg(crate::regloc::X86_64_SCRATCH_REG);
                 let tmpreg2 = Loc::Reg(crate::regloc::XMM15);
-                if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[dynasm] Jump remap: {} int src→dst, {} float src→dst",
+                if majit_ir::debug::have_debug_prints() {
+                    let _s = majit_ir::debug::scope("jit-backend");
+                    majit_ir::debug::debug_print(&format!(
+                        "Jump remap: {} int src→dst, {} float src→dst",
                         src_locations1.len(),
                         src_locations2.len()
-                    );
+                    ));
                     for (i, (s, d)) in src_locations1.iter().zip(dst_locations1.iter()).enumerate()
                     {
-                        eprintln!("[dynasm]   int[{}]: {:?} → {:?}", i, s, d);
+                        majit_ir::debug::debug_print(&format!("  int[{i}]: {s:?} → {d:?}"));
                     }
                 }
                 self.remap_frame_layout_mixed(
@@ -3872,8 +3876,11 @@ impl<'a> Assembler386<'a> {
                 let label = self.mc.new_dynamic_label();
                 let descr_arc = op.getdescr();
                 let label_descr = descr_arc.as_ref().and_then(|d| d.as_loop_target_descr());
-                if crate::majit_log_enabled() {
-                    eprintln!("[dynasm] LABEL: new DynamicLabel({:?})", label);
+                if majit_ir::debug::have_debug_prints() {
+                    majit_ir::debug::log_one(
+                        "jit-backend",
+                        &format!("LABEL: new DynamicLabel({label:?})"),
+                    );
                 }
                 dynasm!(self.mc ; =>label);
                 if let Some(descr) = label_descr {
@@ -4930,8 +4937,11 @@ impl<'a> Assembler386<'a> {
         let stub_start = self.mc.offset();
 
         let fail_label = guard_token.fail_label;
-        if crate::majit_log_enabled() {
-            eprintln!("[dynasm] recovery stub: binding {:?}", fail_label);
+        if majit_ir::debug::have_debug_prints() {
+            majit_ir::debug::log_one(
+                "jit-backend",
+                &format!("recovery stub: binding {fail_label:?}"),
+            );
         }
         dynasm!(self.mc ; .arch x64 ; =>fail_label);
 
@@ -4991,8 +5001,11 @@ impl<'a> Assembler386<'a> {
         for guard_token in std::mem::take(&mut self.pending_guard_tokens) {
             stub_offsets.push(self.generate_quick_failure(guard_token, save_regs_label));
         }
-        if crate::majit_log_enabled() {
-            eprintln!("[dynasm] write_pending done: {} stubs", stub_offsets.len());
+        if majit_ir::debug::have_debug_prints() {
+            majit_ir::debug::log_one(
+                "jit-backend",
+                &format!("write_pending done: {} stubs", stub_offsets.len()),
+            );
         }
         stub_offsets
     }

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -470,14 +470,15 @@ fn build_malloc_slowpath_body(asm: &mut Assembler, slowpath_fn: i64, propagate_p
     // assembler.py:309-322 OOM tail — patched JZ target above.  When the
     // slowpath helper returns NULL (`libc::calloc` / `gc.alloc_nursery_*`
     // OOM) PyPy tail-JMPs to the standalone `propagate_exception_path`
-    // (line 322).  `jmp extern propagate_path` lowers via dynasm-rs's
-    // `value_reloc` to `E9 + rel32`, matching PyPy line-by-line: the
-    // rel32 is computed at `finalize` time from the propagate buffer's
-    // runtime address (the buffer was finalised by the caller before
-    // this trampoline is built, so its address is known).  Requires
-    // the two ExecutableBuffers to land within ±2GB; if not, finalize
-    // returns `ImpossibleRelocation` and the `expect` in the caller
-    // surfaces a clear diagnostic.
+    // (line 322).  Stage `propagate_path` into a scratch register and
+    // jump indirectly so the transfer is range-independent: dynasm-rs's
+    // `jmp extern` would lower to `E9 + rel32`, but the malloc slowpath
+    // and propagate trampoline live in separately-finalized
+    // `ExecutableBuffer`s that aren't guaranteed to land within ±2GB
+    // under ASLR, so `finalize()` would otherwise fail with
+    // `ImpossibleRelocation` and trip the caller's `expect("malloc_slowpath:
+    // finalize")` on affected layouts.
+    let propagate_scratch = crate::regloc::X86_64_SCRATCH_REG.value;
     dynasm!(asm ; .arch x64
         ; =>oom_tail
         // assembler.py:321 `ADD esp, WORD` — pop the trampoline's own
@@ -485,7 +486,8 @@ fn build_malloc_slowpath_body(asm: &mut Assembler, slowpath_fn: i64, propagate_p
         // trampoline sees rsp at the trace's body alignment (the same
         // value the trace's `_call_header` left after its SUB).
         ; add rsp, 8
-        ; jmp extern propagate_path
+        ; mov Rq(propagate_scratch), QWORD propagate_path as i64
+        ; jmp Rq(propagate_scratch)
     );
 }
 
@@ -4025,12 +4027,16 @@ impl<'a> Assembler386<'a> {
                 // path above skipped the probe, so re-stage the
                 // operands here.  `gc_header_size` is added so the
                 // slowpath's `dynasm_nursery_slowpath(total)` sees the
-                // same byte count the fast path proposed.
+                // same byte count the fast path proposed.  With no
+                // active GC descriptor the previous code dereferenced
+                // `[nf_addr]` where `nf_addr == 0` (crash before the
+                // helper-only fallback ever ran), so synthesize
+                // `(rcx=0, rdx=total)` directly — `sub edx, ecx`
+                // recovers `total` for the trampoline either way.
                 if nf_addr == 0 || nt_addr == 0 {
                     dynasm!(self.mc ; .arch x64
-                        ; mov Rq(scratch), QWORD nf_addr as i64
-                        ; mov rcx, [Rq(scratch)]
-                        ; lea rdx, [rcx + Rq(sv) + gc_header_size]
+                        ; xor rcx, rcx
+                        ; lea rdx, [Rq(sv) + gc_header_size]
                     );
                 }
                 if let Some(gcmap) = self.pending_malloc_nursery_gcmap {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -307,10 +307,84 @@ pub(crate) fn build_malloc_slowpath_fixed(
     // standalone propagate trampoline, not re-baked here.
     let _ = cpu_handle;
     let mut asm = Assembler::new().expect("malloc_slowpath: new Assembler");
-    let ignored = [crate::regloc::ECX, crate::regloc::EDX];
 
     // assembler.py:264 `SUB_rr(edx, ecx)` — recover total_size at runtime.
+    // Only the `kind == 'fixed'` arm preprocesses the size; varsize_frame
+    // receives the frame size in RDX directly from the caller (see
+    // `build_malloc_slowpath_varsize_frame`).
     dynasm!(asm ; .arch x64 ; sub rdx, rcx);
+
+    let slowpath_fn = crate::runner::dynasm_nursery_slowpath as *const () as i64;
+    build_malloc_slowpath_body(&mut asm, slowpath_fn, propagate_path);
+
+    let buffer = asm.finalize().expect("malloc_slowpath: finalize");
+    let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
+    (buffer, ptr)
+}
+
+/// `assembler.py:231 _build_malloc_slowpath` `kind='var'` analog for
+/// pyre's `CallMallocNurseryVarsizeFrame`.  Same helper trampoline
+/// shape as [`build_malloc_slowpath_fixed`], differing only in the
+/// size-prep step: the caller stages `frame_size` directly into RDX
+/// (no `nursery_free` recovery), so the trampoline skips the
+/// `sub rdx, rcx` and dispatches straight to
+/// `dynasm_nursery_slowpath_jitframe`.
+///
+/// **Calling convention:**
+/// - Entry: `rbp` = jitframe, `rdx` = frame_size (the same value
+///   the caller's fast path computed for the bump-allocator probe).
+///   Caller has published the gcmap to `[rbp + JF_GCMAP_OFS]`.
+/// - Exit: `rcx` = jitframe payload pointer (or `propagate_exception_path`
+///   tail-call on OOM); every other GPR/XMM restored from the
+///   jitframe save area; `rbp` reloaded from the shadow stack top.
+///
+/// Save mask `[ECX, EDX]` is identical to the fixed variant — the
+/// caller's `MALLOC_NURSERY_CLOBBER` (regalloc.rs:101) is the same set
+/// for both variants, so `_pop_all_regs_from_frame` restores the same
+/// register snapshot in both.
+///
+/// Ownership: caller (`X86CpuExt::ensure_malloc_slowpath_varsize_frame`)
+/// owns the returned `ExecutableBuffer` and the entry address is
+/// memoised on the per-CPU `X86CpuExt`, matching PyPy's per-CPU
+/// `self.malloc_slowpath` cache.
+pub(crate) fn build_malloc_slowpath_varsize_frame(
+    cpu_handle: &crate::guard::CpuDescrHandle,
+    propagate_path: usize,
+) -> (ExecutableBuffer, usize) {
+    let _ = cpu_handle;
+    let mut asm = Assembler::new().expect("malloc_slowpath_varsize_frame: new Assembler");
+
+    let slowpath_fn =
+        crate::runner::dynasm_nursery_slowpath_jitframe as *const () as i64;
+    build_malloc_slowpath_body(&mut asm, slowpath_fn, propagate_path);
+
+    let buffer = asm
+        .finalize()
+        .expect("malloc_slowpath_varsize_frame: finalize");
+    let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
+    (buffer, ptr)
+}
+
+/// Shared body of [`build_malloc_slowpath_fixed`] and
+/// [`build_malloc_slowpath_varsize_frame`].  Emits the
+/// `_push_all_regs_to_frame([ecx, edx])` → CALL helper → reload_frame
+/// → inline WB → OOM check → `MOV ecx, eax` → `_pop_all_regs_from_frame`
+/// → RET sequence shared by both `kind='fixed'` and `kind='var'`
+/// slowpath trampolines.
+///
+/// The caller emits the kind-specific size-prep step (the `SUB rdx, rcx`
+/// for fixed; nothing for varsize_frame, which receives `frame_size`
+/// directly in RDX) and then defers to this helper.
+///
+/// `slowpath_fn` is the absolute address of the GC helper called by
+/// `MOV rax, imm64; CALL rax`.  ABI: size in ARG0 (RCX on Win64, RDI
+/// on SysV).  Result in RAX.
+fn build_malloc_slowpath_body(
+    asm: &mut Assembler,
+    slowpath_fn: i64,
+    propagate_path: usize,
+) {
+    let ignored = [crate::regloc::ECX, crate::regloc::EDX];
 
     // assembler.py:247 `_push_all_regs_to_frame(mc, [ecx, edx], floats)`.
     // Saves every managed GPR/XMM except ECX/EDX so the inner CALL's
@@ -318,7 +392,7 @@ pub(crate) fn build_malloc_slowpath_fixed(
     // set (unlike pyre's prior `[EAX, EDX]` mask), preserving any
     // live caller value across the slowpath — the regalloc only
     // promises ECX/EDX clobber to the caller.
-    push_all_regs_to_jitframe_raw(&mut asm, &ignored, true);
+    push_all_regs_to_jitframe_raw(asm, &ignored, true);
 
     // assembler.py:258-261 — reserve Win64 shadow space (if any).  The
     // caller's `call rax` arrives with rsp at 0-mod-16: pyre's JIT
@@ -337,7 +411,6 @@ pub(crate) fn build_malloc_slowpath_fixed(
     #[cfg(not(target_os = "windows"))]
     let arg0_reg: u8 = 7; // rdi
 
-    let slowpath_fn = crate::runner::dynasm_nursery_slowpath as *const () as i64;
     if align != 0 {
         dynasm!(asm ; .arch x64 ; sub rsp, align);
     }
@@ -411,14 +484,15 @@ pub(crate) fn build_malloc_slowpath_fixed(
         dynasm!(asm ; .arch x64 ; =>skip_wb);
     }
 
-    // assembler.py:300-322 OOM propagate path — when
-    // `dynasm_nursery_slowpath` returns NULL the underlying
-    // `libc::calloc` ran out of memory.  PyPy emits the test+branch
-    // inside `_build_malloc_slowpath` and tail-JMPs to the standalone
-    // `propagate_exception_path` (line 322).  Pyre threads the
-    // propagate path's address in via `propagate_path` and follows
-    // the same structure: `ADD rsp, 8` to drop the trampoline's
-    // own CALL return address, then JMP to the propagate trampoline.
+    // assembler.py:300-322 OOM propagate path — when the slowpath
+    // helper returns NULL the underlying `libc::calloc` /
+    // `gc.alloc_nursery_*` ran out of memory.  PyPy emits the
+    // test+branch inside `_build_malloc_slowpath` and tail-JMPs to
+    // the standalone `propagate_exception_path` (line 322).  Pyre
+    // threads the propagate path's address in via `propagate_path`
+    // and follows the same structure: `ADD rsp, 8` to drop the
+    // trampoline's own CALL return address, then JMP to the propagate
+    // trampoline.
     //
     // dynasm-rs has no direct rel32-JMP-to-absolute-imm encoding, so
     // we materialise the 64-bit immediate into the scratch reg (R11,
@@ -448,12 +522,8 @@ pub(crate) fn build_malloc_slowpath_fixed(
     dynasm!(asm ; .arch x64 ; mov rcx, rax);
 
     // assembler.py:307 `_pop_all_regs_from_frame(mc, [ecx, edx], floats)`.
-    pop_all_regs_from_jitframe_raw(&mut asm, &ignored, true);
+    pop_all_regs_from_jitframe_raw(asm, &ignored, true);
     dynasm!(asm ; .arch x64 ; ret);
-
-    let buffer = asm.finalize().expect("malloc_slowpath: finalize");
-    let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
-    (buffer, ptr)
 }
 
 /// Pointer-identity key for `target_tokens_currently_compiling`. PyPy
@@ -714,6 +784,14 @@ pub struct Assembler386<'a> {
     /// and passed in at construction time so the emit path bakes
     /// it as a 64-bit immediate without re-touching the backend.
     malloc_slowpath_fixed: usize,
+    /// `x86/assembler.py:64 self.malloc_slowpath_varsize` analog —
+    /// entry pointer of the per-CPU jitframe-sized malloc slowpath
+    /// trampoline, resolved by
+    /// `X86CpuExt::ensure_malloc_slowpath_varsize_frame`.  Used by
+    /// `CallMallocNurseryVarsizeFrame` so the inline save/restore
+    /// machinery lives inside the trampoline (PyPy parity), not at
+    /// the call site.
+    malloc_slowpath_varsize_frame: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
@@ -803,6 +881,7 @@ impl<'a> Assembler386<'a> {
         attached_descrs: crate::guard::AttachedDescrPtrs,
         cpu_handle: crate::guard::CpuDescrHandle,
         malloc_slowpath_fixed: usize,
+        malloc_slowpath_varsize_frame: usize,
         inputargs: &'a [InputArg],
         operations: &'a [Op],
     ) -> Self {
@@ -847,6 +926,7 @@ impl<'a> Assembler386<'a> {
             cpu_handle,
             frame_depth_to_patch: Vec::new(),
             malloc_slowpath_fixed,
+            malloc_slowpath_varsize_frame,
         }
     }
 
@@ -3979,38 +4059,63 @@ impl<'a> Assembler386<'a> {
                     );
                 }
                 dynasm!(self.mc ; .arch x64 ; =>slow_path);
-                self.push_all_regs_to_jitframe(&[sizeloc, result_reg], true);
-                self.emit_abi_int_arg_from_reg(0, sizeloc.value as u8);
+                // Trampoline entry convention: frame_size in RDX
+                // (matches PyPy `_build_malloc_slowpath(kind='var')`
+                // which carries the size through EDX).
+                // `MALLOC_NURSERY_CLOBBER` guarantees
+                // `sizeloc ∉ {RCX, RDX}`, so `mov rdx, sizeloc` is
+                // safe; the guard skips the MOV if the regalloc
+                // pre-placed sizeloc in RDX (currently unreachable
+                // but harmless if the clobber set ever flips).
+                if sizeloc.value != crate::regloc::EDX.value {
+                    dynasm!(self.mc ; .arch x64 ; mov rdx, Rq(sv));
+                }
+                // Publish the gcmap before entering the trampoline
+                // (PyPy: "the caller already did push_gcmap(store=True)" —
+                // `_build_malloc_slowpath` reads it via the saved-reg
+                // slot layout encoded in the gcmap).  The trampoline
+                // saves every GPR/XMM except ECX/EDX, so any live Box
+                // the regalloc left in a register survives a minor
+                // collection via the gcmap-described save slots.
                 if let Some(gcmap) = self.pending_malloc_nursery_gcmap {
                     self.push_gcmap(gcmap as *mut usize);
                 } else {
                     let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS;
                     dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
                 }
+                // Stage the trampoline entry through R11
+                // (X86_64_SCRATCH_REG) so RAX stays caller-live
+                // across the call.  The trampoline's
+                // `push_all_regs_to_jitframe_raw([ECX, EDX], true)`
+                // saves the caller's RAX into the jitframe save area
+                // and the matching pop restores it — loading the
+                // helper address into RAX here would clobber that
+                // value before the save (same fix the fixed-size
+                // variant applied in commit daf25bd5874e).
+                let helper_addr = self.malloc_slowpath_varsize_frame as i64;
+                let call_scratch = crate::regloc::X86_64_SCRATCH_REG.value;
                 dynasm!(self.mc ; .arch x64
-                    ; mov rax, QWORD crate::runner::dynasm_nursery_slowpath_jitframe as *const () as i64
+                    ; mov Rq(call_scratch), QWORD helper_addr
+                    ; call Rq(call_scratch)
                 );
-                self.emit_abi_call_rax();
-                // Reload `rbp` first: a minor GC during the slowpath may
-                // have copied the jitframe to old-gen, so the current
-                // `rbp` points at the freed nursery copy. Clearing
-                // `JF_GCMAP_OFS` on it would write garbage and leave the
-                // moved jitframe's gcmap published — a stale gcmap that
-                // a subsequent collecting call would walk.
-                self.reload_frame_if_necessary();
-                // assembler.py:300-322 OOM propagate parity — the
-                // jitframe helper returns NULL on `libc::calloc` /
-                // `gc.alloc_nursery_*` failure; surface that through
-                // `propagate_exception_descr` rather than letting the
-                // caller proceed with a null jitframe.
-                self.emit_propagate_exception_if_zero(0);
+                // Trampoline returns the jitframe payload in RCX
+                // (PyPy line 304 `MOV_rr(ecx, eax)` ahead of
+                // `_pop_all_regs_from_frame([ecx, edx])`).  The
+                // regalloc forces
+                // `result_reg = MALLOC_NURSERY_RESULT = RCX`
+                // (regalloc.rs:105), so the MOV is elided in the
+                // common case.  OOM cases never return here — the
+                // trampoline tail-JMPs to `propagate_exception_path`.
+                if result_reg.value != crate::regloc::ECX.value {
+                    dynasm!(self.mc ; .arch x64 ; mov Rq(rv), rcx);
+                }
+                // Clear gcmap slot.  The trampoline already ran
+                // `_reload_frame_if_necessary` (PyPy assembler.py:1375),
+                // so RBP points at the live (possibly moved) frame
+                // and this write targets the live `JF_GCMAP_OFS`,
+                // not the freed nursery copy.
                 let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS;
                 dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
-                if result_reg.value != 0 {
-                    let rv = result_reg.value;
-                    dynasm!(self.mc ; .arch x64 ; mov Rq(rv), rax);
-                }
-                self.pop_all_regs_from_jitframe(&[sizeloc, result_reg], true);
                 dynasm!(self.mc ; .arch x64 ; =>done);
                 if !op.pos.get().is_none() {
                     if result_reg.value != 0 {

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -25,17 +25,16 @@ use dynasmrt::ExecutableBuffer;
 /// `asmmemmgr`, which roots helper buffers on the CPU.
 pub(crate) struct X86CpuExt {
     /// `assembler.py:63 self.malloc_slowpath` parity.  Entry address
-    /// of the fixed-size malloc slowpath helper built by
-    /// `build_malloc_slowpath_fixed`; `_buffer` is the matching RX
-    /// mapping kept for the lifetime of this struct.
+    /// of the shared malloc slowpath trampoline built by
+    /// `build_malloc_slowpath_fixed`.  PyPy's `malloc_cond` (line
+    /// 2554) and `malloc_cond_varsize_frame` (line 2578) both route
+    /// through this single helper; pyre follows that — both call
+    /// sites reach this address via the same `JA slow_path` jump and
+    /// the trampoline's `SUB rdx, rcx` recovers the byte count.
+    /// `_buffer` is the matching RX mapping kept for the lifetime of
+    /// this struct.
     malloc_slowpath_fixed: Option<usize>,
     _malloc_slowpath_fixed_buffer: Option<ExecutableBuffer>,
-    /// `assembler.py:64 self.malloc_slowpath_varsize` analog for
-    /// pyre's `CallMallocNurseryVarsizeFrame`.  Entry address of the
-    /// trampoline built by `build_malloc_slowpath_varsize_frame`;
-    /// shares the per-CPU cache lifetime with the fixed variant.
-    malloc_slowpath_varsize_frame: Option<usize>,
-    _malloc_slowpath_varsize_frame_buffer: Option<ExecutableBuffer>,
     /// `assembler.py:344 self.propagate_exception_path` parity.
     /// Standalone trampoline that the malloc slowpath (and, in PyPy,
     /// the stack check slowpath) JMPs to on OOM / propagate.
@@ -48,8 +47,6 @@ impl X86CpuExt {
         Self {
             malloc_slowpath_fixed: None,
             _malloc_slowpath_fixed_buffer: None,
-            malloc_slowpath_varsize_frame: None,
-            _malloc_slowpath_varsize_frame_buffer: None,
             propagate_exception_path: None,
             _propagate_exception_path_buffer: None,
         }
@@ -105,32 +102,6 @@ impl X86CpuExt {
         addr
     }
 
-    /// `assembler.py:231 _build_malloc_slowpath(kind='var')` analog —
-    /// materialise the jitframe-sized malloc slowpath trampoline on
-    /// first use of `CallMallocNurseryVarsizeFrame`.  Same per-CPU
-    /// caching contract as [`ensure_malloc_slowpath_fixed`]; the
-    /// propagate trampoline is built first so the OOM `JMP` immediate
-    /// is final before this trampoline is finalised.
-    pub(crate) fn ensure_malloc_slowpath_varsize_frame(
-        &mut self,
-        cpu_handle: &CpuDescrHandle,
-    ) -> usize {
-        if let Some(addr) = self.malloc_slowpath_varsize_frame {
-            return addr;
-        }
-        let propagate_path = self.ensure_propagate_exception_path(cpu_handle);
-        let (buffer, addr) =
-            super::assembler::build_malloc_slowpath_varsize_frame(cpu_handle, propagate_path);
-        debug_assert!(
-            addr != 0,
-            "build_malloc_slowpath_varsize_frame returned NULL entry address — \
-             dynasm finalize is expected to yield a non-zero buffer_ptr"
-        );
-        self._malloc_slowpath_varsize_frame_buffer = Some(buffer);
-        self.malloc_slowpath_varsize_frame = Some(addr);
-        addr
-    }
-
     /// Whether either trampoline that bakes `propagate_exception_descr`
     /// as an immediate has already been materialised.  Used by
     /// `DynasmBackend::set_propagate_exception_descr` to refuse a
@@ -144,8 +115,6 @@ impl X86CpuExt {
     /// upholds the same invariant by panicking instead of dropping
     /// the buffer.
     pub(crate) fn has_propagate_dependent_caches(&self) -> bool {
-        self.malloc_slowpath_fixed.is_some()
-            || self.malloc_slowpath_varsize_frame.is_some()
-            || self.propagate_exception_path.is_some()
+        self.malloc_slowpath_fixed.is_some() || self.propagate_exception_path.is_some()
     }
 }

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -30,6 +30,12 @@ pub(crate) struct X86CpuExt {
     /// mapping kept for the lifetime of this struct.
     malloc_slowpath_fixed: Option<usize>,
     _malloc_slowpath_fixed_buffer: Option<ExecutableBuffer>,
+    /// `assembler.py:64 self.malloc_slowpath_varsize` analog for
+    /// pyre's `CallMallocNurseryVarsizeFrame`.  Entry address of the
+    /// trampoline built by `build_malloc_slowpath_varsize_frame`;
+    /// shares the per-CPU cache lifetime with the fixed variant.
+    malloc_slowpath_varsize_frame: Option<usize>,
+    _malloc_slowpath_varsize_frame_buffer: Option<ExecutableBuffer>,
     /// `assembler.py:344 self.propagate_exception_path` parity.
     /// Standalone trampoline that the malloc slowpath (and, in PyPy,
     /// the stack check slowpath) JMPs to on OOM / propagate.
@@ -42,6 +48,8 @@ impl X86CpuExt {
         Self {
             malloc_slowpath_fixed: None,
             _malloc_slowpath_fixed_buffer: None,
+            malloc_slowpath_varsize_frame: None,
+            _malloc_slowpath_varsize_frame_buffer: None,
             propagate_exception_path: None,
             _propagate_exception_path_buffer: None,
         }
@@ -97,6 +105,32 @@ impl X86CpuExt {
         addr
     }
 
+    /// `assembler.py:231 _build_malloc_slowpath(kind='var')` analog —
+    /// materialise the jitframe-sized malloc slowpath trampoline on
+    /// first use of `CallMallocNurseryVarsizeFrame`.  Same per-CPU
+    /// caching contract as [`ensure_malloc_slowpath_fixed`]; the
+    /// propagate trampoline is built first so the OOM `JMP` immediate
+    /// is final before this trampoline is finalised.
+    pub(crate) fn ensure_malloc_slowpath_varsize_frame(
+        &mut self,
+        cpu_handle: &CpuDescrHandle,
+    ) -> usize {
+        if let Some(addr) = self.malloc_slowpath_varsize_frame {
+            return addr;
+        }
+        let propagate_path = self.ensure_propagate_exception_path(cpu_handle);
+        let (buffer, addr) =
+            super::assembler::build_malloc_slowpath_varsize_frame(cpu_handle, propagate_path);
+        debug_assert!(
+            addr != 0,
+            "build_malloc_slowpath_varsize_frame returned NULL entry address — \
+             dynasm finalize is expected to yield a non-zero buffer_ptr"
+        );
+        self._malloc_slowpath_varsize_frame_buffer = Some(buffer);
+        self.malloc_slowpath_varsize_frame = Some(addr);
+        addr
+    }
+
     /// Whether either trampoline that bakes `propagate_exception_descr`
     /// as an immediate has already been materialised.  Used by
     /// `DynasmBackend::set_propagate_exception_descr` to refuse a
@@ -110,6 +144,8 @@ impl X86CpuExt {
     /// upholds the same invariant by panicking instead of dropping
     /// the buffer.
     pub(crate) fn has_propagate_dependent_caches(&self) -> bool {
-        self.malloc_slowpath_fixed.is_some() || self.propagate_exception_path.is_some()
+        self.malloc_slowpath_fixed.is_some()
+            || self.malloc_slowpath_varsize_frame.is_some()
+            || self.propagate_exception_path.is_some()
     }
 }

--- a/majit/majit-ir/src/debug.rs
+++ b/majit/majit-ir/src/debug.rs
@@ -57,15 +57,15 @@ pub fn have_debug_prints() -> bool {
     majit_log_enabled()
 }
 
-/// `rlib/debug.py:168-172 have_debug_prints_for(prefix)` — true when at
-/// least one active category in the current `debug_start` stack starts
-/// with `prefix`, gated by [`have_debug_prints`].  PyPy uses this to
-/// short-circuit message construction when a section is not active.
-pub fn have_debug_prints_for(prefix: &str) -> bool {
-    if !have_debug_prints() {
-        return false;
-    }
-    CATEGORY_STACK.with(|stack| stack.borrow().iter().any(|cat| cat.starts_with(prefix)))
+/// `rlib/debug.py:168-172 have_debug_prints_for(prefix)` — true when
+/// the active log filter accepts `prefix` (RPython queries the
+/// `PYPYLOG=cat1,cat2:filename` filter spec, not the currently-open
+/// `debug_start` stack).  Pyre has no category-level filter — `MAJIT_LOG`
+/// is all-or-nothing — so this reduces to [`have_debug_prints`].  The
+/// `_prefix` parameter is preserved so callers ported 1:1 from PyPy keep
+/// compiling unchanged once a filter mechanism lands.
+pub fn have_debug_prints_for(_prefix: &str) -> bool {
+    have_debug_prints()
 }
 
 /// `rlib/debug.py:101-108 debug_start(category)` — open a logging
@@ -83,17 +83,24 @@ pub fn debug_start(category: &'static str) {
 
 /// `rlib/debug.py:111-116 debug_stop(category)` — close the matching
 /// section opened by [`debug_start`].  Emits `[<ts>] <category>}` and
-/// pops the stack top.  Mismatched stops are silently ignored to mirror
-/// PyPy's `DebugLog.debug_stop` (which scans backwards for the most
-/// recent matching start and is forgiving on unbalanced calls).
+/// pops the stack top.  Mismatched stops panic, mirroring RPython's
+/// `DebugLog.debug_stop` (`rpython/rlib/debug.py:30`), which raises a
+/// nesting error so unbalanced calls surface immediately instead of
+/// being absorbed.
 pub fn debug_stop(category: &'static str) {
     if !have_debug_prints() {
         return;
     }
     CATEGORY_STACK.with(|stack| {
         let mut s = stack.borrow_mut();
-        if s.last() == Some(&category) {
-            s.pop();
+        match s.last() {
+            Some(top) if *top == category => {
+                s.pop();
+            }
+            Some(top) => panic!(
+                "debug_stop({category:?}) does not match the most recent debug_start({top:?})"
+            ),
+            None => panic!("debug_stop({category:?}) with no matching debug_start"),
         }
     });
     eprintln!("[{:x}] {}}}", read_timestamp(), category);

--- a/majit/majit-ir/src/debug.rs
+++ b/majit/majit-ir/src/debug.rs
@@ -1,5 +1,5 @@
 //! `rpython/rlib/debug.py` parity — PYPYLOG-style debug scope and print
-//! API for the metainterp.
+//! API shared across the metainterp, optimizer, and backends.
 //!
 //! PyPy structures runtime tracing through `debug_start(category)` /
 //! `debug_stop(category)` brackets with intervening `debug_print(...)`
@@ -15,15 +15,21 @@
 //! emits the same wire shape so log captures cross-tool with PyPy when
 //! the `MAJIT_LOG` env var is set (pyre's `PYPYLOG=…:-` analog).
 //!
-//! Conversion is intentionally incremental: this module is the API and
-//! the structurally-explicit `debug_start/stop` pairs in `memmgr` use
-//! it today.  The bulk of inline `eprintln!("[<cat>] …")` sites — 70+
-//! across metainterp/optimizeopt/backends — retain prefix-style output
-//! for backward compatibility and will be migrated in a follow-up pass.
+//! Single-event sites — the common case in Pyre's metainterp/optimizeopt/
+//! backends — use [`log_one`], which opens a single-line section,
+//! emits the body, and closes the section in one call.  Multi-message
+//! pairs use [`scope`] (RAII) wrapping repeated [`debug_print`] calls.
 
 use std::cell::RefCell;
 use std::sync::OnceLock;
 use std::time::Instant;
+
+/// Whether `MAJIT_LOG` is set, cached at first access.  Mirrors PyPy's
+/// `PYPYLOG` env-var check (`rpython/rlib/debug.py:31-38`).
+pub fn majit_log_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("MAJIT_LOG").is_some())
+}
 
 /// Wall-clock origin used as the PyPy `read_timestamp()` analog.
 fn ts_origin() -> Instant {
@@ -46,10 +52,9 @@ thread_local! {
 }
 
 /// `rlib/debug.py:163-166 have_debug_prints()` — true when log output
-/// is enabled at all.  Pyre keys this off `MAJIT_LOG` (cached on first
-/// read, matching `crate::majit_log_enabled`).
+/// is enabled at all.  Pyre keys this off `MAJIT_LOG`.
 pub fn have_debug_prints() -> bool {
-    crate::majit_log_enabled()
+    majit_log_enabled()
 }
 
 /// `rlib/debug.py:168-172 have_debug_prints_for(prefix)` — true when at
@@ -123,4 +128,25 @@ impl Drop for DebugScope {
 pub fn scope(category: &'static str) -> DebugScope {
     debug_start(category);
     DebugScope { category }
+}
+
+/// Emit a single body line wrapped in a `debug_start`/`debug_stop`
+/// section of the given category.  Equivalent to PyPy's common pattern
+///
+/// ```python
+/// debug_start(cat); debug_print(msg); debug_stop(cat)
+/// ```
+///
+/// Used for one-shot events (aborts, single-state-transition notices)
+/// that don't have a natural surrounding scope on the Pyre side.  No-op
+/// when [`have_debug_prints`] is false — callers may still incur the
+/// cost of building `msg`; gate that with [`have_debug_prints`] for
+/// hot paths where formatting is non-trivial.
+pub fn log_one(category: &'static str, msg: &str) {
+    if !have_debug_prints() {
+        return;
+    }
+    debug_start(category);
+    debug_print(msg);
+    debug_stop(category);
 }

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bitstring;
+pub mod debug;
 pub mod descr;
 pub mod descr_registry;
 pub mod effectinfo;

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -844,9 +844,7 @@ fn generate_merge_wrapper(config: &JitInterpConfig, func: &ItemFn) -> TokenStrea
                     .map(|__ctx| __ctx.is_too_long())
                     .unwrap_or(false);
                 if __too_long {
-                    if majit_metainterp::majit_log_enabled() {
-                        eprintln!("[jit] trace too long, aborting");
-                    }
+                    majit_metainterp::debug::log_one("jit-abort", "trace too long, aborting");
                     return majit_metainterp::TraceAction::Abort;
                 }
                 __result

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1948,14 +1948,20 @@ impl BlackholeInterpreter {
                     // blackhole.py:1068: raise ContinueRunningNormally(*args)
                     // Propagates out of run() like RPython's JitException.
                     if trace {
-                        eprintln!("[bh-trace] ContinueRunningNormally at pos={}", pos_before);
+                        crate::debug::log_one(
+                            "jit-blackhole",
+                            &format!("ContinueRunningNormally at pos={pos_before}"),
+                        );
                     }
                     return Some(args);
                 }
                 Err(DispatchError::RaiseException(exc)) => {
                     // blackhole.py:359-361: except Exception → handle_exception_in_frame
                     if trace {
-                        eprintln!("[bh-trace] exception at pos={} exc=0x{:x}", pos_before, exc);
+                        crate::debug::log_one(
+                            "jit-blackhole",
+                            &format!("exception at pos={pos_before} exc=0x{exc:x}"),
+                        );
                     }
                     if self.handle_exception_in_frame(exc) {
                         // Handler found, continue execution at handler target

--- a/majit/majit-metainterp/src/debug.rs
+++ b/majit/majit-metainterp/src/debug.rs
@@ -1,0 +1,126 @@
+//! `rpython/rlib/debug.py` parity — PYPYLOG-style debug scope and print
+//! API for the metainterp.
+//!
+//! PyPy structures runtime tracing through `debug_start(category)` /
+//! `debug_stop(category)` brackets with intervening `debug_print(...)`
+//! lines; the wire format is
+//!
+//! ```text
+//! [<ts>] {<category>
+//! <messages>
+//! [<ts>] <category>}
+//! ```
+//!
+//! Tooling (`pypy/tool/logparser.py`) parses this format directly.  Pyre
+//! emits the same wire shape so log captures cross-tool with PyPy when
+//! the `MAJIT_LOG` env var is set (pyre's `PYPYLOG=…:-` analog).
+//!
+//! Conversion is intentionally incremental: this module is the API and
+//! the structurally-explicit `debug_start/stop` pairs in `memmgr` use
+//! it today.  The bulk of inline `eprintln!("[<cat>] …")` sites — 70+
+//! across metainterp/optimizeopt/backends — retain prefix-style output
+//! for backward compatibility and will be migrated in a follow-up pass.
+
+use std::cell::RefCell;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// Wall-clock origin used as the PyPy `read_timestamp()` analog.
+fn ts_origin() -> Instant {
+    static ORIGIN: OnceLock<Instant> = OnceLock::new();
+    *ORIGIN.get_or_init(Instant::now)
+}
+
+/// `rlib/rtimer.py read_timestamp()` analog — monotonic nanosecond
+/// counter rendered as PyPy's hex `[ts]` prefix.
+fn read_timestamp() -> u128 {
+    ts_origin().elapsed().as_nanos()
+}
+
+thread_local! {
+    /// Per-thread category stack mirroring PyPy's `_log` debug log
+    /// (`rlib/debug.py:24-30`).  Push on `debug_start`, pop on
+    /// `debug_stop`.  The stack is only consulted by `have_debug_prints_for`;
+    /// the on-wire output works without it.
+    static CATEGORY_STACK: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
+}
+
+/// `rlib/debug.py:163-166 have_debug_prints()` — true when log output
+/// is enabled at all.  Pyre keys this off `MAJIT_LOG` (cached on first
+/// read, matching `crate::majit_log_enabled`).
+pub fn have_debug_prints() -> bool {
+    crate::majit_log_enabled()
+}
+
+/// `rlib/debug.py:168-172 have_debug_prints_for(prefix)` — true when at
+/// least one active category in the current `debug_start` stack starts
+/// with `prefix`, gated by [`have_debug_prints`].  PyPy uses this to
+/// short-circuit message construction when a section is not active.
+pub fn have_debug_prints_for(prefix: &str) -> bool {
+    if !have_debug_prints() {
+        return false;
+    }
+    CATEGORY_STACK.with(|stack| stack.borrow().iter().any(|cat| cat.starts_with(prefix)))
+}
+
+/// `rlib/debug.py:101-108 debug_start(category)` — open a logging
+/// section.  Emits `[<ts>] {<category>` on stderr when the log is
+/// enabled and pushes `category` onto the thread-local stack.  No-op
+/// when [`have_debug_prints`] is false (the stack is also untouched,
+/// matching PyPy where `_log` is None).
+pub fn debug_start(category: &'static str) {
+    if !have_debug_prints() {
+        return;
+    }
+    eprintln!("[{:x}] {{{}", read_timestamp(), category);
+    CATEGORY_STACK.with(|stack| stack.borrow_mut().push(category));
+}
+
+/// `rlib/debug.py:111-116 debug_stop(category)` — close the matching
+/// section opened by [`debug_start`].  Emits `[<ts>] <category>}` and
+/// pops the stack top.  Mismatched stops are silently ignored to mirror
+/// PyPy's `DebugLog.debug_stop` (which scans backwards for the most
+/// recent matching start and is forgiving on unbalanced calls).
+pub fn debug_stop(category: &'static str) {
+    if !have_debug_prints() {
+        return;
+    }
+    CATEGORY_STACK.with(|stack| {
+        let mut s = stack.borrow_mut();
+        if s.last() == Some(&category) {
+            s.pop();
+        }
+    });
+    eprintln!("[{:x}] {}}}", read_timestamp(), category);
+}
+
+/// `rlib/debug.py:69-74 debug_print(*args)` — emit a single line inside
+/// the currently-open section.  No-op when the log is disabled.  Pyre
+/// callers format the message themselves and pass the result here.
+pub fn debug_print(msg: &str) {
+    if !have_debug_prints() {
+        return;
+    }
+    eprintln!("{}", msg);
+}
+
+/// RAII scope guard returned by [`scope`]: panics still drop through
+/// `Drop` so `debug_stop` always pairs with the opening `debug_start`.
+#[must_use = "drop the guard to fire the matching debug_stop"]
+pub struct DebugScope {
+    category: &'static str,
+}
+
+impl Drop for DebugScope {
+    fn drop(&mut self) {
+        debug_stop(self.category);
+    }
+}
+
+/// Convenience: open a `debug_start(category)` scope returning a guard
+/// that fires the matching `debug_stop` on drop.  Mirrors PyPy's
+/// typical `debug_start … try: … finally: debug_stop` pattern.
+pub fn scope(category: &'static str) -> DebugScope {
+    debug_start(category);
+    DebugScope { category }
+}

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1237,9 +1237,7 @@ impl<S: JitState> JitDriver<S> {
     /// `take_compile_trace_success` substitutes. Same semantics: stop
     /// tracing immediately, switch into compiled code on next iteration.
     pub fn note_compile_trace_success(&mut self) {
-        if crate::majit_log_enabled() {
-            eprintln!("[jit][compile-trace] note success");
-        }
+        crate::debug::log_one("jit-summary", "compile-trace: note success");
         self.compile_trace_success = true;
     }
 
@@ -1280,9 +1278,7 @@ impl<S: JitState> JitDriver<S> {
             return;
         }
         if self.sym.is_none() || self.meta.trace_meta().is_none() {
-            if crate::majit_log_enabled() {
-                eprintln!("[mp] abort:sym_none");
-            }
+            crate::debug::log_one("jit-abort", "mp: abort:sym_none");
             self.meta.abort_trace(false);
             self.sym = None;
             self.meta.clear_trace_session();
@@ -1293,9 +1289,7 @@ impl<S: JitState> JitDriver<S> {
         // self.meta and self.sym are disjoint fields → standard split-borrow.
         let mut action = {
             let Some(sym) = self.sym.as_mut() else {
-                if crate::majit_log_enabled() {
-                    eprintln!("[mp] abort:sym_none2");
-                }
+                crate::debug::log_one("jit-abort", "mp: abort:sym_none2");
                 self.meta.abort_trace(false);
                 self.meta.clear_trace_session();
                 return;
@@ -1573,9 +1567,7 @@ impl<S: JitState> JitDriver<S> {
                         }
                     }
                 } else {
-                    if crate::majit_log_enabled() {
-                        eprintln!("[mp] abort:validate_close");
-                    }
+                    crate::debug::log_one("jit-abort", "mp: abort:validate_close");
                     self.meta.abort_trace(false);
                     self.meta.clear_trace_session();
                 }
@@ -1766,8 +1758,8 @@ impl<S: JitState> JitDriver<S> {
                 self.meta.clear_trace_session();
             }
             TraceAction::Abort => {
-                if crate::majit_log_enabled() && self.meta.bridge_info().is_some() {
-                    eprintln!("[bridge] Abort during bridge tracing");
+                if self.meta.bridge_info().is_some() {
+                    crate::debug::log_one("jit-abort", "Abort during bridge tracing");
                 }
                 // `pyjitpl.py:2491` `except SwitchToBlackhole as stb:
                 // self.aborted_tracing(stb.reason)` — the
@@ -1825,8 +1817,8 @@ impl<S: JitState> JitDriver<S> {
                 self.meta.clear_trace_session();
             }
             TraceAction::AbortPermanent => {
-                if crate::majit_log_enabled() && self.meta.bridge_info().is_some() {
-                    eprintln!("[bridge] AbortPermanent during bridge tracing");
+                if self.meta.bridge_info().is_some() {
+                    crate::debug::log_one("jit-abort", "AbortPermanent during bridge tracing");
                 }
                 self.meta.abort_trace(true);
                 self.sym = None;
@@ -2307,8 +2299,11 @@ impl<S: JitState> JitDriver<S> {
             return None;
         }
         if !state.can_trace() {
-            if crate::majit_log_enabled() {
-                eprintln!("[jit] back_edge blocked: can_trace=false key={}", green_key);
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-tracing",
+                    &format!("back_edge blocked: can_trace=false key={green_key}"),
+                );
             }
             return None;
         }
@@ -2920,13 +2915,16 @@ impl<S: JitState> JitDriver<S> {
             };
         }
         let live_values = state.extract_live_values(&meta);
-        if crate::majit_log_enabled() {
+        if crate::debug::have_debug_prints() {
             let vals: Vec<String> = live_values
                 .iter()
                 .enumerate()
                 .map(|(i, v)| format!("[{}]={:?}", i, v))
                 .collect();
-            eprintln!("[jit] run_bridge live_values: {}", vals.join(", "));
+            crate::debug::log_one(
+                "jit-running",
+                &format!("run_bridge live_values: {}", vals.join(", ")),
+            );
         }
         if !Self::live_values_match_descriptor(descriptor.as_ref(), &live_values) {
             return DetailedDriverRunOutcome::Abort {
@@ -3037,21 +3035,25 @@ impl<S: JitState> JitDriver<S> {
             };
         }
         let live_values = state.extract_live_values(&meta);
-        if crate::majit_log_enabled() {
+        if crate::debug::have_debug_prints() {
             let vals: Vec<String> = live_values
                 .iter()
                 .enumerate()
                 .map(|(i, v)| format!("[{}]={:?}", i, v))
                 .collect();
-            eprintln!("[jit] BRIDGE live_values: {}", vals.join(", "));
+            crate::debug::log_one(
+                "jit-running",
+                &format!("BRIDGE live_values: {}", vals.join(", ")),
+            );
         }
         if !Self::live_values_match_descriptor(descriptor.as_ref(), &live_values) {
-            if crate::majit_log_enabled() {
-                eprintln!(
-                    "[jit][run-compiled-abort] key={} reason=live-values-descriptor-mismatch target_pc={} nvals={}",
-                    green_key,
-                    target_pc,
-                    live_values.len()
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-abort",
+                    &format!(
+                        "run-compiled-abort key={green_key} reason=live-values-descriptor-mismatch target_pc={target_pc} nvals={}",
+                        live_values.len()
+                    ),
                 );
             }
             return DetailedDriverRunOutcome::Abort {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1755,7 +1755,15 @@ impl<S: JitState> JitDriver<S> {
                     }
                 }
                 // Blackhole transition: clear all driver tracing state.
+                // `take_trace_meta` above drained the session, so the
+                // trailing `clear_trace_session` is a no-op for the
+                // session-end side.  Fire `profiler.end_tracing()`
+                // explicitly here to balance the `start_tracing()` that
+                // ran inside `begin_trace_session` — matches PyPy's
+                // pyjitpl.py:2934 `finally: profiler.end_tracing()` for
+                // the SegmentedLoop compile path (`_create_segmented_trace_and_blackhole`).
                 self.sym = None;
+                self.meta.staticdata.profiler.end_tracing();
                 self.meta.clear_trace_session();
             }
             TraceAction::Abort => {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1755,15 +1755,14 @@ impl<S: JitState> JitDriver<S> {
                     }
                 }
                 // Blackhole transition: clear all driver tracing state.
-                // `take_trace_meta` above drained the session, so the
-                // trailing `clear_trace_session` is a no-op for the
-                // session-end side.  Fire `profiler.end_tracing()`
-                // explicitly here to balance the `start_tracing()` that
-                // ran inside `begin_trace_session` — matches PyPy's
-                // pyjitpl.py:2934 `finally: profiler.end_tracing()` for
-                // the SegmentedLoop compile path (`_create_segmented_trace_and_blackhole`).
+                // `take_trace_meta` above drained the M-ownership side;
+                // `leave_profiler_tracing` fires the matching
+                // `pyjitpl.py:2934 finally: profiler.end_tracing()`.
+                // `clear_trace_session` is then a no-op for both effects
+                // (session already drained, profiler already left) and
+                // only cleans `bridge_info`.
                 self.sym = None;
-                self.meta.staticdata.profiler.end_tracing();
+                self.meta.leave_profiler_tracing();
                 self.meta.clear_trace_session();
             }
             TraceAction::Abort => {

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -380,6 +380,17 @@ impl JitProfiler {
     fn end_event(&self, event: i32) {
         let now = Instant::now();
         let profiler = self.profiler_id();
+        // `ended` mirrors the symmetric `debug_start`/`debug_stop`
+        // pairing in `start_event`: we only close the debug channel
+        // when the TLS frame for this `(profiler, event)` actually
+        // matched and was popped.  On broken-data early returns the
+        // paired `debug_start` either never ran (empty stack) or
+        // belongs to a sibling profiler still owning the top of the
+        // stack; firing `debug_stop` anyway would desynchronize the
+        // per-thread category stack and panic the now-strict
+        // `debug_stop(category)` mismatch guard
+        // (`majit-ir/src/debug.rs:84-`).
+        let mut ended = false;
         TIMING_STATE.with(|cell| {
             let mut state = cell.borrow_mut();
             // RPython peeks the top frame first (`self.current` is
@@ -412,9 +423,12 @@ impl JitProfiler {
                 self.add_time(event, now.saturating_duration_since(t1));
             }
             state.t1 = Some(now);
+            ended = true;
         });
-        if let Some(channel) = debug_channel_for_event(event) {
-            crate::debug::debug_stop(channel);
+        if ended {
+            if let Some(channel) = debug_channel_for_event(event) {
+                crate::debug::debug_stop(channel);
+            }
         }
     }
 

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -178,6 +178,14 @@ impl JitProfiler {
             &self.nvholes,
             &self.nvreused,
             &self.calls,
+            // tracker counters exposed via `get_counter(TOTAL_COMPILED_*
+            // / TOTAL_FREED_*)` — reset on `start()` so a profiler
+            // reused across test setups or explicit restarts does not
+            // report inflated totals carried over from the prior run.
+            &self.total_compiled_loops,
+            &self.total_compiled_bridges,
+            &self.total_freed_loops,
+            &self.total_freed_bridges,
         ] {
             field.store(0, Ordering::Relaxed);
         }

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -8,15 +8,35 @@
 //! `MetaInterpStaticData.profiler` through the shared `Arc` without any
 //! extra synchronisation.
 //!
-//! `Ordering::Relaxed` is sufficient for every counter: there is no causal
-//! relationship between any two counter updates, and we only ever publish
-//! totals via [`JitProfiler::snapshot`] which itself is `Relaxed`.
+//! `Ordering::Relaxed` is sufficient for every counter/timer total: there is
+//! no causal relationship between any two updates, and we only ever publish
+//! totals via [`JitProfiler::snapshot`] which itself is `Relaxed`. The nested
+//! `current` event stack from PyPy's profiler is thread-local, avoiding a
+//! mutex while preserving per-thread event nesting.
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use majit_ir::OpCode;
 
 use crate::pyjitpl::counters;
+
+thread_local! {
+    static TIMING_STATE: RefCell<TimingState> = RefCell::new(TimingState::default());
+}
+
+#[derive(Clone, Copy)]
+struct TimingFrame {
+    profiler: usize,
+    event: i32,
+}
+
+#[derive(Default)]
+struct TimingState {
+    t1: Option<Instant>,
+    current: Vec<TimingFrame>,
+}
 
 /// jitprof.py:52-122 `Profiler` — every `Counters.*` slot is one
 /// `AtomicUsize`, plus the standalone `calls` counter that
@@ -32,12 +52,14 @@ use crate::pyjitpl::counters;
 #[derive(Default, Debug)]
 pub struct JitProfiler {
     /// jit.py:1416 `Counters.TRACING` — RPython tracks this as wall-clock
-    /// time + entry count via `_start`/`_end` (jitprof.py:75-93). Pyre
-    /// only records the entry count today; the wall-clock split lands
-    /// when start_tracing/end_tracing hooks are wired.
+    /// time + entry count via `_start`/`_end` (jitprof.py:75-93).
     pub tracing: AtomicUsize,
     /// jit.py:1417 `Counters.BACKEND` — same shape as TRACING.
     pub backend: AtomicUsize,
+    /// Accumulated nanoseconds for `Counters.TRACING`.
+    pub tracing_time_ns: AtomicU64,
+    /// Accumulated nanoseconds for `Counters.BACKEND`.
+    pub backend_time_ns: AtomicU64,
     /// jit.py:1418 `Counters.OPS` — every executed op
     /// (`execute_and_record_varargs` / `execute_and_record`,
     /// pyjitpl.py:2629/2645).
@@ -137,22 +159,35 @@ impl JitProfiler {
         ] {
             field.store(0, Ordering::Relaxed);
         }
+        self.tracing_time_ns.store(0, Ordering::Relaxed);
+        self.backend_time_ns.store(0, Ordering::Relaxed);
+        let profiler = self.profiler_id();
+        TIMING_STATE.with(|cell| {
+            let mut state = cell.borrow_mut();
+            state.current.retain(|frame| frame.profiler != profiler);
+            state.t1 = Some(Instant::now());
+        });
     }
 
     /// jitprof.py:95 `Profiler.start_tracing`.
-    ///
-    /// PyPy also accounts elapsed time through `_start(Counters.TRACING)`.
-    /// Pyre's profiler currently stores only the entry count for timed
-    /// counters, so this is the counter-side parity hook.
     pub fn start_tracing(&self) {
-        self.tracing.fetch_add(1, Ordering::Relaxed);
+        self.start_event(counters::TRACING);
     }
 
     /// jitprof.py:96 `Profiler.end_tracing`.
-    ///
-    /// Kept as the structural counterpart to `start_tracing`; elapsed-time
-    /// buckets are not represented in Pyre yet.
-    pub fn end_tracing(&self) {}
+    pub fn end_tracing(&self) {
+        self.end_event(counters::TRACING);
+    }
+
+    /// jitprof.py:98 `Profiler.start_backend`.
+    pub fn start_backend(&self) {
+        self.start_event(counters::BACKEND);
+    }
+
+    /// jitprof.py:99 `Profiler.end_backend`.
+    pub fn end_backend(&self) {
+        self.end_event(counters::BACKEND);
+    }
 
     /// jitprof.py:118-122 `Profiler.count_ops(opnum, kind=Counters.OPS)`.
     ///
@@ -191,9 +226,26 @@ impl JitProfiler {
 
     /// jitprof.py:104-113 `Profiler.get_counter(num)` — single-counter
     /// readback via `Counters.*` id. `None` for unknown ids.
+    ///
+    /// PRE-EXISTING-ADAPTATION: upstream's `get_counter` routes
+    /// `TOTAL_COMPILED_LOOPS` / `TOTAL_COMPILED_BRIDGES` /
+    /// `TOTAL_FREED_LOOPS` / `TOTAL_FREED_BRIDGES`
+    /// (`Counters.* = 22..25`) to `self.cpu.tracker.total_*` on the
+    /// per-CPU tracker (`jitprof.py:105-112`).  Pyre has no global
+    /// per-CPU tracker yet (`majit-backend/src/lib.rs:939-943`), so
+    /// those ids fall through to `field_for_kind` and return `None`.
+    /// The constants are defined in [`crate::pyjitpl::counters`] so
+    /// callers can reference them; the query just doesn't yield a
+    /// count.
     pub fn get_counter(&self, kind: i32) -> Option<usize> {
         self.field_for_kind(kind)
             .map(|field| field.load(Ordering::Relaxed))
+    }
+
+    /// jitprof.py:115-116 `Profiler.get_times(num)` — seconds.
+    pub fn get_times(&self, kind: i32) -> Option<f64> {
+        self.time_field_for_kind(kind)
+            .map(|field| field.load(Ordering::Relaxed) as f64 / 1_000_000_000.0)
     }
 
     /// Snapshot every counter at a moment.
@@ -228,7 +280,105 @@ impl JitProfiler {
             nvholes: self.nvholes.load(Ordering::Relaxed),
             nvreused: self.nvreused.load(Ordering::Relaxed),
             calls: self.calls.load(Ordering::Relaxed),
+            tracing_time_ns: self.tracing_time_ns.load(Ordering::Relaxed),
+            backend_time_ns: self.backend_time_ns.load(Ordering::Relaxed),
         }
+    }
+
+    /// Panic-safe RAII pairing for `start_tracing` / `end_tracing`.
+    /// `compile.py:532-546/589-599` wraps the backend compile in a
+    /// `start_backend()`/`end_backend()` pair via `try/finally`; the
+    /// pyre equivalent is this guard, which fires `end_*` from `Drop`
+    /// so panics inside the body still unwind through `end_event` and
+    /// the `current` stack stays balanced.
+    pub fn enter_tracing(&self) -> ProfilerEventGuard<'_> {
+        self.start_tracing();
+        ProfilerEventGuard {
+            profiler: self,
+            event: counters::TRACING,
+        }
+    }
+
+    /// Panic-safe RAII pairing for `start_backend` / `end_backend`.
+    /// Wraps `backend.compile_loop` / `backend.compile_bridge` call
+    /// sites with the same semantics as PyPy's `compile.py:532-546`
+    /// `try: ... finally: end_backend()`.
+    pub fn enter_backend(&self) -> ProfilerEventGuard<'_> {
+        self.start_backend();
+        ProfilerEventGuard {
+            profiler: self,
+            event: counters::BACKEND,
+        }
+    }
+
+    fn start_event(&self, event: i32) {
+        let now = Instant::now();
+        let profiler = self.profiler_id();
+        TIMING_STATE.with(|cell| {
+            let mut state = cell.borrow_mut();
+            if let (Some(t1), Some(frame)) = (state.t1, state.current.last().copied()) {
+                if frame.profiler == profiler {
+                    self.add_time(frame.event, now.saturating_duration_since(t1));
+                }
+            }
+            state.t1 = Some(now);
+            self.count(event, 1);
+            state.current.push(TimingFrame { profiler, event });
+        });
+        if let Some(channel) = debug_channel_for_event(event) {
+            if crate::majit_log_enabled() {
+                eprintln!("[{channel}] start");
+            }
+        }
+    }
+
+    fn end_event(&self, event: i32) {
+        let now = Instant::now();
+        let profiler = self.profiler_id();
+        TIMING_STATE.with(|cell| {
+            let mut state = cell.borrow_mut();
+            let Some(frame) = state.current.pop() else {
+                // jitprof.py:86-88 `if not self.current: debug_print("BROKEN
+                // PROFILER DATA!"); return`.
+                if crate::majit_log_enabled() {
+                    eprintln!("[jit-profiler] BROKEN PROFILER DATA!");
+                }
+                state.t1 = Some(now);
+                return;
+            };
+            if frame.profiler != profiler || frame.event != event {
+                // jitprof.py:90-92 `if ev1 != event: debug_print("BROKEN
+                // PROFILER DATA!"); return`.  pyre additionally diagnoses
+                // a mismatched profiler-instance frame, which RPython
+                // can't reach because each Profiler owns its own `current`
+                // list.
+                if crate::majit_log_enabled() {
+                    eprintln!("[jit-profiler] BROKEN PROFILER DATA!");
+                }
+                state.t1 = Some(now);
+                return;
+            }
+            if let Some(t1) = state.t1 {
+                self.add_time(event, now.saturating_duration_since(t1));
+            }
+            state.t1 = Some(now);
+        });
+        if let Some(channel) = debug_channel_for_event(event) {
+            if crate::majit_log_enabled() {
+                eprintln!("[{channel}] stop");
+            }
+        }
+    }
+
+    fn add_time(&self, event: i32, elapsed: Duration) {
+        let nanos = elapsed.as_nanos().min(u64::MAX as u128) as u64;
+        if let Some(field) = self.time_field_for_kind(event) {
+            field.fetch_add(nanos, Ordering::Relaxed);
+        }
+    }
+
+    fn profiler_id(&self) -> usize {
+        self as *const Self as usize
     }
 
     fn field_for_kind(&self, kind: i32) -> Option<&AtomicUsize> {
@@ -257,6 +407,45 @@ impl JitProfiler {
             counters::NVREUSED => &self.nvreused,
             _ => return None,
         })
+    }
+
+    fn time_field_for_kind(&self, kind: i32) -> Option<&AtomicU64> {
+        Some(match kind {
+            counters::TRACING => &self.tracing_time_ns,
+            counters::BACKEND => &self.backend_time_ns,
+            _ => return None,
+        })
+    }
+}
+
+/// RAII guard returned by [`JitProfiler::enter_tracing`] /
+/// [`JitProfiler::enter_backend`].  Drops by firing the matching
+/// `end_*` so the profiler stack stays balanced even when the
+/// surrounding body panics — the PyPy `try/finally` equivalent.
+#[must_use = "drop the guard to fire the paired end_* event"]
+pub struct ProfilerEventGuard<'a> {
+    profiler: &'a JitProfiler,
+    event: i32,
+}
+
+impl Drop for ProfilerEventGuard<'_> {
+    fn drop(&mut self) {
+        self.profiler.end_event(self.event);
+    }
+}
+
+/// debug.py `debug_start("jit-tracing")` / `debug_start("jit-backend")`
+/// channel name for a `Counters.*` event id.  Returns `None` for events
+/// that don't have a paired debug scope upstream (count-only kinds like
+/// OPS / ABORT_*).  Used by [`JitProfiler::start_event`] /
+/// [`JitProfiler::end_event`] to emit grep-able scope markers under the
+/// single `MAJIT_LOG` switch (see `memmgr.rs` PRE-EXISTING-ADAPTATION
+/// note for the channel-registry deferral).
+fn debug_channel_for_event(event: i32) -> Option<&'static str> {
+    match event {
+        counters::TRACING => Some("jit-tracing"),
+        counters::BACKEND => Some("jit-backend"),
+        _ => None,
     }
 }
 
@@ -290,6 +479,8 @@ pub struct JitProfilerSnapshot {
     pub nvholes: usize,
     pub nvreused: usize,
     pub calls: usize,
+    pub tracing_time_ns: u64,
+    pub backend_time_ns: u64,
 }
 
 #[cfg(test)]
@@ -409,6 +600,30 @@ mod tests {
         assert_eq!(prof.get_counter(counters::ABORT_ESCAPE), Some(1));
         assert_eq!(prof.get_counter(counters::OPS), Some(0));
         assert_eq!(prof.get_counter(-1), None);
+    }
+
+    #[test]
+    fn start_end_timed_events_count_and_accumulate_elapsed_time() {
+        // jitprof.py:75-99 `_start`/`_end` contract: entering a nested
+        // event charges elapsed time to the previously-active event; leaving
+        // charges elapsed time to the ending event.
+        let prof = JitProfiler::default();
+        prof.start();
+        prof.start_tracing();
+        std::thread::sleep(Duration::from_millis(1));
+        prof.start_backend();
+        std::thread::sleep(Duration::from_millis(1));
+        prof.end_backend();
+        std::thread::sleep(Duration::from_millis(1));
+        prof.end_tracing();
+
+        let snap = prof.snapshot();
+        assert_eq!(snap.tracing, 1);
+        assert_eq!(snap.backend, 1);
+        assert!(snap.tracing_time_ns > 0);
+        assert!(snap.backend_time_ns > 0);
+        assert!(prof.get_times(counters::TRACING).unwrap() > 0.0);
+        assert_eq!(prof.get_times(counters::OPS), None);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -373,9 +373,7 @@ impl JitProfiler {
             state.current.push(TimingFrame { profiler, event });
         });
         if let Some(channel) = debug_channel_for_event(event) {
-            if crate::majit_log_enabled() {
-                eprintln!("[{channel}] start");
-            }
+            crate::debug::debug_start(channel);
         }
     }
 
@@ -387,9 +385,7 @@ impl JitProfiler {
             let Some(frame) = state.current.pop() else {
                 // jitprof.py:86-88 `if not self.current: debug_print("BROKEN
                 // PROFILER DATA!"); return`.
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit-profiler] BROKEN PROFILER DATA!");
-                }
+                crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
                 state.t1 = Some(now);
                 return;
             };
@@ -399,9 +395,7 @@ impl JitProfiler {
                 // a mismatched profiler-instance frame, which RPython
                 // can't reach because each Profiler owns its own `current`
                 // list.
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit-profiler] BROKEN PROFILER DATA!");
-                }
+                crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
                 state.t1 = Some(now);
                 return;
             }
@@ -411,9 +405,7 @@ impl JitProfiler {
             state.t1 = Some(now);
         });
         if let Some(channel) = debug_channel_for_event(event) {
-            if crate::majit_log_enabled() {
-                eprintln!("[{channel}] stop");
-            }
+            crate::debug::debug_stop(channel);
         }
     }
 

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -115,6 +115,28 @@ pub struct JitProfiler {
     /// jitprof.Profiler.calls — `count_ops` increments this when the op
     /// is a CALL_* and `kind == RECORDED_OPS` (jitprof.py:121-122).
     pub calls: AtomicUsize,
+    /// jit.py:1438 `Counters.TOTAL_COMPILED_LOOPS`.  jitprof.py:105-106
+    /// reads `self.cpu.tracker.total_compiled_loops` — pyre's backends
+    /// have no shared `cpu.tracker` instance, so this counter lives on
+    /// the per-process profiler and is incremented at the same
+    /// structural points PyPy's `cpu.tracker` is bumped:
+    /// `record_loop_or_bridge` for a freshly-compiled loop
+    /// (`compile.py:213`).
+    pub total_compiled_loops: AtomicUsize,
+    /// jit.py:1439 `Counters.TOTAL_COMPILED_BRIDGES`.  Bumped from the
+    /// bridge close-out path matching PyPy `compile.py:213` /
+    /// `compile.py:601`.
+    pub total_compiled_bridges: AtomicUsize,
+    /// jit.py:1440 `Counters.TOTAL_FREED_LOOPS`.  Bumped from
+    /// `MemoryManager::_kill_old_loops_now` when an evicted token's
+    /// `bridges_count == 0` — PyPy's `cpu.tracker` tracks the loop
+    /// side here.
+    pub total_freed_loops: AtomicUsize,
+    /// jit.py:1441 `Counters.TOTAL_FREED_BRIDGES`.  Bumped from
+    /// `MemoryManager::_kill_old_loops_now` for each bridge attached
+    /// to an evicted token; PyPy's `cpu.tracker.total_freed_bridges`
+    /// is bumped in `cpu.free_loop_and_bridges`.
+    pub total_freed_bridges: AtomicUsize,
     /// pyjitpl.py:2300-2302 `_setup_once` guard — `if not
     /// self.profiler.initialized: self.profiler.start(); ...
     /// initialized = True`.  RPython keeps this flag separate from
@@ -227,19 +249,44 @@ impl JitProfiler {
     /// jitprof.py:104-113 `Profiler.get_counter(num)` — single-counter
     /// readback via `Counters.*` id. `None` for unknown ids.
     ///
-    /// PRE-EXISTING-ADAPTATION: upstream's `get_counter` routes
-    /// `TOTAL_COMPILED_LOOPS` / `TOTAL_COMPILED_BRIDGES` /
-    /// `TOTAL_FREED_LOOPS` / `TOTAL_FREED_BRIDGES`
-    /// (`Counters.* = 22..25`) to `self.cpu.tracker.total_*` on the
-    /// per-CPU tracker (`jitprof.py:105-112`).  Pyre has no global
-    /// per-CPU tracker yet (`majit-backend/src/lib.rs:939-943`), so
-    /// those ids fall through to `field_for_kind` and return `None`.
-    /// The constants are defined in [`crate::pyjitpl::counters`] so
-    /// callers can reference them; the query just doesn't yield a
-    /// count.
+    /// jitprof.py:104-113 `Profiler.get_counter(num)` — single-counter
+    /// readback via `Counters.*` id.  PyPy routes `TOTAL_COMPILED_*` /
+    /// `TOTAL_FREED_*` (ids 22..25) to `self.cpu.tracker.total_*`;
+    /// pyre keeps the same four counters directly on `JitProfiler`
+    /// (no per-CPU tracker in this backend) and routes them through
+    /// [`field_for_kind`] alongside the `Counters.*` slots, so the
+    /// caller sees identical semantics regardless of where the values
+    /// physically live.  Unknown ids return `None`.
     pub fn get_counter(&self, kind: i32) -> Option<usize> {
         self.field_for_kind(kind)
             .map(|field| field.load(Ordering::Relaxed))
+    }
+
+    /// `cpu.tracker.total_compiled_loops += 1` parity.  Fired from the
+    /// loop close-out path (`record_loop_or_bridge` for a root trace,
+    /// `compile.py:213`).
+    pub fn inc_compiled_loop(&self) {
+        self.total_compiled_loops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `cpu.tracker.total_compiled_bridges += 1` parity.  Fired from the
+    /// bridge close-out path (`record_loop_or_bridge` for a bridge,
+    /// `compile.py:601`).
+    pub fn inc_compiled_bridge(&self) {
+        self.total_compiled_bridges.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `cpu.tracker.total_freed_loops += 1` parity.  Fired from the
+    /// memory manager when an evicted token represents a root loop.
+    pub fn inc_freed_loop(&self) {
+        self.total_freed_loops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `cpu.tracker.total_freed_bridges += n` parity.  Fired from the
+    /// memory manager when an evicted token carries `n` bridges; PyPy's
+    /// `cpu.free_loop_and_bridges` bumps the tracker once per bridge.
+    pub fn add_freed_bridges(&self, n: usize) {
+        self.total_freed_bridges.fetch_add(n, Ordering::Relaxed);
     }
 
     /// jitprof.py:115-116 `Profiler.get_times(num)` — seconds.
@@ -405,6 +452,10 @@ impl JitProfiler {
             counters::NVIRTUALS => &self.nvirtuals,
             counters::NVHOLES => &self.nvholes,
             counters::NVREUSED => &self.nvreused,
+            counters::TOTAL_COMPILED_LOOPS => &self.total_compiled_loops,
+            counters::TOTAL_COMPILED_BRIDGES => &self.total_compiled_bridges,
+            counters::TOTAL_FREED_LOOPS => &self.total_freed_loops,
+            counters::TOTAL_FREED_BRIDGES => &self.total_freed_bridges,
             _ => return None,
         })
     }

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -382,7 +382,14 @@ impl JitProfiler {
         let profiler = self.profiler_id();
         TIMING_STATE.with(|cell| {
             let mut state = cell.borrow_mut();
-            let Some(frame) = state.current.pop() else {
+            // RPython peeks the top frame first (`self.current` is
+            // per-Profiler, so a wrong-event peek can only be a
+            // re-entry bug — never another instance leaking in).  Pyre
+            // shares `TIMING_STATE` across `JitProfiler` instances on
+            // the thread, so peek-then-pop is required: popping before
+            // the validation would lose the frame of a sibling
+            // profiler that legitimately owns the stack top.
+            let Some(&frame) = state.current.last() else {
                 // jitprof.py:86-88 `if not self.current: debug_print("BROKEN
                 // PROFILER DATA!"); return`.
                 crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
@@ -394,11 +401,13 @@ impl JitProfiler {
                 // PROFILER DATA!"); return`.  pyre additionally diagnoses
                 // a mismatched profiler-instance frame, which RPython
                 // can't reach because each Profiler owns its own `current`
-                // list.
+                // list.  Leave the top frame in place — its owner will
+                // close it in their own `end_event`.
                 crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
                 state.t1 = Some(now);
                 return;
             }
+            state.current.pop();
             if let Some(t1) = state.t1 {
                 self.add_time(event, now.saturating_duration_since(t1));
             }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -23,7 +23,7 @@ pub mod call_descr;
 pub(crate) mod compile;
 mod constant_pool;
 pub mod cpu;
-pub mod debug;
+pub use majit_ir::debug;
 pub(crate) mod executor;
 pub mod greenfield;
 pub mod history;

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -23,6 +23,7 @@ pub mod call_descr;
 pub(crate) mod compile;
 mod constant_pool;
 pub mod cpu;
+pub mod debug;
 pub(crate) mod executor;
 pub mod greenfield;
 pub mod history;

--- a/majit/majit-metainterp/src/memmgr.rs
+++ b/majit/majit-metainterp/src/memmgr.rs
@@ -233,20 +233,17 @@ impl MemoryManager {
     /// debug_stop("jit-mem-collect")
     /// ```
     /// Pyre uses `VecAssoc::retain` to fuse the iterate + delete steps.
-    /// PRE-EXISTING-ADAPTATION: pyre uses a single `MAJIT_LOG` switch
-    /// instead of `rlib/debug.py debug_start/stop` per-channel
-    /// registry.  Channel name embedded in the message prefix
-    /// (`[jit-mem-collect]`) maintains grep-equivalence with upstream
-    /// traces.  Future: port `debug_start/stop` channel registry.
+    /// Output is routed through [`crate::debug`] (`debug_start /
+    /// debug_print / debug_stop`) so the `jit-mem-collect` section
+    /// brackets match PyPy's `rlib/debug.py` wire format and can be
+    /// consumed by `pypy/tool/logparser.py` without prefix munging.
     fn _kill_old_loops_now(&mut self) -> Vec<Arc<JitCellToken>> {
-        let log = crate::majit_log_enabled();
+        let _scope = crate::debug::scope("jit-mem-collect");
+        let log = crate::debug::have_debug_prints();
         let oldtotal = if log { self.alive_loops.len() } else { 0 };
         if log {
-            eprintln!(
-                "[jit-mem-collect] Current generation: {}",
-                self.current_generation
-            );
-            eprintln!("[jit-mem-collect] Loop tokens before: {}", oldtotal);
+            crate::debug::debug_print(&format!("Current generation: {}", self.current_generation));
+            crate::debug::debug_print(&format!("Loop tokens before: {oldtotal}"));
         }
         let max_generation = self.current_generation - (self.max_age - 1);
         // memmgr.py:70-73 `for looptoken in self.alive_loops.keys(): if
@@ -267,11 +264,8 @@ impl MemoryManager {
         });
         if log {
             let newtotal = self.alive_loops.len();
-            eprintln!(
-                "[jit-mem-collect] Loop tokens freed: {}",
-                oldtotal - newtotal
-            );
-            eprintln!("[jit-mem-collect] Loop tokens left: {}", newtotal);
+            crate::debug::debug_print(&format!("Loop tokens freed: {}", oldtotal - newtotal));
+            crate::debug::debug_print(&format!("Loop tokens left: {newtotal}"));
         }
         evicted_tokens
     }
@@ -285,12 +279,8 @@ impl MemoryManager {
     /// debug_stop("jit-mem-releaseall")
     /// ```
     pub fn release_all_loops(&mut self) {
-        if crate::majit_log_enabled() {
-            eprintln!(
-                "[jit-mem-releaseall] Loop tokens cleared: {}",
-                self.alive_loops.len()
-            );
-        }
+        let _scope = crate::debug::scope("jit-mem-releaseall");
+        crate::debug::debug_print(&format!("Loop tokens cleared: {}", self.alive_loops.len()));
         self.alive_loops.clear();
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -393,8 +393,11 @@ impl Optimizer {
             VirtualStateInfo::Unknown(tp) => *tp,
         };
         let opref = ctx.alloc_op_position_typed(tp);
-        if std::env::var_os("MAJIT_LOG").is_some() {
-            eprintln!("[jit] import_virtual_state_value {opref:?} <= {info:?}");
+        if crate::debug::have_debug_prints() {
+            crate::debug::log_one(
+                "jit-optimizer",
+                &format!("import_virtual_state_value {opref:?} <= {info:?}"),
+            );
         }
         Self::apply_imported_virtual_state(info, opref, ctx);
         opref
@@ -3061,21 +3064,24 @@ impl Optimizer {
         // entries with OpRef::NONE via the snapshot-driven numbering pass
         // (`liveboxes = [None] * n; liveboxes[i] = box for TAGBOX`).
         // No additional const filtering is needed here.
-        if crate::optimizeopt::majit_log_enabled() {
+        if crate::debug::have_debug_prints() {
             let cmf_count = ops.iter().filter(|o| o.opcode.is_call_may_force()).count();
             let gnf_count = ops
                 .iter()
                 .filter(|o| matches!(o.opcode, OpCode::GuardNotForced | OpCode::GuardNotForced2))
                 .count();
-            eprintln!(
-                "[opt] final ops: total={} call_may_force={} guard_not_forced={}",
+            let _s = crate::debug::scope("jit-optimizer");
+            crate::debug::debug_print(&format!(
+                "final ops: total={} call_may_force={cmf_count} guard_not_forced={gnf_count}",
                 ops.len(),
-                cmf_count,
-                gnf_count
-            );
+            ));
             if cmf_count == 0 && gnf_count > 0 {
                 for (i, op) in ops.iter().enumerate() {
-                    eprintln!("[opt] idx={} {:?} pos={:?}", i, op.opcode, op.pos.get());
+                    crate::debug::debug_print(&format!(
+                        "idx={i} {:?} pos={:?}",
+                        op.opcode,
+                        op.pos.get()
+                    ));
                 }
             }
         }
@@ -3298,17 +3304,21 @@ impl Optimizer {
         }
 
         // unroll.py:214-218: retrace check
-        if crate::optimizeopt::majit_log_enabled() {
-            eprintln!(
-                "[jit][bridge-retrace-check] retraced_count={} retrace_limit={} jump_args={} force_boxes=false",
-                retraced_count,
-                retrace_limit,
-                jump_args.len(),
+        if crate::debug::have_debug_prints() {
+            crate::debug::log_one(
+                "jit-tracing",
+                &format!(
+                    "bridge-retrace-check retraced_count={retraced_count} retrace_limit={retrace_limit} jump_args={} force_boxes=false",
+                    jump_args.len(),
+                ),
             );
         }
         if retraced_count < retrace_limit {
-            if crate::optimizeopt::majit_log_enabled() {
-                eprintln!("[jit] Retracing ({}/{})", retraced_count + 1, retrace_limit);
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-tracing",
+                    &format!("Retracing ({}/{retrace_limit})", retraced_count + 1),
+                );
             }
             return (optimized_ops, true);
         }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1371,9 +1371,10 @@ impl UnrollOptimizer {
                     };
                     if !jumped {
                         // unroll.py:228: "Retrace count reached, jumping to preamble"
-                        if std::env::var_os("MAJIT_LOG").is_some() {
-                            eprintln!("[jit] Retrace count reached, jumping to preamble");
-                        }
+                        crate::debug::log_one(
+                            "jit-tracing",
+                            "Retrace count reached, jumping to preamble",
+                        );
                         // jumped stays false → jump_to_preamble below
                     }
                 }
@@ -1474,13 +1475,17 @@ impl UnrollOptimizer {
             } else {
                 body_ops = Self::jump_to_preamble(&body_ops, &preamble_target);
             }
-            if std::env::var_os("MAJIT_LOG").is_some() {
-                eprintln!("[jit] jump_to_preamble: body JUMP retargeted to start descr");
-            }
+            crate::debug::log_one(
+                "jit-tracing",
+                "jump_to_preamble: body JUMP retargeted to start descr",
+            );
         } else if !redirected_tail_ops.is_empty() {
             body_ops = splice_redirected_tail(&body_ops, &redirected_tail_ops);
-        } else if std::env::var_os("MAJIT_LOG").is_some() {
-            eprintln!("[jit] jump_to_existing_trace: body JUMP → self-loop");
+        } else {
+            crate::debug::log_one(
+                "jit-tracing",
+                "jump_to_existing_trace: body JUMP → self-loop",
+            );
         }
 
         // ── Assembly (compile.py:310-338) ──
@@ -1523,15 +1528,18 @@ impl UnrollOptimizer {
             &combined,
             &mut consts_p2,
         );
-        if std::env::var_os("MAJIT_LOG").is_some() {
-            eprintln!("--- peeled trace (assembled) ---");
-            eprint!("{}", majit_ir::format_trace(&combined, &consts_p2));
+        if crate::debug::have_debug_prints() {
+            let _s = crate::debug::scope("jit-log-opt-loop");
+            crate::debug::debug_print("--- peeled trace (assembled) ---");
+            for line in majit_ir::format_trace(&combined, &consts_p2).lines() {
+                crate::debug::debug_print(line);
+            }
             let mut sorted_consts: Vec<_> = consts_p2
                 .iter()
                 .map(|(k, v)| (*k, v.clone()))
                 .collect::<Vec<_>>();
             sorted_consts.sort_by_key(|(k, _)| *k);
-            eprintln!("[jit] consts_p2: {:?}", sorted_consts);
+            crate::debug::debug_print(&format!("consts_p2: {sorted_consts:?}"));
         }
         *constants = consts_p2;
         (combined, p2_ni)
@@ -2946,8 +2954,11 @@ impl OptUnroll {
             .collect();
 
         for (tt_idx, target_token) in target_tokens.iter_mut().enumerate() {
-            if crate::optimizeopt::majit_log_enabled() {
-                eprintln!("[jit][jump_to_existing] trying target_token #{tt_idx}");
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-tracing",
+                    &format!("jump_to_existing trying target_token #{tt_idx}"),
+                );
             }
             let target_vs = match &target_token.virtual_state {
                 Some(vs) => vs,
@@ -3173,8 +3184,11 @@ impl OptUnroll {
                         optimizer,
                         ctx,
                     );
-                    if crate::optimizeopt::majit_log_enabled() {
-                        eprintln!("[jit][jte-isp] done, extra_len={}", extra.len());
+                    if crate::debug::have_debug_prints() {
+                        crate::debug::log_one(
+                            "jit-tracing",
+                            &format!("jte-isp done, extra_len={}", extra.len()),
+                        );
                     }
                 }
             }
@@ -3540,8 +3554,11 @@ impl OptUnroll {
                 .ensure_box(*target)
                 .expect("body-namespace OpRef must have a BoxRef slot");
             ctx.make_equal_to(&b_source, &b_target);
-            if crate::optimizeopt::majit_log_enabled() {
-                eprintln!("[jit] import_state_map[{i}]: source={source:?} target={target:?}");
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-optimizer",
+                    &format!("import_state_map[{i}]: source={source:?} target={target:?}"),
+                );
             }
             // info = exported_state.exported_infos.get(target, None)
             // if info is not None:

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2055,10 +2055,7 @@ impl<M: Clone> MetaInterp<M> {
             self.active_trace_session.is_none(),
             "begin_trace_session called while a trace session is already active",
         );
-        self.active_trace_session = Some(ActiveTraceSession {
-            trace_meta,
-            bridge: None,
-        });
+        self.active_trace_session = Some(ActiveTraceSession { trace_meta });
         self.staticdata.profiler.start_tracing();
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1165,6 +1165,18 @@ pub struct MetaInterp<M: Clone> {
     /// `self.history` exists (RPython places resumekey on `MetaInterp`
     /// directly, not on the history object).
     pub(crate) bridge_info: Option<BridgeTraceInfo>,
+    /// `pyjitpl.py:2890 / 2916` `profiler.start_tracing()` ↔ `:2897 /
+    /// :2934 profiler.end_tracing()` pairing flag.  PyPy fires both at
+    /// the entry/finally of `compile_and_run_once` /
+    /// `handle_guard_failure`; pyre fires them at the same structural
+    /// points (`prepare_trace_start_runtime` for roots,
+    /// `start_retrace_from_guard` for bridges) and balances the pair
+    /// via [`leave_profiler_tracing`].  Decoupled from
+    /// `active_trace_session` because the M-ownership lifecycle and
+    /// the profiler event lifecycle do not coincide: the session
+    /// opens later (`begin_trace_session`) and may be drained earlier
+    /// (`take_trace_meta`) than the profiler event scope.
+    pub(crate) profiler_tracing_active: bool,
 }
 
 /// Internal mutable counters for JIT compilation statistics.
@@ -1888,6 +1900,7 @@ impl<M: Clone> MetaInterp<M> {
             trace_length_at_last_tco: -1,
             active_trace_session: None,
             bridge_info: None,
+            profiler_tracing_active: false,
         };
         // `pyjitpl.py:2222` `make_and_attach_done_descrs([self, cpu])` —
         // now that both sides of the pair exist, publish the
@@ -2042,21 +2055,20 @@ impl<M: Clone> MetaInterp<M> {
     /// RPython's invariant that `self.history` has a single owner per
     /// trace.
     ///
-    /// pyjitpl.py:2890 / 2916 fires `profiler.start_tracing()` at the
-    /// moment a fresh trace session opens — that includes the bridge
-    /// path via `handle_guard_failure`, which pyre routes through
-    /// [`start_retrace_from_guard`] → `begin_trace_session`.  Hosting
-    /// the call here keeps it paired with the eventual
-    /// [`clear_trace_session`] / [`take_trace_meta`] end-of-session
-    /// step regardless of whether the trace closes via root-finish or
-    /// abort.
+    /// Manages only the M-ownership half of the lifecycle; the paired
+    /// `profiler.start_tracing()` ↔ `end_tracing()` events fire at
+    /// PyPy's `compile_and_run_once` / `handle_guard_failure` entry
+    /// and finally — pyre routes those through
+    /// [`enter_profiler_tracing`] (called from
+    /// `prepare_trace_start_runtime` for roots and
+    /// `start_retrace_from_guard` for bridges) and
+    /// [`leave_profiler_tracing`] (called from session-close paths).
     pub fn begin_trace_session(&mut self, trace_meta: M) {
         debug_assert!(
             self.active_trace_session.is_none(),
             "begin_trace_session called while a trace session is already active",
         );
         self.active_trace_session = Some(ActiveTraceSession { trace_meta });
-        self.staticdata.profiler.start_tracing();
     }
 
     /// Attach bridge-origin metadata.  Called once at bridge entry
@@ -2096,9 +2108,16 @@ impl<M: Clone> MetaInterp<M> {
         self.active_trace_session.as_ref().map(|s| &s.trace_meta)
     }
 
-    /// Take ownership of the frontend trace metadata and end the
-    /// session.  Used by the finish-compile helpers that consume `M`
+    /// Drain the frontend trace metadata, leaving the session slot
+    /// empty.  Used by the finish-compile helpers that consume `M`
     /// before calling `recorder.finish()` + backend compile.
+    ///
+    /// Does *not* fire `profiler.end_tracing()`: the profiler event
+    /// scope is owned by [`leave_profiler_tracing`] and matches PyPy's
+    /// `compile_and_run_once` / `handle_guard_failure` `finally`
+    /// boundary, which is reached *after* the finish-compile body
+    /// runs.  Callers fire `leave_profiler_tracing` at the
+    /// finally-equivalent point themselves.
     pub fn take_trace_meta(&mut self) -> Option<M> {
         self.active_trace_session.take().map(|s| s.trace_meta)
     }
@@ -2107,13 +2126,45 @@ impl<M: Clone> MetaInterp<M> {
     /// the abort / cleanup path used when tracing aborts before
     /// finish.  Also clears `bridge_info` — `pyjitpl.py:3105`
     /// `_finish_off_the_metainterp` resets `self.resumekey` together
-    /// with the trace's history.
+    /// with the trace's history, and `pyjitpl.py:2897 / 2934`
+    /// `finally: profiler.end_tracing()` pairs the start fired by
+    /// `prepare_trace_start_runtime` / `start_retrace_from_guard`.
+    /// Both effects are bundled here because every trace-abort path
+    /// reaches `clear_trace_session` (it is the structural close
+    /// point); success paths that drain via [`take_trace_meta`] fire
+    /// [`leave_profiler_tracing`] explicitly at the close-equivalent
+    /// point and reach a no-op here.
     pub fn clear_trace_session(&mut self) {
-        if self.active_trace_session.is_some() {
-            self.staticdata.profiler.end_tracing();
-        }
+        self.leave_profiler_tracing();
         self.active_trace_session = None;
         self.bridge_info = None;
+    }
+
+    /// `pyjitpl.py:2890 / 2916` `profiler.start_tracing()` parity —
+    /// open the tracing profiler event scope.  Idempotent re-entry is
+    /// not allowed (PyPy's compile_and_run_once / handle_guard_failure
+    /// are not re-entrant on the same MetaInterp).
+    pub fn enter_profiler_tracing(&mut self) {
+        debug_assert!(
+            !self.profiler_tracing_active,
+            "enter_profiler_tracing called while tracing profiler event is already open",
+        );
+        self.staticdata.profiler.start_tracing();
+        self.profiler_tracing_active = true;
+    }
+
+    /// `pyjitpl.py:2897 / 2934` `profiler.end_tracing()` parity —
+    /// close the tracing profiler event scope opened by
+    /// [`enter_profiler_tracing`].  No-op if the scope was already
+    /// closed (mirrors PyPy's `finally` semantics: a path that never
+    /// reached `start_tracing` still passes through `finally` without
+    /// firing `end_tracing` because the implicit pairing depends on
+    /// whether the entry method ran past `start_tracing`).
+    pub fn leave_profiler_tracing(&mut self) {
+        if self.profiler_tracing_active {
+            self.staticdata.profiler.end_tracing();
+            self.profiler_tracing_active = false;
+        }
     }
 
     /// warmspot.py:449 — set the per-driver result_type from the portal
@@ -2871,16 +2922,17 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     fn prepare_trace_start_runtime(&mut self) {
-        // pyjitpl.py:2889-2892 `compile_and_run_once`: `_setup_once`,
-        // `profiler.start_tracing()`, then `try_to_free_some_loops()` before
-        // the trace history is created.  `profiler.start_tracing()` itself
-        // lives on `begin_trace_session` so the bridge path
-        // (`start_retrace_from_guard` → `begin_trace_session`) picks it up
-        // too.  pyjitpl.py:2916 fires the same `start_tracing()` from
-        // `handle_guard_failure`, mirrored by the bridge-side
-        // `begin_trace_session`.
+        // pyjitpl.py:2884-2892 `compile_and_run_once` body, line-by-line:
+        //   debug_start('jit-tracing')
+        //   self.staticdata._setup_once()
+        //   self.staticdata.profiler.start_tracing()
+        //   self.staticdata.try_to_free_some_loops()
+        // `ensure_jitlog_initialised` is pyre's pre-`_setup_once` jitlog
+        // bootstrap; it has no PyPy analog (jitlog wiring runs inside
+        // `_setup_once` upstream) and stays idempotent.
         self.warm_state.ensure_jitlog_initialised();
         self.staticdata._setup_once(&mut self.backend);
+        self.enter_profiler_tracing();
         self.try_to_free_some_loops();
     }
 
@@ -3942,12 +3994,11 @@ impl<M: Clone> MetaInterp<M> {
         let constants = std::mem::take(&mut ctx.constants).into_inner();
         let trace = ctx.into_tree_loop();
         self.warm_state.abort_tracing(green_key, false);
-        // pyjitpl.py:2897 / 2934 `finally: profiler.end_tracing()`.  The
-        // parity helper consumes `self.tracing` directly; route the
-        // matching end_tracing through `clear_trace_session` so that
-        // a session started via `begin_trace_session` (the only path
-        // that calls `profiler.start_tracing`) doesn't leak a profiler
-        // stack frame.  No-op when no session was begun.
+        // pyjitpl.py:2897 / 2934 `finally: profiler.end_tracing()`.
+        // `clear_trace_session` bundles `leave_profiler_tracing` with
+        // session/bridge_info cleanup, balancing the `start_tracing`
+        // fired at `prepare_trace_start_runtime` /
+        // `start_retrace_from_guard`.  No-op when no scope was open.
         self.clear_trace_session();
         Some((trace, constants))
     }
@@ -4119,10 +4170,13 @@ impl<M: Clone> MetaInterp<M> {
         let outcome = self.compile_loop_body(jump_args, meta);
         // pyjitpl.py:3015-3032 parity: once the body has taken the trace
         // ctx (tracing=None), drop the matching frontend session so the
-        // next `begin_trace_session` sees a clean slate. Cancelled paths
-        // that kept `self.tracing` alive (e.g. `prior_retraced_count ==
-        // MAX` above) fall through harmlessly and keep tracing running.
-        if self.tracing.is_none() && self.active_trace_session.is_some() {
+        // next `begin_trace_session` sees a clean slate, and fire the
+        // `pyjitpl.py:2897 finally: profiler.end_tracing()` pairing for
+        // the `start_tracing` opened by `prepare_trace_start_runtime`.
+        // Cancelled paths that kept `self.tracing` alive (e.g.
+        // `prior_retraced_count == MAX` above) fall through harmlessly
+        // and keep tracing running.
+        if self.tracing.is_none() {
             self.clear_trace_session();
         }
         outcome
@@ -6112,14 +6166,15 @@ impl<M: Clone> MetaInterp<M> {
             .collect();
         // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
         // ... finally: ... profiler.end_backend()`.
-        self.staticdata.profiler.start_backend();
-        let compile_loop_result = self.backend.compile_loop(
-            &inputargs,
-            &optimized_ops_rc,
-            Arc::get_mut(&mut token)
-                .expect("JitCellToken must stay uniquely owned until backend compile"),
-        );
-        self.staticdata.profiler.end_backend();
+        let compile_loop_result = {
+            let _backend_guard = self.staticdata.profiler.enter_backend();
+            self.backend.compile_loop(
+                &inputargs,
+                &optimized_ops_rc,
+                Arc::get_mut(&mut token)
+                    .expect("JitCellToken must stay uniquely owned until backend compile"),
+            )
+        };
         match compile_loop_result {
             Ok(_) => {
                 self.assign_guard_hashes(token.as_ref());
@@ -6465,14 +6520,15 @@ impl<M: Clone> MetaInterp<M> {
             .collect();
         // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
         // ... finally: ... profiler.end_backend()`.
-        self.staticdata.profiler.start_backend();
-        let compile_loop_result = self.backend.compile_loop(
-            &inputargs,
-            &compiled_ops_rc,
-            Arc::get_mut(&mut token)
-                .expect("JitCellToken must stay uniquely owned until backend compile"),
-        );
-        self.staticdata.profiler.end_backend();
+        let compile_loop_result = {
+            let _backend_guard = self.staticdata.profiler.enter_backend();
+            self.backend.compile_loop(
+                &inputargs,
+                &compiled_ops_rc,
+                Arc::get_mut(&mut token)
+                    .expect("JitCellToken must stay uniquely owned until backend compile"),
+            )
+        };
         match compile_loop_result {
             Ok(_) => {
                 self.assign_guard_hashes(token.as_ref());
@@ -9208,12 +9264,32 @@ impl<M: Clone> MetaInterp<M> {
         fail_index: u32,
         fail_values: &[i64],
     ) -> Option<BridgeRetraceResult> {
+        // pyjitpl.py:2914-2924 `handle_guard_failure` opening, line-by-line:
+        //   debug_start('jit-tracing')
+        //   self.staticdata.profiler.start_tracing()
+        //   key = resumedescr.get_resumestorage()
+        //   ...
+        //   self.staticdata.try_to_free_some_loops()
+        //   self.create_history(...)
+        // pyre's `compiled_loops` lookup below stands in for
+        // `get_resumestorage`/`loop_token_wref()`; both gate the trace on
+        // the source loop still being live.
+        self.enter_profiler_tracing();
+        self.try_to_free_some_loops();
         // bridgeopt.py:124 frontend_boxes come directly from the guard
         // failure values in fail_arg_types order.
         self.pending_frontend_boxes = Some(fail_values.to_vec());
         let compiled = match self.compiled_loops.get(&green_key) {
             Some(c) => c,
-            None => return None,
+            None => {
+                // Source loop already evicted — bail out of the bridge
+                // before opening the M-ownership session.  Pair the
+                // `start_tracing` fired above so the profiler stack
+                // stays balanced (PyPy's `finally` would run even when
+                // `handle_guard_failure` returns early via `giveup`).
+                self.leave_profiler_tracing();
+                return None;
+            }
         };
 
         let norm_tid = trace_id;
@@ -11937,7 +12013,12 @@ impl<M: Clone> MetaInterp<M> {
             .expect("compile_finish_from_active_session: session must be present");
         let result =
             self.finish_and_compile(finish_args, finish_arg_types, meta, exit_with_exception);
-        self.staticdata.profiler.end_tracing();
+        // pyjitpl.py:2897 `finally: profiler.end_tracing()` — close the
+        // tracing event scope opened by `prepare_trace_start_runtime`
+        // / `start_retrace_from_guard` for the root-finish path.  The
+        // session was drained above; `clear_trace_session` is not
+        // needed because `bridge_info` already cleared at bridge entry.
+        self.leave_profiler_tracing();
         result
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2041,12 +2041,25 @@ impl<M: Clone> MetaInterp<M> {
     /// path.  Panics if a prior session was not cleared — mirrors
     /// RPython's invariant that `self.history` has a single owner per
     /// trace.
+    ///
+    /// pyjitpl.py:2890 / 2916 fires `profiler.start_tracing()` at the
+    /// moment a fresh trace session opens — that includes the bridge
+    /// path via `handle_guard_failure`, which pyre routes through
+    /// [`start_retrace_from_guard`] → `begin_trace_session`.  Hosting
+    /// the call here keeps it paired with the eventual
+    /// [`clear_trace_session`] / [`take_trace_meta`] end-of-session
+    /// step regardless of whether the trace closes via root-finish or
+    /// abort.
     pub fn begin_trace_session(&mut self, trace_meta: M) {
         debug_assert!(
             self.active_trace_session.is_none(),
             "begin_trace_session called while a trace session is already active",
         );
-        self.active_trace_session = Some(ActiveTraceSession { trace_meta });
+        self.active_trace_session = Some(ActiveTraceSession {
+            trace_meta,
+            bridge: None,
+        });
+        self.staticdata.profiler.start_tracing();
     }
 
     /// Attach bridge-origin metadata.  Called once at bridge entry
@@ -2099,6 +2112,9 @@ impl<M: Clone> MetaInterp<M> {
     /// `_finish_off_the_metainterp` resets `self.resumekey` together
     /// with the trace's history.
     pub fn clear_trace_session(&mut self) {
+        if self.active_trace_session.is_some() {
+            self.staticdata.profiler.end_tracing();
+        }
         self.active_trace_session = None;
         self.bridge_info = None;
     }
@@ -2857,6 +2873,20 @@ impl<M: Clone> MetaInterp<M> {
         self.on_back_edge_typed(green_key, (0, 0), None, None, &typed_values)
     }
 
+    fn prepare_trace_start_runtime(&mut self) {
+        // pyjitpl.py:2889-2892 `compile_and_run_once`: `_setup_once`,
+        // `profiler.start_tracing()`, then `try_to_free_some_loops()` before
+        // the trace history is created.  `profiler.start_tracing()` itself
+        // lives on `begin_trace_session` so the bridge path
+        // (`start_retrace_from_guard` → `begin_trace_session`) picks it up
+        // too.  pyjitpl.py:2916 fires the same `start_tracing()` from
+        // `handle_guard_failure`, mirrored by the bridge-side
+        // `begin_trace_session`.
+        self.warm_state.ensure_jitlog_initialised();
+        self.staticdata._setup_once(&mut self.backend);
+        self.try_to_free_some_loops();
+    }
+
     /// Force-start tracing for a green key, bypassing the hot counter.
     pub fn force_start_tracing(
         &mut self,
@@ -2865,24 +2895,6 @@ impl<M: Clone> MetaInterp<M> {
         driver_descriptor: Option<JitDriverStaticData>,
         live_values: &[Value],
     ) -> BackEdgeAction {
-        // pyjitpl.py:2884 `compile_and_run_once` invokes `_setup_once`
-        // before every trace start.  pyre routes back-edge traces
-        // through `bound_reached`, but function-entry traces enter
-        // here, so the same gate must fire to materialise per-CPU
-        // trampolines (`cpu.setup_once`), profiler `start`, and the
-        // jitlog header before the first trace records anything.
-        // Idempotent — `globaldata.initialized` short-circuits after
-        // the first call.
-        //
-        // PRE-EXISTING-ADAPTATION: pyre's jitlog `Logger` lives on
-        // `WarmEnterState` rather than `MetaInterpStaticData`, so the
-        // `pyjitpl.py:2295 self.jitlog.setup_once()` step is driven
-        // here against this MetaInterp's own warmstate.  Idempotent
-        // — `ensure_jitlog_initialised` only fills the slot when it
-        // is still `None`.
-        self.warm_state.ensure_jitlog_initialised();
-        self.staticdata._setup_once(&mut self.backend);
-
         if self.tracing.is_some() {
             return BackEdgeAction::AlreadyTracing;
         }
@@ -2890,6 +2902,7 @@ impl<M: Clone> MetaInterp<M> {
         match self.warm_state.force_start_tracing(green_key) {
             HotResult::NotHot => BackEdgeAction::Interpret,
             HotResult::StartTracing => {
+                self.prepare_trace_start_runtime();
                 // RPython pyjitpl.py:2604 create_empty_history(inputargs): the
                 // MetaInterp owns the history/Trace factory, not warmstate.
                 let mut recorder = crate::recorder::Trace::new();
@@ -3014,33 +3027,22 @@ impl<M: Clone> MetaInterp<M> {
         driver_descriptor: Option<JitDriverStaticData>,
         live_values: &[Value],
     ) -> BackEdgeAction {
-        // `pyjitpl.py:2889 self.staticdata._setup_once()` parity —
-        // PyPy's first `compile_and_run_once` per CPU dispatches the
-        // `globaldata.initialized`-gated `_setup_once` which calls
-        // `cpu.setup_once()` (`pyjitpl.py:2292-2303`).  Pyre's
-        // back-edge entry routes through `bound_reached`, so the
-        // gate fires here.  Idempotent.
-        //
-        // PRE-EXISTING-ADAPTATION: pyre's jitlog `Logger` lives on
-        // `WarmEnterState`, not on `MetaInterpStaticData`; drive the
-        // per-warmstate `setup_once` step here before the staticdata
-        // hook runs (matches PyPy's `jitlog → ...` order).
-        self.warm_state.ensure_jitlog_initialised();
-        self.staticdata._setup_once(&mut self.backend);
-
         if self.tracing.is_some() {
             return BackEdgeAction::AlreadyTracing;
         }
 
         match self.warm_state.force_start_tracing(green_key) {
             HotResult::NotHot => BackEdgeAction::Interpret,
-            HotResult::StartTracing => self.setup_tracing(
-                green_key,
-                green_key_raw,
-                green_key_values,
-                driver_descriptor,
-                live_values,
-            ),
+            HotResult::StartTracing => {
+                self.prepare_trace_start_runtime();
+                self.setup_tracing(
+                    green_key,
+                    green_key_raw,
+                    green_key_values,
+                    driver_descriptor,
+                    live_values,
+                )
+            }
             HotResult::RunCompiled => BackEdgeAction::RunCompiled,
             HotResult::AlreadyTracing => BackEdgeAction::AlreadyTracing,
         }
@@ -3061,14 +3063,7 @@ impl<M: Clone> MetaInterp<M> {
         match self.warm_state.maybe_compile(green_key) {
             HotResult::NotHot => BackEdgeAction::Interpret,
             HotResult::StartTracing => {
-                self.warm_state.ensure_jitlog_initialised();
-                self.staticdata._setup_once(&mut self.backend);
-                // pyjitpl.py:2890-2892 `compile_and_run_once`:
-                // `_setup_once`, then `profiler.start_tracing()`, then
-                // `try_to_free_some_loops()` before the trace history is
-                // created.  `setup_tracing` owns the history creation in pyre.
-                self.staticdata.profiler.start_tracing();
-                self.try_to_free_some_loops();
+                self.prepare_trace_start_runtime();
                 self.setup_tracing(
                     green_key,
                     green_key_raw,
@@ -3950,6 +3945,13 @@ impl<M: Clone> MetaInterp<M> {
         let constants = std::mem::take(&mut ctx.constants).into_inner();
         let trace = ctx.into_tree_loop();
         self.warm_state.abort_tracing(green_key, false);
+        // pyjitpl.py:2897 / 2934 `finally: profiler.end_tracing()`.  The
+        // parity helper consumes `self.tracing` directly; route the
+        // matching end_tracing through `clear_trace_session` so that
+        // a session started via `begin_trace_session` (the only path
+        // that calls `profiler.start_tracing`) doesn't leak a profiler
+        // stack frame.  No-op when no session was begun.
+        self.clear_trace_session();
         Some((trace, constants))
     }
 
@@ -4760,6 +4762,9 @@ impl<M: Clone> MetaInterp<M> {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
+        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
+        // ... finally: ... profiler.end_backend()`.
+        self.staticdata.profiler.start_backend();
         let compile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.backend.compile_loop(
                 &inputargs,
@@ -4768,6 +4773,7 @@ impl<M: Clone> MetaInterp<M> {
                     .expect("JitCellToken must stay uniquely owned until backend compile"),
             )
         }));
+        self.staticdata.profiler.end_backend();
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(e) => {
@@ -5578,6 +5584,9 @@ impl<M: Clone> MetaInterp<M> {
         self.backend.set_next_trace_id(trace_id);
         self.backend.set_next_header_pc(green_key);
 
+        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
+        // ... finally: ... profiler.end_backend()`.
+        self.staticdata.profiler.start_backend();
         let compile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             // Wrap to `Vec<OpRc>` for the backend's trait boundary.
             let combined_ops_rc: Vec<majit_ir::OpRc> = combined_ops
@@ -5591,6 +5600,7 @@ impl<M: Clone> MetaInterp<M> {
                     .expect("JitCellToken must stay uniquely owned until backend compile"),
             )
         }));
+        self.staticdata.profiler.end_backend();
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(_) => {
@@ -6103,12 +6113,17 @@ impl<M: Clone> MetaInterp<M> {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
-        match self.backend.compile_loop(
+        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
+        // ... finally: ... profiler.end_backend()`.
+        self.staticdata.profiler.start_backend();
+        let compile_loop_result = self.backend.compile_loop(
             &inputargs,
             &optimized_ops_rc,
             Arc::get_mut(&mut token)
                 .expect("JitCellToken must stay uniquely owned until backend compile"),
-        ) {
+        );
+        self.staticdata.profiler.end_backend();
+        match compile_loop_result {
             Ok(_) => {
                 self.assign_guard_hashes(token.as_ref());
                 self.warm_state.memory_manager.keep_loop_alive(&token);
@@ -6451,12 +6466,17 @@ impl<M: Clone> MetaInterp<M> {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
-        match self.backend.compile_loop(
+        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
+        // ... finally: ... profiler.end_backend()`.
+        self.staticdata.profiler.start_backend();
+        let compile_loop_result = self.backend.compile_loop(
             &inputargs,
             &compiled_ops_rc,
             Arc::get_mut(&mut token)
                 .expect("JitCellToken must stay uniquely owned until backend compile"),
-        ) {
+        );
+        self.staticdata.profiler.end_backend();
+        match compile_loop_result {
             Ok(_) => {
                 self.assign_guard_hashes(token.as_ref());
                 self.warm_state.memory_manager.keep_loop_alive(&token);
@@ -8429,6 +8449,9 @@ impl<M: Clone> MetaInterp<M> {
             token_mut.num_scalar_inputargs = self.num_scalar_inputargs;
         }
 
+        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
+        // ... finally: ... profiler.end_backend()`.
+        self.staticdata.profiler.start_backend();
         let compile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let optimized_ops_rc: Vec<majit_ir::OpRc> = optimized_ops
                 .iter()
@@ -8441,6 +8464,7 @@ impl<M: Clone> MetaInterp<M> {
                     .expect("JitCellToken must stay uniquely owned until backend compile"),
             )
         }));
+        self.staticdata.profiler.end_backend();
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(_) => return false,
@@ -9006,7 +9030,10 @@ impl<M: Clone> MetaInterp<M> {
                 .iter()
                 .map(|op| std::rc::Rc::new(op.clone()))
                 .collect();
-            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // compile.py:589-599 `profiler.start_backend() ... try:
+            // do_compile_bridge ... finally: ... profiler.end_backend()`.
+            self.staticdata.profiler.start_backend();
+            let bridge_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 self.backend.compile_bridge(
                     fail_descr,
                     bridge_inputargs,
@@ -9015,7 +9042,9 @@ impl<M: Clone> MetaInterp<M> {
                     previous_tokens,
                     caller_recovery_layout.as_ref(),
                 )
-            })) {
+            }));
+            self.staticdata.profiler.end_backend();
+            match bridge_result {
                 Ok(r) => r,
                 Err(e) => {
                     if crate::majit_log_enabled() {
@@ -11909,7 +11938,10 @@ impl<M: Clone> MetaInterp<M> {
         let meta = self
             .take_trace_meta()
             .expect("compile_finish_from_active_session: session must be present");
-        self.finish_and_compile(finish_args, finish_arg_types, meta, exit_with_exception)
+        let result =
+            self.finish_and_compile(finish_args, finish_arg_types, meta, exit_with_exception);
+        self.staticdata.profiler.end_tracing();
+        result
     }
 
     /// pyjitpl.py:2174-2186 `MIFrame.do_residual_or_indirect_call`.
@@ -13600,6 +13632,21 @@ pub mod counters {
     pub const NVHOLES: i32 = 20;
     /// jit.py:1437 `Counters.NVREUSED`.
     pub const NVREUSED: i32 = 21;
+    /// jit.py:1438 `Counters.TOTAL_COMPILED_LOOPS`.  jitprof.py:105-106
+    /// routes this id to `cpu.tracker.total_compiled_loops`.  pyre has
+    /// no global per-CPU tracker yet — [`crate::jitprof::JitProfiler::get_counter`]
+    /// returns `None` for this id (see
+    /// `majit-backend/src/lib.rs:939-943` PRE-EXISTING-ADAPTATION note).
+    pub const TOTAL_COMPILED_LOOPS: i32 = 22;
+    /// jit.py:1439 `Counters.TOTAL_COMPILED_BRIDGES`.  See the
+    /// [`TOTAL_COMPILED_LOOPS`] note for the adaptation status.
+    pub const TOTAL_COMPILED_BRIDGES: i32 = 23;
+    /// jit.py:1440 `Counters.TOTAL_FREED_LOOPS`.  See the
+    /// [`TOTAL_COMPILED_LOOPS`] note for the adaptation status.
+    pub const TOTAL_FREED_LOOPS: i32 = 24;
+    /// jit.py:1441 `Counters.TOTAL_FREED_BRIDGES`.  See the
+    /// [`TOTAL_COMPILED_LOOPS`] note for the adaptation status.
+    pub const TOTAL_FREED_BRIDGES: i32 = 25;
 }
 
 impl SwitchToBlackhole {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4983,6 +4983,11 @@ impl<M: Clone> MetaInterp<M> {
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
 
                 self.stats.loops_compiled += 1;
+                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
+                // parity — bump the per-process profiler tracker so
+                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
+                // the post-`record_loop_or_bridge` total.
+                self.staticdata.profiler.inc_compiled_loop();
 
                 if let Some(ref hook) = self.hooks.on_compile_loop {
                     hook(green_key, num_ops_before, num_ops_after);
@@ -5793,6 +5798,11 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
                 self.stats.loops_compiled += 1;
+                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
+                // parity — bump the per-process profiler tracker so
+                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
+                // the post-`record_loop_or_bridge` total.
+                self.staticdata.profiler.inc_compiled_loop();
 
                 if let Some(ref hook) = self.hooks.on_compile_loop {
                     hook(green_key, 0, num_combined_ops);
@@ -6290,6 +6300,11 @@ impl<M: Clone> MetaInterp<M> {
                 }
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
                 self.stats.loops_compiled += 1;
+                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
+                // parity — bump the per-process profiler tracker so
+                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
+                // the post-`record_loop_or_bridge` total.
+                self.staticdata.profiler.inc_compiled_loop();
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] finish_and_compile: compiled trace key={}, trace_id={}",
@@ -6608,6 +6623,11 @@ impl<M: Clone> MetaInterp<M> {
                     },
                 );
                 self.stats.loops_compiled += 1;
+                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
+                // parity — bump the per-process profiler tracker so
+                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
+                // the post-`record_loop_or_bridge` total.
+                self.staticdata.profiler.inc_compiled_loop();
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] compile_simple_loop: compiled segmented trace key={}, trace_id={}",
@@ -7291,6 +7311,26 @@ impl<M: Clone> MetaInterp<M> {
     pub fn try_to_free_some_loops(&mut self) {
         let evicted = self.warm_state.memory_manager.next_generation();
         for token in evicted {
+            // model.py:289 `cpu.free_loop_and_bridges` parity for the
+            // counter side: PyPy's `LoopToken.__del__` runs that
+            // routine, which on its way out bumps
+            // `cpu.tracker.total_freed_loops += 1` plus
+            // `total_freed_bridges += loop.bridges_count`.  Pyre's
+            // backend has no global `cpu.tracker`; we keep the same
+            // four counters on the per-process `JitProfiler` and
+            // increment them here, where the eviction is observed.
+            // `compiled_loop_token` is None before backend compile
+            // completes — never reachable on an evicted token, but
+            // guarded for safety.
+            let bridges = token
+                .compiled_loop_token
+                .as_ref()
+                .map(|clt| *clt.bridges_count.lock())
+                .unwrap_or(0);
+            self.staticdata.profiler.inc_freed_loop();
+            if bridges > 0 {
+                self.staticdata.profiler.add_freed_bridges(bridges);
+            }
             let gk = token.green_key;
             let Some(entry) = self.compiled_loops.get_mut(&gk) else {
                 continue;
@@ -8637,6 +8677,11 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 self.attach_procedure_with_redirect(original_green_key, Arc::clone(&token));
                 self.stats.loops_compiled += 1;
+                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
+                // parity — bump the per-process profiler tracker so
+                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
+                // the post-`record_loop_or_bridge` total.
+                self.staticdata.profiler.inc_compiled_loop();
                 if let Some(ref hook) = self.hooks.on_compile_loop {
                     hook(original_green_key, bridge_ops.len(), num_optimized_ops);
                 }
@@ -9219,6 +9264,9 @@ impl<M: Clone> MetaInterp<M> {
                 self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
                 self.warm_state.log_bridge_compile(fail_index);
                 self.stats.bridges_compiled += 1;
+                // jitprof.py:108 `self.cpu.tracker.total_compiled_bridges`
+                // parity — bump the per-process profiler tracker.
+                self.staticdata.profiler.inc_compiled_bridge();
 
                 if let Some(ref hook) = self.hooks.on_compile_bridge {
                     hook(green_key, fail_index, num_optimized_ops);

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4226,9 +4226,7 @@ impl<M: Clone> MetaInterp<M> {
                     // pyjitpl.py:3004: creation of the loop was cancelled!
                     self.cancel_count += 1;
                     if self.cancelled_too_many_times() {
-                        if crate::majit_log_enabled() {
-                            eprintln!("[jit] retrace cancelled too many times");
-                        }
+                        crate::debug::log_one("jit-tracing", "retrace cancelled too many times");
                         self.clear_retrace_state();
                         if let Some(ctx) = self.tracing.take() {
                             self.warm_state.abort_tracing(ctx.green_key, false);
@@ -4247,9 +4245,10 @@ impl<M: Clone> MetaInterp<M> {
                     // Not too many — clear retrace state and fall through
                     // to normal compile_loop path.
                     self.exported_state = None;
-                    if crate::majit_log_enabled() {
-                        eprintln!("[jit] retrace cancelled, trying normal compilation");
-                    }
+                    crate::debug::log_one(
+                        "jit-tracing",
+                        "retrace cancelled, trying normal compilation",
+                    );
                 } else {
                     // pyjitpl.py:2994-2995: position mismatch — abort.
                     self.clear_retrace_state();
@@ -4323,8 +4322,11 @@ impl<M: Clone> MetaInterp<M> {
             .map(|token| token.get_retraced_count())
             .unwrap_or(0);
         if prior_retraced_count_early == u32::MAX && !prior_front_target_tokens_early.is_empty() {
-            if crate::majit_log_enabled() {
-                eprintln!("[jit] skipping recompile: retraced_count=MAX for key={green_key}");
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-tracing",
+                    &format!("skipping recompile: retraced_count=MAX for key={green_key}"),
+                );
             }
             self.warm_state.abort_tracing(green_key, true);
             return CompileOutcome::Cancelled;
@@ -4680,9 +4682,12 @@ impl<M: Clone> MetaInterp<M> {
         let mut compiled_ops =
             compile::normalize_closing_jump_args(optimized_ops, &constants, final_num_inputs);
 
-        if crate::majit_log_enabled() {
-            eprintln!("--- trace (after opt) ---");
-            eprint!("{}", majit_ir::format_trace(&compiled_ops, &constants));
+        if crate::debug::have_debug_prints() {
+            let _s = crate::debug::scope("jit-log-opt-loop");
+            crate::debug::debug_print("--- trace (after opt) ---");
+            for line in majit_ir::format_trace(&compiled_ops, &constants).lines() {
+                crate::debug::debug_print(line);
+            }
             for op in &compiled_ops {
                 if op.opcode == majit_ir::OpCode::GuardNotInvalidated {
                     if let Some(fa) = op.getfailargs() {
@@ -4690,7 +4695,10 @@ impl<M: Clone> MetaInterp<M> {
                             .iter()
                             .map(|a| format!("OpRef::from_raw({})", a.raw()))
                             .collect();
-                        eprintln!("[jit] FINAL GuardNotInv fail_args=[{}]", raw.join(", "));
+                        crate::debug::debug_print(&format!(
+                            "FINAL GuardNotInv fail_args=[{}]",
+                            raw.join(", ")
+                        ));
                     }
                 }
             }
@@ -4829,13 +4837,16 @@ impl<M: Clone> MetaInterp<M> {
             Ok(r) => r,
             Err(e) => {
                 let is_invalid_loop = e.downcast_ref::<crate::optimize::InvalidLoop>().is_some();
-                if crate::majit_log_enabled() {
+                if crate::debug::have_debug_prints() {
                     let kind = if is_invalid_loop {
                         "InvalidLoop"
                     } else {
                         "panic"
                     };
-                    eprintln!("[jit] compile_loop {kind}, aborting trace at key={green_key}");
+                    crate::debug::log_one(
+                        "jit-abort",
+                        &format!("compile_loop {kind}, aborting trace at key={green_key}"),
+                    );
                 }
                 // compile.py:288 parity: preserve preamble target_tokens
                 // even on InvalidLoop/panic. The unroller's Phase 1 created
@@ -4957,8 +4968,11 @@ impl<M: Clone> MetaInterp<M> {
                     next_global_opref = next_global_opref.max(old_entry.next_global_opref);
                     previous_tokens = self.retire_compiled_entry(green_key, old_entry, &mut traces);
                 }
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit][compiled_loops.insert] green_key={green_key}");
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one(
+                        "jit-summary",
+                        &format!("compiled_loops.insert green_key={green_key}"),
+                    );
                 }
                 token.set_retraced_count(final_retraced_count);
                 self.compiled_loops.insert(
@@ -5010,9 +5024,7 @@ impl<M: Clone> MetaInterp<M> {
             Err(e) => {
                 self.stats.loops_aborted += 1;
                 let msg = format!("JIT compilation failed: {e}");
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit] {msg}");
-                }
+                crate::debug::log_one("jit-summary", &msg);
                 if let Some(ref cb) = self.hooks.on_compile_error {
                     cb(green_key, &msg);
                 }
@@ -5532,8 +5544,11 @@ impl<M: Clone> MetaInterp<M> {
                     .downcast_ref::<crate::optimize::InvalidLoop>()
                     .is_some()
                 {
-                    if crate::majit_log_enabled() {
-                        eprintln!("[jit] compile_retrace: InvalidLoop at key={}", green_key);
+                    if crate::debug::have_debug_prints() {
+                        crate::debug::log_one(
+                            "jit-abort",
+                            &format!("compile_retrace: InvalidLoop at key={green_key}"),
+                        );
                     }
                     return false;
                 }
@@ -5586,17 +5601,18 @@ impl<M: Clone> MetaInterp<M> {
         let combined_ops =
             compile::normalize_closing_jump_args(combined_ops, &constants, final_num_inputs);
 
-        if crate::majit_log_enabled() {
-            eprintln!("--- retrace combined (after opt) ---");
-            eprint!("{}", majit_ir::format_trace(&combined_ops, &constants));
+        if crate::debug::have_debug_prints() {
+            let _s = crate::debug::scope("jit-log-opt-bridge");
+            crate::debug::debug_print("--- retrace combined (after opt) ---");
+            for line in majit_ir::format_trace(&combined_ops, &constants).lines() {
+                crate::debug::debug_print(line);
+            }
         }
 
         let num_combined_ops = combined_ops.len();
         let has_guard = combined_ops.iter().any(|op| op.opcode.is_guard());
         if !has_guard {
-            if crate::majit_log_enabled() {
-                eprintln!("[jit] compile_retrace: guardless loop");
-            }
+            crate::debug::log_one("jit-abort", "compile_retrace: guardless loop");
             return false;
         }
 
@@ -5660,8 +5676,11 @@ impl<M: Clone> MetaInterp<M> {
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(_) => {
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit] compile_retrace panicked at key={green_key}");
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one(
+                        "jit-abort",
+                        &format!("compile_retrace panicked at key={green_key}"),
+                    );
                 }
                 self.warm_state.abort_tracing(green_key, false);
                 return false;
@@ -5775,8 +5794,11 @@ impl<M: Clone> MetaInterp<M> {
                     next_global_opref = next_global_opref.max(old_entry.next_global_opref);
                     previous_tokens = self.retire_compiled_entry(green_key, old_entry, &mut traces);
                 }
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit][compiled_loops.insert] green_key={green_key}",);
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one(
+                        "jit-summary",
+                        &format!("compiled_loops.insert green_key={green_key}"),
+                    );
                 }
                 token.set_retraced_count(unroll_opt.retraced_count);
                 self.compiled_loops.insert(
@@ -5811,8 +5833,8 @@ impl<M: Clone> MetaInterp<M> {
             }
             Err(e) => {
                 self.stats.loops_aborted += 1;
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit] compile_retrace failed: {e}");
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one("jit-abort", &format!("compile_retrace failed: {e}"));
                 }
                 self.warm_state.abort_tracing(green_key, false);
                 false
@@ -6043,8 +6065,11 @@ impl<M: Clone> MetaInterp<M> {
                     .downcast_ref::<crate::optimize::InvalidLoop>()
                     .is_some()
                 {
-                    if crate::majit_log_enabled() {
-                        eprintln!("[jit] abort finish: InvalidLoop at key={}", green_key);
+                    if crate::debug::have_debug_prints() {
+                        crate::debug::log_one(
+                            "jit-abort",
+                            &format!("abort finish: InvalidLoop at key={green_key}"),
+                        );
                     }
                     self.warm_state.abort_tracing(green_key, true);
                     // pyjitpl.py:2760 aborted_tracing() reads greenkey from
@@ -6305,10 +6330,12 @@ impl<M: Clone> MetaInterp<M> {
                 // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
                 // the post-`record_loop_or_bridge` total.
                 self.staticdata.profiler.inc_compiled_loop();
-                if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[jit] finish_and_compile: compiled trace key={}, trace_id={}",
-                        green_key, trace_id
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one(
+                        "jit-summary",
+                        &format!(
+                            "finish_and_compile: compiled trace key={green_key}, trace_id={trace_id}"
+                        ),
                     );
                 }
                 if let Some(ref hook) = self.hooks.on_compile_loop {
@@ -6317,9 +6344,7 @@ impl<M: Clone> MetaInterp<M> {
             }
             Err(e) => {
                 let msg = format!("finish_and_compile: compile_loop FAILED key={green_key}: {e:?}");
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit] {msg}");
-                }
+                crate::debug::log_one("jit-summary", &msg);
                 if let Some(ref cb) = self.hooks.on_compile_error {
                     cb(green_key, &msg);
                 }
@@ -7262,8 +7287,11 @@ impl<M: Clone> MetaInterp<M> {
     pub fn invalidate_loop(&mut self, green_key: u64) {
         if let Some(token) = self.warm_state.get_compiled(green_key) {
             token.invalidate();
-            if crate::majit_log_enabled() {
-                eprintln!("[jit] invalidated loop at key={}", green_key);
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-invalidate",
+                    &format!("invalidated loop at key={green_key}"),
+                );
             }
         }
     }
@@ -7347,8 +7375,11 @@ impl<M: Clone> MetaInterp<M> {
                 // entry (the merged `traces` map and the
                 // previous_tokens Vec drop together).
                 self.compiled_loops.remove(&gk);
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit][memmgr] evicted current loop key={}", gk);
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one(
+                        "jit-mem-collect",
+                        &format!("evicted current loop key={gk}"),
+                    );
                 }
             } else {
                 let before = entry.previous_tokens.len();
@@ -7357,8 +7388,11 @@ impl<M: Clone> MetaInterp<M> {
                         .map(|t| !std::sync::Arc::ptr_eq(&t, &token))
                         .unwrap_or(false)
                 });
-                if crate::majit_log_enabled() && entry.previous_tokens.len() < before {
-                    eprintln!("[jit][memmgr] evicted previous token at key={}", gk);
+                if crate::debug::have_debug_prints() && entry.previous_tokens.len() < before {
+                    crate::debug::log_one(
+                        "jit-mem-collect",
+                        &format!("evicted previous token at key={gk}"),
+                    );
                 }
             }
         }
@@ -7933,9 +7967,7 @@ impl<M: Clone> MetaInterp<M> {
             .map(|jct| jct.green_key)
             .unwrap_or(fallback_green_key);
         if descr_addr == 0 {
-            if crate::majit_log_enabled() {
-                eprintln!("[jit] must_compile: descr_addr=0, skip");
-            }
+            crate::debug::log_one("jit-tracing", "must_compile: descr_addr=0, skip");
             return (false, owning_key);
         }
         // compile.py:741: self.status — read live status directly from the
@@ -9278,9 +9310,7 @@ impl<M: Clone> MetaInterp<M> {
                 // is not permanent — the counter resets and may fire again.
                 // RPython uses ST_BUSY_FLAG only (cleared by done_compiling).
                 let msg = format!("Bridge compilation failed: {e}");
-                if crate::majit_log_enabled() {
-                    eprintln!("[jit] {msg}");
-                }
+                crate::debug::log_one("jit-summary", &msg);
                 if let Some(ref cb) = self.hooks.on_compile_error {
                     cb(green_key, &msg);
                 }

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -22,7 +22,14 @@ use super::super::flowspace::model::{
 use super::bookkeeper::Bookkeeper;
 use super::model::{SomeValue, TLS, UnionError, unionof};
 use super::policy::{AnnotatorPolicy, PolicyHandle};
+use crate::tool::ansi_print::AnsiLogger;
 use crate::translator::translator::TranslationContext;
+
+/// RPython `annrpython.py:18 log = py.log.Producer("annrpython")`.
+/// Upstream uses `py.log` which Pyre approximates with [`AnsiLogger`]
+/// (`rpython/tool/ansi_print.py` parity port); both unconditionally
+/// route output to stderr.
+pub static LOG: AnsiLogger = AnsiLogger::new("annrpython");
 
 /// RPython `class RPythonAnnotator(object)` (annrpython.py:22).
 ///
@@ -471,11 +478,13 @@ impl RPythonAnnotator {
     /// Driver-level logging. Non-ported methods (`build_types`,
     /// `complete`, `processblock`, ...) land with Commit 7 Part A.
     pub fn warning(&self, msg: &str) {
-        // RPython `warning()` routes through `log.WARNING`, an unconditional
-        // diagnostic channel — not the PYPYLOG-gated `debug_print`.  Match
-        // the unconditional behavior so annotator warnings remain visible
-        // without setting `MAJIT_LOG`.
-        eprintln!("[annrpython warning] {msg}");
+        // RPython `annrpython.py:303 log.WARNING("%s/ %s" % (pos, msg))`.
+        // `log` is `py.log.Producer("annrpython")`, an unconditional
+        // diagnostic channel — not the PYPYLOG-gated `debug_print`.
+        // Pyre routes through the `AnsiLogger("annrpython")` port so the
+        // output shape `[annrpython:WARNING] msg` matches upstream's
+        // `_make_method(':WARNING', ...)` emission.
+        LOG.WARNING(msg);
     }
 
     /// Install `self.bookkeeper` into `TLS.bookkeeper` — mirrors

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -471,7 +471,11 @@ impl RPythonAnnotator {
     /// Driver-level logging. Non-ported methods (`build_types`,
     /// `complete`, `processblock`, ...) land with Commit 7 Part A.
     pub fn warning(&self, msg: &str) {
-        majit_ir::debug::log_one("annrpython-warning", msg);
+        // RPython `warning()` routes through `log.WARNING`, an unconditional
+        // diagnostic channel — not the PYPYLOG-gated `debug_print`.  Match
+        // the unconditional behavior so annotator warnings remain visible
+        // without setting `MAJIT_LOG`.
+        eprintln!("[annrpython warning] {msg}");
     }
 
     /// Install `self.bookkeeper` into `TLS.bookkeeper` — mirrors

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -471,7 +471,7 @@ impl RPythonAnnotator {
     /// Driver-level logging. Non-ported methods (`build_types`,
     /// `complete`, `processblock`, ...) land with Commit 7 Part A.
     pub fn warning(&self, msg: &str) {
-        eprintln!("[annrpython warning] {}", msg);
+        majit_ir::debug::log_one("annrpython-warning", msg);
     }
 
     /// Install `self.bookkeeper` into `TLS.bookkeeper` — mirrors

--- a/majit/majit-translate/src/jit_codewriter/codewriter.rs
+++ b/majit/majit-translate/src/jit_codewriter/codewriter.rs
@@ -601,7 +601,7 @@ impl CodeWriter {
             // `format_assembler` is ported.
             let _ = verbose;
             let _ = &ssarepr;
-            eprintln!("[CodeWriter] {}", jitcode.name);
+            majit_ir::debug::log_one("jit-codewriter", &format!("CodeWriter {}", jitcode.name));
         }
     }
 

--- a/majit/majit-translate/src/jit_codewriter/codewriter.rs
+++ b/majit/majit-translate/src/jit_codewriter/codewriter.rs
@@ -601,7 +601,12 @@ impl CodeWriter {
             // `format_assembler` is ported.
             let _ = verbose;
             let _ = &ssarepr;
-            majit_ir::debug::log_one("jit-codewriter", &format!("CodeWriter {}", jitcode.name));
+            // RPython `codewriter.py:72 log.dot()` is unconditional —
+            // the only gate is the `CodeWriter.debug` instance flag
+            // (`codewriter.py:18 debug = True`).  Keep that semantics:
+            // a single `self.debug` gate, no additional `MAJIT_LOG`
+            // dependency.
+            eprintln!("[CodeWriter] {}", jitcode.name);
         }
     }
 


### PR DESCRIPTION
follow-up #69

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profiler now records wall-clock times for tracing and backend compilation, with RAII helpers and new counters exported.
  * Debug logging API added and re-exported for use across crates.

* **Bug Fixes**
  * Fixes to x86 calling/stack-alignment and nursery allocation slowpaths to ensure correct stack/frame behavior and OOM handling.

* **Refactor**
  * Centralized and standardized debug/logging usage across backends and interpreter subsystems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->