### PR TITLE
Retire HashMap; route execution context via liveness; GreenBox MergePoints

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3,7 +3,7 @@ use std::cell::{Cell, RefCell, UnsafeCell};
 ///
 /// Translates majit IR traces into native code via Cranelift, then
 /// executes them as ordinary function pointers.
-use std::collections::{HashMap, HashSet};
+use majit_ir::{VecAssoc, VecSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -584,8 +584,8 @@ thread_local! {
     /// reading `target_token._ll_loop_code` off the descr directly.
     /// Thread-local matches pyre's single-threaded JIT execution and
     /// aligns with the adjacent `CALL_ASSEMBLER_TARGETS` migration.
-    static LOOP_TARGET_REGISTRY: RefCell<HashMap<usize, LoopTargetEntry>> =
-        RefCell::new(HashMap::new());
+    static LOOP_TARGET_REGISTRY: RefCell<VecAssoc<usize, LoopTargetEntry>> =
+        RefCell::new(VecAssoc::new());
 }
 
 /// history.py:470 TargetToken identity key: Arc allocation address.
@@ -1040,7 +1040,7 @@ thread_local! {
     /// space with dummy declarations to fill the gaps. The thread-local
     /// map below replaces that with a sparse-OpRef → dense-Variable lookup
     /// populated during `do_compile`'s declaration loop.
-    static OPREF_VAR_MAP: std::cell::RefCell<Option<std::collections::HashMap<u32, Variable>>> =
+    static OPREF_VAR_MAP: std::cell::RefCell<Option<majit_ir::VecAssoc<u32, Variable>>> =
         const { std::cell::RefCell::new(None) };
 }
 
@@ -1049,7 +1049,7 @@ thread_local! {
 /// past its scope. The early-return branches in do_compile then don't
 /// need explicit cleanup hooks.
 struct OprefVarMapGuard {
-    saved: Option<std::collections::HashMap<u32, Variable>>,
+    saved: Option<majit_ir::VecAssoc<u32, Variable>>,
 }
 
 impl Drop for OprefVarMapGuard {
@@ -1135,11 +1135,11 @@ fn is_vec_float_producing(opcode: OpCode) -> bool {
 }
 
 /// Pre-scan ops to find positions that produce vector values.
-fn build_vec_oprefs(ops: &[Op], num_inputs: usize) -> HashSet<u32> {
+fn build_vec_oprefs(ops: &[Op], num_inputs: usize) -> VecSet<u32> {
     if !USE_NATIVE_SIMD {
-        return HashSet::new();
+        return VecSet::new();
     }
-    let mut set = HashSet::new();
+    let mut set = VecSet::new();
     for (op_idx, op) in ops.iter().enumerate() {
         if is_vec_producing_opcode(op.opcode) {
             let vi = op_var_index(op, op_idx, num_inputs) as u32;
@@ -1150,11 +1150,11 @@ fn build_vec_oprefs(ops: &[Op], num_inputs: usize) -> HashSet<u32> {
 }
 
 /// Pre-scan to find which vector-producing positions have float type (F64X2).
-fn build_vec_float_oprefs(ops: &[Op], num_inputs: usize) -> HashSet<u32> {
+fn build_vec_float_oprefs(ops: &[Op], num_inputs: usize) -> VecSet<u32> {
     if !USE_NATIVE_SIMD {
-        return HashSet::new();
+        return VecSet::new();
     }
-    let mut set = HashSet::new();
+    let mut set = VecSet::new();
     for (op_idx, op) in ops.iter().enumerate() {
         if is_vec_float_producing(op.opcode) {
             let vi = op_var_index(op, op_idx, num_inputs) as u32;
@@ -1170,8 +1170,8 @@ fn build_vec_float_oprefs(ops: &[Op], num_inputs: usize) -> HashSet<u32> {
 fn resolve_opref_vec_int(
     builder: &mut FunctionBuilder,
     constants: &majit_ir::VecAssoc<u32, i64>,
-    vec_oprefs: &HashSet<u32>,
-    vec_float_oprefs: &HashSet<u32>,
+    vec_oprefs: &VecSet<u32>,
+    vec_float_oprefs: &VecSet<u32>,
     opref: OpRef,
 ) -> CValue {
     if let Some(&c) = constants.get(&opref.raw()) {
@@ -1197,8 +1197,8 @@ fn resolve_opref_vec_int(
 fn resolve_opref_vec_float(
     builder: &mut FunctionBuilder,
     constants: &majit_ir::VecAssoc<u32, i64>,
-    vec_oprefs: &HashSet<u32>,
-    vec_float_oprefs: &HashSet<u32>,
+    vec_oprefs: &VecSet<u32>,
+    vec_float_oprefs: &VecSet<u32>,
     opref: OpRef,
 ) -> CValue {
     if let Some(&c) = constants.get(&opref.raw()) {
@@ -1517,16 +1517,16 @@ thread_local! {
     /// `CALL_ASSEMBLER_DEADFRAMES` below) keeps cranelift's per-thread
     /// CA state separated and avoids a process-global registry
     /// (`plan:staged-sauteeing-koala.md` Phase 2 goal).
-    static CALL_ASSEMBLER_TARGETS: RefCell<HashMap<u64, RegisteredLoopTarget>> =
-        RefCell::new(HashMap::new());
+    static CALL_ASSEMBLER_TARGETS: RefCell<VecAssoc<u64, RegisteredLoopTarget>> =
+        RefCell::new(VecAssoc::new());
     /// Per-thread caller->callee result-kind expectations. Same
     /// PRE-EXISTING-ADAPTATION rationale as `CALL_ASSEMBLER_TARGETS`.
-    static CALL_ASSEMBLER_EXPECTATIONS: RefCell<HashMap<u64, HashMap<CallAssemblerCallerId, u64>>> =
-        RefCell::new(HashMap::new());
+    static CALL_ASSEMBLER_EXPECTATIONS: RefCell<VecAssoc<u64, VecAssoc<CallAssemblerCallerId, u64>>> =
+        RefCell::new(VecAssoc::new());
     /// Thread-local deadframe storage for call_assembler results.
     /// Each test thread gets its own isolated registry, preventing
     /// non-deterministic failures from shared global state.
-    static CALL_ASSEMBLER_DEADFRAMES: RefCell<HashMap<u64, DeadFrame>> = RefCell::new(HashMap::new());
+    static CALL_ASSEMBLER_DEADFRAMES: RefCell<VecAssoc<u64, DeadFrame>> = RefCell::new(VecAssoc::new());
     static NEXT_CALL_ASSEMBLER_DEADFRAME_HANDLE: Cell<u64> = const { Cell::new(1) };
 }
 
@@ -1808,12 +1808,12 @@ const CA_FINISH_INDEX_UNKNOWN: u64 = u64::MAX;
 
 thread_local! {
     /// Per-thread CALL_ASSEMBLER dispatch table. Entries are boxed so their
-    /// addresses are stable across HashMap resizes — the JIT-emitted call
+    /// addresses are stable across VecAssoc resizes — the JIT-emitted call
     /// site holds a raw `*const CaDispatchEntry` obtained via
     /// `ca_dispatch_slot`. Thread-local is safe because the JIT code and
     /// the entries live on the same thread; teardown is concurrent.
-    static CA_DISPATCH_TABLE: RefCell<HashMap<u64, Box<CaDispatchEntry>>> =
-        RefCell::new(HashMap::new());
+    static CA_DISPATCH_TABLE: RefCell<VecAssoc<u64, Box<CaDispatchEntry>>> =
+        RefCell::new(VecAssoc::new());
 }
 
 /// Get or create the stable dispatch entry for a token.
@@ -1821,7 +1821,7 @@ thread_local! {
 fn ca_dispatch_slot(token_number: u64, code_ptr: *const u8) -> *const CaDispatchEntry {
     CA_DISPATCH_TABLE.with(|c| {
         let mut table = c.borrow_mut();
-        let entry = table.entry(token_number).or_insert_with(|| {
+        let entry = table.entry_or_insert_with(token_number, || {
             Box::new(CaDispatchEntry {
                 code_ptr: AtomicPtr::new(code_ptr as *mut u8),
                 finish_descr_ptr: AtomicU64::new(CA_FINISH_INDEX_UNKNOWN),
@@ -1869,10 +1869,10 @@ fn ca_dispatch_remove(token_number: u64) {
 
 thread_local! {
     /// Thread-local cache for call_assembler target lookups.
-    /// The HashMap holds Arc ownership; CA_FAST_PTR caches a raw pointer
+    /// The VecAssoc holds Arc ownership; CA_FAST_PTR caches a raw pointer
     /// for the hot path to avoid atomic refcount ops on every call.
-    static CA_TARGET_CACHE: RefCell<HashMap<u64, Arc<RegisteredLoopTarget>>> =
-        RefCell::new(HashMap::new());
+    static CA_TARGET_CACHE: RefCell<VecAssoc<u64, Arc<RegisteredLoopTarget>>> =
+        RefCell::new(VecAssoc::new());
 
     /// Single-entry raw pointer cache: (token_number, ptr_as_usize).
     /// Valid because the Arc in CA_TARGET_CACHE keeps the data alive.
@@ -1892,7 +1892,7 @@ unsafe fn fast_lookup_ca_target(token_number: u64) -> *const RegisteredLoopTarge
             return p as *const RegisteredLoopTarget;
         }
     }
-    // Warm path: HashMap lookup, extract pointer without Arc clone
+    // Warm path: VecAssoc lookup, extract pointer without Arc clone
     if let Ok(Some(ptr)) = CA_TARGET_CACHE.try_with(|c| {
         c.borrow()
             .get(&token_number)
@@ -2043,7 +2043,7 @@ enum CallAssemblerCallerId {
 }
 
 fn with_call_assembler_registry<R>(
-    f: impl FnOnce(&mut HashMap<u64, RegisteredLoopTarget>) -> R,
+    f: impl FnOnce(&mut VecAssoc<u64, RegisteredLoopTarget>) -> R,
 ) -> R {
     // `try_with` + `expect`: normal call paths run long before the thread's
     // TLS destructor fires. The `Drop for CraneliftBackend` path uses
@@ -2055,7 +2055,7 @@ fn with_call_assembler_registry<R>(
 }
 
 fn with_call_assembler_expectations<R>(
-    f: impl FnOnce(&mut HashMap<u64, HashMap<CallAssemblerCallerId, u64>>) -> R,
+    f: impl FnOnce(&mut VecAssoc<u64, VecAssoc<CallAssemblerCallerId, u64>>) -> R,
 ) -> R {
     CALL_ASSEMBLER_EXPECTATIONS
         .try_with(|r| f(&mut r.borrow_mut()))
@@ -2066,12 +2066,12 @@ fn with_call_assembler_expectations<R>(
 /// and may reach these helpers after Rust has destroyed the `RefCell`
 /// thread_local (see `std::thread::LocalKey::try_with`). Since the drop
 /// path is discarding state anyway, silently no-op when TLS is gone.
-fn try_call_assembler_registry_drop(f: impl FnOnce(&mut HashMap<u64, RegisteredLoopTarget>)) {
+fn try_call_assembler_registry_drop(f: impl FnOnce(&mut VecAssoc<u64, RegisteredLoopTarget>)) {
     let _ = CALL_ASSEMBLER_TARGETS.try_with(|r| f(&mut r.borrow_mut()));
 }
 
 fn try_call_assembler_expectations_drop(
-    f: impl FnOnce(&mut HashMap<u64, HashMap<CallAssemblerCallerId, u64>>),
+    f: impl FnOnce(&mut VecAssoc<u64, VecAssoc<CallAssemblerCallerId, u64>>),
 ) {
     let _ = CALL_ASSEMBLER_EXPECTATIONS.try_with(|r| f(&mut r.borrow_mut()));
 }
@@ -2142,7 +2142,7 @@ fn validate_registered_target_against_call_assembler_expectations(
 }
 
 fn remove_call_assembler_expectations_locked(
-    expectations: &mut HashMap<u64, HashMap<CallAssemblerCallerId, u64>>,
+    expectations: &mut VecAssoc<u64, VecAssoc<CallAssemblerCallerId, u64>>,
     caller_id: CallAssemblerCallerId,
 ) {
     expectations.retain(|_, callers| {
@@ -2177,8 +2177,8 @@ fn unregister_call_assembler_bridge_tree(fail_descrs: &[DescrRef]) {
     }
 }
 
-fn collect_call_assembler_expectations(ops: &[Op]) -> Result<HashMap<u64, u64>, BackendError> {
-    let mut expectations = HashMap::new();
+fn collect_call_assembler_expectations(ops: &[Op]) -> Result<VecAssoc<u64, u64>, BackendError> {
+    let mut expectations = VecAssoc::new();
     for op in ops {
         let opcode = op.opcode;
         if !matches!(
@@ -2205,7 +2205,7 @@ fn collect_call_assembler_expectations(ops: &[Op]) -> Result<HashMap<u64, u64>, 
         let resolved_target = resolve_call_assembler_target(opcode, call_descr)?;
         let expected_result_kind =
             expected_call_assembler_result_kind(call_descr, resolved_target.as_ref())?;
-        if let Some(previous) = expectations.insert(target_token, expected_result_kind) {
+        if let Some(&previous) = expectations.get(&target_token) {
             validate_call_assembler_target_result_kind(
                 target_token,
                 previous,
@@ -2213,6 +2213,7 @@ fn collect_call_assembler_expectations(ops: &[Op]) -> Result<HashMap<u64, u64>, 
                 "caller result expectation",
             )?;
         }
+        expectations.insert(target_token, expected_result_kind);
     }
     Ok(expectations)
 }
@@ -2254,8 +2255,7 @@ fn install_call_assembler_expectations(
         remove_call_assembler_expectations_locked(registry, caller_id);
         for (&target_token, &expected_result_kind) in &expectations {
             registry
-                .entry(target_token)
-                .or_default()
+                .entry_or_default(target_token)
                 .insert(caller_id, expected_result_kind);
         }
         Ok(())
@@ -3792,11 +3792,11 @@ extern "C" fn gc_jit_remember_young_pointer_from_array_shim(obj: u64) {
 }
 
 thread_local! {
-    static DECLARED_VARS_DEBUG: std::cell::RefCell<Option<std::collections::HashSet<u32>>> = const { std::cell::RefCell::new(None) };
+    static DECLARED_VARS_DEBUG: std::cell::RefCell<Option<majit_ir::VecSet<u32>>> = const { std::cell::RefCell::new(None) };
     /// Op-result variable positions: ops that define a result via def_var.
     /// When an OpRef collides (in both constants map and op-result set),
     /// the variable takes precedence over the constant.
-    static OP_RESULT_VARS: std::cell::RefCell<Option<std::collections::HashSet<u32>>> = const { std::cell::RefCell::new(None) };
+    static OP_RESULT_VARS: std::cell::RefCell<Option<majit_ir::VecSet<u32>>> = const { std::cell::RefCell::new(None) };
 }
 
 fn opref_is_op_result_var(opref: OpRef) -> bool {
@@ -4071,7 +4071,7 @@ fn validate_oprefs_for_compile(
     // recoverable case. Walk the ops in trace order with a single
     // `seen` set; do NOT pre-collect a `defined` set that lets
     // forward-references slip through.
-    let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    let mut seen: majit_ir::VecSet<u32> = majit_ir::VecSet::new();
     for input in inputargs {
         seen.insert(input.index);
     }
@@ -4356,8 +4356,8 @@ fn expected_call_assembler_result_kind(
     }
 }
 
-fn build_known_values_set(inputargs: &[InputArg], ops: &[Op]) -> HashSet<u32> {
-    let mut known = HashSet::new();
+fn build_known_values_set(inputargs: &[InputArg], ops: &[Op]) -> VecSet<u32> {
+    let mut known = VecSet::new();
     for input in inputargs {
         known.insert(input.index);
     }
@@ -4369,8 +4369,8 @@ fn build_known_values_set(inputargs: &[InputArg], ops: &[Op]) -> HashSet<u32> {
     known
 }
 
-fn build_force_token_set(inputargs: &[InputArg], ops: &[Op]) -> Result<HashSet<u32>, BackendError> {
-    let mut force_tokens = HashSet::new();
+fn build_force_token_set(inputargs: &[InputArg], ops: &[Op]) -> Result<VecSet<u32>, BackendError> {
+    let mut force_tokens = VecSet::new();
     for (op_idx, op) in ops.iter().enumerate() {
         if op.pos.get().is_none() {
             continue;
@@ -4424,9 +4424,9 @@ fn build_force_token_set(inputargs: &[InputArg], ops: &[Op]) -> Result<HashSet<u
 fn build_type_overrides(
     ops: &[Op],
     type_index: &OpTypeIndex<'_>,
-) -> (HashMap<u32, Type>, HashMap<u32, usize>) {
-    let mut overrides: HashMap<u32, Type> = HashMap::new();
-    let mut op_def_positions: HashMap<u32, usize> = HashMap::new();
+) -> (VecAssoc<u32, Type>, VecAssoc<u32, usize>) {
+    let mut overrides: VecAssoc<u32, Type> = VecAssoc::new();
+    let mut op_def_positions: VecAssoc<u32, usize> = VecAssoc::new();
 
     for (op_idx, op) in ops.iter().enumerate() {
         let result_type = op.result_type();
@@ -4455,7 +4455,7 @@ fn build_type_overrides(
     // Box objects carry their own types; in our flat OpRef namespace we
     // must propagate types through the JUMP→LABEL edge explicitly.
     // Collect LABEL→descr and JUMP→descr, then match by descr index.
-    let mut label_by_descr: HashMap<u32, usize> = HashMap::new();
+    let mut label_by_descr: VecAssoc<u32, usize> = VecAssoc::new();
     let mut jumps_by_descr: Vec<(u32, usize)> = Vec::new();
     for (op_idx, op) in ops.iter().enumerate() {
         if op.opcode == OpCode::Label {
@@ -4471,7 +4471,7 @@ fn build_type_overrides(
         }
     }
     let lookup =
-        |opref: OpRef, at_op_index: usize, fallback: Type, ovrs: &HashMap<u32, Type>| -> Type {
+        |opref: OpRef, at_op_index: usize, fallback: Type, ovrs: &VecAssoc<u32, Type>| -> Type {
             if let Some(&tp) = ovrs.get(&opref.raw()) {
                 return tp;
             }
@@ -4510,7 +4510,7 @@ fn build_type_overrides(
 #[inline]
 fn lookup_type_at(
     type_index: &OpTypeIndex<'_>,
-    overrides: &HashMap<u32, Type>,
+    overrides: &VecAssoc<u32, Type>,
     opref: OpRef,
     op_index: usize,
 ) -> Option<Type> {
@@ -4524,10 +4524,10 @@ fn build_ref_root_slots(
     inputargs: &[InputArg],
     ops: &[Op],
     type_index: &OpTypeIndex<'_>,
-    overrides: &HashMap<u32, Type>,
-    force_tokens: &HashSet<u32>,
+    overrides: &VecAssoc<u32, Type>,
+    force_tokens: &VecSet<u32>,
 ) -> Result<Vec<(u32, usize)>, BackendError> {
-    let mut seen = HashSet::new();
+    let mut seen = VecSet::new();
     let mut slots = Vec::new();
 
     // RPython parity: when jump_to_preamble is used without
@@ -4546,8 +4546,8 @@ fn build_ref_root_slots(
     // `non_ref_at_backedge` and `used_inputargs` by the InputArg's raw
     // OpRef value so the downstream loop's `contains(&input.index)` checks
     // line up with the keys we inserted.
-    let inputarg_oprefs: HashSet<u32> = inputargs.iter().map(|ia| ia.index).collect();
-    let mut non_ref_at_backedge: HashSet<u32> = HashSet::new();
+    let inputarg_oprefs: VecSet<u32> = inputargs.iter().map(|ia| ia.index).collect();
+    let mut non_ref_at_backedge: VecSet<u32> = VecSet::new();
     let mut has_float_at_ref_position = false;
     // Find the closing JUMP and check arg types against inputarg types
     if let Some((jump_idx, jump)) = ops
@@ -4596,7 +4596,7 @@ fn build_ref_root_slots(
     // optimizer replaced with constants (e.g. guard_value'd code/namespace)
     // are never referenced by ops — they don't need GC root slots.
     // Build the set of inputarg OpRef raw values actually used in ops.
-    let mut used_inputargs: HashSet<u32> = HashSet::new();
+    let mut used_inputargs: VecSet<u32> = VecSet::new();
     for op in ops.iter() {
         for &arg in op.getarglist().iter().chain(
             op.getfailargs()
@@ -4706,7 +4706,7 @@ fn inject_builtin_string_descrs(ops: &mut [Op]) {
 fn resolve_opref_or_imm(
     builder: &mut FunctionBuilder,
     constants: &majit_ir::VecAssoc<u32, i64>,
-    known_values: &HashSet<u32>,
+    known_values: &VecSet<u32>,
     opref: OpRef,
 ) -> CValue {
     if opref.is_none() {
@@ -4733,7 +4733,7 @@ fn resolve_failarg_opref(
     constants: &majit_ir::VecAssoc<u32, i64>,
     jf_ptr: CValue,
     ref_root_slots: &[(u32, usize)],
-    stale_ref_vars: &HashSet<u32>,
+    stale_ref_vars: &VecSet<u32>,
     ref_root_base_ofs: i32,
     opref: OpRef,
 ) -> CValue {
@@ -4751,7 +4751,7 @@ fn resolve_failarg_opref(
 
 fn resolve_constant_i64(
     constants: &majit_ir::VecAssoc<u32, i64>,
-    known_values: &HashSet<u32>,
+    known_values: &VecSet<u32>,
     opcode: OpCode,
     opref: OpRef,
     what: &str,
@@ -4783,8 +4783,8 @@ fn resolve_rewriter_immediate_i64(constants: &majit_ir::VecAssoc<u32, i64>, opre
 
 fn type_for_opref(
     type_index: &OpTypeIndex<'_>,
-    overrides: &HashMap<u32, Type>,
-    known_values: &HashSet<u32>,
+    overrides: &VecAssoc<u32, Type>,
+    known_values: &VecSet<u32>,
     opcode: OpCode,
     opref: OpRef,
     op_index: usize,
@@ -4906,7 +4906,7 @@ fn emit_store_to_addr(
 fn emit_dynamic_offset_addr(
     builder: &mut FunctionBuilder,
     constants: &majit_ir::VecAssoc<u32, i64>,
-    known_values: &HashSet<u32>,
+    known_values: &VecSet<u32>,
     base_arg: OpRef,
     offset_arg: OpRef,
 ) -> CValue {
@@ -4976,8 +4976,8 @@ fn spill_ref_roots(
     builder: &mut FunctionBuilder,
     jf_ptr: CValue,
     ref_root_slots: &[(u32, usize)],
-    defined_ref_vars: &HashSet<u32>,
-    stale_ref_vars: &HashSet<u32>,
+    defined_ref_vars: &VecSet<u32>,
+    stale_ref_vars: &VecSet<u32>,
     ref_root_base_ofs: i32,
 ) {
     for &(var_idx, slot) in ref_root_slots {
@@ -4998,8 +4998,8 @@ fn spill_unsynced_ref_roots(
     builder: &mut FunctionBuilder,
     jf_ptr: CValue,
     ref_root_slots: &[(u32, usize)],
-    defined_ref_vars: &HashSet<u32>,
-    synced_ref_vars: &HashSet<u32>,
+    defined_ref_vars: &VecSet<u32>,
+    synced_ref_vars: &VecSet<u32>,
     ref_root_base_ofs: i32,
 ) {
     for &(var_idx, slot) in ref_root_slots {
@@ -5019,7 +5019,7 @@ fn reload_ref_roots(
     builder: &mut FunctionBuilder,
     jf_ptr: CValue,
     ref_root_slots: &[(u32, usize)],
-    defined_ref_vars: &HashSet<u32>,
+    defined_ref_vars: &VecSet<u32>,
     ref_root_base_ofs: i32,
 ) {
     for &(var_idx, slot) in ref_root_slots {
@@ -5041,7 +5041,7 @@ fn sync_ref_root_var(
     var_idx: u32,
     value: CValue,
     ref_root_base_ofs: i32,
-    synced_ref_vars: &mut HashSet<u32>,
+    synced_ref_vars: &mut VecSet<u32>,
 ) {
     if let Some((_, slot)) = ref_root_slots.iter().find(|(idx, _)| *idx == var_idx) {
         let offset = ref_root_base_ofs + (*slot as i32) * 8;
@@ -5050,20 +5050,20 @@ fn sync_ref_root_var(
     }
 }
 
-fn mark_ref_roots_synced(synced_ref_vars: &mut HashSet<u32>, ref_root_slots: &[(u32, usize)]) {
+fn mark_ref_roots_synced(synced_ref_vars: &mut VecSet<u32>, ref_root_slots: &[(u32, usize)]) {
     for &(var_idx, _) in ref_root_slots {
         synced_ref_vars.insert(var_idx);
     }
 }
 
-fn mark_ref_roots_fresh(stale_ref_vars: &mut HashSet<u32>, ref_root_slots: &[(u32, usize)]) {
+fn mark_ref_roots_fresh(stale_ref_vars: &mut VecSet<u32>, ref_root_slots: &[(u32, usize)]) {
     for &(var_idx, _) in ref_root_slots {
         stale_ref_vars.remove(&var_idx);
     }
 }
 
 fn mark_ref_roots_after_selective_reload(
-    stale_ref_vars: &mut HashSet<u32>,
+    stale_ref_vars: &mut VecSet<u32>,
     live_ref_root_slots: &[(u32, usize)],
     reloaded_ref_root_slots: &[(u32, usize)],
 ) {
@@ -5109,8 +5109,8 @@ fn get_gcmap(
     position: usize,
     max_output_slots: usize,
     ref_root_slots: &[(u32, usize)],
-    longevity: &HashMap<u32, usize>,
-    defined_ref_vars: &HashSet<u32>,
+    longevity: &VecAssoc<u32, usize>,
+    defined_ref_vars: &VecSet<u32>,
 ) -> i64 {
     // regalloc.py:1093-1105: iterate bindings, include only alive refs.
     let mut live_bit_positions: Vec<usize> = Vec::new();
@@ -5154,8 +5154,8 @@ fn get_gcmap(
 fn live_ref_root_slots_at(
     position: usize,
     ref_root_slots: &[(u32, usize)],
-    longevity: &HashMap<u32, usize>,
-    defined_ref_vars: &HashSet<u32>,
+    longevity: &VecAssoc<u32, usize>,
+    defined_ref_vars: &VecSet<u32>,
 ) -> Vec<(u32, usize)> {
     ref_root_slots
         .iter()
@@ -5173,7 +5173,7 @@ fn ref_root_slots_with_future_regular_uses(
     position: usize,
     ops: &[Op],
     ref_root_slots: &[(u32, usize)],
-    defined_ref_vars: &HashSet<u32>,
+    defined_ref_vars: &VecSet<u32>,
 ) -> Vec<(u32, usize)> {
     // RPython regalloc reloads values that remain live after a collecting
     // call. Guard failargs are live uses too: failure recovery reads them
@@ -5390,8 +5390,8 @@ fn emit_collecting_gc_call(
     call_conv: cranelift_codegen::isa::CallConv,
     jf_ptr: CValue,
     ref_root_slots: &[(u32, usize)],
-    defined_ref_vars: &HashSet<u32>,
-    stale_ref_vars: &HashSet<u32>,
+    defined_ref_vars: &VecSet<u32>,
+    stale_ref_vars: &VecSet<u32>,
     ref_root_base_ofs: i32,
     per_call_gcmap: i64,
     func_ptr: usize,
@@ -5440,8 +5440,8 @@ fn emit_indirect_call_from_parts(
     ptr_type: cranelift_codegen::ir::Type,
     jf_ptr: CValue,
     ref_root_slots: &[(u32, usize)],
-    defined_ref_vars: &HashSet<u32>,
-    stale_ref_vars: &HashSet<u32>,
+    defined_ref_vars: &VecSet<u32>,
+    stale_ref_vars: &VecSet<u32>,
     ref_root_base_ofs: i32,
     per_call_gcmap: i64,
 ) -> Option<CValue> {
@@ -5791,7 +5791,7 @@ fn emit_guard_exit(
     jf_ptr: CValue,
     info: &GuardInfo,
     ref_root_slots: &[(u32, usize)],
-    stale_ref_vars: &HashSet<u32>,
+    stale_ref_vars: &VecSet<u32>,
     ref_root_base_ofs: i32,
     ptr_type: cranelift_codegen::ir::Type,
     call_conv: cranelift_codegen::isa::CallConv,
@@ -5802,7 +5802,7 @@ fn emit_guard_exit(
     // vector_ext.py:119-156 _update_at_exit parity:
     // If accumulation is done in this loop, at the guard exit some vector
     // values must be reduced to scalars before storing to jf_frame.
-    let accum_positions: HashMap<usize, &AccumInfo> = info
+    let accum_positions: VecAssoc<usize, &AccumInfo> = info
         .accum_info
         .iter()
         .map(|ai| (ai.failargs_pos, ai))
@@ -6902,7 +6902,7 @@ fn patch_terminal_exit_recovery_layout(
 fn infer_fail_arg_types(
     fail_arg_refs: &[OpRef],
     type_index: &OpTypeIndex<'_>,
-    overrides: &HashMap<u32, Type>,
+    overrides: &VecAssoc<u32, Type>,
     op_index: usize,
 ) -> Result<Vec<Type>, BackendError> {
     let mut fail_arg_types = Vec::with_capacity(fail_arg_refs.len());
@@ -6933,8 +6933,8 @@ fn resolve_fail_arg_types(
     fail_arg_refs: &[OpRef],
     fd: Option<&dyn majit_ir::descr::FailDescr>,
     type_index: &OpTypeIndex<'_>,
-    overrides: &HashMap<u32, Type>,
-    op_def_positions: &HashMap<u32, usize>,
+    overrides: &VecAssoc<u32, Type>,
+    op_def_positions: &VecAssoc<u32, usize>,
     guard_op_index: usize,
 ) -> Result<Vec<Type>, BackendError> {
     // Use descriptor types as base, then fix positional conflicts.
@@ -6997,8 +6997,8 @@ pub struct CraneliftBackend {
     trace_counter: u64,
     next_trace_id: Option<u64>,
     next_header_pc: Option<u64>,
-    registered_call_assembler_tokens: HashSet<u64>,
-    registered_call_assembler_bridge_traces: HashSet<u64>,
+    registered_call_assembler_tokens: VecSet<u64>,
+    registered_call_assembler_bridge_traces: VecSet<u64>,
     /// llmodel.py: self.vtable_offset — byte offset for vtable in objects.
     /// pyre PyObject layout: ob_type at offset 0.
     vtable_offset: Option<usize>,
@@ -7017,7 +7017,7 @@ impl CraneliftBackend {
     /// Legacy test-only entry point.  Production code passes the typed
     /// pool through `Backend::set_constants_pool`; this raw-`i64`
     /// helper is retained for in-crate tests that construct
-    /// `HashMap<u32, i64>` literals by hand.
+    /// `VecAssoc<u32, i64>` literals by hand.
     pub fn set_constants(&mut self, constants: majit_ir::VecAssoc<u32, i64>) {
         self.constants = constants;
     }
@@ -7192,8 +7192,8 @@ impl CraneliftBackend {
             trace_counter: 1,
             next_trace_id: None,
             next_header_pc: None,
-            registered_call_assembler_tokens: HashSet::new(),
-            registered_call_assembler_bridge_traces: HashSet::new(),
+            registered_call_assembler_tokens: VecSet::new(),
+            registered_call_assembler_bridge_traces: VecSet::new(),
             // llmodel.py:64-69: vtable_offset is None when gcremovetypeptr is
             // enabled; otherwise it comes from
             //   symbolic.get_field_token(rclass.OBJECT, 'typeptr', ...).
@@ -7808,19 +7808,19 @@ impl CraneliftBackend {
             with_cranelift_gc(|gc| gc.get_typeid_from_classptr_if_gcremovetypeptr(classptr))
                 .flatten()
         };
-        let mut defined_ref_vars: HashSet<u32> = inputargs
+        let mut defined_ref_vars: VecSet<u32> = inputargs
             .iter()
             .filter(|input| input.tp == Type::Ref && !force_tokens.contains(&input.index))
             .map(|input| input.index)
             .collect();
-        let mut synced_ref_vars: HashSet<u32> = HashSet::new();
-        let mut stale_ref_vars: HashSet<u32> = HashSet::new();
+        let mut synced_ref_vars: VecSet<u32> = VecSet::new();
+        let mut stale_ref_vars: VecSet<u32> = VecSet::new();
 
         // regalloc.py:1173-1213 compute_vars_longevity
         // Compute last_usage for each ref root variable. Used by get_gcmap
         // to build per-call-site gcmaps (only alive refs are marked).
-        let longevity: HashMap<u32, usize> = {
-            let mut m: HashMap<u32, usize> = HashMap::new();
+        let longevity: VecAssoc<u32, usize> = {
+            let mut m: VecAssoc<u32, usize> = VecAssoc::new();
             for (i, op) in ops.iter().enumerate() {
                 for &arg in op.getarglist().iter().chain(
                     op.getfailargs()
@@ -7831,9 +7831,9 @@ impl CraneliftBackend {
                 ) {
                     let idx = arg.raw();
                     if ref_root_slots.iter().any(|(vi, _)| *vi == idx) {
-                        m.entry(idx)
-                            .and_modify(|last| *last = (*last).max(i))
-                            .or_insert(i);
+                        // iteration order is monotonic in `i`, so a later
+                        // visit always supersedes any earlier `last_usage`.
+                        m.insert(idx, i);
                     }
                 }
             }
@@ -8006,7 +8006,7 @@ impl CraneliftBackend {
         // num_block_params past the original label arity. Used by the
         // OpCode::Jump handler to detect arity-mismatched local jumps and
         // lower them as external jumps (rewriter.py LABEL/JUMP redirect parity).
-        let label_arity_by_descr: HashMap<u32, usize> = label_indices
+        let label_arity_by_descr: VecAssoc<u32, usize> = label_indices
             .iter()
             .filter_map(|&li| ops[li].getdescr().map(|d| (d.index(), ops[li].num_args())))
             .collect();
@@ -8028,9 +8028,9 @@ impl CraneliftBackend {
         // Collect all variable declarations into a map (index -> type)
         // before declaring them sequentially. Cranelift 0.130 declare_var
         // returns auto-assigned indices, so we must declare in order 0..max.
-        let mut var_types: std::collections::HashMap<u32, cranelift_codegen::ir::Type> =
-            std::collections::HashMap::new();
-        let mut declared_vars = std::collections::HashSet::new();
+        let mut var_types: majit_ir::VecAssoc<u32, cranelift_codegen::ir::Type> =
+            majit_ir::VecAssoc::new();
+        let mut declared_vars = majit_ir::VecSet::new();
 
         // Always declare inputarg variables, even when the trace starts
         // with a LABEL (preamble peeling). Preamble guards reference
@@ -8149,8 +8149,8 @@ impl CraneliftBackend {
         // index assignment is deterministic across runs.
         let mut var_keys: Vec<u32> = var_types.keys().copied().collect();
         var_keys.sort_unstable();
-        let mut opref_var_map: std::collections::HashMap<u32, Variable> =
-            std::collections::HashMap::with_capacity(var_keys.len());
+        let mut opref_var_map: majit_ir::VecAssoc<u32, Variable> =
+            majit_ir::VecAssoc::with_capacity(var_keys.len());
         for opref_idx in var_keys {
             let ty = var_types.get(&opref_idx).copied().unwrap_or(cl_types::I64);
             let returned_var = builder.declare_var(ty);
@@ -8182,7 +8182,7 @@ impl CraneliftBackend {
         });
 
         // Save op-result positions for resolve_opref collision handling.
-        let mut op_result_positions = std::collections::HashSet::new();
+        let mut op_result_positions = majit_ir::VecSet::new();
         for ia in inputargs {
             op_result_positions.insert(ia.index);
         }
@@ -8257,7 +8257,7 @@ impl CraneliftBackend {
         // a Cranelift block per LABEL descr.
 
         let mut label_blocks = Vec::with_capacity(label_indices.len());
-        let mut label_blocks_by_descr = HashMap::new();
+        let mut label_blocks_by_descr = VecAssoc::new();
         for &label_idx in &label_indices {
             let block = builder.create_block();
             for _ in 0..ops[label_idx].num_args() {
@@ -13191,7 +13191,7 @@ fn precompute_max_output_slots(inputargs: &[InputArg], ops: &[Op]) -> usize {
 fn collect_guards(
     ops: &[Op],
     inputargs: &[InputArg],
-    force_tokens: &HashSet<u32>,
+    force_tokens: &VecSet<u32>,
     fail_descrs: &mut Vec<DescrRef>,
     fail_descr_cells: &mut Vec<Arc<majit_ir::FailDescrCell>>,
     guard_infos: &mut Vec<GuardInfo>,
@@ -13212,7 +13212,7 @@ fn collect_guards(
     // also lowers as an external jump (the target's stack frame layout
     // doesn't match, so we exit this trace and re-enter the target via the
     // dispatcher instead of jumping locally).
-    let label_arity_by_descr: HashMap<u32, usize> = ops
+    let label_arity_by_descr: VecAssoc<u32, usize> = ops
         .iter()
         .filter(|op| op.opcode == OpCode::Label)
         .filter_map(|op| op.getdescr().map(|d| (d.index(), op.num_args())))
@@ -13381,8 +13381,8 @@ fn collect_guards(
 
             // Rebuild frame slots from rd_numb values.
             // Track Virtual(vidx) → slot_idx for target_slot in virtual_layouts.
-            let mut vidx_to_slot: std::collections::HashMap<usize, usize> =
-                std::collections::HashMap::new();
+            let mut vidx_to_slot: majit_ir::VecAssoc<usize, usize> =
+                majit_ir::VecAssoc::new();
             let mut new_slots: Vec<ExitValueSourceLayout> = Vec::new();
             for frame in &frames {
                 for val in &frame.values {
@@ -13954,7 +13954,7 @@ fn collect_guards(
 fn collect_terminal_exit_layouts(
     ops: &[Op],
     inputargs: &[InputArg],
-    force_tokens: &HashSet<u32>,
+    force_tokens: &VecSet<u32>,
     trace_id: u64,
     header_pc: u64,
     source_guard: Option<(u64, u32)>,
@@ -15550,7 +15550,6 @@ mod tests {
     use majit_gc::header::{GcHeader, header_of};
     use majit_gc::trace::TypeInfo;
     use majit_ir::descr::{Descr, EffectInfo, ExtraEffect, SizeDescr};
-    use std::collections::HashMap;
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
         let o = Op::new(opcode, args);
@@ -16018,7 +16017,7 @@ mod tests {
         // resoperation.py:719 `InputArgInt.type = 'i'` parity: Label /
         // IntAdd / Jump args that reference the inputarg slot are
         // `InputArgInt` boxes, not `IntOp` results. The op-position
-        // raw-keyed `constants` HashMap (positions 100/101 below) is a
+        // raw-keyed `constants` VecAssoc (positions 100/101 below) is a
         // PRE-EXISTING-ADAPTATION mirroring `make_constant`'s op-position
         // inline-constant path; that part of the fixture is left alone.
         let ia0 = OpRef::input_arg_int(0);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1,9 +1,9 @@
-use std::cell::{Cell, RefCell, UnsafeCell};
 /// Cranelift-based JIT code generation backend.
 ///
 /// Translates majit IR traces into native code via Cranelift, then
 /// executes them as ordinary function pointers.
 use majit_ir::{VecAssoc, VecSet};
+use std::cell::{Cell, RefCell, UnsafeCell};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -13381,8 +13381,7 @@ fn collect_guards(
 
             // Rebuild frame slots from rd_numb values.
             // Track Virtual(vidx) → slot_idx for target_slot in virtual_layouts.
-            let mut vidx_to_slot: majit_ir::VecAssoc<usize, usize> =
-                majit_ir::VecAssoc::new();
+            let mut vidx_to_slot: majit_ir::VecAssoc<usize, usize> = majit_ir::VecAssoc::new();
             let mut new_slots: Vec<ExitValueSourceLayout> = Vec::new();
             for frame in &frames {
                 for val in &frame.values {

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -9,7 +9,7 @@
 ///   _assemble — assembler.py:779 (walk ops + emit code)
 ///   patch_jump_for_descr — assembler.py:965
 ///   redirect_call_assembler — assembler.py:1138
-use std::collections::HashMap;
+use majit_ir::VecAssoc;
 use std::sync::Arc;
 
 // aarch64/assembler.py parity: aarch64-only backend.
@@ -212,7 +212,7 @@ pub struct AssemblerARM64<'a> {
 
     // ── State tracking for code generation ──
     /// Maps OpRef → jitframe slot index.
-    opref_to_slot: HashMap<OpRef, usize>,
+    opref_to_slot: VecAssoc<OpRef, usize>,
     /// Trace inputargs — borrowed for `opref_type` lookups.
     inputargs: &'a [InputArg],
     /// Trace operations — borrowed for `opref_type` lookups (reads
@@ -238,7 +238,7 @@ pub struct AssemblerARM64<'a> {
     guard_success_cc: Option<u8>,
     /// x86/assembler.py:93 target_tokens_currently_compiling parity.
     /// Keyed by descriptor pointer identity (PyPy uses Python `is`).
-    target_tokens_currently_compiling: HashMap<usize, DynamicLabel>,
+    target_tokens_currently_compiling: VecAssoc<usize, DynamicLabel>,
     compiled_target_tokens: Vec<majit_ir::DescrRef>,
     /// llmodel.py:64-69 self.vtable_offset — typeptr field byte offset.
     /// `None` corresponds to RPython's gcremovetypeptr config.
@@ -246,14 +246,14 @@ pub struct AssemblerARM64<'a> {
     /// llsupport/gc.py:563 vtable→typeid table, materialized by the runner
     /// via gc_ll_descr.get_typeid_from_classptr_if_gcremovetypeptr. Used by
     /// the gcremovetypeptr branch of `_cmp_guard_class`.
-    classptr_to_typeid: HashMap<i64, u32>,
+    classptr_to_typeid: VecAssoc<i64, u32>,
     /// TYPE_INFO / CLASSTYPE constants for `GUARD_IS_OBJECT` and
     /// `GUARD_SUBCLASS`, fetched by the runner from the active gc_ll_descr.
     guard_gc_type_info: Option<GuardGcTypeInfo>,
     /// Constant classptr → `(subclassrange_min, subclassrange_max)`, matching
     /// `loc_check_against_class.getint()` field reads in
     /// `aarch64/opassembler.py:695-698`.
-    classptr_to_subclass_range: HashMap<i64, (i64, i64)>,
+    classptr_to_subclass_range: VecAssoc<i64, (i64, i64)>,
     /// Dynamic label at the function entry for self-recursive CALL_ASSEMBLER.
     self_entry_label: Option<DynamicLabel>,
     /// Leaked pointer holding the resolved entry address for self-recursive
@@ -262,7 +262,7 @@ pub struct AssemblerARM64<'a> {
     /// assembler.py:320 descr._ll_function_addr parity:
     /// Maps call_target_token → compiled code address for CALL_ASSEMBLER.
     /// Populated by the runner before compilation, from registered loop targets.
-    call_assembler_targets: HashMap<u64, usize>,
+    call_assembler_targets: VecAssoc<u64, usize>,
     /// opassembler.py:1177 _finish_gcmap.
     finish_gcmap: Option<*mut usize>,
     /// opassembler.py:1215 gcmap_for_finish.
@@ -382,9 +382,9 @@ impl<'a> AssemblerARM64<'a> {
         header_pc: u64,
         constants: majit_ir::VecAssoc<u32, i64>,
         vtable_offset: Option<usize>,
-        classptr_to_typeid: HashMap<i64, u32>,
+        classptr_to_typeid: VecAssoc<i64, u32>,
         guard_gc_type_info: Option<GuardGcTypeInfo>,
-        classptr_to_subclass_range: HashMap<i64, (i64, i64)>,
+        classptr_to_subclass_range: VecAssoc<i64, (i64, i64)>,
         attached_descrs: crate::guard::AttachedDescrPtrs,
         cpu_handle: crate::guard::CpuDescrHandle,
         inputargs: &'a [InputArg],
@@ -402,7 +402,7 @@ impl<'a> AssemblerARM64<'a> {
             header_pc,
             input_types: Vec::new(),
             bridge_input_locs: None,
-            opref_to_slot: HashMap::new(),
+            opref_to_slot: VecAssoc::new(),
             inputargs,
             operations,
             inputarg_pos,
@@ -411,7 +411,7 @@ impl<'a> AssemblerARM64<'a> {
             constant_types: majit_ir::VecAssoc::new(),
             next_slot: 0,
             guard_success_cc: None,
-            target_tokens_currently_compiling: HashMap::new(),
+            target_tokens_currently_compiling: VecAssoc::new(),
             compiled_target_tokens: Vec::new(),
             vtable_offset,
             classptr_to_typeid,
@@ -419,7 +419,7 @@ impl<'a> AssemblerARM64<'a> {
             classptr_to_subclass_range,
             self_entry_label: None,
             self_entry_addr_ptr: Box::into_raw(Box::new(0usize)),
-            call_assembler_targets: HashMap::new(),
+            call_assembler_targets: VecAssoc::new(),
             finish_gcmap: None,
             gcmap_for_finish: {
                 let gcmap = allocate_gcmap(1, JITFRAME_FIXED_SIZE);
@@ -712,7 +712,7 @@ impl<'a> AssemblerARM64<'a> {
 
     fn remap_frame_layout(&mut self, src_locations: &[Loc], dst_locations: &[Loc], tmpreg: Loc) {
         let mut pending_dests = dst_locations.len() as i32;
-        let mut srccount: HashMap<i32, i32> = HashMap::new();
+        let mut srccount: VecAssoc<i32, i32> = VecAssoc::new();
         for dst in dst_locations {
             srccount.insert(Self::loc_as_key(dst), 0);
         }
@@ -757,7 +757,7 @@ impl<'a> AssemblerARM64<'a> {
                 }
             }
             if !progress {
-                let mut sources: HashMap<i32, Loc> = HashMap::new();
+                let mut sources: VecAssoc<i32, Loc> = VecAssoc::new();
                 for i in 0..dst_locations.len() {
                     sources.insert(Self::loc_as_key(&dst_locations[i]), src_locations[i]);
                 }
@@ -799,7 +799,7 @@ impl<'a> AssemblerARM64<'a> {
         tmpreg2: Loc,
     ) {
         let mut extrapushes = Vec::new();
-        let mut dst_keys = HashMap::new();
+        let mut dst_keys = VecAssoc::new();
         for loc in dst_locations1 {
             dst_keys.insert(Self::loc_as_key(loc), ());
         }
@@ -1470,7 +1470,7 @@ impl<'a> AssemblerARM64<'a> {
 
     /// assembler.py:320 descr._ll_function_addr parity: store
     /// call_target_token → code_addr mappings for CALL_ASSEMBLER.
-    pub fn set_call_assembler_targets(&mut self, targets: HashMap<u64, usize>) {
+    pub fn set_call_assembler_targets(&mut self, targets: VecAssoc<u64, usize>) {
         self.call_assembler_targets = targets;
     }
 
@@ -4258,9 +4258,9 @@ impl<'a> AssemblerARM64<'a> {
         // jump.py:1-64 remap_frame_layout: topological order with
         // cycle breaking via push/pop.
         // srccount[dst] = number of times dst appears as a src
-        let mut srccount: HashMap<i32, i32> = HashMap::new();
+        let mut srccount: VecAssoc<i32, i32> = VecAssoc::new();
         for m in &moves {
-            srccount.entry(m.1).or_insert(0); // ensure dst exists
+            srccount.entry_or_default(m.1); // ensure dst exists
         }
         let mut pending = n as i32;
         for (i, m) in moves.iter().enumerate() {

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -17,19 +17,22 @@ use majit_ir::{OpRef, Type};
 /// aarch64/regalloc.py:159 `DEFAULT_IMM_SIZE = 4096`.
 const DEFAULT_IMM_SIZE: i64 = 4096;
 
-/// aarch64/regalloc.py:169 `check_imm_box`. PyPy accepts only
-/// `ConstInt` values in the AArch64 immediate range; non-Int
-/// constants (ConstFloat/ConstPtr) and box references fall through
-/// to the register form. PyPy reads `arg.getint()` directly because
-/// the int is inlined on `ConstInt`; pyre's `OpRef::ConstInt` carries
-/// only a const-pool slot, so the actual i64 must be looked up. A
-/// missing pool entry is *not* the same as `#0` — it falls through
-/// to the register path.
-fn check_imm_box(arg: OpRef, val: Option<i64>) -> bool {
+/// aarch64/regalloc.py:169 `check_imm_box`. Accepts only `ConstInt`
+/// values in the AArch64 immediate range; non-Int constants
+/// (ConstFloat/ConstPtr) and box references fall through to the
+/// register form. `ConstInt(slot)` is a structural promise that the
+/// constant-pool entry exists (parity with `ConstInt.value` being
+/// set during `__init__`); a missing entry would be a corrupted IR
+/// and panics here, matching the assumption baked into
+/// `arg.getint()` upstream.
+fn check_imm_box(arg: OpRef, constants: &majit_ir::VecAssoc<u32, i64>) -> bool {
     if !matches!(arg, OpRef::ConstInt(_)) {
         return false;
     }
-    matches!(val, Some(v) if v >= 0 && v < DEFAULT_IMM_SIZE)
+    let val = *constants
+        .get(&arg.raw())
+        .expect("ConstInt slot must have a constant-pool entry (parity with ConstInt.getint())");
+    val >= 0 && val < DEFAULT_IMM_SIZE
 }
 
 /// aarch64/registers.py:14
@@ -185,7 +188,7 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         let boxes = [lhs, rhs];
-        let imm_rhs = check_imm_box(rhs, self.constants.get(&rhs.raw()).copied());
+        let imm_rhs = check_imm_box(rhs, &self.constants);
         let lhs_loc = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
         let rhs_loc = if imm_rhs {
             self.loc(rhs, Type::Int)
@@ -303,8 +306,8 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         let boxes = [lhs, rhs];
-        let imm_lhs = check_imm_box(lhs, self.constants.get(&lhs.raw()).copied());
-        let imm_rhs = check_imm_box(rhs, self.constants.get(&rhs.raw()).copied());
+        let imm_lhs = check_imm_box(lhs, &self.constants);
+        let imm_rhs = check_imm_box(rhs, &self.constants);
         let (l0, l1) = if !imm_lhs && imm_rhs {
             let r0 = self.make_sure_var_in_reg(lhs, Type::Int, &boxes, None, false);
             let r1 = self.loc(rhs, Type::Int);

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -12,7 +12,7 @@
 ///   compute_vars_longevity — regalloc.py:1173
 ///   valid_addressing_size  — regalloc.py:1236
 ///   get_scale              — regalloc.py:1239
-use std::collections::HashMap;
+use majit_ir::VecAssoc;
 
 use crate::arch::*;
 use crate::gcmap::{allocate_gcmap, gcmap_set_bit};
@@ -251,16 +251,16 @@ impl FixedRegisterPositions {
 
 /// regalloc.py:1054 LifetimeManager — manages Lifetime info for all variables.
 pub struct LifetimeManager {
-    lifetimes: HashMap<OpRef, Lifetime>,
+    lifetimes: VecAssoc<OpRef, Lifetime>,
     /// regalloc.py:1064 maps register → FixedRegisterPositions
-    pub fixed_register_use: HashMap<RegLoc, FixedRegisterPositions>,
+    pub fixed_register_use: VecAssoc<RegLoc, FixedRegisterPositions>,
 }
 
 impl LifetimeManager {
     pub fn new() -> Self {
         LifetimeManager {
-            lifetimes: HashMap::new(),
-            fixed_register_use: HashMap::new(),
+            lifetimes: VecAssoc::new(),
+            fixed_register_use: VecAssoc::new(),
         }
     }
 
@@ -295,8 +295,7 @@ impl LifetimeManager {
             }
         };
         self.fixed_register_use
-            .entry(register)
-            .or_insert_with(|| FixedRegisterPositions::new(register))
+            .entry_or_insert_with(register, || FixedRegisterPositions::new(register))
             .fixed_register(opindex, definition_pos);
     }
 
@@ -1885,7 +1884,7 @@ impl<'a> RegAlloc<'a> {
 
     /// x86/regalloc.py:291 _update_bindings — bind bridge inputargs to their locations.
     fn _update_bindings(&mut self, locs: &[Loc], inputargs: &[InputArg]) {
-        let mut used: HashMap<RegLoc, ()> = HashMap::new();
+        let mut used: VecAssoc<RegLoc, ()> = VecAssoc::new();
 
         // x86/regalloc.py:295-312
         for (iarg, loc) in inputargs.iter().zip(locs.iter()) {
@@ -5916,7 +5915,7 @@ fn loc_eq(a: &Loc, b: &Loc) -> bool {
 mod tests {
     use super::*;
     use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
-    use std::collections::HashMap;
+    use majit_ir::VecAssoc;
 
     fn make_op(opcode: OpCode, pos: u32, args: &[OpRef]) -> Op {
         let mut op = Op::new(opcode, args);

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -3628,12 +3628,7 @@ impl<'a> RegAlloc<'a> {
     /// and has no `flush_cc` equivalent, so receiving `frame_reg` as
     /// the result there would clobber x29 (the frame pointer). On
     /// non-x86 architectures, fall through to a plain force-allocate.
-    pub(crate) fn force_allocate_reg_or_cc(
-        &mut self,
-        result: OpRef,
-        ops: &[Op],
-        i: usize,
-    ) -> Loc {
+    pub(crate) fn force_allocate_reg_or_cc(&mut self, result: OpRef, ops: &[Op], i: usize) -> Loc {
         #[cfg(target_arch = "x86_64")]
         if self.next_op_can_accept_cc(ops, i, result) {
             self.rm.force_allocate_frame_reg(result);
@@ -5914,8 +5909,8 @@ fn loc_eq(a: &Loc, b: &Loc) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
     use majit_ir::VecAssoc;
+    use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
 
     fn make_op(opcode: OpCode, pos: u32, args: &[OpRef]) -> Op {
         let mut op = Op::new(opcode, args);

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -1592,7 +1592,7 @@ pub struct RegAlloc<'a> {
     inputargs: &'a [InputArg],
     /// Trace operations — borrowed for `opref_type` lookups (reads
     /// `op.type_` directly, RPython `box.type` parity).
-    operations: &'a [Op],
+    pub(crate) operations: &'a [Op],
     /// `inputarg_pos[arg.index] = idx in inputargs`, sentinel
     /// [`OpTypeIndex::NO_POS`] for unset slots. Mirrors
     /// `OpTypeIndex::inputarg_pos`.
@@ -3629,7 +3629,12 @@ impl<'a> RegAlloc<'a> {
     /// and has no `flush_cc` equivalent, so receiving `frame_reg` as
     /// the result there would clobber x29 (the frame pointer). On
     /// non-x86 architectures, fall through to a plain force-allocate.
-    fn force_allocate_reg_or_cc(&mut self, result: OpRef, ops: &[Op], i: usize) -> Loc {
+    pub(crate) fn force_allocate_reg_or_cc(
+        &mut self,
+        result: OpRef,
+        ops: &[Op],
+        i: usize,
+    ) -> Loc {
         #[cfg(target_arch = "x86_64")]
         if self.next_op_can_accept_cc(ops, i, result) {
             self.rm.force_allocate_frame_reg(result);

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use majit_ir::VecAssoc;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
@@ -61,8 +61,8 @@ struct DynasmCaTarget {
     index_of_virtualizable: i32,
 }
 
-static CALL_ASSEMBLER_TARGETS: LazyLock<Mutex<HashMap<u64, DynasmCaTarget>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static CALL_ASSEMBLER_TARGETS: LazyLock<Mutex<VecAssoc<u64, DynasmCaTarget>>> =
+    LazyLock::new(|| Mutex::new(VecAssoc::new()));
 
 /// `rewrite.py:665-695` `handle_call_assembler` per-callee metadata
 /// lookup, sourced from the registered `DynasmCaTarget`'s CLT Arc.
@@ -1201,13 +1201,13 @@ impl DynasmBackend {
     /// GuardNonnullClass operand seen in `ops`. RPython resolves these on
     /// demand inside `_cmp_guard_class` (assembler.py:1887-1890); pyre's
     /// dynasm assembler runs without a borrow of `self`, so we materialize
-    /// the resolver as a HashMap up front.
+    /// the resolver as a VecAssoc up front.
     fn collect_classptr_typeid_table(
         &self,
         ops: &[Op],
         constants: &majit_ir::VecAssoc<u32, i64>,
-    ) -> std::collections::HashMap<i64, u32> {
-        let mut table = std::collections::HashMap::new();
+    ) -> majit_ir::VecAssoc<i64, u32> {
+        let mut table = majit_ir::VecAssoc::new();
         if self.vtable_offset.is_some() || DYNASM_ACTIVE_GC.with(|cell| cell.borrow().is_none()) {
             // vtable_offset path doesn't need typeid lookups; without a
             // gc_ll_descr there is nothing to resolve anyway.
@@ -1240,8 +1240,8 @@ impl DynasmBackend {
         &self,
         ops: &[Op],
         constants: &majit_ir::VecAssoc<u32, i64>,
-    ) -> std::collections::HashMap<i64, (i64, i64)> {
-        let mut table = std::collections::HashMap::new();
+    ) -> majit_ir::VecAssoc<i64, (i64, i64)> {
+        let mut table = majit_ir::VecAssoc::new();
         if DYNASM_ACTIVE_GC.with(|cell| cell.borrow().is_none()) {
             return table;
         }
@@ -1525,7 +1525,7 @@ impl DynasmBackend {
         None
     }
 
-    fn call_assembler_targets_snapshot() -> HashMap<u64, usize> {
+    fn call_assembler_targets_snapshot() -> VecAssoc<u64, usize> {
         CALL_ASSEMBLER_TARGETS
             .lock()
             .expect("CALL_ASSEMBLER_TARGETS poisoned")
@@ -1627,8 +1627,7 @@ impl DynasmBackend {
         CALL_ASSEMBLER_TARGETS
             .lock()
             .expect("CALL_ASSEMBLER_TARGETS poisoned")
-            .entry(token_number)
-            .or_insert_with(|| DynasmCaTarget {
+            .entry_or_insert_with(token_number, || DynasmCaTarget {
                 code_addr: 0,
                 compiled_loop_token: pending_clt,
                 index_of_virtualizable,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1,5 +1,5 @@
-use std::cell::RefCell;
 use majit_ir::VecAssoc;
+use std::cell::RefCell;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2803,11 +2803,10 @@ impl<'a> Assembler386<'a> {
                                 // disp32 = `-2147483648`. `i32::try_from`
                                 // panics if the regalloc guard somehow let
                                 // through a non-encodable value.
-                                let v = i32::try_from(i.value.wrapping_neg())
-                                    .expect(
-                                        "IntSub LEA requires an immediate \
+                                let v = i32::try_from(i.value.wrapping_neg()).expect(
+                                    "IntSub LEA requires an immediate \
                                          encodable as signed disp32 after negation",
-                                    );
+                                );
                                 dynasm!(self.mc ; .arch x64
                                     ; lea Rq(dst.value), [Rq(a.value) + v])
                             }

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -5719,7 +5719,9 @@ impl<'a> Assembler386<'a> {
         // srccount[dst] = number of times dst appears as a src
         let mut srccount: VecAssoc<i32, i32> = VecAssoc::new();
         for m in &moves {
-            srccount.entry(m.1).or_insert(0); // ensure dst exists
+            if !srccount.contains_key(&m.1) {
+                srccount.insert(m.1, 0); // ensure dst exists
+            }
         }
         let mut pending = n as i32;
         for (i, m) in moves.iter().enumerate() {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -9,7 +9,7 @@
 ///   _assemble — assembler.py:779 (walk ops + emit code)
 ///   patch_jump_for_descr — assembler.py:965
 ///   redirect_call_assembler — assembler.py:1138
-use std::collections::HashMap;
+use majit_ir::VecAssoc;
 use std::sync::Arc;
 
 // x86/assembler.py parity: x86_64-only backend.
@@ -655,7 +655,7 @@ pub struct Assembler386<'a> {
 
     // ── State tracking for code generation ──
     /// Maps OpRef → jitframe slot index.
-    opref_to_slot: HashMap<OpRef, usize>,
+    opref_to_slot: VecAssoc<OpRef, usize>,
     /// Trace inputargs — borrowed for `opref_type` lookups.
     inputargs: &'a [InputArg],
     /// Trace operations — borrowed for `opref_type` lookups (reads
@@ -681,7 +681,7 @@ pub struct Assembler386<'a> {
     guard_success_cc: Option<u8>,
     /// x86/assembler.py:93 target_tokens_currently_compiling parity.
     /// Keyed by descriptor pointer identity (PyPy uses Python `is`).
-    target_tokens_currently_compiling: HashMap<usize, DynamicLabel>,
+    target_tokens_currently_compiling: VecAssoc<usize, DynamicLabel>,
     compiled_target_tokens: Vec<majit_ir::DescrRef>,
     /// llmodel.py:64-69 self.vtable_offset — typeptr field byte offset.
     /// `None` corresponds to RPython's gcremovetypeptr config.
@@ -689,14 +689,14 @@ pub struct Assembler386<'a> {
     /// llsupport/gc.py:563 vtable→typeid table, materialized by the runner
     /// via gc_ll_descr.get_typeid_from_classptr_if_gcremovetypeptr. Used by
     /// the gcremovetypeptr branch of `_cmp_guard_class`.
-    classptr_to_typeid: HashMap<i64, u32>,
+    classptr_to_typeid: VecAssoc<i64, u32>,
     /// TYPE_INFO / CLASSTYPE constants for `GUARD_IS_OBJECT` and
     /// `GUARD_SUBCLASS`, fetched by the runner from the active gc_ll_descr.
     guard_gc_type_info: Option<GuardGcTypeInfo>,
     /// Constant classptr → `(subclassrange_min, subclassrange_max)`, matching
     /// `loc_check_against_class.getint()` field reads in
     /// `x86/assembler.py:1971-1974`.
-    classptr_to_subclass_range: HashMap<i64, (i64, i64)>,
+    classptr_to_subclass_range: VecAssoc<i64, (i64, i64)>,
     /// Dynamic label at the function entry for self-recursive CALL_ASSEMBLER.
     self_entry_label: Option<DynamicLabel>,
     /// Leaked pointer holding the resolved entry address for self-recursive
@@ -705,7 +705,7 @@ pub struct Assembler386<'a> {
     /// assembler.py:320 descr._ll_function_addr parity:
     /// Maps call_target_token → compiled code address for CALL_ASSEMBLER.
     /// Populated by the runner before compilation, from registered loop targets.
-    call_assembler_targets: HashMap<u64, usize>,
+    call_assembler_targets: VecAssoc<u64, usize>,
     /// opassembler.py:1177 _finish_gcmap.
     finish_gcmap: Option<*mut usize>,
     /// opassembler.py:1215 gcmap_for_finish.
@@ -781,7 +781,7 @@ struct GuardToken {
     fail_args: Vec<OpRef>,
     /// regalloc parity: snapshot of opref_to_slot at guard emission time.
     /// Needed by recovery stubs to read fail_args from correct slots.
-    opref_to_slot_snapshot: HashMap<OpRef, usize>,
+    opref_to_slot_snapshot: VecAssoc<OpRef, usize>,
     /// Constants to store in frame during recovery.
     /// Each entry: (frame_slot_index, constant_value).
     const_stores: Vec<(usize, i64)>,
@@ -849,9 +849,9 @@ impl<'a> Assembler386<'a> {
         header_pc: u64,
         constants: majit_ir::VecAssoc<u32, i64>,
         vtable_offset: Option<usize>,
-        classptr_to_typeid: HashMap<i64, u32>,
+        classptr_to_typeid: VecAssoc<i64, u32>,
         guard_gc_type_info: Option<GuardGcTypeInfo>,
-        classptr_to_subclass_range: HashMap<i64, (i64, i64)>,
+        classptr_to_subclass_range: VecAssoc<i64, (i64, i64)>,
         attached_descrs: crate::guard::AttachedDescrPtrs,
         cpu_handle: crate::guard::CpuDescrHandle,
         malloc_slowpath_fixed: usize,
@@ -870,7 +870,7 @@ impl<'a> Assembler386<'a> {
             header_pc,
             input_types: Vec::new(),
             bridge_input_locs: None,
-            opref_to_slot: HashMap::new(),
+            opref_to_slot: VecAssoc::new(),
             inputargs,
             operations,
             inputarg_pos,
@@ -879,7 +879,7 @@ impl<'a> Assembler386<'a> {
             constant_types: majit_ir::VecAssoc::new(),
             next_slot: 0,
             guard_success_cc: None,
-            target_tokens_currently_compiling: HashMap::new(),
+            target_tokens_currently_compiling: VecAssoc::new(),
             compiled_target_tokens: Vec::new(),
             vtable_offset,
             classptr_to_typeid,
@@ -887,7 +887,7 @@ impl<'a> Assembler386<'a> {
             classptr_to_subclass_range,
             self_entry_label: None,
             self_entry_addr_ptr: Box::into_raw(Box::new(0usize)),
-            call_assembler_targets: HashMap::new(),
+            call_assembler_targets: VecAssoc::new(),
             finish_gcmap: None,
             gcmap_for_finish: {
                 let gcmap = allocate_gcmap(1, JITFRAME_FIXED_SIZE);
@@ -1130,7 +1130,7 @@ impl<'a> Assembler386<'a> {
 
     fn remap_frame_layout(&mut self, src_locations: &[Loc], dst_locations: &[Loc], tmpreg: Loc) {
         let mut pending_dests = dst_locations.len() as i32;
-        let mut srccount: HashMap<i32, i32> = HashMap::new();
+        let mut srccount: VecAssoc<i32, i32> = VecAssoc::new();
         for dst in dst_locations {
             srccount.insert(Self::loc_as_key(dst), 0);
         }
@@ -1175,7 +1175,7 @@ impl<'a> Assembler386<'a> {
                 }
             }
             if !progress {
-                let mut sources: HashMap<i32, Loc> = HashMap::new();
+                let mut sources: VecAssoc<i32, Loc> = VecAssoc::new();
                 for i in 0..dst_locations.len() {
                     sources.insert(Self::loc_as_key(&dst_locations[i]), src_locations[i]);
                 }
@@ -1217,7 +1217,7 @@ impl<'a> Assembler386<'a> {
         tmpreg2: Loc,
     ) {
         let mut extrapushes = Vec::new();
-        let mut dst_keys = HashMap::new();
+        let mut dst_keys = VecAssoc::new();
         for loc in dst_locations1 {
             dst_keys.insert(Self::loc_as_key(loc), ());
         }
@@ -2393,7 +2393,7 @@ impl<'a> Assembler386<'a> {
 
     /// assembler.py:320 descr._ll_function_addr parity: store
     /// call_target_token → code_addr mappings for CALL_ASSEMBLER.
-    pub fn set_call_assembler_targets(&mut self, targets: HashMap<u64, usize>) {
+    pub fn set_call_assembler_targets(&mut self, targets: VecAssoc<u64, usize>) {
         self.call_assembler_targets = targets;
     }
 
@@ -5718,7 +5718,7 @@ impl<'a> Assembler386<'a> {
         // jump.py:1-64 remap_frame_layout: topological order with
         // cycle breaking via push/pop.
         // srccount[dst] = number of times dst appears as a src
-        let mut srccount: HashMap<i32, i32> = HashMap::new();
+        let mut srccount: VecAssoc<i32, i32> = VecAssoc::new();
         for m in &moves {
             srccount.entry(m.1).or_insert(0); // ensure dst exists
         }

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2797,15 +2797,13 @@ impl<'a> Assembler386<'a> {
                         match (a0, src) {
                             (Loc::Reg(a), Loc::Immed(i)) => {
                                 // regalloc.py:577 — `_consider_lea` is guarded
-                                // by `rx86.fits_in_32bits(-y.value)`, so check
-                                // the negated value directly.  `y.value =
-                                // 2147483648` is valid here because the disp32
-                                // is `-2147483648`; converting y to i32 first
-                                // would incorrectly reject that PyPy-valid case.
-                                let v = i
-                                    .value
-                                    .checked_neg()
-                                    .and_then(|negated| i32::try_from(negated).ok())
+                                // by `rx86.fits_in_32bits(-y.value)`. The
+                                // wrapping negate matches PyPy `-y.value`;
+                                // `y.value = 2147483648` is valid because
+                                // disp32 = `-2147483648`. `i32::try_from`
+                                // panics if the regalloc guard somehow let
+                                // through a non-encodable value.
+                                let v = i32::try_from(i.value.wrapping_neg())
                                     .expect(
                                         "IntSub LEA requires an immediate \
                                          encodable as signed disp32 after negation",
@@ -2916,15 +2914,15 @@ impl<'a> Assembler386<'a> {
                 self.flush_cc(cc, result_loc);
             }
             OpCode::IntIsTrue => {
-                if let (Some(src), Some(Loc::Reg(r))) = (arglocs.first(), result_loc) {
+                if let Some(src) = arglocs.first() {
                     self.emit_test_loc(src);
-                    self.emit_setcc(CC_NE, r.value);
+                    self.flush_cc(CC_NE, result_loc);
                 }
             }
             OpCode::IntIsZero => {
-                if let (Some(src), Some(Loc::Reg(r))) = (arglocs.first(), result_loc) {
+                if let Some(src) = arglocs.first() {
                     self.emit_test_loc(src);
-                    self.emit_setcc(CC_E, r.value);
+                    self.flush_cc(CC_E, result_loc);
                 }
             }
             OpCode::UintMulHigh => {

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -15,7 +15,7 @@ use crate::regloc::{
     EAX, EBP, EBX, ECX, EDI, EDX, ESI, R8, R9, R10, R12, R13, R14, R15, RegLoc, XMM0, XMM1, XMM2,
     XMM3, XMM4, XMM5, XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14,
 };
-use majit_ir::{OpRef, Type};
+use majit_ir::{Op, OpRef, Type};
 
 /// x86/regalloc.py X86_64_RegisterManager.all_regs — the GPR allocation
 /// pool.  Order chosen to prefer caller-save first (popped from end).
@@ -240,14 +240,13 @@ impl<'a> RegAlloc<'a> {
     ) {
         if rhs.is_constant() {
             let val = self.const_value(rhs);
-            // PyPy `rx86.fits_in_32bits(-y.value)` (regalloc.py:577) is safe
-            // because Python ints are arbitrary precision; Rust `-i64::MIN`
-            // overflows. `checked_neg` returns None for that single edge
-            // case and falls back to the normal SUB path.
-            if let Some(neg) = val.checked_neg() {
-                if fits_in_32bits(neg) {
-                    return self._consider_lea_j2(dst, lhs, rhs, i, output);
-                }
+            // x86/regalloc.py:577 `rx86.fits_in_32bits(-y.value)`. The
+            // negate-then-range-check filters `i64::MIN` naturally
+            // because `wrapping_neg(i64::MIN) == i64::MIN`, which sits
+            // outside the i32 range, so the LEA shortcut is skipped
+            // and the regular SUB path is taken.
+            if fits_in_32bits(val.wrapping_neg()) {
+                return self._consider_lea_j2(dst, lhs, rhs, i, output);
             }
         }
         self.consider_binop_j2(dst, lhs, rhs, i, output);
@@ -336,12 +335,10 @@ impl<'a> RegAlloc<'a> {
 
     /// x86/regalloc.py:1199 `consider_int_is_true` / `consider_int_is_zero`.
     /// `TEST src, src ; SETcc dst` — input does not need to be in a
-    /// register, and the result lives in a distinct byte-addressable
-    /// register selected by `force_allocate_reg`. PyPy uses
-    /// `force_allocate_reg_or_cc` to leave the result in the condition
-    /// code when the consumer is a GUARD/jump; pyre's emit path always
-    /// materialises a byte register via SETcc, so the plain
-    /// `force_allocate_reg` is the closest available primitive.
+    /// register, and the result is allocated via
+    /// `force_allocate_reg_or_cc` so that consumers like
+    /// `GUARD_TRUE/FALSE`/`COND_CALL` may receive the boolean via the
+    /// CPU condition flags instead of materialising it through SETcc.
     pub(crate) fn consider_int_is_true_j2(
         &mut self,
         dst: OpRef,
@@ -350,10 +347,9 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         let argloc = self.loc(arg, Type::Int);
-        let resloc =
-            self.rm
-                .force_allocate_reg(dst, &[], None, false, &mut self.longevity, &mut self.fm);
-        self.perform(i, vec![argloc], Some(Loc::Reg(resloc)), output);
+        let ops_ref: &[Op] = self.operations;
+        let resloc = self.force_allocate_reg_or_cc(dst, ops_ref, i);
+        self.perform(i, vec![argloc], Some(resloc), output);
     }
 
     /// x86/regalloc.py:591 `consider_uint_mul_high` — emits `MUL src`,

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -3372,38 +3372,6 @@ mod tests {
         assert_ne!(OpRef::ref_op(0), OpRef::float_op(0));
     }
 
-    #[test]
-    fn opref_same_box_mirrors_partial_eq() {
-        // `resoperation.py:38 AbstractValue.same_box` is identity-only.
-        // For pyre's flat-OpRef encoding identity = variant + raw payload
-        // equality (`derive(PartialEq)`), so `same_box` must equal `==`
-        // for every OpRef pair the caller can construct.
-        let a = OpRef::int_op(7);
-        assert!(a.same_box(a));
-        assert!(a.same_box(OpRef::int_op(7)));
-
-        // Disjoint variants with matching payload: not same box.
-        assert!(!OpRef::int_op(0).same_box(OpRef::ref_op(0)));
-        assert!(!OpRef::int_op(0).same_box(OpRef::float_op(0)));
-        assert!(!OpRef::ref_op(0).same_box(OpRef::float_op(0)));
-
-        // None vs typed: not same box (history.py:182 `None` vs Box).
-        assert!(!OpRef::NONE.same_box(OpRef::int_op(0)));
-        assert!(!OpRef::int_op(0).same_box(OpRef::NONE));
-        assert!(OpRef::NONE.same_box(OpRef::NONE));
-
-        // Two distinct Const-namespace mints of the same value (different
-        // pool indices) compare unequal via `same_box` because their raw
-        // payloads (CONST_BIT | idx) differ. This matches PyPy where
-        // `ConstInt(42)` and `ConstInt(42)` are distinct Box objects with
-        // `same_box == False`; value-aware comparison is the separate
-        // `same_constant` method (history.py:204/244).
-        let c0 = OpRef::const_int(0);
-        let c1 = OpRef::const_int(1);
-        assert!(!c0.same_box(c1));
-        assert!(c0.same_box(OpRef::const_int(0)));
-    }
-
     // ── Metadata table coverage ──
 
     #[test]

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -331,6 +331,31 @@ impl OpRef {
         matches!(self, Self::TempVar(_))
     }
 
+    /// `resoperation.py:38 AbstractValue.same_box(other)` — identity
+    /// comparison. PyPy's base implementation reads `self is other`, so
+    /// two distinct `ConstInt(42)` Box instances return `false` even
+    /// though their `.value` agrees; value equality is the separate
+    /// `same_constant` method (history.py:204/244).
+    ///
+    /// Pyre's flat `OpRef` encoding makes Box identity = variant + raw
+    /// payload equality (`derive(PartialEq)`), so the implementation is
+    /// `self == other`. This method exists as the explicit API name so
+    /// callers don't reach for `==` for an identity check (the operator
+    /// is also used for non-Box comparisons elsewhere).
+    ///
+    /// Const-namespace OpRefs minted by `ConstantPool::get_or_insert`
+    /// receive fresh indices per call (history.py:220 fresh-alloc), so
+    /// `same_box` returns `false` for two pool-minted ConstInts of the
+    /// same value — matching PyPy. Use `ConstantPool::same_constant` for
+    /// value-aware Const comparison; that path is the subject of the
+    /// Phase A.3 OpRef inline-storage epic which will let `same_box`
+    /// return value equality directly for Const variants without pool
+    /// consultation.
+    #[inline]
+    pub fn same_box(self, other: OpRef) -> bool {
+        self == other
+    }
+
     /// Re-encode this OpRef's variant with a fresh raw payload while
     /// preserving the type tag. Used by post-optimization remaps that
     /// renumber positions but keep RPython's `box.type` attached
@@ -3345,6 +3370,38 @@ mod tests {
         assert_ne!(OpRef::int_op(0), OpRef::ref_op(0));
         assert_ne!(OpRef::int_op(0), OpRef::float_op(0));
         assert_ne!(OpRef::ref_op(0), OpRef::float_op(0));
+    }
+
+    #[test]
+    fn opref_same_box_mirrors_partial_eq() {
+        // `resoperation.py:38 AbstractValue.same_box` is identity-only.
+        // For pyre's flat-OpRef encoding identity = variant + raw payload
+        // equality (`derive(PartialEq)`), so `same_box` must equal `==`
+        // for every OpRef pair the caller can construct.
+        let a = OpRef::int_op(7);
+        assert!(a.same_box(a));
+        assert!(a.same_box(OpRef::int_op(7)));
+
+        // Disjoint variants with matching payload: not same box.
+        assert!(!OpRef::int_op(0).same_box(OpRef::ref_op(0)));
+        assert!(!OpRef::int_op(0).same_box(OpRef::float_op(0)));
+        assert!(!OpRef::ref_op(0).same_box(OpRef::float_op(0)));
+
+        // None vs typed: not same box (history.py:182 `None` vs Box).
+        assert!(!OpRef::NONE.same_box(OpRef::int_op(0)));
+        assert!(!OpRef::int_op(0).same_box(OpRef::NONE));
+        assert!(OpRef::NONE.same_box(OpRef::NONE));
+
+        // Two distinct Const-namespace mints of the same value (different
+        // pool indices) compare unequal via `same_box` because their raw
+        // payloads (CONST_BIT | idx) differ. This matches PyPy where
+        // `ConstInt(42)` and `ConstInt(42)` are distinct Box objects with
+        // `same_box == False`; value-aware comparison is the separate
+        // `same_constant` method (history.py:204/244).
+        let c0 = OpRef::const_int(0);
+        let c1 = OpRef::const_int(1);
+        assert!(!c0.same_box(c1));
+        assert!(c0.same_box(OpRef::const_int(0)));
     }
 
     // ── Metadata table coverage ──

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5111,18 +5111,9 @@ impl TraceCtx {
     pub fn add_merge_point(
         &mut self,
         key: u64,
-        live_args: Vec<OpRef>,
-        live_arg_types: Vec<Type>,
+        green_boxes: Vec<crate::trace_ctx::GreenBox>,
         header_pc: usize,
     ) {
-        debug_assert_eq!(
-            live_args.len(),
-            live_arg_types.len(),
-            "add_merge_point: live_args/live_arg_types length mismatch \
-             (key={key:#x}, header_pc={header_pc}, args={}, types={})",
-            live_args.len(),
-            live_arg_types.len(),
-        );
         // Use the TraceCtx-level position so `snapshot_data_len` reflects
         // the current Vec<Snapshot> side table length (Task #70 moved
         // snapshots off `recorder::Trace`; a bare `recorder.get_position()`
@@ -5132,11 +5123,7 @@ impl TraceCtx {
         self.current_merge_points.push(MergePoint {
             green_key: key,
             position,
-            green_boxes: live_args
-                .into_iter()
-                .zip(live_arg_types.into_iter())
-                .map(|(opref, ty)| crate::trace_ctx::GreenBox::new(opref, ty))
-                .collect(),
+            green_boxes,
             header_pc,
         });
     }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5099,7 +5099,7 @@ impl TraceCtx {
         self.current_merge_points
             .iter()
             .rev()
-            .any(|mp| mp.green_key == key && mp.original_boxes.len() == live_args_len)
+            .any(|mp| mp.green_key == key && mp.green_boxes.len() == live_args_len)
     }
 
     /// pyjitpl.py:3029-3030 — record a loop header visit with position
@@ -5132,8 +5132,11 @@ impl TraceCtx {
         self.current_merge_points.push(MergePoint {
             green_key: key,
             position,
-            original_boxes: live_args,
-            original_box_types: live_arg_types,
+            green_boxes: live_args
+                .into_iter()
+                .zip(live_arg_types.into_iter())
+                .map(|(opref, ty)| crate::trace_ctx::GreenBox::new(opref, ty))
+                .collect(),
             header_pc,
         });
     }

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -371,17 +371,16 @@ impl TreeLoop {
     }
 
     /// opencoder.py CutTrace parity — create a new trace by cutting at the
-    /// given position. `original_boxes` become the new inputargs; any OpRef
-    /// referenced after the cut but defined before it (and not in
-    /// `original_boxes`) is re-emitted as a prefix operation (transitive
-    /// closure of dependencies).
+    /// given position. `original_boxes` (paired OpRef + Type via `GreenBox`)
+    /// become the new inputargs; any OpRef referenced after the cut but
+    /// defined before it (and not in `original_boxes`) is re-emitted as a
+    /// prefix operation (transitive closure of dependencies).
     pub fn cut_trace_from(
         &self,
         start: TreeLoopCutPosition,
-        original_boxes: &[OpRef],
-        original_box_types: &[majit_ir::Type],
+        original_boxes: &[crate::trace_ctx::GreenBox],
     ) -> TreeLoop {
-        self.cut_trace_from_with_consts(start, original_boxes, original_box_types, &[])
+        self.cut_trace_from_with_consts(start, original_boxes, &[])
     }
 
     /// Like `cut_trace_from`, but with pre-allocated constant OpRefs for each
@@ -391,8 +390,7 @@ impl TreeLoop {
     pub fn cut_trace_from_with_consts(
         &self,
         start: TreeLoopCutPosition,
-        original_boxes: &[OpRef],
-        original_box_types: &[majit_ir::Type],
+        original_boxes: &[crate::trace_ctx::GreenBox],
         inputarg_consts: &[OpRef],
     ) -> TreeLoop {
         use majit_ir::vec_set::VecSet;
@@ -402,16 +400,19 @@ impl TreeLoop {
         let cut_ops = &self.ops[start.op_index..];
 
         // Phase 1: Build initial remap from original_boxes → new inputargs.
-        // Each new inputarg carries the type recorded in `original_box_types[i]`.
+        // Each new inputarg carries the type recorded in `GreenBox.ty`.
         let mut remap: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef> =
             crate::optimizeopt::vec_assoc::VecAssoc::new();
-        let original_set: VecSet<OpRef> = original_boxes.iter().copied().collect();
-        for (i, &old_ref) in original_boxes.iter().enumerate() {
-            remap.insert(
-                old_ref,
-                OpRef::input_arg_typed(i as u32, original_box_types[i]),
-            );
+        let original_set: VecSet<OpRef> = original_boxes.iter().map(|gb| gb.opref).collect();
+        for (i, gb) in original_boxes.iter().enumerate() {
+            remap.insert(gb.opref, OpRef::input_arg_typed(i as u32, gb.ty));
         }
+        // Project GreenBox slice into the two split-shape vectors used
+        // by the rest of the function (new_ia_boxes / new_ia_types
+        // grow with escaped-inputarg fallback so they need to be owned).
+        let original_box_opref: Vec<OpRef> = original_boxes.iter().map(|gb| gb.opref).collect();
+        let original_box_types: Vec<majit_ir::Type> =
+            original_boxes.iter().map(|gb| gb.ty).collect();
 
         // Collect all OpRefs defined by post-cut ops.
         let defined_after_cut: VecSet<OpRef> = cut_ops
@@ -481,8 +482,8 @@ impl TreeLoop {
         // If concrete initial values are available, escaped original inputargs
         // become typed constants (avoiding entry-contract mismatch at runtime).
         // Otherwise, they become additional inputargs (original behavior).
-        let mut new_ia_boxes = original_boxes.to_vec();
-        let mut new_ia_types = original_box_types.to_vec();
+        let mut new_ia_boxes = original_box_opref;
+        let mut new_ia_types = original_box_types;
         for &r in &orig_inputarg_escaped {
             if let Some(&const_opref) = inputarg_consts.get(r.raw() as usize) {
                 // Remap to the pre-allocated pool constant (already GC-rooted).
@@ -1454,10 +1455,12 @@ mod tests {
         let trace = TreeLoop::new(inputargs, ops);
 
         let start = TreeLoopCutPosition::new(1); // cut after op0
-        let original_boxes = vec![iarg(0), iarg(1)];
-        let original_box_types = vec![Type::Int, Type::Int];
+        let original_boxes = vec![
+            crate::trace_ctx::GreenBox::new(iarg(0), Type::Int),
+            crate::trace_ctx::GreenBox::new(iarg(1), Type::Int),
+        ];
 
-        let cut = trace.cut_trace_from(start, &original_boxes, &original_box_types);
+        let cut = trace.cut_trace_from(start, &original_boxes);
         assert_eq!(cut.inputargs.len(), 2);
         assert_eq!(cut.ops.len(), 2); // IntMul + Jump
         assert_eq!(cut.ops[0].opcode, OpCode::IntMul);
@@ -1488,10 +1491,9 @@ mod tests {
 
         let start = TreeLoopCutPosition::new(1); // cut after op0
         // original_boxes only has v0 — v2 is escaped
-        let original_boxes = vec![iarg(0)];
-        let original_box_types = vec![Type::Int];
+        let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
 
-        let cut = trace.cut_trace_from(start, &original_boxes, &original_box_types);
+        let cut = trace.cut_trace_from(start, &original_boxes);
         // v1 = OpRef::input_arg_int(1) is an original trace inputarg NOT in original_boxes.
         // It's referenced by the escaped int_add op → added as extra inputarg.
         // Result: inputargs = [v0, v1], prefix = [int_add], post-cut = [int_mul, jump]
@@ -1519,10 +1521,9 @@ mod tests {
         let trace = TreeLoop::new(inputargs, ops);
 
         let start = TreeLoopCutPosition::new(1);
-        let original_boxes = vec![iarg(0)];
-        let original_box_types = vec![Type::Int];
+        let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
 
-        let cut = trace.cut_trace_from(start, &original_boxes, &original_box_types);
+        let cut = trace.cut_trace_from(start, &original_boxes);
         assert_eq!(cut.ops.len(), 2);
         // Constant ref should be preserved as-is
         assert_eq!(cut.ops[0].arg(1), const_ref);
@@ -1551,10 +1552,9 @@ mod tests {
         let trace = TreeLoop::new(inputargs, ops);
 
         let start = TreeLoopCutPosition::new(2); // cut after op0 and op1
-        let original_boxes = vec![iarg(0)];
-        let original_box_types = vec![Type::Int];
+        let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
 
-        let cut = trace.cut_trace_from(start, &original_boxes, &original_box_types);
+        let cut = trace.cut_trace_from(start, &original_boxes);
         // 1 inputarg, 2 prefix ops (v1=int_add, v2=int_mul), 2 post-cut ops
         assert_eq!(cut.inputargs.len(), 1);
         assert_eq!(cut.ops.len(), 4);

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -264,11 +264,12 @@ pub trait JitState: Sized {
     fn build_meta_from_merge_point(
         provisional: &Self::Meta,
         header_pc: usize,
-        original_box_types: &[Type],
+        original_boxes: &[crate::trace_ctx::GreenBox],
     ) -> Self::Meta {
         // Default: clone + patch (backward compat for non-pyre consumers)
         let mut meta = provisional.clone();
-        Self::update_meta_for_cut(&mut meta, header_pc, original_box_types);
+        let original_box_types: Vec<Type> = original_boxes.iter().map(|gb| gb.ty).collect();
+        Self::update_meta_for_cut(&mut meta, header_pc, &original_box_types);
         meta
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1537,8 +1537,8 @@ impl<S: JitState> JitDriver<S> {
                     // rebuild meta from merge point to get the inner header's
                     // frame layout (vsd, slot_types).
                     let meta = {
-                        if let Some((cut_pc, ref cut_types)) = self.meta.cross_loop_cut_info() {
-                            S::build_meta_from_merge_point(&provisional_meta, cut_pc, cut_types)
+                        if let Some((cut_pc, ref cut_boxes)) = self.meta.cross_loop_cut_info() {
+                            S::build_meta_from_merge_point(&provisional_meta, cut_pc, cut_boxes)
                         } else {
                             provisional_meta
                         }
@@ -1650,8 +1650,8 @@ impl<S: JitState> JitDriver<S> {
                     // without consuming.
                     let provisional_meta = self.meta.trace_meta().cloned().unwrap();
                     let meta = {
-                        if let Some((cut_pc, ref cut_types)) = self.meta.cross_loop_cut_info() {
-                            S::build_meta_from_merge_point(&provisional_meta, cut_pc, cut_types)
+                        if let Some((cut_pc, ref cut_boxes)) = self.meta.cross_loop_cut_info() {
+                            S::build_meta_from_merge_point(&provisional_meta, cut_pc, cut_boxes)
                         } else {
                             provisional_meta
                         }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -98,6 +98,7 @@ pub use pyjitpl::{
     trace_jitcode_with_args_and_runtime,
 };
 pub use quasiimmut::QuasiImmut;
+pub use trace_ctx::GreenBox;
 pub use trace_ctx::MergePoint;
 pub use trace_ctx::TraceCtx;
 

--- a/majit/majit-metainterp/src/optimizeopt/dependency.rs
+++ b/majit/majit-metainterp/src/optimizeopt/dependency.rs
@@ -1099,6 +1099,14 @@ impl<'a> IntegralForwardModification<'a> {
         }
     }
 
+    fn set_index_var(&mut self, key: OpRef, idx: IndexVar) {
+        self.index_vars.insert(key, idx);
+    }
+
+    fn set_memory_ref(&mut self, node_idx: usize, mref: MemoryRef) {
+        self.memory_refs.insert(node_idx, mref);
+    }
+
     fn is_const(opref: OpRef) -> bool {
         opref.is_constant()
     }
@@ -1108,14 +1116,17 @@ impl<'a> IntegralForwardModification<'a> {
     }
 
     fn get_or_create(&mut self, arg: OpRef) -> IndexVar {
-        self.index_vars.get(&arg).cloned().unwrap_or_else(|| {
-            if Self::is_const(arg) {
-                let val = self.const_val(arg).unwrap_or(0);
-                IndexVar::new_const(arg, val)
-            } else {
-                IndexVar::new(arg)
-            }
-        })
+        self.index_vars
+            .get(&arg)
+            .cloned()
+            .unwrap_or_else(|| {
+                if Self::is_const(arg) {
+                    let val = self.const_val(arg).unwrap_or(0);
+                    IndexVar::new_const(arg, val)
+                } else {
+                    IndexVar::new(arg)
+                }
+            })
     }
 
     /// dependency.py:896-920: operation_INT_ADD / operation_INT_SUB.
@@ -1128,7 +1139,7 @@ impl<'a> IntegralForwardModification<'a> {
             let v0 = self.const_val(a0).unwrap_or(0);
             let v1 = self.const_val(a1).unwrap_or(0);
             idx.constant = if is_sub { v0 - v1 } else { v0 + v1 };
-            self.index_vars.insert(result, idx);
+            self.set_index_var(result, idx);
         } else if Self::is_const(a0) {
             let mut idx = self.get_or_create(a1);
             idx = idx.clone_var();
@@ -1139,7 +1150,7 @@ impl<'a> IntegralForwardModification<'a> {
                     idx.constant += v;
                 }
             }
-            self.index_vars.insert(result, idx);
+            self.set_index_var(result, idx);
         } else if Self::is_const(a1) {
             let mut idx = self.get_or_create(a0);
             idx = idx.clone_var();
@@ -1150,11 +1161,11 @@ impl<'a> IntegralForwardModification<'a> {
                     idx.constant += v;
                 }
             }
-            self.index_vars.insert(result, idx);
+            self.set_index_var(result, idx);
         } else {
             // Both non-const: track the variable.
             let idx = self.get_or_create(a0);
-            self.index_vars.insert(result, idx);
+            self.set_index_var(result, idx);
         }
     }
 
@@ -1168,7 +1179,7 @@ impl<'a> IntegralForwardModification<'a> {
             let v0 = self.const_val(a0).unwrap_or(0);
             let v1 = self.const_val(a1).unwrap_or(0);
             idx.constant = v0 * v1;
-            self.index_vars.insert(result, idx);
+            self.set_index_var(result, idx);
         } else if Self::is_const(a0) {
             let mut idx = self.get_or_create(a1);
             idx = idx.clone_var();
@@ -1176,7 +1187,7 @@ impl<'a> IntegralForwardModification<'a> {
                 idx.coefficient_mul *= v;
                 idx.constant *= v;
             }
-            self.index_vars.insert(result, idx);
+            self.set_index_var(result, idx);
         } else if Self::is_const(a1) {
             let mut idx = self.get_or_create(a0);
             idx = idx.clone_var();
@@ -1184,7 +1195,7 @@ impl<'a> IntegralForwardModification<'a> {
                 idx.coefficient_mul *= v;
                 idx.constant *= v;
             }
-            self.index_vars.insert(result, idx);
+            self.set_index_var(result, idx);
         }
     }
 
@@ -1212,7 +1223,7 @@ impl<'a> IntegralForwardModification<'a> {
                 index_var: idx_var,
                 raw_access,
             };
-            self.memory_refs.insert(node_idx, mref);
+            self.set_memory_ref(node_idx, mref);
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/dependency.rs
+++ b/majit/majit-metainterp/src/optimizeopt/dependency.rs
@@ -1116,17 +1116,14 @@ impl<'a> IntegralForwardModification<'a> {
     }
 
     fn get_or_create(&mut self, arg: OpRef) -> IndexVar {
-        self.index_vars
-            .get(&arg)
-            .cloned()
-            .unwrap_or_else(|| {
-                if Self::is_const(arg) {
-                    let val = self.const_val(arg).unwrap_or(0);
-                    IndexVar::new_const(arg, val)
-                } else {
-                    IndexVar::new(arg)
-                }
-            })
+        self.index_vars.get(&arg).cloned().unwrap_or_else(|| {
+            if Self::is_const(arg) {
+                let val = self.const_val(arg).unwrap_or(0);
+                IndexVar::new_const(arg, val)
+            } else {
+                IndexVar::new(arg)
+            }
+        })
     }
 
     /// dependency.py:896-920: operation_INT_ADD / operation_INT_SUB.

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -510,11 +510,8 @@ impl GuardStrengthenOpt {
         // Determine the strengthening interactions before mutating `self.guards`
         // (we can't hold &mut on self.strongest_guards while passing &mut guards).
         let mut updates: Vec<(usize, Option<Guard>)> = Vec::new();
-        let mut new_strongest: Vec<Guard> = self
-            .strongest_guards
-            .get(&key)
-            .cloned()
-            .unwrap_or_default();
+        let mut new_strongest: Vec<Guard> =
+            self.strongest_guards.get(&key).cloned().unwrap_or_default();
         let mut replaced = false;
         for slot in new_strongest.iter_mut() {
             if guard.implies(slot, None) {

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -849,8 +849,9 @@ impl OptGuard {
                 // guard.py: record the known class for subsumption checks.
                 if op.num_args() >= 2 {
                     if let Some(class_val) = ctx.get_constant_int(op.arg(1)) {
-                        self.known_classes
-                            .insert(op.arg(0), majit_ir::GcRef(class_val as usize));
+                        let val = majit_ir::GcRef(class_val as usize);
+                        let key = op.arg(0);
+                        self.known_classes.insert(key, val);
                     }
                 }
             }
@@ -869,14 +870,14 @@ impl OptGuard {
                 if self.truthy_values.contains(&op.arg(0)) {
                     return true;
                 }
-                if let Some(&c) = self.known_constants.get(&op.arg(0)) {
+                if let Some(c) = self.known_constants.get(&op.arg(0)).copied() {
                     return c != 0;
                 }
                 false
             }
             OpCode::GuardFalse => {
                 // Subsumed if value is a known zero constant.
-                if let Some(&c) = self.known_constants.get(&op.arg(0)) {
+                if let Some(c) = self.known_constants.get(&op.arg(0)).copied() {
                     return c == 0;
                 }
                 false
@@ -889,7 +890,7 @@ impl OptGuard {
             // rewrite.py: optimize_GUARD_CLASS — if the class is already
             // known for this value, and it matches, remove the guard.
             OpCode::GuardClass if op.num_args() >= 2 => {
-                if let Some(&known_class) = self.known_classes.get(&op.arg(0)) {
+                if let Some(known_class) = self.known_classes.get(&op.arg(0)).copied() {
                     if let Some(expected) = ctx.get_constant_int(op.arg(1)) {
                         return known_class.0 as i64 == expected;
                     }
@@ -908,7 +909,7 @@ impl OptGuard {
             // guard.py: GUARD_VALUE subsumed if value is already known to be
             // that exact constant from a previous GuardValue.
             OpCode::GuardValue if op.num_args() >= 2 => {
-                if let Some(&known) = self.known_constants.get(&op.arg(0)) {
+                if let Some(known) = self.known_constants.get(&op.arg(0)).copied() {
                     if let Some(expected) = ctx.get_constant_int(op.arg(1)) {
                         return known == expected;
                     }
@@ -927,7 +928,7 @@ impl OptGuard {
                     return false;
                 }
                 // Check class via guard pass state
-                if let Some(&known_class) = self.known_classes.get(&op.arg(0)) {
+                if let Some(known_class) = self.known_classes.get(&op.arg(0)).copied() {
                     if let Some(expected) = ctx.get_constant_int(op.arg(1)) {
                         return known_class.0 as i64 == expected;
                     }

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -507,31 +507,45 @@ impl GuardStrengthenOpt {
         if key.is_none() {
             return;
         }
-        let others = self.strongest_guards.entry_or_insert_with(key, Vec::new);
-        if !others.is_empty() {
-            let mut replaced = false;
-            for i in 0..others.len() {
-                if guard.implies(&others[i], None) {
-                    // guard.py:204-210: strengthened
-                    let old = others[i].clone();
-                    self.guards.insert(guard.index, None); // mark new as 'do not emit'
-                    let mut new_guard = guard.clone();
-                    new_guard.inhert_attributes(&old);
-                    self.guards.insert(old.index, Some(new_guard.clone()));
-                    others[i] = new_guard;
-                    replaced = true;
-                } else if others[i].implies(&guard, None) {
-                    // guard.py:211-215: implied
-                    self.guards.insert(guard.index, None);
-                    replaced = true;
-                }
+        // Determine the strengthening interactions before mutating `self.guards`
+        // (we can't hold &mut on self.strongest_guards while passing &mut guards).
+        let mut updates: Vec<(usize, Option<Guard>)> = Vec::new();
+        let mut new_strongest: Vec<Guard> = self
+            .strongest_guards
+            .get(&key)
+            .cloned()
+            .unwrap_or_default();
+        let mut replaced = false;
+        for slot in new_strongest.iter_mut() {
+            if guard.implies(slot, None) {
+                // guard.py:204-210: strengthened
+                updates.push((guard.index, None));
+                let mut new_guard = guard.clone();
+                new_guard.inhert_attributes(slot);
+                updates.push((slot.index, Some(new_guard.clone())));
+                *slot = new_guard;
+                replaced = true;
+            } else if slot.implies(&guard, None) {
+                // guard.py:211-215: implied
+                updates.push((guard.index, None));
+                replaced = true;
             }
-            if !replaced {
-                others.push(guard);
-            }
-        } else {
-            others.push(guard);
         }
+        if !replaced {
+            new_strongest.push(guard);
+        }
+        self.strongest_guards.insert(key, new_strongest);
+        for (idx, val) in updates {
+            Self::set_guard(&mut self.guards, idx, val);
+        }
+    }
+
+    fn set_guard(
+        guards: &mut crate::optimizeopt::vec_assoc::VecAssoc<usize, Option<Guard>>,
+        idx: usize,
+        val: Option<Guard>,
+    ) {
+        guards.insert(idx, val);
     }
 
     /// guard.py:221-249: eliminate_guards(loop)

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -621,6 +621,23 @@ impl ArrayCacheSubMap {
         }
     }
 
+    fn const_get(&self, index: i64) -> Option<&ArrayCachedItem> {
+        self.const_indexes.get(&index)
+    }
+
+    fn const_get_mut(&mut self, index: i64) -> Option<&mut ArrayCachedItem> {
+        self.const_indexes.get_mut(&index)
+    }
+
+    fn const_keys(&self) -> Vec<i64> {
+        self.const_indexes.keys().copied().collect()
+    }
+
+    fn const_get_or_new(&mut self, index: i64) -> &mut ArrayCachedItem {
+        self.const_indexes
+            .entry_or_insert_with(index, || ArrayCachedItem::new(index))
+    }
+
     /// heap.py:305-306 clear_varindex
     fn clear_varindex(&mut self) {
         self.cached_varindex_triples = None;
@@ -668,7 +685,7 @@ impl ArrayCacheSubMap {
     /// The parent step is inlined here because Rust forbids the
     /// back-pointer that PyPy uses on `ArrayCachedItem.parent`.
     fn invalidate_index(&mut self, index: i64, ctx: &mut OptContext) {
-        if let Some(cai) = self.const_indexes.get_mut(&index) {
+        if let Some(cai) = self.const_get_mut(index) {
             cai.invalidate(ctx);
         }
         self.clear_varindex();
@@ -948,9 +965,7 @@ impl OptHeap {
     /// heap.py:409-415 arrayitem_cache(descr, index)
     /// → submap[descr].const_indexes[index] (or insert).
     fn arrayitem_cache(&mut self, descr: &DescrRef, index: i64) -> &mut ArrayCachedItem {
-        self.arrayitem_submap(&descr)
-            .const_indexes
-            .entry_or_insert_with(index, || ArrayCachedItem::new(index))
+        self.arrayitem_submap(descr).const_get_or_new(index)
     }
 
     fn get_cached_array_submap(&self, descr_idx: u32) -> Option<&ArrayCacheSubMap> {
@@ -970,7 +985,7 @@ impl OptHeap {
 
     fn invalidate_arrayitem_cache(&mut self, descr_idx: u32, index: i64, ctx: &mut OptContext) {
         if let Some(submap) = self.get_cached_array_submap_mut(descr_idx) {
-            if let Some(cai) = submap.const_indexes.get_mut(&index) {
+            if let Some(cai) = submap.const_get_mut(index) {
                 cai.invalidate(ctx);
             }
         }
@@ -985,10 +1000,7 @@ impl OptHeap {
     ) {
         let Some(descr) = descr else {
             if let Some(submap) = self.get_cached_array_submap_mut(descr_idx) {
-                submap
-                    .const_indexes
-                    .entry_or_insert_with(index, || ArrayCachedItem::new(index))
-                    .register_info(array);
+                submap.const_get_or_new(index).register_info(array);
             }
             return;
         };
@@ -1081,7 +1093,7 @@ impl OptHeap {
             .cached_arrayitems
             .iter()
             .map(|(idx, descr, submap)| {
-                let mut indexes: Vec<i64> = submap.const_indexes.keys().copied().collect();
+                let mut indexes: Vec<i64> = submap.const_keys();
                 indexes.sort();
                 (*idx, descr.clone(), indexes)
             })
@@ -1205,10 +1217,10 @@ impl OptHeap {
                 submap
                     .const_indexes
                     .iter_mut()
-                    .filter_map(move |(&index, cai)| {
+                    .filter_map(move |(index, cai)| {
                         cai.lazy_set
                             .take()
-                            .map(|(obj, op)| (*descr_idx, index, obj, op))
+                            .map(|(obj, op)| (*descr_idx, *index, obj, op))
                     })
             })
             .collect();
@@ -1290,12 +1302,12 @@ impl OptHeap {
                 continue;
             }
             let indexes: Vec<i64> = match self.get_cached_array_submap(descr_idx) {
-                Some(submap) => submap.const_indexes.keys().copied().collect(),
+                Some(submap) => submap.const_keys(),
                 None => continue,
             };
             for index in indexes {
                 if let Some(submap) = self.get_cached_array_submap_mut(descr_idx) {
-                    if let Some(cai) = submap.const_indexes.get_mut(&index) {
+                    if let Some(cai) = submap.const_get_mut(index) {
                         cai.invalidate(ctx);
                     }
                     // heap.py:266 self.parent.clear_varindex()
@@ -1329,7 +1341,7 @@ impl OptHeap {
             .collect();
         for descr_idx in descr_idxs {
             let indexes: Vec<i64> = match self.get_cached_array_submap(descr_idx) {
-                Some(submap) => submap.const_indexes.keys().copied().collect(),
+                Some(submap) => submap.const_keys(),
                 None => continue,
             };
             for index in indexes {
@@ -1342,7 +1354,7 @@ impl OptHeap {
                 }
                 if let Some(cai) = self
                     .get_cached_array_submap_mut(descr_idx)
-                    .and_then(|s| s.const_indexes.get_mut(&index))
+                    .and_then(|s| s.const_get_mut(index))
                 {
                     cai.cached_structs.retain(|obj| *obj != dest_ref);
                 }
@@ -1641,7 +1653,7 @@ impl OptHeap {
             let mut index_entries: Vec<_> = submap
                 .const_indexes
                 .iter_mut()
-                .map(|(&index, cai)| (index, cai))
+                .map(|(index, cai)| (*index, cai))
                 .collect();
             sort_array_index_entries_untranslated(&mut index_entries);
             for (index, cai) in index_entries {
@@ -1772,7 +1784,7 @@ impl OptHeap {
                 continue;
             }
             let indexes: Vec<i64> = match self.get_cached_array_submap(descr_idx) {
-                Some(submap) => submap.const_indexes.keys().copied().collect(),
+                Some(submap) => submap.const_keys(),
                 None => continue,
             };
             for index in indexes {
@@ -2024,7 +2036,7 @@ impl OptHeap {
 
         // Check quasi-immutable cache: if this field was marked by
         // QUASIIMMUT_FIELD, the value is stable (guarded by GUARD_NOT_INVALIDATED).
-        if let Some(&qi_cached) = self.quasi_immut_cache.get(&key) {
+        if let Some(qi_cached) = self.quasi_immut_cache.get(&key).copied() {
             if !qi_cached.is_none() {
                 // Subsequent read: reuse the cached value.
                 let qi_cached = ctx.get_box_replacement(qi_cached);
@@ -2238,7 +2250,7 @@ impl OptHeap {
         // heap.py:123 op = self._lazy_set
         let lazy_data = self
             .get_cached_array_submap_mut(descr_idx)
-            .and_then(|s| s.const_indexes.get_mut(&const_index))
+            .and_then(|s| s.const_get_mut(const_index))
             .and_then(|cai| cai.lazy_set.take());
         match lazy_data {
             Some((lazy_obj, mut lazy_op)) => {
@@ -2303,7 +2315,7 @@ impl OptHeap {
         //                  self.force_lazy_set(optheap, op.getdescr())
         let needs_force = self
             .get_cached_array_submap(descr_idx)
-            .and_then(|s| s.const_indexes.get(&const_index))
+            .and_then(|s| s.const_get(const_index))
             .map_or(false, |cai| cai.possible_aliasing(array));
         if needs_force {
             // heap.py:122-145 force_lazy_set(self, optheap, descr) [can_cache=True]
@@ -2445,7 +2457,7 @@ impl OptHeap {
             let mut force_lazy_arr = false;
             if let Some(cai) = self
                 .get_cached_array_submap(descr_idx)
-                .and_then(|s| s.const_indexes.get(&const_index))
+                .and_then(|s| s.const_get(const_index))
             {
                 if let Some((lazy_obj, lazy_op)) = &cai.lazy_set {
                     if *lazy_obj == array {
@@ -2519,7 +2531,7 @@ impl OptHeap {
             if force_lazy_arr {
                 let lazy_data = self
                     .get_cached_array_submap_mut(descr_idx)
-                    .and_then(|s| s.const_indexes.get_mut(&const_index))
+                    .and_then(|s| s.const_get_mut(const_index))
                     .and_then(|cai| cai.lazy_set.take());
                 if let Some((_lazy_obj, mut lazy_op)) = lazy_data {
                     if let Some(submap) = self.get_cached_array_submap_mut(descr_idx) {
@@ -2574,7 +2586,7 @@ impl OptHeap {
             }
             if let Some(cai) = self
                 .get_cached_array_submap(descr_idx)
-                .and_then(|s| s.const_indexes.get(&const_index))
+                .and_then(|s| s.const_get(const_index))
             {
                 if let Some(entry) = cai._getfield(array, &op.getdescr().unwrap(), ctx) {
                     match entry {
@@ -3062,7 +3074,8 @@ impl OptHeap {
                     }
                 }
                 if let Some(key) = cache_field_key {
-                    self.quasi_immut_cache.insert((obj, key), OpRef::NONE);
+                    let full_key = (obj, key);
+                    self.quasi_immut_cache.insert(full_key, OpRef::NONE);
                 }
                 OptimizationResult::Remove
             }
@@ -3279,7 +3292,7 @@ impl Optimization for OptHeap {
         //         for index, d in submap.const_indexes.items():
         //             d.produce_potential_short_preamble_ops(self.optimizer, sb, descr, index)
         for (_, descr, submap) in &self.cached_arrayitems {
-            for cai in submap.const_indexes.values() {
+            for (_, cai) in &submap.const_indexes {
                 cai.produce_potential_short_preamble_ops(sb, &descr, ctx);
             }
         }
@@ -4310,7 +4323,7 @@ mod tests {
         // _lazy_set holds the pending op; PtrInfo is NOT yet written.
         let cai = pass
             .get_cached_array_submap(d.index())
-            .and_then(|s| s.const_indexes.get(&3))
+            .and_then(|s| s.const_get(3))
             .expect("ArrayCachedItem must exist");
         assert!(
             cai.lazy_set.is_some(),

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1452,7 +1452,7 @@ impl OptHeap {
             DictArgKey::from_arg(op.arg(2), ctx),
         ];
 
-        if let Some(&res_v) = d.get(&key) {
+        if let Some(res_v) = d.get(&key).copied() {
             // heap.py:523-525: flag != FLAG_LOOKUP → self.getintbound(res_v).known_ge_const(0)
             if flag != FLAG_LOOKUP {
                 let known_ge_zero = ctx
@@ -1761,7 +1761,8 @@ impl OptHeap {
                 self.force_lazy_set_field(&descr, false, ctx);
                 // heap.py:547-552 del self.cached_dict_reads[fielddescr]
                 if !descr.is_always_pure() {
-                    self.cached_dict_reads.remove(&descr_identity(&descr));
+                    let did = descr_identity(&descr);
+                    self.cached_dict_reads.remove(&did);
                 }
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4650,6 +4650,33 @@ impl OptContext {
         self.get_constant(opref).is_some()
     }
 
+    /// `history.py:204-205 Const.same_box → same_constant` — value-aware
+    /// `same_box(query, stored)`. Walks both operands through
+    /// `get_box_replacement` first (`resoperation.py:58`), then compares:
+    ///   1. Identity (`OpRef ==`) — matches PyPy `AbstractValue.same_box`
+    ///      for the non-Const fast path.
+    ///   2. Value equality via `get_constant` for both sides — matches
+    ///      PyPy `Const.same_box` overload which delegates to
+    ///      `same_constant`. Two distinct ConstInt slots holding the same
+    ///      `Value::Int(42)` are `same_box == true`.
+    ///
+    /// Extracted from the previous `lookup_pure` closure + the inline body
+    /// of `_same_args` in `optimizeopt/pure.rs`. Future Phase A.3 inline-
+    /// storage work for `OpRef` will let this method shed the `&self`
+    /// parameter for Const-Const cases; until then callers route through
+    /// `OptContext` to reach the constant pool.
+    pub fn same_box(&self, query: OpRef, stored: OpRef) -> bool {
+        let query = self.get_box_replacement(query);
+        let stored = self.get_box_replacement(stored);
+        if query == stored {
+            return true;
+        }
+        match (self.get_constant(query), self.get_constant(stored)) {
+            (Some(a), Some(b)) => a == b,
+            _ => false,
+        }
+    }
+
     /// Get constant integer value, if known.
     pub fn get_constant_int(&self, opref: OpRef) -> Option<i64> {
         self.get_constant(opref).and_then(|v| match v {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -766,9 +766,10 @@ impl Optimizer {
         let mut installed_heads: majit_ir::vec_set::VecSet<OpRef> =
             majit_ir::vec_set::VecSet::new();
         for entry in entries {
-            if !installed_heads.insert(entry.head) {
+            if installed_heads.contains(&entry.head) {
                 continue;
             }
+            installed_heads.insert(entry.head);
             if std::env::var_os("MAJIT_LOG").is_some() {
                 eprintln!(
                     "[jit] install_imported_virtual head={:?} fields={:?}",

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1588,9 +1588,10 @@ impl Optimizer {
                 | crate::optimizeopt::info::PtrInfo::VirtualArray(_)
                 | crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(_)
         ) {
-            if !rec.insert(resolved) {
+            if rec.contains(&resolved) {
                 return resolved;
             }
+            rec.insert(resolved);
             info.force_at_the_end_of_preamble(|child| {
                 self.force_at_the_end_of_preamble_rec(child, ctx, rec)
             });

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -616,7 +616,7 @@ impl Optimizer {
         // Non-virtual states advance label_slot without creating entries.
         // Virtual states create entries with fields from label_args.
         // Build a map from inputarg_index to imported_virtual for virtual lookup.
-        let mut iv_map: crate::optimizeopt::vec_assoc::VecAssoc<usize, &_> =
+        let mut iv_map: crate::optimizeopt::vec_assoc::VecAssoc<usize, &ImportedVirtual> =
             crate::optimizeopt::vec_assoc::VecAssoc::new();
         for iv in &self.imported_virtuals {
             iv_map.insert(iv.inputarg_index, iv);
@@ -636,7 +636,7 @@ impl Optimizer {
         let mut walk_visited: crate::optimizeopt::vec_assoc::VecAssoc<usize, OpRef> =
             crate::optimizeopt::vec_assoc::VecAssoc::new();
         for (state_idx, state_info) in all_states.iter().enumerate() {
-            if let Some(iv) = iv_map.get(&state_idx) {
+            if let Some(iv) = iv_map.get(&state_idx).copied() {
                 // Virtual state: process fields recursively, consuming slots
                 // for non-virtual leaf fields.
                 //

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -419,25 +419,11 @@ impl OptPure {
     /// (history.py:204-205): two distinct ConstInt slots with the same
     /// value are `same_box` true even though `OpRef ==` is false.
     fn lookup_pure(&self, key: &PureOpKey, ctx: &OptContext) -> Option<OpRef> {
-        let same_box = |query: OpRef, stored: OpRef| -> bool {
-            // pure.py:62 / :72-73 — both the currently looked-up op arg
-            // and the stored pure-op arg are walked through forwarding
-            // before same_box comparison.
-            let query = ctx.get_box_replacement(query);
-            let stored = ctx.get_box_replacement(stored);
-            if query == stored {
-                return true;
-            }
-            // history.py:204-205 Const.same_box → same_constant.
-            // OptContext::get_constant covers both namespaces:
-            // CONST_BIT (constant pool) and op-namespace make_constant.
-            // Identical constant values
-            // count as same_box even when their OpRef slots differ.
-            match (ctx.get_constant(query), ctx.get_constant(stored)) {
-                (Some(a), Some(b)) => a == b,
-                _ => false,
-            }
-        };
+        // pure.py:62 / :72-73 — `box.same_box(get_box_replacement(other))`
+        // routes through `OptContext::same_box`, which walks both sides
+        // through `get_box_replacement` and dispatches Const value equality
+        // for the `history.py:204-205 Const.same_box → same_constant` overload.
+        let same_box = |query: OpRef, stored: OpRef| -> bool { ctx.same_box(query, stored) };
         // pure.py:88-93 — `commutative` is forwarded into `lookup2`,
         // which checks both `(arg0, arg1)` and `(arg1, arg0)` orderings.
         let commutative = Self::is_commutative(key.opcode);
@@ -741,17 +727,11 @@ impl OptPure {
         }
         let mut j = start_index2;
         for i in start_index1..op1_args.len() {
-            let a = ctx.get_box_replacement(op1_args[i]);
-            let b = ctx.get_box_replacement(op2_args[j]);
-            if a == b {
-                j += 1;
-                continue;
-            }
-            // Const same_box semantics: matching constant values are equal
-            // even when their OpRefs differ.
-            match (ctx.get_constant(a), ctx.get_constant(b)) {
-                (Some(va), Some(vb)) if va == vb => {}
-                _ => return false,
+            // pure.py:240-247 — same_box(op1_args[i], op2_args[j])
+            // applies `get_box_replacement` to both sides, then dispatches
+            // identity vs Const value equality (`history.py:204-205`).
+            if !ctx.same_box(op1_args[i], op2_args[j]) {
+                return false;
             }
             j += 1;
         }

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -840,7 +840,10 @@ impl OptPure {
             };
             arg_consts.push(const_value);
         }
-        self.call_pure_results.get(&arg_consts).cloned()
+        self.call_pure_results
+            .iter()
+            .find(|(k, _)| k.as_slice() == arg_consts.as_slice())
+            .map(|(_, v)| v.clone())
     }
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -571,24 +571,13 @@ impl OptPure {
             }
             // pure.py:62 lookup1: `box0.same_box(get_box_replacement(op.getarg(0)))`.
             // Both stored and query are walked through the forwarding chain
-            // (the caller already walks the query at lookup; the stored arg
-            // is walked here line-by-line per pure.py:62, :72-73).
-            let args_match =
-                entry
-                    .args
-                    .iter()
-                    .zip(op.getarglist().iter())
-                    .all(|(&stored, &query)| {
-                        let s = ctx.get_box_replacement(stored);
-                        let q = ctx.get_box_replacement(query);
-                        if s == q {
-                            return true;
-                        }
-                        matches!(
-                            (ctx.get_constant(s), ctx.get_constant(q)),
-                            (Some(a), Some(b)) if a == b
-                        )
-                    });
+            // via `OptContext::same_box` (pure.py:62, :72-73 +
+            // history.py:204-205 Const.same_box → same_constant).
+            let args_match = entry
+                .args
+                .iter()
+                .zip(op.getarglist().iter())
+                .all(|(&stored, &query)| ctx.same_box(stored, query));
             if args_match {
                 // pure.py:50-55: force_preamble_op — isinstance check → force → replace
                 if let Some(result) = entry.forced_result {

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -19,10 +19,14 @@ impl Renamer {
         }
     }
 
+    fn lookup(&self, opref: OpRef) -> Option<OpRef> {
+        self.rename_map.get(&opref).copied()
+    }
+
     /// renamer.py:7-8: rename_box — look up the renamed OpRef.
     /// Returns the original if no mapping exists.
     pub fn rename_box(&self, opref: OpRef) -> OpRef {
-        self.rename_map.get(&opref).copied().unwrap_or(opref)
+        self.lookup(opref).unwrap_or(opref)
     }
 
     /// renamer.py:10-18: start_renaming — register a mapping from var to tovar.
@@ -53,7 +57,7 @@ impl Renamer {
             if let Some(fail_args) = op.fail_args_mut() {
                 let cloned: Vec<OpRef> = fail_args
                     .iter()
-                    .map(|arg| self.rename_map.get(arg).copied().unwrap_or(*arg))
+                    .map(|arg| self.lookup(*arg).unwrap_or(*arg))
                     .collect();
                 fail_args.clear();
                 fail_args.extend(cloned);
@@ -67,7 +71,7 @@ impl Renamer {
     pub fn rename_failargs(&self, fail_args: &[OpRef]) -> Vec<OpRef> {
         fail_args
             .iter()
-            .map(|arg| self.rename_map.get(arg).copied().unwrap_or(*arg))
+            .map(|arg| self.lookup(*arg).unwrap_or(*arg))
             .collect()
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -2448,7 +2448,7 @@ impl OptRewrite {
         ctx: &mut OptContext,
     ) -> Option<OptimizationResult> {
         let key = (inverse_opcode, arg0, arg1);
-        let &cached_ref = self.bool_result_cache.get(&key)?;
+        let cached_ref = self.bool_result_cache.get(&key).copied()?;
         // rewrite.py:60-65: b = self.getintbound(oldop)
         // First try direct constant (fast path)
         if let Some(val) = ctx.get_constant_int(cached_ref) {
@@ -3190,7 +3190,11 @@ impl Optimization for OptRewrite {
                         .iter()
                         .find(|(k, _)| *k == func_val)
                     {
-                        if !self.loop_invariant_results.contains_key(&func_val) {
+                        if !self
+                            .loop_invariant_results
+                            .iter()
+                            .any(|(k, _)| *k == func_val)
+                        {
                             // RPython shortpreamble.py:158-159. Cat-2.2 dual-slot:
                             // `produce_loop_invariant` installs
                             // `make_equal_to(source, result_opref)`, so the source
@@ -3447,7 +3451,7 @@ impl Optimization for OptRewrite {
         sb: &mut crate::optimizeopt::shortpreamble::ShortBoxes,
         _ctx: &mut OptContext,
     ) {
-        for op in self.loop_invariant_producer.values() {
+        for (_, op) in &self.loop_invariant_producer {
             sb.add_loopinvariant_op(op.clone());
         }
     }
@@ -3456,9 +3460,9 @@ impl Optimization for OptRewrite {
     fn serialize_optrewrite(&self) -> Vec<(i64, OpRef)> {
         self.loop_invariant_results
             .iter()
-            .filter_map(|(&func_ptr, entry)| match entry {
-                LoopInvariantEntry::Direct(r) => Some((func_ptr, *r)),
-                LoopInvariantEntry::Preamble(pop) => Some((func_ptr, pop.op)),
+            .filter_map(|(func_ptr, entry)| match entry {
+                LoopInvariantEntry::Direct(r) => Some((*func_ptr, *r)),
+                LoopInvariantEntry::Preamble(pop) => Some((*func_ptr, pop.op)),
             })
             .collect()
     }

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -1185,14 +1185,16 @@ impl VecScheduleState {
             // schedule.py:617-618: filter by index match AND possible.get(vecop, True)
             let candidates: Vec<OpRef> = expansions
                 .iter()
-                .filter(|&&(vecop, idx)| idx == i as i32 && *possible.get(&vecop).unwrap_or(&true))
+                .filter(|&&(vecop, idx)| {
+                    idx == i as i32
+                        && possible.get(&vecop).copied().unwrap_or(true)
+                })
                 .map(|&(vecop, _)| vecop)
                 .collect();
             // schedule.py:620-623: invalidate vecops NOT in this position's candidates
-            let keys: Vec<OpRef> = possible.keys().cloned().collect();
-            for key in keys {
-                if !candidates.contains(&key) {
-                    possible.insert(key, false);
+            for (k, v) in possible.iter_mut() {
+                if !candidates.contains(k) {
+                    *v = false;
                 }
             }
             // schedule.py:625: mark surviving candidates as valid

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -1186,8 +1186,7 @@ impl VecScheduleState {
             let candidates: Vec<OpRef> = expansions
                 .iter()
                 .filter(|&&(vecop, idx)| {
-                    idx == i as i32
-                        && possible.get(&vecop).copied().unwrap_or(true)
+                    idx == i as i32 && possible.get(&vecop).copied().unwrap_or(true)
                 })
                 .map(|&(vecop, _)| vecop)
                 .collect();

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1791,11 +1791,9 @@ impl AbstractShortPreambleBuilderState {
             // In RPython, Box identity makes this lookup trivial. In majit,
             // produce_arg returns preamble_op.pos which may differ from the
             // produced_short_boxes key.
-            let dep = all_produced.get(&arg).or_else(|| {
-                pos_to_key
-                    .get(&arg)
-                    .and_then(|key| all_produced.get(key))
-            });
+            let dep = all_produced
+                .get(&arg)
+                .or_else(|| pos_to_key.get(&arg).and_then(|key| all_produced.get(key)));
             if let Some(dep) = dep {
                 let dep_canonical = dep.preamble_op.pos.get();
                 if !self.short_results.contains(&dep_canonical)
@@ -2208,8 +2206,7 @@ impl ExtendedShortPreambleBuilder {
                 if let Some(&phase1_ref) = entry.op.getarglist().get(arg_pos) {
                     if let Some(&current_inputarg) = label_args.get(label_idx) {
                         if phase1_ref != current_inputarg {
-                            self.phase1_to_inputarg
-                                .insert(phase1_ref, current_inputarg);
+                            self.phase1_to_inputarg.insert(phase1_ref, current_inputarg);
                         }
                     }
                 }
@@ -2304,15 +2301,11 @@ impl ExtendedShortPreambleBuilder {
         // RPython uses Box identity; pyre needs both direct lookup and the
         // reverse `preamble_op.pos → key` lookup because produce_arg may
         // return a `.pos` distinct from the original key.
-        let dep = self
-            .produced_short_boxes
-            .get(&arg)
-            .cloned()
-            .or_else(|| {
-                pos_to_key
-                    .get(&arg)
-                    .and_then(|key| self.produced_short_boxes.get(key).cloned())
-            });
+        let dep = self.produced_short_boxes.get(&arg).cloned().or_else(|| {
+            pos_to_key
+                .get(&arg)
+                .and_then(|key| self.produced_short_boxes.get(key).cloned())
+        });
         let Some(dep) = dep else {
             return false;
         };
@@ -2392,7 +2385,11 @@ impl ExtendedShortPreambleBuilder {
         preamble_op: &crate::optimizeopt::info::PreambleOp,
         resolved_op: OpRef,
     ) {
-        let lookup_key = if self.produced_short_boxes.iter().any(|(k, _)| *k == resolved_op) {
+        let lookup_key = if self
+            .produced_short_boxes
+            .iter()
+            .any(|(k, _)| *k == resolved_op)
+        {
             resolved_op
         } else {
             preamble_op.op

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2206,7 +2206,8 @@ impl ExtendedShortPreambleBuilder {
                 if let Some(&phase1_ref) = entry.op.getarglist().get(arg_pos) {
                     if let Some(&current_inputarg) = label_args.get(label_idx) {
                         if phase1_ref != current_inputarg {
-                            self.phase1_to_inputarg.insert(phase1_ref, current_inputarg);
+                            self.phase1_to_inputarg
+                                .insert(phase1_ref, current_inputarg);
                         }
                     }
                 }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -454,7 +454,9 @@ pub struct ShortBoxes {
     known_constants: VecSet<OpRef>,
     /// shortpreamble.py: short_inputargs
     short_inputargs: Vec<OpRef>,
-    /// shortpreamble.py: boxes_in_production
+    /// shortpreamble.py: boxes_in_production — cycle-detection set
+    /// for `materialize_one` recursion. Active set is bounded by
+    /// recursion depth (linear scan suffices).
     boxes_in_production: VecSet<OpRef>,
     /// The number of label args.
     pub num_label_args: usize,
@@ -651,7 +653,7 @@ impl ShortBoxes {
         if let Some(existing) = self.produced_short_boxes.get(&opref) {
             return Some(existing.preamble_op.pos.get());
         }
-        if self.boxes_in_production.contains(&opref) {
+        if self.boxes_in_production.iter().any(|x| *x == opref) {
             return None;
         }
         if self.known_constants.contains(&opref) {
@@ -701,7 +703,7 @@ impl ShortBoxes {
         if let Some(existing) = self.produced_short_boxes.get(&result) {
             return Some(existing.clone());
         }
-        if self.boxes_in_production.contains(&result) {
+        if self.boxes_in_production.iter().any(|x| *x == result) {
             return None;
         }
         let candidate = self.potential_ops.get(&result)?.clone();

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -548,7 +548,7 @@ impl ShortBoxes {
     pub fn is_reachable(&self, opref: OpRef) -> bool {
         self.short_inputargs.contains(&opref)
             || self.known_constants.contains(&opref)
-            || self.potential_ops.contains_key(&opref)
+            || self.potential_ops.iter().any(|(k, _)| *k == opref)
     }
 
     pub fn note_known_constant(&mut self, opref: OpRef) {
@@ -662,7 +662,7 @@ impl ShortBoxes {
         if self.known_constants.contains(&opref) {
             return Some(opref);
         }
-        if self.potential_ops.contains_key(&opref) {
+        if self.potential_ops.iter().any(|(k, _)| *k == opref) {
             return self
                 .materialize_one(ctx, opref)
                 .map(|produced| produced.preamble_op.pos.get());

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1791,9 +1791,11 @@ impl AbstractShortPreambleBuilderState {
             // In RPython, Box identity makes this lookup trivial. In majit,
             // produce_arg returns preamble_op.pos which may differ from the
             // produced_short_boxes key.
-            let dep = all_produced
-                .get(&arg)
-                .or_else(|| pos_to_key.get(&arg).and_then(|key| all_produced.get(key)));
+            let dep = all_produced.get(&arg).or_else(|| {
+                pos_to_key
+                    .get(&arg)
+                    .and_then(|key| all_produced.get(key))
+            });
             if let Some(dep) = dep {
                 let dep_canonical = dep.preamble_op.pos.get();
                 if !self.short_results.contains(&dep_canonical)
@@ -1987,7 +1989,7 @@ impl ShortPreambleBuilder {
             if self.state.known_constants.contains(&arg) {
                 continue;
             }
-            if self.produced_short_boxes.contains_key(&arg) {
+            if self.produced_short_boxes.iter().any(|(k, _)| *k == arg) {
                 let _ = self.use_box_recursive(arg, visiting);
             }
         }
@@ -2302,11 +2304,15 @@ impl ExtendedShortPreambleBuilder {
         // RPython uses Box identity; pyre needs both direct lookup and the
         // reverse `preamble_op.pos → key` lookup because produce_arg may
         // return a `.pos` distinct from the original key.
-        let dep = self.produced_short_boxes.get(&arg).cloned().or_else(|| {
-            pos_to_key
-                .get(&arg)
-                .and_then(|key| self.produced_short_boxes.get(key).cloned())
-        });
+        let dep = self
+            .produced_short_boxes
+            .get(&arg)
+            .cloned()
+            .or_else(|| {
+                pos_to_key
+                    .get(&arg)
+                    .and_then(|key| self.produced_short_boxes.get(key).cloned())
+            });
         let Some(dep) = dep else {
             return false;
         };
@@ -2352,7 +2358,7 @@ impl ExtendedShortPreambleBuilder {
             if self.known_constants.contains(&arg) {
                 continue;
             }
-            if self.produced_short_boxes.contains_key(&arg) {
+            if self.produced_short_boxes.iter().any(|(k, _)| *k == arg) {
                 let _ = self.use_box_recursive(arg, visiting);
             }
         }
@@ -2386,7 +2392,7 @@ impl ExtendedShortPreambleBuilder {
         preamble_op: &crate::optimizeopt::info::PreambleOp,
         resolved_op: OpRef,
     ) {
-        let lookup_key = if self.produced_short_boxes.contains_key(&resolved_op) {
+        let lookup_key = if self.produced_short_boxes.iter().any(|(k, _)| *k == resolved_op) {
             resolved_op
         } else {
             preamble_op.op

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -203,8 +203,10 @@ impl ShortPreamble {
 pub struct CollectedShortPreambleBuilder {
     /// Raw ops collected during the preamble phase (before Label).
     raw_ops: Vec<Op>,
-    /// Label args carried across the Label (set when Label is found).
-    /// The index into this Vec is the label arg index.
+    /// shortpreamble.py:414 `ShortPreambleBuilder.label_args` — the
+    /// OpRefs that the Label carries. Index in this list IS the label
+    /// arg index. Lookup uses linear scan (label_args is small —
+    /// bounded by loop-carried value count).
     label_args: Vec<OpRef>,
     /// Whether the builder is still collecting (before Label).
     active: bool,
@@ -224,7 +226,8 @@ impl CollectedShortPreambleBuilder {
     /// Called when the Label is encountered. `label_args` are the OpRefs
     /// that the Label carries (= the loop-carried values from the preamble).
     pub fn set_label_args(&mut self, label_args: &[OpRef]) {
-        self.label_args = label_args.to_vec();
+        self.label_args.clear();
+        self.label_args.extend_from_slice(label_args);
         self.active = false; // Switch from preamble to body phase
     }
 
@@ -879,8 +882,9 @@ pub struct CollectedExtendedShortPreambleBuilder {
     pure_ops: Vec<PreambleOp>,
     /// Loop-invariant calls from the preamble.
     loopinvariant_ops: Vec<PreambleOp>,
-    /// Label args carried across the Label. Index into this Vec is the label
-    /// arg index.
+    /// shortpreamble.py:414 `ShortPreambleBuilder.label_args` — the
+    /// OpRefs that the Label carries. Index in this list IS the label
+    /// arg index. Lookup uses linear scan (label_args is small).
     label_args: Vec<OpRef>,
 }
 
@@ -897,7 +901,8 @@ impl CollectedExtendedShortPreambleBuilder {
 
     /// Set the label args mapping.
     pub fn set_label_args(&mut self, label_args: &[OpRef]) {
-        self.label_args = label_args.to_vec();
+        self.label_args.clear();
+        self.label_args.extend_from_slice(label_args);
     }
 
     fn lookup_label_arg(&self, opref: OpRef) -> Option<usize> {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1052,9 +1052,10 @@ impl UnrollOptimizer {
                             if !is_trace_runtime_ref(arg, &consts_p2) {
                                 continue;
                             }
-                            if !visited_force.insert(arg) {
+                            if visited_force.contains(&arg) {
                                 continue;
                             }
+                            visited_force.insert(arg);
                             let resolved = final_ctx.get_box_replacement(arg);
                             let needs_force = final_ctx
                                 .potential_extra_ops
@@ -1174,7 +1175,7 @@ impl UnrollOptimizer {
             // when two virtuals share the same OpRef. Allocate fresh
             // OpRefs for duplicates so the LABEL carries independent slots.
             {
-                let mut seen_used = majit_ir::vec_set::VecSet::new();
+                let mut seen_used: majit_ir::vec_set::VecSet<OpRef> = majit_ir::vec_set::VecSet::new();
                 let mut next_fresh = current_label_args
                     .iter()
                     .chain(initial_sp.used_boxes.iter())
@@ -1184,7 +1185,8 @@ impl UnrollOptimizer {
                     .saturating_add(1)
                     .max(body_num_inputs as u32 + 100);
                 for &ub in &initial_sp.used_boxes {
-                    if seen_used.insert(ub) {
+                    if !seen_used.contains(&ub) {
+                        seen_used.insert(ub);
                         current_label_args.push(ub);
                     } else {
                         // shortpreamble.py:343-350 inputarg_from_tp parity:

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3505,7 +3505,7 @@ impl OptUnroll {
         current_short_jump_args(short_preamble, ctx)
             .iter()
             .map(|&jump_arg| {
-                let mapped = *mapping.get(&jump_arg).unwrap_or(&jump_arg);
+                let mapped = mapping.get(&jump_arg).copied().unwrap_or(jump_arg);
                 ctx.get_box_replacement(mapped)
             })
             .collect()

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3391,7 +3391,9 @@ impl OptUnroll {
                     // only (ConstInt/ConstPtr/ConstFloat). make_constant'd values
                     // are NOT Const objects — they are regular boxes with forwarded
                     // set to a Const, so they must go through the mapping.
-                    if arg.is_constant() || short_preamble.constants.contains_key(&arg.raw()) {
+                    if arg.is_constant()
+                        || short_preamble.constants.iter().any(|(k, _)| *k == arg.raw())
+                    {
                         continue;
                     }
                     // unroll.py:404: _map_args — non-Const must be in mapping.
@@ -3470,7 +3472,10 @@ impl OptUnroll {
                 let mapped_jump_args: Vec<OpRef> = short_jump_args
                     .iter()
                     .map(|jump_arg| {
-                        let mapped = if short_preamble.constants.contains_key(&jump_arg.raw())
+                        let mapped = if short_preamble
+                            .constants
+                            .iter()
+                            .any(|(k, _)| *k == jump_arg.raw())
                             || jump_arg.is_constant()
                         {
                             *jump_arg

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4897,7 +4897,9 @@ fn remap_snapshot_boxes(
 ) -> Vec<SnapshotBox> {
     boxes
         .iter()
-        .map(|&boxref| boxref.map_opref(|opref| ref_map.get(&opref).copied().unwrap_or(opref)))
+        .map(|&boxref| {
+            boxref.map_opref(|opref| ref_map.get(&opref).copied().unwrap_or(opref))
+        })
         .collect()
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1175,7 +1175,8 @@ impl UnrollOptimizer {
             // when two virtuals share the same OpRef. Allocate fresh
             // OpRefs for duplicates so the LABEL carries independent slots.
             {
-                let mut seen_used: majit_ir::vec_set::VecSet<OpRef> = majit_ir::vec_set::VecSet::new();
+                let mut seen_used: majit_ir::vec_set::VecSet<OpRef> =
+                    majit_ir::vec_set::VecSet::new();
                 let mut next_fresh = current_label_args
                     .iter()
                     .chain(initial_sp.used_boxes.iter())
@@ -3392,7 +3393,10 @@ impl OptUnroll {
                     // are NOT Const objects — they are regular boxes with forwarded
                     // set to a Const, so they must go through the mapping.
                     if arg.is_constant()
-                        || short_preamble.constants.iter().any(|(k, _)| *k == arg.raw())
+                        || short_preamble
+                            .constants
+                            .iter()
+                            .any(|(k, _)| *k == arg.raw())
                     {
                         continue;
                     }
@@ -4897,9 +4901,7 @@ fn remap_snapshot_boxes(
 ) -> Vec<SnapshotBox> {
     boxes
         .iter()
-        .map(|&boxref| {
-            boxref.map_opref(|opref| ref_map.get(&opref).copied().unwrap_or(opref))
-        })
+        .map(|&boxref| boxref.map_opref(|opref| ref_map.get(&opref).copied().unwrap_or(opref)))
         .collect()
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -135,7 +135,8 @@ impl VectorLoop {
             // Map label args → jump args (or remapped jump args)
             for (i, la) in label_args.iter().enumerate() {
                 if i < jump_args.len() {
-                    let ja = *remap.get(&jump_args[i]).unwrap_or(&jump_args[i]);
+                    let key = jump_args[i];
+                    let ja = remap.get(&key).copied().unwrap_or(key);
                     if *la != ja {
                         remap.insert(*la, ja);
                     }
@@ -713,11 +714,12 @@ impl VectorizingOptimizer {
         }
 
         // Build node→pack mapping
-        let mut node_to_pack: crate::optimizeopt::vec_assoc::VecAssoc<usize, usize> =
-            crate::optimizeopt::vec_assoc::VecAssoc::new();
+        let mut node_to_pack: Vec<Option<usize>> = vec![None; self.body_ops.len()];
         for (pi, group) in profitable.iter().enumerate() {
             for &idx in &group.members {
-                node_to_pack.insert(idx, pi);
+                if idx < node_to_pack.len() {
+                    node_to_pack[idx] = Some(pi);
+                }
             }
         }
 
@@ -728,7 +730,7 @@ impl VectorizingOptimizer {
         // Walk in scheduled (dependency) order
         let scheduled_order = schedule_operations(&dep_graph);
         for &node_idx in &scheduled_order {
-            if let Some(&pack_idx) = node_to_pack.get(&node_idx) {
+            if let Some(pack_idx) = node_to_pack.get(node_idx).copied().flatten() {
                 // schedule.py:683-695: delay() gating.
                 pack_visited_count[pack_idx] += 1;
                 let pack = &profitable[pack_idx];

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -282,7 +282,7 @@ fn ensure_args_unpacked(state: &mut VecScheduleState, op: &mut Op, seen: &mut Ve
             if state.invariant_vector_vars.contains(&vec_ref) {
                 continue; // schedule.py:723-724: invariant_vector_vars
             }
-            if state.accumulation.contains_key(&arg) {
+            if state.accumulation.iter().any(|(k, _)| *k == arg) {
                 continue; // schedule.py:725-726
             }
             let unpacked = unpack_from_vector(state, vec_ref, pos, 1);
@@ -299,7 +299,7 @@ fn ensure_args_unpacked(state: &mut VecScheduleState, op: &mut Op, seen: &mut Ve
                     continue;
                 }
                 if let Some((pos, vec_ref)) = state.getvector_of_box(*arg) {
-                    if state.accumulation.contains_key(arg) {
+                    if state.accumulation.iter().any(|(k, _)| *k == *arg) {
                         continue;
                     }
                     let unpacked = unpack_from_vector(state, vec_ref, pos, 1);

--- a/majit/majit-metainterp/src/optimizeopt/version.rs
+++ b/majit/majit-metainterp/src/optimizeopt/version.rs
@@ -64,9 +64,9 @@ impl LoopVersionInfo {
 
     /// version.py:38-42: remove(descr)
     pub fn remove(&mut self, fail_index: u32) {
-        if self.leads_to.remove(&fail_index).is_none() {
-            panic!("version.py:42 could not remove fail_index={}", fail_index);
-        }
+        self.leads_to.remove(&fail_index).unwrap_or_else(|| {
+            panic!("version.py:42 could not remove fail_index={}", fail_index)
+        });
         self.descrs.retain(|d| *d != fail_index);
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/version.rs
+++ b/majit/majit-metainterp/src/optimizeopt/version.rs
@@ -64,9 +64,9 @@ impl LoopVersionInfo {
 
     /// version.py:38-42: remove(descr)
     pub fn remove(&mut self, fail_index: u32) {
-        self.leads_to.remove(&fail_index).unwrap_or_else(|| {
-            panic!("version.py:42 could not remove fail_index={}", fail_index)
-        });
+        self.leads_to
+            .remove(&fail_index)
+            .unwrap_or_else(|| panic!("version.py:42 could not remove fail_index={}", fail_index));
         self.descrs.retain(|d| *d != fail_index);
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -2541,7 +2541,7 @@ fn export_single_value(
     // spectral_norm, inline_helper). The cyclic-virtual-graph regression
     // (RPython parity gap documented above) is therefore latent — no
     // benchmark constructs the necessary self-referential structures.
-    if !cache.in_progress.insert(opref) {
+    if cache.in_progress.contains(&opref) {
         // Fallback to Ref for the cycle leaf: pyre's virtual DAGs only
         // form through ptr fields, so the only reachable cycles are on
         // Ref-typed nodes. Matches `not_virtual(cpu, 'r', None)` in
@@ -2549,6 +2549,7 @@ fn export_single_value(
         // with LEVEL_UNKNOWN.
         return VirtualStateInfoNode::new_rc(VirtualStateInfo::Unknown(Type::Ref));
     }
+    cache.in_progress.insert(opref);
 
     let info = export_single_value_inner(opref, ctx, cache);
     let rc = VirtualStateInfoNode::new_rc(info);

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -668,9 +668,10 @@ impl VirtualState {
         visited: &mut majit_ir::vec_set::VecSet<usize>,
     ) {
         let key = Rc::as_ptr(node) as usize;
-        if !visited.insert(key) {
+        if visited.contains(&key) {
             return;
         }
+        visited.insert(key);
         node.position.set(-1);
         node.position_in_notvirtuals.set(-1);
         match &node.info {

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -952,16 +952,10 @@ impl OptString {
         let a_nonnull = i1 && self.is_known_nonnull(arg1, ctx);
         let b_nonnull = i2 && self.is_known_nonnull(arg2, ctx);
         if a_nonnull && b_nonnull {
-            // vstring.py:728: l1box.same_box(l2box)
-            // history.py:204: same identity OR both constants with equal value
-            let same_len = match (l1box, l2box) {
-                (Some(a), Some(b)) if a == b => true,
-                (Some(a), Some(b)) => {
-                    ctx.get_constant_int(a).is_some()
-                        && ctx.get_constant_int(a) == ctx.get_constant_int(b)
-                }
-                _ => false,
-            };
+            // vstring.py:728: l1box.same_box(l2box) routes through
+            // `OptContext::same_box` (history.py:204-205) which combines
+            // `get_box_replacement` + identity + Const value equality.
+            let same_len = matches!((l1box, l2box), (Some(a), Some(b)) if ctx.same_box(a, b));
             let oopspec = if same_len {
                 OopSpecIndex::StreqLengthok
             } else {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4490,8 +4490,7 @@ impl<M: Clone> MetaInterp<M> {
                 .filter(|mp| mp.position._pos > 0)
                 .map(|mp| {
                     (
-                        mp.original_boxes(),
-                        mp.original_box_types(),
+                        mp.green_boxes.clone(),
                         crate::history::TreeLoopCutPosition::new(mp.position._pos),
                     )
                 })
@@ -4533,9 +4532,7 @@ impl<M: Clone> MetaInterp<M> {
         // When the trace was retargeted to a different loop header,
         // cut_trace_from removes ops before the merge point and
         // replaces inputargs with original_boxes at the cut position.
-        let trace = if let Some((ref original_boxes, ref original_box_types, start)) =
-            cross_loop_cut
-        {
+        let trace = if let Some((ref original_boxes, start)) = cross_loop_cut {
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] cut_trace_from: start.op_index={} original_boxes={} trace_ops={} header_pc={}",
@@ -4548,7 +4545,6 @@ impl<M: Clone> MetaInterp<M> {
             trace.cut_trace_from_with_consts(
                 start,
                 original_boxes,
-                original_box_types,
                 &ctx.initial_inputarg_consts,
             )
         } else {
@@ -5566,8 +5562,7 @@ impl<M: Clone> MetaInterp<M> {
                     .filter(|mp| mp.position == retrace_pos && mp.position._pos > 0)
                     .map(|mp| {
                         (
-                            mp.original_boxes(),
-                            mp.original_box_types(),
+                            mp.green_boxes.clone(),
                             crate::history::TreeLoopCutPosition::new(mp.position._pos),
                         )
                     })
@@ -5585,9 +5580,7 @@ impl<M: Clone> MetaInterp<M> {
             // so close once, then cut the completed trace.
             ctx.close_loop(jump_args);
             let trace = ctx.into_tree_loop();
-            let trace = if let Some((ref original_boxes, ref original_box_types, start)) =
-                retrace_cut
-            {
+            let trace = if let Some((ref original_boxes, start)) = retrace_cut {
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] cut_retrace_from: start.op_index={} original_boxes={} trace_ops={} header_pc={}",
@@ -5600,7 +5593,6 @@ impl<M: Clone> MetaInterp<M> {
                 trace.cut_trace_from_with_consts(
                     start,
                     original_boxes,
-                    original_box_types,
                     &initial_inputarg_consts,
                 )
             } else {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2607,7 +2607,7 @@ impl<M: Clone> MetaInterp<M> {
         // Lookup by inner_key (not ctx.green_key which is the outer loop).
         ctx.get_merge_point_at(inner_key, ctx.header_pc)
             .filter(|mp| mp.position._pos > 0)
-            .map(|mp| (mp.header_pc, mp.original_box_types.clone()))
+            .map(|mp| (mp.header_pc, mp.original_box_types()))
     }
 
     /// Compat alias: delegates to set_trace_eagerness.
@@ -4490,8 +4490,8 @@ impl<M: Clone> MetaInterp<M> {
                 .filter(|mp| mp.position._pos > 0)
                 .map(|mp| {
                     (
-                        mp.original_boxes.clone(),
-                        mp.original_box_types.clone(),
+                        mp.original_boxes(),
+                        mp.original_box_types(),
                         crate::history::TreeLoopCutPosition::new(mp.position._pos),
                     )
                 })
@@ -5566,8 +5566,8 @@ impl<M: Clone> MetaInterp<M> {
                     .filter(|mp| mp.position == retrace_pos && mp.position._pos > 0)
                     .map(|mp| {
                         (
-                            mp.original_boxes.clone(),
-                            mp.original_box_types.clone(),
+                            mp.original_boxes(),
+                            mp.original_box_types(),
                             crate::history::TreeLoopCutPosition::new(mp.position._pos),
                         )
                     })

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1000,7 +1000,9 @@ pub struct MetaInterp<M: Clone> {
     /// Checked by compile_bridge_trace to return RetraceNeeded.
     pub(crate) retrace_after_bridge: bool,
     /// compile.py:288-290 parity: preamble target tokens saved from Phase 1
-    /// even when Phase 2 raises InvalidLoop.
+    /// even when Phase 2 raises InvalidLoop. Indexed by `green_key`; entries
+    /// are added on InvalidLoop and removed when the next retrace succeeds,
+    /// so the active set is bounded by the count of in-flight retraces.
     pending_preamble_tokens:
         crate::optimizeopt::vec_assoc::VecAssoc<u64, Vec<crate::optimizeopt::unroll::TargetToken>>,
     // pyjitpl.py:2289 `self.staticdata.all_descrs = self.cpu.setup_descrs()` now
@@ -5004,7 +5006,11 @@ impl<M: Clone> MetaInterp<M> {
                         if compiled.front_target_tokens.is_empty() {
                             compiled.front_target_tokens = unroll_opt.target_tokens.clone();
                         }
-                    } else {
+                    } else if !self
+                        .pending_preamble_tokens
+                        .iter()
+                        .any(|(k, _)| *k == green_key)
+                    {
                         self.pending_preamble_tokens
                             .entry_or_insert_with(green_key, || unroll_opt.target_tokens.clone());
                     }

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2600,9 +2600,7 @@ impl<M: Clone> MetaInterp<M> {
 
     /// compile.py:269-270: return cross-loop cut info if the current trace
     /// closes at a different loop header than where it started.
-    pub fn cross_loop_cut_info(
-        &self,
-    ) -> Option<(usize, Vec<crate::trace_ctx::GreenBox>)> {
+    pub fn cross_loop_cut_info(&self) -> Option<(usize, Vec<crate::trace_ctx::GreenBox>)> {
         let ctx = self.tracing.as_ref()?;
         let inner_key = ctx.cut_inner_green_key?;
         // compile.py:269: cross-loop cut uses the inner loop's merge point.
@@ -4544,11 +4542,7 @@ impl<M: Clone> MetaInterp<M> {
                     ctx.header_pc,
                 );
             }
-            trace.cut_trace_from_with_consts(
-                start,
-                original_boxes,
-                &ctx.initial_inputarg_consts,
-            )
+            trace.cut_trace_from_with_consts(start, original_boxes, &ctx.initial_inputarg_consts)
         } else {
             trace
         };
@@ -5592,11 +5586,7 @@ impl<M: Clone> MetaInterp<M> {
                         header_pc,
                     );
                 }
-                trace.cut_trace_from_with_consts(
-                    start,
-                    original_boxes,
-                    &initial_inputarg_consts,
-                )
+                trace.cut_trace_from_with_consts(start, original_boxes, &initial_inputarg_consts)
             } else {
                 trace
             };

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -2600,14 +2600,16 @@ impl<M: Clone> MetaInterp<M> {
 
     /// compile.py:269-270: return cross-loop cut info if the current trace
     /// closes at a different loop header than where it started.
-    pub fn cross_loop_cut_info(&self) -> Option<(usize, Vec<Type>)> {
+    pub fn cross_loop_cut_info(
+        &self,
+    ) -> Option<(usize, Vec<crate::trace_ctx::GreenBox>)> {
         let ctx = self.tracing.as_ref()?;
         let inner_key = ctx.cut_inner_green_key?;
         // compile.py:269: cross-loop cut uses the inner loop's merge point.
         // Lookup by inner_key (not ctx.green_key which is the outer loop).
         ctx.get_merge_point_at(inner_key, ctx.header_pc)
             .filter(|mp| mp.position._pos > 0)
-            .map(|mp| (mp.header_pc, mp.original_box_types()))
+            .map(|mp| (mp.header_pc, mp.green_boxes.clone()))
     }
 
     /// Compat alias: delegates to set_trace_eagerness.

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -854,7 +854,6 @@ pub struct PartialTrace {
 ///   return ConstInt(ptr2int(obj.typeptr))
 /// Reads the first word of the object (typeptr/vtable pointer).
 fn default_cls_of_box(raw_ref: i64) -> i64 {
-    debug_assert!(raw_ref != 0, "cls_of_box: null ref");
     unsafe { *(raw_ref as *const usize) as i64 }
 }
 

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -124,27 +124,60 @@ fn concrete_ptrs_eq(a: &Value, b: &Value) -> bool {
     }
 }
 
+/// pyjitpl.py:2989 box-with-type pair.
+///
+/// RPython's `Box` carries type implicitly via Python class identity
+/// (`ConstInt`/`ConstFloat`/`InputArgRef` etc.).  Pyre's flat-OpRef
+/// encoding stores type as a separate `Type` tag, so `GreenBox` bundles
+/// the position + type tag into one struct — Phase A.4 step in
+/// `~/.claude/plans/ec-wiring-gentle-wave.md` folding away the
+/// previous parallel `Vec<OpRef>` + `Vec<Type>` adaptation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GreenBox {
+    pub opref: OpRef,
+    pub ty: Type,
+}
+
+impl GreenBox {
+    pub fn new(opref: OpRef, ty: Type) -> Self {
+        Self { opref, ty }
+    }
+}
+
 /// pyjitpl.py:2989 — a visited loop header with its trace position.
 ///
 /// RPython stores `(original_boxes, start)` where `original_boxes` is the
 /// full list of green+red args at the first visit, and `start` is a 5-tuple
-/// trace position. majit stores the equivalent as OpRef vectors + TracePosition.
+/// trace position. majit stores the equivalent as a `Vec<GreenBox>` (each
+/// pairing OpRef + Type tag) + TracePosition.
 #[derive(Clone, Debug)]
 pub struct MergePoint {
     /// Green key of the loop header.
     pub green_key: u64,
     /// Trace position when this loop header was first visited.
     pub position: crate::recorder::TracePosition,
-    /// pyjitpl.py:2989: original_boxes — live variable OpRefs at the first
-    /// visit to this loop header. Used by compile_loop/compile_retrace as
-    /// the inputargs for trace cutting.
-    pub original_boxes: Vec<OpRef>,
-    /// Types of original_boxes. RPython Box carries type implicitly;
-    /// majit stores types alongside OpRefs for compile_retrace parity.
-    pub original_box_types: Vec<Type>,
+    /// pyjitpl.py:2989: `original_boxes` — live variable boxes (OpRef +
+    /// type tag) at the first visit to this loop header. Used by
+    /// compile_loop/compile_retrace as the inputargs for trace cutting.
+    pub green_boxes: Vec<GreenBox>,
     /// Bytecode PC of this loop header. Used by cut_trace_from to update
     /// meta when the trace closes at a different loop.
     pub header_pc: usize,
+}
+
+impl MergePoint {
+    /// pyjitpl.py:2989 `original_boxes` view — produces a fresh
+    /// `Vec<OpRef>` for callers that still consume the legacy split shape.
+    pub fn original_boxes(&self) -> Vec<OpRef> {
+        self.green_boxes.iter().map(|gb| gb.opref).collect()
+    }
+
+    /// pyjitpl.py:2989 `[b.type for b in original_boxes]` view — pyre-only
+    /// because PyPy Box objects carry their type implicitly, but pyre's
+    /// flat OpRef encoding needs the parallel Type tag for compile_retrace.
+    pub fn original_box_types(&self) -> Vec<Type> {
+        self.green_boxes.iter().map(|gb| gb.ty).collect()
+    }
 }
 
 /// Tracing context: wraps Trace + ConstantPool with convenience API.
@@ -985,8 +1018,11 @@ impl TraceCtx {
             current_merge_points: vec![MergePoint {
                 green_key,
                 position: initial_position,
-                original_box_types: initial_types,
-                original_boxes: initial_boxes.clone(),
+                green_boxes: initial_boxes
+                    .iter()
+                    .zip(initial_types.iter())
+                    .map(|(&opref, &ty)| GreenBox::new(opref, ty))
+                    .collect(),
                 header_pc: 0,
             }],
             heap_cache: HeapCache::new(),
@@ -1047,8 +1083,11 @@ impl TraceCtx {
             current_merge_points: vec![MergePoint {
                 green_key,
                 position: initial_position,
-                original_box_types: initial_input_types,
-                original_boxes: initial_boxes.clone(),
+                green_boxes: initial_boxes
+                    .iter()
+                    .zip(initial_input_types.iter())
+                    .map(|(&opref, &ty)| GreenBox::new(opref, ty))
+                    .collect(),
                 header_pc: 0,
             }],
             heap_cache: HeapCache::new(),

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -165,21 +165,6 @@ pub struct MergePoint {
     pub header_pc: usize,
 }
 
-impl MergePoint {
-    /// pyjitpl.py:2989 `original_boxes` view — produces a fresh
-    /// `Vec<OpRef>` for callers that still consume the legacy split shape.
-    pub fn original_boxes(&self) -> Vec<OpRef> {
-        self.green_boxes.iter().map(|gb| gb.opref).collect()
-    }
-
-    /// pyjitpl.py:2989 `[b.type for b in original_boxes]` view — pyre-only
-    /// because PyPy Box objects carry their type implicitly, but pyre's
-    /// flat OpRef encoding needs the parallel Type tag for compile_retrace.
-    pub fn original_box_types(&self) -> Vec<Type> {
-        self.green_boxes.iter().map(|gb| gb.ty).collect()
-    }
-}
-
 /// Tracing context: wraps Trace + ConstantPool with convenience API.
 ///
 /// The interpreter uses this during trace recording to:

--- a/majit/majit-translate/src/jit_codewriter/insns.rs
+++ b/majit/majit-translate/src/jit_codewriter/insns.rs
@@ -26,7 +26,7 @@
 //! stability adaptation should be documented at the table site —
 //! see slice #86f.
 
-use std::collections::HashMap;
+use majit_ir::VecAssoc;
 
 // Canonical RPython keys filling free low bytes (`blackhole.py:1149-1525`).
 // One byte per `(opname, argcodes)` per `assembler.py:221
@@ -482,7 +482,7 @@ pub fn insn_byte(key: &str) -> u8 {
 /// the dynamic-allocation path without tripping the runtime decoder.
 pub fn insn_byte_opt(key: &str) -> Option<u8> {
     use std::sync::OnceLock;
-    static TABLE: OnceLock<HashMap<&'static str, u8>> = OnceLock::new();
+    static TABLE: OnceLock<VecAssoc<&'static str, u8>> = OnceLock::new();
     let table = TABLE.get_or_init(|| {
         // Build-time consumers (`JitCodeBuilder::write_insn`) lookup any
         // canonical opname (RPython parity) AND any pyre-only Rust-
@@ -564,8 +564,8 @@ pub fn is_reserved_opcode_byte(byte: u8) -> bool {
 ///   `i` int reg, `r` ref reg, `f` float reg, `c` short-const int,
 ///   `I/R/F` constant-pool int/ref/float, `L` label, `d` descr,
 ///   `N` `ListOfKind` (mixed-kind literal list).
-pub fn wellknown_bh_insns() -> HashMap<&'static str, u8> {
-    let mut m = HashMap::new();
+pub fn wellknown_bh_insns() -> VecAssoc<&'static str, u8> {
+    let mut m = VecAssoc::new();
 
     // pyjitpl.py:2236-2243 — fields `setup_insns` probes explicitly.
     m.insert("live/", BC_LIVE);
@@ -1022,8 +1022,8 @@ pub fn wellknown_bh_insns() -> HashMap<&'static str, u8> {
 /// `wellknown_bh_insns()` at OnceLock init time, so build-time
 /// `write_insn(...)` callers resolve transparently. Runtime dispatch
 /// reads `BC_*` constants directly and is unaffected.
-pub fn pyre_extension_insns() -> HashMap<&'static str, u8> {
-    let mut m = HashMap::new();
+pub fn pyre_extension_insns() -> VecAssoc<&'static str, u8> {
+    let mut m = VecAssoc::new();
     // Borrow-checker abort signals.
     m.insert("abort/", BC_ABORT);
     m.insert("abort_permanent/", BC_ABORT_PERMANENT);

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -618,9 +618,9 @@ pub fn register_host_value(host: HostObject, entry: ExtRegistryEntry) -> Result<
 /// is itself OnceLock-gated.
 pub fn register_r_uint(host: HostObject) {
     let mut registry = host_value_registry().lock().unwrap();
-    registry
-        .entry(host.clone())
-        .or_insert(ExtRegistryEntry::ForType { instance: host });
+    if !registry.contains_key(&host) {
+        registry.insert(host.clone(), ExtRegistryEntry::ForType { instance: host });
+    }
 }
 
 /// Rust equivalent of `AutoRegisteringType._register_type`.

--- a/pyre/pyre-jit-trace/src/assembler.rs
+++ b/pyre/pyre-jit-trace/src/assembler.rs
@@ -20,7 +20,8 @@
 //! (`self.liveness_info = "".join(asm.all_liveness)`).
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+
+use majit_ir::VecAssoc;
 
 /// RPython `assembler.py:19-32` `Assembler.__init__`.
 ///
@@ -32,20 +33,20 @@ use std::collections::HashMap;
 /// - `all_liveness_positions` — dedup dict from bitset key to offset.
 /// - `num_liveness_ops` — running count of liveness writes (diagnostic).
 pub struct AssemblerState {
-    pub insns: HashMap<String, u8>,
+    pub insns: VecAssoc<String, u8>,
     pub all_liveness: Vec<u8>,
     pub all_liveness_length: usize,
-    pub all_liveness_positions: HashMap<(Vec<u8>, Vec<u8>, Vec<u8>), u16>,
+    pub all_liveness_positions: VecAssoc<(Vec<u8>, Vec<u8>, Vec<u8>), u16>,
     pub num_liveness_ops: usize,
 }
 
 impl AssemblerState {
     fn new() -> Self {
         Self {
-            insns: HashMap::new(),
+            insns: VecAssoc::new(),
             all_liveness: Vec::new(),
             all_liveness_length: 0,
-            all_liveness_positions: HashMap::new(),
+            all_liveness_positions: VecAssoc::new(),
             num_liveness_ops: 0,
         }
     }
@@ -101,7 +102,7 @@ pub fn num_liveness_ops() -> usize {
 /// without a circular dep on `pyre_jit`. Not a second source of truth
 /// — every publish replaces the mirror entirely.
 pub fn publish_state(
-    insns: &HashMap<String, u8>,
+    insns: &VecAssoc<String, u8>,
     all_liveness: &[u8],
     all_liveness_length: usize,
     num_liveness_ops: usize,

--- a/pyre/pyre-jit-trace/src/assembler.rs
+++ b/pyre/pyre-jit-trace/src/assembler.rs
@@ -114,6 +114,10 @@ pub fn publish_state(
         asm.all_liveness.extend_from_slice(all_liveness);
         asm.all_liveness_length = all_liveness_length;
         asm.num_liveness_ops = num_liveness_ops;
+        // The dedup table is keyed by offsets into the previous
+        // all_liveness buffer; clear it so subsequent intern_liveness
+        // lookups cannot reuse stale offsets against the fresh buffer.
+        asm.all_liveness_positions.clear();
     });
     crate::state::publish_liveness_info(all_liveness.to_vec());
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -5,7 +5,6 @@
 //! provides a concrete `PyreFieldDescr` implementing majit's
 //! `FieldDescr` trait for pyre's `#[repr(C)]` object layout.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
@@ -149,8 +148,8 @@ static NEXT_ARRAY_DESCR_ID: AtomicU32 = AtomicU32::new(0);
 /// `FIELD_DESCR_TAG`.
 const ARRAY_DESCR_ID_MAX: u32 = 1 << 28;
 
-static ARRAY_DESCR_REGISTRY: LazyLock<Mutex<HashMap<ArrayDescrKey, DescrRef>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static ARRAY_DESCR_REGISTRY: LazyLock<Mutex<majit_ir::VecAssoc<ArrayDescrKey, DescrRef>>> =
+    LazyLock::new(|| Mutex::new(majit_ir::VecAssoc::new()));
 
 fn alloc_array_descr_id() -> u32 {
     let id = NEXT_ARRAY_DESCR_ID.fetch_add(1, Ordering::Relaxed);
@@ -2373,7 +2372,7 @@ fn simple_field_spec_from_bh(
 /// the closest orthodox behaviour is "each call is a distinct
 /// STRUCT" — mint fresh per call.
 static SIMPLE_DESCR_GROUP_CACHE: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<u64, majit_ir::descr::SimpleDescrGroup>>,
+    std::sync::Mutex<majit_ir::VecAssoc<u64, majit_ir::descr::SimpleDescrGroup>>,
 > = std::sync::OnceLock::new();
 
 fn simple_descr_group_from_bh_size(
@@ -2416,7 +2415,7 @@ fn simple_descr_group_from_bh_size(
     }
 
     let cache = SIMPLE_DESCR_GROUP_CACHE
-        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+        .get_or_init(|| std::sync::Mutex::new(majit_ir::VecAssoc::new()));
     {
         let cache = cache.lock().unwrap();
         if let Some(group) = cache.get(&spec.type_id) {
@@ -2425,7 +2424,7 @@ fn simple_descr_group_from_bh_size(
     }
     let group = mint();
     let mut cache = cache.lock().unwrap();
-    cache.entry(spec.type_id).or_insert(group).clone()
+    cache.entry_or_insert_with(spec.type_id, || group).clone()
 }
 
 #[derive(Debug)]

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2414,8 +2414,8 @@ fn simple_descr_group_from_bh_size(
         return mint();
     }
 
-    let cache = SIMPLE_DESCR_GROUP_CACHE
-        .get_or_init(|| std::sync::Mutex::new(majit_ir::VecAssoc::new()));
+    let cache =
+        SIMPLE_DESCR_GROUP_CACHE.get_or_init(|| std::sync::Mutex::new(majit_ir::VecAssoc::new()));
     {
         let cache = cache.lock().unwrap();
         if let Some(group) = cache.get(&spec.type_id) {

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
@@ -24,19 +24,18 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             // pyjitpl.py:2957-2965 build live_arg_boxes ONCE.
             let live_args =
                 crate::state::MIFrame::close_loop_args_at(this, ctx, Some(target));
-            let live_types = {
-                live_args
-                    .iter()
-                    .map(|opref| {
-                        ctx.get_opref_type(*opref).unwrap_or_else(|| {
-                            panic!(
-                                "live_arg {opref:?} has no type in OptContext; \
-                                 RPython Box always carries its type"
-                            )
-                        })
-                    })
-                    .collect()
-            };
+            let live_green_boxes: Vec<majit_metainterp::GreenBox> = live_args
+                .iter()
+                .map(|opref| {
+                    let ty = ctx.get_opref_type(*opref).unwrap_or_else(|| {
+                        panic!(
+                            "live_arg {opref:?} has no type in OptContext; \
+                             RPython Box always carries its type"
+                        )
+                    });
+                    majit_metainterp::GreenBox::new(*opref, ty)
+                })
+                .collect();
 
             // pyjitpl.py:2978-2983 compile_trace attempt.
             {
@@ -77,7 +76,7 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             // structural red-bank invariant under the same jitdriver.
             if !ctx.has_merge_point_with_shape_assert(back_edge_key, live_args.len()) {
                 // pyjitpl.py:3034-3036 first visit, register & continue
-                ctx.add_merge_point(back_edge_key, live_args, live_types, target);
+                ctx.add_merge_point(back_edge_key, live_green_boxes, target);
                 if majit_metainterp::majit_log_enabled() {
                     eprintln!(
                         "[jit][reached_loop_header] first visit, unroll: key={} pc={}",

--- a/pyre/pyre-jit-trace/src/shadow_walker.rs
+++ b/pyre/pyre-jit-trace/src/shadow_walker.rs
@@ -121,20 +121,17 @@ pub fn opname_in_shadow_allow_list(instruction: &Instruction) -> bool {
     // the shadow allow-list is intentionally empty for this phase.
     // `MAJIT_SHADOW_WALKER=1` therefore does not enable any Nop-family
     // exceptions; the env flag remains plumbed for future expansion
-    // (M4 LoadFast / arithmetic / branch ops, gated on the Int-bank
-    // concrete shadow work below) but is presently inert.
+    // (M4 LoadFast / arithmetic / branch ops, Phase B per-opcode
+    // allow-list expansion) but is presently inert.
+    //
+    // The Int-bank concrete shadow plumbing prerequisite landed: see
+    // `WalkContext::concrete_registers_i` at
+    // `jitcode_dispatch.rs:360`.  Re-enabling per-opcode allow-list
+    // entries is now a per-opcode investigation (decode the arm bytes,
+    // confirm walker handlers cover every embedded opname, run shadow
+    // diff under `MAJIT_SHADOW_WALKER=1`), not a structural blocker.
     let _ = instruction;
     false
-    // M4.PoC.1 LoadFast attempt (2026-05-17) panicked on fib_loop with
-    // `GotoIfNotValueNotConcrete { pc: 28, value: IntOp(35) }`.  The
-    // codewriter-emitted LoadFastCheck arm body contains a
-    // `goto_if_not/iL` whose value lives in the Int register bank;
-    // walker `dispatch_goto_if_not` falls into the strict-mode
-    // fail-loud path because `concrete_registers_i` doesn't exist.
-    // Blocker is the Int-bank concrete shadow plumbing — see
-    // `[[project-tracer-m4-cutover-decision]]` "Architectural blocker
-    // for the Int-bank shadow" section.  Allow-list expansion past
-    // PopTop into LoadFast/arithmetic/branch ops is gated on that work.
 }
 
 /// Carrier for the symbolic walker's record output — the trace ops it

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5529,8 +5529,10 @@ impl JitState for PyreJitState {
     fn build_meta_from_merge_point(
         provisional: &PyreMeta,
         _header_pc: usize,
-        original_box_types: &[Type],
+        original_boxes: &[majit_metainterp::GreenBox],
     ) -> PyreMeta {
+        let original_box_types: Vec<Type> = original_boxes.iter().map(|gb| gb.ty).collect();
+        let original_box_types = &original_box_types[..];
         // `NUM_SCALAR_INPUTARGS` already counts `NUM_EXTRA_REDS` (frame +
         // extra_reds + vable scalars), so do NOT add `trace_extra_reds`.
         use crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -18,7 +18,6 @@ use pyre_object::PyObjectRef;
 use pyre_object::boolobject::w_bool_get_value;
 use pyre_object::pyobject::{is_bool, is_float, is_int};
 use pyre_object::{PY_NULL, w_float_get_value, w_int_get_value, w_int_new};
-use std::collections::HashMap;
 
 /// jitcode.py:9-21 / codewriter.py:68: JitCode — compiled bytecode unit.
 ///
@@ -183,7 +182,7 @@ impl MetaInterpStaticData {
     /// pyjitpl.py:2227-2243 `MetaInterpStaticData.setup_insns(self, insns)`:
     /// copy opcode numbers for the well-known bytecodes out of the
     /// assembler's `insns` dict in the same order as upstream.
-    fn setup_insns(&mut self, insns: &HashMap<String, u8>) {
+    fn setup_insns(&mut self, insns: &majit_ir::VecAssoc<String, u8>) {
         self.op_live = insns.get("live/").copied().unwrap_or(u8::MAX);
         self.op_goto = insns.get("goto/L").copied().unwrap_or(u8::MAX);
         self.op_catch_exception = insns.get("catch_exception/L").copied().unwrap_or(u8::MAX);
@@ -196,7 +195,7 @@ impl MetaInterpStaticData {
 
     /// pyjitpl.py:2255-2264 `finish_setup`: wire the assembler's opcode table
     /// into this staticdata object and snapshot the current `all_liveness`.
-    fn finish_setup_if_needed(&mut self, insns: &HashMap<String, u8>, all_liveness: Vec<u8>) {
+    fn finish_setup_if_needed(&mut self, insns: &majit_ir::VecAssoc<String, u8>, all_liveness: Vec<u8>) {
         let was_done = self.finish_setup_done;
         self.setup_insns(insns);
         self.liveness_info = std::sync::Arc::<[u8]>::from(all_liveness.into_boxed_slice());
@@ -7229,7 +7228,7 @@ mod tests {
         let mut builder = majit_metainterp::JitCodeBuilder::default();
         let live_patch = builder.live_placeholder();
         builder.patch_live_offset(live_patch, 0);
-        let mut insns = std::collections::HashMap::new();
+        let mut insns = majit_ir::VecAssoc::new();
         insns.insert(
             "live/".to_string(),
             majit_metainterp::jitcode::insns::BC_LIVE,
@@ -9261,12 +9260,12 @@ mod finish_setup_tests {
     #[test]
     fn finish_setup_refreshes_opcode_cache_after_initial_empty_snapshot() {
         let mut sd = MetaInterpStaticData::new();
-        let empty = std::collections::HashMap::new();
+        let empty: majit_ir::VecAssoc<String, u8> = majit_ir::VecAssoc::new();
         sd.finish_setup_if_needed(&empty, Vec::new());
         assert_eq!(sd.op_live, u8::MAX);
         assert_eq!(sd.op_goto, u8::MAX);
 
-        let mut insns = std::collections::HashMap::new();
+        let mut insns = majit_ir::VecAssoc::new();
         insns.insert("live/".to_string(), 88u8);
         insns.insert("goto/L".to_string(), 16u8);
         insns.insert("catch_exception/L".to_string(), 89u8);
@@ -9292,7 +9291,7 @@ mod finish_setup_tests {
     #[test]
     fn blackhole_control_opcodes_reflect_finish_setup_cache() {
         let mut sd = MetaInterpStaticData::new();
-        let mut insns = std::collections::HashMap::new();
+        let mut insns = majit_ir::VecAssoc::new();
         insns.insert("live/".to_string(), 88u8);
         insns.insert("catch_exception/L".to_string(), 89u8);
         insns.insert("rvmprof_code/ii".to_string(), 91u8);
@@ -9307,13 +9306,13 @@ mod finish_setup_tests {
     #[test]
     fn blackhole_control_opcodes_refresh_after_initial_empty_snapshot() {
         let mut sd = MetaInterpStaticData::new();
-        let empty = std::collections::HashMap::new();
+        let empty: majit_ir::VecAssoc<String, u8> = majit_ir::VecAssoc::new();
         sd.finish_setup_if_needed(&empty, Vec::new());
         METAINTERP_SD.with(|slot| {
             *slot.borrow_mut() = sd;
         });
 
-        let mut insns = std::collections::HashMap::new();
+        let mut insns = majit_ir::VecAssoc::new();
         insns.insert("live/".to_string(), 88u8);
         insns.insert("catch_exception/L".to_string(), 89u8);
         insns.insert("rvmprof_code/ii".to_string(), 91u8);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -195,7 +195,11 @@ impl MetaInterpStaticData {
 
     /// pyjitpl.py:2255-2264 `finish_setup`: wire the assembler's opcode table
     /// into this staticdata object and snapshot the current `all_liveness`.
-    fn finish_setup_if_needed(&mut self, insns: &majit_ir::VecAssoc<String, u8>, all_liveness: Vec<u8>) {
+    fn finish_setup_if_needed(
+        &mut self,
+        insns: &majit_ir::VecAssoc<String, u8>,
+        all_liveness: Vec<u8>,
+    ) {
         let was_done = self.finish_setup_done;
         self.setup_insns(insns);
         self.liveness_info = std::sync::Arc::<[u8]>::from(all_liveness.into_boxed_slice());

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -68,12 +68,17 @@ pub fn trace_bytecode(
         // RPython Box identity (variant-aware Eq) rather than collapsing
         // through an Untyped position (history.py:182 `box.type`).
         let input_types = ctx.inputarg_types();
-        let input_args: Vec<majit_ir::OpRef> = input_types
+        let input_args: Vec<majit_metainterp::GreenBox> = input_types
             .iter()
             .enumerate()
-            .map(|(i, &tp)| majit_ir::OpRef::input_arg_typed(i as u32, tp))
+            .map(|(i, &tp)| {
+                majit_metainterp::GreenBox::new(
+                    majit_ir::OpRef::input_arg_typed(i as u32, tp),
+                    tp,
+                )
+            })
             .collect();
-        ctx.add_merge_point(start_key, input_args, input_types, start_pc);
+        ctx.add_merge_point(start_key, input_args, start_pc);
     }
 
     let action = metainterp.interpret(ctx);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -72,10 +72,7 @@ pub fn trace_bytecode(
             .iter()
             .enumerate()
             .map(|(i, &tp)| {
-                majit_metainterp::GreenBox::new(
-                    majit_ir::OpRef::input_arg_typed(i as u32, tp),
-                    tp,
-                )
+                majit_metainterp::GreenBox::new(majit_ir::OpRef::input_arg_typed(i as u32, tp), tp)
             })
             .collect();
         ctx.add_merge_point(start_key, input_args, start_pc);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8658,14 +8658,14 @@ mod tests {
     #[test]
     fn get_list_of_active_boxes_reads_kind_specific_register_banks() {
         use majit_translate::liveness::encode_liveness;
-        use std::collections::HashMap;
+        use majit_ir::VecAssoc;
         use std::sync::Arc;
 
         let mut all_liveness = vec![1, 1, 1];
         all_liveness.extend(encode_liveness(&[2]));
         all_liveness.extend(encode_liveness(&[1]));
         all_liveness.extend(encode_liveness(&[3]));
-        let mut insns = HashMap::new();
+        let mut insns: VecAssoc<String, u8> = VecAssoc::new();
         insns.insert(
             "live/".to_string(),
             majit_metainterp::jitcode::insns::BC_LIVE,
@@ -8741,12 +8741,12 @@ mod tests {
     #[test]
     fn pre_opcode_snapshot_reads_coalesced_stack_color_by_semantic_slot() {
         use majit_translate::liveness::encode_liveness;
-        use std::collections::HashMap;
+        use majit_ir::VecAssoc;
         use std::sync::Arc;
 
         let mut all_liveness = vec![0, 1, 0];
         all_liveness.extend(encode_liveness(&[0]));
-        let mut insns = HashMap::new();
+        let mut insns: VecAssoc<String, u8> = VecAssoc::new();
         insns.insert(
             "live/".to_string(),
             majit_metainterp::jitcode::insns::BC_LIVE,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8657,8 +8657,8 @@ mod tests {
 
     #[test]
     fn get_list_of_active_boxes_reads_kind_specific_register_banks() {
-        use majit_translate::liveness::encode_liveness;
         use majit_ir::VecAssoc;
+        use majit_translate::liveness::encode_liveness;
         use std::sync::Arc;
 
         let mut all_liveness = vec![1, 1, 1];
@@ -8740,8 +8740,8 @@ mod tests {
 
     #[test]
     fn pre_opcode_snapshot_reads_coalesced_stack_color_by_semantic_slot() {
-        use majit_translate::liveness::encode_liveness;
         use majit_ir::VecAssoc;
+        use majit_translate::liveness::encode_liveness;
         use std::sync::Arc;
 
         let mut all_liveness = vec![0, 1, 0];

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -512,19 +512,18 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             // pyjitpl.py:2957-2965 build live_arg_boxes ONCE.
             let live_args =
                 crate::state::MIFrame::close_loop_args_at(this, ctx, Some(target));
-            let live_types = {
-                live_args
-                    .iter()
-                    .map(|opref| {
-                        ctx.get_opref_type(*opref).unwrap_or_else(|| {
-                            panic!(
-                                "live_arg {opref:?} has no type in OptContext; \
-                                 RPython Box always carries its type"
-                            )
-                        })
-                    })
-                    .collect()
-            };
+            let live_green_boxes: Vec<majit_metainterp::GreenBox> = live_args
+                .iter()
+                .map(|opref| {
+                    let ty = ctx.get_opref_type(*opref).unwrap_or_else(|| {
+                        panic!(
+                            "live_arg {opref:?} has no type in OptContext; \
+                             RPython Box always carries its type"
+                        )
+                    });
+                    majit_metainterp::GreenBox::new(*opref, ty)
+                })
+                .collect();
 
             // pyjitpl.py:2978-2983 compile_trace attempt.
             {
@@ -565,7 +564,7 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             // structural red-bank invariant under the same jitdriver.
             if !ctx.has_merge_point_with_shape_assert(back_edge_key, live_args.len()) {
                 // pyjitpl.py:3034-3036 first visit, register & continue
-                ctx.add_merge_point(back_edge_key, live_args, live_types, target);
+                ctx.add_merge_point(back_edge_key, live_green_boxes, target);
                 if majit_metainterp::majit_log_enabled() {
                     eprintln!(
                         "[jit][reached_loop_header] first visit, unroll: key={} pc={}",

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -108,7 +108,7 @@ impl std::hash::Hash for ArcByPtr {
 struct AssemblyState {
     builder: JitCodeBuilder,
     /// `assembler.py:59` `self.label_positions = {}`.
-    label_positions: HashMap<String, usize>,
+    label_positions: VecAssoc<String, usize>,
     /// Builder adapter for `Label/TLabel` name → builder label id.
     /// RPython stores bytecode positions directly in `label_positions`; this
     /// extra vector exists only because `JitCodeBuilder` patches jumps by
@@ -208,7 +208,7 @@ impl Assembler {
 
         let mut state = AssemblyState {
             builder,
-            label_positions: HashMap::new(),
+            label_positions: VecAssoc::new(),
             builder_labels: Vec::new(),
         };
 

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -10,6 +10,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
 
+use majit_ir::VecAssoc;
 use majit_metainterp::jitcode::{JitCallArg, JitCode, JitCodeBuilder};
 use vecset::VecSet;
 
@@ -48,7 +49,7 @@ pub struct Assembler {
     /// records only the actually-emitted well-known keys with their runtime
     /// opcode byte. That is sufficient for the lazy `finish_setup` cache
     /// refresh in `pyre_jit_trace::state`.
-    insns: HashMap<String, u8>,
+    insns: VecAssoc<String, u8>,
     /// `assembler.py:29` `self.all_liveness = []`.
     all_liveness: Vec<u8>,
     /// `assembler.py:30` `self.all_liveness_length = 0`.
@@ -131,7 +132,7 @@ impl Assembler {
     }
 
     /// Snapshot of the emitted well-known `opname/argcodes` keys.
-    pub fn insns_snapshot(&self) -> HashMap<String, u8> {
+    pub fn insns_snapshot(&self) -> VecAssoc<String, u8> {
         self.insns.clone()
     }
 
@@ -401,7 +402,7 @@ impl Assembler {
             insn_key(opname, args, result)
         };
         if let Some(&opcode) = WELLKNOWN_BH_INSNS.get(key.as_str()) {
-            self.insns.entry(key).or_insert(opcode);
+            self.insns.entry_or_insert_with(key, || opcode);
         }
     }
 }

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -407,7 +407,7 @@ impl Assembler {
     }
 }
 
-static WELLKNOWN_BH_INSNS: LazyLock<HashMap<&'static str, u8>> =
+static WELLKNOWN_BH_INSNS: LazyLock<majit_ir::VecAssoc<&'static str, u8>> =
     LazyLock::new(majit_metainterp::jitcode::wellknown_bh_insns);
 
 fn is_adapter_only_helper_call_family(opname: &str) -> bool {


### PR DESCRIPTION
Fix https://github.com/youknowone/pyre/issues/38Fix https://github.com/youknowone/pyre/issues/38
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an identity-style OpRef comparator and introduced a typed "green box" wrapper re-exported for merge-point/trace APIs.

* **Performance Improvements**
  * Replaced many internal maps/sets with compact vector-backed containers for faster lookups and lower memory overhead across compilation, JIT and optimizer paths.

* **Refactor**
  * Adjusted several public-facing APIs to accept the new typed containers/green-box inputs (call-site shapes updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->