### PR TITLE
regalloc: align AArch64/x86 with PyPy and tighten asserts

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -262,6 +262,19 @@ impl<'a> RegAlloc<'a> {
         self.perform(i, vec![arg_loc], Some(Loc::Reg(res)), output);
     }
 
+    /// aarch64 `int_is_true` / `int_is_zero`: shares the 3-op `prepare_unary`
+    /// shape from regalloc.py:456 since `cmp Xn, #0 ; cset Wd, ne` keeps
+    /// the input register live while writing a fresh destination.
+    pub(crate) fn consider_int_is_true_j2(
+        &mut self,
+        dst: OpRef,
+        arg: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        self.consider_unary_int_j2(dst, arg, i, output);
+    }
+
     /// aarch64/regalloc.py:397 `prepare_op_uint_mul_high = prepare_op_int_mul`.
     /// `umulh Rd, Rn, Rm` is 3-operand; no scratch-pair constraints
     /// (unlike x86 which forces EAX/EDX).

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -20,12 +20,16 @@ const DEFAULT_IMM_SIZE: i64 = 4096;
 /// aarch64/regalloc.py:169 `check_imm_box`. PyPy accepts only
 /// `ConstInt` values in the AArch64 immediate range; non-Int
 /// constants (ConstFloat/ConstPtr) and box references fall through
-/// to the register form.
-fn check_imm_box(arg: OpRef, val: i64) -> bool {
+/// to the register form. PyPy reads `arg.getint()` directly because
+/// the int is inlined on `ConstInt`; pyre's `OpRef::ConstInt` carries
+/// only a const-pool slot, so the actual i64 must be looked up. A
+/// missing pool entry is *not* the same as `#0` — it falls through
+/// to the register path.
+fn check_imm_box(arg: OpRef, val: Option<i64>) -> bool {
     if !matches!(arg, OpRef::ConstInt(_)) {
         return false;
     }
-    val >= 0 && val < DEFAULT_IMM_SIZE
+    matches!(val, Some(v) if v >= 0 && v < DEFAULT_IMM_SIZE)
 }
 
 /// aarch64/registers.py:14
@@ -181,7 +185,7 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         let boxes = [lhs, rhs];
-        let imm_rhs = check_imm_box(rhs, self.const_value(rhs));
+        let imm_rhs = check_imm_box(rhs, self.constants.get(&rhs.raw()).copied());
         let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
         let rhs_loc = if imm_rhs {
             self.loc(rhs, Type::Int)
@@ -286,8 +290,8 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         let boxes = [lhs, rhs];
-        let imm_lhs = check_imm_box(lhs, self.const_value(lhs));
-        let imm_rhs = check_imm_box(rhs, self.const_value(rhs));
+        let imm_lhs = check_imm_box(lhs, self.constants.get(&lhs.raw()).copied());
+        let imm_rhs = check_imm_box(rhs, self.constants.get(&rhs.raw()).copied());
         let (l0, l1) = if !imm_lhs && imm_rhs {
             let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
             let r1 = self.loc(rhs, Type::Int);

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -252,7 +252,7 @@ impl<'a> RegAlloc<'a> {
         i: usize,
         output: &mut Vec<RegAllocOp>,
     ) {
-        debug_assert!(
+        assert!(
             !arg.is_constant(),
             "prepare_unary expects a non-const arg; got constant OpRef {arg:?} (should have been folded earlier)"
         );

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2586,10 +2586,17 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         match kind {
-            IntUnaryKind::Neg
-            | IntUnaryKind::Invert
-            | IntUnaryKind::IsTrue
-            | IntUnaryKind::IsZero => self.consider_unary_int_j2(dst, arg, i, output),
+            IntUnaryKind::Neg | IntUnaryKind::Invert => {
+                self.consider_unary_int_j2(dst, arg, i, output)
+            }
+            // x86/regalloc.py:1199 `consider_int_is_true` — arg stays in
+            // memory/imm (no force-into-reg), result goes through
+            // `force_allocate_reg_or_cc`. AArch64 wraps to its 3-op unary
+            // handler since `neg`/`mvn` already keep arg and result in
+            // distinct registers.
+            IntUnaryKind::IsTrue | IntUnaryKind::IsZero => {
+                self.consider_int_is_true_j2(dst, arg, i, output)
+            }
         }
     }
 

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -4865,8 +4865,13 @@ impl<'a> RegAlloc<'a> {
         // that before_call just synced to the jitframe.  In particular,
         // call_assembler frame helpers allocate PyFrames and can collect
         // before the following vable_token materialization reads inputarg 0.
+        //
+        // x86/callbuilder.py:93 + aarch64/callbuilder.py:70 exclude the
+        // call_result_gpr from the gcmap so its post-call payload is not
+        // mistaken for a live Ref root before the result-extension step
+        // narrows it to the declared result type.
         let gcmap = if calldescr.get_extra_info().check_can_collect() {
-            Some(self.get_gcmap(&[], false) as usize)
+            Some(self.get_gcmap(&[call_result_gpr()], false) as usize)
         } else {
             None
         };
@@ -4958,9 +4963,11 @@ impl<'a> RegAlloc<'a> {
         // Same gcmap snapshot as `consider_call` above. The j2 dispatch
         // handles the same Call*/CallMayForce*/CallReleaseGil* opcodes,
         // so a collecting callee must record the live Ref slots that
-        // before_call just synced to the jitframe.
+        // before_call just synced to the jitframe.  call_result_gpr is
+        // excluded for the same reason as `consider_call`
+        // (x86/callbuilder.py:93, aarch64/callbuilder.py:70).
         let gcmap = if can_collect {
-            Some(self.get_gcmap(&[], false) as usize)
+            Some(self.get_gcmap(&[call_result_gpr()], false) as usize)
         } else {
             None
         };

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -6787,7 +6787,24 @@ impl<'a> Assembler386<'a> {
     }
 
     fn genop_call_with_arglocs(&mut self, op: &Op, arglocs: &[Loc]) {
+        // llsupport/callbuilder.py:36 emit order — prepare_arguments() then
+        // push_gcmap(); emit_raw_call(); ...; pop_gcmap() — collecting calls
+        // must publish the regalloc gcmap before the raw call so live `Ref`
+        // roots survive the slow path, and clear it after reloading a
+        // possibly-moved frame pointer (assembler.py:296
+        // `_reload_frame_if_necessary`).
+        let can_collect = op
+            .with_call_descr(|descr| descr.get_extra_info().check_can_collect())
+            .unwrap_or(false);
+        let pushed_gcmap = if can_collect {
+            self.push_pending_call_gcmap()
+        } else {
+            false
+        };
         self._genop_call_with_arglocs(op, arglocs);
+        if can_collect {
+            self.pop_pending_call_gcmap_after_collect(pushed_gcmap);
+        }
         if !op.pos.get().is_none() {
             self.store_rax_to_result(op.pos.get());
         }

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -350,14 +350,9 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         let argloc = self.loc(arg, Type::Int);
-        let resloc = self.rm.force_allocate_reg(
-            dst,
-            &[],
-            None,
-            false,
-            &mut self.longevity,
-            &mut self.fm,
-        );
+        let resloc =
+            self.rm
+                .force_allocate_reg(dst, &[], None, false, &mut self.longevity, &mut self.fm);
         self.perform(i, vec![argloc], Some(Loc::Reg(resloc)), output);
     }
 
@@ -389,8 +384,7 @@ impl<'a> RegAlloc<'a> {
             "consider_uint_mul_high_j2: l1 must be a register/frame, got immediate {l1:?}"
         );
         assert!(
-            !matches!(l1, Loc::Reg(r) if r.value == EAX.value)
-                || arg1 == arg2,
+            !matches!(l1, Loc::Reg(r) if r.value == EAX.value) || arg1 == arg2,
             "consider_uint_mul_high_j2: l1==eax only allowed when arg1 is arg2"
         );
         self.possibly_free_var(arg2, Type::Int);

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -334,6 +334,33 @@ impl<'a> RegAlloc<'a> {
         self.perform(i, vec![loc], Some(loc), output);
     }
 
+    /// x86/regalloc.py:1199 `consider_int_is_true` / `consider_int_is_zero`.
+    /// `TEST src, src ; SETcc dst` — input does not need to be in a
+    /// register, and the result lives in a distinct byte-addressable
+    /// register selected by `force_allocate_reg`. PyPy uses
+    /// `force_allocate_reg_or_cc` to leave the result in the condition
+    /// code when the consumer is a GUARD/jump; pyre's emit path always
+    /// materialises a byte register via SETcc, so the plain
+    /// `force_allocate_reg` is the closest available primitive.
+    pub(crate) fn consider_int_is_true_j2(
+        &mut self,
+        dst: OpRef,
+        arg: OpRef,
+        i: usize,
+        output: &mut Vec<RegAllocOp>,
+    ) {
+        let argloc = self.loc(arg, Type::Int);
+        let resloc = self.rm.force_allocate_reg(
+            dst,
+            &[],
+            None,
+            false,
+            &mut self.longevity,
+            &mut self.fm,
+        );
+        self.perform(i, vec![argloc], Some(Loc::Reg(resloc)), output);
+    }
+
     /// x86/regalloc.py:591 `consider_uint_mul_high` — emits `MUL src`,
     /// which clobbers EAX (low) and EDX (high), so EAX must be
     /// pinned to one operand and EDX to the result.
@@ -352,6 +379,20 @@ impl<'a> RegAlloc<'a> {
         }
         self.make_sure_var_in_reg(arg2, Type::Int, &[], Some(EAX), false);
         let l1 = self.loc(arg1, Type::Int);
+        // x86/regalloc.py:600-601 asserts l1 can be `MUL`'s operand:
+        // it must not be an immediate (immediate would need a scratch
+        // register to materialise, which the optimiser already folded),
+        // and it can only coincide with eax when arg1 IS arg2 (the
+        // swap above already pinned arg2 to eax).
+        assert!(
+            !matches!(l1, Loc::Immed(_)),
+            "consider_uint_mul_high_j2: l1 must be a register/frame, got immediate {l1:?}"
+        );
+        assert!(
+            !matches!(l1, Loc::Reg(r) if r.value == EAX.value)
+                || arg1 == arg2,
+            "consider_uint_mul_high_j2: l1==eax only allowed when arg1 is arg2"
+        );
         self.possibly_free_var(arg2, Type::Int);
         let tmp = self.fresh_temp_var();
         self.longevity.set(


### PR DESCRIPTION
Fix https://github.com/youknowone/pyre/issues/38

## Summary

Three small backend regalloc fixes carried over from PR #61 review feedback.

- **aarch64 `check_imm_box`**: probe `self.constants` directly for a `ConstInt` slot instead of going through `const_value(arg)`, which used `unwrap_or(0)` and silently treated a missing pool entry as the in-range immediate `#0`. Mirrors PyPy reading `ConstInt.getint()` directly (the int is inlined on the Const).
- **x86 collecting calls**: wrap `_genop_call_with_arglocs` with `push_pending_call_gcmap` / `pop_pending_call_gcmap_after_collect` when `check_can_collect`, matching the AArch64 path and `llsupport/callbuilder.py:36` ordering (`push_gcmap → emit_raw_call → pop_gcmap`). Also pass `[call_result_gpr()]` as forbidden_regs to `get_gcmap` in `consider_call` / `consider_call_j2`, matching `x86/callbuilder.py:93` and `aarch64/callbuilder.py:70` (eax / x0 are not part of the gcmap because they hold the result).
- **AArch64 `consider_unary_int_j2`**: promote `debug_assert!(!arg.is_constant())` to `assert!` so release builds also enforce `rpython/jit/backend/aarch64/regalloc.py:458 prepare_unary`'s `assert not isinstance(a0, Const)`.
- **x86 `consider_int_is_true_j2`**: split from `consider_unary_int_j2`. `loc(arg) + force_allocate_reg(dst)` matches `rpython/jit/backend/x86/regalloc.py:1199` rather than forcing arg and result to share a register via `force_result_in_reg`. AArch64 keeps it as a thin delegate since `neg/cmp Xn,#0/cset` already keep arg and result distinct.
- **x86 `consider_uint_mul_high_j2`**: add asserts that `l1` is not an `ImmedLoc` and not `eax` unless `arg1 IS arg2`, matching `regalloc.py:600-601`.

## Test plan

- [x] cargo build (dynasm + cranelift)
- [x] pyre/check.py 39/39 dynasm + 39/39 cranelift + 2/2 ec-wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved constant handling in register allocation to correctly distinguish missing entries
  * Fixed GC map generation for garbage-collected calls

* **Improvements**
  * Optimized register allocation for boolean integer operations across all architectures
  * Enhanced runtime assertions for better error detection in release builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->