### PR TITLE
JIT profiler parity: timing state, CompiledLoopToken counters, debug section nesting

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7007,6 +7007,12 @@ fn resolve_fail_arg_types(
 // ---------------------------------------------------------------------------
 
 pub struct CraneliftBackend {
+    /// `rpython/jit/backend/model.py:28-29 self.tracker =
+    /// CPUTotalTracker()` parity — per-instance `cpu.tracker`
+    /// exposed via [`Backend::cpu_tracker`].  See the DynasmBackend
+    /// counterpart for the shared-Arc pairing rationale with the
+    /// metainterp `JitProfiler`.
+    cpu_tracker: Arc<majit_backend::CpuTotalTracker>,
     module: JITModule,
     func_ctx: FunctionBuilderContext,
     constants: majit_ir::VecAssoc<u32, i64>,
@@ -7207,6 +7213,7 @@ impl CraneliftBackend {
         let func_ctx = FunctionBuilderContext::new();
 
         CraneliftBackend {
+            cpu_tracker: Arc::new(majit_backend::CpuTotalTracker::default()),
             module,
             func_ctx,
             constants: majit_ir::VecAssoc::new(),
@@ -14072,6 +14079,10 @@ impl majit_backend::Backend for CraneliftBackend {
         "cranelift"
     }
 
+    fn cpu_tracker(&self) -> &Arc<majit_backend::CpuTotalTracker> {
+        &self.cpu_tracker
+    }
+
     fn compile_loop(
         &mut self,
         inputargs: &[InputArg],
@@ -14081,11 +14092,9 @@ impl majit_backend::Backend for CraneliftBackend {
         // `x86/assembler.py:514` parity — bump
         // `cpu.tracker.total_compiled_loops` and open the
         // `jit-mem-looptoken-alloc` debug section at the same point
-        // PyPy's `assemble_loop` creates the `CompiledLoopToken`.  See
-        // `majit_backend::record_compiled_loop_token` for the
-        // eager-vs-lazy CLT adaptation note.
+        // PyPy's `assemble_loop` creates the `CompiledLoopToken`.
         if let Some(clt) = token.compiled_loop_token.as_ref() {
-            majit_backend::record_compiled_loop_token(clt);
+            majit_backend::record_compiled_loop_token(&self.cpu_tracker, clt);
         }
         // Deep-clone Op out of OpRc for the internal pipeline (post-optimizer
         // boundary; backend stages do not depend on `_forwarded` sharing).
@@ -14233,10 +14242,10 @@ impl majit_backend::Backend for CraneliftBackend {
         previous_tokens: &[std::sync::Arc<JitCellToken>],
         caller_recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
     ) -> Result<AsmInfo, BackendError> {
-        // `x86/runner.py:100-101` parity — bump the global tracker and
-        // the per-loop bridges_count before assembling.
+        // `x86/runner.py:100-101` parity — bump this backend's
+        // tracker and the per-loop bridges_count before assembling.
         if let Some(clt) = original_token.compiled_loop_token.as_ref() {
-            clt.compiling_a_bridge();
+            clt.compiling_a_bridge(&self.cpu_tracker);
         }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -14078,6 +14078,15 @@ impl majit_backend::Backend for CraneliftBackend {
         ops: &[OpRc],
         token: &mut JitCellToken,
     ) -> Result<AsmInfo, BackendError> {
+        // `x86/assembler.py:514` parity — bump
+        // `cpu.tracker.total_compiled_loops` and open the
+        // `jit-mem-looptoken-alloc` debug section at the same point
+        // PyPy's `assemble_loop` creates the `CompiledLoopToken`.  See
+        // `majit_backend::record_compiled_loop_token` for the
+        // eager-vs-lazy CLT adaptation note.
+        if let Some(clt) = token.compiled_loop_token.as_ref() {
+            majit_backend::record_compiled_loop_token(clt);
+        }
         // Deep-clone Op out of OpRc for the internal pipeline (post-optimizer
         // boundary; backend stages do not depend on `_forwarded` sharing).
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -14224,6 +14224,11 @@ impl majit_backend::Backend for CraneliftBackend {
         previous_tokens: &[std::sync::Arc<JitCellToken>],
         caller_recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
     ) -> Result<AsmInfo, BackendError> {
+        // `x86/runner.py:100-101` parity — bump the global tracker and
+        // the per-loop bridges_count before assembling.
+        if let Some(clt) = original_token.compiled_loop_token.as_ref() {
+            clt.compiling_a_bridge();
+        }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
         let invalidated_arc = original_token.invalidated.clone();

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -687,6 +687,16 @@ pub unsafe extern "C" fn dynasm_realloc_frame(
 
 /// runner.py:23 AbstractX86CPU — concrete Backend implementation.
 pub struct DynasmBackend {
+    /// `rpython/jit/backend/model.py:28-29 self.tracker = CPUTotalTracker()`
+    /// parity — per-instance `cpu.tracker` exposed via
+    /// [`Backend::cpu_tracker`].  Held behind `Arc` so the same
+    /// counters are shared with the paired `JitProfiler` (which
+    /// borrows the same `Arc` during [`crate::pyjitpl::MetaInterp::new`]
+    /// setup in metainterp) — reads through `Profiler.get_counter`
+    /// and writes through [`majit_backend::record_compiled_loop_token`]
+    /// / [`CompiledLoopToken::compiling_a_bridge`] hit one shared
+    /// store.
+    cpu_tracker: Arc<majit_backend::CpuTotalTracker>,
     /// Next unique trace ID.
     next_trace_id: u64,
     /// Next header PC (green key).
@@ -792,6 +802,7 @@ impl DynasmBackend {
         // `compile.make_and_attach_done_descrs([self, cpu])` during
         // `MetaInterpStaticData.finish_setup` (pyjitpl.py:2222).
         DynasmBackend {
+            cpu_tracker: Arc::new(majit_backend::CpuTotalTracker::default()),
             next_trace_id: 1,
             next_header_pc: 0,
             constants: majit_ir::VecAssoc::new(),
@@ -1635,6 +1646,10 @@ impl DynasmBackend {
 }
 
 impl Backend for DynasmBackend {
+    fn cpu_tracker(&self) -> &Arc<majit_backend::CpuTotalTracker> {
+        &self.cpu_tracker
+    }
+
     fn compile_loop(
         &mut self,
         inputargs: &[InputArg],
@@ -1649,7 +1664,7 @@ impl Backend for DynasmBackend {
         // `CompiledLoopToken::new`; defer both to here so the counter
         // matches PyPy at the same structural moment.
         if let Some(clt) = token.compiled_loop_token.as_ref() {
-            majit_backend::record_compiled_loop_token(clt);
+            majit_backend::record_compiled_loop_token(&self.cpu_tracker, clt);
         }
         // Deep-clone Op out of OpRc for the internal pipeline. Backend
         // stages do not depend on shared `_forwarded` identity with the
@@ -1875,11 +1890,11 @@ impl Backend for DynasmBackend {
         // `x86/runner.py:100-101` parity:
         //   clt = original_loop_token.compiled_loop_token
         //   clt.compiling_a_bridge()
-        // Bumps `cpu.tracker.total_compiled_bridges`, the per-loop
-        // `bridges_count`, and emits the `jit-mem-looptoken-alloc`
-        // debug section.
+        // Bumps this backend's `cpu.tracker.total_compiled_bridges`,
+        // the per-loop `bridges_count`, and emits the
+        // `jit-mem-looptoken-alloc` debug section.
         if let Some(clt) = original_token.compiled_loop_token.as_ref() {
-            clt.compiling_a_bridge();
+            clt.compiling_a_bridge(&self.cpu_tracker);
         }
         // Deep-clone Op out of OpRc for the internal pipeline (see
         // compile_loop above for rationale).

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1641,6 +1641,16 @@ impl Backend for DynasmBackend {
         ops: &[OpRc],
         token: &mut JitCellToken,
     ) -> Result<AsmInfo, BackendError> {
+        // `x86/assembler.py:514` parity: PyPy creates the
+        // `CompiledLoopToken` inside `assemble_loop`, and that's where
+        // the `cpu.tracker.total_compiled_loops` bump and the
+        // `jit-mem-looptoken-alloc` debug section fire.  Pyre's eager
+        // CLT creation makes that point unreachable from
+        // `CompiledLoopToken::new`; defer both to here so the counter
+        // matches PyPy at the same structural moment.
+        if let Some(clt) = token.compiled_loop_token.as_ref() {
+            majit_backend::record_compiled_loop_token(clt);
+        }
         // Deep-clone Op out of OpRc for the internal pipeline. Backend
         // stages do not depend on shared `_forwarded` identity with the
         // trace; the optimizer has already resolved forwarding by the

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -401,8 +401,31 @@ pub extern "C" fn dynasm_nursery_slowpath_jitframe(frame_size: u64) -> u64 {
     })
 }
 
-/// _build_malloc_slowpath(kind='var') parity: varsize nursery overflow.
-/// Called with (base_size, item_size, length). Returns payload pointer.
+/// `_build_malloc_slowpath(kind='var')` parity: varsize nursery
+/// overflow.  Called with `(base_size, item_size, length)`; returns the
+/// payload pointer.
+///
+/// **PRE-EXISTING-ADAPTATION (str/unicode/var slowpath collapse).**
+/// PyPy `x86/assembler.py:231-323 _build_malloc_slowpath(kind)` builds
+/// four distinct trampolines (`'fixed'`, `'str'`, `'unicode'`, `'var'`)
+/// stored as separate fields on the assembler
+/// (`malloc_slowpath`/`malloc_slowpath_varsize`/`malloc_slowpath_str`/
+/// `malloc_slowpath_unicode`).  Each callsite (`assembler.py:2592-2598`
+/// in `genop_call_malloc_nursery_varsize`) jumps to the trampoline
+/// matching the requested kind, which in turn calls the GC helper
+/// (`malloc_str`, `malloc_unicode`, `gc_ll_descr.malloc_slowpath_array`).
+///
+/// Pyre collapses the three varsize kinds into this single helper —
+/// `gc.alloc_varsize(base, item, length)` covers all three since pyre's
+/// `majit-gc` does not specialise on str/unicode object headers.  The
+/// fast path (`OpCode::CallMallocNurseryVarsize` in
+/// `x86/assembler.rs`) `CALL`s this directly instead of `JMP`-ing into
+/// a per-kind trampoline; OOM propagation flows through the same
+/// `propagate_exception_path` PyPy uses, just inlined per callsite
+/// rather than reached via the trampoline's tail `JMP`.  The behaviour
+/// is observationally identical (allocate-or-OOM-propagate); the
+/// missing per-kind trampolines are a code-shape divergence to revisit
+/// if pyre adopts the PyPy-style header-specialised GC allocators.
 pub extern "C" fn dynasm_nursery_slowpath_varsize(
     base_size: u64,
     item_size: u64,
@@ -1839,6 +1862,15 @@ impl Backend for DynasmBackend {
         _previous_tokens: &[std::sync::Arc<JitCellToken>],
         _caller_recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
     ) -> Result<AsmInfo, BackendError> {
+        // `x86/runner.py:100-101` parity:
+        //   clt = original_loop_token.compiled_loop_token
+        //   clt.compiling_a_bridge()
+        // Bumps `cpu.tracker.total_compiled_bridges`, the per-loop
+        // `bridges_count`, and emits the `jit-mem-looptoken-alloc`
+        // debug section.
+        if let Some(clt) = original_token.compiled_loop_token.as_ref() {
+            clt.compiling_a_bridge();
+        }
         // Deep-clone Op out of OpRc for the internal pipeline (see
         // compile_loop above for rationale).
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -125,6 +125,10 @@ fn wasm_gc_owns_object(addr: usize) -> bool {
 }
 
 pub struct WasmBackend {
+    /// `rpython/jit/backend/model.py:28-29 self.tracker =
+    /// CPUTotalTracker()` parity — per-instance `cpu.tracker`
+    /// exposed via [`majit_backend::Backend::cpu_tracker`].
+    cpu_tracker: std::sync::Arc<majit_backend::CpuTotalTracker>,
     trace_counter: u64,
     /// Optimizer constant pool (constant-namespace OpRef → i64 value).
     constants: majit_ir::VecAssoc<u32, i64>,
@@ -135,6 +139,7 @@ pub struct WasmBackend {
 impl WasmBackend {
     pub fn new() -> Self {
         WasmBackend {
+            cpu_tracker: std::sync::Arc::new(majit_backend::CpuTotalTracker::default()),
             trace_counter: 0,
             constants: majit_ir::VecAssoc::new(),
             vtable_offset: None,
@@ -291,6 +296,10 @@ impl WasmBackend {
 unsafe impl Send for WasmBackend {}
 
 impl majit_backend::Backend for WasmBackend {
+    fn cpu_tracker(&self) -> &std::sync::Arc<majit_backend::CpuTotalTracker> {
+        &self.cpu_tracker
+    }
+
     fn backend_name(&self) -> &'static str {
         "wasm"
     }
@@ -305,7 +314,7 @@ impl majit_backend::Backend for WasmBackend {
         // `cpu.tracker.total_compiled_loops` at the same point PyPy
         // creates the `CompiledLoopToken`.
         if let Some(clt) = token.compiled_loop_token.as_ref() {
-            majit_backend::record_compiled_loop_token(clt);
+            majit_backend::record_compiled_loop_token(&self.cpu_tracker, clt);
         }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -301,6 +301,12 @@ impl majit_backend::Backend for WasmBackend {
         ops: &[OpRc],
         token: &mut JitCellToken,
     ) -> Result<AsmInfo, BackendError> {
+        // `x86/assembler.py:514` parity — bump
+        // `cpu.tracker.total_compiled_loops` at the same point PyPy
+        // creates the `CompiledLoopToken`.
+        if let Some(clt) = token.compiled_loop_token.as_ref() {
+            majit_backend::record_compiled_loop_token(clt);
+        }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
         self.collect_constants_from_ops(ops);

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1590,16 +1590,23 @@ pub trait Backend: Send {
     /// [`CompiledLoopToken::compiling_a_bridge`] read this through
     /// `&self` so multi-backend processes (e.g. test fixtures
     /// creating fresh `MetaInterpStaticData` repeatedly) keep
-    /// counters isolated.  Default returns the process-wide
-    /// [`fallback_cpu_tracker`] so synthetic/test backends that
-    /// haven't migrated continue to behave like the previous
-    /// process-global singleton.
+    /// counters isolated.
+    ///
+    /// Default returns a process-wide `Arc<CpuTotalTracker>` distinct
+    /// from [`fallback_cpu_tracker`]: the trait signature is
+    /// `&Arc<CpuTotalTracker>` (so callers can `Arc::clone` into
+    /// [`crate::JitProfiler::set_cpu_tracker`]) while
+    /// `fallback_cpu_tracker` returns a `&'static CpuTotalTracker`
+    /// reference for callers that already have direct access.  The
+    /// two statics therefore back independent counter stores;
+    /// synthetic/test backends that don't override this method
+    /// continue to behave like a process-global singleton among
+    /// themselves but won't observe writes through
+    /// `fallback_cpu_tracker`.
     fn cpu_tracker(&self) -> &Arc<CpuTotalTracker> {
-        // SAFETY: the fallback Arc is borrowed from a process-global
-        // OnceLock; reading the cached value is sound from any
-        // thread.
-        static FALLBACK: std::sync::OnceLock<Arc<CpuTotalTracker>> = std::sync::OnceLock::new();
-        FALLBACK.get_or_init(|| Arc::new(CpuTotalTracker::default()))
+        static FALLBACK_ARC: std::sync::OnceLock<Arc<CpuTotalTracker>> =
+            std::sync::OnceLock::new();
+        FALLBACK_ARC.get_or_init(|| Arc::new(CpuTotalTracker::default()))
     }
 
     /// Compile a loop trace into native code.

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -5,9 +5,48 @@
 /// and the code generation backend (Cranelift, etc.).
 use std::cell::Cell;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
+
+/// `rpython/jit/backend/model.py:8-12 CPUTotalTracker` — per-CPU totals
+/// bumped by `CompiledLoopToken.__init__` / `compiling_a_bridge` (loops
+/// and bridges created) and by the memory manager (loops and bridges
+/// freed).  PyPy attaches one tracker per `AbstractCPU` instance
+/// (`model.py:28-29 self.tracker = CPUTotalTracker()`); pyre has a
+/// single backend per process (no multi-CPU JIT setup) so the
+/// `cpu.tracker` chain collapses to one process-global instance
+/// reachable via [`cpu_tracker`].
+///
+/// Each field is an [`AtomicUsize`] because PyPy's GIL-protected
+/// `+= 1` on a Python int becomes a cross-thread mutation in pyre — the
+/// backend may compile loops/bridges from worker threads while another
+/// reads totals.  `Relaxed` ordering matches PyPy: there is no causal
+/// relationship between bumps and snapshots.
+#[derive(Default, Debug)]
+pub struct CpuTotalTracker {
+    /// `model.py:9` `total_compiled_loops` — bumped by
+    /// [`CompiledLoopToken::new`] on every fresh `CompiledLoopToken`.
+    pub total_compiled_loops: AtomicUsize,
+    /// `model.py:10` `total_compiled_bridges` — bumped by
+    /// [`CompiledLoopToken::compiling_a_bridge`] before bridge assembly.
+    pub total_compiled_bridges: AtomicUsize,
+    /// `model.py:11` `total_freed_loops` — bumped by the memory manager
+    /// (`memmgr.py:_kill_old_loops_now`) when an evicted token had no
+    /// attached bridges.
+    pub total_freed_loops: AtomicUsize,
+    /// `model.py:12` `total_freed_bridges` — bumped by the memory
+    /// manager for each bridge attached to an evicted token.
+    pub total_freed_bridges: AtomicUsize,
+}
+
+/// Process-global [`CpuTotalTracker`] singleton.  Mirrors PyPy's
+/// `cpu.tracker` for the single-backend pyre runtime; reads/writes
+/// share one instance across all profilers and backends.
+pub fn cpu_tracker() -> &'static CpuTotalTracker {
+    static TRACKER: std::sync::OnceLock<CpuTotalTracker> = std::sync::OnceLock::new();
+    TRACKER.get_or_init(CpuTotalTracker::default)
+}
 
 pub mod call_stub;
 pub mod finish_descrs;
@@ -901,7 +940,17 @@ pub struct CompiledLoopToken {
 impl CompiledLoopToken {
     /// `model.py:296-307` `__init__(self, cpu, number)`. The `cpu` is
     /// implicit in pyre — the owning `Backend` holds the token lifetime.
+    /// Bumps [`cpu_tracker().total_compiled_loops`](cpu_tracker) and emits
+    /// the `jit-mem-looptoken-alloc` debug section line-for-line with
+    /// upstream (`model.py:297, 305-307`).
     pub fn new(number: u64) -> Self {
+        cpu_tracker()
+            .total_compiled_loops
+            .fetch_add(1, Ordering::Relaxed);
+        majit_ir::debug::log_one(
+            "jit-mem-looptoken-alloc",
+            &format!("allocating Loop # {}", number),
+        );
         CompiledLoopToken {
             number,
             loop_token_wref: parking_lot::Mutex::new(std::sync::Weak::new()),
@@ -933,13 +982,26 @@ impl CompiledLoopToken {
         self.loop_token_wref.lock().upgrade()
     }
 
-    /// `model.py:309-314` `compiling_a_bridge(self)`. The accompanying
-    /// `self.cpu.tracker.total_compiled_bridges += 1` and
-    /// `debug_start/debug_print/debug_stop` on the RPython side are
-    /// **PRE-EXISTING-ADAPTATION** (pyre has no global `cpu.tracker`
-    /// counter and uses `tracing` crate instead of `rpython.rlib.debug`).
+    /// `model.py:309-314` `compiling_a_bridge(self)` — bumps the global
+    /// `total_compiled_bridges` tracker, increments this token's local
+    /// `bridges_count`, and emits the `jit-mem-looptoken-alloc` debug
+    /// section line-for-line with upstream.
     pub fn compiling_a_bridge(&self) {
-        *self.bridges_count.lock() += 1;
+        cpu_tracker()
+            .total_compiled_bridges
+            .fetch_add(1, Ordering::Relaxed);
+        let bridges_count = {
+            let mut count = self.bridges_count.lock();
+            *count += 1;
+            *count
+        };
+        majit_ir::debug::log_one(
+            "jit-mem-looptoken-alloc",
+            &format!(
+                "allocating Bridge # {} of Loop # {}",
+                bridges_count, self.number
+            ),
+        );
     }
 
     /// `rpython/jit/backend/model.py:316-329`

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -971,9 +971,7 @@ pub struct CompiledLoopToken {
 /// same process keep separate totals — matching PyPy's per-CPU
 /// `cpu.tracker`.
 pub fn record_compiled_loop_token(tracker: &CpuTotalTracker, clt: &CompiledLoopToken) {
-    tracker
-        .total_compiled_loops
-        .fetch_add(1, Ordering::Relaxed);
+    tracker.total_compiled_loops.fetch_add(1, Ordering::Relaxed);
     majit_ir::debug::log_one(
         "jit-mem-looptoken-alloc",
         &format!("allocating Loop # {}", clt.number),

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -18,6 +18,20 @@ use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
 /// `cpu.tracker` chain collapses to one process-global instance
 /// reachable via [`cpu_tracker`].
 ///
+/// **STRUCTURAL ADAPTATION — process-global vs per-instance.**  PyPy
+/// reads totals via `Profiler.get_counter(TOTAL_*)` →
+/// `getattr(self.cpu.tracker, ...)` so each `AbstractCPU` instance owns
+/// its own counts.  Pyre's `cpu_tracker()` collapses that to one
+/// `OnceLock<CpuTotalTracker>`; if pyre later supports multiple
+/// `Backend` instances in one process (e.g. cross-isolate JIT, parallel
+/// translation tests holding their own backend), counts will be shared
+/// across them — diverging from PyPy where each CPU has private
+/// totals.  Until that scenario materialises, the single tracker is
+/// the simplest faithful port; the lift to per-`Backend` ownership
+/// only needs to (a) move the field onto `Backend`, (b) thread a
+/// `&CpuTotalTracker` into `CompiledLoopToken::new`/`compiling_a_bridge`,
+/// and (c) give `JitProfiler` an `Arc<CpuTotalTracker>` to read.
+///
 /// Each field is an [`AtomicUsize`] because PyPy's GIL-protected
 /// `+= 1` on a Python int becomes a cross-thread mutation in pyre — the
 /// backend may compile loops/bridges from worker threads while another

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -951,20 +951,41 @@ pub struct CompiledLoopToken {
     pub _ll_initial_locs: parking_lot::Mutex<Vec<i32>>,
 }
 
+/// PyPy `model.py:296-307` `CompiledLoopToken.__init__` opens the
+/// `jit-mem-looptoken-alloc` debug section and bumps
+/// `cpu.tracker.total_compiled_loops` at the point where the CLT is
+/// created — `x86/assembler.py:514` and the per-backend equivalents do
+/// that *inside* `assemble_loop`.  Pyre's [`CompiledLoopToken::new`]
+/// runs eagerly from [`JitCellToken::new`] (line 1265 documents the
+/// eager-vs-lazy adaptation), so doing the bump there would
+/// over-count loops whose JitCellToken is allocated but never reaches
+/// `backend.compile_loop` (the `register_pending_target` path in
+/// `dynasm/runner.rs` is one such caller).
+///
+/// Each backend's `compile_loop` calls this helper as its first act so
+/// the bump fires at the same structural point PyPy does, matching
+/// `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` line-for-line.
+pub fn record_compiled_loop_token(clt: &CompiledLoopToken) {
+    cpu_tracker()
+        .total_compiled_loops
+        .fetch_add(1, Ordering::Relaxed);
+    majit_ir::debug::log_one(
+        "jit-mem-looptoken-alloc",
+        &format!("allocating Loop # {}", clt.number),
+    );
+}
+
 impl CompiledLoopToken {
     /// `model.py:296-307` `__init__(self, cpu, number)`. The `cpu` is
     /// implicit in pyre — the owning `Backend` holds the token lifetime.
-    /// Bumps [`cpu_tracker().total_compiled_loops`](cpu_tracker) and emits
-    /// the `jit-mem-looptoken-alloc` debug section line-for-line with
-    /// upstream (`model.py:297, 305-307`).
+    ///
+    /// **Counter / debug-section moved.**  PyPy bumps
+    /// `cpu.tracker.total_compiled_loops` and emits the
+    /// `jit-mem-looptoken-alloc` debug section here.  Pyre defers both
+    /// to [`record_compiled_loop_token`] called at the
+    /// [`Backend::compile_loop`] entry — see that helper's doc for the
+    /// eager-CLT rationale.
     pub fn new(number: u64) -> Self {
-        cpu_tracker()
-            .total_compiled_loops
-            .fetch_add(1, Ordering::Relaxed);
-        majit_ir::debug::log_one(
-            "jit-mem-looptoken-alloc",
-            &format!("allocating Loop # {}", number),
-        );
         CompiledLoopToken {
             number,
             loop_token_wref: parking_lot::Mutex::new(std::sync::Weak::new()),

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -13,24 +13,14 @@ use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
 /// bumped by `CompiledLoopToken.__init__` / `compiling_a_bridge` (loops
 /// and bridges created) and by the memory manager (loops and bridges
 /// freed).  PyPy attaches one tracker per `AbstractCPU` instance
-/// (`model.py:28-29 self.tracker = CPUTotalTracker()`); pyre has a
-/// single backend per process (no multi-CPU JIT setup) so the
-/// `cpu.tracker` chain collapses to one process-global instance
-/// reachable via [`cpu_tracker`].
-///
-/// **STRUCTURAL ADAPTATION — process-global vs per-instance.**  PyPy
-/// reads totals via `Profiler.get_counter(TOTAL_*)` →
-/// `getattr(self.cpu.tracker, ...)` so each `AbstractCPU` instance owns
-/// its own counts.  Pyre's `cpu_tracker()` collapses that to one
-/// `OnceLock<CpuTotalTracker>`; if pyre later supports multiple
-/// `Backend` instances in one process (e.g. cross-isolate JIT, parallel
-/// translation tests holding their own backend), counts will be shared
-/// across them — diverging from PyPy where each CPU has private
-/// totals.  Until that scenario materialises, the single tracker is
-/// the simplest faithful port; the lift to per-`Backend` ownership
-/// only needs to (a) move the field onto `Backend`, (b) thread a
-/// `&CpuTotalTracker` into `CompiledLoopToken::new`/`compiling_a_bridge`,
-/// and (c) give `JitProfiler` an `Arc<CpuTotalTracker>` to read.
+/// (`model.py:28-29 self.tracker = CPUTotalTracker()`).  Pyre matches
+/// that shape: each [`Backend`] impl owns an `Arc<CpuTotalTracker>`
+/// exposed via [`Backend::cpu_tracker`], and `MetaInterp::new` rebinds
+/// the paired profiler's tracker handle to the same Arc so reads
+/// through `Profiler.get_counter(TOTAL_*)` hit the same sink the
+/// backend's `compile_loop` / `compile_bridge` write to.  Multiple
+/// backend instances coexisting in one process (e.g. parallel
+/// translation tests) keep their totals isolated.
 ///
 /// Each field is an [`AtomicUsize`] because PyPy's GIL-protected
 /// `+= 1` on a Python int becomes a cross-thread mutation in pyre — the
@@ -59,10 +49,16 @@ pub struct CpuTotalTracker {
     pub total_freed_bridges: AtomicUsize,
 }
 
-/// Process-global [`CpuTotalTracker`] singleton.  Mirrors PyPy's
-/// `cpu.tracker` for the single-backend pyre runtime; reads/writes
-/// share one instance across all profilers and backends.
-pub fn cpu_tracker() -> &'static CpuTotalTracker {
+/// Process-wide fallback [`CpuTotalTracker`] for callers that have no
+/// backend handle in scope.  Should be reserved for legacy/test paths
+/// that pre-date the per-backend [`Backend::cpu_tracker`] hook; the
+/// production path threads each backend's own `Arc<CpuTotalTracker>`
+/// through [`record_compiled_loop_token`] and
+/// [`CompiledLoopToken::compiling_a_bridge`] so PyPy's per-CPU
+/// `cpu.tracker` semantics survive when multiple backends or
+/// `MetaInterpStaticData` instances coexist (e.g. tests that build
+/// fresh fixtures inside one process).
+pub fn fallback_cpu_tracker() -> &'static CpuTotalTracker {
     static TRACKER: std::sync::OnceLock<CpuTotalTracker> = std::sync::OnceLock::new();
     TRACKER.get_or_init(CpuTotalTracker::default)
 }
@@ -969,9 +965,13 @@ pub struct CompiledLoopToken {
 ///
 /// Each backend's `compile_loop` calls this helper as its first act so
 /// the bump fires at the same structural point PyPy does, matching
-/// `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` line-for-line.
-pub fn record_compiled_loop_token(clt: &CompiledLoopToken) {
-    cpu_tracker()
+/// `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` line-for-line.  The
+/// caller passes its own [`CpuTotalTracker`] (via
+/// [`Backend::cpu_tracker`]) so multiple backend instances in the
+/// same process keep separate totals — matching PyPy's per-CPU
+/// `cpu.tracker`.
+pub fn record_compiled_loop_token(tracker: &CpuTotalTracker, clt: &CompiledLoopToken) {
+    tracker
         .total_compiled_loops
         .fetch_add(1, Ordering::Relaxed);
     majit_ir::debug::log_one(
@@ -1022,12 +1022,16 @@ impl CompiledLoopToken {
         self.loop_token_wref.lock().upgrade()
     }
 
-    /// `model.py:309-314` `compiling_a_bridge(self)` — bumps the global
-    /// `total_compiled_bridges` tracker, increments this token's local
-    /// `bridges_count`, and emits the `jit-mem-looptoken-alloc` debug
-    /// section line-for-line with upstream.
-    pub fn compiling_a_bridge(&self) {
-        cpu_tracker()
+    /// `model.py:309-314` `compiling_a_bridge(self)` — bumps the
+    /// owning backend's `total_compiled_bridges` tracker, increments
+    /// this token's local `bridges_count`, and emits the
+    /// `jit-mem-looptoken-alloc` debug section line-for-line with
+    /// upstream.  The `tracker` parameter is the backend's own
+    /// [`CpuTotalTracker`] (via [`Backend::cpu_tracker`]) so multiple
+    /// backend instances stay isolated, matching PyPy's per-CPU
+    /// `cpu.tracker`.
+    pub fn compiling_a_bridge(&self, tracker: &CpuTotalTracker) {
+        tracker
             .total_compiled_bridges
             .fetch_add(1, Ordering::Relaxed);
         let bridges_count = {
@@ -1582,6 +1586,24 @@ pub type CpuDescrHandle = Arc<std::sync::RwLock<CpuDescrAttachments>>;
 ///
 /// Mirrors rpython/jit/backend/model.py AbstractCPU.
 pub trait Backend: Send {
+    /// `rpython/jit/backend/model.py:28-29` `self.tracker =
+    /// CPUTotalTracker()` parity — each backend instance owns its
+    /// own [`CpuTotalTracker`].  [`record_compiled_loop_token`] and
+    /// [`CompiledLoopToken::compiling_a_bridge`] read this through
+    /// `&self` so multi-backend processes (e.g. test fixtures
+    /// creating fresh `MetaInterpStaticData` repeatedly) keep
+    /// counters isolated.  Default returns the process-wide
+    /// [`fallback_cpu_tracker`] so synthetic/test backends that
+    /// haven't migrated continue to behave like the previous
+    /// process-global singleton.
+    fn cpu_tracker(&self) -> &Arc<CpuTotalTracker> {
+        // SAFETY: the fallback Arc is borrowed from a process-global
+        // OnceLock; reading the cached value is sound from any
+        // thread.
+        static FALLBACK: std::sync::OnceLock<Arc<CpuTotalTracker>> = std::sync::OnceLock::new();
+        FALLBACK.get_or_init(|| Arc::new(CpuTotalTracker::default()))
+    }
+
     /// Compile a loop trace into native code.
     fn compile_loop(
         &mut self,

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -40,7 +40,12 @@ use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
 #[derive(Default, Debug)]
 pub struct CpuTotalTracker {
     /// `model.py:9` `total_compiled_loops` — bumped by
-    /// [`CompiledLoopToken::new`] on every fresh `CompiledLoopToken`.
+    /// [`record_compiled_loop_token`] at each backend's `compile_loop`
+    /// entry (PyPy `x86/assembler.py:514` parity).  The bump used to
+    /// live in [`CompiledLoopToken::new`] but moved because pyre
+    /// eagerly creates the CLT in `JitCellToken::new`, which would
+    /// over-count tokens that are allocated but never assembled
+    /// (the `register_pending_target` path is one such caller).
     pub total_compiled_loops: AtomicUsize,
     /// `model.py:10` `total_compiled_bridges` — bumped by
     /// [`CompiledLoopToken::compiling_a_bridge`] before bridge assembly.

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -29,13 +29,14 @@ use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
 /// relationship between bumps and snapshots.
 #[derive(Default, Debug)]
 pub struct CpuTotalTracker {
-    /// `model.py:9` `total_compiled_loops` — bumped by
-    /// [`record_compiled_loop_token`] at each backend's `compile_loop`
-    /// entry (PyPy `x86/assembler.py:514` parity).  The bump used to
-    /// live in [`CompiledLoopToken::new`] but moved because pyre
-    /// eagerly creates the CLT in `JitCellToken::new`, which would
-    /// over-count tokens that are allocated but never assembled
-    /// (the `register_pending_target` path is one such caller).
+    /// `model.py:9` `total_compiled_loops` — bumped once by
+    /// [`record_compiled_loop_token`] for each [`CompiledLoopToken`],
+    /// at backend `compile_loop` entry (PyPy `x86/assembler.py:514`
+    /// parity).  The bump used to live in [`CompiledLoopToken::new`]
+    /// but moved because pyre eagerly creates the CLT in
+    /// `JitCellToken::new`, which would over-count tokens that are
+    /// allocated but never assembled (the `register_pending_target`
+    /// path is one such caller).
     pub total_compiled_loops: AtomicUsize,
     /// `model.py:10` `total_compiled_bridges` — bumped by
     /// [`CompiledLoopToken::compiling_a_bridge`] before bridge assembly.
@@ -950,6 +951,18 @@ pub struct CompiledLoopToken {
     /// `CALL_ASSEMBLER` uses in `handle_call_assembler`
     /// (rewrite.py:673) to spill callee arguments.
     pub _ll_initial_locs: parking_lot::Mutex<Vec<i32>>,
+    /// Pyre-only one-shot latch for the side effects PyPy performs in
+    /// `CompiledLoopToken.__init__` (`model.py:296-307`): increment
+    /// `cpu.tracker.total_compiled_loops` and emit the
+    /// `jit-mem-looptoken-alloc` log section.
+    ///
+    /// PyPy creates the CLT inside backend `assemble_loop`, so the
+    /// constructor side effects are naturally tied to actual assembly.
+    /// Pyre creates `CompiledLoopToken` eagerly with `JitCellToken`;
+    /// this latch lets `record_compiled_loop_token` fire at backend
+    /// assembly time while preserving PyPy's strict "once per CLT"
+    /// semantics if a caller retries `compile_loop` with the same token.
+    loop_allocation_recorded: AtomicBool,
 }
 
 /// PyPy `model.py:296-307` `CompiledLoopToken.__init__` opens the
@@ -963,14 +976,18 @@ pub struct CompiledLoopToken {
 /// `backend.compile_loop` (the `register_pending_target` path in
 /// `dynasm/runner.rs` is one such caller).
 ///
-/// Each backend's `compile_loop` calls this helper as its first act so
-/// the bump fires at the same structural point PyPy does, matching
-/// `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` line-for-line.  The
-/// caller passes its own [`CpuTotalTracker`] (via
+/// Each backend's `compile_loop` calls this helper as its first act.
+/// The helper records at most once per [`CompiledLoopToken`], matching
+/// PyPy's constructor side effect even if a Rust caller retries
+/// `compile_loop` with the same token.  The caller passes its own
+/// [`CpuTotalTracker`] (via
 /// [`Backend::cpu_tracker`]) so multiple backend instances in the
 /// same process keep separate totals — matching PyPy's per-CPU
 /// `cpu.tracker`.
 pub fn record_compiled_loop_token(tracker: &CpuTotalTracker, clt: &CompiledLoopToken) {
+    if clt.loop_allocation_recorded.swap(true, Ordering::AcqRel) {
+        return;
+    }
     tracker.total_compiled_loops.fetch_add(1, Ordering::Relaxed);
     majit_ir::debug::log_one(
         "jit-mem-looptoken-alloc",
@@ -999,6 +1016,7 @@ impl CompiledLoopToken {
             asmmemmgr_gcreftracers: parking_lot::Mutex::new(Vec::new()),
             frame_info: parking_lot::Mutex::new(JitFrameInfo::default()),
             _ll_initial_locs: parking_lot::Mutex::new(Vec::new()),
+            loop_allocation_recorded: AtomicBool::new(false),
         }
     }
 
@@ -1604,8 +1622,7 @@ pub trait Backend: Send {
     /// themselves but won't observe writes through
     /// `fallback_cpu_tracker`.
     fn cpu_tracker(&self) -> &Arc<CpuTotalTracker> {
-        static FALLBACK_ARC: std::sync::OnceLock<Arc<CpuTotalTracker>> =
-            std::sync::OnceLock::new();
+        static FALLBACK_ARC: std::sync::OnceLock<Arc<CpuTotalTracker>> = std::sync::OnceLock::new();
         FALLBACK_ARC.get_or_init(|| Arc::new(CpuTotalTracker::default()))
     }
 

--- a/majit/majit-backend/src/synthetic_cpu.rs
+++ b/majit/majit-backend/src/synthetic_cpu.rs
@@ -74,18 +74,28 @@ pub fn decode_synthetic(fnaddr: i64) -> Option<usize> {
 /// of `~/.claude/plans/pyre-call-family-canonical-migration.md`.
 #[derive(Default)]
 #[allow(dead_code)]
-pub struct SyntheticCpu;
+pub struct SyntheticCpu {
+    /// `model.py:28-29 self.tracker = CPUTotalTracker()` — synthetic
+    /// backends own a private tracker so cross-test/cross-instance
+    /// total counts stay isolated rather than aliasing through the
+    /// process-wide fallback.
+    cpu_tracker: std::sync::Arc<crate::CpuTotalTracker>,
+}
 
 impl SyntheticCpu {
     #[allow(dead_code)]
     pub fn new() -> Self {
-        SyntheticCpu
+        SyntheticCpu::default()
     }
 }
 
 impl crate::Backend for SyntheticCpu {
     fn backend_name(&self) -> &'static str {
         "synthetic"
+    }
+
+    fn cpu_tracker(&self) -> &std::sync::Arc<crate::CpuTotalTracker> {
+        &self.cpu_tracker
     }
 
     /// `rpython/jit/backend/model.py:79-91` declares `compile_loop` on every

--- a/majit/majit-ir/src/debug.rs
+++ b/majit/majit-ir/src/debug.rs
@@ -19,6 +19,47 @@
 //! backends — use [`log_one`], which opens a single-line section,
 //! emits the body, and closes the section in one call.  Multi-message
 //! pairs use [`scope`] (RAII) wrapping repeated [`debug_print`] calls.
+//!
+//! # Known divergences from `rpython/rlib/debug.py` / PYPYLOG
+//!
+//! The wire format matches, but four behaviours are deliberately
+//! reduced versions of upstream — each marked here so callers know
+//! what to expect:
+//!
+//! 1. **No category-prefix filter.**  PyPy's
+//!    `PYPYLOG=jit-tracing,jit-backend:filename` parses a comma list of
+//!    accepted category prefixes; only matching `debug_start` sections
+//!    are emitted.  Pyre's [`majit_log_enabled`] is a single all-or-
+//!    nothing switch — any value of `MAJIT_LOG` turns *every* category
+//!    on.  [`have_debug_prints_for`] preserves the upstream signature
+//!    so a future category parser can drop in without touching
+//!    callers.
+//!
+//! 2. **No translated/untranslated split.**  RPython's
+//!    `_log_capture` versus `_log` distinction (`rlib/debug.py:24-30`,
+//!    `60-67`) lets untranslated tests assert against captured
+//!    sections without writing to stderr.  Pyre always writes to
+//!    `stderr` via `eprintln!` — tests that need to assert on log
+//!    output redirect `stderr` at the OS level.
+//!
+//! 3. **Strict `debug_stop` nesting.**  RPython's
+//!    `DebugLog.debug_stop` (`rpython/rlib/debug.py:30`) raises on
+//!    mismatch; Pyre [`debug_stop`] panics with the same intent.  This
+//!    is intentional, but it does mean a mid-stack panic propagates
+//!    through any `debug_start`/`debug_stop` pair that was already
+//!    opened (the RAII [`scope`] guard absorbs this by closing in
+//!    `Drop`; bare `debug_start`/`debug_stop` callers must use
+//!    `try/finally`-equivalent unwind discipline).
+//!
+//! 4. **Single-file output, no `:filename` sink.**  PyPy's
+//!    `PYPYLOG=…:my.log` redirects to a file; pyre always uses
+//!    `stderr`.  External tools that consume PYPYLOG-formatted output
+//!    can capture pyre's `stderr` directly — the wire format is
+//!    identical.
+//!
+//! The first three are revisit candidates if pyre gains category-
+//! scoped log filtering or a per-test capture sink.  Until then
+//! `MAJIT_LOG=1` is the only knob.
 
 use std::cell::RefCell;
 use std::sync::OnceLock;

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -65,9 +65,11 @@ pub enum BoxKind {
 
     /// `resoperation.py:699 AbstractInputArg`.
     /// `position` mirrors `AbstractInputArg.position`
-    /// (resoperation.py:699) — `Optional` because pyre constructs
-    /// inputargs without an assigned slot in some test fixtures.
-    InputArg { position: Option<u32> },
+    /// (resoperation.py:699) — non-optional, matching upstream:
+    /// every `AbstractInputArg` has a fixed slot index.  Test
+    /// fixtures that previously constructed positionless inputargs
+    /// must now supply a concrete index.
+    InputArg { position: u32 },
 
     /// `history.py:220 ConstInt` / `:261 ConstFloat` / `:307 ConstPtr`.
     /// `const_index` is a pyre-only field carrying the
@@ -130,8 +132,11 @@ impl BoxRef {
         }))
     }
 
-    /// New `AbstractInputArg` Box.
-    pub fn new_inputarg(type_: Type, position: Option<u32>) -> Self {
+    /// New `AbstractInputArg` Box.  `position` is the input slot
+    /// index (`resoperation.py:699 AbstractInputArg.position`) — pyre
+    /// requires it at construction time matching upstream where every
+    /// inputarg has a definite slot.
+    pub fn new_inputarg(type_: Type, position: u32) -> Self {
         Self(Rc::new(Box {
             forwarded: RefCell::new(Forwarded::None),
             type_,
@@ -205,7 +210,7 @@ impl BoxRef {
     pub fn position(&self) -> Option<u32> {
         match &self.0.kind {
             BoxKind::ResOp { position } => Some(position.get()),
-            BoxKind::InputArg { position } => *position,
+            BoxKind::InputArg { position } => Some(*position),
             BoxKind::Const { .. } => None,
         }
     }
@@ -236,7 +241,7 @@ impl BoxRef {
     /// Extract `AbstractInputArg.position`.
     pub fn inputarg_position(&self) -> Option<u32> {
         match self.0.kind {
-            BoxKind::InputArg { position } => position,
+            BoxKind::InputArg { position } => Some(position),
             _ => None,
         }
     }
@@ -823,7 +828,7 @@ mod tests {
 
     #[test]
     fn inputarg_position_preserved() {
-        let arg = BoxRef::new_inputarg(Type::Ref, Some(3));
+        let arg = BoxRef::new_inputarg(Type::Ref, 3);
         assert!(arg.is_inputarg());
         assert_eq!(arg.inputarg_position(), Some(3));
         assert_eq!(arg.type_(), Type::Ref);
@@ -862,11 +867,13 @@ mod tests {
     }
 
     #[test]
-    fn position_returns_inputarg_position_when_set() {
-        let arg = BoxRef::new_inputarg(Type::Ref, Some(7));
+    fn position_returns_inputarg_position() {
+        // `resoperation.py:699 AbstractInputArg.position` is
+        // construction-time assigned and required (non-optional);
+        // the round-trip mirrors that contract.
+        let arg = BoxRef::new_inputarg(Type::Ref, 7);
         assert_eq!(arg.position(), Some(7));
-        let unset = BoxRef::new_inputarg(Type::Int, None);
-        assert_eq!(unset.position(), None);
+        assert_eq!(arg.inputarg_position(), Some(7));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -490,7 +490,7 @@ impl TreeLoop {
         let mut box_pool: crate::r#box::BoxPool =
             Vec::with_capacity(new_ia_boxes.len() + op_escaped.len() + cut_ops.len()).into();
         for (i, &tp) in new_ia_types.iter().enumerate() {
-            box_pool.push(BoxRef::new_inputarg(tp, Some(i as u32)));
+            box_pool.push(BoxRef::new_inputarg(tp, i as u32));
         }
         for &r in op_escaped.iter() {
             let op_idx = (r.raw() - num_original_inputargs) as usize;

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -17,10 +17,11 @@
 //! `Mutex<TimingState>` so concurrent threads sharing the profiler via
 //! `Arc` serialize on the same lock the GIL gives PyPy.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
+use majit_backend::CpuTotalTracker;
 use majit_ir::OpCode;
 
 use crate::pyjitpl::counters;
@@ -127,6 +128,20 @@ pub struct JitProfiler {
     /// profiler via `Arc` cannot race on `_start`/`_end`; PyPy's GIL
     /// gives the same exclusion.
     timing: Mutex<TimingState>,
+    /// `self.cpu.tracker` (`jitprof.py:105-106`) — PyPy reads
+    /// `Counters.TOTAL_COMPILED_*` / `TOTAL_FREED_*` via
+    /// `self.cpu.tracker.total_*`.  Pyre's `JitProfiler` holds an
+    /// `Arc<CpuTotalTracker>` so reads through
+    /// [`get_counter`](Self::get_counter) and writes through
+    /// [`inc_freed_loop`](Self::inc_freed_loop) /
+    /// [`add_freed_bridges`](Self::add_freed_bridges) hit the same
+    /// store the paired [`majit_backend::Backend`] writes to via
+    /// [`record_compiled_loop_token`](majit_backend::record_compiled_loop_token).
+    /// `MetaInterp::new` rebinds this field to share the backend's
+    /// `Arc` once both are constructed (see
+    /// [`set_cpu_tracker`](Self::set_cpu_tracker)) so the metainterp
+    /// pair behaves like PyPy's per-CPU tracker.
+    cpu_tracker: Mutex<Arc<CpuTotalTracker>>,
 }
 
 impl JitProfiler {
@@ -163,10 +178,10 @@ impl JitProfiler {
             &self.nvreused,
             &self.calls,
             // `cpu.tracker` counters (`TOTAL_COMPILED_*` /
-            // `TOTAL_FREED_*`) live on `majit_backend::cpu_tracker()`
-            // matching PyPy's instance-on-cpu shape — they survive
-            // `Profiler.start()` (which only resets `self.counters` and
-            // `self.calls`, jitprof.py:55-61).
+            // `TOTAL_FREED_*`) live on the per-instance `cpu_tracker`
+            // Arc bound to the backend's `CpuTotalTracker` — they
+            // survive `Profiler.start()` (which only resets
+            // `self.counters` and `self.calls`, jitprof.py:55-61).
         ] {
             field.store(0, Ordering::Relaxed);
         }
@@ -223,7 +238,7 @@ impl JitProfiler {
         debug_assert!(
             !is_cpu_tracker_kind(kind),
             "Profiler.count_ops({kind}) called with a CPU-total id; \
-             use majit_backend::cpu_tracker() directly (PyPy raises \
+             route through CpuTotalTracker directly (PyPy raises \
              IndexError here)",
         );
         if let Some(field) = self.field_for_kind(kind) {
@@ -247,14 +262,15 @@ impl JitProfiler {
     /// PyPy `self.counters[TOTAL_*]` is out-of-range
     /// (`Counters.ncounters = 22`) and raises `IndexError`.  Pyre
     /// signals the same misuse through `debug_assert!` and silently
-    /// no-ops in release.  Use [`majit_backend::cpu_tracker`] directly
-    /// (or [`Self::inc_freed_loop`] / [`Self::add_freed_bridges`])
-    /// when a tracker bump is actually intended.
+    /// no-ops in release.  Use the backend's [`CpuTotalTracker`]
+    /// directly (or [`Self::inc_freed_loop`] /
+    /// [`Self::add_freed_bridges`]) when a tracker bump is actually
+    /// intended.
     pub fn count(&self, kind: i32, inc: usize) {
         debug_assert!(
             !is_cpu_tracker_kind(kind),
             "Profiler.count({kind}) called with a CPU-total id; \
-             use majit_backend::cpu_tracker() directly (PyPy raises \
+             route through CpuTotalTracker directly (PyPy raises \
              IndexError here)",
         );
         if let Some(field) = self.field_for_kind(kind) {
@@ -265,11 +281,11 @@ impl JitProfiler {
     /// jitprof.py:104-113 `Profiler.get_counter(num)` — single-counter
     /// readback via `Counters.*` id.  PyPy routes `TOTAL_COMPILED_*` /
     /// `TOTAL_FREED_*` (ids 22..25) to `self.cpu.tracker.total_*`; pyre
-    /// reads from [`majit_backend::cpu_tracker`] for the same four ids
-    /// and from `self` for everything else.  Unknown ids return `None`.
+    /// reads from `self.cpu_tracker` for the same four ids and from
+    /// `self` for everything else.  Unknown ids return `None`.
     pub fn get_counter(&self, kind: i32) -> Option<usize> {
-        if let Some(field) = cpu_tracker_field_for_kind(kind) {
-            return Some(field.load(Ordering::Relaxed));
+        if is_cpu_tracker_kind(kind) {
+            return Some(self.with_cpu_tracker(|t| cpu_tracker_field(t, kind).load(Ordering::Relaxed)));
         }
         self.field_for_kind(kind)
             .map(|field| field.load(Ordering::Relaxed))
@@ -277,20 +293,45 @@ impl JitProfiler {
 
     /// `cpu.tracker.total_freed_loops += 1` parity.  Fired from the
     /// memory manager when an evicted token represents a root loop.
-    /// Delegates to [`majit_backend::cpu_tracker`].
+    /// Hits `self.cpu_tracker` so the paired backend (rebound via
+    /// [`set_cpu_tracker`]) and profiler share the same per-CPU
+    /// instance.
     pub fn inc_freed_loop(&self) {
-        majit_backend::cpu_tracker()
-            .total_freed_loops
-            .fetch_add(1, Ordering::Relaxed);
+        self.with_cpu_tracker(|t| t.total_freed_loops.fetch_add(1, Ordering::Relaxed));
     }
 
     /// `cpu.tracker.total_freed_bridges += n` parity.  Fired from the
     /// memory manager when an evicted token carries `n` bridges; PyPy's
     /// `cpu.free_loop_and_bridges` bumps the tracker once per bridge.
     pub fn add_freed_bridges(&self, n: usize) {
-        majit_backend::cpu_tracker()
-            .total_freed_bridges
-            .fetch_add(n, Ordering::Relaxed);
+        self.with_cpu_tracker(|t| t.total_freed_bridges.fetch_add(n, Ordering::Relaxed));
+    }
+
+    /// Rebind `self.cpu_tracker` to the backend's
+    /// [`CpuTotalTracker`] so the profiler and backend share one
+    /// counter sink.  `MetaInterp::new` calls this once the backend is
+    /// available, mirroring PyPy where `Profiler` reads through
+    /// `self.cpu.tracker` (jitprof.py:105-106) — `self.cpu` being the
+    /// backend's `AbstractCPU` instance, not a process global.
+    pub fn set_cpu_tracker(&self, tracker: Arc<CpuTotalTracker>) {
+        let mut slot = self.cpu_tracker.lock().expect("cpu_tracker poisoned");
+        *slot = tracker;
+    }
+
+    /// Clone the current `Arc<CpuTotalTracker>` (cheap refcount bump)
+    /// and run `f` against it outside the mutex so the lock is held
+    /// only for the swap window.  Callers (`inc_freed_loop`,
+    /// `add_freed_bridges`, `get_counter`) avoid serialising on the
+    /// mutex during the atomic op itself.
+    fn with_cpu_tracker<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&CpuTotalTracker) -> R,
+    {
+        let tracker = {
+            let slot = self.cpu_tracker.lock().expect("cpu_tracker poisoned");
+            Arc::clone(&slot)
+        };
+        f(&tracker)
     }
 
     /// jitprof.py:115-116 `Profiler.get_times(num)` — seconds.
@@ -612,25 +653,29 @@ fn is_cpu_tracker_kind(kind: i32) -> bool {
 }
 
 /// Route `Counters.TOTAL_COMPILED_*` / `Counters.TOTAL_FREED_*` ids
-/// (jit.py:1438-1441) to the matching field on
-/// [`majit_backend::cpu_tracker`].  Mirrors `jitprof.py:105-106`:
+/// (jit.py:1438-1441) to the matching field on a
+/// [`CpuTotalTracker`].  Mirrors `jitprof.py:105-106`:
 ///
 /// ```python
 /// if num >= Counters.TOTAL_COMPILED_LOOPS:
 ///     return getattr(self.cpu.tracker, Counters.counter_names[num])
 /// ```
 ///
-/// Returns `None` for any other id (the per-instance counters on
-/// [`JitProfiler`] handle those).
-fn cpu_tracker_field_for_kind(kind: i32) -> Option<&'static AtomicUsize> {
-    let tracker = majit_backend::cpu_tracker();
-    Some(match kind {
+/// Caller must restrict `kind` to the four `TOTAL_*` ids
+/// ([`is_cpu_tracker_kind`]); other ids panic in debug and silently
+/// route to `total_compiled_loops` in release, but no caller passes
+/// such an id today.
+fn cpu_tracker_field(tracker: &CpuTotalTracker, kind: i32) -> &AtomicUsize {
+    match kind {
         counters::TOTAL_COMPILED_LOOPS => &tracker.total_compiled_loops,
         counters::TOTAL_COMPILED_BRIDGES => &tracker.total_compiled_bridges,
         counters::TOTAL_FREED_LOOPS => &tracker.total_freed_loops,
         counters::TOTAL_FREED_BRIDGES => &tracker.total_freed_bridges,
-        _ => return None,
-    })
+        _ => {
+            debug_assert!(false, "cpu_tracker_field({kind}) — not a TOTAL_* id");
+            &tracker.total_compiled_loops
+        }
+    }
 }
 
 /// debug.py `debug_start("jit-tracing")` / `debug_start("jit-backend")`
@@ -823,6 +868,39 @@ mod tests {
         assert!(snap.backend_time_ns > 0);
         assert!(prof.get_times(counters::TRACING).unwrap() > 0.0);
         assert_eq!(prof.get_times(counters::OPS), None);
+    }
+
+    #[test]
+    fn set_cpu_tracker_routes_total_counters_to_bound_tracker() {
+        // jitprof.py:105-106 contract: `Counters.TOTAL_*` reads go
+        // through `self.cpu.tracker`.  After `set_cpu_tracker(arc)`,
+        // writes to that Arc must be visible to the profiler's
+        // `get_counter` and freed-bump helpers.  Two independent
+        // profilers bound to separate trackers must NOT share state —
+        // this is the regression Codex P2 flagged.
+        let prof_a = JitProfiler::default();
+        let prof_b = JitProfiler::default();
+        let tracker_a = Arc::new(CpuTotalTracker::default());
+        let tracker_b = Arc::new(CpuTotalTracker::default());
+        prof_a.set_cpu_tracker(Arc::clone(&tracker_a));
+        prof_b.set_cpu_tracker(Arc::clone(&tracker_b));
+
+        tracker_a.total_compiled_loops.store(3, Ordering::Relaxed);
+        tracker_a.total_compiled_bridges.store(5, Ordering::Relaxed);
+        prof_a.inc_freed_loop();
+        prof_a.add_freed_bridges(7);
+
+        assert_eq!(prof_a.get_counter(counters::TOTAL_COMPILED_LOOPS), Some(3));
+        assert_eq!(prof_a.get_counter(counters::TOTAL_COMPILED_BRIDGES), Some(5));
+        assert_eq!(prof_a.get_counter(counters::TOTAL_FREED_LOOPS), Some(1));
+        assert_eq!(prof_a.get_counter(counters::TOTAL_FREED_BRIDGES), Some(7));
+
+        // `prof_b` saw none of those updates because it is bound to a
+        // separate `CpuTotalTracker` instance.
+        assert_eq!(prof_b.get_counter(counters::TOTAL_COMPILED_LOOPS), Some(0));
+        assert_eq!(prof_b.get_counter(counters::TOTAL_COMPILED_BRIDGES), Some(0));
+        assert_eq!(prof_b.get_counter(counters::TOTAL_FREED_LOOPS), Some(0));
+        assert_eq!(prof_b.get_counter(counters::TOTAL_FREED_BRIDGES), Some(0));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -10,11 +10,14 @@
 //!
 //! `Ordering::Relaxed` is sufficient for every counter/timer total: there is
 //! no causal relationship between any two updates, and we only ever publish
-//! totals via [`JitProfiler::snapshot`] which itself is `Relaxed`. The nested
-//! `current` event stack from PyPy's profiler is thread-local, avoiding a
-//! mutex while preserving per-thread event nesting.
+//! totals via [`JitProfiler::snapshot`] which itself is `Relaxed`.
+//!
+//! The `t1` / `current` event stack mirrors PyPy's `self.t1`/`self.current`
+//! instance fields (`jitprof.py:56,60`) — held behind a per-`JitProfiler`
+//! `Mutex<TimingState>` so concurrent threads sharing the profiler via
+//! `Arc` serialize on the same lock the GIL gives PyPy.
 
-use std::cell::RefCell;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
@@ -22,20 +25,18 @@ use majit_ir::OpCode;
 
 use crate::pyjitpl::counters;
 
-thread_local! {
-    static TIMING_STATE: RefCell<TimingState> = RefCell::new(TimingState::default());
-}
-
-#[derive(Clone, Copy)]
-struct TimingFrame {
-    profiler: usize,
-    event: i32,
-}
-
-#[derive(Default)]
+/// `self.t1` + `self.current` from `jitprof.py:56,60`.  Kept behind a
+/// `Mutex` on the owning [`JitProfiler`] so the GIL-protected
+/// list/scalar pair in upstream becomes a critical section here.
+#[derive(Default, Debug)]
 struct TimingState {
+    /// `self.t1` (`jitprof.py:56`) — timer baseline for the next
+    /// `_start`/`_end` to charge time against.
     t1: Option<Instant>,
-    current: Vec<TimingFrame>,
+    /// `self.current` (`jitprof.py:60,69`) — nested event stack.  Each
+    /// entry is a `Counters.*` id matching the matching `_start(event)`
+    /// push at `jitprof.py:81`.
+    current: Vec<i32>,
 }
 
 /// jitprof.py:52-122 `Profiler` — every `Counters.*` slot is one
@@ -115,34 +116,17 @@ pub struct JitProfiler {
     /// jitprof.Profiler.calls — `count_ops` increments this when the op
     /// is a CALL_* and `kind == RECORDED_OPS` (jitprof.py:121-122).
     pub calls: AtomicUsize,
-    /// jit.py:1438 `Counters.TOTAL_COMPILED_LOOPS`.  jitprof.py:105-106
-    /// reads `self.cpu.tracker.total_compiled_loops` — pyre's backends
-    /// have no shared `cpu.tracker` instance, so this counter lives on
-    /// the per-process profiler and is incremented at the same
-    /// structural points PyPy's `cpu.tracker` is bumped:
-    /// `record_loop_or_bridge` for a freshly-compiled loop
-    /// (`compile.py:213`).
-    pub total_compiled_loops: AtomicUsize,
-    /// jit.py:1439 `Counters.TOTAL_COMPILED_BRIDGES`.  Bumped from the
-    /// bridge close-out path matching PyPy `compile.py:213` /
-    /// `compile.py:601`.
-    pub total_compiled_bridges: AtomicUsize,
-    /// jit.py:1440 `Counters.TOTAL_FREED_LOOPS`.  Bumped from
-    /// `MemoryManager::_kill_old_loops_now` when an evicted token's
-    /// `bridges_count == 0` — PyPy's `cpu.tracker` tracks the loop
-    /// side here.
-    pub total_freed_loops: AtomicUsize,
-    /// jit.py:1441 `Counters.TOTAL_FREED_BRIDGES`.  Bumped from
-    /// `MemoryManager::_kill_old_loops_now` for each bridge attached
-    /// to an evicted token; PyPy's `cpu.tracker.total_freed_bridges`
-    /// is bumped in `cpu.free_loop_and_bridges`.
-    pub total_freed_bridges: AtomicUsize,
     /// pyjitpl.py:2300-2302 `_setup_once` guard — `if not
     /// self.profiler.initialized: self.profiler.start(); ...
     /// initialized = True`.  RPython keeps this flag separate from
     /// `Profiler.start()`: `start()` always resets counters, while
     /// `_setup_once` decides whether to call it.
     pub initialized: AtomicBool,
+    /// `jitprof.py:56,60 self.t1 / self.current` — instance-owned
+    /// timing state.  Held behind `Mutex` so threads sharing the
+    /// profiler via `Arc` cannot race on `_start`/`_end`; PyPy's GIL
+    /// gives the same exclusion.
+    timing: Mutex<TimingState>,
 }
 
 impl JitProfiler {
@@ -178,25 +162,24 @@ impl JitProfiler {
             &self.nvholes,
             &self.nvreused,
             &self.calls,
-            // tracker counters exposed via `get_counter(TOTAL_COMPILED_*
-            // / TOTAL_FREED_*)` — reset on `start()` so a profiler
-            // reused across test setups or explicit restarts does not
-            // report inflated totals carried over from the prior run.
-            &self.total_compiled_loops,
-            &self.total_compiled_bridges,
-            &self.total_freed_loops,
-            &self.total_freed_bridges,
+            // `cpu.tracker` counters (`TOTAL_COMPILED_*` /
+            // `TOTAL_FREED_*`) live on `majit_backend::cpu_tracker()`
+            // matching PyPy's instance-on-cpu shape — they survive
+            // `Profiler.start()` (which only resets `self.counters` and
+            // `self.calls`, jitprof.py:55-61).
         ] {
             field.store(0, Ordering::Relaxed);
         }
         self.tracing_time_ns.store(0, Ordering::Relaxed);
         self.backend_time_ns.store(0, Ordering::Relaxed);
-        let profiler = self.profiler_id();
-        TIMING_STATE.with(|cell| {
-            let mut state = cell.borrow_mut();
-            state.current.retain(|frame| frame.profiler != profiler);
-            state.t1 = Some(Instant::now());
-        });
+        // `jitprof.py:64-69 start()`:
+        //   self.starttime = self.timer()
+        //   self.t1 = self.starttime
+        //   ...
+        //   self.current = []
+        let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
+        state.t1 = Some(Instant::now());
+        state.current.clear();
     }
 
     /// jitprof.py:95 `Profiler.start_tracing`.
@@ -229,9 +212,15 @@ impl JitProfiler {
     /// ```
     ///
     /// `kind` is a [`crate::pyjitpl::counters`] id. Unknown ids are a
-    /// silent no-op (see field doc).
+    /// silent no-op (see field doc).  `TOTAL_COMPILED_*` /
+    /// `TOTAL_FREED_*` route through [`majit_backend::cpu_tracker`] to
+    /// match PyPy's per-cpu tracker storage; pyre callers never bump
+    /// these via `count_ops` in practice, but the route is wired so
+    /// stray callers stay consistent with `get_counter`.
     pub fn count_ops(&self, opnum: OpCode, kind: i32) {
-        if let Some(field) = self.field_for_kind(kind) {
+        if let Some(field) = cpu_tracker_field_for_kind(kind) {
+            field.fetch_add(1, Ordering::Relaxed);
+        } else if let Some(field) = self.field_for_kind(kind) {
             field.fetch_add(1, Ordering::Relaxed);
         }
         if opnum.is_call() && kind == counters::RECORDED_OPS {
@@ -248,53 +237,46 @@ impl JitProfiler {
     ///
     /// Used for non-op events (ABORT_*, NV*, OPT_VECTORIZE_*, ...).
     /// Unknown ids are a silent no-op (matching the OPS variant above).
+    /// `TOTAL_COMPILED_*` / `TOTAL_FREED_*` route through
+    /// [`majit_backend::cpu_tracker`] (PyPy stores them on
+    /// `self.cpu.tracker`, not `self.counters`).
     pub fn count(&self, kind: i32, inc: usize) {
-        if let Some(field) = self.field_for_kind(kind) {
+        if let Some(field) = cpu_tracker_field_for_kind(kind) {
+            field.fetch_add(inc, Ordering::Relaxed);
+        } else if let Some(field) = self.field_for_kind(kind) {
             field.fetch_add(inc, Ordering::Relaxed);
         }
     }
 
     /// jitprof.py:104-113 `Profiler.get_counter(num)` — single-counter
-    /// readback via `Counters.*` id. `None` for unknown ids.
-    ///
-    /// jitprof.py:104-113 `Profiler.get_counter(num)` — single-counter
     /// readback via `Counters.*` id.  PyPy routes `TOTAL_COMPILED_*` /
-    /// `TOTAL_FREED_*` (ids 22..25) to `self.cpu.tracker.total_*`;
-    /// pyre keeps the same four counters directly on `JitProfiler`
-    /// (no per-CPU tracker in this backend) and routes them through
-    /// [`field_for_kind`] alongside the `Counters.*` slots, so the
-    /// caller sees identical semantics regardless of where the values
-    /// physically live.  Unknown ids return `None`.
+    /// `TOTAL_FREED_*` (ids 22..25) to `self.cpu.tracker.total_*`; pyre
+    /// reads from [`majit_backend::cpu_tracker`] for the same four ids
+    /// and from `self` for everything else.  Unknown ids return `None`.
     pub fn get_counter(&self, kind: i32) -> Option<usize> {
+        if let Some(field) = cpu_tracker_field_for_kind(kind) {
+            return Some(field.load(Ordering::Relaxed));
+        }
         self.field_for_kind(kind)
             .map(|field| field.load(Ordering::Relaxed))
     }
 
-    /// `cpu.tracker.total_compiled_loops += 1` parity.  Fired from the
-    /// loop close-out path (`record_loop_or_bridge` for a root trace,
-    /// `compile.py:213`).
-    pub fn inc_compiled_loop(&self) {
-        self.total_compiled_loops.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// `cpu.tracker.total_compiled_bridges += 1` parity.  Fired from the
-    /// bridge close-out path (`record_loop_or_bridge` for a bridge,
-    /// `compile.py:601`).
-    pub fn inc_compiled_bridge(&self) {
-        self.total_compiled_bridges.fetch_add(1, Ordering::Relaxed);
-    }
-
     /// `cpu.tracker.total_freed_loops += 1` parity.  Fired from the
     /// memory manager when an evicted token represents a root loop.
+    /// Delegates to [`majit_backend::cpu_tracker`].
     pub fn inc_freed_loop(&self) {
-        self.total_freed_loops.fetch_add(1, Ordering::Relaxed);
+        majit_backend::cpu_tracker()
+            .total_freed_loops
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     /// `cpu.tracker.total_freed_bridges += n` parity.  Fired from the
     /// memory manager when an evicted token carries `n` bridges; PyPy's
     /// `cpu.free_loop_and_bridges` bumps the tracker once per bridge.
     pub fn add_freed_bridges(&self, n: usize) {
-        self.total_freed_bridges.fetch_add(n, Ordering::Relaxed);
+        majit_backend::cpu_tracker()
+            .total_freed_bridges
+            .fetch_add(n, Ordering::Relaxed);
     }
 
     /// jitprof.py:115-116 `Profiler.get_times(num)` — seconds.
@@ -367,76 +349,75 @@ impl JitProfiler {
     }
 
     fn start_event(&self, event: i32) {
+        // `jitprof.py:75-81 _start(event)`:
+        //   t0 = self.t1
+        //   self.t1 = self.timer()
+        //   if self.current:
+        //       self.times[self.current[-1]] += self.t1 - t0
+        //   self.counters[event] += 1
+        //   self.current.append(event)
         let now = Instant::now();
-        let profiler = self.profiler_id();
-        TIMING_STATE.with(|cell| {
-            let mut state = cell.borrow_mut();
-            if let (Some(t1), Some(frame)) = (state.t1, state.current.last().copied()) {
-                if frame.profiler == profiler {
-                    self.add_time(frame.event, now.saturating_duration_since(t1));
-                }
+        {
+            let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
+            if let (Some(t1), Some(&top_event)) = (state.t1, state.current.last()) {
+                self.add_time(top_event, now.saturating_duration_since(t1));
             }
             state.t1 = Some(now);
             self.count(event, 1);
-            state.current.push(TimingFrame { profiler, event });
-        });
+            state.current.push(event);
+        }
+        // PyPy keeps `debug_start("jit-tracing"|"jit-backend")` separate
+        // from `_start`/`_end` (it lives at the `compile.py:541` caller
+        // around the `start_tracing()/end_tracing()` pair).  Pyre folds
+        // the two together here so the metainterp callers only have
+        // to hold one RAII guard ([`enter_tracing`]/[`enter_backend`]);
+        // the debug-section pairing stays balanced because [`end_event`]
+        // only fires `debug_stop` on the success branch where the
+        // matching pop happened.
         if let Some(channel) = debug_channel_for_event(event) {
             crate::debug::debug_start(channel);
         }
     }
 
     fn end_event(&self, event: i32) {
+        // `jitprof.py:83-93 _end(event)` — pop-first, then validate.
+        //   t0 = self.t1
+        //   self.t1 = self.timer()
+        //   if not self.current:
+        //       debug_print("BROKEN PROFILER DATA!"); return
+        //   ev1 = self.current.pop()
+        //   if ev1 != event:
+        //       debug_print("BROKEN PROFILER DATA!"); return
+        //   self.times[ev1] += self.t1 - t0
         let now = Instant::now();
-        let profiler = self.profiler_id();
-        // `ended` mirrors the symmetric `debug_start`/`debug_stop`
-        // pairing in `start_event`: we only close the debug channel
-        // when the TLS frame for this `(profiler, event)` actually
-        // matched and was popped.  On broken-data early returns the
-        // paired `debug_start` either never ran (empty stack) or
-        // belongs to a sibling profiler still owning the top of the
-        // stack; firing `debug_stop` anyway would desynchronize the
-        // per-thread category stack and panic the now-strict
-        // `debug_stop(category)` mismatch guard
-        // (`majit-ir/src/debug.rs:84-`).
-        let mut ended = false;
-        TIMING_STATE.with(|cell| {
-            let mut state = cell.borrow_mut();
-            // RPython peeks the top frame first (`self.current` is
-            // per-Profiler, so a wrong-event peek can only be a
-            // re-entry bug — never another instance leaking in).  Pyre
-            // shares `TIMING_STATE` across `JitProfiler` instances on
-            // the thread, so peek-then-pop is required: popping before
-            // the validation would lose the frame of a sibling
-            // profiler that legitimately owns the stack top.
-            let Some(&frame) = state.current.last() else {
-                // jitprof.py:86-88 `if not self.current: debug_print("BROKEN
-                // PROFILER DATA!"); return`.
+        let popped_event;
+        let t0;
+        {
+            let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
+            t0 = state.t1;
+            state.t1 = Some(now);
+            let Some(ev1) = state.current.pop() else {
                 crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
-                state.t1 = Some(now);
                 return;
             };
-            if frame.profiler != profiler || frame.event != event {
-                // jitprof.py:90-92 `if ev1 != event: debug_print("BROKEN
-                // PROFILER DATA!"); return`.  pyre additionally diagnoses
-                // a mismatched profiler-instance frame, which RPython
-                // can't reach because each Profiler owns its own `current`
-                // list.  Leave the top frame in place — its owner will
-                // close it in their own `end_event`.
-                crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
-                state.t1 = Some(now);
-                return;
-            }
-            state.current.pop();
-            if let Some(t1) = state.t1 {
-                self.add_time(event, now.saturating_duration_since(t1));
-            }
-            state.t1 = Some(now);
-            ended = true;
-        });
-        if ended {
-            if let Some(channel) = debug_channel_for_event(event) {
-                crate::debug::debug_stop(channel);
-            }
+            popped_event = ev1;
+        }
+        if popped_event != event {
+            crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
+            // Note: the matching `debug_start` (if any) was issued for
+            // `popped_event`'s channel, not `event`'s — closing
+            // `event`'s channel here would mis-pair against the
+            // strict `debug_stop` nesting guard
+            // (`majit-ir/src/debug.rs:84-`).  Leave the section open;
+            // the broken-data log line is the externally-visible
+            // signal that something went wrong.
+            return;
+        }
+        if let Some(t1) = t0 {
+            self.add_time(popped_event, now.saturating_duration_since(t1));
+        }
+        if let Some(channel) = debug_channel_for_event(event) {
+            crate::debug::debug_stop(channel);
         }
     }
 
@@ -445,10 +426,6 @@ impl JitProfiler {
         if let Some(field) = self.time_field_for_kind(event) {
             field.fetch_add(nanos, Ordering::Relaxed);
         }
-    }
-
-    fn profiler_id(&self) -> usize {
-        self as *const Self as usize
     }
 
     fn field_for_kind(&self, kind: i32) -> Option<&AtomicUsize> {
@@ -475,10 +452,6 @@ impl JitProfiler {
             counters::NVIRTUALS => &self.nvirtuals,
             counters::NVHOLES => &self.nvholes,
             counters::NVREUSED => &self.nvreused,
-            counters::TOTAL_COMPILED_LOOPS => &self.total_compiled_loops,
-            counters::TOTAL_COMPILED_BRIDGES => &self.total_compiled_bridges,
-            counters::TOTAL_FREED_LOOPS => &self.total_freed_loops,
-            counters::TOTAL_FREED_BRIDGES => &self.total_freed_bridges,
             _ => return None,
         })
     }
@@ -506,6 +479,28 @@ impl Drop for ProfilerEventGuard<'_> {
     fn drop(&mut self) {
         self.profiler.end_event(self.event);
     }
+}
+
+/// Route `Counters.TOTAL_COMPILED_*` / `Counters.TOTAL_FREED_*` ids
+/// (jit.py:1438-1441) to the matching field on
+/// [`majit_backend::cpu_tracker`].  Mirrors `jitprof.py:105-106`:
+///
+/// ```python
+/// if num >= Counters.TOTAL_COMPILED_LOOPS:
+///     return getattr(self.cpu.tracker, Counters.counter_names[num])
+/// ```
+///
+/// Returns `None` for any other id (the per-instance counters on
+/// [`JitProfiler`] handle those).
+fn cpu_tracker_field_for_kind(kind: i32) -> Option<&'static AtomicUsize> {
+    let tracker = majit_backend::cpu_tracker();
+    Some(match kind {
+        counters::TOTAL_COMPILED_LOOPS => &tracker.total_compiled_loops,
+        counters::TOTAL_COMPILED_BRIDGES => &tracker.total_compiled_bridges,
+        counters::TOTAL_FREED_LOOPS => &tracker.total_freed_loops,
+        counters::TOTAL_FREED_BRIDGES => &tracker.total_freed_bridges,
+        _ => return None,
+    })
 }
 
 /// debug.py `debug_start("jit-tracing")` / `debug_start("jit-backend")`

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -17,8 +17,8 @@
 //! `Mutex<TimingState>` so concurrent threads sharing the profiler via
 //! `Arc` serialize on the same lock the GIL gives PyPy.
 
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use majit_backend::CpuTotalTracker;
@@ -228,14 +228,16 @@ impl JitProfiler {
     ///
     /// `kind` is a [`crate::pyjitpl::counters`] id. Unknown ids are a
     /// silent no-op (see field doc).  `TOTAL_COMPILED_*` /
-    /// `TOTAL_FREED_*` are debug-asserted out — PyPy
-    /// `Profiler.counters` is sized `Counters.ncounters = 22` and
-    /// `count(TOTAL_*)` would raise `IndexError`.  Pyre flags the
-    /// same misuse via `debug_assert!`, then silently no-ops in
-    /// release so a single stray caller cannot turn into a hard
-    /// crash in production.
+    /// `TOTAL_FREED_*` panic in both debug and release: PyPy
+    /// `Profiler.counters` is sized `Counters.ncounters = 22` so
+    /// `self.counters[TOTAL_*]` raises `IndexError`.  Pyre uses
+    /// `assert!` so the release path crashes too — the unknown-id
+    /// silent no-op below is for truly out-of-range ids, while
+    /// `TOTAL_*` has a well-defined alternate sink (the backend's
+    /// [`CpuTotalTracker`]); silently routing a stray write to
+    /// nowhere would mask the bug.
     pub fn count_ops(&self, opnum: OpCode, kind: i32) {
-        debug_assert!(
+        assert!(
             !is_cpu_tracker_kind(kind),
             "Profiler.count_ops({kind}) called with a CPU-total id; \
              route through CpuTotalTracker directly (PyPy raises \
@@ -258,16 +260,15 @@ impl JitProfiler {
     ///
     /// Used for non-op events (ABORT_*, NV*, OPT_VECTORIZE_*, ...).
     /// Unknown ids are a silent no-op (matching the OPS variant above).
-    /// `TOTAL_COMPILED_*` / `TOTAL_FREED_*` are debug-asserted out —
-    /// PyPy `self.counters[TOTAL_*]` is out-of-range
-    /// (`Counters.ncounters = 22`) and raises `IndexError`.  Pyre
-    /// signals the same misuse through `debug_assert!` and silently
-    /// no-ops in release.  Use the backend's [`CpuTotalTracker`]
-    /// directly (or [`Self::inc_freed_loop`] /
-    /// [`Self::add_freed_bridges`]) when a tracker bump is actually
-    /// intended.
+    /// `TOTAL_COMPILED_*` / `TOTAL_FREED_*` panic in both debug and
+    /// release: PyPy `self.counters[TOTAL_*]` is out-of-range
+    /// (`Counters.ncounters = 22`) and raises `IndexError`, so pyre
+    /// uses `assert!` to crash on both build profiles.  Use the
+    /// backend's [`CpuTotalTracker`] directly (or
+    /// [`Self::inc_freed_loop`] / [`Self::add_freed_bridges`]) when a
+    /// tracker bump is actually intended.
     pub fn count(&self, kind: i32, inc: usize) {
-        debug_assert!(
+        assert!(
             !is_cpu_tracker_kind(kind),
             "Profiler.count({kind}) called with a CPU-total id; \
              route through CpuTotalTracker directly (PyPy raises \
@@ -285,7 +286,9 @@ impl JitProfiler {
     /// `self` for everything else.  Unknown ids return `None`.
     pub fn get_counter(&self, kind: i32) -> Option<usize> {
         if is_cpu_tracker_kind(kind) {
-            return Some(self.with_cpu_tracker(|t| cpu_tracker_field(t, kind).load(Ordering::Relaxed)));
+            return Some(
+                self.with_cpu_tracker(|t| cpu_tracker_field(t, kind).load(Ordering::Relaxed)),
+            );
         }
         self.field_for_kind(kind)
             .map(|field| field.load(Ordering::Relaxed))
@@ -871,6 +874,26 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "PyPy raises IndexError")]
+    fn count_panics_on_total_compiled_loops_id() {
+        // jitprof.py:101 `self.counters[kind] += inc` raises
+        // `IndexError` when `kind` is `TOTAL_COMPILED_LOOPS` (id 22)
+        // because `self.counters` is sized `Counters.ncounters = 22`.
+        // Pyre uses `assert!` (not `debug_assert!`) so the panic
+        // fires in release builds too, matching upstream's crash on
+        // a programmer-error caller.
+        let prof = JitProfiler::default();
+        prof.count(counters::TOTAL_COMPILED_LOOPS, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "PyPy raises IndexError")]
+    fn count_ops_panics_on_total_freed_bridges_id() {
+        let prof = JitProfiler::default();
+        prof.count_ops(OpCode::IntAdd, counters::TOTAL_FREED_BRIDGES);
+    }
+
+    #[test]
     fn set_cpu_tracker_routes_total_counters_to_bound_tracker() {
         // jitprof.py:105-106 contract: `Counters.TOTAL_*` reads go
         // through `self.cpu.tracker`.  After `set_cpu_tracker(arc)`,
@@ -891,14 +914,20 @@ mod tests {
         prof_a.add_freed_bridges(7);
 
         assert_eq!(prof_a.get_counter(counters::TOTAL_COMPILED_LOOPS), Some(3));
-        assert_eq!(prof_a.get_counter(counters::TOTAL_COMPILED_BRIDGES), Some(5));
+        assert_eq!(
+            prof_a.get_counter(counters::TOTAL_COMPILED_BRIDGES),
+            Some(5)
+        );
         assert_eq!(prof_a.get_counter(counters::TOTAL_FREED_LOOPS), Some(1));
         assert_eq!(prof_a.get_counter(counters::TOTAL_FREED_BRIDGES), Some(7));
 
         // `prof_b` saw none of those updates because it is bound to a
         // separate `CpuTotalTracker` instance.
         assert_eq!(prof_b.get_counter(counters::TOTAL_COMPILED_LOOPS), Some(0));
-        assert_eq!(prof_b.get_counter(counters::TOTAL_COMPILED_BRIDGES), Some(0));
+        assert_eq!(
+            prof_b.get_counter(counters::TOTAL_COMPILED_BRIDGES),
+            Some(0)
+        );
         assert_eq!(prof_b.get_counter(counters::TOTAL_FREED_LOOPS), Some(0));
         assert_eq!(prof_b.get_counter(counters::TOTAL_FREED_BRIDGES), Some(0));
     }

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -213,14 +213,19 @@ impl JitProfiler {
     ///
     /// `kind` is a [`crate::pyjitpl::counters`] id. Unknown ids are a
     /// silent no-op (see field doc).  `TOTAL_COMPILED_*` /
-    /// `TOTAL_FREED_*` are accepted but discarded — PyPy
-    /// `Profiler.count_ops` bumps `self.counters[kind]` for these slots
-    /// while [`get_counter`](Self::get_counter) reads from
-    /// `self.cpu.tracker`, so the bump is write-only into an unread
-    /// slot.  Routing them to `cpu_tracker()` here would let a stray
-    /// caller inflate the global tracker; matching PyPy's
-    /// disconnected-storage shape means the discard is intentional.
+    /// `TOTAL_FREED_*` are debug-asserted out — PyPy
+    /// `Profiler.counters` is sized `Counters.ncounters = 22` and
+    /// `count(TOTAL_*)` would raise `IndexError`.  Pyre flags the
+    /// same misuse via `debug_assert!`, then silently no-ops in
+    /// release so a single stray caller cannot turn into a hard
+    /// crash in production.
     pub fn count_ops(&self, opnum: OpCode, kind: i32) {
+        debug_assert!(
+            !is_cpu_tracker_kind(kind),
+            "Profiler.count_ops({kind}) called with a CPU-total id; \
+             use majit_backend::cpu_tracker() directly (PyPy raises \
+             IndexError here)",
+        );
         if let Some(field) = self.field_for_kind(kind) {
             field.fetch_add(1, Ordering::Relaxed);
         }
@@ -238,14 +243,20 @@ impl JitProfiler {
     ///
     /// Used for non-op events (ABORT_*, NV*, OPT_VECTORIZE_*, ...).
     /// Unknown ids are a silent no-op (matching the OPS variant above).
-    /// `TOTAL_COMPILED_*` / `TOTAL_FREED_*` are accepted but discarded
-    /// — PyPy `Profiler.count` bumps `self.counters[kind]` while
-    /// [`get_counter`](Self::get_counter) reads from `self.cpu.tracker`,
-    /// so the bump is write-only into an unread slot.  Use
-    /// [`majit_backend::cpu_tracker`] directly (or
-    /// [`Self::inc_freed_loop`] / [`Self::add_freed_bridges`]) when a
-    /// tracker bump is actually intended.
+    /// `TOTAL_COMPILED_*` / `TOTAL_FREED_*` are debug-asserted out —
+    /// PyPy `self.counters[TOTAL_*]` is out-of-range
+    /// (`Counters.ncounters = 22`) and raises `IndexError`.  Pyre
+    /// signals the same misuse through `debug_assert!` and silently
+    /// no-ops in release.  Use [`majit_backend::cpu_tracker`] directly
+    /// (or [`Self::inc_freed_loop`] / [`Self::add_freed_bridges`])
+    /// when a tracker bump is actually intended.
     pub fn count(&self, kind: i32, inc: usize) {
+        debug_assert!(
+            !is_cpu_tracker_kind(kind),
+            "Profiler.count({kind}) called with a CPU-total id; \
+             use majit_backend::cpu_tracker() directly (PyPy raises \
+             IndexError here)",
+        );
         if let Some(field) = self.field_for_kind(kind) {
             field.fetch_add(inc, Ordering::Relaxed);
         }
@@ -325,26 +336,22 @@ impl JitProfiler {
         }
     }
 
-    /// Panic-safe RAII pairing for `debug_start("jit-tracing")` +
-    /// `start_tracing` / `end_tracing` + `debug_stop("jit-tracing")`.
-    /// PyPy keeps the debug section and the profiler call separate at
-    /// the metainterp caller (`pyjitpl.py:1907-1925`):
+    /// Panic-safe RAII pairing matching `pyjitpl.py:2884-2898 / 2914-2935`:
     ///
     /// ```python
-    /// debug_start("jit-tracing")
-    /// self.staticdata.profiler.start_tracing()
+    /// debug_start('jit-tracing')      # outer
+    /// profiler.start_tracing()        # inner
     /// try:
     ///     ...
     /// finally:
-    ///     self.staticdata.profiler.end_tracing()
-    ///     debug_stop("jit-tracing")
+    ///     profiler.end_tracing()      # inner close
+    ///     debug_stop('jit-tracing')   # outer close
     /// ```
     ///
-    /// Pyre folds both layers into one RAII guard: construction fires
-    /// `debug_start` then `start_event`, drop fires `end_event` then
-    /// `debug_stop` (LIFO unwind order matching the try/finally above).
-    /// Panics inside the body still unwind through both, so the
-    /// `current` stack and the debug section stay balanced.
+    /// Construction fires `debug_start` then `start_tracing`; drop
+    /// fires `end_tracing` then `debug_stop`.  Panics inside the body
+    /// still unwind through both layers, so the `current` stack and
+    /// the debug section stay balanced.
     pub fn enter_tracing(&self) -> ProfilerEventGuard<'_> {
         if let Some(channel) = debug_channel_for_event(counters::TRACING) {
             crate::debug::debug_start(channel);
@@ -353,24 +360,36 @@ impl JitProfiler {
         ProfilerEventGuard {
             profiler: self,
             event: counters::TRACING,
+            nesting: GuardNesting::DebugOuter,
         }
     }
 
-    /// Panic-safe RAII pairing for `debug_start("jit-backend")` +
-    /// `start_backend` / `end_backend` + `debug_stop("jit-backend")`.
-    /// Wraps `backend.compile_loop` / `backend.compile_bridge` call
-    /// sites with the same try/finally shape as PyPy
-    /// `compile.py:532-546` (debug section outside, profiler call
-    /// inside).  See [`enter_tracing`](Self::enter_tracing) for the
-    /// detailed unwind order.
+    /// Panic-safe RAII pairing matching `compile.py:532-546 / 589-599`:
+    ///
+    /// ```python
+    /// metainterp_sd.profiler.start_backend()   # outer
+    /// debug_start('jit-backend')               # inner
+    /// try:
+    ///     ...
+    /// finally:
+    ///     debug_stop('jit-backend')            # inner close
+    /// metainterp_sd.profiler.end_backend()     # outer close
+    /// ```
+    ///
+    /// Note that backend nesting is **reversed** relative to tracing:
+    /// `profiler.start_backend()` opens the outer scope here, while
+    /// `debug_start('jit-tracing')` opens the outer scope in
+    /// [`enter_tracing`].  PyPy uses both orders depending on the
+    /// callsite — this guard matches each one exactly.
     pub fn enter_backend(&self) -> ProfilerEventGuard<'_> {
+        self.start_backend();
         if let Some(channel) = debug_channel_for_event(counters::BACKEND) {
             crate::debug::debug_start(channel);
         }
-        self.start_backend();
         ProfilerEventGuard {
             profiler: self,
             event: counters::BACKEND,
+            nesting: GuardNesting::ProfilerOuter,
         }
     }
 
@@ -473,33 +492,72 @@ impl JitProfiler {
     }
 }
 
+/// Which scope is the outer one — tracing wraps `debug_start` around
+/// the profiler call (`pyjitpl.py:2884-2898`), backend wraps the
+/// profiler call around `debug_start` (`compile.py:532-546`).
+/// [`ProfilerEventGuard::drop`] dispatches the LIFO close order based
+/// on this flag so each callsite matches its PyPy counterpart exactly.
+enum GuardNesting {
+    /// `debug_start` is outer, `profiler.start_*` is inner.  Used by
+    /// [`JitProfiler::enter_tracing`].
+    DebugOuter,
+    /// `profiler.start_*` is outer, `debug_start` is inner.  Used by
+    /// [`JitProfiler::enter_backend`].
+    ProfilerOuter,
+}
+
 /// RAII guard returned by [`JitProfiler::enter_tracing`] /
-/// [`JitProfiler::enter_backend`].  Drops by firing the matching
-/// `end_*` then `debug_stop(channel)` so the profiler stack and the
-/// debug section stay balanced even when the surrounding body panics
-/// — the PyPy `try/finally` equivalent
-/// (`debug_start; profiler.start; try: ...; finally:
-/// profiler.end; debug_stop`).
+/// [`JitProfiler::enter_backend`].  Drops by firing both the
+/// profiler-event close and the `debug_stop` close in the LIFO order
+/// dictated by [`GuardNesting`], so the profiler stack and the debug
+/// section stay balanced even when the surrounding body panics.
 #[must_use = "drop the guard to fire the paired end_* event"]
 pub struct ProfilerEventGuard<'a> {
     profiler: &'a JitProfiler,
     event: i32,
+    nesting: GuardNesting,
 }
 
 impl Drop for ProfilerEventGuard<'_> {
     fn drop(&mut self) {
-        // Unwind order matches PyPy's nested `try/finally`: inner
-        // (`profiler.end_*`) before outer (`debug_stop`).  If
-        // `end_event` detects a mismatch (broken-data path) we still
-        // emit `debug_stop` because the matching `debug_start` was
-        // already published in [`enter_tracing`] / [`enter_backend`];
-        // skipping it would leave the section open against the
-        // strict nesting guard in [`crate::debug::debug_stop`].
-        self.profiler.end_event(self.event);
-        if let Some(channel) = debug_channel_for_event(self.event) {
-            crate::debug::debug_stop(channel);
+        // LIFO close: inner scope first, then outer.  If `end_event`
+        // detects a mismatch (broken-data path) we still emit
+        // `debug_stop` because the matching `debug_start` was already
+        // published; skipping it would leave the section open against
+        // the strict nesting guard in [`crate::debug::debug_stop`].
+        let channel = debug_channel_for_event(self.event);
+        match self.nesting {
+            // tracing: inner = profiler, outer = debug.
+            GuardNesting::DebugOuter => {
+                self.profiler.end_event(self.event);
+                if let Some(ch) = channel {
+                    crate::debug::debug_stop(ch);
+                }
+            }
+            // backend: inner = debug, outer = profiler.
+            GuardNesting::ProfilerOuter => {
+                if let Some(ch) = channel {
+                    crate::debug::debug_stop(ch);
+                }
+                self.profiler.end_event(self.event);
+            }
         }
     }
+}
+
+/// `Counters.TOTAL_COMPILED_*` / `Counters.TOTAL_FREED_*` (jit.py:1438-1441)
+/// — the four ids PyPy reads via `cpu.tracker` instead of
+/// `self.counters`.  Used by [`JitProfiler::count`] /
+/// [`JitProfiler::count_ops`] `debug_assert!` to flag callers that
+/// would land an out-of-range write upstream.
+fn is_cpu_tracker_kind(kind: i32) -> bool {
+    matches!(
+        kind,
+        counters::TOTAL_COMPILED_LOOPS
+            | counters::TOTAL_COMPILED_BRIDGES
+            | counters::TOTAL_FREED_LOOPS
+            | counters::TOTAL_FREED_BRIDGES
+    )
 }
 
 /// Route `Counters.TOTAL_COMPILED_*` / `Counters.TOTAL_FREED_*` ids

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -353,10 +353,19 @@ impl JitProfiler {
     /// still unwind through both layers, so the `current` stack and
     /// the debug section stay balanced.
     pub fn enter_tracing(&self) -> ProfilerEventGuard<'_> {
-        if let Some(channel) = debug_channel_for_event(counters::TRACING) {
-            crate::debug::debug_start(channel);
+        let channel = debug_channel_for_event(counters::TRACING);
+        if let Some(ch) = channel {
+            crate::debug::debug_start(ch);
         }
+        // Rollback guard: the debug section is open; `start_tracing`
+        // takes the timing-state mutex, which can panic on poison.
+        // Without the guard, that panic would leave the section open
+        // for later `debug_stop` mismatch panics.  Disarm via
+        // `mem::forget` once both opens succeed so the returned
+        // `ProfilerEventGuard::drop` owns the normal-path close.
+        let rollback = TracingOpenRollback { channel };
         self.start_tracing();
+        std::mem::forget(rollback);
         ProfilerEventGuard {
             profiler: self,
             event: counters::TRACING,
@@ -383,9 +392,19 @@ impl JitProfiler {
     /// callsite — this guard matches each one exactly.
     pub fn enter_backend(&self) -> ProfilerEventGuard<'_> {
         self.start_backend();
+        // Rollback guard: the backend event is now open, but
+        // `debug_start` may still panic on a nesting violation
+        // (`debug.rs:84-` strict-stop guard).  Without the guard, a
+        // panic between the two opens would leave the profiler stack
+        // dirty for later calls.  The local guard fires
+        // `end_backend()` on unwind; `mem::forget` disarms it once
+        // both opens succeed so the returned RAII guard owns the
+        // normal-path close.
+        let rollback = BackendOpenRollback { profiler: self };
         if let Some(channel) = debug_channel_for_event(counters::BACKEND) {
             crate::debug::debug_start(channel);
         }
+        std::mem::forget(rollback);
         ProfilerEventGuard {
             profiler: self,
             event: counters::BACKEND,
@@ -489,6 +508,38 @@ impl JitProfiler {
             counters::BACKEND => &self.backend_time_ns,
             _ => return None,
         })
+    }
+}
+
+/// Rollback guard used inside [`JitProfiler::enter_backend`] for the
+/// short window after `start_backend()` and before `debug_start` has
+/// returned cleanly.  If `debug_start` panics, the unwind path fires
+/// the matching `end_backend()` so the profiler stack does not stay
+/// dirty.  Disarmed via `mem::forget` once both opens succeed.
+struct BackendOpenRollback<'a> {
+    profiler: &'a JitProfiler,
+}
+
+impl Drop for BackendOpenRollback<'_> {
+    fn drop(&mut self) {
+        self.profiler.end_backend();
+    }
+}
+
+/// Rollback guard used inside [`JitProfiler::enter_tracing`] for the
+/// short window after `debug_start("jit-tracing")` and before
+/// `start_tracing()` has returned cleanly.  If `start_tracing` panics
+/// (timing-state mutex poisoned), the unwind path fires the matching
+/// `debug_stop` so the PYPYLOG category stack stays balanced.
+struct TracingOpenRollback {
+    channel: Option<&'static str>,
+}
+
+impl Drop for TracingOpenRollback {
+    fn drop(&mut self) {
+        if let Some(ch) = self.channel {
+            crate::debug::debug_stop(ch);
+        }
     }
 }
 

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -29,6 +29,21 @@ use crate::pyjitpl::counters;
 /// `self.t1` + `self.current` from `jitprof.py:56,60`.  Kept behind a
 /// `Mutex` on the owning [`JitProfiler`] so the GIL-protected
 /// list/scalar pair in upstream becomes a critical section here.
+///
+/// **Single-thread contract.**  PyPy's GIL serialises every
+/// `_start`/`_end` call, so `current` behaves as a strict LIFO stack
+/// with no cross-thread interleaving.  Pyre cannot rely on GIL —
+/// every `JitProfiler` is shared via `Arc` and JIT operations may
+/// touch the same profiler from multiple worker threads.  The
+/// `Mutex` only protects each individual `_start`/`_end` push/pop;
+/// between calls the lock is released, so two threads opening
+/// overlapping scopes would interleave the stack and trip
+/// `BROKEN PROFILER DATA!` on the second drop.  Callers MUST
+/// serialise profiler `start_*`/`end_*` at a higher level (typically
+/// by holding a JIT-wide lock); the [`owner_thread`] field below
+/// catches accidental sharing in debug builds.
+///
+/// [`owner_thread`]: TimingState::owner_thread
 #[derive(Default, Debug)]
 struct TimingState {
     /// `self.t1` (`jitprof.py:56`) — timer baseline for the next
@@ -38,6 +53,15 @@ struct TimingState {
     /// entry is a `Counters.*` id matching the matching `_start(event)`
     /// push at `jitprof.py:81`.
     current: Vec<i32>,
+    /// Set to the thread that first pushes onto an empty stack; cleared
+    /// once the stack drains back to empty.  Same-thread re-entry is
+    /// fine (the GIL-equivalent invariant only requires serialisation,
+    /// not single-thread exclusivity across the profiler lifetime); a
+    /// `_start`/`_end` from a *different* thread while the stack is
+    /// non-empty trips a debug-build panic.  Detects the cross-thread
+    /// interleaving bug at the point it would corrupt state instead of
+    /// at the later `BROKEN PROFILER DATA!` mismatch.
+    owner_thread: Option<std::thread::ThreadId>,
 }
 
 /// jitprof.py:52-122 `Profiler` — every `Counters.*` slot is one
@@ -469,6 +493,7 @@ impl JitProfiler {
         //   self.current.append(event)
         let now = Instant::now();
         let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
+        check_or_claim_owner_thread(&mut state, "start_event");
         if let (Some(t1), Some(&top_event)) = (state.t1, state.current.last()) {
             self.add_time(top_event, now.saturating_duration_since(t1));
         }
@@ -494,6 +519,7 @@ impl JitProfiler {
         let t0;
         {
             let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
+            check_or_claim_owner_thread(&mut state, "end_event");
             t0 = state.t1;
             state.t1 = Some(now);
             let Some(ev1) = state.current.pop() else {
@@ -501,6 +527,11 @@ impl JitProfiler {
                 return;
             };
             popped_event = ev1;
+            // Drained back to empty — release ownership so the next
+            // `start_event`/`end_event` from any thread can claim it.
+            if state.current.is_empty() {
+                state.owner_thread = None;
+            }
         }
         if popped_event != event {
             crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
@@ -664,6 +695,36 @@ fn is_cpu_tracker_kind(kind: i32) -> bool {
 ///     return getattr(self.cpu.tracker, Counters.counter_names[num])
 /// ```
 ///
+/// Enforce the single-thread contract documented on [`TimingState`]:
+/// once a thread has pushed onto the empty stack, only that thread
+/// may push/pop until the stack drains back to empty.  Same-thread
+/// re-entry (nested `start_event`/`end_event` on one thread) is
+/// fine; a *different* thread arriving while `owner_thread.is_some()`
+/// would interleave the LIFO stack and trip the `BROKEN PROFILER
+/// DATA!` mismatch detector later.
+///
+/// Debug builds panic immediately with the offending caller name so
+/// the cross-thread bug is visible at the actual misuse site.
+/// Release builds skip the check (the caller is expected to
+/// serialise profiler operations at a higher level, matching PyPy's
+/// GIL-equivalent invariant).
+fn check_or_claim_owner_thread(state: &mut TimingState, caller: &'static str) {
+    if cfg!(debug_assertions) {
+        let here = std::thread::current().id();
+        match state.owner_thread {
+            None => state.owner_thread = Some(here),
+            Some(existing) if existing == here => {}
+            Some(existing) => {
+                panic!(
+                    "JitProfiler {caller} from thread {here:?} while stack is owned by \
+                     {existing:?}; profiler operations must be serialised at the caller \
+                     (see TimingState single-thread contract)"
+                );
+            }
+        }
+    }
+}
+
 /// Caller must restrict `kind` to the four `TOTAL_*` ids
 /// ([`is_cpu_tracker_kind`]); any other id panics on both debug and
 /// release builds, matching the `assert!` strictness of
@@ -804,6 +865,60 @@ mod tests {
                 "kind {kind} did not land in the expected atomic field",
             );
         }
+    }
+
+    #[test]
+    fn start_end_on_one_thread_drains_owner_thread_for_the_next_caller() {
+        // `TimingState.owner_thread` is set on the first push into an
+        // empty stack and cleared when the stack drains back to empty.
+        // Subsequent callers (from any thread) must be able to claim
+        // ownership again — otherwise normal sequential use across
+        // worker threads would trip the cross-thread check.
+        let prof = JitProfiler::default();
+        prof.start();
+        prof.start_tracing();
+        prof.end_tracing();
+        // Stack is now empty; a fresh start from another thread (or
+        // the same thread) must succeed.
+        let prof_arc = Arc::new(prof);
+        let prof_clone = Arc::clone(&prof_arc);
+        std::thread::spawn(move || {
+            prof_clone.start_backend();
+            prof_clone.end_backend();
+        })
+        .join()
+        .expect("worker should complete without panic");
+        // Bookkeeping shows both events landed.
+        let snap = prof_arc.snapshot();
+        assert_eq!(snap.tracing, 1);
+        assert_eq!(snap.backend, 1);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "JitProfiler")]
+    fn cross_thread_start_event_while_stack_owned_panics_in_debug() {
+        // The owner_thread guard exists to catch the cross-thread
+        // interleaving bug the previous Mutex-only design hid: thread
+        // A opens TRACING, thread B opens BACKEND, then A drops first
+        // and pops B's BACKEND (mismatch → BROKEN PROFILER DATA).
+        // Detect the bug at the second thread's push instead.
+        let prof = Arc::new(JitProfiler::default());
+        prof.start();
+        prof.start_tracing();
+        let prof_clone = Arc::clone(&prof);
+        let join = std::thread::spawn(move || {
+            prof_clone.start_backend();
+        });
+        // The worker thread's `start_backend` must panic on the owner
+        // check.  Surface the panic to the test thread.
+        let result = join.join();
+        assert!(result.is_err(), "cross-thread push should panic in debug");
+        // Drain on this thread so the panic doesn't leak owner_thread
+        // (irrelevant for assertion shape but keeps the profiler
+        // structurally tidy for any downstream code).
+        prof.end_tracing();
+        panic!("JitProfiler cross-thread check fired (expected by #[should_panic])");
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -665,19 +665,17 @@ fn is_cpu_tracker_kind(kind: i32) -> bool {
 /// ```
 ///
 /// Caller must restrict `kind` to the four `TOTAL_*` ids
-/// ([`is_cpu_tracker_kind`]); other ids panic in debug and silently
-/// route to `total_compiled_loops` in release, but no caller passes
-/// such an id today.
+/// ([`is_cpu_tracker_kind`]); any other id panics on both debug and
+/// release builds, matching the `assert!` strictness of
+/// [`JitProfiler::count`] / [`JitProfiler::count_ops`] (PyPy raises
+/// `IndexError` / `AttributeError` for the equivalent paths).
 fn cpu_tracker_field(tracker: &CpuTotalTracker, kind: i32) -> &AtomicUsize {
     match kind {
         counters::TOTAL_COMPILED_LOOPS => &tracker.total_compiled_loops,
         counters::TOTAL_COMPILED_BRIDGES => &tracker.total_compiled_bridges,
         counters::TOTAL_FREED_LOOPS => &tracker.total_freed_loops,
         counters::TOTAL_FREED_BRIDGES => &tracker.total_freed_bridges,
-        _ => {
-            debug_assert!(false, "cpu_tracker_field({kind}) — not a TOTAL_* id");
-            &tracker.total_compiled_loops
-        }
+        _ => panic!("cpu_tracker_field({kind}) — not a TOTAL_* id"),
     }
 }
 

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -213,14 +213,15 @@ impl JitProfiler {
     ///
     /// `kind` is a [`crate::pyjitpl::counters`] id. Unknown ids are a
     /// silent no-op (see field doc).  `TOTAL_COMPILED_*` /
-    /// `TOTAL_FREED_*` route through [`majit_backend::cpu_tracker`] to
-    /// match PyPy's per-cpu tracker storage; pyre callers never bump
-    /// these via `count_ops` in practice, but the route is wired so
-    /// stray callers stay consistent with `get_counter`.
+    /// `TOTAL_FREED_*` are accepted but discarded — PyPy
+    /// `Profiler.count_ops` bumps `self.counters[kind]` for these slots
+    /// while [`get_counter`](Self::get_counter) reads from
+    /// `self.cpu.tracker`, so the bump is write-only into an unread
+    /// slot.  Routing them to `cpu_tracker()` here would let a stray
+    /// caller inflate the global tracker; matching PyPy's
+    /// disconnected-storage shape means the discard is intentional.
     pub fn count_ops(&self, opnum: OpCode, kind: i32) {
-        if let Some(field) = cpu_tracker_field_for_kind(kind) {
-            field.fetch_add(1, Ordering::Relaxed);
-        } else if let Some(field) = self.field_for_kind(kind) {
+        if let Some(field) = self.field_for_kind(kind) {
             field.fetch_add(1, Ordering::Relaxed);
         }
         if opnum.is_call() && kind == counters::RECORDED_OPS {
@@ -237,13 +238,15 @@ impl JitProfiler {
     ///
     /// Used for non-op events (ABORT_*, NV*, OPT_VECTORIZE_*, ...).
     /// Unknown ids are a silent no-op (matching the OPS variant above).
-    /// `TOTAL_COMPILED_*` / `TOTAL_FREED_*` route through
-    /// [`majit_backend::cpu_tracker`] (PyPy stores them on
-    /// `self.cpu.tracker`, not `self.counters`).
+    /// `TOTAL_COMPILED_*` / `TOTAL_FREED_*` are accepted but discarded
+    /// — PyPy `Profiler.count` bumps `self.counters[kind]` while
+    /// [`get_counter`](Self::get_counter) reads from `self.cpu.tracker`,
+    /// so the bump is write-only into an unread slot.  Use
+    /// [`majit_backend::cpu_tracker`] directly (or
+    /// [`Self::inc_freed_loop`] / [`Self::add_freed_bridges`]) when a
+    /// tracker bump is actually intended.
     pub fn count(&self, kind: i32, inc: usize) {
-        if let Some(field) = cpu_tracker_field_for_kind(kind) {
-            field.fetch_add(inc, Ordering::Relaxed);
-        } else if let Some(field) = self.field_for_kind(kind) {
+        if let Some(field) = self.field_for_kind(kind) {
             field.fetch_add(inc, Ordering::Relaxed);
         }
     }
@@ -322,13 +325,30 @@ impl JitProfiler {
         }
     }
 
-    /// Panic-safe RAII pairing for `start_tracing` / `end_tracing`.
-    /// `compile.py:532-546/589-599` wraps the backend compile in a
-    /// `start_backend()`/`end_backend()` pair via `try/finally`; the
-    /// pyre equivalent is this guard, which fires `end_*` from `Drop`
-    /// so panics inside the body still unwind through `end_event` and
-    /// the `current` stack stays balanced.
+    /// Panic-safe RAII pairing for `debug_start("jit-tracing")` +
+    /// `start_tracing` / `end_tracing` + `debug_stop("jit-tracing")`.
+    /// PyPy keeps the debug section and the profiler call separate at
+    /// the metainterp caller (`pyjitpl.py:1907-1925`):
+    ///
+    /// ```python
+    /// debug_start("jit-tracing")
+    /// self.staticdata.profiler.start_tracing()
+    /// try:
+    ///     ...
+    /// finally:
+    ///     self.staticdata.profiler.end_tracing()
+    ///     debug_stop("jit-tracing")
+    /// ```
+    ///
+    /// Pyre folds both layers into one RAII guard: construction fires
+    /// `debug_start` then `start_event`, drop fires `end_event` then
+    /// `debug_stop` (LIFO unwind order matching the try/finally above).
+    /// Panics inside the body still unwind through both, so the
+    /// `current` stack and the debug section stay balanced.
     pub fn enter_tracing(&self) -> ProfilerEventGuard<'_> {
+        if let Some(channel) = debug_channel_for_event(counters::TRACING) {
+            crate::debug::debug_start(channel);
+        }
         self.start_tracing();
         ProfilerEventGuard {
             profiler: self,
@@ -336,11 +356,17 @@ impl JitProfiler {
         }
     }
 
-    /// Panic-safe RAII pairing for `start_backend` / `end_backend`.
+    /// Panic-safe RAII pairing for `debug_start("jit-backend")` +
+    /// `start_backend` / `end_backend` + `debug_stop("jit-backend")`.
     /// Wraps `backend.compile_loop` / `backend.compile_bridge` call
-    /// sites with the same semantics as PyPy's `compile.py:532-546`
-    /// `try: ... finally: end_backend()`.
+    /// sites with the same try/finally shape as PyPy
+    /// `compile.py:532-546` (debug section outside, profiler call
+    /// inside).  See [`enter_tracing`](Self::enter_tracing) for the
+    /// detailed unwind order.
     pub fn enter_backend(&self) -> ProfilerEventGuard<'_> {
+        if let Some(channel) = debug_channel_for_event(counters::BACKEND) {
+            crate::debug::debug_start(channel);
+        }
         self.start_backend();
         ProfilerEventGuard {
             profiler: self,
@@ -349,7 +375,10 @@ impl JitProfiler {
     }
 
     fn start_event(&self, event: i32) {
-        // `jitprof.py:75-81 _start(event)`:
+        // `jitprof.py:75-81 _start(event)` — profiler bookkeeping only.
+        // The matching `debug_start(channel)` lives at the caller
+        // (PyPy convention; mirrored by [`enter_tracing`] /
+        // [`enter_backend`]).
         //   t0 = self.t1
         //   self.t1 = self.timer()
         //   if self.current:
@@ -357,30 +386,19 @@ impl JitProfiler {
         //   self.counters[event] += 1
         //   self.current.append(event)
         let now = Instant::now();
-        {
-            let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
-            if let (Some(t1), Some(&top_event)) = (state.t1, state.current.last()) {
-                self.add_time(top_event, now.saturating_duration_since(t1));
-            }
-            state.t1 = Some(now);
-            self.count(event, 1);
-            state.current.push(event);
+        let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
+        if let (Some(t1), Some(&top_event)) = (state.t1, state.current.last()) {
+            self.add_time(top_event, now.saturating_duration_since(t1));
         }
-        // PyPy keeps `debug_start("jit-tracing"|"jit-backend")` separate
-        // from `_start`/`_end` (it lives at the `compile.py:541` caller
-        // around the `start_tracing()/end_tracing()` pair).  Pyre folds
-        // the two together here so the metainterp callers only have
-        // to hold one RAII guard ([`enter_tracing`]/[`enter_backend`]);
-        // the debug-section pairing stays balanced because [`end_event`]
-        // only fires `debug_stop` on the success branch where the
-        // matching pop happened.
-        if let Some(channel) = debug_channel_for_event(event) {
-            crate::debug::debug_start(channel);
-        }
+        state.t1 = Some(now);
+        self.count(event, 1);
+        state.current.push(event);
     }
 
     fn end_event(&self, event: i32) {
         // `jitprof.py:83-93 _end(event)` — pop-first, then validate.
+        // The matching `debug_stop(channel)` lives at the caller
+        // (PyPy convention; mirrored by [`ProfilerEventGuard::drop`]).
         //   t0 = self.t1
         //   self.t1 = self.timer()
         //   if not self.current:
@@ -404,20 +422,10 @@ impl JitProfiler {
         }
         if popped_event != event {
             crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
-            // Note: the matching `debug_start` (if any) was issued for
-            // `popped_event`'s channel, not `event`'s — closing
-            // `event`'s channel here would mis-pair against the
-            // strict `debug_stop` nesting guard
-            // (`majit-ir/src/debug.rs:84-`).  Leave the section open;
-            // the broken-data log line is the externally-visible
-            // signal that something went wrong.
             return;
         }
         if let Some(t1) = t0 {
             self.add_time(popped_event, now.saturating_duration_since(t1));
-        }
-        if let Some(channel) = debug_channel_for_event(event) {
-            crate::debug::debug_stop(channel);
         }
     }
 
@@ -467,8 +475,11 @@ impl JitProfiler {
 
 /// RAII guard returned by [`JitProfiler::enter_tracing`] /
 /// [`JitProfiler::enter_backend`].  Drops by firing the matching
-/// `end_*` so the profiler stack stays balanced even when the
-/// surrounding body panics — the PyPy `try/finally` equivalent.
+/// `end_*` then `debug_stop(channel)` so the profiler stack and the
+/// debug section stay balanced even when the surrounding body panics
+/// — the PyPy `try/finally` equivalent
+/// (`debug_start; profiler.start; try: ...; finally:
+/// profiler.end; debug_stop`).
 #[must_use = "drop the guard to fire the paired end_* event"]
 pub struct ProfilerEventGuard<'a> {
     profiler: &'a JitProfiler,
@@ -477,7 +488,17 @@ pub struct ProfilerEventGuard<'a> {
 
 impl Drop for ProfilerEventGuard<'_> {
     fn drop(&mut self) {
+        // Unwind order matches PyPy's nested `try/finally`: inner
+        // (`profiler.end_*`) before outer (`debug_stop`).  If
+        // `end_event` detects a mismatch (broken-data path) we still
+        // emit `debug_stop` because the matching `debug_start` was
+        // already published in [`enter_tracing`] / [`enter_backend`];
+        // skipping it would leave the section open against the
+        // strict nesting guard in [`crate::debug::debug_stop`].
         self.profiler.end_event(self.event);
+        if let Some(channel) = debug_channel_for_event(self.event) {
+            crate::debug::debug_stop(channel);
+        }
     }
 }
 

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -350,7 +350,7 @@ impl<'a> TraceIterator<'a> {
                     });
                     let r = OpRef::input_arg_typed(_fresh, tp);
                     // Slice 77b.A: companion BoxRef per inputarg, fresh per iter.
-                    box_pool.push(BoxRef::new_inputarg(tp, Some(_fresh)));
+                    box_pool.push(BoxRef::new_inputarg(tp, _fresh));
                     _fresh += 1;
                     r
                 })
@@ -372,7 +372,7 @@ impl<'a> TraceIterator<'a> {
                 .map(|&tp| {
                     let r = OpRef::input_arg_typed(_fresh, tp);
                     // Slice 77b.A: companion BoxRef per inputarg, fresh per iter.
-                    box_pool.push(BoxRef::new_inputarg(tp, Some(_fresh)));
+                    box_pool.push(BoxRef::new_inputarg(tp, _fresh));
                     _fresh += 1;
                     r
                 })

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1644,7 +1644,7 @@ impl OptContext {
     }
 
     /// Construct an `OptContext` and seed `box_pool` with one
-    /// `BoxRef::new_inputarg(tp, Some(i))` per entry of `inputarg_types`.
+    /// `BoxRef::new_inputarg(tp, i)` per entry of `inputarg_types`.
     ///
     /// Mirrors `TraceIterator::new` (`opencoder.rs:373-426`, parity with
     /// `opencoder.py:259-262` `inputarg_from_tp(arg.type)`). Test fixtures
@@ -1662,7 +1662,7 @@ impl OptContext {
         let seed: Vec<crate::r#box::BoxRef> = inputarg_types
             .iter()
             .enumerate()
-            .map(|(i, &tp)| crate::r#box::BoxRef::new_inputarg(tp, Some(i as u32)))
+            .map(|(i, &tp)| crate::r#box::BoxRef::new_inputarg(tp, i as u32))
             .collect();
         ctx.box_pool = seed.into();
         // Mirror the production wiring at `setup_optimizations`
@@ -3773,6 +3773,34 @@ impl OptContext {
         }
         let idx = opref.raw() as usize;
         let placeholder_type = opref.ty().unwrap_or(majit_ir::Type::Void);
+        let is_inputarg_variant = matches!(
+            opref,
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+        );
+        // Empty-slot variant-aware lazy materialisation:
+        // `resoperation.py:699 AbstractInputArg` and `resoperation.py:250
+        // AbstractResOp` are distinct classes upstream.  A Box minted
+        // for an `OpRef::InputArg*` must report `is_inputarg()`, not
+        // `is_resop()`, so the chain walker reconstructs the same
+        // variant when it round-trips through `Forwarded::Box`.  Plain
+        // `ensure_box_at_typed` always emits `new_resop`; without this
+        // pre-step, every retrace/synthetic path that lazily references
+        // an inputarg through the optimizer (e.g. `set_pending_box_pool`
+        // omitted, or a test fixture going through `with_num_inputs`
+        // that hands an OpRef::InputArg* in before its slot is
+        // populated) would silently demote the inputarg to a resop.
+        if self.box_pool.get(idx).is_none() && is_inputarg_variant && opref.ty().is_some() {
+            self.box_pool.set(
+                idx,
+                crate::r#box::BoxRef::new_inputarg(placeholder_type, idx as u32),
+            );
+            return Some(
+                self.box_pool
+                    .get(idx)
+                    .cloned()
+                    .expect("just inserted inputarg box"),
+            );
+        }
         // Phantom-target upgrade: when the OpRef carries a non-Void type
         // tag but the existing `box_pool[idx]` entry is a *clean* Void
         // placeholder (no live forwarding / Info), re-mint it with the
@@ -3794,11 +3822,8 @@ impl OptContext {
             && existing.type_() == majit_ir::Type::Void
             && matches!(&*existing.get_forwarded(), crate::r#box::Forwarded::None)
         {
-            let upgraded = if matches!(
-                opref,
-                OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
-            ) {
-                crate::r#box::BoxRef::new_inputarg(placeholder_type, Some(idx as u32))
+            let upgraded = if is_inputarg_variant {
+                crate::r#box::BoxRef::new_inputarg(placeholder_type, idx as u32)
             } else {
                 crate::r#box::BoxRef::new_resop(placeholder_type, idx as u32)
             };
@@ -7142,8 +7167,8 @@ mod boxref_forwarding_tests {
 
     fn ctx_with_two_int_boxes() -> (OptContext, BoxRef, BoxRef) {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let b0 = BoxRef::new_inputarg(Type::Int, Some(0));
-        let b1 = BoxRef::new_inputarg(Type::Int, Some(1));
+        let b0 = BoxRef::new_inputarg(Type::Int, 0);
+        let b1 = BoxRef::new_inputarg(Type::Int, 1);
         ctx.box_pool = vec![b0.clone(), b1.clone()].into();
         (ctx, b0, b1)
     }
@@ -7221,7 +7246,7 @@ mod boxref_forwarding_tests {
     fn h3_1_set_ptr_info_mirrors_box_info() {
         // PtrInfo applies to ref-typed boxes.
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let b = BoxRef::new_inputarg(Type::Ref, Some(0));
+        let b = BoxRef::new_inputarg(Type::Ref, 0);
         ctx.box_pool = vec![b.clone()].into();
         let info = PtrInfo::NonNull { last_guard_pos: -1 };
         ctx.set_ptr_info(&b, info);
@@ -7240,7 +7265,7 @@ mod boxref_forwarding_tests {
     fn audit_a_make_nonnull_preserves_box_constant_slot() {
         use majit_ir::GcRef;
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let b = BoxRef::new_inputarg(Type::Ref, Some(0));
+        let b = BoxRef::new_inputarg(Type::Ref, 0);
         ctx.box_pool = vec![b.clone()].into();
         let opref = OpRef::input_arg_typed(0, Type::Ref);
         ctx.make_constant(opref, Value::Ref(GcRef(0xdead_beef)));
@@ -7275,8 +7300,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn audit_a_chain_walker_reaches_constant_through_forwarded_box() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let b0 = BoxRef::new_inputarg(Type::Int, Some(0));
-        let b1 = BoxRef::new_inputarg(Type::Int, Some(1));
+        let b0 = BoxRef::new_inputarg(Type::Int, 0);
+        let b1 = BoxRef::new_inputarg(Type::Int, 1);
         ctx.box_pool = vec![b0, b1.clone()].into();
         // (a) Const-namespace OpRef terminates at a Const box.
         let const_opref = OpRef::const_int(0);
@@ -7296,7 +7321,7 @@ mod boxref_forwarding_tests {
         ctx.const_pool.insert(1, Value::Int(42));
         assert!(b1.get_box_replacement(false).is_constant());
         // Negative case: BoxRef with no constant forwarding.
-        let nb = BoxRef::new_inputarg(Type::Int, Some(0));
+        let nb = BoxRef::new_inputarg(Type::Int, 0);
         assert!(!nb.get_box_replacement(false).is_constant());
     }
 
@@ -7430,8 +7455,8 @@ mod boxref_forwarding_tests {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 4, 0, 4);
         let placeholder_target = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 0);
         let placeholder_other = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 1);
-        let source_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, Some(2));
-        let other_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, Some(3));
+        let source_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 2);
+        let other_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 3);
         ctx.box_pool = vec![
             placeholder_target.clone(),
             placeholder_other,
@@ -7504,8 +7529,8 @@ mod boxref_forwarding_tests {
         // (PyPy `box.type` invariant; `make_equal_to` cross-type assertion).
         let placeholder_target = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 0);
         let placeholder_other = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 1);
-        let source_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, Some(2));
-        let other_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, Some(3));
+        let source_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 2);
+        let other_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 3);
         ctx.box_pool = vec![
             placeholder_target.clone(),
             placeholder_other,
@@ -7652,7 +7677,7 @@ mod boxref_forwarding_tests {
 
     fn ctx_with_one_ref_box() -> (OptContext, BoxRef) {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let b = BoxRef::new_inputarg(Type::Ref, Some(0));
+        let b = BoxRef::new_inputarg(Type::Ref, 0);
         ctx.box_pool = vec![b.clone()].into();
         (ctx, b)
     }
@@ -8018,9 +8043,9 @@ mod boxref_forwarding_tests {
     #[test]
     fn chain_walk_preserves_ptr_info_rc_identity_across_two_hops() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 3, 0, 3);
-        let a = BoxRef::new_inputarg(Type::Ref, Some(0));
-        let b = BoxRef::new_inputarg(Type::Ref, Some(1));
-        let c = BoxRef::new_inputarg(Type::Ref, Some(2));
+        let a = BoxRef::new_inputarg(Type::Ref, 0);
+        let b = BoxRef::new_inputarg(Type::Ref, 1);
+        let c = BoxRef::new_inputarg(Type::Ref, 2);
         ctx.box_pool = vec![a.clone(), b.clone(), c.clone()].into();
         ctx.set_ptr_info(&a, PtrInfo::NonNull { last_guard_pos: 7 });
 
@@ -8050,8 +8075,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn replace_op_preserves_int_bound_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Int, Some(0));
-        let new_box = BoxRef::new_inputarg(Type::Int, Some(1));
+        let old_box = BoxRef::new_inputarg(Type::Int, 0);
+        let new_box = BoxRef::new_inputarg(Type::Int, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.setintbound(
             &old_box,
@@ -8087,8 +8112,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn replace_op_preserves_ptr_info_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Ref, Some(0));
-        let new_box = BoxRef::new_inputarg(Type::Ref, Some(1));
+        let old_box = BoxRef::new_inputarg(Type::Ref, 0);
+        let new_box = BoxRef::new_inputarg(Type::Ref, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.set_ptr_info(&old_box, PtrInfo::NonNull { last_guard_pos: 0 });
 
@@ -8122,8 +8147,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn make_equal_to_preserves_int_bound_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Int, Some(0));
-        let new_box = BoxRef::new_inputarg(Type::Int, Some(1));
+        let old_box = BoxRef::new_inputarg(Type::Int, 0);
+        let new_box = BoxRef::new_inputarg(Type::Int, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.setintbound(
             &old_box,
@@ -8146,8 +8171,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn make_equal_to_preserves_ptr_info_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Ref, Some(0));
-        let new_box = BoxRef::new_inputarg(Type::Ref, Some(1));
+        let old_box = BoxRef::new_inputarg(Type::Ref, 0);
+        let new_box = BoxRef::new_inputarg(Type::Ref, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.set_ptr_info(&old_box, PtrInfo::NonNull { last_guard_pos: 0 });
 
@@ -8170,7 +8195,7 @@ mod boxref_forwarding_tests {
     #[test]
     fn clear_forwarded_drops_int_bound() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let old_box = BoxRef::new_inputarg(Type::Int, Some(0));
+        let old_box = BoxRef::new_inputarg(Type::Int, 0);
         ctx.box_pool = vec![old_box.clone()].into();
         ctx.setintbound(
             &old_box,
@@ -8866,7 +8891,7 @@ mod intbound_invariant_tests {
         let ctx = OptContext::new(0);
         // BoxRef-direct setintbound asserts `op.type_()` is Int/Void per
         // optimizer.py:116. A Ref-typed BoxRef should trigger the panic.
-        let ref_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, Some(0));
+        let ref_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 0);
         ctx.setintbound(&ref_box, &IntBound::nonnegative());
     }
 }
@@ -8984,6 +9009,62 @@ mod opt_box_env_tests {
         assert!(
             env.is_virtual_ref(source),
             "forwarded snapshot boxes must classify as virtual via replacement"
+        );
+    }
+
+    #[test]
+    fn ensure_box_lazy_materialises_inputarg_for_empty_inputarg_slot() {
+        // `resoperation.py:699 AbstractInputArg` and
+        // `resoperation.py:250 AbstractResOp` are distinct classes
+        // upstream — a Box materialised against `OpRef::InputArg*`
+        // must be `is_inputarg()` so the chain walker reconstructs
+        // the same variant on the round-trip through
+        // `Forwarded::Box`.  Prior to the per-variant empty-slot
+        // path, `ensure_box` routed through `ensure_box_at_typed`
+        // which always emits `new_resop`, silently demoting the
+        // inputarg.
+        // `with_inputarg_types` would seed the inputarg slots
+        // eagerly, defeating the lazy-materialisation check.  Use
+        // `with_num_inputs(_, 0)` to get an empty pool then hand an
+        // `OpRef::InputArg*` in directly — the regression we are
+        // covering is exactly the path where the empty slot must
+        // mint a `new_inputarg`.
+        let mut ctx = OptContext::with_num_inputs(8, 0);
+        let arg = OpRef::input_arg_typed(0, majit_ir::Type::Int);
+        let materialised = ctx
+            .ensure_box(arg)
+            .expect("InputArg OpRef must materialise a BoxRef");
+        assert!(
+            materialised.is_inputarg(),
+            "empty InputArg* slot lazy-materialised the wrong BoxKind",
+        );
+        assert_eq!(materialised.inputarg_position(), Some(0));
+        assert_eq!(materialised.type_(), majit_ir::Type::Int);
+
+        // Re-entering must keep the same identity (no second lazy
+        // mint): `BoxRef` `PartialEq` is `Rc::ptr_eq` matching
+        // PyPy's `_forwarded` identity.
+        let second = ctx
+            .ensure_box(arg)
+            .expect("InputArg OpRef must continue to resolve");
+        assert_eq!(
+            materialised, second,
+            "second ensure_box must return the same Box identity",
+        );
+    }
+
+    #[test]
+    fn ensure_box_lazy_materialises_resop_for_empty_resop_slot() {
+        // Companion to the InputArg case — `OpRef::int_op(_)` must
+        // continue to produce a `new_resop` Box so `is_resop()` holds.
+        let mut ctx = OptContext::with_num_inputs(8, 0);
+        let result = OpRef::int_op(3);
+        let materialised = ctx
+            .ensure_box(result)
+            .expect("ResOp OpRef must materialise a BoxRef");
+        assert!(
+            materialised.is_resop(),
+            "empty ResOp slot lazy-materialised the wrong BoxKind",
         );
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3773,22 +3773,33 @@ impl OptContext {
         }
         let idx = opref.raw() as usize;
         let placeholder_type = opref.ty().unwrap_or(majit_ir::Type::Void);
-        let is_inputarg_variant = matches!(
-            opref,
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
-        );
-        // Empty-slot variant-aware lazy materialisation:
         // `resoperation.py:699 AbstractInputArg` and `resoperation.py:250
         // AbstractResOp` are distinct classes upstream.  A Box minted
         // for an `OpRef::InputArg*` must report `is_inputarg()`, not
         // `is_resop()`, so the chain walker reconstructs the same
-        // variant when it round-trips through `Forwarded::Box`.  Plain
-        // `ensure_box_at_typed` always emits `new_resop`; without this
-        // pre-step, every retrace/synthetic path that lazily references
-        // an inputarg through the optimizer (e.g. `set_pending_box_pool`
-        // omitted, or a test fixture going through `with_num_inputs`
-        // that hands an OpRef::InputArg* in before its slot is
-        // populated) would silently demote the inputarg to a resop.
+        // variant when it round-trips through `Forwarded::Box`.
+        //
+        // Variant-only classification is correct here:
+        // `AbstractInputArg` vs `AbstractResOp` is a class-level
+        // distinction in PyPy, not a slot-position one.  Slot-range
+        // classification (matching `inputarg_type` on
+        // `[inputarg_base, inputarg_base + num_inputs)`) would also
+        // sweep in op-result positions that happen to land inside
+        // that window in test fixtures whose `assign_positions`
+        // starts at 0 — promoting a resop result to inputarg breaks
+        // those layouts.  Production callers that need a
+        // slot-classified inputarg always use the typed
+        // `OpRef::input_arg_typed(i, tp)` factory, which produces
+        // the matching `OpRef::InputArg*` variant.
+        let is_inputarg_variant = matches!(
+            opref,
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+        );
+        // Empty-slot lazy materialisation: route through `new_inputarg`
+        // for inputarg variants, leaving `ensure_box_at_typed` to
+        // handle ResOp slots below.  Without this, retrace/synthetic
+        // paths handing an `OpRef::InputArg*` in before its slot is
+        // populated would silently demote the inputarg to a resop.
         if self.box_pool.get(idx).is_none() && is_inputarg_variant && opref.ty().is_some() {
             self.box_pool.set(
                 idx,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4369,7 +4369,7 @@ mod tests {
     fn h3_0b_pending_box_pool_transfers_to_ctx() {
         use crate::r#box::BoxRef;
         let mut opt = Optimizer::default_pipeline();
-        let b0 = BoxRef::new_inputarg(Type::Int, Some(0));
+        let b0 = BoxRef::new_inputarg(Type::Int, 0);
         let pool = vec![b0.clone()];
         opt.set_pending_box_pool(pool);
         let ops: Vec<Op> = Vec::new();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5001,8 +5001,8 @@ mod tests {
 
     #[test]
     fn test_retrace_box_pool_snapshot_preserves_inputargs_for_p1_full_prefix() {
-        let input0 = crate::r#box::BoxRef::new_inputarg(Type::Ref, Some(0));
-        let input1 = crate::r#box::BoxRef::new_inputarg(Type::Int, Some(1));
+        let input0 = crate::r#box::BoxRef::new_inputarg(Type::Ref, 0);
+        let input1 = crate::r#box::BoxRef::new_inputarg(Type::Int, 1);
         let emit2 = crate::r#box::BoxRef::new_resop(Type::Ref, 2);
         let emit3 = crate::r#box::BoxRef::new_resop(Type::Int, 3);
         let snapshot = vec![

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -7334,10 +7334,21 @@ impl<M: Clone> MetaInterp<M> {
             // counter side: PyPy's `LoopToken.__del__` runs that
             // routine, which on its way out bumps
             // `cpu.tracker.total_freed_loops += 1` plus
-            // `total_freed_bridges += loop.bridges_count`.  Pyre's
-            // backend has no global `cpu.tracker`; we keep the same
-            // four counters on the per-process `JitProfiler` and
-            // increment them here, where the eviction is observed.
+            // `total_freed_bridges += loop.bridges_count`.  Pyre routes
+            // both bumps through `majit_backend::cpu_tracker` via
+            // `JitProfiler::inc_freed_loop` / `add_freed_bridges`.
+            //
+            // **TIMING DIVERGENCE.**  RPython fires `__del__` exactly
+            // when the GC collects the LoopToken — Rust's `Arc`
+            // cannot match that timing because the last strong ref
+            // may be held by a guard-failure path that hasn't dropped
+            // yet.  Pyre instead bumps the counters at memmgr
+            // eviction (memmgr.py:73 `_kill_old_loops_now`), which is
+            // strictly upstream of `__del__` in PyPy: every evicted
+            // token will eventually `__del__`, but the counter is
+            // bumped at observe-time, not at the (later, unpredictable)
+            // Arc-drop time.  The observable difference is a small
+            // lead in the counter relative to actual memory release.
             // `compiled_loop_token` is None before backend compile
             // completes — never reachable on an evicted token, but
             // guarded for safety.

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2146,12 +2146,34 @@ impl<M: Clone> MetaInterp<M> {
     /// matching close lives in [`leave_profiler_tracing`]; both halves
     /// must move as a pair to keep the `debug_start`/`debug_stop`
     /// nesting balanced (PyPy convention).
+    ///
+    /// Use [`open_profiler_tracing_inner`](Self::open_profiler_tracing_inner)
+    /// instead when the caller needs `_setup_once` to run *inside*
+    /// the debug section but *before* the profiler event (PyPy
+    /// `compile_and_run_once` order at `pyjitpl.py:2888-2892`).
     pub fn enter_profiler_tracing(&mut self) {
         debug_assert!(
             !self.profiler_tracing_active,
             "enter_profiler_tracing called while tracing profiler event is already open",
         );
         crate::debug::debug_start("jit-tracing");
+        self.staticdata.profiler.start_tracing();
+        self.profiler_tracing_active = true;
+    }
+
+    /// Open the profiler tracing event scope assuming the
+    /// `jit-tracing` debug section has *already* been opened upstream
+    /// by the caller.  Used by [`prepare_trace_start_runtime`] so the
+    /// debug section can wrap `_setup_once` while the profiler event
+    /// only opens after `_setup_once` completes — matching the
+    /// `debug_start; _setup_once; start_tracing` order at
+    /// `pyjitpl.py:2888-2892`.  The matching close still routes
+    /// through [`leave_profiler_tracing`].
+    pub fn open_profiler_tracing_inner(&mut self) {
+        debug_assert!(
+            !self.profiler_tracing_active,
+            "open_profiler_tracing_inner called while tracing profiler event is already open",
+        );
         self.staticdata.profiler.start_tracing();
         self.profiler_tracing_active = true;
     }
@@ -2930,16 +2952,29 @@ impl<M: Clone> MetaInterp<M> {
 
     fn prepare_trace_start_runtime(&mut self) {
         // pyjitpl.py:2884-2892 `compile_and_run_once` body, line-by-line:
-        //   debug_start('jit-tracing')
+        //   debug_start('jit-tracing')                  # OUTER open
         //   self.staticdata._setup_once()
-        //   self.staticdata.profiler.start_tracing()
+        //   self.staticdata.profiler.start_tracing()    # INNER open
         //   self.staticdata.try_to_free_some_loops()
         // `ensure_jitlog_initialised` is pyre's pre-`_setup_once` jitlog
         // bootstrap; it has no PyPy analog (jitlog wiring runs inside
         // `_setup_once` upstream) and stays idempotent.
+        //
+        // The debug section wraps `_setup_once` upstream so any
+        // `debug_print` inside the one-shot bootstrap (vector-ext
+        // setup, jitlog handshake, etc.) lands inside the
+        // `jit-tracing` PYPYLOG section.  Pyre matches that by opening
+        // the debug section *before* `_setup_once` and the profiler
+        // event *after*, splitting the work that
+        // [`enter_profiler_tracing`] would normally combine.
         self.warm_state.ensure_jitlog_initialised();
+        crate::debug::debug_start("jit-tracing");
         self.staticdata._setup_once(&mut self.backend);
-        self.enter_profiler_tracing();
+        // Profiler event opens after `_setup_once`, matching PyPy
+        // line 2890.  `open_profiler_tracing_inner` is the
+        // debug_start-skipping variant of `enter_profiler_tracing`
+        // since the section is already open above.
+        self.open_profiler_tracing_inner();
         self.try_to_free_some_loops();
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2204,7 +2204,15 @@ impl<M: Clone> MetaInterp<M> {
     /// the debug section but *before* the profiler event (PyPy
     /// `compile_and_run_once` order at `pyjitpl.py:2888-2892`).
     pub fn enter_profiler_tracing(&mut self) {
-        debug_assert!(
+        // `assert!` (not `debug_assert!`): in release, a second
+        // entry would open another profiler/debug scope that
+        // `leave_profiler_tracing` cannot close (the boolean flag
+        // only tracks one scope), leaving the stacks permanently
+        // unbalanced and corrupting later `debug_stop` mismatch
+        // detection.  Crash-on-misuse matches PyPy's intolerance for
+        // recursive `start_tracing()` (`jitprof.py:81` would push
+        // a second TRACING and `_print_stats` would observe it).
+        assert!(
             !self.profiler_tracing_active,
             "enter_profiler_tracing called while tracing profiler event is already open",
         );
@@ -2222,7 +2230,11 @@ impl<M: Clone> MetaInterp<M> {
     /// `pyjitpl.py:2888-2892`.  The matching close still routes
     /// through [`leave_profiler_tracing`].
     pub fn open_profiler_tracing_inner(&mut self) {
-        debug_assert!(
+        // Same release-build assertion contract as
+        // [`enter_profiler_tracing`] — a second entry would leak a
+        // profiler scope past `leave_profiler_tracing`'s single-flag
+        // close.
+        assert!(
             !self.profiler_tracing_active,
             "open_profiler_tracing_inner called while tracing profiler event is already open",
         );
@@ -3029,14 +3041,24 @@ impl<M: Clone> MetaInterp<M> {
         // mismatch panics).
         let rollback = DebugSectionRollback::arm("jit-tracing");
         self.staticdata._setup_once(&mut self.backend);
-        // `_setup_once` succeeded — hand the close off to
-        // `leave_profiler_tracing` via `profiler_tracing_active`.
-        rollback.dismiss();
         // Profiler event opens after `_setup_once`, matching PyPy
         // line 2890.  `open_profiler_tracing_inner` is the
         // debug_start-skipping variant of `enter_profiler_tracing`
         // since the section is already open above.
+        //
+        // The rollback stays armed across `open_profiler_tracing_inner`:
+        // that call's `start_tracing()` can panic on a poisoned
+        // timing mutex, and the active flag is only set *after*
+        // `start_tracing()` returns.  If we dismissed earlier and
+        // `start_tracing()` then panicked, `profiler_tracing_active`
+        // would stay `false` so `leave_profiler_tracing` would skip
+        // the close — leaking the debug section.  Dismissing only
+        // after `open_profiler_tracing_inner` returns hands the
+        // close off cleanly: success → `leave_profiler_tracing`
+        // owns it via the now-`true` flag; panic → the rollback
+        // fires `debug_stop` on the unwind path.
         self.open_profiler_tracing_inner();
+        rollback.dismiss();
         self.try_to_free_some_loops();
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -29,6 +29,47 @@ pub(crate) use majit_backend_wasm::WasmBackend as BackendImpl;
 #[cfg(not(any(feature = "cranelift", feature = "dynasm", target_arch = "wasm32")))]
 compile_error!("majit-metainterp requires a backend: enable feature \"cranelift\" or \"dynasm\"");
 
+/// Dismissable RAII guard around `crate::debug::debug_start(channel)`.
+/// On drop without [`dismiss`](Self::dismiss), fires
+/// `debug_stop(channel)` so the PYPYLOG category stack stays balanced
+/// when the surrounding code panics before the normal `debug_stop`
+/// site (e.g. an `assert!` inside `_setup_once`).  Used by
+/// [`MetaInterp::prepare_trace_start_runtime`] to bridge the gap
+/// between `debug_start("jit-tracing")` and
+/// [`MetaInterp::open_profiler_tracing_inner`], after which ownership
+/// of the close transfers to
+/// [`MetaInterp::leave_profiler_tracing`].
+#[must_use = "drop the rollback guard to fire debug_stop on the unwind path"]
+struct DebugSectionRollback {
+    channel: &'static str,
+    armed: bool,
+}
+
+impl DebugSectionRollback {
+    fn arm(channel: &'static str) -> Self {
+        crate::debug::debug_start(channel);
+        Self {
+            channel,
+            armed: true,
+        }
+    }
+
+    /// Cancel the rollback — the caller has reached a point where
+    /// some downstream code path is now responsible for issuing the
+    /// matching `debug_stop`.
+    fn dismiss(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for DebugSectionRollback {
+    fn drop(&mut self) {
+        if self.armed {
+            crate::debug::debug_stop(self.channel);
+        }
+    }
+}
+
 use crate::history::TreeLoop;
 use crate::warmstate::{HotResult, WarmEnterState};
 use majit_ir::descr::DescrRef;
@@ -2968,8 +3009,18 @@ impl<M: Clone> MetaInterp<M> {
         // event *after*, splitting the work that
         // [`enter_profiler_tracing`] would normally combine.
         self.warm_state.ensure_jitlog_initialised();
-        crate::debug::debug_start("jit-tracing");
+        // `_setup_once` contains unconditional asserts (vector_ext
+        // setup, jitdriver registration sanity, etc.) — a failure
+        // panics out of this function.  Use a dismissable RAII
+        // guard so the debug section closes on the unwind path
+        // instead of leaving `MAJIT_LOG`'s category stack
+        // unbalanced (which would trigger later `debug_stop`
+        // mismatch panics).
+        let rollback = DebugSectionRollback::arm("jit-tracing");
         self.staticdata._setup_once(&mut self.backend);
+        // `_setup_once` succeeded — hand the close off to
+        // `leave_profiler_tracing` via `profiler_tracing_active`.
+        rollback.dismiss();
         // Profiler event opens after `_setup_once`, matching PyPy
         // line 2890.  `open_profiler_tracing_inner` is the
         // debug_start-skipping variant of `enter_profiler_tracing`

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2136,29 +2136,40 @@ impl<M: Clone> MetaInterp<M> {
         self.bridge_info = None;
     }
 
-    /// `pyjitpl.py:2890 / 2916` `profiler.start_tracing()` parity —
-    /// open the tracing profiler event scope.  Idempotent re-entry is
-    /// not allowed (PyPy's compile_and_run_once / handle_guard_failure
-    /// are not re-entrant on the same MetaInterp).
+    /// `pyjitpl.py:2890 / 2916`
+    /// `debug_start("jit-tracing"); profiler.start_tracing()` parity —
+    /// open the tracing debug section and profiler event scope.
+    /// Idempotent re-entry is not allowed (PyPy's
+    /// `compile_and_run_once` / `handle_guard_failure` are not
+    /// re-entrant on the same MetaInterp).  The debug section and
+    /// profiler event are issued together here because the
+    /// matching close lives in [`leave_profiler_tracing`]; both halves
+    /// must move as a pair to keep the `debug_start`/`debug_stop`
+    /// nesting balanced (PyPy convention).
     pub fn enter_profiler_tracing(&mut self) {
         debug_assert!(
             !self.profiler_tracing_active,
             "enter_profiler_tracing called while tracing profiler event is already open",
         );
+        crate::debug::debug_start("jit-tracing");
         self.staticdata.profiler.start_tracing();
         self.profiler_tracing_active = true;
     }
 
-    /// `pyjitpl.py:2897 / 2934` `profiler.end_tracing()` parity —
-    /// close the tracing profiler event scope opened by
-    /// [`enter_profiler_tracing`].  No-op if the scope was already
-    /// closed (mirrors PyPy's `finally` semantics: a path that never
-    /// reached `start_tracing` still passes through `finally` without
-    /// firing `end_tracing` because the implicit pairing depends on
-    /// whether the entry method ran past `start_tracing`).
+    /// `pyjitpl.py:2897 / 2934`
+    /// `profiler.end_tracing(); debug_stop("jit-tracing")` parity —
+    /// close the profiler event scope opened by
+    /// [`enter_profiler_tracing`], then the matching debug section
+    /// (LIFO unwind matching PyPy's nested `try/finally`).  No-op if
+    /// the scope was already closed (mirrors PyPy's `finally`
+    /// semantics: a path that never reached `start_tracing` still
+    /// passes through `finally` without firing `end_tracing` because
+    /// the implicit pairing depends on whether the entry method ran
+    /// past `start_tracing`).
     pub fn leave_profiler_tracing(&mut self) {
         if self.profiler_tracing_active {
             self.staticdata.profiler.end_tracing();
+            crate::debug::debug_stop("jit-tracing");
             self.profiler_tracing_active = false;
         }
     }
@@ -4823,18 +4834,22 @@ impl<M: Clone> MetaInterp<M> {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
-        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
-        // ... finally: ... profiler.end_backend()`.
-        self.staticdata.profiler.start_backend();
-        let compile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.backend.compile_loop(
-                &inputargs,
-                &compiled_ops_rc,
-                Arc::get_mut(&mut token)
-                    .expect("JitCellToken must stay uniquely owned until backend compile"),
-            )
-        }));
-        self.staticdata.profiler.end_backend();
+        // compile.py:532-546 `debug_start("jit-backend") +
+        // profiler.start_backend() ... try: do_compile_loop ... finally:
+        // ... profiler.end_backend() + debug_stop("jit-backend")`.
+        // `enter_backend` RAII guard pairs the debug section + profiler
+        // event; drop fires end_backend then debug_stop in LIFO order.
+        let compile_result = {
+            let _backend_scope = self.staticdata.profiler.enter_backend();
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.backend.compile_loop(
+                    &inputargs,
+                    &compiled_ops_rc,
+                    Arc::get_mut(&mut token)
+                        .expect("JitCellToken must stay uniquely owned until backend compile"),
+                )
+            }))
+        };
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(e) => {
@@ -5656,23 +5671,25 @@ impl<M: Clone> MetaInterp<M> {
         self.backend.set_next_trace_id(trace_id);
         self.backend.set_next_header_pc(green_key);
 
-        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
-        // ... finally: ... profiler.end_backend()`.
-        self.staticdata.profiler.start_backend();
-        let compile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            // Wrap to `Vec<OpRc>` for the backend's trait boundary.
-            let combined_ops_rc: Vec<majit_ir::OpRc> = combined_ops
-                .iter()
-                .map(|op| std::rc::Rc::new(op.clone()))
-                .collect();
-            self.backend.compile_loop(
-                &inputargs,
-                &combined_ops_rc,
-                Arc::get_mut(&mut token)
-                    .expect("JitCellToken must stay uniquely owned until backend compile"),
-            )
-        }));
-        self.staticdata.profiler.end_backend();
+        // compile.py:532-546 `debug_start("jit-backend") +
+        // profiler.start_backend() ... try: do_compile_loop ... finally:
+        // ... profiler.end_backend() + debug_stop("jit-backend")`.
+        let compile_result = {
+            let _backend_scope = self.staticdata.profiler.enter_backend();
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                // Wrap to `Vec<OpRc>` for the backend's trait boundary.
+                let combined_ops_rc: Vec<majit_ir::OpRc> = combined_ops
+                    .iter()
+                    .map(|op| std::rc::Rc::new(op.clone()))
+                    .collect();
+                self.backend.compile_loop(
+                    &inputargs,
+                    &combined_ops_rc,
+                    Arc::get_mut(&mut token)
+                        .expect("JitCellToken must stay uniquely owned until backend compile"),
+                )
+            }))
+        };
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(_) => {
@@ -6196,8 +6213,9 @@ impl<M: Clone> MetaInterp<M> {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
-        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
-        // ... finally: ... profiler.end_backend()`.
+        // compile.py:532-546 `debug_start("jit-backend") +
+        // profiler.start_backend() ... try: do_compile_loop ... finally:
+        // ... profiler.end_backend() + debug_stop("jit-backend")`.
         let compile_loop_result = {
             let _backend_guard = self.staticdata.profiler.enter_backend();
             self.backend.compile_loop(
@@ -6552,8 +6570,9 @@ impl<M: Clone> MetaInterp<M> {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
-        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
-        // ... finally: ... profiler.end_backend()`.
+        // compile.py:532-546 `debug_start("jit-backend") +
+        // profiler.start_backend() ... try: do_compile_loop ... finally:
+        // ... profiler.end_backend() + debug_stop("jit-backend")`.
         let compile_loop_result = {
             let _backend_guard = self.staticdata.profiler.enter_backend();
             self.backend.compile_loop(
@@ -8536,22 +8555,24 @@ impl<M: Clone> MetaInterp<M> {
             token_mut.num_scalar_inputargs = self.num_scalar_inputargs;
         }
 
-        // compile.py:532-546 `profiler.start_backend() ... try: do_compile_loop
-        // ... finally: ... profiler.end_backend()`.
-        self.staticdata.profiler.start_backend();
-        let compile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let optimized_ops_rc: Vec<majit_ir::OpRc> = optimized_ops
-                .iter()
-                .map(|op| std::rc::Rc::new(op.clone()))
-                .collect();
-            self.backend.compile_loop(
-                bridge_inputargs,
-                &optimized_ops_rc,
-                Arc::get_mut(&mut token)
-                    .expect("JitCellToken must stay uniquely owned until backend compile"),
-            )
-        }));
-        self.staticdata.profiler.end_backend();
+        // compile.py:532-546 `debug_start("jit-backend") +
+        // profiler.start_backend() ... try: do_compile_loop ... finally:
+        // ... profiler.end_backend() + debug_stop("jit-backend")`.
+        let compile_result = {
+            let _backend_scope = self.staticdata.profiler.enter_backend();
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let optimized_ops_rc: Vec<majit_ir::OpRc> = optimized_ops
+                    .iter()
+                    .map(|op| std::rc::Rc::new(op.clone()))
+                    .collect();
+                self.backend.compile_loop(
+                    bridge_inputargs,
+                    &optimized_ops_rc,
+                    Arc::get_mut(&mut token)
+                        .expect("JitCellToken must stay uniquely owned until backend compile"),
+                )
+            }))
+        };
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(_) => return false,
@@ -9116,20 +9137,23 @@ impl<M: Clone> MetaInterp<M> {
                 .iter()
                 .map(|op| std::rc::Rc::new(op.clone()))
                 .collect();
-            // compile.py:589-599 `profiler.start_backend() ... try:
-            // do_compile_bridge ... finally: ... profiler.end_backend()`.
-            self.staticdata.profiler.start_backend();
-            let bridge_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                self.backend.compile_bridge(
-                    fail_descr,
-                    bridge_inputargs,
-                    &optimized_ops_rc_for_bridge,
-                    &source_jct,
-                    previous_tokens,
-                    caller_recovery_layout.as_ref(),
-                )
-            }));
-            self.staticdata.profiler.end_backend();
+            // compile.py:589-599 `debug_start("jit-backend") +
+            // profiler.start_backend() ... try: do_compile_bridge ...
+            // finally: ... profiler.end_backend() +
+            // debug_stop("jit-backend")`.
+            let bridge_result = {
+                let _backend_scope = self.staticdata.profiler.enter_backend();
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    self.backend.compile_bridge(
+                        fail_descr,
+                        bridge_inputargs,
+                        &optimized_ops_rc_for_bridge,
+                        &source_jct,
+                        previous_tokens,
+                        caller_recovery_layout.as_ref(),
+                    )
+                }))
+            };
             match bridge_result {
                 Ok(r) => r,
                 Err(e) => {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4999,11 +4999,9 @@ impl<M: Clone> MetaInterp<M> {
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
 
                 self.stats.loops_compiled += 1;
-                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
-                // parity — bump the per-process profiler tracker so
-                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
-                // the post-`record_loop_or_bridge` total.
-                self.staticdata.profiler.inc_compiled_loop();
+                // `cpu.tracker.total_compiled_loops` is bumped inside
+                // `CompiledLoopToken::new` (model.py:297 parity); no
+                // explicit metainterp-side bump needed here.
 
                 if let Some(ref hook) = self.hooks.on_compile_loop {
                     hook(green_key, num_ops_before, num_ops_after);
@@ -5822,11 +5820,8 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
                 self.stats.loops_compiled += 1;
-                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
-                // parity — bump the per-process profiler tracker so
-                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
-                // the post-`record_loop_or_bridge` total.
-                self.staticdata.profiler.inc_compiled_loop();
+                // `cpu.tracker.total_compiled_loops` is bumped inside
+                // `CompiledLoopToken::new` (model.py:297 parity).
 
                 if let Some(ref hook) = self.hooks.on_compile_loop {
                     hook(green_key, 0, num_combined_ops);
@@ -6327,11 +6322,8 @@ impl<M: Clone> MetaInterp<M> {
                 }
                 self.attach_procedure_with_redirect(green_key, Arc::clone(&token));
                 self.stats.loops_compiled += 1;
-                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
-                // parity — bump the per-process profiler tracker so
-                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
-                // the post-`record_loop_or_bridge` total.
-                self.staticdata.profiler.inc_compiled_loop();
+                // `cpu.tracker.total_compiled_loops` is bumped inside
+                // `CompiledLoopToken::new` (model.py:297 parity).
                 if crate::debug::have_debug_prints() {
                     crate::debug::log_one(
                         "jit-summary",
@@ -6650,11 +6642,8 @@ impl<M: Clone> MetaInterp<M> {
                     },
                 );
                 self.stats.loops_compiled += 1;
-                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
-                // parity — bump the per-process profiler tracker so
-                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
-                // the post-`record_loop_or_bridge` total.
-                self.staticdata.profiler.inc_compiled_loop();
+                // `cpu.tracker.total_compiled_loops` is bumped inside
+                // `CompiledLoopToken::new` (model.py:297 parity).
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] compile_simple_loop: compiled segmented trace key={}, trace_id={}",
@@ -8671,11 +8660,8 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 self.attach_procedure_with_redirect(original_green_key, Arc::clone(&token));
                 self.stats.loops_compiled += 1;
-                // jitprof.py:106 `self.cpu.tracker.total_compiled_loops`
-                // parity — bump the per-process profiler tracker so
-                // `Profiler.get_counter(TOTAL_COMPILED_LOOPS)` returns
-                // the post-`record_loop_or_bridge` total.
-                self.staticdata.profiler.inc_compiled_loop();
+                // `cpu.tracker.total_compiled_loops` is bumped inside
+                // `CompiledLoopToken::new` (model.py:297 parity).
                 if let Some(ref hook) = self.hooks.on_compile_loop {
                     hook(original_green_key, bridge_ops.len(), num_optimized_ops);
                 }
@@ -9255,9 +9241,9 @@ impl<M: Clone> MetaInterp<M> {
                 self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
                 self.warm_state.log_bridge_compile(fail_index);
                 self.stats.bridges_compiled += 1;
-                // jitprof.py:108 `self.cpu.tracker.total_compiled_bridges`
-                // parity — bump the per-process profiler tracker.
-                self.staticdata.profiler.inc_compiled_bridge();
+                // `cpu.tracker.total_compiled_bridges` is bumped inside
+                // `Backend::compile_bridge` via `clt.compiling_a_bridge()`
+                // (x86/runner.py:100-101, model.py:309-314 parity).
 
                 if let Some(ref hook) = self.hooks.on_compile_bridge {
                     hook(green_key, fail_index, num_optimized_ops);

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1953,6 +1953,17 @@ impl<M: Clone> MetaInterp<M> {
             .expect("MetaInterpStaticData must be uniquely owned during MetaInterp::new")
             .jit_starting_line = format!("JIT starting ({})", backend.backend_name());
         staticdata.attach_descrs_to_cpu(backend);
+        // jitprof.py:105-106 `self.cpu.tracker` — bind the profiler's
+        // tracker handle to the backend's `CpuTotalTracker` Arc so
+        // `TOTAL_COMPILED_*` / `TOTAL_FREED_*` reads route to the same
+        // per-CPU sink the backend writes via
+        // `record_compiled_loop_token` / `clt.compiling_a_bridge`.
+        // Without this rebind, the freshly-constructed profiler holds
+        // a private tracker disconnected from the backend's, so totals
+        // would silently zero out.
+        staticdata
+            .profiler
+            .set_cpu_tracker(std::sync::Arc::clone(backend.cpu_tracker()));
         this
     }
 
@@ -7440,8 +7451,10 @@ impl<M: Clone> MetaInterp<M> {
             // routine, which on its way out bumps
             // `cpu.tracker.total_freed_loops += 1` plus
             // `total_freed_bridges += loop.bridges_count`.  Pyre routes
-            // both bumps through `majit_backend::cpu_tracker` via
-            // `JitProfiler::inc_freed_loop` / `add_freed_bridges`.
+            // both bumps through the backend's `CpuTotalTracker` Arc
+            // via `JitProfiler::inc_freed_loop` / `add_freed_bridges`
+            // (the profiler is rebound onto that Arc in
+            // `MetaInterp::new`).
             //
             // **TIMING DIVERGENCE.**  RPython fires `__del__` exactly
             // when the GC collects the LoopToken — Rust's `Arc`

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -184,8 +184,7 @@ impl Trace {
             Type::Void => panic!("input args cannot be Void"),
         };
         // H-2.1 parallel BoxRef: `AbstractInputArg` mirror with position.
-        self.box_pool
-            .push(BoxRef::new_inputarg(tp, Some(self.op_count)));
+        self.box_pool.push(BoxRef::new_inputarg(tp, self.op_count));
         self.op_count += 1;
         self.box_count += 1;
         opref

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2678,18 +2678,15 @@ fn jit_ca_handle_guard_failure(
     }
     let frame = unsafe { &mut *frame_ptr };
 
-    // `compile.py:786-788` `self.start_compiling()` — direct method
-    // call on the resume-guard descr instance.
-    if let Some(fd) = descr_arc.as_fail_descr() {
-        fd.start_compiling();
-    }
-
-    let compiled = trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout);
-
-    // `compile.py:790-795` `self.done_compiling()` — direct method call.
-    if let Some(fd) = descr_arc.as_fail_descr() {
-        fd.done_compiling();
-    }
+    // compile.py:704-709 try/finally: `start_compiling()` before
+    // bridge, `done_compiling()` on every unwind path.  RAII guard
+    // dispatches both via `descr.as_fail_descr()` (instance-method
+    // dispatch per `compile.py:786-795`); drop pairs `done_compiling`
+    // with the matching `start_compiling` even on panic.
+    let compiled = {
+        let _guard = crate::eval::GuardCompilingScope::new(&descr_arc);
+        trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout)
+    };
 
     if majit_metainterp::majit_log_enabled() {
         eprintln!(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3367,6 +3367,20 @@ pub(crate) struct GuardCompilingScope {
 
 impl GuardCompilingScope {
     pub(crate) fn new(descr: &std::sync::Arc<dyn majit_ir::Descr>) -> Self {
+        // `compile.py:786-795 ResumeGuardDescr.start_compiling` is an
+        // instance method on `FailDescr` upstream — PyPy structurally
+        // cannot reach this code path with a non-fail descriptor (the
+        // `handle_fail` caller is itself a method on `FailDescr`).
+        // Pyre takes a `&Arc<dyn Descr>` to avoid an upfront downcast
+        // at the call site; assert here so a programmer error that
+        // routes a non-fail descr into the guard fires in debug
+        // builds instead of silently skipping `start_compiling` /
+        // `done_compiling`.
+        debug_assert!(
+            descr.as_fail_descr().is_some(),
+            "GuardCompilingScope built on a non-fail descr; PyPy can \
+             only reach handle_fail through a FailDescr instance",
+        );
         if let Some(fd) = descr.as_fail_descr() {
             fd.start_compiling();
         }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3340,6 +3340,50 @@ fn maybe_compile_and_run(
     None
 }
 
+/// Panic-safe RAII pairing for `FailDescr::start_compiling` /
+/// `done_compiling`.  `compile.py:704-709`:
+///
+/// ```python
+/// self.start_compiling()
+/// try:
+///     self._trace_and_compile_from_bridge(...)
+/// finally:
+///     self.done_compiling()
+/// ```
+///
+/// brackets bridge compilation with `start_compiling()` (set
+/// `ST_BUSY_FLAG`) and `done_compiling()` (clear it) in a try/finally —
+/// even when bridge compilation raises, `done_compiling` runs on the
+/// unwind path.  Pyre would otherwise leave the busy flag latched if
+/// the inner `trace_and_compile_from_bridge` panics, blocking every
+/// subsequent guard-fail retry on the same descriptor.  Holding an
+/// `Arc<dyn Descr>` clone keeps the descr alive across the scope and
+/// lets the drop call `as_fail_descr().done_compiling()` directly,
+/// matching `compile.py:786-795` instance-method dispatch.
+#[must_use = "drop the guard to clear ST_BUSY_FLAG"]
+pub(crate) struct GuardCompilingScope {
+    descr: std::sync::Arc<dyn majit_ir::Descr>,
+}
+
+impl GuardCompilingScope {
+    pub(crate) fn new(descr: &std::sync::Arc<dyn majit_ir::Descr>) -> Self {
+        if let Some(fd) = descr.as_fail_descr() {
+            fd.start_compiling();
+        }
+        Self {
+            descr: std::sync::Arc::clone(descr),
+        }
+    }
+}
+
+impl Drop for GuardCompilingScope {
+    fn drop(&mut self) {
+        if let Some(fd) = self.descr.as_fail_descr() {
+            fd.done_compiling();
+        }
+    }
+}
+
 /// compile.py:701-717 handle_fail outcome.
 /// compile.py:701-717: handle_fail NEVER returns in RPython — it raises
 /// ContinueRunningNormally or DoneWithThisFrame. In pyre, we return the
@@ -3379,15 +3423,18 @@ fn handle_fail(
             driver.is_tracing()
         };
         if !is_tracing {
-            // `compile.py:704` `self.start_compiling()` — direct method
-            // call on the resume-guard descr instance.
-            if let Some(fd) = descr_arc.as_fail_descr() {
-                fd.start_compiling();
-            }
-            // compile.py:706-708: _trace_and_compile_from_bridge(deadframe)
-            // force_plain_eval prevents concrete calls during bridge
-            // tracing from re-entering compiled code.
+            // compile.py:704-709 try/finally: start_compiling() before
+            // bridge, done_compiling() on every unwind path.  The RAII
+            // guard packages both halves: ctor fires `start_compiling`
+            // via `descr.as_fail_descr()` (direct instance-method
+            // dispatch matching `compile.py:786-795`); drop fires
+            // `done_compiling` so a panic inside
+            // `trace_and_compile_from_bridge` cannot latch
+            // `ST_BUSY_FLAG`.
             let compiled = {
+                let _guard = GuardCompilingScope::new(descr_arc);
+                // force_plain_eval prevents concrete calls during bridge
+                // tracing from re-entering compiled code.
                 let _plain = pyre_interpreter::call::force_plain_eval();
                 crate::call_jit::trace_and_compile_from_bridge(
                     descr_arc,
@@ -3396,10 +3443,6 @@ fn handle_fail(
                     exit_layout,
                 )
             };
-            // `compile.py:709` `self.done_compiling()` — direct method call.
-            if let Some(fd) = descr_arc.as_fail_descr() {
-                fd.done_compiling();
-            }
             if compiled {
                 // compile.py:708: bridge compiled → ContinueRunningNormally.
                 // RPython: the bridge is attached to the guard descr;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3372,18 +3372,15 @@ impl GuardCompilingScope {
         // cannot reach this code path with a non-fail descriptor (the
         // `handle_fail` caller is itself a method on `FailDescr`).
         // Pyre takes a `&Arc<dyn Descr>` to avoid an upfront downcast
-        // at the call site; assert here so a programmer error that
-        // routes a non-fail descr into the guard fires in debug
-        // builds instead of silently skipping `start_compiling` /
-        // `done_compiling`.
-        debug_assert!(
-            descr.as_fail_descr().is_some(),
-            "GuardCompilingScope built on a non-fail descr; PyPy can \
-             only reach handle_fail through a FailDescr instance",
-        );
-        if let Some(fd) = descr.as_fail_descr() {
-            fd.start_compiling();
-        }
+        // at the call site; PyPy raises `AttributeError` on a non-fail
+        // descr at the very first `start_compiling` lookup, so we
+        // panic in both debug and release builds via `expect` to match
+        // that fail-fast contract instead of silently skipping the
+        // start/done pair.
+        let fd = descr
+            .as_fail_descr()
+            .expect("GuardCompilingScope built on a non-fail descr; PyPy can only reach handle_fail through a FailDescr instance");
+        fd.start_compiling();
         Self {
             descr: std::sync::Arc::clone(descr),
         }
@@ -3392,9 +3389,15 @@ impl GuardCompilingScope {
 
 impl Drop for GuardCompilingScope {
     fn drop(&mut self) {
-        if let Some(fd) = self.descr.as_fail_descr() {
-            fd.done_compiling();
-        }
+        // The constructor's `expect` guarantees the underlying
+        // concrete type behind `dyn Descr` is a `FailDescr`; that
+        // type does not change for the lifetime of the Arc, so the
+        // downcast on the unwind path must also succeed.
+        let fd = self
+            .descr
+            .as_fail_descr()
+            .expect("GuardCompilingScope dropped with a descr that lost its FailDescr identity");
+        fd.done_compiling();
     }
 }
 


### PR DESCRIPTION
Follow-up #69

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-backend CPU trackers (with a process-global fallback); loop/bridge compile events are recorded earlier in compilation paths.

* **Bug Fixes**
  * New RAII scope guards to ensure proper cleanup on unwind for compilation/guard flows.

* **Refactor**
  * Profiler and tracing internals reworked for safer nesting and centralized CPU-total accounting.

* **Behavioral**
  * Input-argument positions are now mandatory where supplied; callsites updated.

* **Documentation**
  * Expanded debug/tracing semantics notes.

* **Tests**
  * Updated and added tests for profiler tracking and input-arg handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->