### PR TITLE
Post-#86 cleanup: retire descr_addr/get_guard_status, fix stale comments

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -705,9 +705,9 @@ fn wrap_call_assembler_deadframe_with_caller_prefix(mut frame: DeadFrame) -> Dea
     // on demand.  The deadframe's `fail_descr` keeps the callee's own
     // Arc identity, so `cpu.get_latest_descr(deadframe)` returns the
     // callee descr (`llmodel.py:411-419` get_latest_descr parity), and
-    // the raw `jf_descr` slot still carries an address that's resolvable
-    // through the regular `fail_descr_registry` (no overlay registry
-    // needed).
+    // the raw `jf_descr` slot still carries a `FailDescrCell` thin
+    // pointer resolvable via `recover_fail_descr_cell` (Slice 80-G.7),
+    // with no overlay descr needed.
     let Some(jf) = frame.data.downcast_mut::<JitFrameDeadFrame>() else {
         // Fallback: return as-is (should not happen after FrameData removal).
         return frame;
@@ -7227,11 +7227,14 @@ impl CraneliftBackend {
         }
     }
 
-    /// Register metainterp `AbstractFailDescr` Arcs into the addr→Arc
-    /// lookup table keyed on the data-pointer half of each
-    /// `Arc<dyn Descr>` fat pointer (`history.py:125` identity).
-    /// Mirrors dynasm's API: callable from future late-stamp helpers
-    /// that need to land entries after the in-codegen call missed them.
+    /// Pin the metainterp descr Arcs referenced by this compiled trace
+    /// onto the owning CLT's `asmmemmgr_gcreftracers` (`model.py:294`,
+    /// `assembler.py:820-823 gcreftracers.append(tracer)`).  The raw
+    /// addresses baked into JIT code are `FailDescrCell` thin pointers,
+    /// kept alive separately by `CompiledLoop::fail_descr_cells` /
+    /// `BridgeData::fail_descr_cells`; this tracer pins the inner descrs
+    /// those cells dereference for the same CLT lifetime.  Mirrors
+    /// dynasm's API for late-stamp helpers.
     pub fn register_fail_descrs(&self, token: &majit_backend::JitCellToken, descrs: &[DescrRef]) {
         // `assembler.py:820-823 gcreftracers.append(tracer)` parity —
         // each `register_fail_descrs` call appends one tracer that
@@ -13739,7 +13742,7 @@ fn collect_guards(
         // `Arc<ExitFrameWithExceptionDescrRef>` for FINISH, or the
         // metainterp `Arc<ResumeGuardDescr>` (op.descr or synthesized)
         // for guards.  No CraneliftFailDescr wrapper between codegen
-        // and the runtime registry.  Matches PyPy's single-descr
+        // and the runtime descr identity.  Matches PyPy's single-descr
         // identity (`history.py:121`: one ResumeGuardDescr per guard,
         // shared between metainterp and backend).
         let descr: DescrRef = if is_finish {
@@ -14431,29 +14434,6 @@ impl majit_backend::Backend for CraneliftBackend {
         Ok(info)
     }
 
-    fn get_guard_status(
-        &self,
-        token: &JitCellToken,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> (u64, usize) {
-        let compiled = token
-            .compiled
-            .as_ref()
-            .and_then(|c| c.downcast_ref::<CompiledLoop>());
-        if let Some(compiled) = compiled {
-            if let Some(descr) =
-                find_fail_descr_in_fail_descrs(&compiled.fail_descrs, trace_id, fail_index)
-            {
-                return (
-                    as_fd(&descr).get_status(),
-                    std::sync::Arc::as_ptr(&descr) as *const () as usize,
-                );
-            }
-        }
-        (0, 0)
-    }
-
     /// resume.py:1143-1188 parity — publish `metainterp.staticdata.
     /// callinfocollection` so the guard-exit recovery builder at
     /// `collect_guards` can resolve OS_STR_CONCAT / OS_UNI_CONCAT /
@@ -14707,7 +14687,6 @@ impl majit_backend::Backend for CraneliftBackend {
                         }
                     }
                 }
-                let descr_addr = Arc::as_ptr(&descr_arc) as *const () as usize;
                 return majit_backend::RawExecResult {
                     outputs: result,
                     typed_outputs: typed_result,
@@ -14720,7 +14699,6 @@ impl majit_backend::Backend for CraneliftBackend {
                     is_finish: descr.is_finish(),
                     is_exit_frame_with_exception: descr.is_exit_frame_with_exception(),
                     status: descr.get_status(),
-                    descr_addr,
                     descr_arc,
                 };
             }
@@ -14796,7 +14774,6 @@ impl majit_backend::Backend for CraneliftBackend {
                     }
                 }
 
-                let descr_addr = Arc::as_ptr(&fail_descr_arc) as *const () as usize;
                 let fail_descr_ref: DescrRef = fail_descr_arc.clone();
                 let trace_id = fail_descr_fd.trace_id();
                 return majit_backend::RawExecResult {
@@ -14811,7 +14788,6 @@ impl majit_backend::Backend for CraneliftBackend {
                     is_finish: true,
                     is_exit_frame_with_exception: fail_descr_fd.is_exit_frame_with_exception(),
                     status: fail_descr_fd.get_status(),
-                    descr_addr,
                     descr_arc: fail_descr_arc.clone(),
                 };
             }
@@ -14859,7 +14835,6 @@ impl majit_backend::Backend for CraneliftBackend {
                 }
             }
 
-            let descr_addr = Arc::as_ptr(&fail_descr_arc) as *const () as usize;
             let fail_descr_ref: DescrRef = fail_descr_arc.clone();
             let trace_id = fail_descr_fd.trace_id();
             return majit_backend::RawExecResult {
@@ -14874,7 +14849,6 @@ impl majit_backend::Backend for CraneliftBackend {
                 is_finish: false,
                 is_exit_frame_with_exception: fail_descr_fd.is_exit_frame_with_exception(),
                 status: fail_descr_fd.get_status(),
-                descr_addr,
                 descr_arc: fail_descr_arc.clone(),
             };
         }
@@ -15033,9 +15007,10 @@ impl majit_backend::Backend for CraneliftBackend {
         if force_token.0 == 0 {
             return None;
         }
-        // `force_token_to_dead_frame` resolves `jf_force_descr` via the
-        // process-global `FAIL_DESCR_REGISTRY_GLOBAL` (`history.py:109-
-        // 114` `AbstractDescr.show`); no TLS handle needed.
+        // `force_token_to_dead_frame` resolves `jf_force_descr` via
+        // `recover_fail_descr_cell` (`history.py:109-114
+        // AbstractDescr.show` = pure cast against the per-emission
+        // `FailDescrCell` baked at codegen).
         Some(force_token_to_dead_frame(force_token))
     }
 
@@ -15102,10 +15077,11 @@ impl majit_backend::Backend for CraneliftBackend {
         unregister_call_assembler_target(token.number);
         self.registered_call_assembler_tokens.remove(&token.number);
         // `llmodel.py:252-268 free_loop_and_bridges` parity.  Strong
-        // refs to baked descrs live on `clt.asmmemmgr_gcreftracers`
-        // (`model.py:294`); dropping the CLT releases them, and Weak
-        // entries in `FAIL_DESCR_REGISTRY_GLOBAL` upgrade to `None`
-        // next time someone looks them up.  Nothing to sweep here.
+        // refs to baked `FailDescrCell` Arcs live on
+        // `clt.asmmemmgr_gcreftracers` (`model.py:294`); dropping the
+        // CLT releases them, and the JIT-emitted code that holds the
+        // baked `FailDescrCell` thin pointers is retired in lockstep,
+        // so no live caller can reach a stale pointer.
         let _ = token;
     }
 

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3488,15 +3488,14 @@ impl<'a> AssemblerARM64<'a> {
                 Some(Loc::Ebp(_)) | Some(Loc::Addr(_)) => 0xFFFF,
             })
             .collect();
-        // Slice KK/NN: source_op_index uses SOURCE_OP_INDEX_TABLE (kept
-        // pending source_op_index removal); recovery_layout caching is
-        // removed — the metainterp's `StoredExitLayout.recovery_layout`
-        // (populated by `patch_guard_recovery_layouts_for_trace`)
-        // is the canonical store per `resume.py:450-488`.
         // Stamp source_op_index directly on the meta descr (UnsafeCell slot
         // owned by ResumeGuardDescr / ResumeGuardCopiedDescr per
         // resume_guard_descr.rs:166); `layout_for_fail_descr` reads it back
         // via `fd.source_op_index()` so no side-table is needed.
+        // Recovery layouts are owned by the metainterp's
+        // `StoredExitLayout.recovery_layout` (populated by
+        // `patch_guard_recovery_layouts_for_trace`) per
+        // `resume.py:450-488`; the backend keeps no parallel cache.
         if descr_fd.is_resume_guard() || descr_fd.is_resume_guard_copied() {
             descr_fd.set_source_op_index(op_index);
         }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -889,25 +889,20 @@ impl DynasmBackend {
         Arc::clone(&self.descr_attachments)
     }
 
-    /// Add a newly-compiled loop/bridge's fail_descrs to the ptr-indexed
-    /// registry. Called after every `compile_loop` / `compile_bridge`
-    /// returns so subsequent `resolve_latest_descr` lookups can cross
-    /// token boundaries — required when a bridge JUMPs into another
-    /// compiled loop and that loop's guard fires before control returns
-    /// to the bridge's owning token.
-
-    /// Register `DescrRef` instances into the addr→`DescrRef` lookup
-    /// table.  Called from `compile_loop` / `compile_bridge` to
-    /// populate after codegen.  Re-running is idempotent: existing
-    /// entries are preserved via `entry().or_insert_with`.
+    /// Pin a newly compiled loop/bridge's baked `FailDescrCell`s on the
+    /// owning CLT.  Called after every `compile_loop` / `compile_bridge`
+    /// returns so `recover_fail_descr_cell` can safely recover a descr
+    /// even when a bridge JUMPs into another compiled loop and that
+    /// loop's guard fires before control returns to the bridge's owning
+    /// token.
     ///
     /// Lifetime root: `token.compiled_loop_token.asmmemmgr_gcreftracers`
     /// (`model.py:294`, `llsupport/assembler.py:190-194`
     /// `get_asmmemmgr_gcreftracers`).  Pushes one tracer per
     /// `register_fail_descrs` call mirroring
     /// `assembler.py:822 gcreftracers.append(tracer)`; the tracer owns
-    /// the descr `Arc`s for the lifetime of the compiled loop so the
-    /// addresses baked into machine code stay live until
+    /// the cell `Arc`s for the lifetime of the compiled loop so the
+    /// `FailDescrCell` addresses baked into machine code stay live until
     /// `free_loop_and_bridges` drops the CLT (`llmodel.py:252-268`).
     pub fn register_fail_descrs(
         &self,
@@ -2207,7 +2202,6 @@ impl Backend for DynasmBackend {
 
         let jf_descr_raw = unsafe { crate::llmodel::get_latest_descr(result_jf) as i64 };
         let descr = self.find_descr_by_ptr(token, jf_descr_raw as usize, result_jf);
-        let descr_addr = Arc::as_ptr(&descr) as *const () as usize;
         let descr_fd = descr
             .as_fail_descr()
             .expect("find_descr_by_ptr result must implement FailDescr");
@@ -2267,7 +2261,6 @@ impl Backend for DynasmBackend {
             is_finish: descr_fd.is_finish(),
             is_exit_frame_with_exception: descr_fd.is_exit_frame_with_exception(),
             status: descr_fd.get_status(),
-            descr_addr,
             descr_arc,
         }
     }
@@ -2415,17 +2408,6 @@ impl Backend for DynasmBackend {
                 }
             }
         }
-    }
-
-    fn get_guard_status(
-        &self,
-        token: &JitCellToken,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> (u64, usize) {
-        let descr = Self::find_descr(token, trace_id, fail_index);
-        let fd = descr.as_fail_descr().expect("descr is FailDescr");
-        (fd.get_status(), Arc::as_ptr(&descr) as *const () as usize)
     }
 
     fn store_bridge_guard_hashes(

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -65,14 +65,11 @@ pub struct RawExecResult {
     pub is_exit_frame_with_exception: bool,
     /// compile.py:741-745: ResumeGuardDescr.status at guard failure time.
     pub status: u64,
-    /// compile.py:780: current_object_addr_as_int(self) — descriptor pointer.
-    pub descr_addr: usize,
     /// `cpu.get_latest_descr(deadframe)` (`history.py:125`,
     /// `compile.py:701`) — the runtime descr Arc owning this exit.
-    /// Always set: routes through `Backend::get_latest_descr_arc`
-    /// rather than the `fail_descr_addr` registry, so FINISH /
-    /// `DoneWithThisFrame*` / `ExitFrameWithExceptionDescrRef`
-    /// singletons return their global Arc identity instead of `None`.
+    /// Always set: routes through `Backend::get_latest_descr_arc`, so
+    /// FINISH / `DoneWithThisFrame*` / `ExitFrameWithExceptionDescrRef`
+    /// singletons return their attached Arc identity directly.
     /// Bridge consumers (`start_bridge_tracing`,
     /// `_trace_and_compile_from_bridge`) call `descr_arc.as_fail_descr()`
     /// to read `rd_loop_token_clt` / `fail_index_per_trace` directly.
@@ -1627,19 +1624,6 @@ pub trait Backend: Send {
     /// no-op — bridges are attached to the guard's machine code directly.
     fn migrate_bridges(&self, _old_token: &JitCellToken, _new_token: &JitCellToken) {}
 
-    /// compile.py:741-745: look up (status, descr_addr) for a guard.
-    /// Uses (trace_id, fail_index) to find the exact descriptor, including
-    /// bridge guards and previous tokens — matching start_guard_compiling's
-    /// find_fail_descr_in_fail_descrs pattern.
-    fn get_guard_status(
-        &self,
-        _token: &JitCellToken,
-        _trace_id: u64,
-        _fail_index: u32,
-    ) -> (u64, usize) {
-        (0, 0)
-    }
-
     /// compile.py:826-830 store_hash: assign jitcounter hashes to guards.
     /// Called after compile_loop/compile_bridge with hashes from
     /// jitcounter.fetch_next_hash(). Skips guards that already have
@@ -1725,7 +1709,6 @@ pub trait Backend: Send {
                 }
             }
         }
-        let descr_addr = Arc::as_ptr(&descr_arc) as *const () as usize;
         RawExecResult {
             outputs,
             typed_outputs,
@@ -1738,7 +1721,6 @@ pub trait Backend: Send {
             is_finish: descr.is_finish(),
             is_exit_frame_with_exception: descr.is_exit_frame_with_exception(),
             status: descr.get_status(),
-            descr_addr,
             descr_arc,
         }
     }
@@ -1913,25 +1895,28 @@ pub trait Backend: Send {
     /// be transported as a raw `usize` (`descr_addr`) and recovered here
     /// via this method.
     ///
-    /// `descr_addr` is the `usize` identity captured at native-code emission
-    /// time (e.g. embedded in a recovery stub or stamped into `jf_descr`).
-    /// Backends that maintain an `addr → Arc` registry (mirroring RPython's
-    /// `cpu` keeping descr objects alive while their pointers are live in
-    /// emitted code) override this to upgrade the raw address back to its
-    /// owning Arc.
+    /// `descr_addr` is the thin pointer of a `majit_ir::FailDescrCell`
+    /// baked at code-emission time (`history.py:109-114
+    /// AbstractDescr.show` = pure cast against the cell).  Backends
+    /// recover via `majit_ir::recover_fail_descr_cell` (`Arc::from_raw`
+    /// + `Arc::increment_strong_count`); strong refs live on
+    /// `CompiledLoopToken.asmmemmgr_gcreftracers` (`model.py:294`,
+    /// `assembler.py:820-823 gcreftracers.append(tracer)`).  Singletons
+    /// without a cell wrapper (FINISH `DoneWithThisFrame*`,
+    /// `ExitFrameWithExceptionDescrRef`, `PropagateExceptionDescr`) are
+    /// pointer-matched at higher layers before reaching this method.
     ///
     /// `warmspot.py:1021 cpu.get_latest_descr(deadframe)` has no failure
     /// mode — every live deadframe carries a valid descr handle.  Pyre
-    /// backends mirror this contract by holding strong `Arc` refs in the
-    /// registry for the full lifetime of every emitted FailDescr; the
-    /// lookup is therefore infallible.  Default panics so backends that
-    /// receive C-ABI guard-fail callbacks must opt in explicitly;
+    /// backends mirror this contract via the CLT-pinned cell lifetime;
+    /// the recovery is therefore infallible.  Default panics so backends
+    /// that receive C-ABI guard-fail callbacks must opt in explicitly;
     /// `SyntheticCpu` and `wasm` never reach this path.
     fn fail_descr_arc_from_addr(&self, _descr_addr: usize) -> majit_ir::DescrRef {
         panic!(
             "Backend::fail_descr_arc_from_addr default invoked: backend wired into a runtime \
-             guard-fail path must register every emitted FailDescr in an addr→Arc table and \
-             override this method (warmspot.py:1021 cpu.get_latest_descr parity)"
+             guard-fail path must bake FailDescrCell thin pointers at emission and override \
+             this method (warmspot.py:1021 cpu.get_latest_descr parity)"
         )
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -8083,35 +8083,6 @@ impl<M: Clone> MetaInterp<M> {
         );
     }
 
-    /// compile.py:741-745: look up (status, descr_addr) for a guard.
-    /// Search current token + previous_tokens by (trace_id, fail_index)
-    /// to find the exact descriptor — same pattern as start_guard_compiling.
-    /// Returns None if descriptor not found (no tick should happen).
-    pub fn get_guard_status(
-        &self,
-        green_key: u64,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> Option<(u64, usize)> {
-        let compiled = self.compiled_loops.get(&green_key)?;
-        let tid = trace_id;
-        if let Some(token) = compiled.live_token() {
-            let (s, a) = self.backend.get_guard_status(&token, tid, fail_index);
-            if a != 0 {
-                return Some((s, a));
-            }
-        }
-        for prev in &compiled.previous_tokens {
-            if let Some(prev) = prev.upgrade() {
-                let (s, a) = self.backend.get_guard_status(&prev, tid, fail_index);
-                if a != 0 {
-                    return Some((s, a));
-                }
-            }
-        }
-        None
-    }
-
     /// Check whether a bridge was actually compiled and attached for a guard.
     /// Used by jit_bridge_compile_for_guard to distinguish successful bridge
     /// compilation from trace abort (RPython pyjitpl.py:2906-2907 parity).
@@ -18445,11 +18416,14 @@ mod tests {
                     .map_or(false, |fd| fd.fail_index_per_trace() == fail_index)
             })
             .expect("fail descr");
-        // After backend struct deletion, the `fail_descrs` vec stores
-        // `Arc<ResumeGuardDescr>` directly (production guards use op.descr;
-        // test scaffolds where op.descr is None mint a fresh metainterp
-        // ResumeGuardDescr at codegen time).  Either way, the rd_* setters
-        // route through the FailDescr trait surface on the descr Arc.
+        // After Slice 80-G.7 the `fail_descrs` vec stores
+        // `Arc<FailDescrCell>` thin wrappers (the cell is the JIT-baked
+        // identity in `jf_descr`).  The inner descr is reached via
+        // `FailDescrCell::Deref<Target = dyn Descr>`, so `.as_fail_descr()`
+        // auto-derefs to the trait surface on the metainterp's
+        // `Arc<ResumeGuardDescr>` (production: op.descr; test scaffolds
+        // where op.descr is None mint a fresh ResumeGuardDescr at codegen
+        // time).
         let descr_fd = descr_ref
             .as_fail_descr()
             .expect("descr must implement FailDescr");

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1801,9 +1801,10 @@ fn jit_blackhole_resume_from_guard(
     // compile.py:710-716 `resume_in_blackhole(descr, deadframe)` parity:
     // recover the failed descr from `descr_addr` (history.py:125
     // `cpu.get_latest_descr` is the C-ABI carrier) and derive
-    // (trace_id, fail_index) from descr identity.  The lookup is
-    // infallible — `Backend::fail_descr_arc_from_addr` panics on a
-    // registry miss, matching RPython's `cpu.get_latest_descr(deadframe)`
+    // (trace_id, fail_index) from descr identity.  The recovery is
+    // infallible for live JIT code — `Backend::fail_descr_arc_from_addr`
+    // panics if the raw value is not a live `FailDescrCell` pointer,
+    // matching RPython's `cpu.get_latest_descr(deadframe)`
     // (warmspot.py:1021) which has no failure mode.
     use majit_backend::Backend;
     let (driver, _) = crate::eval::driver_pair();
@@ -2342,8 +2343,9 @@ pub fn trace_and_compile_from_bridge(
     // (eval.rs `handle_fail`) and the CALL_ASSEMBLER bridge entry
     // (call_jit.rs `jit_ca_handle_guard_failure`) — have an Arc available
     // before reaching this function (T-CA + T-CA.cranelift gave both
-    // backends the `Backend::fail_descr_arc_from_addr` registry), so the
-    // surrogate `(green_key, trace_id, fail_index)` parameters retired
+    // backends `Backend::fail_descr_arc_from_addr` recovery from
+    // `FailDescrCell` thin pointers), so the surrogate
+    // `(green_key, trace_id, fail_index)` parameters retired
     // in T-final.B.
     descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
     frame: &mut PyFrame,
@@ -2613,10 +2615,12 @@ fn jit_ca_handle_guard_failure(
     // crosses the backend boundary with only the raw descr pointer; recover
     // the backend FailDescr Arc before any guard-failure routing so identity
     // is read from the descr just like PyPy reads `resumedescr`.  The
-    // lookup is infallible — `Backend::fail_descr_arc_from_addr` panics
-    // on a registry miss, matching RPython's `cpu.get_latest_descr(deadframe)`
-    // (warmspot.py:1021) which has no failure mode.  T-final.B made
-    // `trace_and_compile_from_bridge` itself descr-only.
+    // recovery is infallible for live JIT code —
+    // `Backend::fail_descr_arc_from_addr` panics if the raw value is not
+    // a live `FailDescrCell` pointer, matching RPython's
+    // `cpu.get_latest_descr(deadframe)` (warmspot.py:1021) which has no
+    // failure mode.  T-final.B made `trace_and_compile_from_bridge`
+    // itself descr-only.
     let descr_arc: std::sync::Arc<dyn majit_ir::Descr> = {
         use majit_backend::Backend;
         let (driver, _) = crate::eval::driver_pair();


### PR DESCRIPTION
Fix #80

After PR #86 several pre-existing
APIs and comments still described the retired FAIL_DESCR_REGISTRY_GLOBAL / addr-to-Arc registry design.  This commit retires the dead surfaces and brings the remaining comments in line with the FailDescrCell recovery contract.

Dead API retired:
  - Backend::get_guard_status trait method + DynasmBackend/CraneliftBackend impls + MetaInterp::get_guard_status wrapper.  No callers outside the wrapper itself.  The pre-existing dynasm-returns-cell-ptr vs cranelift-returns-meta-ptr divergence disappears with the API.
  - RawExecResult.descr_addr field (held the meta Arc data pointer; would have been a latent UB hazard if anyone passed it to fail_descr_arc_from_addr, which after Slice 80-G.7 expects FailDescrCell thin pointers).  Zero readers in the repo; descr_arc supersedes it. Removed at the 5 setter sites in lib.rs/dynasm/cranelift.

Stale comments fixed:
  - majit-metainterp/src/pyjitpl/mod.rs: 'fail_descrs vec stores Arc<ResumeGuardDescr> directly' now correctly describes the Arc<FailDescrCell> wrapper introduced in Slice 80-G.7.
  - majit-backend-cranelift/src/compiler.rs: three FAIL_DESCR_REGISTRY_GLOBAL references replaced with FailDescrCell / recover_fail_descr_cell wording; register_fail_descrs docstring no longer claims an addr-to-Arc lookup table (it pins descrs onto CompiledLoopToken.asmmemmgr_gcreftracers).
  - majit-backend-dynasm/src/aarch64/assembler.rs: SOURCE_OP_INDEX_TABLE 'kept pending removal' note retired (the side-table is gone; source_op_index is stamped directly on the meta descr).
  - majit-backend/src/lib.rs: Backend::fail_descr_arc_from_addr doc and default-panic message rewritten to describe the FailDescrCell thin-pointer contract (history.py:109-114 AbstractDescr.show = pure cast) instead of the retired addr-to-Arc registry.

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured fail descriptor handling in the JIT compiler backend for improved architectural clarity.
  * Removed internal helper methods to streamline descriptor recovery logic.

* **Documentation**
  * Updated internal documentation to reflect changes to descriptor lifecycle management and JIT token teardown behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->