### PR TITLE
Eliminate fail_descr HashMap registries in dynasm and cranelift

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -128,30 +128,18 @@ static DONE_WITH_THIS_FRAME_DESCR_VOID: std::sync::LazyLock<DescrRef> =
 /// (`_DoneWithThisFrameDescr*`, `ExitFrameWithExceptionDescrRef`,
 /// `PropagateExceptionDescr`) bake their `Arc::as_ptr` addresses
 /// into the FINISH emit sites (`attached_descr_ptrs_with_fallbacks`)
-/// and propagate trampoline.  Mirror each singleton's address into
-/// `FAIL_DESCR_REGISTRY_GLOBAL` so `Backend::fail_descr_arc_from_addr`
-/// resolves consistently for singletons too — `history.py:109-114`
-/// `AbstractDescr.show` makes no distinction between FINISH and
-/// resume-guard descrs.
-fn register_singleton_in_global(descr: &majit_ir::DescrRef) {
-    let ptr = Arc::as_ptr(descr) as *const () as usize;
-    crate::guard::register_fail_descr_global(ptr, descr);
-}
-
+/// and propagate trampoline.  Singletons are matched ptr-eq against
+/// the `CpuDescrAttachments` slot list at the guard-fail boundary
+/// (`match_metainterp_finish_descr`) — no process-global Weak
+/// registry needed (Slice 80-G.7 retirement of
+/// `FAIL_DESCR_REGISTRY_GLOBAL`).
 fn done_with_this_frame_descr(result_types: &[Type]) -> &'static DescrRef {
-    let descr = match result_types {
+    match result_types {
         [Type::Float] => &DONE_WITH_THIS_FRAME_DESCR_FLOAT,
         [Type::Ref] => &DONE_WITH_THIS_FRAME_DESCR_REF,
         [] => &DONE_WITH_THIS_FRAME_DESCR_VOID,
         _ => &DONE_WITH_THIS_FRAME_DESCR_INT,
-    };
-    // Backend-only test paths bypass `MetaInterp::attach_descrs_to_cpu`
-    // and bake the LazyLock fallback directly; register it on first
-    // access so `fail_descr_arc_from_addr` and CALL_ASSEMBLER lookups
-    // resolve it.  Idempotent: `register_fail_descr_global` `insert`s
-    // the same Weak each time.
-    register_singleton_in_global(descr);
-    descr
+    }
 }
 
 /// Helper for the `fail_descrs: Box<[DescrRef]>` storage migration
@@ -220,13 +208,7 @@ fn attached_descr_ptrs_with_fallbacks(
         ),
         exit_frame_with_exception_descr_ref: or_fallback(
             attached.exit_frame_with_exception_descr_ref,
-            {
-                // Backend-only test path: register the LazyLock fallback
-                // into `FAIL_DESCR_REGISTRY_GLOBAL` on first access (see
-                // `done_with_this_frame_descr` rationale).
-                register_singleton_in_global(&EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL);
-                Arc::as_ptr(&*EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL) as *const () as i64
-            },
+            Arc::as_ptr(&*EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL) as *const () as i64,
         ),
         propagate_exception_descr: attached.propagate_exception_descr,
     }
@@ -531,6 +513,16 @@ struct RegisteredLoopTarget {
     /// contract (compile.py:183-203 record_loop_or_bridge).  Position
     /// equals `descr.fail_index` by an invariant asserted at construction.
     fail_descrs: Box<[DescrRef]>,
+    /// `FailDescrCell` thin wrappers, one per non-finish `fail_descrs[i]`
+    /// position.  `Arc<FailDescrCell>` is a thin pointer (concrete-typed)
+    /// so the address baked into JIT code (`jf_descr`) round-trips back
+    /// to the cell via `Arc::from_raw` (`majit_ir::recover_fail_descr_cell`)
+    /// without a process-global Weak registry.  Keep-alive root is this
+    /// field on `CompiledLoop`; the CLT drop releases the JIT code and
+    /// the cells together so a stale baked address never outlives its
+    /// cell.  Position-aligned with `fail_descrs` (singleton finish
+    /// emissions still get a wrapping cell so position equality holds).
+    fail_descr_cells: Box<[Arc<majit_ir::FailDescrCell>]>,
     num_inputs: usize,
     num_ref_roots: usize,
     max_output_slots: usize,
@@ -575,6 +567,8 @@ struct LoopTargetEntry {
     /// Frozen after compile — `Box<[T]>` reflects RPython's no-mutation
     /// contract (compile.py:183-203 record_loop_or_bridge).
     fail_descrs: Box<[DescrRef]>,
+    /// Position-aligned `FailDescrCell` wrappers — see `CompiledLoop`.
+    fail_descr_cells: Box<[Arc<majit_ir::FailDescrCell>]>,
     num_inputs: usize,
     num_ref_roots: usize,
     max_output_slots: usize,
@@ -1709,9 +1703,17 @@ fn rebuild_state_after_failure_dispatch(
         "RESUMEDATA_DEOPT_FN not registered — pyre-jit's init_callbacks (eval.rs) must call \
          register_resumedata_deopt before any guard can fail.",
     );
-    let descr_addr = Arc::as_ptr(fail_descr) as *const () as usize;
+    // Slice 80-G.7: `cranelift_resumedata_deopt` recovers the descr
+    // via `Backend::fail_descr_arc_from_addr` → `recover_fail_descr_cell`,
+    // which requires a `FailDescrCell` thin pointer.  Wrap in a fresh
+    // cell and bake its address; the cell stays alive through the
+    // callback, and the recovery bumps the refcount.
+    let cell = majit_ir::FailDescrCell::wrap(fail_descr.clone());
+    let descr_addr = Arc::as_ptr(&cell) as *const () as usize;
     let _ = (fail_arg_types, bridge_num_inputs); // walker path removed
-    if !cb(descr_addr, outputs, fail_arg_types, bridge_num_inputs) {
+    let ok = cb(descr_addr, outputs, fail_arg_types, bridge_num_inputs);
+    drop(cell);
+    if !ok {
         let fd = as_fd(fail_descr);
         panic!(
             "cranelift_resumedata_deopt callback returned false for a runtime guard \
@@ -2343,6 +2345,7 @@ fn register_call_assembler_target(
         caller_prefix_layout: compiled.caller_prefix_layout.clone(),
         code_ptr: compiled.code_ptr,
         fail_descrs: compiled.fail_descrs.clone(),
+        fail_descr_cells: compiled.fail_descr_cells.clone(),
         num_inputs: compiled.num_inputs,
         num_ref_roots: compiled.num_ref_roots,
         max_output_slots: compiled.max_output_slots,
@@ -2430,6 +2433,7 @@ pub(crate) fn register_pending_call_assembler_target(
         caller_prefix_layout: None,
         code_ptr: std::ptr::null(),
         fail_descrs: Box::new([]),
+        fail_descr_cells: Box::new([]),
         num_inputs,
         num_ref_roots: 0,
         max_output_slots: 1,
@@ -2562,12 +2566,21 @@ fn call_assembler_finish_or_blackhole_deadframe(mut frame: DeadFrame) -> Option<
     // the descr is the sole identity carrier crossing the C-ABI; the
     // receiver derives green_key (memmgr-evicted JCT recovery via
     // `frame.pycode`), trace_id, and fail_index from the descr Arc.
-    let (is_finish, descr_addr, fail_arg_types) = {
+    //
+    // Slice 80-G.7: the blackhole hook recovers its descr via
+    // `Backend::fail_descr_arc_from_addr` → `recover_fail_descr_cell`,
+    // which requires `descr_addr` to be a `FailDescrCell` thin pointer.
+    // The deadframe carries only `DescrRef`, so wrap it in a fresh cell
+    // and bake that cell's address.  The recovery inside the BH call
+    // bumps the strong refcount before returning, so the local cell can
+    // safely drop after BH completes.
+    let (is_finish, fail_descr_arc, fail_arg_types) = {
         let jf = frame.data.downcast_ref::<JitFrameDeadFrame>()?;
-        let fail_descr = &jf.fail_descr;
-        let descr_addr = Arc::as_ptr(fail_descr) as *const () as usize;
-        let fd = as_fd(fail_descr);
-        (fd.is_finish(), descr_addr, fd.fail_arg_types().to_vec())
+        let fail_descr = jf.fail_descr.clone();
+        let fd = as_fd(&fail_descr);
+        let is_finish = fd.is_finish();
+        let fail_arg_types = fd.fail_arg_types().to_vec();
+        (is_finish, fail_descr, fail_arg_types)
     };
     if is_finish {
         return finish_result_from_deadframe(&mut frame).ok();
@@ -2575,13 +2588,17 @@ fn call_assembler_finish_or_blackhole_deadframe(mut frame: DeadFrame) -> Option<
 
     let raw_values = raw_values_from_deadframe_typed(&frame, &fail_arg_types).ok()?;
     let blackhole = CALL_ASSEMBLER_BLACKHOLE_FN.get()?;
-    blackhole(
+    let cell = majit_ir::FailDescrCell::wrap(fail_descr_arc);
+    let descr_addr = Arc::as_ptr(&cell) as *const () as usize;
+    let result = blackhole(
         descr_addr,
         raw_values.as_ptr(),
         raw_values.len(),
         raw_values.as_ptr(),
         raw_values.len(),
-    )
+    );
+    drop(cell);
+    result
 }
 
 fn take_call_assembler_deadframe_from_outputs(outputs: &[i64]) -> DeadFrame {
@@ -2633,16 +2650,16 @@ pub fn force_token_to_dead_frame(force_token: GcRef) -> DeadFrame {
         "force_token_to_dead_frame: jf_force_descr is null"
     );
     // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref)`
-    // parity.  `jf_force_descr` carries the metainterp
-    // `AbstractFailDescr` Arc's data pointer (`history.py:125`).
-    // Resolve via the process-global Weak registry that
-    // `register_fail_descrs` populated alongside the CLT's
-    // `asmmemmgr_gcreftracers` strong root.
-    let fail_descr = crate::guard::lookup_fail_descr_global(jf_force_descr as usize)
-        .expect(
-            "force_token_to_dead_frame: jf_force_descr address not in \
-             FAIL_DESCR_REGISTRY_GLOBAL — every JIT-baked descr must be registered",
-        );
+    // parity.  `jf_force_descr` carries the per-emission
+    // `FailDescrCell` thin pointer baked at codegen
+    // (`collect_guards` Slice 80-G.7).  Recovery is a pure
+    // `Arc::from_raw` against the cell, with the strong refcount
+    // held by the owning `CompiledLoop::fail_descr_cells` for the
+    // life of the executing JIT code.
+    let fail_descr = {
+        let cell = unsafe { majit_ir::recover_fail_descr_cell(jf_force_descr as usize) };
+        cell.descr.clone()
+    };
     deadframe_from_jitframe(jf_gcref, fail_descr, None)
 }
 
@@ -3004,15 +3021,14 @@ fn call_assembler_guard_failure_inner(
     let target = unsafe { &*fast_lookup_ca_target(token_number) };
 
     // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref)`
-    // parity.  `fail_descr_ptr` is the JIT-baked metainterp
-    // `AbstractFailDescr` Arc's data pointer.  Resolve via the
-    // process-global Weak registry populated by `register_fail_descrs`.
-    let fail_descr_owned = crate::guard::lookup_fail_descr_global(fail_descr_ptr as usize)
-        .expect(
-            "call_assembler helper: fail_descr_ptr not registered in \
-             FAIL_DESCR_REGISTRY_GLOBAL — every JIT-baked descr must \
-             round-trip through register_fail_descrs",
-        );
+    // parity.  `fail_descr_ptr` is the JIT-baked
+    // `FailDescrCell` thin pointer; recovery is a pure
+    // `Arc::from_raw` (`recover_fail_descr_cell`).  Strong refcount
+    // lives on the callee `CompiledLoop::fail_descr_cells`.
+    let fail_descr_owned = {
+        let cell = unsafe { majit_ir::recover_fail_descr_cell(fail_descr_ptr as usize) };
+        cell.descr.clone()
+    };
     let fail_descr_ref: &dyn FailDescr = as_fd(&fail_descr_owned);
 
     // Fast path: read the attached bridge directly from the fail_descr
@@ -3244,7 +3260,13 @@ fn call_assembler_fast_path_heap(
     }
     // resume.py:1312 blackhole_from_resumedata parity.
     if let Some(bh_fn) = CALL_ASSEMBLER_BLACKHOLE_FN.get() {
-        let descr_addr = Arc::as_ptr(fail_descr) as *const () as usize;
+        // Slice 80-G.7: BH expects a `FailDescrCell` thin pointer (see
+        // `Backend::fail_descr_arc_from_addr`).  Wrap in a fresh cell
+        // and bake its address; the local cell stays alive across the
+        // BH call, and the recovery inside BH bumps the strong refcount
+        // so the descr survives independently afterward.
+        let bh_cell = majit_ir::FailDescrCell::wrap(fail_descr.clone());
+        let descr_addr = Arc::as_ptr(&bh_cell) as *const () as usize;
         let raw_num = fail_descr_fd.fail_arg_types().len();
         let raw_outputs = outputs.to_vec();
         let mut bh_outputs = outputs.to_vec();
@@ -3257,13 +3279,15 @@ fn call_assembler_fast_path_heap(
             raw_num,
         );
         let num_outputs = bh_outputs.len();
-        if let Some(result) = bh_fn(
+        let bh_result = bh_fn(
             descr_addr,
             bh_outputs.as_ptr(),
             num_outputs,
             raw_outputs.as_ptr(),
             raw_num,
-        ) {
+        );
+        drop(bh_cell);
+        if let Some(result) = bh_result {
             unsafe {
                 *outcome.add(0) = CALL_ASSEMBLER_OUTCOME_FINISH;
                 *outcome.add(1) = 0;
@@ -3396,10 +3420,20 @@ fn call_assembler_shim_inner(
             );
         }
         let num_outputs = bh_outputs.len();
-        // `descr` is the deadframe's attached `&dyn FailDescr`; the
-        // data portion of the fat pointer matches the `Arc::as_ptr`
-        // address registered in `fail_descr_registry` (compiler.rs:6685).
-        let descr_addr = descr as *const dyn FailDescr as *const () as usize;
+        // Slice 80-G.7: BH recovers its descr via
+        // `Backend::fail_descr_arc_from_addr` → `recover_fail_descr_cell`
+        // which requires a `FailDescrCell` thin pointer.  Use the
+        // position-aligned cell from `target.fail_descr_cells`; fall back
+        // to a fresh wrap when the index is out-of-bounds (synthetic).
+        let bh_cell;
+        let descr_addr = if let Some(cell) = target.fail_descr_cells.get(fail_index as usize) {
+            Arc::as_ptr(cell) as *const () as usize
+        } else if let Some(fail_descr_arc) = target.fail_descrs.get(fail_index as usize) {
+            bh_cell = majit_ir::FailDescrCell::wrap(fail_descr_arc.clone());
+            Arc::as_ptr(&bh_cell) as *const () as usize
+        } else {
+            0
+        };
         if let Some(result) = bh_fn(
             descr_addr,
             bh_outputs.as_ptr(),
@@ -5996,6 +6030,9 @@ struct CompiledLoop {
     code_ptr: *const u8,
     code_size: usize,
     fail_descrs: Box<[DescrRef]>,
+    /// Position-aligned `FailDescrCell` wrappers (see
+    /// `RegisteredLoopTarget::fail_descr_cells`).
+    fail_descr_cells: Box<[Arc<majit_ir::FailDescrCell>]>,
     terminal_exit_layouts: UnsafeCell<Vec<TerminalExitLayout>>,
     num_inputs: usize,
     num_ref_roots: usize,
@@ -6051,8 +6088,17 @@ pub(crate) fn fail_descr_gc_map(fd: &dyn FailDescr) -> GcMap {
 /// callback is registered (test scaffolds without pyre-jit) or when
 /// the descr is synthetic (no `rd_loop_token_clt`).
 fn fail_descr_recovery_layout(descr: &DescrRef) -> Option<ExitRecoveryLayout> {
-    let addr = Arc::as_ptr(descr) as *const () as usize;
-    recovery_layout_via_callback(addr, None)
+    // Slice 80-G.7: the callback (`cranelift_recovery_layout_for_descr`)
+    // resolves the descr via `Backend::fail_descr_arc_from_addr` →
+    // `recover_fail_descr_cell`, which requires a `FailDescrCell` thin
+    // pointer.  Wrap in a fresh cell and bake its address; the local
+    // cell stays alive through the callback and the recovery bumps the
+    // refcount inside.
+    let cell = majit_ir::FailDescrCell::wrap(descr.clone());
+    let addr = Arc::as_ptr(&cell) as *const () as usize;
+    let result = recovery_layout_via_callback(addr, None);
+    drop(cell);
+    result
 }
 
 /// Read the per-trace `CompiledTraceInfo` from the meta-side
@@ -6343,23 +6389,26 @@ fn find_fail_descr_in_fail_descrs(
     None
 }
 
-fn find_fail_descr_by_ptr(fail_descrs: &[DescrRef], descr_ptr: usize) -> Option<DescrRef> {
-    for descr in fail_descrs {
-        // `history.py:125` identity: the JIT-baked `jf_descr` pointer
-        // is the metainterp `AbstractFailDescr` Arc's data pointer.
-        // Post Slice 7-Tβ14f, `fail_descrs` holds metainterp Arcs
-        // directly (no backend wrapper), so a single addr comparison
-        // resolves the lookup.
-        if Arc::as_ptr(descr) as *const () as usize == descr_ptr {
-            return Some(descr.clone());
-        }
-        if let Some(bridge) = fail_descr_bridge_ref(as_fd(descr)).as_ref() {
-            if let Some(found) = find_fail_descr_by_ptr(&bridge.fail_descrs, descr_ptr) {
-                return Some(found);
-            }
-        }
+/// Resolve a JIT-baked `jf_descr` pointer back to its owning
+/// `DescrRef` (`history.py:109-114 AbstractDescr.show`).
+///
+/// Two address kinds reach this lookup:
+///
+/// * Non-FINISH guards bake the per-emission `FailDescrCell` thin
+///   pointer (`collect_guards` Slice 80-G.7).  `recover_fail_descr_cell`
+///   recovers the cell via `Arc::from_raw` (strong refcount lives on
+///   the owning `CompiledLoop::fail_descr_cells`).
+/// * FINISH emissions bake the metainterp `AbstractFailDescr` Arc's
+///   data pointer (singleton `DoneWithThisFrame*` /
+///   `ExitFrameWithExceptionDescrRef` / `PropagateExceptionDescr`).
+///   The caller (`run_compiled_code_inner`) handles these via
+///   `match_metainterp_finish_descr` before reaching this fallback.
+fn find_fail_descr_by_ptr(_fail_descrs: &[DescrRef], descr_ptr: usize) -> Option<DescrRef> {
+    if descr_ptr == 0 {
+        return None;
     }
-    None
+    let cell = unsafe { majit_ir::recover_fail_descr_cell(descr_ptr) };
+    Some(cell.descr.clone())
 }
 
 /// Result of `run_compiled_code` — RPython llmodel.py:328 parity.
@@ -7074,6 +7123,7 @@ impl CraneliftBackend {
                                             caller_prefix_layout: b.caller_prefix_layout.clone(),
                                             code_ptr: b.code_ptr,
                                             fail_descrs: b.fail_descrs.clone(),
+                                            fail_descr_cells: b.fail_descr_cells.clone(),
                                             num_inputs: b.num_inputs,
                                             num_ref_roots: b.num_ref_roots,
                                             max_output_slots: b.max_output_slots,
@@ -7138,21 +7188,18 @@ impl CraneliftBackend {
         // owns the batch of descr `Arc`s, scoped to the token's
         // `CompiledLoopToken` lifetime (`model.py:294`,
         // `llmodel.py:252-268 free_loop_and_bridges`).
+        //
+        // Slice 80-G.7: `recover_fail_descr_cell` lifts the descr Arc
+        // from the JIT-baked `FailDescrCell` thin pointer directly
+        // (`history.py:109-114 AbstractDescr.show` = pure cast); the
+        // process-global Weak registry that used to bridge addr→Arc
+        // no longer exists.  Cells are pinned by
+        // `CompiledLoop::fail_descr_cells` for the life of the CLT
+        // they belong to; this tracer keeps the descrs alive for the
+        // same scope.
         if let Some(clt) = token.compiled_loop_token.as_ref() {
             let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(descrs.to_vec());
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
-        }
-        // The trampoline-reachable global Weak registry retains the
-        // addr→`Weak<dyn Descr>` lookup PyPy's
-        // `AbstractDescr.show(cpu, descr_gcref)` does as a direct cast
-        // (`history.py:109-114`); pyre needs the indirection because a
-        // thin `usize` can't reconstruct the fat `Arc<dyn Descr>` vtable.
-        // Eviction is implicit: when the owning CLT drops, the tracer
-        // batch drops, the descr `Arc`s drop, and Weak upgrades return
-        // `None`.
-        for descr in descrs {
-            let ptr = Arc::as_ptr(descr) as *const () as usize;
-            crate::guard::register_fail_descr_global(ptr, descr);
         }
     }
 
@@ -7675,6 +7722,7 @@ impl CraneliftBackend {
         // Pre-scan
         let force_tokens = build_force_token_set(inputargs, ops)?;
         let mut fail_descrs: Vec<DescrRef> = Vec::new();
+        let mut fail_descr_cells: Vec<Arc<majit_ir::FailDescrCell>> = Vec::new();
         let mut guard_infos: Vec<GuardInfo> = Vec::new();
         let mut max_output_slots: usize = 0;
         let attached_descrs = self.attached_descr_ptrs();
@@ -7683,6 +7731,7 @@ impl CraneliftBackend {
             inputargs,
             &force_tokens,
             &mut fail_descrs,
+            &mut fail_descr_cells,
             &mut guard_infos,
             &mut max_output_slots,
             trace_id,
@@ -12957,6 +13006,8 @@ impl CraneliftBackend {
         // post-Slice 7-Tβ1 the runtime lookup is position-based via
         // `find_fail_descr_in_fail_descrs` rather than descr-internal.
         let fail_descrs: Box<[DescrRef]> = fail_descrs.into_boxed_slice();
+        let fail_descr_cells: Box<[Arc<majit_ir::FailDescrCell>]> =
+            fail_descr_cells.into_boxed_slice();
         // history.py:470-499 / x86/regalloc.py:1397 / x86/assembler.py:990-993
         // parity: set TargetToken._ll_loop_code on every Label in this
         // function, and register the entry in LOOP_TARGET_REGISTRY so that
@@ -12986,6 +13037,7 @@ impl CraneliftBackend {
         let entry: LoopTargetEntry = LoopTargetEntry {
             code_ptr,
             fail_descrs: fail_descrs.clone(),
+            fail_descr_cells: fail_descr_cells.clone(),
             num_inputs: inputargs.len(),
             num_ref_roots: ref_root_slots.len(),
             max_output_slots,
@@ -13013,6 +13065,7 @@ impl CraneliftBackend {
             code_ptr,
             code_size: 0,
             fail_descrs,
+            fail_descr_cells,
             terminal_exit_layouts: UnsafeCell::new(terminal_exit_layouts),
             num_inputs: inputargs.len(),
             num_ref_roots: ref_root_slots.len(),
@@ -13113,6 +13166,7 @@ fn collect_guards(
     inputargs: &[InputArg],
     force_tokens: &HashSet<u32>,
     fail_descrs: &mut Vec<DescrRef>,
+    fail_descr_cells: &mut Vec<Arc<majit_ir::FailDescrCell>>,
     guard_infos: &mut Vec<GuardInfo>,
     max_output_slots: &mut usize,
     trace_id: u64,
@@ -13775,10 +13829,16 @@ fn collect_guards(
         }
         // assembler.py:2126 get_gcref_from_faildescr parity: store the
         // FailDescr Arc data pointer in jf_descr.  Slice 7-Tβ14f:
-        // FINISH and non-FINISH alike bake the metainterp Arc address;
+        // FINISH and non-FINISH alike bake a thin pointer identity;
         // FINISH still routes through `attached_descrs` so multiple
         // traces share the same pointer for
         // `_call_assembler_check_descr` (assembler.py:2274) identity.
+        // Non-FINISH guards bake the per-emission `FailDescrCell` thin
+        // ptr (Slice 80-G.7 cranelift): `Arc<dyn Descr>` is fat and
+        // can't round-trip through a `usize` JIT bake, while
+        // `Arc<FailDescrCell>` is concrete-typed and `Arc::from_raw`
+        // recovers identity without a process-global Weak registry.
+        let cell = majit_ir::FailDescrCell::wrap(descr.clone());
         let fail_descr_ptr = if is_finish {
             if FailDescr::is_exit_frame_with_exception(as_fd(&descr)) {
                 attached_descrs.exit_frame_with_exception_descr_ref as i64
@@ -13791,9 +13851,12 @@ fn collect_guards(
                 attached_descrs.done_with_this_frame_descr_ptr_for_type(result_type) as i64
             }
         } else {
-            // Slice 7-Tβ14f: descr IS the metainterp Arc — bake its
-            // data pointer into jf_descr (`history.py:125` identity).
-            Arc::as_ptr(&descr) as *const () as i64
+            // `history.py:109-114 AbstractDescr.show(cpu, descr_gcref)`
+            // parity — the JIT bake address is recovered by a pure cast
+            // (`majit_ir::recover_fail_descr_cell`) at the guard-fail
+            // C-ABI boundary.  Strong refcount lives on
+            // `CompiledLoop::fail_descr_cells` (this push site below).
+            Arc::as_ptr(&cell) as *const () as i64
         };
         // Slice 7-Tβ14e: pre-compute the per-emission bridge cache cell
         // addresses while we still have a typed `&dyn FailDescr` handle.
@@ -13839,6 +13902,7 @@ fn collect_guards(
             None
         };
         fail_descrs.push(descr);
+        fail_descr_cells.push(cell);
         // assembler.py:40-44 must_save_exception parity:
         let must_save_exception = matches!(
             op.opcode,
@@ -14035,42 +14099,36 @@ impl majit_backend::Backend for CraneliftBackend {
     }
 
     fn set_done_with_this_frame_descr_void(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_void = Some(descr);
     }
     fn set_done_with_this_frame_descr_int(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_int = Some(descr);
     }
     fn set_done_with_this_frame_descr_ref(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_ref = Some(descr);
     }
     fn set_done_with_this_frame_descr_float(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_float = Some(descr);
     }
     fn set_exit_frame_with_exception_descr_ref(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .exit_frame_with_exception_descr_ref = Some(descr);
     }
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
@@ -14261,6 +14319,7 @@ impl majit_backend::Backend for CraneliftBackend {
                     caller_prefix_layout: compiled.caller_prefix_layout.clone(),
                     code_ptr: compiled.code_ptr,
                     fail_descrs: compiled.fail_descrs,
+                    fail_descr_cells: compiled.fail_descr_cells,
                     terminal_exit_layouts: compiled.terminal_exit_layouts,
                     loop_reentry,
                     num_inputs: bridge_num_inputs,
@@ -14300,6 +14359,7 @@ impl majit_backend::Backend for CraneliftBackend {
                                         caller_prefix_layout: b.caller_prefix_layout.clone(),
                                         code_ptr: b.code_ptr,
                                         fail_descrs: b.fail_descrs.clone(),
+                                        fail_descr_cells: b.fail_descr_cells.clone(),
                                         num_inputs: b.num_inputs,
                                         num_ref_roots: b.num_ref_roots,
                                         max_output_slots: b.max_output_slots,
@@ -14459,6 +14519,7 @@ impl majit_backend::Backend for CraneliftBackend {
                             caller_prefix_layout: b.caller_prefix_layout.clone(),
                             code_ptr: b.code_ptr,
                             fail_descrs: b.fail_descrs.clone(),
+                            fail_descr_cells: b.fail_descr_cells.clone(),
                             num_inputs: b.num_inputs,
                             num_ref_roots: b.num_ref_roots,
                             max_output_slots: b.max_output_slots,
@@ -14940,18 +15001,14 @@ impl majit_backend::Backend for CraneliftBackend {
 
     fn fail_descr_arc_from_addr(&self, descr_addr: usize) -> majit_ir::DescrRef {
         // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref)`
-        // parity.  Pyre routes through the process-global Weak registry
-        // populated by `register_fail_descrs`; the strong refs that
-        // keep entries upgradeable live on `clt.asmmemmgr_gcreftracers`
-        // (`model.py:294`).
-        crate::guard::lookup_fail_descr_global(descr_addr).unwrap_or_else(|| {
-            panic!(
-                "fail_descr_arc_from_addr: descr_addr {descr_addr:#x} not in \
-                 FAIL_DESCR_REGISTRY_GLOBAL — every emitted fail descr must \
-                 be registered before its address reaches the C-ABI guard-fail \
-                 boundary, and its owning CLT must still be live"
-            )
-        })
+        // parity.  `descr_addr` is the per-emission `FailDescrCell`
+        // thin pointer baked at codegen (`collect_guards` Slice
+        // 80-G.7).  Recovery is a pure `Arc::from_raw` with a
+        // refcount bump; the strong reference is pinned by the
+        // owning `CompiledLoop::fail_descr_cells` for the life of
+        // the executing JIT code (`model.py:294`).
+        let cell = unsafe { majit_ir::recover_fail_descr_cell(descr_addr) };
+        cell.descr.clone()
     }
 
     fn get_int_value(&self, frame: &DeadFrame, index: usize) -> i64 {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3424,7 +3424,10 @@ fn call_assembler_shim_inner(
         // `Backend::fail_descr_arc_from_addr` → `recover_fail_descr_cell`
         // which requires a `FailDescrCell` thin pointer.  Use the
         // position-aligned cell from `target.fail_descr_cells`; fall back
-        // to a fresh wrap when the index is out-of-bounds (synthetic).
+        // to a fresh wrap when only `fail_descrs` carries the descr.
+        // Both lookups must succeed — `recover_fail_descr_cell(0)` is UB,
+        // so an out-of-range `fail_index` here would corrupt the BH-side
+        // address recovery silently.
         let bh_cell;
         let descr_addr = if let Some(cell) = target.fail_descr_cells.get(fail_index as usize) {
             Arc::as_ptr(cell) as *const () as usize
@@ -3432,7 +3435,13 @@ fn call_assembler_shim_inner(
             bh_cell = majit_ir::FailDescrCell::wrap(fail_descr_arc.clone());
             Arc::as_ptr(&bh_cell) as *const () as usize
         } else {
-            0
+            panic!(
+                "call_assembler BH dispatch: fail_index {} out of range \
+                 (fail_descr_cells.len()={}, fail_descrs.len()={})",
+                fail_index,
+                target.fail_descr_cells.len(),
+                target.fail_descrs.len()
+            );
         };
         if let Some(result) = bh_fn(
             descr_addr,
@@ -6400,10 +6409,9 @@ fn find_fail_descr_in_fail_descrs(
 ///   the owning `CompiledLoop::fail_descr_cells`).
 /// * FINISH emissions bake the metainterp `AbstractFailDescr` Arc's
 ///   data pointer (singleton `DoneWithThisFrame*` /
-///   `ExitFrameWithExceptionDescrRef` / `PropagateExceptionDescr`).
-///   The caller (`run_compiled_code_inner`) handles attached
-///   metainterp singletons via `match_metainterp_finish_descr` before
-///   reaching this fallback.
+///   `ExitFrameWithExceptionDescrRef`).  The caller
+///   (`run_compiled_code_inner`) handles attached metainterp singletons
+///   via `match_metainterp_finish_descr` before reaching this fallback.
 /// * Backend-only test paths bypass `MetaInterp::attach_descrs_to_cpu`,
 ///   so the FINISH bake falls back to the cranelift-local LazyLock
 ///   singletons via `attached_descr_ptrs_with_fallbacks`.  We MUST
@@ -6411,7 +6419,21 @@ fn find_fail_descr_in_fail_descrs(
 ///   because the LazyLock addresses are bare `Arc<dyn Descr>` data
 ///   pointers, not `FailDescrCell` thin pointers — feeding them to
 ///   `Arc::from_raw` as cells is undefined behavior.
-fn find_fail_descr_by_ptr(_fail_descrs: &[DescrRef], descr_ptr: usize) -> Option<DescrRef> {
+/// * The propagate-exception singleton (`pyjitpl.py:2283
+///   self.cpu.propagate_exception_descr = exc_descr`) is per-cpu
+///   (no cl-local LazyLock fallback).  `run_compiled_code_inner`
+///   rewrites a propagate-pointer in jf_descr to the attached
+///   ExitFrameWithExceptionDescrRef before reaching this lookup
+///   (see line ~6644), but match it here too so any future bake site
+///   that leaves the propagate Arc data pointer in jf_descr cannot
+///   reach `recover_fail_descr_cell` — feeding the metainterp's bare
+///   `Arc<PropagateExceptionDescr>` data pointer to `Arc::from_raw`
+///   as a `FailDescrCell` would be undefined behavior.
+fn find_fail_descr_by_ptr(
+    _fail_descrs: &[DescrRef],
+    descr_ptr: usize,
+    propagate_exception_descr: Option<&DescrRef>,
+) -> Option<DescrRef> {
     if descr_ptr == 0 {
         return None;
     }
@@ -6424,6 +6446,11 @@ fn find_fail_descr_by_ptr(_fail_descrs: &[DescrRef], descr_ptr: usize) -> Option
     ] {
         if Arc::as_ptr(global) as *const () as usize == descr_ptr {
             return Some(global.clone());
+        }
+    }
+    if let Some(propagate) = propagate_exception_descr {
+        if Arc::as_ptr(propagate) as *const () as usize == descr_ptr {
+            return Some(propagate.clone());
         }
     }
     let cell = unsafe { majit_ir::recover_fail_descr_cell(descr_ptr) };
@@ -6712,7 +6739,11 @@ fn run_compiled_code_inner(
         // the resolved Arc via the FailDescr trait — never dereference
         // the raw pointer as a concrete type, since the meta side can
         // be either `ResumeGuardDescr` or `DoneWithThisFrameDescr*`.
-        let arc = find_fail_descr_by_ptr(fail_descrs, jf_descr_raw as usize);
+        let arc = find_fail_descr_by_ptr(
+            fail_descrs,
+            jf_descr_raw as usize,
+            attachments.propagate_exception_descr.as_ref(),
+        );
         let fi = arc.as_ref().map(|a| as_fd(a).fail_index()).unwrap_or(0);
         // compile.py:665-674 parity: done_with_this_frame_descr is a
         // global singleton — it won't appear in per-trace fail_descrs.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6392,7 +6392,7 @@ fn find_fail_descr_in_fail_descrs(
 /// Resolve a JIT-baked `jf_descr` pointer back to its owning
 /// `DescrRef` (`history.py:109-114 AbstractDescr.show`).
 ///
-/// Two address kinds reach this lookup:
+/// Three address kinds reach this lookup:
 ///
 /// * Non-FINISH guards bake the per-emission `FailDescrCell` thin
 ///   pointer (`collect_guards` Slice 80-G.7).  `recover_fail_descr_cell`
@@ -6401,11 +6401,30 @@ fn find_fail_descr_in_fail_descrs(
 /// * FINISH emissions bake the metainterp `AbstractFailDescr` Arc's
 ///   data pointer (singleton `DoneWithThisFrame*` /
 ///   `ExitFrameWithExceptionDescrRef` / `PropagateExceptionDescr`).
-///   The caller (`run_compiled_code_inner`) handles these via
-///   `match_metainterp_finish_descr` before reaching this fallback.
+///   The caller (`run_compiled_code_inner`) handles attached
+///   metainterp singletons via `match_metainterp_finish_descr` before
+///   reaching this fallback.
+/// * Backend-only test paths bypass `MetaInterp::attach_descrs_to_cpu`,
+///   so the FINISH bake falls back to the cranelift-local LazyLock
+///   singletons via `attached_descr_ptrs_with_fallbacks`.  We MUST
+///   pointer-match these here before attempting `recover_fail_descr_cell`,
+///   because the LazyLock addresses are bare `Arc<dyn Descr>` data
+///   pointers, not `FailDescrCell` thin pointers — feeding them to
+///   `Arc::from_raw` as cells is undefined behavior.
 fn find_fail_descr_by_ptr(_fail_descrs: &[DescrRef], descr_ptr: usize) -> Option<DescrRef> {
     if descr_ptr == 0 {
         return None;
+    }
+    for global in [
+        &*DONE_WITH_THIS_FRAME_DESCR_INT,
+        &*DONE_WITH_THIS_FRAME_DESCR_FLOAT,
+        &*DONE_WITH_THIS_FRAME_DESCR_REF,
+        &*DONE_WITH_THIS_FRAME_DESCR_VOID,
+        &*EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL,
+    ] {
+        if Arc::as_ptr(global) as *const () as usize == descr_ptr {
+            return Some(global.clone());
+        }
     }
     let cell = unsafe { majit_ir::recover_fail_descr_cell(descr_ptr) };
     Some(cell.descr.clone())
@@ -14578,7 +14597,6 @@ impl majit_backend::Backend for CraneliftBackend {
             .expect("token has no compiled code")
             .downcast_ref::<CompiledLoop>()
             .expect("compiled data is not CompiledLoop");
-
 
         // llmodel.py:290-329 `execute_token` parity (raw-output variant).
         // PyPy's `execute_token` performs one `func(ll_frame, ...)` call

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7158,7 +7158,16 @@ impl CraneliftBackend {
     /// `Arc<dyn Descr>` fat pointer (`history.py:125` identity).
     /// Mirrors dynasm's API: callable from future late-stamp helpers
     /// that need to land entries after the in-codegen call missed them.
-    pub fn register_fail_descrs(&self, descrs: &[DescrRef]) {
+    pub fn register_fail_descrs(&self, token: &majit_backend::JitCellToken, descrs: &[DescrRef]) {
+        // `assembler.py:820-823 gcreftracers.append(tracer)` parity —
+        // each `register_fail_descrs` call appends one tracer that
+        // owns the batch of descr `Arc`s, scoped to the token's
+        // `CompiledLoopToken` lifetime (`model.py:294`,
+        // `llmodel.py:252-268 free_loop_and_bridges`).
+        if let Some(clt) = token.compiled_loop_token.as_ref() {
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(descrs.to_vec());
+            clt.asmmemmgr_gcreftracers.lock().push(tracer);
+        }
         let mut registry = self.fail_descr_registry.lock().unwrap();
         for descr in descrs {
             let descr_ref: majit_ir::DescrRef = descr.clone();
@@ -13995,7 +14004,7 @@ impl majit_backend::Backend for CraneliftBackend {
             return Err(err);
         }
         self.registered_call_assembler_tokens.insert(token.number);
-        self.register_fail_descrs(&compiled.fail_descrs);
+        self.register_fail_descrs(token, &compiled.fail_descrs);
 
         // `compile.py:183-186 record_loop_or_bridge`: for each ResumeDescr
         // in the newly-compiled trace, stamp the owning CompiledLoopToken.
@@ -14201,7 +14210,10 @@ impl majit_backend::Backend for CraneliftBackend {
         )?;
         self.registered_call_assembler_bridge_traces
             .insert(compiled.trace_id);
-        self.register_fail_descrs(&compiled.fail_descrs);
+        // `compile.py:183-186 record_loop_or_bridge`: bridge descrs
+        // are scoped to the original loop's CLT, so the tracer batch
+        // lands on `original_token`'s `asmmemmgr_gcreftracers`.
+        self.register_fail_descrs(original_token, &compiled.fail_descrs);
 
         // Attach the bridge to the original guard's fail descriptor so that
         // execute_token can dispatch to it on subsequent guard failures.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1258,21 +1258,6 @@ thread_local! {
     /// the GC sees its first JITFRAME, cleared when the active GC is
     /// replaced or torn down.
     static CRANELIFT_JITFRAME_TYPE_ID: Cell<Option<u32>> = const { Cell::new(None) };
-    /// Active backend's `fail_descr_registry` handle. Set by
-    /// `execute_token*` entry points around compiled-code dispatch so
-    /// the runtime helper `wrap_call_assembler_deadframe_with_caller_prefix`
-    /// (`compiler.rs:646`) can register the freshly-allocated overlay
-    /// `CraneliftFailDescr` it attaches to the deadframe at line 682.
-    /// Without registration, `Backend::fail_descr_arc_from_addr`
-    /// (`compiler.rs:14200`) panics when the BH callback (`call_jit.rs:1711`)
-    /// looks up the overlay's address. PyPy's `compile.py:701
-    /// descr.handle_fail()` dispatches via descr object identity and has
-    /// no addr→Arc indirection — pyre's Rust C-ABI carries `descr_addr`
-    /// across the FFI boundary so the registry round-trip is needed for
-    /// ABI safety.
-    static CRANELIFT_ACTIVE_FAIL_DESCR_REGISTRY: RefCell<
-        Option<Arc<Mutex<HashMap<usize, majit_ir::DescrRef>>>>,
-    > = const { RefCell::new(None) };
 }
 
 fn with_cranelift_gc<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> {
@@ -1322,24 +1307,6 @@ fn set_cranelift_jitframe_type_id(type_id: Option<u32>) {
 
 fn cranelift_gc_active() -> bool {
     CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some())
-}
-
-/// Set/clear the active backend's `fail_descr_registry` handle for the
-/// duration of compiled-code dispatch. Mirrors `set_cranelift_active_gc`.
-fn set_cranelift_active_fail_descr_registry(
-    registry: Option<Arc<Mutex<HashMap<usize, majit_ir::DescrRef>>>>,
-) {
-    CRANELIFT_ACTIVE_FAIL_DESCR_REGISTRY.with(|cell| *cell.borrow_mut() = registry);
-}
-
-/// RAII guard that clears `CRANELIFT_ACTIVE_FAIL_DESCR_REGISTRY` on drop.
-/// Used by `execute_token*` so the TLS handle is restored on panic /
-/// early return, not just on the normal-completion path.
-struct FailDescrRegistryGuard;
-impl Drop for FailDescrRegistryGuard {
-    fn drop(&mut self) {
-        set_cranelift_active_fail_descr_registry(None);
-    }
 }
 
 /// `majit_gc::CheckIsObjectFn` installed by `set_gc_allocator`. Dispatches
@@ -2638,22 +2605,16 @@ pub fn force_token_to_dead_frame(force_token: GcRef) -> DeadFrame {
         jf_force_descr != 0,
         "force_token_to_dead_frame: jf_force_descr is null"
     );
-    // Slice 7-Tβ14e: `jf_force_descr` carries the metainterp
-    // `AbstractFailDescr` Arc's data pointer (`history.py:125`
-    // identity).  Recover the live DescrRef from the active backend's
-    // registry — the JIT-baked address must round-trip through
-    // `register_fail_descrs` for this lookup to succeed.
-    let fail_descr = CRANELIFT_ACTIVE_FAIL_DESCR_REGISTRY
-        .with(|cell| {
-            cell.borrow().as_ref().and_then(|reg| {
-                reg.lock()
-                    .ok()
-                    .and_then(|m| m.get(&(jf_force_descr as usize)).cloned())
-            })
-        })
+    // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref)`
+    // parity.  `jf_force_descr` carries the metainterp
+    // `AbstractFailDescr` Arc's data pointer (`history.py:125`).
+    // Resolve via the process-global Weak registry that
+    // `register_fail_descrs` populated alongside the CLT's
+    // `asmmemmgr_gcreftracers` strong root.
+    let fail_descr = crate::guard::lookup_fail_descr_global(jf_force_descr as usize)
         .expect(
             "force_token_to_dead_frame: jf_force_descr address not in \
-             fail_descr_registry — every JIT-baked descr must be registered",
+             FAIL_DESCR_REGISTRY_GLOBAL — every JIT-baked descr must be registered",
         );
     deadframe_from_jitframe(jf_gcref, fail_descr, None)
 }
@@ -3015,24 +2976,15 @@ fn call_assembler_guard_failure_inner(
 
     let target = unsafe { &*fast_lookup_ca_target(token_number) };
 
-    // Slice 7-Tβ14e: `fail_descr_ptr` is the JIT-baked metainterp
-    // `AbstractFailDescr` Arc's data pointer (`history.py:125`).
-    // Resolve via the active backend's registry — `register_fail_descrs`
-    // dual-keys the table on both backend and meta addresses, so this
-    // lookup succeeds whether the runtime stamps the meta pointer
-    // (post-14e) or the backend wrapper pointer (legacy paths).
-    let fail_descr_owned = CRANELIFT_ACTIVE_FAIL_DESCR_REGISTRY
-        .with(|cell| {
-            cell.borrow().as_ref().and_then(|reg| {
-                reg.lock()
-                    .ok()
-                    .and_then(|m| m.get(&(fail_descr_ptr as usize)).cloned())
-            })
-        })
+    // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref)`
+    // parity.  `fail_descr_ptr` is the JIT-baked metainterp
+    // `AbstractFailDescr` Arc's data pointer.  Resolve via the
+    // process-global Weak registry populated by `register_fail_descrs`.
+    let fail_descr_owned = crate::guard::lookup_fail_descr_global(fail_descr_ptr as usize)
         .expect(
             "call_assembler helper: fail_descr_ptr not registered in \
-             fail_descr_registry — every JIT-baked descr must round-trip \
-             through register_fail_descrs",
+             FAIL_DESCR_REGISTRY_GLOBAL — every JIT-baked descr must \
+             round-trip through register_fail_descrs",
         );
     let fail_descr_ref: &dyn FailDescr = as_fd(&fail_descr_owned);
 
@@ -6958,10 +6910,6 @@ pub struct CraneliftBackend {
     /// clone so the attachments outlive this backend for the lifetime of
     /// emitted code that baked the handle as an immediate.
     descr_attachments: CpuDescrHandle,
-    /// Native guards carry raw `CraneliftFailDescr` addresses.  Keep the
-    /// corresponding Arcs alive and recoverable across call-assembler
-    /// guard failures, matching PyPy's CPU-held descr object identity.
-    fail_descr_registry: Arc<Mutex<HashMap<usize, majit_ir::DescrRef>>>,
 }
 
 impl CraneliftBackend {
@@ -7149,7 +7097,6 @@ impl CraneliftBackend {
             // Callers configure pyre's PyObject layout via set_vtable_offset.
             vtable_offset: None,
             descr_attachments: Arc::new(std::sync::RwLock::new(CpuDescrAttachments::default())),
-            fail_descr_registry: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -7168,12 +7115,17 @@ impl CraneliftBackend {
             let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(descrs.to_vec());
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
         }
-        let mut registry = self.fail_descr_registry.lock().unwrap();
+        // The trampoline-reachable global Weak registry retains the
+        // addr→`Weak<dyn Descr>` lookup PyPy's
+        // `AbstractDescr.show(cpu, descr_gcref)` does as a direct cast
+        // (`history.py:109-114`); pyre needs the indirection because a
+        // thin `usize` can't reconstruct the fat `Arc<dyn Descr>` vtable.
+        // Eviction is implicit: when the owning CLT drops, the tracer
+        // batch drops, the descr `Arc`s drop, and Weak upgrades return
+        // `None`.
         for descr in descrs {
-            let descr_ref: majit_ir::DescrRef = descr.clone();
-            registry
-                .entry(Arc::as_ptr(descr) as *const () as usize)
-                .or_insert_with(|| descr_ref);
+            let ptr = Arc::as_ptr(descr) as *const () as usize;
+            crate::guard::register_fail_descr_global(ptr, descr);
         }
     }
 
@@ -14507,13 +14459,6 @@ impl majit_backend::Backend for CraneliftBackend {
             });
         }
 
-        // Publish the backend's `fail_descr_registry` handle for the
-        // duration of dispatch so `wrap_call_assembler_deadframe_with_caller_prefix`
-        // can register transient overlay descrs at construction
-        // (compiler.rs:646 — see `register_overlay_in_active_registry`).
-        // RAII guard so a panic in `execute_with_inputs` still clears the TLS.
-        set_cranelift_active_fail_descr_registry(Some(Arc::clone(&self.fail_descr_registry)));
-        let _registry_guard = FailDescrRegistryGuard;
         Self::execute_with_inputs(compiled, &inputs)
     }
 
@@ -14525,8 +14470,6 @@ impl majit_backend::Backend for CraneliftBackend {
             .downcast_ref::<CompiledLoop>()
             .expect("compiled data is not CompiledLoop");
 
-        set_cranelift_active_fail_descr_registry(Some(Arc::clone(&self.fail_descr_registry)));
-        let _registry_guard = FailDescrRegistryGuard;
         Self::execute_with_inputs(compiled, args)
     }
 
@@ -14542,8 +14485,6 @@ impl majit_backend::Backend for CraneliftBackend {
             .downcast_ref::<CompiledLoop>()
             .expect("compiled data is not CompiledLoop");
 
-        set_cranelift_active_fail_descr_registry(Some(Arc::clone(&self.fail_descr_registry)));
-        let _registry_guard = FailDescrRegistryGuard;
 
         // llmodel.py:290-329 `execute_token` parity (raw-output variant).
         // PyPy's `execute_token` performs one `func(ll_frame, ...)` call
@@ -14949,15 +14890,9 @@ impl majit_backend::Backend for CraneliftBackend {
         if force_token.0 == 0 {
             return None;
         }
-        // `force_token_to_dead_frame` resolves `jf_force_descr` via
-        // `CRANELIFT_ACTIVE_FAIL_DESCR_REGISTRY`. `execute_token*` paths
-        // install this TLS handle via `FailDescrRegistryGuard`, but
-        // `force()` may also be invoked outside an `execute_token*`
-        // scope (e.g. async-forcing / virtualref paths).  Establish the
-        // registry on this thread first so the helper can resolve the
-        // JIT-baked descr address regardless of caller.
-        set_cranelift_active_fail_descr_registry(Some(Arc::clone(&self.fail_descr_registry)));
-        let _registry_guard = FailDescrRegistryGuard;
+        // `force_token_to_dead_frame` resolves `jf_force_descr` via the
+        // process-global `FAIL_DESCR_REGISTRY_GLOBAL` (`history.py:109-
+        // 114` `AbstractDescr.show`); no TLS handle needed.
         Some(force_token_to_dead_frame(force_token))
     }
 
@@ -14971,25 +14906,19 @@ impl majit_backend::Backend for CraneliftBackend {
     }
 
     fn fail_descr_arc_from_addr(&self, descr_addr: usize) -> majit_ir::DescrRef {
-        // warmspot.py:1021 cpu.get_latest_descr(deadframe) parity:
-        // every compiled guard descr is registered strongly in
-        // `fail_descr_registry` for the lifetime of its owning machine
-        // code.  Slice X3-D removed the transient CALL_ASSEMBLER overlay
-        // registry — the deadframe's `JitFrameDeadFrame.fail_descr` now
-        // holds the callee's own Arc identity, so addr→Arc lookups
-        // resolve through the regular registry without a Weak side
-        // table.
-        let registry = self
-            .fail_descr_registry
-            .lock()
-            .expect("fail_descr_registry mutex poisoned");
-        registry.get(&descr_addr).cloned().unwrap_or_else(|| {
+        // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref)`
+        // parity.  Pyre routes through the process-global Weak registry
+        // populated by `register_fail_descrs`; the strong refs that
+        // keep entries upgradeable live on `clt.asmmemmgr_gcreftracers`
+        // (`model.py:294`).
+        crate::guard::lookup_fail_descr_global(descr_addr).unwrap_or_else(|| {
             panic!(
                 "fail_descr_arc_from_addr: descr_addr {descr_addr:#x} not in \
-                     fail_descr_registry — every emitted FailDescr must be strongly \
-                     registered"
+                 FAIL_DESCR_REGISTRY_GLOBAL — every emitted fail descr must \
+                 be registered before its address reaches the C-ABI guard-fail \
+                 boundary, and its owning CLT must still be live"
             )
-        }) as majit_ir::DescrRef
+        })
     }
 
     fn get_int_value(&self, frame: &DeadFrame, index: usize) -> i64 {
@@ -15033,40 +14962,12 @@ impl majit_backend::Backend for CraneliftBackend {
     fn free_loop(&mut self, token: &JitCellToken) {
         unregister_call_assembler_target(token.number);
         self.registered_call_assembler_tokens.remove(&token.number);
-        // memmgr.py:9 `MemoryManager.alive_loops` parity: when a JCT is
-        // evicted, RPython's GC reclaims the token's compiled code and
-        // every dependent FailDescr naturally because nothing keeps a
-        // strong ref past `alive_loops`.  Pyre's `fail_descr_registry`
-        // holds strong Arcs to every emitted descr for the C-ABI
-        // recovery path (`fail_descr_arc_from_addr` parity with
-        // `cpu.get_latest_descr`), so we must explicitly release the
-        // entries belonging to this token here — otherwise the descrs
-        // (and their `rd_loop_token_clt` chain) outlive their owning
-        // loop and pyre keeps memory PyPy would have freed.
-        //
-        // Sweep strong entries whose owning-JCT upgrade points back at
-        // this token. Ownerless strong entries (`descr_owning_jct == None`)
-        // are PRESERVED: in PyPy these correspond to FINISH descrs
-        // (`_DoneWithThisFrameDescr` family / `ExitFrameWithExceptionDescr`,
-        // `compile.py:185` skipped via `isinstance(descr, ResumeDescr)`)
-        // which are module-level singletons not subject to per-loop GC.
-        // Transient CALL_ASSEMBLER overlays are not stored here; their
-        // separate Weak registry is swept below.
-        let mut registry = self
-            .fail_descr_registry
-            .lock()
-            .expect("fail_descr_registry mutex poisoned");
-        registry.retain(|_, descr| {
-            let fd = match descr.as_fail_descr() {
-                Some(fd) => fd,
-                None => return true,
-            };
-            match majit_backend::descr_owning_jct(fd) {
-                Some(owner) => owner.number != token.number,
-                None => true,
-            }
-        });
-        drop(registry);
+        // `llmodel.py:252-268 free_loop_and_bridges` parity.  Strong
+        // refs to baked descrs live on `clt.asmmemmgr_gcreftracers`
+        // (`model.py:294`); dropping the CLT releases them, and Weak
+        // entries in `FAIL_DESCR_REGISTRY_GLOBAL` upgrade to `None`
+        // next time someone looks them up.  Nothing to sweep here.
+        let _ = token;
     }
 
     /// llmodel.py:775 bh_new(sizedescr) → gc_ll_descr.gc_malloc(sizedescr).

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -14425,45 +14425,6 @@ impl majit_backend::Backend for CraneliftBackend {
         }
     }
 
-    fn read_descr_status(&self, descr_addr: usize) -> u64 {
-        // `compile.py:741 self.status` — route through the registry-backed
-        // `Arc<dyn FailDescr>` so the dispatch is trait-based, mirroring
-        // dynasm.  After the Unified-Descr identity flip, only the
-        // registry value changes; this dispatch chain stays the same.
-        if descr_addr == 0 {
-            return 0;
-        }
-        <Self as majit_backend::Backend>::fail_descr_arc_from_addr(self, descr_addr)
-            .as_fail_descr()
-            .map_or(0, |fd| fd.get_status())
-    }
-
-    fn start_compiling_descr(&self, descr_addr: usize) {
-        // `compile.py:786-788 self.start_compiling()` — trait dispatch.
-        if descr_addr == 0 {
-            return;
-        }
-        if let Some(fd) =
-            <Self as majit_backend::Backend>::fail_descr_arc_from_addr(self, descr_addr)
-                .as_fail_descr()
-        {
-            fd.start_compiling();
-        }
-    }
-
-    fn done_compiling_descr(&self, descr_addr: usize) {
-        // `compile.py:790-795 self.done_compiling()` — trait dispatch.
-        if descr_addr == 0 {
-            return;
-        }
-        if let Some(fd) =
-            <Self as majit_backend::Backend>::fail_descr_arc_from_addr(self, descr_addr)
-                .as_fail_descr()
-        {
-            fd.done_compiling();
-        }
-    }
-
     fn migrate_bridges(&self, old_token: &JitCellToken, new_token: &JitCellToken) {
         let old_compiled = old_token
             .compiled

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -124,13 +124,34 @@ static DONE_WITH_THIS_FRAME_DESCR_VOID: std::sync::LazyLock<DescrRef> =
 /// compile.py:665-674 parity: return the singleton FailDescr for a
 /// given Finish result type.  Slice 7-Tβ14f: returns the metainterp
 /// `DescrRef` directly (no cranelift wrapper).
+/// `compile.py:665-674` `make_and_attach_done_descrs` singletons
+/// (`_DoneWithThisFrameDescr*`, `ExitFrameWithExceptionDescrRef`,
+/// `PropagateExceptionDescr`) bake their `Arc::as_ptr` addresses
+/// into the FINISH emit sites (`attached_descr_ptrs_with_fallbacks`)
+/// and propagate trampoline.  Mirror each singleton's address into
+/// `FAIL_DESCR_REGISTRY_GLOBAL` so `Backend::fail_descr_arc_from_addr`
+/// resolves consistently for singletons too — `history.py:109-114`
+/// `AbstractDescr.show` makes no distinction between FINISH and
+/// resume-guard descrs.
+fn register_singleton_in_global(descr: &majit_ir::DescrRef) {
+    let ptr = Arc::as_ptr(descr) as *const () as usize;
+    crate::guard::register_fail_descr_global(ptr, descr);
+}
+
 fn done_with_this_frame_descr(result_types: &[Type]) -> &'static DescrRef {
-    match result_types {
+    let descr = match result_types {
         [Type::Float] => &DONE_WITH_THIS_FRAME_DESCR_FLOAT,
         [Type::Ref] => &DONE_WITH_THIS_FRAME_DESCR_REF,
         [] => &DONE_WITH_THIS_FRAME_DESCR_VOID,
         _ => &DONE_WITH_THIS_FRAME_DESCR_INT,
-    }
+    };
+    // Backend-only test paths bypass `MetaInterp::attach_descrs_to_cpu`
+    // and bake the LazyLock fallback directly; register it on first
+    // access so `fail_descr_arc_from_addr` and CALL_ASSEMBLER lookups
+    // resolve it.  Idempotent: `register_fail_descr_global` `insert`s
+    // the same Weak each time.
+    register_singleton_in_global(descr);
+    descr
 }
 
 /// Helper for the `fail_descrs: Box<[DescrRef]>` storage migration
@@ -199,7 +220,13 @@ fn attached_descr_ptrs_with_fallbacks(
         ),
         exit_frame_with_exception_descr_ref: or_fallback(
             attached.exit_frame_with_exception_descr_ref,
-            Arc::as_ptr(&*EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL) as *const () as i64,
+            {
+                // Backend-only test path: register the LazyLock fallback
+                // into `FAIL_DESCR_REGISTRY_GLOBAL` on first access (see
+                // `done_with_this_frame_descr` rationale).
+                register_singleton_in_global(&EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL);
+                Arc::as_ptr(&*EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL) as *const () as i64
+            },
         ),
         propagate_exception_descr: attached.propagate_exception_descr,
     }
@@ -14008,36 +14035,42 @@ impl majit_backend::Backend for CraneliftBackend {
     }
 
     fn set_done_with_this_frame_descr_void(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_void = Some(descr);
     }
     fn set_done_with_this_frame_descr_int(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_int = Some(descr);
     }
     fn set_done_with_this_frame_descr_ref(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_ref = Some(descr);
     }
     fn set_done_with_this_frame_descr_float(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_float = Some(descr);
     }
     fn set_exit_frame_with_exception_descr_ref(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .exit_frame_with_exception_descr_ref = Some(descr);
     }
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()

--- a/majit/majit-backend-cranelift/src/guard.rs
+++ b/majit/majit-backend-cranelift/src/guard.rs
@@ -18,9 +18,44 @@
 // of truth for both the `_attrs_` set and the backend-only cells.
 use crate::compiler::{register_gc_roots, unregister_gc_roots};
 use majit_backend::{ExitRecoveryLayout, TerminalExitLayout};
-use majit_ir::{DescrRef, GcRef, Type};
+use majit_ir::{Descr, DescrRef, GcRef, Type};
 use std::cell::UnsafeCell;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref) =
+/// cast_gcref_to_instance(...)` parity.  Pyre cannot reconstruct a
+/// fat `Arc<dyn Descr>` from a thin `usize`, so the trampoline-
+/// reachable global Weak registry serves the addr→Arc indirection.
+/// The strong refs that keep entries upgradeable live on the owning
+/// `CompiledLoopToken.asmmemmgr_gcreftracers` (`model.py:294`,
+/// `llmodel.py:252-268 free_loop_and_bridges`); when the CLT drops,
+/// Weak upgrades return `None` on the next lookup.
+static FAIL_DESCR_REGISTRY_GLOBAL:
+    OnceLock<Mutex<HashMap<usize, std::sync::Weak<dyn Descr>>>> = OnceLock::new();
+
+fn fail_descr_registry_global() -> &'static Mutex<HashMap<usize, std::sync::Weak<dyn Descr>>> {
+    FAIL_DESCR_REGISTRY_GLOBAL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn register_fail_descr_global(descr_ptr: usize, descr: &DescrRef) {
+    // `insert` (not `entry().or_insert_with`): after the original descr
+    // at this address is dropped, the allocator may reuse the address
+    // for a freshly registered descr.  Leaving the stale `Weak` in
+    // place would route live guard failures into the fallback path.
+    fail_descr_registry_global()
+        .lock()
+        .expect("FAIL_DESCR_REGISTRY_GLOBAL mutex poisoned")
+        .insert(descr_ptr, std::sync::Arc::downgrade(descr));
+}
+
+pub fn lookup_fail_descr_global(descr_ptr: usize) -> Option<DescrRef> {
+    fail_descr_registry_global()
+        .lock()
+        .expect("FAIL_DESCR_REGISTRY_GLOBAL mutex poisoned")
+        .get(&descr_ptr)
+        .and_then(|w| w.upgrade())
+}
 
 /// Compiled bridge data attached to a guard's fail descriptor.
 ///

--- a/majit/majit-backend-cranelift/src/guard.rs
+++ b/majit/majit-backend-cranelift/src/guard.rs
@@ -18,44 +18,21 @@
 // of truth for both the `_attrs_` set and the backend-only cells.
 use crate::compiler::{register_gc_roots, unregister_gc_roots};
 use majit_backend::{ExitRecoveryLayout, TerminalExitLayout};
-use majit_ir::{Descr, DescrRef, GcRef, Type};
+use majit_ir::{DescrRef, GcRef, Type};
 use std::cell::UnsafeCell;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
-/// `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref) =
-/// cast_gcref_to_instance(...)` parity.  Pyre cannot reconstruct a
-/// fat `Arc<dyn Descr>` from a thin `usize`, so the trampoline-
-/// reachable global Weak registry serves the addr→Arc indirection.
-/// The strong refs that keep entries upgradeable live on the owning
-/// `CompiledLoopToken.asmmemmgr_gcreftracers` (`model.py:294`,
-/// `llmodel.py:252-268 free_loop_and_bridges`); when the CLT drops,
-/// Weak upgrades return `None` on the next lookup.
-static FAIL_DESCR_REGISTRY_GLOBAL:
-    OnceLock<Mutex<HashMap<usize, std::sync::Weak<dyn Descr>>>> = OnceLock::new();
-
-fn fail_descr_registry_global() -> &'static Mutex<HashMap<usize, std::sync::Weak<dyn Descr>>> {
-    FAIL_DESCR_REGISTRY_GLOBAL.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-pub fn register_fail_descr_global(descr_ptr: usize, descr: &DescrRef) {
-    // `insert` (not `entry().or_insert_with`): after the original descr
-    // at this address is dropped, the allocator may reuse the address
-    // for a freshly registered descr.  Leaving the stale `Weak` in
-    // place would route live guard failures into the fallback path.
-    fail_descr_registry_global()
-        .lock()
-        .expect("FAIL_DESCR_REGISTRY_GLOBAL mutex poisoned")
-        .insert(descr_ptr, std::sync::Arc::downgrade(descr));
-}
-
-pub fn lookup_fail_descr_global(descr_ptr: usize) -> Option<DescrRef> {
-    fail_descr_registry_global()
-        .lock()
-        .expect("FAIL_DESCR_REGISTRY_GLOBAL mutex poisoned")
-        .get(&descr_ptr)
-        .and_then(|w| w.upgrade())
-}
+// Slice 80-G.7 (cranelift mirror of dynasm Slice 80-G.6) — the
+// process-global `FAIL_DESCR_REGISTRY_GLOBAL` Weak HashMap was
+// retired.  `history.py:109-114 AbstractDescr.show(cpu, descr_gcref)
+// = cast_gcref_to_instance(...)` parity is now a pure
+// `Arc::from_raw` against the `FailDescrCell` wrapper baked at
+// codegen time (`majit_ir::recover_fail_descr_cell` in
+// `majit-ir/src/descr.rs`).  The strong refcount lives on
+// `CompiledLoop::fail_descr_cells` / `BridgeData::fail_descr_cells`
+// / `RegisteredLoopTarget::fail_descr_cells` for the life of the
+// CLT they belong to (`model.py:294`,
+// `llmodel.py:252-268 free_loop_and_bridges`).
 
 /// Compiled bridge data attached to a guard's fail descriptor.
 ///
@@ -81,6 +58,11 @@ pub struct BridgeData {
     /// contract (compile.py:183-203 record_loop_or_bridge). Position
     /// equals `descr.fail_index` by an invariant asserted at construction.
     pub fail_descrs: Box<[DescrRef]>,
+    /// Position-aligned `FailDescrCell` wrappers (see
+    /// `CompiledLoop::fail_descr_cells`).  Each cell pins the strong
+    /// refcount the JIT-baked `jf_descr` address relies on for
+    /// `Arc::from_raw` recovery (`majit_ir::recover_fail_descr_cell`).
+    pub fail_descr_cells: Box<[Arc<majit_ir::FailDescrCell>]>,
     /// Number of input arguments the bridge expects.
     /// Set to parent guard's fail_arg count (not optimizer-reduced count)
     /// so execute_bridge passes all parent outputs and indices align.

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2657,8 +2657,9 @@ impl<'a> AssemblerARM64<'a> {
                 // and `handle_fail_exit_frame_with_exception` match by
                 // ptr-equality on the singleton, so the cell only carries
                 // the keep-alive identity for `clt.asmmemmgr_gcreftracers`.
-                self.fail_descrs
-                    .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
+                self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
+                    descr.clone() as majit_ir::DescrRef
+                ));
             }
             OpCode::Label => {
                 let label = self.mc.new_dynamic_label();
@@ -3564,7 +3565,9 @@ impl<'a> AssemblerARM64<'a> {
 
     /// assembler.py:1005 write_pending_failure_recoveries.
     /// Returns recovery stub offsets for post-finalize address fixup.
-    fn write_pending_failure_recoveries(&mut self) -> Vec<(std::sync::Arc<majit_ir::FailDescrCell>, usize)> {
+    fn write_pending_failure_recoveries(
+        &mut self,
+    ) -> Vec<(std::sync::Arc<majit_ir::FailDescrCell>, usize)> {
         // Emit a shared _push_all_regs_to_frame routine once, then let each
         // generate_quick_failure() stub call it.
         let save_regs_label = self.mc.new_dynamic_label();
@@ -4410,8 +4413,9 @@ impl<'a> AssemblerARM64<'a> {
 
         // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
         // not the cell pointer (see OpCode::Finish comment above).
-        self.fail_descrs
-            .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
+        self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
+            descr.clone() as majit_ir::DescrRef
+        ));
     }
 
     // ----------------------------------------------------------------

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -337,6 +337,8 @@ pub struct CompiledCode {
     /// AtomicUsize for redirect_call_assembler's update_frame_info
     /// parity: may be updated through &CompiledCode (shared ref).
     pub frame_depth: std::sync::atomic::AtomicUsize,
+    /// `None` for root loops; bridges set `(source_trace_id, source_fail_index_per_trace)`.
+    pub source_guard: Option<(u64, u32)>,
 }
 
 #[allow(dead_code)]
@@ -1450,6 +1452,7 @@ impl<'a> AssemblerARM64<'a> {
             trace_id: self.trace_id,
             header_pc: self.header_pc,
             frame_depth: std::sync::atomic::AtomicUsize::new(self.frame_depth),
+            source_guard: None,
         })
     }
 
@@ -1504,7 +1507,7 @@ impl<'a> AssemblerARM64<'a> {
     /// assembler.py:623 assemble_bridge: compile a bridge trace.
     pub fn assemble_bridge(
         mut self,
-        _: &dyn FailDescr,
+        fail_descr: &dyn FailDescr,
         arglocs: &[Loc],
     ) -> Result<CompiledCode, BackendError> {
         if crate::majit_log_enabled() {
@@ -1575,6 +1578,7 @@ impl<'a> AssemblerARM64<'a> {
             trace_id: self.trace_id,
             header_pc: self.header_pc,
             frame_depth: std::sync::atomic::AtomicUsize::new(self.frame_depth),
+            source_guard: Some((fail_descr.trace_id(), fail_descr.fail_index_per_trace())),
         })
     }
 

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -199,7 +199,7 @@ pub struct AssemblerARM64<'a> {
     /// Frame depth (in WORD units) for the current trace.
     frame_depth: usize,
     /// Fail descriptors built during assembly.
-    fail_descrs: Vec<majit_ir::DescrRef>,
+    fail_descrs: Vec<std::sync::Arc<majit_ir::FailDescrCell>>,
     /// trace_id for this compilation.
     trace_id: u64,
     /// header_pc (green_key) for this compilation.
@@ -300,8 +300,11 @@ struct GuardToken {
     /// Dynamic label that the guard's Jcc jumps to — bound in
     /// write_pending_failure_recoveries to the recovery stub.
     fail_label: DynamicLabel,
-    /// The fail descriptor for this guard.
-    fail_descr: majit_ir::DescrRef,
+    /// The fail descriptor cell for this guard.  `Arc::as_ptr(&fail_descr)`
+    /// is the thin pointer baked into `jf_descr`; the same cell instance is
+    /// stored on `Asm::fail_descrs` so registration on the owning CLT keeps
+    /// it alive while the recovery stub references its address.
+    fail_descr: std::sync::Arc<majit_ir::FailDescrCell>,
     /// Constants to store in frame during recovery.
     /// Each entry: (frame_slot_index, constant_value).
     const_stores: Vec<(usize, i64)>,
@@ -320,7 +323,7 @@ pub struct CompiledCode {
     /// contract (compile.py:183-203 record_loop_or_bridge). Position
     /// equals `descr.fail_index` by an invariant asserted at conversion
     /// from the in-progress `AssemblerARM64.fail_descrs` Vec.
-    pub fail_descrs: Box<[majit_ir::DescrRef]>,
+    pub fail_descrs: Box<[std::sync::Arc<majit_ir::FailDescrCell>]>,
     /// Input argument types.
     pub input_types: Vec<Type>,
     /// `compile.py:665-674` parity: `Arc` clone of the owning cpu's
@@ -2649,7 +2652,13 @@ impl<'a> AssemblerARM64<'a> {
                 }
 
                 self._call_footer();
-                self.fail_descrs.push(descr.clone() as majit_ir::DescrRef);
+                // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
+                // not the cell pointer.  `handle_fail_done_with_this_frame`
+                // and `handle_fail_exit_frame_with_exception` match by
+                // ptr-equality on the singleton, so the cell only carries
+                // the keep-alive identity for `clt.asmmemmgr_gcreftracers`.
+                self.fail_descrs
+                    .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
             }
             OpCode::Label => {
                 let label = self.mc.new_dynamic_label();
@@ -3475,7 +3484,13 @@ impl<'a> AssemblerARM64<'a> {
         // removed — the metainterp's `StoredExitLayout.recovery_layout`
         // (populated by `patch_guard_recovery_layouts_for_trace`)
         // is the canonical store per `resume.py:450-488`.
-        crate::guard::register_source_op_index(Arc::as_ptr(&descr) as *const () as usize, op_index);
+        // Stamp source_op_index directly on the meta descr (UnsafeCell slot
+        // owned by ResumeGuardDescr / ResumeGuardCopiedDescr per
+        // resume_guard_descr.rs:166); `layout_for_fail_descr` reads it back
+        // via `fd.source_op_index()` so no side-table is needed.
+        if descr_fd.is_resume_guard() || descr_fd.is_resume_guard_copied() {
+            descr_fd.set_source_op_index(op_index);
+        }
         // `llsupport/assembler.py:279 guardtok.faildescr.rd_locs = positions`
         // — write through the trait accessor so the metainterp
         // `AbstractFailDescr` (`history.py:132 _attrs_`) receives the
@@ -3491,16 +3506,17 @@ impl<'a> AssemblerARM64<'a> {
         }
         let gcmap = self.guard_gcmap_from_faillocs(descr_fd.fail_arg_types(), faillocs);
 
+        let cell = majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef);
         self.pending_guard_tokens.push(GuardToken {
             fail_label,
-            fail_descr: descr.clone(),
+            fail_descr: cell.clone(),
             const_stores,
             gcmap,
         });
         if op.opcode == OpCode::GuardNotForced2 {
             self.finish_gcmap = Some(gcmap);
         }
-        self.fail_descrs.push(descr.clone() as majit_ir::DescrRef);
+        self.fail_descrs.push(cell);
     }
 
     // ----------------------------------------------------------------
@@ -3515,7 +3531,7 @@ impl<'a> AssemblerARM64<'a> {
         &mut self,
         guard_token: GuardToken,
         save_regs_label: DynamicLabel,
-    ) -> (majit_ir::DescrRef, usize) {
+    ) -> (std::sync::Arc<majit_ir::FailDescrCell>, usize) {
         let stub_start = self.mc.offset();
 
         let fail_label = guard_token.fail_label;
@@ -3548,7 +3564,7 @@ impl<'a> AssemblerARM64<'a> {
 
     /// assembler.py:1005 write_pending_failure_recoveries.
     /// Returns recovery stub offsets for post-finalize address fixup.
-    fn write_pending_failure_recoveries(&mut self) -> Vec<(majit_ir::DescrRef, usize)> {
+    fn write_pending_failure_recoveries(&mut self) -> Vec<(std::sync::Arc<majit_ir::FailDescrCell>, usize)> {
         // Emit a shared _push_all_regs_to_frame routine once, then let each
         // generate_quick_failure() stub call it.
         let save_regs_label = self.mc.new_dynamic_label();
@@ -3590,11 +3606,11 @@ impl<'a> AssemblerARM64<'a> {
     /// buffer-relative offsets to absolute addresses after finalize.
     fn patch_pending_failure_recoveries(
         rawstart: usize,
-        stub_offsets: &[(majit_ir::DescrRef, usize)],
+        stub_offsets: &[(std::sync::Arc<majit_ir::FailDescrCell>, usize)],
     ) {
-        for (descr, stub_offset) in stub_offsets {
+        for (cell, stub_offset) in stub_offsets {
             let abs_addr = rawstart + stub_offset;
-            if let Some(fd) = descr.as_fail_descr() {
+            if let Some(fd) = cell.as_fail_descr() {
                 fd.set_adr_jump_offset(abs_addr);
             }
         }
@@ -4392,7 +4408,10 @@ impl<'a> AssemblerARM64<'a> {
         // Emit epilogue (return jf_ptr).
         self._call_footer();
 
-        self.fail_descrs.push(descr.clone() as majit_ir::DescrRef);
+        // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
+        // not the cell pointer (see OpCode::Finish comment above).
+        self.fail_descrs
+            .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
     }
 
     // ----------------------------------------------------------------

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -273,6 +273,14 @@ pub struct AssemblerARM64<'a> {
     /// jf_force_descr before the call. Consumed by the subsequent
     /// GUARD_NOT_FORCED guard emission.
     pending_force_descr: Option<majit_ir::DescrRef>,
+    /// Pre-wrapped `FailDescrCell` for the same pending guard.  Codegen
+    /// bakes the cell's thin pointer into `JF_FORCE_DESCR_OFS` so that
+    /// `force_token_to_dead_frame` (cranelift/compiler.rs:2660) can
+    /// recover the descr via `recover_fail_descr_cell` without the
+    /// fat-pointer mismatch a bare `Arc<dyn Descr>` ptr would cause.
+    /// The same cell is consumed by `append_guard_token_with_faillocs`
+    /// so jf_force_descr and jf_descr resolve to the same identity.
+    pending_force_cell: Option<std::sync::Arc<majit_ir::FailDescrCell>>,
     /// `compile.py:665-674` + `pyjitpl.py:2283`: construction-time
     /// snapshot of the six descr pointers attached to the owning cpu
     /// instance.  Retained for constructor signature stability across
@@ -419,6 +427,7 @@ impl<'a> AssemblerARM64<'a> {
                 gcmap
             },
             pending_force_descr: None,
+            pending_force_cell: None,
             attached_descrs,
             cpu_handle,
         }
@@ -2657,9 +2666,8 @@ impl<'a> AssemblerARM64<'a> {
                 // and `handle_fail_exit_frame_with_exception` match by
                 // ptr-equality on the singleton, so the cell only carries
                 // the keep-alive identity for `clt.asmmemmgr_gcreftracers`.
-                self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
-                    descr.clone() as majit_ir::DescrRef
-                ));
+                self.fail_descrs
+                    .push(majit_ir::FailDescrCell::wrap(descr.clone()));
             }
             OpCode::Label => {
                 let label = self.mc.new_dynamic_label();
@@ -3507,7 +3515,14 @@ impl<'a> AssemblerARM64<'a> {
         }
         let gcmap = self.guard_gcmap_from_faillocs(descr_fd.fail_arg_types(), faillocs);
 
-        let cell = majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef);
+        // Reuse the cell pre-allocated by `_store_force_index_if_next_guard`
+        // when this guard is paired with a CALL_ASSEMBLER's force-store —
+        // jf_force_descr and jf_descr then resolve to the same cell, and
+        // `fail_descrs[fail_index]` carries exactly one entry per guard.
+        let cell = self
+            .pending_force_cell
+            .take()
+            .unwrap_or_else(|| majit_ir::FailDescrCell::wrap(descr.clone()));
         self.pending_guard_tokens.push(GuardToken {
             fail_label,
             fail_descr: cell.clone(),
@@ -4128,8 +4143,16 @@ impl<'a> AssemblerARM64<'a> {
             }
             fresh
         };
-        let descr_ptr = Arc::as_ptr(&descr) as *const () as i64;
+        // `force_token_to_dead_frame` (cranelift/compiler.rs:2660)
+        // recovers `jf_force_descr` via `recover_fail_descr_cell`, which
+        // requires a `FailDescrCell` thin pointer.  Bake the cell pointer
+        // here (not the bare `Arc<dyn Descr>` fat-pointer data half) and
+        // hand the cell off to `append_guard_token_with_faillocs` so the
+        // inline guard-exit path bakes the same identity into jf_descr.
+        let cell = majit_ir::FailDescrCell::wrap(descr.clone());
+        let descr_ptr = Arc::as_ptr(&cell) as *const () as i64;
         self.pending_force_descr = Some(descr);
+        self.pending_force_cell = Some(cell);
 
         // x86/assembler.py:2210-2222: store descr to jf_force_descr,
         // zero jf_descr.
@@ -4413,9 +4436,8 @@ impl<'a> AssemblerARM64<'a> {
 
         // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
         // not the cell pointer (see OpCode::Finish comment above).
-        self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
-            descr.clone() as majit_ir::DescrRef
-        ));
+        self.fail_descrs
+            .push(majit_ir::FailDescrCell::wrap(descr.clone()));
     }
 
     // ----------------------------------------------------------------

--- a/majit/majit-backend-dynasm/src/guard.rs
+++ b/majit/majit-backend-dynasm/src/guard.rs
@@ -2,79 +2,14 @@
 /// jump offset (`history.py:132 _attrs_` `adr_jump_offset`) lives on the
 /// metainterp `ResumeGuardDescr` (`majit-metainterp/src/compile.rs`) and
 /// is accessed here via `meta_resume_fd()` forwarding.
-use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+use majit_ir::FailDescr;
 
-/// Backend-static side-table mapping a `DynasmFailDescr` Arc's
-/// `Arc::as_ptr` address to the codegen-time `source_op_index`
-/// (the index of the trace op that produced this exit).
-///
-/// PyPy's `AbstractFailDescr._attrs_` (`history.py:132`) does not
-/// carry this slot — RPython's `assembler.py` never re-fetches the
-/// op index after codegen.  Pyre keeps it because backend layouts
-/// (`FailDescrLayout::source_op_index`) cross the backend→metainterp
-/// boundary and the metainterp consumer needs to align deadframe
-/// metadata with the trace it came from.  Sharing the same shape
-/// as the cranelift counterpart (`majit-backend-cranelift/src/
-/// guard.rs::SOURCE_OP_INDEX_TABLE`).
-static SOURCE_OP_INDEX_TABLE: OnceLock<Mutex<HashMap<usize, usize>>> = OnceLock::new();
-
-fn source_op_index_table() -> &'static Mutex<HashMap<usize, usize>> {
-    SOURCE_OP_INDEX_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-pub fn register_source_op_index(descr_ptr: usize, op_index: usize) {
-    source_op_index_table()
-        .lock()
-        .expect("SOURCE_OP_INDEX_TABLE mutex poisoned")
-        .insert(descr_ptr, op_index);
-}
-
-pub fn lookup_source_op_index(descr_ptr: usize) -> Option<usize> {
-    source_op_index_table()
-        .lock()
-        .expect("SOURCE_OP_INDEX_TABLE mutex poisoned")
-        .get(&descr_ptr)
-        .copied()
-}
-
-use majit_ir::{Descr, DescrRef, FailDescr};
-
-/// Backend-static descr-by-address registry, mirroring the per-backend
-/// `DynasmBackend::fail_descr_registry` so the `call_assembler_helper_trampoline`
-/// (which has no `&DynasmBackend` reachable from its `extern "C"` body)
-/// can recover the descr identity without dereferencing the raw pointer
-/// as `*const DynasmFailDescr`.  Stored as `Weak<dyn Descr>` so the
-/// global table does not keep evicted descrs alive past their owning
-/// `CompiledLoop`/`CompiledBridge`; the per-backend registry retains a
-/// strong reference for the live set.
-static FAIL_DESCR_REGISTRY_GLOBAL: OnceLock<Mutex<HashMap<usize, std::sync::Weak<dyn Descr>>>> =
-    OnceLock::new();
-
-fn fail_descr_registry_global() -> &'static Mutex<HashMap<usize, std::sync::Weak<dyn Descr>>> {
-    FAIL_DESCR_REGISTRY_GLOBAL.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-pub fn register_fail_descr_global(descr_ptr: usize, descr: &DescrRef) {
-    // `insert` (not `entry().or_insert_with`): after the original descr
-    // at this address is dropped, the allocator may reuse the address
-    // for a freshly registered descr.  `or_insert_with` would leave the
-    // stale `Weak` in place and `lookup_fail_descr_global` would keep
-    // upgrading to `None`, dropping live guard failures into the
-    // fallback `handle_fail_dispatch == 0` path.
-    fail_descr_registry_global()
-        .lock()
-        .expect("FAIL_DESCR_REGISTRY_GLOBAL mutex poisoned")
-        .insert(descr_ptr, std::sync::Arc::downgrade(descr));
-}
-
-pub fn lookup_fail_descr_global(descr_ptr: usize) -> Option<DescrRef> {
-    fail_descr_registry_global()
-        .lock()
-        .expect("FAIL_DESCR_REGISTRY_GLOBAL mutex poisoned")
-        .get(&descr_ptr)
-        .and_then(|w| w.upgrade())
-}
+// Descr-by-address recovery is now a pure `Arc::from_raw` against the
+// `FailDescrCell` wrapper baked at codegen time —
+// `majit_ir::recover_fail_descr_cell(addr)` in `majit-ir/src/descr.rs`.
+// `history.py:113 AbstractDescr.show(cpu, descr_gcref) =
+// cast_gcref_to_instance(...)` parity.  The strong refcount is held by
+// `CompiledLoopToken.asmmemmgr_gcreftracers` (`model.py:294`).
 
 // RECOVERY_LAYOUT_TABLE removed (Slice NN): `recovery_layout` is not in
 // PyPy `AbstractFailDescr._attrs_` (`history.py:132`).  Upstream resume
@@ -145,7 +80,6 @@ pub use majit_backend::{AttachedDescrPtrs, CpuDescrAttachments, CpuDescrHandle};
 /// must read position from the Vec, not from the descr.
 pub fn layout_for_fail_descr(
     fd: &dyn FailDescr,
-    descr_addr: usize,
     fail_index: u32,
     trace_id: u64,
 ) -> majit_backend::FailDescrLayout {
@@ -159,7 +93,7 @@ pub fn layout_for_fail_descr(
         is_finish: fd.is_finish(),
         is_exception_exit: fd.is_exit_frame_with_exception(),
         trace_id,
-        source_op_index: lookup_source_op_index(descr_addr),
+        source_op_index: fd.source_op_index(),
         // Forward through `FailDescr::is_gc_ref_slot` / `force_token_slots`
         // so concrete descrs that override these (e.g. cranelift descrs
         // that suppress force-token producer slots from GC classification)

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -457,15 +457,15 @@ fn handle_fail_dispatch(
         return handle_fail_propagate_exception(frame_ptr);
     }
     // compile.py:701-717 `AbstractResumeGuardDescr.handle_fail`.
-    // Recover the descr identity through the global Weak-registry that
-    // `DynasmBackend::register_fail_descrs` populates in lockstep with
-    // its per-backend table — only the `FailDescr` trait surface is
-    // consumed.  Synthetic test descrs (lib.rs:781 / :803) never
-    // register, so the miss path returns 0, matching the prior
-    // cast-based path's "no blackhole hook installed" exit.
-    let descr_arc = match guard::lookup_fail_descr_global(descr_raw) {
-        Some(arc) => arc,
-        None => return 0,
+    // `history.py:109-114 AbstractDescr.show(cpu, descr_gcref)` parity:
+    // `descr_raw` is the thin pointer of the `FailDescrCell` baked at
+    // codegen time; reconstruct the cell via `Arc::from_raw` and read
+    // the wrapped descr.  No global lookup — the cell's strong refcount
+    // is held by `clt.asmmemmgr_gcreftracers` for the lifetime of the
+    // executing JIT code.
+    let descr_arc = {
+        let cell = unsafe { majit_ir::recover_fail_descr_cell(descr_raw) };
+        cell.descr.clone()
     };
     let descr_fd = match descr_arc.as_fail_descr() {
         Some(fd) => fd,
@@ -791,13 +791,14 @@ mod tests {
         // checking the trampoline reads fail_arg values correctly.
 
         let descr = majit_backend::make_resume_guard_descr_typed(vec![Type::Int, Type::Int]);
-        let descr_ptr = Arc::as_ptr(&descr) as *const () as usize;
-        guard::register_fail_descr_global(descr_ptr, &descr);
+        let cell = majit_ir::FailDescrCell::wrap(descr.clone());
+        let descr_ptr = Arc::as_ptr(&cell) as *const () as usize;
 
         let jf = unsafe { alloc_test_jitframe(descr_ptr, &[100, 200, 0, 0]) };
         let result = call_assembler_helper_trampoline(std::ptr::null(), jf, 42);
         // No blackhole registered → returns 0, no crash.
         assert_eq!(result, 0);
+        drop(cell);
         drop(descr);
     }
 
@@ -810,14 +811,15 @@ mod tests {
         // table, so this test simply confirms the trampoline returns
         // the blackhole result (or 0) regardless of bridge presence.
         let descr = majit_backend::make_resume_guard_descr_typed(vec![Type::Int]);
-        let descr_ptr = Arc::as_ptr(&descr) as *const () as usize;
-        guard::register_fail_descr_global(descr_ptr, &descr);
+        let cell = majit_ir::FailDescrCell::wrap(descr.clone());
+        let descr_ptr = Arc::as_ptr(&cell) as *const () as usize;
 
         let jf = unsafe { alloc_test_jitframe(descr_ptr, &[123, 0, 0, 0]) };
         let result = call_assembler_helper_trampoline(std::ptr::null(), jf, 99);
         // Helper blackhole-resumes (no blackhole registered → 0), NOT bridge result.
         assert_eq!(result, 0);
 
+        drop(cell);
         drop(descr);
     }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -686,15 +686,6 @@ pub struct DynasmBackend {
     descr_attachments: crate::guard::CpuDescrHandle,
     /// ptr → `DescrRef` registry enabling cross-token resolution of
     /// guard fail descriptors. RPython resolves
-    /// `AbstractDescr.show(jf_descr)` via direct pointer dereference,
-    /// so the lookup naturally crosses loop/bridge boundaries. Pyre
-    /// keeps each descr as a `DescrRef` and stores them in per-token
-    /// `asmmemmgr_blocks`, so a bridge that JUMPs into another
-    /// compiled loop can leave the runtime holding a jf_descr whose
-    /// owning token is not the one currently executing. This registry
-    /// is the ptr-indexed view needed to complete that lookup.
-    fail_descr_registry:
-        Arc<std::sync::Mutex<std::collections::HashMap<usize, majit_ir::DescrRef>>>,
     /// Backend-internal side-table mapping a source guard descr's
     /// `Arc::as_ptr` address to the entry pointer of the compiled bridge
     /// patched in for that guard.  PyPy's `AbstractFailDescr._attrs_`
@@ -798,7 +789,6 @@ impl DynasmBackend {
             descr_attachments: Arc::new(std::sync::RwLock::new(
                 crate::guard::CpuDescrAttachments::default(),
             )),
-            fail_descr_registry: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             bridge_addr_by_descr: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             arch_cpu_ext: ArchCpuExt::new(),
         }
@@ -930,17 +920,23 @@ impl DynasmBackend {
     /// `free_loop_and_bridges` drops the CLT (`llmodel.py:252-268`).
     pub fn register_fail_descrs(&self, token: &majit_backend::JitCellToken, descrs: &[majit_ir::DescrRef]) {
         // `assembler.py:820-823` parity: each call appends one tracer.
+        // `clt.asmmemmgr_gcreftracers` is the sole lifetime root for the
+        // baked descrs (`model.py:294` / `llmodel.py:252-268
+        // free_loop_and_bridges`).
         if let Some(clt) = token.compiled_loop_token.as_ref() {
             let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(descrs.to_vec());
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
         }
-        let mut reg = self.fail_descr_registry.lock().unwrap();
+        // The trampoline-reachable global Weak registry retains the
+        // addr→`Weak<dyn Descr>` lookup PyPy's
+        // `AbstractDescr.show(cpu, descr_gcref) =
+        // cast_gcref_to_instance(...)` does as a direct cast; pyre needs
+        // the indirection because a thin `usize` can't reconstruct the
+        // fat `Arc<dyn Descr>` vtable.  Eviction is implicit: when the
+        // owning CLT drops, the tracer batch drops, the descr `Arc`s
+        // drop, and Weak upgrades return `None`.
         for descr_ref in descrs {
             let ptr = Arc::as_ptr(descr_ref) as *const () as usize;
-            reg.entry(ptr).or_insert_with(|| descr_ref.clone());
-            // Mirror into the trampoline-reachable global registry as a
-            // `Weak<dyn Descr>` so the JIT helper trampoline can recover
-            // the descr identity without going through a backend instance.
             crate::guard::register_fail_descr_global(ptr, descr_ref);
         }
     }
@@ -1422,10 +1418,10 @@ impl DynasmBackend {
         // currently-executing `token` is still A. RPython's
         // `AbstractDescr.show(jf_descr)` dereferences the pointer directly,
         // so the lookup is inherently global; pyre emulates that with the
-        // per-backend ptr-indexed registry populated by `compile_loop` /
-        // `compile_bridge`.
-        if let Some(found) = self.fail_descr_registry.lock().unwrap().get(&ptr) {
-            return found.clone();
+        // process-global Weak registry populated by `register_fail_descrs`
+        // (strong refs live on `clt.asmmemmgr_gcreftracers`).
+        if let Some(found) = crate::guard::lookup_fail_descr_global(ptr) {
+            return found;
         }
 
         panic!(
@@ -2306,53 +2302,28 @@ impl Backend for DynasmBackend {
         Arc::clone(&data.fail_descr)
     }
 
-    /// `fail_descr_registry` is the `addr → DescrRef` table populated by
-    /// `register_fail_descrs` at compile time, keeping every emitted
-    /// descr alive for the lifetime of its owning compiled code
-    /// (mirroring RPython's `cpu` retaining descr objects).  The cloned
-    /// `DescrRef` lets the CA bridge entry route descr identity into
-    /// `_trace_and_compile_from_bridge` (compile.py:704-709) without
-    /// going through the `(trace_id, fail_index)` surrogate key.
+    /// `llmodel.py:252-268 free_loop_and_bridges` parity.  When the CLT
+    /// drops, `asmmemmgr_gcreftracers` releases its strong refs to the
+    /// baked descrs (`clear_gcref_tracer` per tracer); Weak entries in
+    /// the global `FAIL_DESCR_REGISTRY_GLOBAL` upgrade to `None` next
+    /// time someone looks them up.  Only `bridge_addr_by_descr` (a pyre-
+    /// only slot — `history.py:132` `AbstractFailDescr._attrs_` has no
+    /// `bridge_addr`) still requires explicit eviction here; we
+    /// enumerate the token's descrs through the tracer batches and
+    /// remove the matching `bridge_addr_by_descr` entries.
     fn free_loop(&mut self, token: &JitCellToken) {
-        // memmgr.py:9 `MemoryManager.alive_loops` parity: when a JCT is
-        // evicted, RPython's GC reclaims the token's compiled code and
-        // every dependent FailDescr naturally because nothing keeps a
-        // strong ref past `alive_loops`.  Pyre's `fail_descr_registry`
-        // holds strong Arcs to every emitted descr for the C-ABI
-        // recovery path (`fail_descr_arc_from_addr` parity with
-        // `cpu.get_latest_descr`), so we must explicitly release the
-        // entries belonging to this token here — otherwise the descrs
-        // (and their `rd_loop_token_clt` chain) outlive their owning
-        // loop and pyre keeps memory PyPy would have freed.
-        //
-        // Sweep entries whose owning-JCT upgrade points back at this
-        // token. Ownerless entries (`descr_owning_jct == None`) are
-        // PRESERVED: in PyPy these correspond to FINISH descrs
-        // (`_DoneWithThisFrameDescr` family / `ExitFrameWithExceptionDescr`,
-        // `compile.py:185` skipped via `isinstance(descr, ResumeDescr)`)
-        // which are module-level singletons not subject to per-loop GC.
-        // Treating `None` as "delete" would over-shoot PyPy's lifetime
-        // contract.
+        let Some(clt) = token.compiled_loop_token.as_ref() else {
+            return;
+        };
         let mut removed_bridge_addr_keys = Vec::new();
-        let mut registry = self
-            .fail_descr_registry
-            .lock()
-            .expect("fail_descr_registry mutex poisoned");
-        registry.retain(|_, descr| {
-            let dyn_descr = match descr.as_fail_descr() {
-                Some(fd) => fd,
-                None => return true,
-            };
-            match majit_backend::descr_owning_jct(dyn_descr) {
-                Some(owner) if owner.number == token.number => {
-                    removed_bridge_addr_keys.push(Arc::as_ptr(descr) as *const () as usize);
-                    false
+        for tracer in clt.asmmemmgr_gcreftracers.lock().iter() {
+            if let Some(descrs) = tracer.downcast_ref::<Vec<majit_ir::DescrRef>>() {
+                for descr in descrs {
+                    removed_bridge_addr_keys
+                        .push(Arc::as_ptr(descr) as *const () as usize);
                 }
-                Some(_) => true,
-                None => true,
             }
-        });
-        drop(registry);
+        }
         if !removed_bridge_addr_keys.is_empty() {
             let mut bridge_addrs = self
                 .bridge_addr_by_descr
@@ -2365,24 +2336,20 @@ impl Backend for DynasmBackend {
     }
 
     fn fail_descr_arc_from_addr(&self, descr_addr: usize) -> majit_ir::DescrRef {
-        // warmspot.py:1021 cpu.get_latest_descr(deadframe) parity: the
-        // dynasm registry holds a strong DescrRef for every emitted
-        // descr through its full lifetime, so a `descr_addr` arriving
-        // from the C-ABI guard-fail path is always present in the
-        // table.  A miss is an invariant violation, not a recoverable
-        // runtime mode.
-        let registry = self
-            .fail_descr_registry
-            .lock()
-            .expect("fail_descr_registry mutex poisoned");
-        let descr = registry.get(&descr_addr).cloned().unwrap_or_else(|| {
+        // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref) =
+        // cast_gcref_to_instance(...)` parity.  Pyre routes through the
+        // process-global Weak registry populated by
+        // `register_fail_descrs`; the strong refs that keep the entries
+        // upgradeable live on `clt.asmmemmgr_gcreftracers`
+        // (`model.py:294`).
+        crate::guard::lookup_fail_descr_global(descr_addr).unwrap_or_else(|| {
             panic!(
                 "fail_descr_arc_from_addr: descr_addr {descr_addr:#x} not in \
-                 fail_descr_registry — every emitted fail descr must be \
-                 registered before its address reaches the C-ABI guard-fail boundary"
+                 FAIL_DESCR_REGISTRY_GLOBAL — every emitted fail descr must \
+                 be registered before its address reaches the C-ABI guard-fail \
+                 boundary, and its owning CLT must still be live"
             )
-        });
-        descr as majit_ir::DescrRef
+        })
     }
 
     fn get_int_value(&self, frame: &DeadFrame, index: usize) -> i64 {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -14,6 +14,22 @@ use majit_ir::{FailDescr, GcRef, InputArg, Op, OpRc, OpRef, Type, Value};
 
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::assembler::{AssemblerARM64 as Asm, CompiledCode};
+
+/// `compile.py:665-674` `make_and_attach_done_descrs` singletons
+/// (`_DoneWithThisFrameDescr*`, `ExitFrameWithExceptionDescrRef`,
+/// `PropagateExceptionDescr`) bake their `Arc::as_ptr` addresses into
+/// the assembler's FINISH / propagate trampolines (see
+/// `attached_descr_ptrs_with_fallbacks` and
+/// `X86CpuExt::ensure_propagate_exception_path`).  Mirror each
+/// singleton's address into `FAIL_DESCR_REGISTRY_GLOBAL` so
+/// `Backend::fail_descr_arc_from_addr` resolves consistently for
+/// singletons too — `history.py:109-114` `AbstractDescr.show` makes
+/// no distinction between FINISH and resume-guard descrs.
+fn register_singleton_in_global(descr: &majit_ir::DescrRef) {
+    let ptr = Arc::as_ptr(descr) as *const () as usize;
+    crate::guard::register_fail_descr_global(ptr, descr);
+}
+
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::cpu_ext::Aarch64CpuExt as ArchCpuExt;
 use crate::arch;
@@ -905,6 +921,7 @@ impl DynasmBackend {
     /// token boundaries — required when a bridge JUMPs into another
     /// compiled loop and that loop's guard fires before control returns
     /// to the bridge's owning token.
+
     /// Register `DescrRef` instances into the addr→`DescrRef` lookup
     /// table.  Called from `compile_loop` / `compile_bridge` to
     /// populate after codegen.  Re-running is idempotent: existing
@@ -1772,30 +1789,35 @@ impl Backend for DynasmBackend {
     }
 
     fn set_done_with_this_frame_descr_void(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_void = Some(descr);
     }
     fn set_done_with_this_frame_descr_int(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_int = Some(descr);
     }
     fn set_done_with_this_frame_descr_ref(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_ref = Some(descr);
     }
     fn set_done_with_this_frame_descr_float(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_float = Some(descr);
     }
     fn set_exit_frame_with_exception_descr_ref(&mut self, descr: majit_ir::DescrRef) {
+        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
@@ -1843,6 +1865,7 @@ impl Backend for DynasmBackend {
              previous descr pointer; bind propagate_exception_descr once \
              before backend.setup_once() (pyjitpl.py:2273-2283 ordering)"
         );
+        register_singleton_in_global(&descr);
         attachments.propagate_exception_descr = Some(descr);
     }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -15,21 +15,6 @@ use majit_ir::{FailDescr, GcRef, InputArg, Op, OpRc, OpRef, Type, Value};
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::assembler::{AssemblerARM64 as Asm, CompiledCode};
 
-/// `compile.py:665-674` `make_and_attach_done_descrs` singletons
-/// (`_DoneWithThisFrameDescr*`, `ExitFrameWithExceptionDescrRef`,
-/// `PropagateExceptionDescr`) bake their `Arc::as_ptr` addresses into
-/// the assembler's FINISH / propagate trampolines (see
-/// `attached_descr_ptrs_with_fallbacks` and
-/// `X86CpuExt::ensure_propagate_exception_path`).  Mirror each
-/// singleton's address into `FAIL_DESCR_REGISTRY_GLOBAL` so
-/// `Backend::fail_descr_arc_from_addr` resolves consistently for
-/// singletons too — `history.py:109-114` `AbstractDescr.show` makes
-/// no distinction between FINISH and resume-guard descrs.
-fn register_singleton_in_global(descr: &majit_ir::DescrRef) {
-    let ptr = Arc::as_ptr(descr) as *const () as usize;
-    crate::guard::register_fail_descr_global(ptr, descr);
-}
-
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::cpu_ext::Aarch64CpuExt as ArchCpuExt;
 use crate::arch;
@@ -917,26 +902,21 @@ impl DynasmBackend {
     /// the descr `Arc`s for the lifetime of the compiled loop so the
     /// addresses baked into machine code stay live until
     /// `free_loop_and_bridges` drops the CLT (`llmodel.py:252-268`).
-    pub fn register_fail_descrs(&self, token: &majit_backend::JitCellToken, descrs: &[majit_ir::DescrRef]) {
+    pub fn register_fail_descrs(
+        &self,
+        token: &majit_backend::JitCellToken,
+        cells: &[Arc<majit_ir::FailDescrCell>],
+    ) {
         // `assembler.py:820-823` parity: each call appends one tracer.
         // `clt.asmmemmgr_gcreftracers` is the sole lifetime root for the
         // baked descrs (`model.py:294` / `llmodel.py:252-268
-        // free_loop_and_bridges`).
+        // free_loop_and_bridges`).  The cells' addresses are baked into
+        // machine code, so the tracer must keep them alive — recovery
+        // (`recover_fail_descr_cell`) does `Arc::increment_strong_count`
+        // against these live cells and would UB-fault otherwise.
         if let Some(clt) = token.compiled_loop_token.as_ref() {
-            let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(descrs.to_vec());
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(cells.to_vec());
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
-        }
-        // The trampoline-reachable global Weak registry retains the
-        // addr→`Weak<dyn Descr>` lookup PyPy's
-        // `AbstractDescr.show(cpu, descr_gcref) =
-        // cast_gcref_to_instance(...)` does as a direct cast; pyre needs
-        // the indirection because a thin `usize` can't reconstruct the
-        // fat `Arc<dyn Descr>` vtable.  Eviction is implicit: when the
-        // owning CLT drops, the tracer batch drops, the descr `Arc`s
-        // drop, and Weak upgrades return `None`.
-        for descr_ref in descrs {
-            let ptr = Arc::as_ptr(descr_ref) as *const () as usize;
-            crate::guard::register_fail_descr_global(ptr, descr_ref);
         }
     }
 
@@ -1393,7 +1373,7 @@ impl DynasmBackend {
             .iter()
             .find(|d| Arc::as_ptr(d) as *const () as usize == ptr)
         {
-            return found.clone();
+            return found.descr.clone();
         }
 
         // Search bridge fail_descrs in asmmemmgr_blocks
@@ -1405,30 +1385,23 @@ impl DynasmBackend {
                     .iter()
                     .find(|d| Arc::as_ptr(d) as *const () as usize == ptr)
                 {
-                    return found.clone();
+                    return found.descr.clone();
                 }
             }
         }
         drop(blocks);
 
         // Cross-token fallback: a bridge attached to loop A may JUMP into
-        // loop B's body. When B's guard fires, the jf_descr ptr identifies
+        // loop B's body.  When B's guard fires, the jf_descr ptr identifies
         // a fail descr owned by B (or by a bridge attached to B), but the
-        // currently-executing `token` is still A. RPython's
-        // `AbstractDescr.show(jf_descr)` dereferences the pointer directly,
-        // so the lookup is inherently global; pyre emulates that with the
-        // process-global Weak registry populated by `register_fail_descrs`
-        // (strong refs live on `clt.asmmemmgr_gcreftracers`).
-        if let Some(found) = crate::guard::lookup_fail_descr_global(ptr) {
-            return found;
-        }
-
-        panic!(
-            "find_descr_by_ptr: jf_descr {:#x} not found in root loop, \
-             bridges, or ptr registry — RPython equivalent \
-             (AbstractDescr.show) never fails",
-            ptr
-        );
+        // currently-executing `token` is still A.  RPython's
+        // `AbstractDescr.show(jf_descr)` dereferences the pointer directly;
+        // pyre matches that via `recover_fail_descr_cell`, a pure cast
+        // through `Arc::from_raw` against the `FailDescrCell` wrapper that
+        // `register_fail_descrs` pinned onto the owning CLT's
+        // `asmmemmgr_gcreftracers`.
+        let cell = unsafe { majit_ir::recover_fail_descr_cell(ptr) };
+        cell.descr.clone()
     }
 
     /// Find a descr by (trace_id, fail_index) across root loop + all
@@ -1490,7 +1463,7 @@ impl DynasmBackend {
         // with the trait default `0`.
         if compiled.trace_id == trace_id {
             if let Some(found) = compiled.fail_descrs.get(fail_index as usize) {
-                return Some(found.clone());
+                return Some(found.descr.clone());
             }
         }
         let blocks = token.asmmemmgr_blocks();
@@ -1498,7 +1471,7 @@ impl DynasmBackend {
             if let Some(bridge) = block.downcast_ref::<CompiledCode>() {
                 if bridge.trace_id == trace_id {
                     if let Some(found) = bridge.fail_descrs.get(fail_index as usize) {
-                        return Some(found.clone());
+                        return Some(found.descr.clone());
                     }
                 }
             }
@@ -1771,35 +1744,30 @@ impl Backend for DynasmBackend {
     }
 
     fn set_done_with_this_frame_descr_void(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_void = Some(descr);
     }
     fn set_done_with_this_frame_descr_int(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_int = Some(descr);
     }
     fn set_done_with_this_frame_descr_ref(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_ref = Some(descr);
     }
     fn set_done_with_this_frame_descr_float(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
             .done_with_this_frame_descr_float = Some(descr);
     }
     fn set_exit_frame_with_exception_descr_ref(&mut self, descr: majit_ir::DescrRef) {
-        register_singleton_in_global(&descr);
         self.descr_attachments
             .write()
             .unwrap()
@@ -1847,7 +1815,6 @@ impl Backend for DynasmBackend {
              previous descr pointer; bind propagate_exception_descr once \
              before backend.setup_once() (pyjitpl.py:2273-2283 ordering)"
         );
-        register_singleton_in_global(&descr);
         attachments.propagate_exception_descr = Some(descr);
     }
 
@@ -2263,7 +2230,6 @@ impl Backend for DynasmBackend {
         }
         let exit_layout = Some(crate::guard::layout_for_fail_descr(
             descr_fd,
-            descr_addr,
             descr_fd.fail_index_per_trace(),
             descr_fd.trace_id(),
         ));
@@ -2309,26 +2275,21 @@ impl Backend for DynasmBackend {
 
     /// `llmodel.py:252-268 free_loop_and_bridges` parity.  When the CLT
     /// drops, `asmmemmgr_gcreftracers` releases its strong refs to the
-    /// baked descrs (`clear_gcref_tracer` per tracer); Weak entries in
-    /// the global `FAIL_DESCR_REGISTRY_GLOBAL` upgrade to `None` next
-    /// time someone looks them up.
+    /// baked `FailDescrCell` Arcs; subsequent recovery from a stale
+    /// address would be UB, but the JIT-emitted code holding the address
+    /// is also retired when its CLT drops, so no live caller can reach a
+    /// stale `descr_addr`.
     fn free_loop(&mut self, _token: &JitCellToken) {}
 
     fn fail_descr_arc_from_addr(&self, descr_addr: usize) -> majit_ir::DescrRef {
-        // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref) =
-        // cast_gcref_to_instance(...)` parity.  Pyre routes through the
-        // process-global Weak registry populated by
-        // `register_fail_descrs`; the strong refs that keep the entries
-        // upgradeable live on `clt.asmmemmgr_gcreftracers`
-        // (`model.py:294`).
-        crate::guard::lookup_fail_descr_global(descr_addr).unwrap_or_else(|| {
-            panic!(
-                "fail_descr_arc_from_addr: descr_addr {descr_addr:#x} not in \
-                 FAIL_DESCR_REGISTRY_GLOBAL — every emitted fail descr must \
-                 be registered before its address reaches the C-ABI guard-fail \
-                 boundary, and its owning CLT must still be live"
-            )
-        })
+        // `history.py:109-114 AbstractDescr.show(cpu, descr_gcref) =
+        // cast_gcref_to_instance(...)` parity.  `descr_addr` is the thin
+        // pointer to the `FailDescrCell` that was baked at codegen time;
+        // recovery is a direct `Arc::from_raw` with a refcount bump.
+        // Safety: the cell is kept alive by `clt.asmmemmgr_gcreftracers`
+        // for the life of the executing JIT code (`model.py:294`).
+        let cell = unsafe { majit_ir::recover_fail_descr_cell(descr_addr) };
+        cell.descr.clone()
     }
 
     fn get_int_value(&self, frame: &DeadFrame, index: usize) -> i64 {
@@ -2933,7 +2894,6 @@ impl Backend for DynasmBackend {
                 .map(|(idx, d)| {
                     crate::guard::layout_for_fail_descr(
                         d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
-                        Arc::as_ptr(d) as *const () as usize,
                         idx as u32,
                         trace_id,
                     )
@@ -2957,7 +2917,6 @@ impl Backend for DynasmBackend {
                     .map(|(idx, d)| {
                         crate::guard::layout_for_fail_descr(
                             d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
-                            Arc::as_ptr(d) as *const () as usize,
                             idx as u32,
                             trace_id,
                         )
@@ -2978,7 +2937,6 @@ impl Backend for DynasmBackend {
                             .map(|(idx, d)| {
                                 crate::guard::layout_for_fail_descr(
                                     d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
-                                    Arc::as_ptr(d) as *const () as usize,
                                     idx as u32,
                                     trace_id,
                                 )
@@ -3021,7 +2979,6 @@ impl Backend for DynasmBackend {
                             .map(|(idx, d)| {
                                 crate::guard::layout_for_fail_descr(
                                     d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
-                                    Arc::as_ptr(d) as *const () as usize,
                                     idx as u32,
                                     bridge_trace_id,
                                 )

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2506,44 +2506,6 @@ impl Backend for DynasmBackend {
         }
     }
 
-    fn read_descr_status(&self, descr_addr: usize) -> u64 {
-        // `compile.py:741 self.status` — route through the registry-backed
-        // `Arc<dyn FailDescr>` so the dispatch is trait-based.  Once
-        // `jf_descr` carries the meta Arc address (Unified-Descr identity
-        // flip), only the registry value changes; this dispatch chain
-        // stays the same.
-        if descr_addr == 0 {
-            return 0;
-        }
-        <Self as Backend>::fail_descr_arc_from_addr(self, descr_addr)
-            .as_fail_descr()
-            .map_or(0, |fd| fd.get_status())
-    }
-
-    fn start_compiling_descr(&self, descr_addr: usize) {
-        // `compile.py:786-788 self.start_compiling()` — trait dispatch.
-        if descr_addr == 0 {
-            return;
-        }
-        if let Some(fd) =
-            <Self as Backend>::fail_descr_arc_from_addr(self, descr_addr).as_fail_descr()
-        {
-            fd.start_compiling();
-        }
-    }
-
-    fn done_compiling_descr(&self, descr_addr: usize) {
-        // `compile.py:790-795 self.done_compiling()` — trait dispatch.
-        if descr_addr == 0 {
-            return;
-        }
-        if let Some(fd) =
-            <Self as Backend>::fail_descr_arc_from_addr(self, descr_addr).as_fail_descr()
-        {
-            fd.done_compiling();
-        }
-    }
-
     fn bh_new(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
         let size = sizedescr.as_size();
         let ptr = unsafe { libc::malloc(size) };

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -700,19 +700,6 @@ pub struct DynasmBackend {
     /// owning backend — matches the lifetime guarantee RPython gets from
     /// `cpu` being a long-lived Python object.
     descr_attachments: crate::guard::CpuDescrHandle,
-    /// ptr → `DescrRef` registry enabling cross-token resolution of
-    /// guard fail descriptors. RPython resolves
-    /// Backend-internal side-table mapping a source guard descr's
-    /// `Arc::as_ptr` address to the entry pointer of the compiled bridge
-    /// patched in for that guard.  PyPy's `AbstractFailDescr._attrs_`
-    /// (`history.py:132`) carries no `bridge_addr` slot; once a bridge is
-    /// patched in, RPython relies on the in-place machine-code JMP and
-    /// recovers structural state from `asmmemmgr_blocks`.  Pyre's
-    /// metainterp queries `store_bridge_guard_hashes` /
-    /// `compiled_bridge_fail_descr_layouts` need to walk back from a
-    /// source descr to its bridge `CompiledCode`; this table is the
-    /// indirection that lets us do that without polluting the descr.
-    bridge_addr_by_descr: Arc<std::sync::Mutex<std::collections::HashMap<usize, usize>>>,
     /// Arch-specific per-CPU state PyPy keeps on `Assembler386` /
     /// `AssemblerARM64` (e.g. `self.malloc_slowpath`,
     /// `self.propagate_exception_path` at `assembler.py:63,344` and
@@ -805,34 +792,29 @@ impl DynasmBackend {
             descr_attachments: Arc::new(std::sync::RwLock::new(
                 crate::guard::CpuDescrAttachments::default(),
             )),
-            bridge_addr_by_descr: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             arch_cpu_ext: ArchCpuExt::new(),
         }
     }
 
-    /// Bridge entry-pointer registration keyed on the source guard
-    /// descr's `Arc::as_ptr` address.  Called from `compile_bridge`
-    /// immediately after `patch_jump_for_descr` redirects the source
-    /// guard at `runner.rs::compile_bridge` to point at the freshly
-    /// compiled bridge.
-    pub fn register_bridge_addr(&self, source_descr_ptr: usize, bridge_addr: usize) {
-        self.bridge_addr_by_descr
-            .lock()
-            .expect("bridge_addr_by_descr mutex poisoned")
-            .insert(source_descr_ptr, bridge_addr);
-    }
-
-    /// Bridge entry-pointer lookup by source descr `Arc::as_ptr` address.
-    /// Returns `0` when no bridge has been registered for the source
-    /// (PyPy parity: `assembler.py` treats `adr_jump_offset == 0`
-    /// uniformly as "patched / no entry").
-    pub fn lookup_bridge_addr(&self, source_descr_ptr: usize) -> usize {
-        self.bridge_addr_by_descr
-            .lock()
-            .expect("bridge_addr_by_descr mutex poisoned")
-            .get(&source_descr_ptr)
-            .copied()
-            .unwrap_or(0)
+    /// Bridge entry-pointer lookup by source guard `(trace_id, fail_index_per_trace)`.
+    /// Scans `token.asmmemmgr_blocks` for a `CompiledCode` whose `source_guard`
+    /// matches; returns `0` if none — `assembler.py` treats `adr_jump_offset == 0`
+    /// uniformly as "patched / no entry".
+    pub fn lookup_bridge_addr(
+        &self,
+        token: &JitCellToken,
+        source_trace_id: u64,
+        source_fail_index: u32,
+    ) -> usize {
+        let blocks = token.asmmemmgr_blocks();
+        for block in blocks.iter() {
+            if let Some(bridge) = block.downcast_ref::<CompiledCode>() {
+                if bridge.source_guard == Some((source_trace_id, source_fail_index)) {
+                    return codebuf::buffer_ptr(&bridge.buffer) as usize;
+                }
+            }
+        }
+        0
     }
 
     /// Test helper: attach synthetic per-cpu `DoneWithThisFrame*` +
@@ -1993,7 +1975,6 @@ impl Backend for DynasmBackend {
         }
         if ajo != 0 {
             Asm::patch_jump_for_descr(guard_fd, bridge_addr);
-            self.register_bridge_addr(Arc::as_ptr(&guard_descr) as *const () as usize, bridge_addr);
         } else {
             majit_ir::debug::log_one(
                 "jit-backend",
@@ -2116,8 +2097,9 @@ impl Backend for DynasmBackend {
         // Debug: verify bridge patches are visible
         if crate::majit_log_enabled() {
             for descr in &compiled.fail_descrs {
-                let bridge_addr = self.lookup_bridge_addr(Arc::as_ptr(descr) as *const () as usize);
                 if let Some(fd) = descr.as_fail_descr() {
+                    let bridge_addr =
+                        self.lookup_bridge_addr(token, fd.trace_id(), fd.fail_index_per_trace());
                     if bridge_addr != 0 && fd.adr_jump_offset() == 0 {
                         eprintln!(
                             "[dynasm] bridge-patched guard fi={} bridge_addr={:#x} ajo=0 (patched)",
@@ -2329,34 +2311,8 @@ impl Backend for DynasmBackend {
     /// drops, `asmmemmgr_gcreftracers` releases its strong refs to the
     /// baked descrs (`clear_gcref_tracer` per tracer); Weak entries in
     /// the global `FAIL_DESCR_REGISTRY_GLOBAL` upgrade to `None` next
-    /// time someone looks them up.  Only `bridge_addr_by_descr` (a pyre-
-    /// only slot — `history.py:132` `AbstractFailDescr._attrs_` has no
-    /// `bridge_addr`) still requires explicit eviction here; we
-    /// enumerate the token's descrs through the tracer batches and
-    /// remove the matching `bridge_addr_by_descr` entries.
-    fn free_loop(&mut self, token: &JitCellToken) {
-        let Some(clt) = token.compiled_loop_token.as_ref() else {
-            return;
-        };
-        let mut removed_bridge_addr_keys = Vec::new();
-        for tracer in clt.asmmemmgr_gcreftracers.lock().iter() {
-            if let Some(descrs) = tracer.downcast_ref::<Vec<majit_ir::DescrRef>>() {
-                for descr in descrs {
-                    removed_bridge_addr_keys
-                        .push(Arc::as_ptr(descr) as *const () as usize);
-                }
-            }
-        }
-        if !removed_bridge_addr_keys.is_empty() {
-            let mut bridge_addrs = self
-                .bridge_addr_by_descr
-                .lock()
-                .expect("bridge_addr_by_descr mutex poisoned");
-            for key in removed_bridge_addr_keys {
-                bridge_addrs.remove(&key);
-            }
-        }
-    }
+    /// time someone looks them up.
+    fn free_loop(&mut self, _token: &JitCellToken) {}
 
     fn fail_descr_arc_from_addr(&self, descr_addr: usize) -> majit_ir::DescrRef {
         // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref) =
@@ -2490,8 +2446,7 @@ impl Backend for DynasmBackend {
         source_fail_index: u32,
         hashes: &[u64],
     ) {
-        let source_descr = Self::find_descr(token, source_trace_id, source_fail_index);
-        let bridge_addr = self.lookup_bridge_addr(Arc::as_ptr(&source_descr) as *const () as usize);
+        let bridge_addr = self.lookup_bridge_addr(token, source_trace_id, source_fail_index);
         if bridge_addr == 0 {
             return;
         }
@@ -3047,9 +3002,8 @@ impl Backend for DynasmBackend {
         // by (trace_id, fail_index) and must treat the miss as `None`
         // — match cranelift's `?` semantics in
         // `compiler.rs:11723 compiled_bridge_fail_descr_layouts`.
-        let source_descr =
-            Self::try_find_descr(original_token, source_trace_id, source_fail_index)?;
-        let bridge_addr = self.lookup_bridge_addr(Arc::as_ptr(&source_descr) as *const () as usize);
+        let bridge_addr =
+            self.lookup_bridge_addr(original_token, source_trace_id, source_fail_index);
         if bridge_addr == 0 {
             return None;
         }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -919,7 +919,21 @@ impl DynasmBackend {
     /// table.  Called from `compile_loop` / `compile_bridge` to
     /// populate after codegen.  Re-running is idempotent: existing
     /// entries are preserved via `entry().or_insert_with`.
-    pub fn register_fail_descrs(&self, descrs: &[majit_ir::DescrRef]) {
+    ///
+    /// Lifetime root: `token.compiled_loop_token.asmmemmgr_gcreftracers`
+    /// (`model.py:294`, `llsupport/assembler.py:190-194`
+    /// `get_asmmemmgr_gcreftracers`).  Pushes one tracer per
+    /// `register_fail_descrs` call mirroring
+    /// `assembler.py:822 gcreftracers.append(tracer)`; the tracer owns
+    /// the descr `Arc`s for the lifetime of the compiled loop so the
+    /// addresses baked into machine code stay live until
+    /// `free_loop_and_bridges` drops the CLT (`llmodel.py:252-268`).
+    pub fn register_fail_descrs(&self, token: &majit_backend::JitCellToken, descrs: &[majit_ir::DescrRef]) {
+        // `assembler.py:820-823` parity: each call appends one tracer.
+        if let Some(clt) = token.compiled_loop_token.as_ref() {
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(descrs.to_vec());
+            clt.asmmemmgr_gcreftracers.lock().push(tracer);
+        }
         let mut reg = self.fail_descr_registry.lock().unwrap();
         for descr_ref in descrs {
             let ptr = Arc::as_ptr(descr_ref) as *const () as usize;
@@ -1681,7 +1695,7 @@ impl Backend for DynasmBackend {
         let code_size = compiled.buffer.len();
         let frame_depth = compiled.frame_depth.load(Ordering::Acquire) as i64;
         Self::register_call_assembler_target(token, code_addr);
-        self.register_fail_descrs(&compiled.fail_descrs);
+        self.register_fail_descrs(token, &compiled.fail_descrs);
 
         // `compile.py:183-186 record_loop_or_bridge`: for each ResumeDescr
         // in the newly-compiled trace, stamp the owning CompiledLoopToken.
@@ -1976,7 +1990,12 @@ impl Backend for DynasmBackend {
         // when a bridge-internal guard fires.  RPython's asmmemmgr
         // ties code blocks and their resume descriptors to the same
         // compiled_loop_token lifetime.
-        self.register_fail_descrs(&compiled.fail_descrs);
+        //
+        // `compile.py:183-186 record_loop_or_bridge` attaches a
+        // bridge's resume descrs to the original loop's CLT, so the
+        // tracer batch lands on `original_token`'s
+        // `asmmemmgr_gcreftracers` (`model.py:294`).
+        self.register_fail_descrs(original_token, &compiled.fail_descrs);
 
         // `compile.py:183-186 record_loop_or_bridge`: a bridge's ResumeDescrs
         // inherit the original loop's CompiledLoopToken.  See the

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -785,6 +785,13 @@ impl DynasmBackend {
     /// Scans `token.asmmemmgr_blocks` for a `CompiledCode` whose `source_guard`
     /// matches; returns `0` if none — `assembler.py` treats `adr_jump_offset == 0`
     /// uniformly as "patched / no entry".
+    ///
+    /// `asmmemmgr_blocks` is append-only, so retracing the same guard
+    /// leaves multiple matching bridges in place.  Walk in reverse to
+    /// return the most recently compiled bridge — that is the one
+    /// `store_bridge_guard_hashes` / `compiled_bridge_fail_descr_layouts`
+    /// just wrote against and the one subsequent guard failures should
+    /// dispatch into.
     pub fn lookup_bridge_addr(
         &self,
         token: &JitCellToken,
@@ -792,7 +799,7 @@ impl DynasmBackend {
         source_fail_index: u32,
     ) -> usize {
         let blocks = token.asmmemmgr_blocks();
-        for block in blocks.iter() {
+        for block in blocks.iter().rev() {
             if let Some(bridge) = block.downcast_ref::<CompiledCode>() {
                 if bridge.source_guard == Some((source_trace_id, source_fail_index)) {
                     return codebuf::buffer_ptr(&bridge.buffer) as usize;
@@ -1400,6 +1407,16 @@ impl DynasmBackend {
         // through `Arc::from_raw` against the `FailDescrCell` wrapper that
         // `register_fail_descrs` pinned onto the owning CLT's
         // `asmmemmgr_gcreftracers`.
+        //
+        // A 0 `ptr` here means the JIT-baked code never wrote `jf_descr`
+        // (e.g. a force-token flow that bypassed both
+        // `_store_force_index_if_next_guard` and the inline guard-exit
+        // stub).  `Arc::from_raw(0)` is UB; refuse to recover and surface
+        // the producer-side defect.
+        assert_ne!(
+            ptr, 0,
+            "find_descr_by_ptr: jf_descr was not written; refusing to recover a null FailDescrCell"
+        );
         let cell = unsafe { majit_ir::recover_fail_descr_cell(ptr) };
         cell.descr.clone()
     }
@@ -2279,7 +2296,18 @@ impl Backend for DynasmBackend {
     /// address would be UB, but the JIT-emitted code holding the address
     /// is also retired when its CLT drops, so no live caller can reach a
     /// stale `descr_addr`.
-    fn free_loop(&mut self, _token: &JitCellToken) {}
+    ///
+    /// `compile_loop` inserts the token into `CALL_ASSEMBLER_TARGETS`
+    /// (`runner.rs:1578`) and that map stores a strong
+    /// `Arc<CompiledLoopToken>`; without removal here the CLT — and the
+    /// fail-descr cells it pins — would live for the entire process
+    /// lifetime.  Drop the entry so the Arc chain unwinds.
+    fn free_loop(&mut self, token: &JitCellToken) {
+        CALL_ASSEMBLER_TARGETS
+            .lock()
+            .expect("CALL_ASSEMBLER_TARGETS poisoned")
+            .remove(&token.number);
+    }
 
     fn fail_descr_arc_from_addr(&self, descr_addr: usize) -> majit_ir::DescrRef {
         // `history.py:109-114 AbstractDescr.show(cpu, descr_gcref) =

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -804,6 +804,8 @@ pub struct CompiledCode {
     /// AtomicUsize for redirect_call_assembler's update_frame_info
     /// parity: may be updated through &CompiledCode (shared ref).
     pub frame_depth: std::sync::atomic::AtomicUsize,
+    /// `None` for root loops; bridges set `(source_trace_id, source_fail_index_per_trace)`.
+    pub source_guard: Option<(u64, u32)>,
 }
 
 impl<'a> Assembler386<'a> {
@@ -2371,6 +2373,7 @@ impl<'a> Assembler386<'a> {
             trace_id: self.trace_id,
             header_pc: self.header_pc,
             frame_depth: std::sync::atomic::AtomicUsize::new(self.frame_depth),
+            source_guard: None,
         })
     }
 
@@ -2496,6 +2499,7 @@ impl<'a> Assembler386<'a> {
             trace_id: self.trace_id,
             header_pc: self.header_pc,
             frame_depth: std::sync::atomic::AtomicUsize::new(self.frame_depth),
+            source_guard: Some((fail_descr.trace_id(), fail_descr.fail_index_per_trace())),
         })
     }
 

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -716,6 +716,14 @@ pub struct Assembler386<'a> {
     /// jf_force_descr before the call. Consumed by the subsequent
     /// GUARD_NOT_FORCED guard emission.
     pending_force_descr: Option<majit_ir::DescrRef>,
+    /// Pre-wrapped `FailDescrCell` for the same pending guard.  Codegen
+    /// bakes the cell's thin pointer into `JF_FORCE_DESCR_OFS` so that
+    /// `force_token_to_dead_frame` (cranelift/compiler.rs:2660) can
+    /// recover the descr via `recover_fail_descr_cell` without the
+    /// fat-pointer mismatch a bare `Arc<dyn Descr>` ptr would cause.
+    /// The same cell is consumed by `append_guard_token_with_faillocs`
+    /// so jf_force_descr and jf_descr resolve to the same identity.
+    pending_force_cell: Option<std::sync::Arc<majit_ir::FailDescrCell>>,
     /// `compile.py:665-674` + `pyjitpl.py:2283`: construction-time
     /// snapshot of the six descr pointers attached to the owning cpu
     /// instance.  Retained for constructor signature stability across
@@ -887,6 +895,7 @@ impl<'a> Assembler386<'a> {
                 gcmap
             },
             pending_force_descr: None,
+            pending_force_cell: None,
             attached_descrs,
             cpu_handle,
             frame_depth_to_patch: Vec::new(),
@@ -3887,9 +3896,8 @@ impl<'a> Assembler386<'a> {
                 // and `handle_fail_exit_frame_with_exception` match by
                 // ptr-equality on the singleton, so the cell only carries
                 // the keep-alive identity for `clt.asmmemmgr_gcreftracers`.
-                self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
-                    descr.clone() as majit_ir::DescrRef
-                ));
+                self.fail_descrs
+                    .push(majit_ir::FailDescrCell::wrap(descr.clone()));
             }
             OpCode::Label => {
                 let label = self.mc.new_dynamic_label();
@@ -4897,7 +4905,14 @@ impl<'a> Assembler386<'a> {
         }
         let gcmap = self.guard_gcmap_from_faillocs(descr_fd.fail_arg_types(), faillocs);
 
-        let cell = majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef);
+        // Reuse the cell pre-allocated by `_store_force_index_if_next_guard`
+        // when this guard is paired with a CALL_ASSEMBLER's force-store —
+        // jf_force_descr and jf_descr then resolve to the same cell, and
+        // `fail_descrs[fail_index]` carries exactly one entry per guard.
+        let cell = self
+            .pending_force_cell
+            .take()
+            .unwrap_or_else(|| majit_ir::FailDescrCell::wrap(descr.clone()));
         self.pending_guard_tokens.push(GuardToken {
             jump_offset: self.mc.offset(),
             fail_label,
@@ -5588,8 +5603,16 @@ impl<'a> Assembler386<'a> {
             }
             fresh
         };
-        let descr_ptr = Arc::as_ptr(&descr) as *const () as i64;
+        // `force_token_to_dead_frame` (cranelift/compiler.rs:2660)
+        // recovers `jf_force_descr` via `recover_fail_descr_cell`, which
+        // requires a `FailDescrCell` thin pointer.  Bake the cell pointer
+        // here (not the bare `Arc<dyn Descr>` fat-pointer data half) and
+        // hand the cell off to `append_guard_token_with_faillocs` so the
+        // inline guard-exit path bakes the same identity into jf_descr.
+        let cell = majit_ir::FailDescrCell::wrap(descr.clone());
+        let descr_ptr = Arc::as_ptr(&cell) as *const () as i64;
         self.pending_force_descr = Some(descr);
+        self.pending_force_cell = Some(cell);
 
         // x86/assembler.py:2210-2222: store descr to jf_force_descr,
         // zero jf_descr.
@@ -5880,9 +5903,8 @@ impl<'a> Assembler386<'a> {
 
         // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
         // not the cell pointer (see OpCode::Finish comment above).
-        self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
-            descr.clone() as majit_ir::DescrRef
-        ));
+        self.fail_descrs
+            .push(majit_ir::FailDescrCell::wrap(descr.clone()));
     }
 
     // ----------------------------------------------------------------

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -3887,8 +3887,9 @@ impl<'a> Assembler386<'a> {
                 // and `handle_fail_exit_frame_with_exception` match by
                 // ptr-equality on the singleton, so the cell only carries
                 // the keep-alive identity for `clt.asmmemmgr_gcreftracers`.
-                self.fail_descrs
-                    .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
+                self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
+                    descr.clone() as majit_ir::DescrRef
+                ));
             }
             OpCode::Label => {
                 let label = self.mc.new_dynamic_label();
@@ -4993,7 +4994,9 @@ impl<'a> Assembler386<'a> {
 
     /// assembler.py:1005 write_pending_failure_recoveries.
     /// Returns recovery stub offsets for post-finalize address fixup.
-    fn write_pending_failure_recoveries(&mut self) -> Vec<(std::sync::Arc<majit_ir::FailDescrCell>, usize)> {
+    fn write_pending_failure_recoveries(
+        &mut self,
+    ) -> Vec<(std::sync::Arc<majit_ir::FailDescrCell>, usize)> {
         // Emit a shared _push_all_regs_to_frame routine once, then let each
         // generate_quick_failure() stub call it.  Iterate `ALL_CORE_REGS`
         // / `ALL_FLOAT_REGS` (Win64-aware: R13 dropped from GPRs, XMM5..14
@@ -5877,8 +5880,9 @@ impl<'a> Assembler386<'a> {
 
         // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
         // not the cell pointer (see OpCode::Finish comment above).
-        self.fail_descrs
-            .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
+        self.fail_descrs.push(majit_ir::FailDescrCell::wrap(
+            descr.clone() as majit_ir::DescrRef
+        ));
     }
 
     // ----------------------------------------------------------------

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -639,8 +639,10 @@ pub struct Assembler386<'a> {
     pending_malloc_nursery_gcmap: Option<usize>,
     /// Frame depth (in WORD units) for the current trace.
     frame_depth: usize,
-    /// Fail descriptors built during assembly.
-    fail_descrs: Vec<majit_ir::DescrRef>,
+    /// Fail descriptors built during assembly — wrapped in `FailDescrCell`
+    /// so `Arc::as_ptr` is a thin pointer suitable for direct
+    /// `Arc::from_raw` recovery (`history.py:113 AbstractDescr.show`).
+    fail_descrs: Vec<std::sync::Arc<majit_ir::FailDescrCell>>,
     /// trace_id for this compilation.
     trace_id: u64,
     /// header_pc (green_key) for this compilation.
@@ -762,8 +764,11 @@ struct GuardToken {
     /// Dynamic label that the guard's Jcc jumps to — bound in
     /// write_pending_failure_recoveries to the recovery stub.
     fail_label: DynamicLabel,
-    /// The fail descriptor for this guard.
-    fail_descr: majit_ir::DescrRef,
+    /// The fail descriptor cell for this guard.  `Arc::as_ptr(&fail_descr)`
+    /// is the thin pointer baked into `jf_descr`; the same cell instance is
+    /// stored on `Assembler386::fail_descrs` so registration on the owning CLT
+    /// keeps it alive while the recovery stub references its address.
+    fail_descr: std::sync::Arc<majit_ir::FailDescrCell>,
     /// Fail argument OpRefs for recovery (to save to sequential output slots).
     fail_args: Vec<OpRef>,
     /// regalloc parity: snapshot of opref_to_slot at guard emission time.
@@ -787,7 +792,7 @@ pub struct CompiledCode {
     /// contract (compile.py:183-203 record_loop_or_bridge). Position
     /// equals `descr.fail_index` by an invariant asserted at conversion
     /// from the in-progress `Assembler386.fail_descrs` Vec.
-    pub fail_descrs: Box<[majit_ir::DescrRef]>,
+    pub fail_descrs: Box<[std::sync::Arc<majit_ir::FailDescrCell>]>,
     /// Input argument types.
     pub input_types: Vec<Type>,
     /// `compile.py:665-674` parity: `Arc` clone of the owning cpu's
@@ -3877,7 +3882,13 @@ impl<'a> Assembler386<'a> {
                 }
 
                 self._call_footer();
-                self.fail_descrs.push(descr.clone() as majit_ir::DescrRef);
+                // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
+                // not the cell pointer.  `handle_fail_done_with_this_frame`
+                // and `handle_fail_exit_frame_with_exception` match by
+                // ptr-equality on the singleton, so the cell only carries
+                // the keep-alive identity for `clt.asmmemmgr_gcreftracers`.
+                self.fail_descrs
+                    .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
             }
             OpCode::Label => {
                 let label = self.mc.new_dynamic_label();
@@ -4864,13 +4875,13 @@ impl<'a> Assembler386<'a> {
                 Some(Loc::Ebp(_)) | Some(Loc::Addr(_)) => 0xFFFF,
             })
             .collect();
-        // Slice KK/NN: source_op_index uses the dynasm SOURCE_OP_INDEX_TABLE
-        // (kept until source_op_index is removed from FailDescrLayout per
-        // PyPy parity); recovery_layout is no longer cached on the backend —
-        // the metainterp's `StoredExitLayout.recovery_layout`
-        // (populated by `patch_guard_recovery_layouts_for_trace` from
-        // the resume snapshot per `resume.py:450-488`) is the canonical store.
-        crate::guard::register_source_op_index(Arc::as_ptr(&descr) as *const () as usize, op_index);
+        // Stamp source_op_index directly on the meta descr (UnsafeCell slot
+        // owned by ResumeGuardDescr / ResumeGuardCopiedDescr per
+        // resume_guard_descr.rs:166); `layout_for_fail_descr` reads it back
+        // via `fd.source_op_index()` so no side-table is needed.
+        if descr_fd.is_resume_guard() || descr_fd.is_resume_guard_copied() {
+            descr_fd.set_source_op_index(op_index);
+        }
         // `llsupport/assembler.py:279 guardtok.faildescr.rd_locs = positions`
         // — write through the trait accessor so the metainterp
         // `AbstractFailDescr` (`history.py:132 _attrs_`) receives the
@@ -4885,10 +4896,11 @@ impl<'a> Assembler386<'a> {
         }
         let gcmap = self.guard_gcmap_from_faillocs(descr_fd.fail_arg_types(), faillocs);
 
+        let cell = majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef);
         self.pending_guard_tokens.push(GuardToken {
             jump_offset: self.mc.offset(),
             fail_label,
-            fail_descr: descr.clone(),
+            fail_descr: cell.clone(),
             fail_args: op.getfailargs().map(|fa| fa.to_vec()).unwrap_or_default(),
             opref_to_slot_snapshot: self.opref_to_slot.clone(),
             const_stores,
@@ -4897,7 +4909,7 @@ impl<'a> Assembler386<'a> {
         if op.opcode == OpCode::GuardNotForced2 {
             self.finish_gcmap = Some(gcmap);
         }
-        self.fail_descrs.push(descr.clone());
+        self.fail_descrs.push(cell);
     }
 
     /// Update `rd_locs` on all pending guard descriptors after the
@@ -4944,7 +4956,7 @@ impl<'a> Assembler386<'a> {
         &mut self,
         guard_token: GuardToken,
         save_regs_label: DynamicLabel,
-    ) -> (majit_ir::DescrRef, usize) {
+    ) -> (std::sync::Arc<majit_ir::FailDescrCell>, usize) {
         let stub_start = self.mc.offset();
 
         let fail_label = guard_token.fail_label;
@@ -4981,7 +4993,7 @@ impl<'a> Assembler386<'a> {
 
     /// assembler.py:1005 write_pending_failure_recoveries.
     /// Returns recovery stub offsets for post-finalize address fixup.
-    fn write_pending_failure_recoveries(&mut self) -> Vec<(majit_ir::DescrRef, usize)> {
+    fn write_pending_failure_recoveries(&mut self) -> Vec<(std::sync::Arc<majit_ir::FailDescrCell>, usize)> {
         // Emit a shared _push_all_regs_to_frame routine once, then let each
         // generate_quick_failure() stub call it.  Iterate `ALL_CORE_REGS`
         // / `ALL_FLOAT_REGS` (Win64-aware: R13 dropped from GPRs, XMM5..14
@@ -5025,11 +5037,11 @@ impl<'a> Assembler386<'a> {
     /// buffer-relative offsets to absolute addresses after finalize.
     fn patch_pending_failure_recoveries(
         rawstart: usize,
-        stub_offsets: &[(majit_ir::DescrRef, usize)],
+        stub_offsets: &[(std::sync::Arc<majit_ir::FailDescrCell>, usize)],
     ) {
-        for (descr, stub_offset) in stub_offsets {
+        for (cell, stub_offset) in stub_offsets {
             let abs_addr = rawstart + stub_offset;
-            if let Some(fd) = descr.as_fail_descr() {
+            if let Some(fd) = cell.as_fail_descr() {
                 fd.set_adr_jump_offset(abs_addr);
             }
         }
@@ -5863,7 +5875,10 @@ impl<'a> Assembler386<'a> {
         // Emit epilogue (return jf_ptr).
         self._call_footer();
 
-        self.fail_descrs.push(descr.clone() as majit_ir::DescrRef);
+        // Singleton: jf_descr bakes the cpu-attached `global_descr_ptr`,
+        // not the cell pointer (see OpCode::Finish comment above).
+        self.fail_descrs
+            .push(majit_ir::FailDescrCell::wrap(descr.clone() as majit_ir::DescrRef));
     }
 
     // ----------------------------------------------------------------

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1674,31 +1674,6 @@ pub trait Backend: Send {
     ) {
     }
 
-    /// compile.py:741: self.status — read status from the failed descriptor
-    /// directly by its raw address (no re-lookup). RPython calls self.status
-    /// on the same descriptor object; descr_addr IS that object's identity.
-    ///
-    /// # Safety
-    /// descr_addr must be a valid pointer returned from a guard failure in
-    /// the same compilation session. The descriptor must still be alive
-    /// (held by compiled_loops or previous_tokens).
-    fn read_descr_status(&self, _descr_addr: usize) -> u64 {
-        0
-    }
-
-    /// compile.py:786-788: `self.start_compiling()`.
-    ///
-    /// RPython calls `self.status |= ST_BUSY_FLAG` directly on the
-    /// descriptor. In Rust, the descriptor is behind a trait object and
-    /// Arc, so we pass `descr_addr` (the Arc's raw pointer from the guard
-    /// failure result) and let the backend cast it back. This is the Rust
-    /// equivalent of RPython's `self` — both identify the exact descriptor.
-    fn start_compiling_descr(&self, _descr_addr: usize) {}
-
-    /// compile.py:790-795: `self.done_compiling()`.
-    /// Same pattern as start_compiling_descr — see above.
-    fn done_compiling_descr(&self, _descr_addr: usize) {}
-
     /// Execute compiled code starting at the given token.
     fn execute_token(&self, token: &JitCellToken, args: &[Value]) -> DeadFrame;
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -145,7 +145,11 @@ impl std::ops::Deref for FailDescrCell {
 
 impl std::fmt::Debug for FailDescrCell {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FailDescrCell({:p})", Arc::as_ptr(&self.descr) as *const ())
+        write!(
+            f,
+            "FailDescrCell({:p})",
+            Arc::as_ptr(&self.descr) as *const ()
+        )
     }
 }
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -89,12 +89,11 @@
 ///   matching `virtualref.rs` `VREF_FIELD_*` packed constants are
 ///   retired.  RPython caches real `Arc<dyn FieldDescr>` /
 ///   `Arc<dyn SizeDescr>` on the equivalent struct
-///   (`virtualref.py:40-42 cpu.fielddescrof`); pyre constructs vref
-///   field descrs on demand at the SETFIELD_GC emit sites
-///   (`optimizeopt/virtualize.rs:1521/1528 make_vref_field_descr`).
-///   Caching them on `VirtualRefInfo` for identity stability is a
-///   separate follow-up (no current pyre call site relied on the
-///   removed u32 placeholders).
+///   (`virtualref.py:40-42 cpu.fielddescrof`); pyre now does the same
+///   with `VirtualRefInfo::{descr, descr_virtual_token, descr_forced}`.
+///   The module-level vref descriptor constructors return the same
+///   cached Arcs, so `OptVirtualize` emits SETFIELD_GC ops with the
+///   same identities carried by `MetaInterp.virtualref_info`.
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -147,7 +147,8 @@ impl std::fmt::Debug for FailDescrCell {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "FailDescrCell({:p})",
+            "FailDescrCell(cell={:p}, descr={:p})",
+            self as *const Self,
             Arc::as_ptr(&self.descr) as *const ()
         )
     }

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -109,6 +109,62 @@ use serde::{Deserialize, Serialize};
 /// Opaque reference to a descriptor, shared across the JIT pipeline.
 pub type DescrRef = Arc<dyn Descr>;
 
+/// Thin-pointer wrapper for descrs whose address is baked into JIT-emitted
+/// code.  `history.py:109-114 AbstractDescr.{hide,show}` parity: PyPy bakes
+/// the GCREF of an `AbstractFailDescr` directly and recovers via
+/// `cast_gcref_to_instance(AbstractDescr, descr_gcref)` — a pure cast
+/// because every RPython GCREF is a typed pointer.
+///
+/// Rust's `Arc<dyn Descr>` is a fat pointer (data + vtable).  Codegen can
+/// only bake the data half, so reconstructing the fat Arc at recovery
+/// time needs a side-channel for the vtable.  `FailDescrCell` is a
+/// concrete-typed wrapper: `Arc<FailDescrCell>` is thin, so
+/// `Arc::as_ptr(&cell) as *const () as usize` bakes a complete identity
+/// and `Arc::from_raw(addr as *const FailDescrCell)` recovers it
+/// without a registry.
+///
+/// The cell is the unit kept alive by
+/// `CompiledLoopToken.asmmemmgr_gcreftracers` (`model.py:294`);
+/// the inner `DescrRef` carries the dynamic trait dispatch.
+pub struct FailDescrCell {
+    pub descr: DescrRef,
+}
+
+impl FailDescrCell {
+    pub fn wrap(descr: DescrRef) -> Arc<Self> {
+        Arc::new(Self { descr })
+    }
+}
+
+impl std::ops::Deref for FailDescrCell {
+    type Target = dyn Descr + 'static;
+    fn deref(&self) -> &(dyn Descr + 'static) {
+        &*self.descr
+    }
+}
+
+impl std::fmt::Debug for FailDescrCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FailDescrCell({:p})", Arc::as_ptr(&self.descr) as *const ())
+    }
+}
+
+/// `history.py:113 AbstractDescr.show(cpu, descr_gcref)` parity.
+///
+/// # Safety
+/// `addr` MUST be the address of a live `Arc<FailDescrCell>` whose
+/// strong refcount is held by `CompiledLoopToken.asmmemmgr_gcreftracers`
+/// (or an equivalent keep-alive collection) while the baked JIT code
+/// references this address.  Calling with any other address — including
+/// the address of a different concrete type — is undefined behavior.
+pub unsafe fn recover_fail_descr_cell(addr: usize) -> Arc<FailDescrCell> {
+    let ptr = addr as *const FailDescrCell;
+    unsafe {
+        Arc::increment_strong_count(ptr);
+        Arc::from_raw(ptr)
+    }
+}
+
 /// descr.py: GcCache dict keys.
 ///
 /// RPython uses the actual lltype object (STRUCT, ARRAY_OR_STRUCT,

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -18,12 +18,12 @@ pub use descr::{
     DescrRef, FailDescr, FailDescrCell, FieldDescr, GcCache, InteriorFieldDescr, JitCodeDescr,
     LLType, LoopTargetDescr, LoopTokenDescr, SimpleCallDescr, SimpleFailDescr, SimpleFieldDescr,
     SizeDescr, SwitchDescr, TargetArgLoc, UnpackAtExitInfo, VableExpansion, descr_identity,
-    make_array_descr, recover_fail_descr_cell,
-    make_array_descr_signed, make_call_descr, make_field_descr, make_field_descr_full,
-    make_loop_target_descr, make_malloc_array_calldescr, make_malloc_array_nonstandard_calldescr,
-    make_malloc_big_fixedsize_calldescr, make_malloc_str_calldescr, make_malloc_unicode_calldescr,
-    make_memcpy_calldescr, make_raw_malloc_calldescr, make_size_descr_full,
-    make_size_descr_with_vtable, make_tid_field_descr, make_vtable_field_descr, memcpy_fn_addr,
+    make_array_descr, make_array_descr_signed, make_call_descr, make_field_descr,
+    make_field_descr_full, make_loop_target_descr, make_malloc_array_calldescr,
+    make_malloc_array_nonstandard_calldescr, make_malloc_big_fixedsize_calldescr,
+    make_malloc_str_calldescr, make_malloc_unicode_calldescr, make_memcpy_calldescr,
+    make_raw_malloc_calldescr, make_size_descr_full, make_size_descr_with_vtable,
+    make_tid_field_descr, make_vtable_field_descr, memcpy_fn_addr, recover_fail_descr_cell,
     unpack_fielddescr,
 };
 pub use effectinfo::{

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -15,9 +15,10 @@ pub mod vec_set;
 // Re-export key types at crate root for convenience.
 pub use descr::{
     AccumInfo, ArrayDescr, ArrayFlag, CallDescr, DebugMergePointDescr, DebugMergePointInfo, Descr,
-    DescrRef, FailDescr, FieldDescr, GcCache, InteriorFieldDescr, JitCodeDescr, LLType,
-    LoopTargetDescr, LoopTokenDescr, SimpleCallDescr, SimpleFailDescr, SimpleFieldDescr, SizeDescr,
-    SwitchDescr, TargetArgLoc, UnpackAtExitInfo, VableExpansion, descr_identity, make_array_descr,
+    DescrRef, FailDescr, FailDescrCell, FieldDescr, GcCache, InteriorFieldDescr, JitCodeDescr,
+    LLType, LoopTargetDescr, LoopTokenDescr, SimpleCallDescr, SimpleFailDescr, SimpleFieldDescr,
+    SizeDescr, SwitchDescr, TargetArgLoc, UnpackAtExitInfo, VableExpansion, descr_identity,
+    make_array_descr, recover_fail_descr_cell,
     make_array_descr_signed, make_call_descr, make_field_descr, make_field_descr_full,
     make_loop_target_descr, make_malloc_array_calldescr, make_malloc_array_nonstandard_calldescr,
     make_malloc_big_fixedsize_calldescr, make_malloc_str_calldescr, make_malloc_unicode_calldescr,

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -7970,9 +7970,10 @@ impl<M: Clone> MetaInterp<M> {
             crate::debug::log_one("jit-tracing", "must_compile: descr_addr=0, skip");
             return (false, owning_key);
         }
-        // compile.py:741: self.status — read live status directly from the
-        // failed descriptor object (not a re-lookup by trace_id/fail_index).
-        let status = self.backend.read_descr_status(descr_addr);
+        // `compile.py:741` `status = self.status` — direct field read on
+        // the resume-guard descr.  `descr_fd` is the live `FailDescr`
+        // we already resolved above; no backend round-trip.
+        let status = descr_fd.get_status();
         // compile.py:741-751: decode status to get hash
         let hash = if status & (Self::ST_BUSY_FLAG | Self::ST_TYPE_MASK) == 0 {
             // compile.py:745: common case — TY_NONE, not busy.
@@ -8110,18 +8111,6 @@ impl<M: Clone> MetaInterp<M> {
             }
         }
         None
-    }
-
-    /// compile.py:786-788: self.start_compiling() — set ST_BUSY_FLAG
-    /// on the exact failed descriptor (by descr_addr, not re-lookup).
-    pub fn start_guard_compiling(&self, descr_addr: usize) {
-        self.backend.start_compiling_descr(descr_addr);
-    }
-
-    /// compile.py:790-795: self.done_compiling() — clear ST_BUSY_FLAG
-    /// on the exact failed descriptor (by descr_addr, not re-lookup).
-    pub fn done_guard_compiling(&self, descr_addr: usize) {
-        self.backend.done_compiling_descr(descr_addr);
     }
 
     /// Check whether a bridge was actually compiled and attached for a guard.

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -18458,7 +18458,8 @@ mod tests {
         descr_fd.set_rd_consts(Some(rd_consts));
         descr_fd.set_rd_virtuals(Some(vec![]));
         descr_fd.set_rd_pendingfields(Some(vec![]));
-        backend.register_fail_descrs(&compiled.fail_descrs);
+        let fail_descrs = compiled.fail_descrs.clone();
+        backend.register_fail_descrs(token, &fail_descrs);
     }
 
     #[cfg(all(feature = "dynasm", not(feature = "cranelift")))]

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2674,18 +2674,17 @@ fn jit_ca_handle_guard_failure(
     }
     let frame = unsafe { &mut *frame_ptr };
 
-    // compile.py:786-788 self.start_compiling(): set ST_BUSY_FLAG
-    {
-        let (driver, _) = crate::eval::driver_pair();
-        driver.meta_interp_mut().start_guard_compiling(descr_addr);
+    // `compile.py:786-788` `self.start_compiling()` — direct method
+    // call on the resume-guard descr instance.
+    if let Some(fd) = descr_arc.as_fail_descr() {
+        fd.start_compiling();
     }
 
     let compiled = trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout);
 
-    // compile.py:790-795 self.done_compiling(): clear ST_BUSY_FLAG
-    {
-        let (driver, _) = crate::eval::driver_pair();
-        driver.meta_interp_mut().done_guard_compiling(descr_addr);
+    // `compile.py:790-795` `self.done_compiling()` — direct method call.
+    if let Some(fd) = descr_arc.as_fail_descr() {
+        fd.done_compiling();
     }
 
     if majit_metainterp::majit_log_enabled() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3372,11 +3372,6 @@ fn handle_fail(
     raw_values: &[i64],
     _info: &majit_metainterp::virtualizable::VirtualizableInfo,
 ) -> HandleFailOutcome {
-    // compile.py:780 `current_object_addr_as_int(self)` — descriptor
-    // identity used by `start_compiling` / `done_compiling` to flip
-    // `ResumeGuardDescr.status`'s ST_BUSY_FLAG.  Recover from the Arc
-    // each call rather than threading it through outer signatures.
-    let descr_addr = std::sync::Arc::as_ptr(descr_arc) as *const () as usize;
     // compile.py:702-703: must_compile() AND not stack_almost_full()
     if should_bridge && !stack_almost_full() {
         let is_tracing = {
@@ -3384,10 +3379,10 @@ fn handle_fail(
             driver.is_tracing()
         };
         if !is_tracing {
-            // compile.py:704: self.start_compiling() (set ST_BUSY_FLAG)
-            {
-                let (driver, _) = driver_pair();
-                driver.meta_interp_mut().start_guard_compiling(descr_addr);
+            // `compile.py:704` `self.start_compiling()` — direct method
+            // call on the resume-guard descr instance.
+            if let Some(fd) = descr_arc.as_fail_descr() {
+                fd.start_compiling();
             }
             // compile.py:706-708: _trace_and_compile_from_bridge(deadframe)
             // force_plain_eval prevents concrete calls during bridge
@@ -3401,10 +3396,9 @@ fn handle_fail(
                     exit_layout,
                 )
             };
-            // compile.py:709: done_compiling (clear ST_BUSY_FLAG)
-            {
-                let (driver, _) = driver_pair();
-                driver.meta_interp_mut().done_guard_compiling(descr_addr);
+            // `compile.py:709` `self.done_compiling()` — direct method call.
+            if let Some(fd) = descr_arc.as_fail_descr() {
+                fd.done_compiling();
             }
             if compiled {
                 // compile.py:708: bridge compiled → ContinueRunningNormally.


### PR DESCRIPTION
Fix #80

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned guard-failure identity handling to use loop-scoped pinned descriptor cells instead of global/address-keyed registries, simplifying lifecycle and cleanup.
  * Bridge lookup/patching and guard recovery now use token-scoped source identities (trace + fail index), improving consistency.

* **Bug Fixes**
  * More reliable recovery of guard/bridge failures and clearer cleanup when loops are freed.

* **Tests**
  * Updated unit tests to exercise the new descriptor-scoped recovery approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->