### PR TITLE
pc-map

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -1998,10 +1998,20 @@ impl TraceCtx {
     ) -> Vec<crate::recorder::SnapshotTagged> {
         active_boxes
             .iter()
-            .map(|opref| {
-                let tp = self
-                    .get_opref_type(*opref)
-                    .expect("capture_snapshot_for_last_guard: active OpRef missing Box.type");
+            .enumerate()
+            .map(|(slot, opref)| {
+                let tp = self.get_opref_type(*opref).unwrap_or_else(|| {
+                    panic!(
+                        "capture_snapshot_for_last_guard: active OpRef missing Box.type \
+                         (slot={slot}, opref={opref:?}, raw={raw}, ty()={ty:?}, \
+                          is_constant={is_const}, num_inputargs={ninputs}, num_ops={nops})",
+                        raw = opref.raw(),
+                        ty = opref.ty(),
+                        is_const = opref.is_constant(),
+                        ninputs = self.recorder.num_inputargs(),
+                        nops = self.recorder.ops().len(),
+                    )
+                });
                 if opref.is_constant() {
                     let value = self.constant_value(*opref).expect(
                         "capture_snapshot_for_last_guard: constant OpRef missing recorded value",

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1498,31 +1498,35 @@ impl TraceCtx {
         let Some(lengths) = self.virtualizable_array_lengths.as_ref() else {
             return;
         };
+        // Clone `lengths` (small — one entry per vable array; one entry total
+        // for PyFrame) to release the immutable borrow before reborrowing
+        // `virtualizable_values` mutably.  The decode loop below reads
+        // statics + array items field-by-field straight into the shadow,
+        // avoiding the `Vec<i64>` + `Vec<Vec<i64>>` allocations that
+        // `read_all_boxes` would materialise on every hot-path call.
         let array_lengths = lengths.clone();
-        let (static_bits, array_bits) = unsafe { info.read_all_boxes(heap_ptr, &array_lengths) };
         let static_count = info.num_static_extra_boxes;
         let info = info.clone();
         let Some(values) = self.virtualizable_values.as_mut() else {
             return;
         };
-        for (i, bits) in static_bits.iter().enumerate().take(static_count) {
-            if i >= values.len() {
-                break;
-            }
+        for i in 0..static_count.min(values.len()) {
             let ty = info.static_fields[i].field_type;
-            values[i] = crate::pyjitpl::heap_value_for_pub(ty, *bits);
+            let bits = unsafe { info.read_field(heap_ptr, i) };
+            values[i] = crate::pyjitpl::heap_value_for_pub(ty, bits);
         }
         let mut cursor = static_count;
-        for (a, items) in array_bits.iter().enumerate() {
-            if a >= info.array_fields.len() {
+        for (a_idx, &length) in array_lengths.iter().enumerate() {
+            if a_idx >= info.array_fields.len() {
                 break;
             }
-            let ty = info.array_fields[a].item_type;
-            for bits in items {
+            let ty = info.array_fields[a_idx].item_type;
+            for item_idx in 0..length {
                 if cursor >= values.len() {
                     break;
                 }
-                values[cursor] = crate::pyjitpl::heap_value_for_pub(ty, *bits);
+                let bits = unsafe { info.read_array_item(heap_ptr, a_idx, item_idx) };
+                values[cursor] = crate::pyjitpl::heap_value_for_pub(ty, bits);
                 cursor += 1;
             }
         }

--- a/majit/majit-translate/src/front/ast.rs
+++ b/majit/majit-translate/src/front/ast.rs
@@ -3891,15 +3891,29 @@ fn collect_jit_hints(attrs: &[syn::Attribute], sig: Option<&syn::Signature>) -> 
                 // a citation to `jit.py:172-178 _get_args(func)`, so
                 // there is no silent single-graph fallback.
                 //
-                // `call.py:292-299 getcalldescr` still runs the
-                // `_canraise(op)` analysis on every elidable callsite,
-                // so collapsing `elidable_cannot_raise` /
-                // `elidable_or_memerror` to a single `"elidable"` hint
-                // remains parity-correct — `getcalldescr` recovers the
-                // `EF_ELIDABLE_*` 3-way from the per-op raise analysis
-                // at `jit_codewriter/call.rs:2773-2782`.
-                "elidable_cannot_raise" | "elidable_or_memerror" => {
+                // `call.py:292-299 getcalldescr` runs `_canraise(op)` on
+                // every elidable callsite to recover the `EF_ELIDABLE_*`
+                // 3-way split.  Pyre's `_canraise` is conservative for
+                // callees outside `function_graphs` (Vec::len,
+                // pyframe_get_pycode, etc.) — `analyze_external_call`
+                // defaults to `True` (`call.rs:3631`), so the analyser
+                // alone cannot recover `EF_ELIDABLE_CANNOT_RAISE` /
+                // `EF_ELIDABLE_OR_MEMORYERROR` even on callees the user
+                // has explicitly annotated.  Preserve the assertion as a
+                // distinct hint string alongside the canonical
+                // `"elidable"` so `lib.rs` can register it with
+                // `mark_cannot_raise_assertion` /
+                // `mark_memerror_only_assertion` and
+                // `getcalldescr`'s elidable branch can honour the
+                // user-asserted shape before falling back to
+                // `_canraise`.
+                "elidable_cannot_raise" => {
                     hints.push("elidable".into());
+                    hints.push("elidable_cannot_raise".into());
+                }
+                "elidable_or_memerror" => {
+                    hints.push("elidable".into());
+                    hints.push("elidable_or_memerror".into());
                 }
                 "dont_look_inside" => hints.push("dont_look_inside".into()),
                 "unroll_safe" => hints.push("unroll_safe".into()),

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3066,6 +3066,50 @@ impl CallControl {
                     if self.function_graphs.contains_key(&qualified) {
                         return Some(qualified);
                     }
+                    // Suffix-match fallback for in-impl `self.method()` calls.
+                    //
+                    // When the parser walks `impl PyFrame { fn pop(&mut self) {
+                    // self.stack_base() } }`, the inner `self.stack_base()` is
+                    // recorded as `Method { receiver_root: Some("PyFrame") }`
+                    // — the syntactic spelling, not the canonical
+                    // `pyframe::PyFrame`.  `for_impl_method("PyFrame",
+                    // "stack_base")` produces the 2-segment
+                    // `["PyFrame", "stack_base"]`, but `function_graphs`
+                    // registers the impl method under the 3-segment
+                    // module-qualified key `["pyframe", "PyFrame",
+                    // "stack_base"]`.  The literal lookup above misses, and
+                    // without this fallback every in-impl `self.method()`
+                    // call falls through to residual_call — inflating IR
+                    // emission whenever the BFS would have inlined the
+                    // method body otherwise.
+                    //
+                    // Scan `function_graphs` for keys whose last 2 segments
+                    // match `[receiver, name]`.  Accept the match only if it
+                    // is unique: an ambiguous suffix (e.g. two crates both
+                    // exposing a `PyFrame::pop`) falls through to the trait
+                    // resolution path, which mirrors Rust's name-resolution
+                    // ambiguity error rather than silently picking one.
+                    let needle = (receiver, name.as_str());
+                    let mut matched: Option<&CallPath> = None;
+                    let mut multi = false;
+                    for key in self.function_graphs.keys() {
+                        let segs = &key.segments;
+                        if segs.len() >= 2
+                            && segs[segs.len() - 2] == needle.0
+                            && segs[segs.len() - 1] == needle.1
+                        {
+                            if matched.is_some() {
+                                multi = true;
+                                break;
+                            }
+                            matched = Some(key);
+                        }
+                    }
+                    if !multi {
+                        if let Some(path) = matched {
+                            return Some(path.clone());
+                        }
+                    }
                 }
                 // Fall back to trait method resolution for polymorphic calls.
                 let impl_type =

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3609,9 +3609,25 @@ impl CallControl {
 
     /// Pyre extension: check if `target` carries the
     /// `#[elidable_cannot_raise]` assertion.
+    ///
+    /// Additionally requires the target's fnaddr to be registered via
+    /// `register_function_fnaddr`.  Without a real fnaddr,
+    /// `fnaddr_for_target` returns a synthetic 64-bit hash via
+    /// [`symbolic_fnaddr_for_path`]; that hash lands in the sub-jitcode
+    /// `constants_i` slot for the funcbox.  When the walker observes
+    /// `EF_ELIDABLE_CANNOT_RAISE` on the descr it routes through
+    /// `try_fold_pure_call_via_executor`
+    /// (pyre-jit-trace/src/jitcode_dispatch.rs:3099) which dereferences
+    /// the constant_i as a C function pointer — SIGSEGV on the hash.
+    /// Pyre's symbolic placeholder is a NEW-DEVIATION vs RPython (where
+    /// every callee has a real `MixLevelHelperAnnotator.constfunc(impl)`
+    /// address); the gate restores the upstream-equivalent invariant
+    /// that `EF_ELIDABLE_CANNOT_RAISE` callees are always executable.
     pub fn has_cannot_raise_assertion(&self, target: &CallTarget) -> bool {
-        self.target_to_path(target)
-            .is_some_and(|p| self.cannot_raise_assertion_targets.contains(&p))
+        self.target_to_path(target).is_some_and(|p| {
+            self.cannot_raise_assertion_targets.contains(&p)
+                && self.function_fnaddrs.contains_key(&p)
+        })
     }
 
     /// Pyre extension: register a target as carrying the
@@ -3622,9 +3638,17 @@ impl CallControl {
 
     /// Pyre extension: check if `target` carries the
     /// `#[elidable_or_memerror]` assertion.
+    ///
+    /// Same fnaddr-registration gate as
+    /// [`Self::has_cannot_raise_assertion`]: `EF_ELIDABLE_OR_MEMORYERROR`
+    /// walker arms also route through the executor fold path when the
+    /// caller has no MemoryError stamping, so a symbolic placeholder
+    /// would crash there too.
     pub fn has_memerror_only_assertion(&self, target: &CallTarget) -> bool {
-        self.target_to_path(target)
-            .is_some_and(|p| self.memerror_only_assertion_targets.contains(&p))
+        self.target_to_path(target).is_some_and(|p| {
+            self.memerror_only_assertion_targets.contains(&p)
+                && self.function_fnaddrs.contains_key(&p)
+        })
     }
 
     /// RPython: call.py:240 — check if target has `_jit_loop_invariant_`.

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -624,6 +624,25 @@ pub struct CallControl {
     /// Targets known to be elidable (pure, no side effects).
     elidable_targets: HashSet<CallPath>,
 
+    /// Pyre extension: targets whose source carries
+    /// `#[majit_macros::elidable_cannot_raise]` — a user assertion that
+    /// the callee never raises.  Honoured by `getcalldescr`'s elidable
+    /// branch before consulting `_canraise`, because pyre's exception
+    /// analyser defaults to `analyze_external_call → True` for any
+    /// callee outside `function_graphs` (Vec::len, pyframe_get_pycode,
+    /// etc.) and cannot recover `EF_ELIDABLE_CANNOT_RAISE` on its own
+    /// the way RPython's analyser does upstream.  Without honouring the
+    /// assertion, every `#[elidable_cannot_raise]` callsite is downgraded
+    /// to `ElidableCanRaise` and pays an unnecessary GUARD_NO_EXCEPTION.
+    cannot_raise_assertion_targets: HashSet<CallPath>,
+
+    /// Pyre extension: targets whose source carries
+    /// `#[majit_macros::elidable_or_memerror]` — a user assertion that
+    /// the callee raises only MemoryError.  Mirrors
+    /// `cannot_raise_assertion_targets` for the `EF_ELIDABLE_OR_MEMORYERROR`
+    /// branch of RPython's `call.py:292-298` 3-way split.
+    memerror_only_assertion_targets: HashSet<CallPath>,
+
     /// RPython: `getattr(func, "_jit_loop_invariant_", False)` (call.py:240).
     /// Targets known to be loop-invariant (call once per loop).
     loopinvariant_targets: HashSet<CallPath>,
@@ -1044,6 +1063,8 @@ impl CallControl {
             quasiimmut_analyzer: majit_ir::effectinfo::QuasiImmutAnalyzer,
             randomeffects_analyzer: majit_ir::effectinfo::RandomEffectsAnalyzer,
             elidable_targets: HashSet::new(),
+            cannot_raise_assertion_targets: HashSet::new(),
+            memerror_only_assertion_targets: HashSet::new(),
             loopinvariant_targets: HashSet::new(),
             known_struct_names: HashSet::new(),
             struct_fields: crate::front::StructFieldRegistry::default(),
@@ -3536,6 +3557,32 @@ impl CallControl {
             .is_some_and(|p| self.elidable_targets.contains(&p))
     }
 
+    /// Pyre extension: register a target as carrying the
+    /// `#[elidable_cannot_raise]` user assertion.
+    pub fn mark_cannot_raise_assertion(&mut self, path: CallPath) {
+        self.cannot_raise_assertion_targets.insert(path);
+    }
+
+    /// Pyre extension: check if `target` carries the
+    /// `#[elidable_cannot_raise]` assertion.
+    pub fn has_cannot_raise_assertion(&self, target: &CallTarget) -> bool {
+        self.target_to_path(target)
+            .is_some_and(|p| self.cannot_raise_assertion_targets.contains(&p))
+    }
+
+    /// Pyre extension: register a target as carrying the
+    /// `#[elidable_or_memerror]` user assertion.
+    pub fn mark_memerror_only_assertion(&mut self, path: CallPath) {
+        self.memerror_only_assertion_targets.insert(path);
+    }
+
+    /// Pyre extension: check if `target` carries the
+    /// `#[elidable_or_memerror]` assertion.
+    pub fn has_memerror_only_assertion(&self, target: &CallTarget) -> bool {
+        self.target_to_path(target)
+            .is_some_and(|p| self.memerror_only_assertion_targets.contains(&p))
+    }
+
     /// RPython: call.py:240 — check if target has `_jit_loop_invariant_`.
     pub fn is_loopinvariant(&self, target: &CallTarget) -> bool {
         self.target_to_path(target)
@@ -4365,14 +4412,43 @@ impl CallControl {
                 ExtraEffect::LoopInvariant
             } else if elidable {
                 // call.py:292-298 — direct branch only.
-                let canraise = match shape {
-                    CallShape::Direct(target) => self._canraise(target, cache),
+                //
+                // Pyre extension: the user-facing
+                // `#[majit_macros::elidable_cannot_raise]` /
+                // `#[majit_macros::elidable_or_memerror]` macros assert
+                // an `EF_ELIDABLE_*` shape the on-graph `_canraise`
+                // analyser cannot recover on its own — pyre's
+                // `analyze_external_call` defaults to `True` (call.rs:3631)
+                // so any callee that reaches Vec::len / pyframe_get_pycode
+                // / etc. propagates back as CanRaise::Yes.  Honour the
+                // assertion before consulting `_canraise` so the
+                // `EF_ELIDABLE_CANNOT_RAISE` walker arm (no trailing
+                // GUARD_NO_EXCEPTION) actually fires on annotated
+                // callees.
+                let assertion = match shape {
+                    CallShape::Direct(target) => {
+                        if self.has_cannot_raise_assertion(target) {
+                            Some(ExtraEffect::ElidableCannotRaise)
+                        } else if self.has_memerror_only_assertion(target) {
+                            Some(ExtraEffect::ElidableOrMemoryError)
+                        } else {
+                            None
+                        }
+                    }
                     CallShape::Indirect(_) => unreachable!("indirect cannot be elidable"),
                 };
-                match canraise {
-                    CanRaise::No => ExtraEffect::ElidableCannotRaise,
-                    CanRaise::MemoryErrorOnly => ExtraEffect::ElidableOrMemoryError,
-                    CanRaise::Yes => ExtraEffect::ElidableCanRaise,
+                if let Some(ee) = assertion {
+                    ee
+                } else {
+                    let canraise = match shape {
+                        CallShape::Direct(target) => self._canraise(target, cache),
+                        CallShape::Indirect(_) => unreachable!("indirect cannot be elidable"),
+                    };
+                    match canraise {
+                        CanRaise::No => ExtraEffect::ElidableCannotRaise,
+                        CanRaise::MemoryErrorOnly => ExtraEffect::ElidableOrMemoryError,
+                        CanRaise::Yes => ExtraEffect::ElidableCanRaise,
+                    }
                 }
             } else {
                 let canraise = match shape {

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3604,6 +3604,11 @@ impl CallControl {
     /// Pyre extension: register a target as carrying the
     /// `#[elidable_cannot_raise]` user assertion.
     pub fn mark_cannot_raise_assertion(&mut self, path: CallPath) {
+        assert!(
+            !self.memerror_only_assertion_targets.contains(&path),
+            "conflicting elidable exception assertions for {path:?}: \
+             already marked memerror-only, cannot also mark cannot-raise"
+        );
         self.cannot_raise_assertion_targets.insert(path);
     }
 
@@ -3626,13 +3631,21 @@ impl CallControl {
     pub fn has_cannot_raise_assertion(&self, target: &CallTarget) -> bool {
         self.target_to_path(target).is_some_and(|p| {
             self.cannot_raise_assertion_targets.contains(&p)
-                && self.function_fnaddrs.contains_key(&p)
+                && self
+                    .function_fnaddrs
+                    .get(&p)
+                    .is_some_and(|&fnaddr| fnaddr != 0)
         })
     }
 
     /// Pyre extension: register a target as carrying the
     /// `#[elidable_or_memerror]` user assertion.
     pub fn mark_memerror_only_assertion(&mut self, path: CallPath) {
+        assert!(
+            !self.cannot_raise_assertion_targets.contains(&path),
+            "conflicting elidable exception assertions for {path:?}: \
+             already marked cannot-raise, cannot also mark memerror-only"
+        );
         self.memerror_only_assertion_targets.insert(path);
     }
 
@@ -3647,7 +3660,10 @@ impl CallControl {
     pub fn has_memerror_only_assertion(&self, target: &CallTarget) -> bool {
         self.target_to_path(target).is_some_and(|p| {
             self.memerror_only_assertion_targets.contains(&p)
-                && self.function_fnaddrs.contains_key(&p)
+                && self
+                    .function_fnaddrs
+                    .get(&p)
+                    .is_some_and(|&fnaddr| fnaddr != 0)
         })
     }
 

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -748,6 +748,18 @@ fn analyze_pipeline_from_parsed(
                             call_control.mark_elidable(dp.clone());
                         }
                     }
+                    "elidable_cannot_raise" => {
+                        call_control.mark_cannot_raise_assertion(path.clone());
+                        if let Some(ref dp) = default_direct_path {
+                            call_control.mark_cannot_raise_assertion(dp.clone());
+                        }
+                    }
+                    "elidable_or_memerror" => {
+                        call_control.mark_memerror_only_assertion(path.clone());
+                        if let Some(ref dp) = default_direct_path {
+                            call_control.mark_memerror_only_assertion(dp.clone());
+                        }
+                    }
                     "loopinvariant" => {
                         call_control.mark_loopinvariant(path.clone());
                         if let Some(ref dp) = default_direct_path {
@@ -795,6 +807,12 @@ fn analyze_pipeline_from_parsed(
         for hint in &method_info.hints {
             match hint.as_str() {
                 "elidable" => call_control.mark_elidable(path.clone()),
+                "elidable_cannot_raise" => {
+                    call_control.mark_cannot_raise_assertion(path.clone())
+                }
+                "elidable_or_memerror" => {
+                    call_control.mark_memerror_only_assertion(path.clone())
+                }
                 "loopinvariant" => call_control.mark_loopinvariant(path.clone()),
                 "close_stack" => call_control.mark_close_stack(path.clone()),
                 "cannot_collect" => call_control.mark_cannot_collect(path.clone()),
@@ -886,6 +904,12 @@ fn analyze_pipeline_from_parsed(
                 }
                 match hint.as_str() {
                     "elidable" => call_control.mark_elidable(p.clone()),
+                    "elidable_cannot_raise" => {
+                        call_control.mark_cannot_raise_assertion(p.clone())
+                    }
+                    "elidable_or_memerror" => {
+                        call_control.mark_memerror_only_assertion(p.clone())
+                    }
                     "loopinvariant" => call_control.mark_loopinvariant(p.clone()),
                     "close_stack" => call_control.mark_close_stack(p.clone()),
                     "cannot_collect" => call_control.mark_cannot_collect(p.clone()),

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -807,12 +807,8 @@ fn analyze_pipeline_from_parsed(
         for hint in &method_info.hints {
             match hint.as_str() {
                 "elidable" => call_control.mark_elidable(path.clone()),
-                "elidable_cannot_raise" => {
-                    call_control.mark_cannot_raise_assertion(path.clone())
-                }
-                "elidable_or_memerror" => {
-                    call_control.mark_memerror_only_assertion(path.clone())
-                }
+                "elidable_cannot_raise" => call_control.mark_cannot_raise_assertion(path.clone()),
+                "elidable_or_memerror" => call_control.mark_memerror_only_assertion(path.clone()),
                 "loopinvariant" => call_control.mark_loopinvariant(path.clone()),
                 "close_stack" => call_control.mark_close_stack(path.clone()),
                 "cannot_collect" => call_control.mark_cannot_collect(path.clone()),
@@ -904,12 +900,8 @@ fn analyze_pipeline_from_parsed(
                 }
                 match hint.as_str() {
                     "elidable" => call_control.mark_elidable(p.clone()),
-                    "elidable_cannot_raise" => {
-                        call_control.mark_cannot_raise_assertion(p.clone())
-                    }
-                    "elidable_or_memerror" => {
-                        call_control.mark_memerror_only_assertion(p.clone())
-                    }
+                    "elidable_cannot_raise" => call_control.mark_cannot_raise_assertion(p.clone()),
+                    "elidable_or_memerror" => call_control.mark_memerror_only_assertion(p.clone()),
                     "loopinvariant" => call_control.mark_loopinvariant(p.clone()),
                     "close_stack" => call_control.mark_close_stack(p.clone()),
                     "cannot_collect" => call_control.mark_cannot_collect(p.clone()),

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -833,7 +833,7 @@ impl SharedOpcodeHandler for PyFrame {
     type Value = PyObjectRef;
 
     fn push_value(&mut self, value: Self::Value) -> Result<(), PyError> {
-        PyFrame::push(self, value);
+        self.push(value);
         Ok(())
     }
 
@@ -841,7 +841,7 @@ impl SharedOpcodeHandler for PyFrame {
         if self.valuestackdepth <= self.nlocals() {
             return Err(stack_underflow_error("interpreter opcode"));
         }
-        Ok(PyFrame::pop(self))
+        Ok(self.pop())
     }
 
     fn peek_at(&mut self, depth: usize) -> Result<Self::Value, PyError> {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -539,6 +539,41 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         pyframe_ncells_method as *const (),
     );
 
+    // B1 LoadFast/LoadFastBorrow/LoadFastCheck arm folding helpers.  Both
+    // carry `#[elidable_cannot_raise]` so `has_cannot_raise_assertion`
+    // requires the fnaddr registration to fire (`call.rs:3626-3631`
+    // gates the assertion on `function_fnaddrs.contains_key(p)`).
+    // Without these the chained `Arg::get` / `VarNum::as_usize` /
+    // `Vec::len` third-party helpers reach the walker as unfolded
+    // `residual_call` ops and the walker's `goto_if_not` bounds-check
+    // aborts with `GotoIfNotValueNotConcrete`.
+    //
+    // `push_alias_pair` (vs plain `push_fnaddr`) is required because the
+    // in-module call site `load_fast_var_num_to_index(var_num, op_arg)`
+    // inside `pyopcode.rs` resolves to a bare-segment `CallPath`
+    // (`["load_fast_var_num_to_index"]`) that the assertion-aware hint
+    // walker DOES populate but the module-qualified-only fnaddr
+    // registration would miss.  Register the bare alias alongside the
+    // canonical `pyopcode::name` form so the assertion gate fires.
+    let load_fast_var_num_to_index: fn(
+        crate::bytecode::Arg<crate::bytecode::oparg::VarNum>,
+        crate::bytecode::OpArg,
+    ) -> usize = crate::pyopcode::load_fast_var_num_to_index;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::pyopcode::load_fast_var_num_to_index",
+        "pyre_interpreter::load_fast_var_num_to_index",
+        load_fast_var_num_to_index as *const (),
+    );
+
+    let code_varnames_len: fn(&crate::CodeObject) -> usize = crate::pyopcode::code_varnames_len;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::pyopcode::code_varnames_len",
+        "pyre_interpreter::code_varnames_len",
+        code_varnames_len as *const (),
+    );
+
     // `PyError::type_error` — invoked by `stack_underflow_error`'s body
     // (`shared_opcode.rs:181-183`). The codewriter resolves it to the
     // 2-segment CallPath `["PyError", "type_error"]` (impl-method shape:

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -504,6 +504,41 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         stack_underflow as *const (),
     );
 
+    // `pyframe_get_pycode` / `ncells` / `npure_cellvars` / `PyFrame::ncells`
+    // carry `#[elidable_cannot_raise]`.  `call.rs:has_cannot_raise_assertion`
+    // only honours the assertion when `function_fnaddrs.contains_key(p)`,
+    // so without a registration the descr falls back to
+    // `EF_ELIDABLE_CAN_RAISE`.
+    let pyframe_get_pycode_fn: unsafe fn(&crate::pyframe::PyFrame) -> *const crate::CodeObject =
+        crate::pyframe::pyframe_get_pycode;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::pyframe::pyframe_get_pycode",
+        pyframe_get_pycode_fn as *const (),
+    );
+
+    let pyframe_ncells_free: fn(&crate::CodeObject) -> usize = crate::pyframe::ncells;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::pyframe::ncells",
+        pyframe_ncells_free as *const (),
+    );
+
+    let pyframe_npure_cellvars: fn(&crate::CodeObject) -> usize = crate::pyframe::npure_cellvars;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::pyframe::npure_cellvars",
+        pyframe_npure_cellvars as *const (),
+    );
+
+    let pyframe_ncells_method: fn(&crate::pyframe::PyFrame) -> usize =
+        crate::pyframe::PyFrame::ncells;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::pyframe::PyFrame::ncells",
+        pyframe_ncells_method as *const (),
+    );
+
     // `PyError::type_error` — invoked by `stack_underflow_error`'s body
     // (`shared_opcode.rs:181-183`). The codewriter resolves it to the
     // 2-segment CallPath `["PyError", "type_error"]` (impl-method shape:

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -468,17 +468,29 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
 
     // `PyFrame::pop` — invoked by `<PyFrame as SharedOpcodeHandler>::pop_value`
-    // at `eval.rs:844 Ok(PyFrame::pop(self))`. The codewriter resolves
-    // the qualified `PyFrame::pop(self)` syntax to a 2-segment CallPath
-    // `["PyFrame", "pop"]` (without the `pyframe::` module prefix that a
-    // bare method call like `self.nlocals()` would have).
+    // at `eval.rs:844 Ok(self.pop())`.  Two CallPath shapes need binding:
+    //
+    // 1. The qualified `PyFrame::pop(self)` spelling resolves to the
+    //    2-segment CallPath `["PyFrame", "pop"]` via `for_impl_method`.
+    // 2. The bare `self.pop()` spelling goes through `target_to_path`'s
+    //    suffix-match fallback (call.rs:3069-3112), which returns the
+    //    3-segment module-qualified key `["pyframe", "PyFrame", "pop"]`
+    //    that `function_graphs` actually stores inherent impl methods
+    //    under (per `parse::extract_inherent_impl_methods`).
+    //
     // `register_macro_helper_trace_fnaddr` strips the leading segment,
-    // so the 3-segment input string `pyre_interpreter::PyFrame::pop`
-    // produces the matching 2-segment canonical form.
+    // so we register both spellings via `push_alias_pair`: the 3-segment
+    // input `pyre_interpreter::PyFrame::pop` produces the 2-segment
+    // canonical, and the 4-segment input `pyre_interpreter::pyframe::PyFrame::pop`
+    // produces the 3-segment module-qualified form.  Without the second
+    // binding, `fnaddr_for_target` for `self.pop()` falls back to the
+    // symbolic hash from [`symbolic_fnaddr_for_path`], which SEGVs at
+    // trace-time call.
     let pyframe_pop: fn(&mut crate::pyframe::PyFrame) -> pyre_object::PyObjectRef =
         crate::pyframe::PyFrame::pop;
-    push_fnaddr(
+    push_alias_pair(
         &mut entries,
+        "pyre_interpreter::pyframe::PyFrame::pop",
         "pyre_interpreter::PyFrame::pop",
         pyframe_pop as *const (),
     );

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -552,6 +552,7 @@ pub fn offset2lineno(code: &CodeObject, stopat: isize) -> usize {
 /// `def repeat(n): def wrap(fn): def inner(): return (n, fn)`
 /// where `n` resolved to `fn` because of the off-by-one slot.
 #[inline]
+#[majit_macros::elidable_cannot_raise]
 pub fn npure_cellvars(code: &CodeObject) -> usize {
     code.cellvars
         .iter()
@@ -566,6 +567,7 @@ pub fn npure_cellvars(code: &CodeObject) -> usize {
 }
 
 #[inline]
+#[majit_macros::elidable_cannot_raise]
 pub fn ncells(code: &CodeObject) -> usize {
     npure_cellvars(code) + code.freevars.len()
 }
@@ -1135,6 +1137,7 @@ impl PyFrame {
     }
 
     /// Number of cell + free variable slots.
+    #[majit_macros::elidable_cannot_raise]
     #[inline]
     pub fn ncells(&self) -> usize {
         unsafe { ncells(&*pyframe_get_pycode(self)) }

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1407,6 +1407,35 @@ fn op_arg_as_usize(arg: OpArg) -> usize {
         .expect("u32 fits in usize on supported pyre targets (64-bit only)")
 }
 
+/// Walker-fold helper for `var_num.get(op_arg).as_usize()` — chains
+/// the third-party `Arg::get` + `VarNum::as_usize` calls under a single
+/// `#[elidable_cannot_raise]` first-party wrapper.  Without it, the
+/// codewriter sees two unfolded `residual_call` ops with
+/// `oopspec=None CanRaise`, and the walker's bounds-check `goto_if_not`
+/// downstream aborts with `GotoIfNotValueNotConcrete`.  The wrapper's
+/// body still emits a residual_call to the third-party helpers, but
+/// the OUTER call site is tagged elidable so the walker's
+/// `try_fold_pure_call_via_executor` fold path runs end-to-end.
+#[inline]
+#[majit_macros::elidable_cannot_raise]
+pub fn load_fast_var_num_to_index(
+    var_num: crate::bytecode::Arg<crate::bytecode::oparg::VarNum>,
+    op_arg: OpArg,
+) -> usize {
+    var_num.get(op_arg).as_usize()
+}
+
+/// Walker-fold helper for `code.varnames.len()` — `Vec::len` is a std
+/// method the analyzer cannot tag elidable from its definition site,
+/// so the bounds-check upper bound reaches the walker as an unfolded
+/// `residual_call`.  Same `#[elidable_cannot_raise]` rationale as
+/// [`load_fast_var_num_to_index`].
+#[inline]
+#[majit_macros::elidable_cannot_raise]
+pub fn code_varnames_len(code: &CodeObject) -> usize {
+    code.varnames.len()
+}
+
 /// Extract a [`RaiseKind`]'s discriminant as `usize`. Same parity
 /// rationale as [`u32_as_i64`] / [`u32_as_usize`]: upstream Python
 /// has no enum-discriminant cast syntax, so the bare `kind as usize`
@@ -1460,7 +1489,7 @@ where
         }
 
         Instruction::LoadFast { var_num } | Instruction::LoadFastBorrow { var_num } => {
-            let idx = var_num.get(op_arg).as_usize();
+            let idx = load_fast_var_num_to_index(var_num, op_arg);
             // closure-free, Option-pattern-free `varnames.get(idx)` rewrite to
             // keep the body within the Rust-AST adapter's RPython-orthodox
             // subset (Position-2 adaptation per the annotator-monomorphization
@@ -1468,7 +1497,7 @@ where
             // at the annotator layer). The bounds check stays a plain `<`
             // comparison + indexed access so the lowered op sequence stays
             // `lt + getitem` rather than walking into an `Option<&str>` enum.
-            let name = if idx < code.varnames.len() {
+            let name = if idx < code_varnames_len(code) {
                 code.varnames[idx].as_ref()
             } else {
                 "<cell>"
@@ -1496,10 +1525,10 @@ where
         }
 
         Instruction::LoadFastCheck { var_num } => {
-            let idx = var_num.get(op_arg).as_usize();
+            let idx = load_fast_var_num_to_index(var_num, op_arg);
             // closure-free, Option-pattern-free rewrite — see LoadFast above
             // for the rationale.
-            let name = if idx < code.varnames.len() {
+            let name = if idx < code_varnames_len(code) {
                 code.varnames[idx].as_ref()
             } else {
                 "<cell>"

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -372,6 +372,17 @@ fn build_call_effect_overrides() -> Vec<majit_translate::CallEffectOverride> {
 /// outside the canonical layout (synthesized files, fixtures) keep
 /// the simple-name registration.
 fn module_path_from_source_file(path: &str) -> String {
+    // Windows `WalkDir` yields native paths with `\` separators; the marker
+    // search + `/lib` / `/mod` suffix strips + final `/` → `::` rewrite
+    // below all assume forward slashes, so an unnormalised Windows path
+    // falls into the `rfind` `None` branch and every source file ends up
+    // with an empty `module_path`.  Empty module paths skip
+    // `register_struct_origins` (`lib.rs:374-382`), which breaks
+    // classdef-keyed method resolution downstream and silently drops
+    // graphs from the analyzer — surfacing later as missing opcodes in
+    // `pipeline.insns` (e.g. `setfield_vable_i/rid`).
+    let normalized_path = path.replace('\\', "/");
+    let path = normalized_path.as_str();
     let marker = "/src/";
     let Some(idx) = path.rfind(marker) else {
         return String::new();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8362,6 +8362,59 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn dump_load_fast_family_arm_bytes() {
+        // B1 allow-list batch diagnostic — dump LoadFast and LoadFastBorrow
+        // arm bytes side-by-side with LoadFastCheck so we can decide which
+        // of the three lands first.  Same decoder loop as
+        // `dump_load_fast_check_arm_bytes` above.
+        use crate::jitcode_runtime::{all_descrs, decoded_ops, jitcode_for_instruction};
+        use pyre_interpreter::bytecode::Arg;
+        let descrs = all_descrs();
+        for instr in [
+            Instruction::LoadFast {
+                var_num: Arg::marker(),
+            },
+            Instruction::LoadFastBorrow {
+                var_num: Arg::marker(),
+            },
+        ] {
+            let jc = jitcode_for_instruction(&instr)
+                .expect("LoadFast family must resolve to an arm jitcode");
+            let code = jc.code.as_slice();
+            eprintln!(
+                "{} arm: num_regs_r={} num_regs_i={} num_regs_f={} code_len={}",
+                jc.name,
+                jc.num_regs_r(),
+                jc.num_regs_i(),
+                jc.num_regs_f(),
+                code.len(),
+            );
+            for op in decoded_ops(code) {
+                let operand_bytes = &code[op.pc + 1..op.next_pc];
+                eprintln!(
+                    "  pc={:>3}..{:<3} key={:>30}  operands={:02x?}",
+                    op.pc, op.next_pc, op.key, operand_bytes,
+                );
+                if op.key.starts_with("residual_call_") {
+                    let descr_byte_offset = op.next_pc - 3;
+                    let didx =
+                        u16::from_le_bytes([code[descr_byte_offset], code[descr_byte_offset + 1]])
+                            as usize;
+                    if let Some(d) = descrs.get(didx) {
+                        let cd = d.as_calldescr();
+                        let ei = &cd.extra_info;
+                        eprintln!(
+                            "      → descr#{didx} args={:?} result={} extraeffect={:?} oopspec={:?}",
+                            cd.arg_classes, cd.result_type, ei.extraeffect, ei.oopspecindex,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
     fn dump_nop_arm_bytes() {
         // Phase D-3 Blocker #2 diagnostic: decode `Instruction::Nop`'s
         // arm jitcode by following per-opname argcode arity (NOT a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3579,7 +3579,11 @@ fn collect_outer_active_boxes(
         )
     };
     for &idx in &banks.int {
-        let v = sym.registers_i[idx as usize];
+        let v = sym
+            .registers_i
+            .get(idx as usize)
+            .copied()
+            .unwrap_or_else(|| panic!("{}", dump_ctx("int", idx)));
         if v == OpRef::NONE {
             panic!("{}", dump_ctx("int", idx));
         }
@@ -3588,7 +3592,11 @@ fn collect_outer_active_boxes(
     for &idx in &banks.ref_ {
         let reg_idx = idx as usize;
         // Vable-first read for portal frames (see comment at function top).
-        let mut v = sym.registers_r[reg_idx];
+        let mut v = sym
+            .registers_r
+            .get(reg_idx)
+            .copied()
+            .unwrap_or_else(|| panic!("{}", dump_ctx("ref", idx)));
         if v == OpRef::NONE && portal_vable_owner {
             if let Some(vable_box) = trace_ctx.virtualizable_box_at(nvs + reg_idx) {
                 if vable_box != OpRef::NONE {
@@ -3602,7 +3610,11 @@ fn collect_outer_active_boxes(
         active.push(v);
     }
     for &idx in &banks.float {
-        let v = sym.registers_f[idx as usize];
+        let v = sym
+            .registers_f
+            .get(idx as usize)
+            .copied()
+            .unwrap_or_else(|| panic!("{}", dump_ctx("float", idx)));
         if v == OpRef::NONE {
             panic!("{}", dump_ctx("float", idx));
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8165,6 +8165,66 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn dump_pop_top_sub_jitcode_ops() {
+        // PopTop arm body's `inline_call_r_r/dR>r` recurses into a sub-jitcode.
+        // Walk the chain down to the actual leaf (no more inline_call) so we
+        // can audit every IR op the walker emits per PopTop call.
+        use crate::jitcode_runtime::{
+            all_descrs, all_jitcodes, decoded_ops, jitcode_for_instruction,
+        };
+        let arm_jc = jitcode_for_instruction(&Instruction::PopTop)
+            .expect("PopTop must resolve to an arm jitcode");
+        let descrs = all_descrs();
+        let jitcodes = all_jitcodes();
+
+        let extract_sub_index = |descr_dbg: &str| -> Option<usize> {
+            let pos = descr_dbg.find("jitcode_index: ")?;
+            let rest = &descr_dbg[pos + "jitcode_index: ".len()..];
+            let end = rest.find(|c: char| !c.is_ascii_digit())?;
+            rest[..end].parse().ok()
+        };
+
+        let mut queue: Vec<(String, &[u8], String)> = vec![(
+            "PopTop arm".to_string(),
+            arm_jc.code.as_slice(),
+            arm_jc.name.clone(),
+        )];
+        let mut seen_indices: Vec<usize> = Vec::new();
+
+        while let Some((label, code, name)) = queue.pop() {
+            eprintln!("=== {label}: name={} code_len={}", name, code.len());
+            for op in decoded_ops(code) {
+                let operand_bytes = &code[op.pc + 1..op.next_pc];
+                eprintln!(
+                    "  pc={:>3}..{:<3} key={:>32}  operands={:02x?}",
+                    op.pc, op.next_pc, op.key, operand_bytes,
+                );
+                if op.key.starts_with("inline_call_") {
+                    let didx =
+                        u16::from_le_bytes([code[op.pc + 1], code[op.pc + 2]]) as usize;
+                    if let Some(d) = descrs.get(didx) {
+                        let s = format!("{:?}", d);
+                        if let Some(sub_idx) = extract_sub_index(&s) {
+                            eprintln!("      → sub-jitcode index {sub_idx}");
+                            if !seen_indices.contains(&sub_idx) {
+                                seen_indices.push(sub_idx);
+                                if let Some(sub_jc) = jitcodes.get(sub_idx) {
+                                    queue.push((
+                                        format!("{label}→{sub_idx}"),
+                                        sub_jc.code.as_slice(),
+                                        sub_jc.name.clone(),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
     fn dump_pop_top_arm_bytes() {
         use crate::jitcode_runtime::{all_descrs, decoded_ops, jitcode_for_instruction};
         let jc = jitcode_for_instruction(&Instruction::PopTop)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3528,18 +3528,33 @@ fn collect_outer_active_boxes(
     let live_i = banks.int.clone();
     let live_r = banks.ref_.clone();
     let live_f = banks.float.clone();
-    let (ni, nr, nf) = (sym.registers_i.len(), sym.registers_r.len(), sym.registers_f.len());
+    let (ni, nr, nf) = (
+        sym.registers_i.len(),
+        sym.registers_r.len(),
+        sym.registers_f.len(),
+    );
     let nlocals = sym.nlocals;
     let vable_len = trace_ctx.virtualizable_boxes_len().unwrap_or(0);
+    // Int / Float bank candidates: pyre's vable static fields decode as
+    // Int (last_instr, valuestackdepth, etc.); if liveness expects an Int
+    // register that the trait dispatcher never filled, the candidate fill
+    // is one of these sym shadow OpRefs.  Including them in the diagnostic
+    // lets Task #30 fallback work jump straight to the right source.
+    let vable_vsd = sym.vable_valuestackdepth;
+    let vable_last_instr = sym.vable_last_instr;
     let dump_ctx = |bank: &'static str, reg_idx: u32| -> String {
         let vable_idx = nvs + reg_idx as usize;
         let vable_val = if portal_vable_owner {
-            format!(
-                "{:?}",
-                trace_ctx.virtualizable_box_at(vable_idx)
-            )
+            format!("{:?}", trace_ctx.virtualizable_box_at(vable_idx))
         } else {
             "n/a (non-portal)".to_string()
+        };
+        let int_hint = if bank == "int" {
+            format!(
+                ", sym.vable_valuestackdepth={vable_vsd:?}, sym.vable_last_instr={vable_last_instr:?}"
+            )
+        } else {
+            String::new()
         };
         format!(
             "collect_outer_active_boxes: liveness-active {bank} \
@@ -3548,7 +3563,8 @@ fn collect_outer_active_boxes(
               nlocals={nlocals}, portal_vable_owner={portal_vable_owner}, \
               vable_len={vable_len}, vable[{vable_idx}]={vable_val}, \
               num_regs_i={ni}, num_regs_r={nr}, num_regs_f={nf}, \
-              live_banks_i={live_i:?}, live_banks_r={live_r:?}, live_banks_f={live_f:?})",
+              live_banks_i={live_i:?}, live_banks_r={live_r:?}, live_banks_f={live_f:?}\
+              {int_hint})",
         )
     };
     for &idx in &banks.int {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1810,7 +1810,8 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
     } else {
         unsafe { (*sym.jitcode).index as u32 }
     };
-    let outer_active_boxes = collect_outer_active_boxes(sym, outer_jitcode_index, entry_py_pc);
+    let outer_active_boxes =
+        collect_outer_active_boxes(sym, trace_ctx, outer_jitcode_index, entry_py_pc);
 
     // pyjitpl.py:82-90 `setup` per-bank allocation: each bank gets
     // `copy_constants(registers, constants, num_regs_X, ConstClass)`.
@@ -3480,6 +3481,7 @@ fn write_residual_call_result_to_dst(
 /// the downstream optimizer surfaces the empty snapshot as a no-op.
 fn collect_outer_active_boxes(
     sym: &crate::state::PyreSym,
+    trace_ctx: &majit_metainterp::TraceCtx,
     outer_jitcode_index: u32,
     entry_py_pc: u32,
 ) -> Vec<OpRef> {
@@ -3488,6 +3490,24 @@ fn collect_outer_active_boxes(
         entry_py_pc as i32,
     );
     let mut active = Vec::with_capacity(banks.int.len() + banks.ref_.len() + banks.float.len());
+    // Portal-frame ref bank read parity: when the outer frame owns the
+    // virtualizable shadow (`pyjitpl.py:1242 _opimpl_setarrayitem_vable`),
+    // trait dispatch's `store_local_value` (trace_opcode.rs:2174-2177)
+    // and `write_stack_slot` (trace_opcode.rs:590-595) write the symbolic
+    // value into `virtualizable_boxes[NUM_VABLE_SCALARS + semantic_idx]`
+    // and SKIP writing `registers_r[semantic_idx]` because the latter
+    // would shadow the authoritative vable view.  Walker-emitted snapshot
+    // active boxes still index by register, so for portal frames read
+    // the ref bank through the vable shadow first and fall back to
+    // `registers_r[idx]` only if the vable lookup misses (e.g. for
+    // bridge-local or non-vable scratch slots).  Mirrors `read_stack_slot`
+    // / `load_local_value`'s vable-first read path.
+    //
+    // `reg_idx == semantic_idx` for ref bank registers because
+    // `stack_slot_reg_idx(sym, stack_idx) = nlocals + stack_idx`
+    // (trace_opcode.rs:543) and locals occupy `[0..nlocals)` directly.
+    let portal_vable_owner = sym.owns_virtualizable_shadow();
+    let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
     // RPython `pyjitpl.py:216-233 _get_list_of_active_boxes` reads
     // `self.registers_X[index]` directly per liveness index — an
     // out-of-bounds index is an IndexError, not a silent NONE.  Pyre's
@@ -3498,14 +3518,68 @@ fn collect_outer_active_boxes(
     // surfaces at the encode site instead of bleeding NONE values into
     // `encode_snapshot_boxes` where `get_opref_type(NONE)` panics with
     // no breadcrumb pointing at the source.
+    //
+    // Per-bank NONE check: if the trait dispatcher (or any path that
+    // writes to `sym.registers_X`) leaves a liveness-active slot
+    // unfilled, the snapshot encoder downstream would panic with a
+    // generic "active OpRef missing Box.type" message that obscures
+    // which bank/index was bad.  Catch it here at the source so the
+    // diagnostic points at the actual register-fill gap.
+    let live_i = banks.int.clone();
+    let live_r = banks.ref_.clone();
+    let live_f = banks.float.clone();
+    let (ni, nr, nf) = (sym.registers_i.len(), sym.registers_r.len(), sym.registers_f.len());
+    let nlocals = sym.nlocals;
+    let vable_len = trace_ctx.virtualizable_boxes_len().unwrap_or(0);
+    let dump_ctx = |bank: &'static str, reg_idx: u32| -> String {
+        let vable_idx = nvs + reg_idx as usize;
+        let vable_val = if portal_vable_owner {
+            format!(
+                "{:?}",
+                trace_ctx.virtualizable_box_at(vable_idx)
+            )
+        } else {
+            "n/a (non-portal)".to_string()
+        };
+        format!(
+            "collect_outer_active_boxes: liveness-active {bank} \
+             register {reg_idx} holds OpRef::NONE \
+             (outer_jitcode_index={outer_jitcode_index}, entry_py_pc={entry_py_pc}, \
+              nlocals={nlocals}, portal_vable_owner={portal_vable_owner}, \
+              vable_len={vable_len}, vable[{vable_idx}]={vable_val}, \
+              num_regs_i={ni}, num_regs_r={nr}, num_regs_f={nf}, \
+              live_banks_i={live_i:?}, live_banks_r={live_r:?}, live_banks_f={live_f:?})",
+        )
+    };
     for &idx in &banks.int {
-        active.push(sym.registers_i[idx as usize]);
+        let v = sym.registers_i[idx as usize];
+        if v == OpRef::NONE {
+            panic!("{}", dump_ctx("int", idx));
+        }
+        active.push(v);
     }
     for &idx in &banks.ref_ {
-        active.push(sym.registers_r[idx as usize]);
+        let reg_idx = idx as usize;
+        // Vable-first read for portal frames (see comment at function top).
+        let mut v = sym.registers_r[reg_idx];
+        if v == OpRef::NONE && portal_vable_owner {
+            if let Some(vable_box) = trace_ctx.virtualizable_box_at(nvs + reg_idx) {
+                if vable_box != OpRef::NONE {
+                    v = vable_box;
+                }
+            }
+        }
+        if v == OpRef::NONE {
+            panic!("{}", dump_ctx("ref", idx));
+        }
+        active.push(v);
     }
     for &idx in &banks.float {
-        active.push(sym.registers_f[idx as usize]);
+        let v = sym.registers_f[idx as usize];
+        if v == OpRef::NONE {
+            panic!("{}", dump_ctx("float", idx));
+        }
+        active.push(v);
     }
     active
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8218,6 +8218,22 @@ mod tests {
                             }
                         }
                     }
+                } else if op.key.starts_with("residual_call_") {
+                    let descr_byte_offset = op.next_pc - 3;
+                    let didx = u16::from_le_bytes([code[descr_byte_offset], code[descr_byte_offset + 1]]) as usize;
+                    if let Some(d) = descrs.get(didx) {
+                        let cd = d.as_calldescr();
+                        let ei = &cd.extra_info;
+                        eprintln!(
+                            "      → descr#{didx} args={:?} result={} extraeffect={:?} oopspec={:?} elidable={} canraise={}",
+                            cd.arg_classes,
+                            cd.result_type,
+                            ei.extraeffect,
+                            ei.oopspecindex,
+                            ei.check_is_elidable(),
+                            ei.check_can_raise(false),
+                        );
+                    }
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3127,6 +3127,17 @@ fn try_fold_pure_call_via_executor(
     // pyjitpl.py:1960-1993 `_build_allboxes`: slot 0 is funcbox, slots
     // 1.. are user args in `descr.arg_types()` ABI order.  Walker's
     // [`build_allboxes`] preserves the same layout.
+    //
+    // pyjitpl.py:1352 invariant: `_record_helper_pure` requires
+    // `funcbox` to be a Const so its `getint()` is the actual fn
+    // pointer.  Non-constant funcboxes carry a stale-stamped Int
+    // (from `cast_ptr_to_int` of a Ref-bank receiver, etc.) and
+    // dereferencing as a code address yields SIGSEGV.  Skip the fold
+    // when the funcbox is non-constant; the recorded `CallPure*` op
+    // stays in the trace for the optimizer to consume later.
+    if !allboxes[0].is_constant() {
+        return;
+    }
     let funcptr_val = ctx.trace_ctx.box_value(allboxes[0]);
     let func_ptr = match funcptr_val {
         Some(majit_ir::Value::Int(addr)) => addr,
@@ -8200,8 +8211,7 @@ mod tests {
                     op.pc, op.next_pc, op.key, operand_bytes,
                 );
                 if op.key.starts_with("inline_call_") {
-                    let didx =
-                        u16::from_le_bytes([code[op.pc + 1], code[op.pc + 2]]) as usize;
+                    let didx = u16::from_le_bytes([code[op.pc + 1], code[op.pc + 2]]) as usize;
                     if let Some(d) = descrs.get(didx) {
                         let s = format!("{:?}", d);
                         if let Some(sub_idx) = extract_sub_index(&s) {
@@ -8220,7 +8230,9 @@ mod tests {
                     }
                 } else if op.key.starts_with("residual_call_") {
                     let descr_byte_offset = op.next_pc - 3;
-                    let didx = u16::from_le_bytes([code[descr_byte_offset], code[descr_byte_offset + 1]]) as usize;
+                    let didx =
+                        u16::from_le_bytes([code[descr_byte_offset], code[descr_byte_offset + 1]])
+                            as usize;
                     if let Some(d) = descrs.get(didx) {
                         let cd = d.as_calldescr();
                         let ei = &cd.extra_info;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8404,8 +8404,13 @@ mod tests {
                         let cd = d.as_calldescr();
                         let ei = &cd.extra_info;
                         eprintln!(
-                            "      → descr#{didx} args={:?} result={} extraeffect={:?} oopspec={:?}",
-                            cd.arg_classes, cd.result_type, ei.extraeffect, ei.oopspecindex,
+                            "      → descr#{didx} args={:?} result={} extraeffect={:?} oopspec={:?} elidable={} canraise={}",
+                            cd.arg_classes,
+                            cd.result_type,
+                            ei.extraeffect,
+                            ei.oopspecindex,
+                            ei.check_is_elidable(),
+                            ei.check_can_raise(false),
                         );
                     }
                 }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6763,7 +6763,21 @@ impl MIFrame {
             }
             Some(Err(e)) => Err(e),
             None => {
-                if production_walker_handles(&instruction) {
+                // Inline-frame gate (Issue #73 Phase 4 PopTop activation):
+                // `walker_capture_snapshot_for_last_guard` only captures a
+                // single Python frame (the outer pyjitcode coordinates,
+                // jitcode_dispatch.rs:3568) because pyre's blackhole cannot
+                // resume into helper/sub jitcodes.  For inline-traced sub
+                // frames (`self.parent_frames` non-empty), the snapshot
+                // must carry the full framestack chain to make the resume
+                // point well-defined; walker dispatch in that context drops
+                // the parent frames, so deopt would re-enter at the wrong
+                // PyFrame.  Until the walker grows multi-frame snapshot
+                // capture (analogous to `capture_snapshot_for_last_guard_
+                // multi_frame_with_vable_vref`), fall back to trait
+                // dispatch in inline frames.
+                let in_inline_frame = !self.parent_frames.is_empty();
+                if production_walker_handles(&instruction) && !in_inline_frame {
                     self.dispatch_via_walker_for_opcode(&instruction)
                 } else {
                     let shadow_outcome =
@@ -7299,19 +7313,24 @@ impl MIFrame {
             }
             Some(Err(e)) => Err(e),
             None => {
-                if production_walker_handles(&instruction) {
-                    self.dispatch_via_walker_for_opcode(&instruction)
-                } else {
-                    let shadow_outcome =
-                        crate::shadow_walker::shadow_validate_pre(self, &instruction, op_arg);
-                    let result = execute_opcode_step(self, code, instruction, op_arg, pc + 1);
-                    if result.is_ok() {
-                        if let Some(outcome) = shadow_outcome {
-                            crate::shadow_walker::shadow_validate_post(self, outcome);
-                        }
+                // Inline-frame gate: `trace_code_step_inline` always
+                // steps in an inline-traced sub frame, so
+                // `walker_capture_snapshot_for_last_guard`'s single-frame
+                // capture would drop the parent chain (see comment in
+                // `trace_code_step` for full rationale).  Walker dispatch
+                // remains disabled here until multi-frame walker
+                // snapshots land; route every opcode through trait
+                // dispatch so the snapshot encoder sees a fully formed
+                // framestack at every guard.
+                let shadow_outcome =
+                    crate::shadow_walker::shadow_validate_pre(self, &instruction, op_arg);
+                let result = execute_opcode_step(self, code, instruction, op_arg, pc + 1);
+                if result.is_ok() {
+                    if let Some(outcome) = shadow_outcome {
+                        crate::shadow_walker::shadow_validate_post(self, outcome);
                     }
-                    result
                 }
+                result
             }
         };
         if needs_pre_opcode_snapshot {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7330,9 +7330,16 @@ impl MIFrame {
                 // remains disabled here until multi-frame walker
                 // snapshots land; route every opcode through trait
                 // dispatch so the snapshot encoder sees a fully formed
-                // framestack at every guard.
-                let shadow_outcome =
-                    crate::shadow_walker::shadow_validate_pre(self, &instruction, op_arg);
+                // framestack at every guard.  Shadow validation is gated
+                // the same way: `shadow_validate_pre` runs the symbolic
+                // walker, which captures a single-frame snapshot under
+                // `MAJIT_SHADOW_WALKER=1` and would diverge from the
+                // trait dispatcher's multi-frame view in inline frames.
+                let shadow_outcome = if self.parent_frames.is_empty() {
+                    crate::shadow_walker::shadow_validate_pre(self, &instruction, op_arg)
+                } else {
+                    None
+                };
                 let result = execute_opcode_step(self, code, instruction, op_arg, pc + 1);
                 if result.is_ok() {
                     if let Some(outcome) = shadow_outcome {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2293,20 +2293,17 @@ impl MIFrame {
 
     /// Set the original PC for the current opcode (RPython orgpc).
     /// All guards within this opcode will use orgpc as their resume PC.
-    pub(crate) fn set_orgpc(&mut self, pc: usize) {
-        self.orgpc = pc;
-        self.publish_last_instr_to_vable(pc);
-    }
-
+    ///
     /// Pyre-only shadow refresh hook.  RPython's metainterp owns every opcode
     /// boundary so `metainterp.virtualizable_boxes` stays in lockstep with
     /// heap automatically.  Pyre splits dispatch between the walker (which
     /// mirrors via `vable_setfield → synchronize_virtualizable`) and
     /// `execute_opcode_step` (which mutates the heap PyFrame directly via
     /// `PyFrame::push` / `PyFrame::pop` etc.), so the shadow can lag the
-    /// heap between opcodes.  Pull the heap values into the shadow before
-    /// entering walker dispatch so the arm body's `getfield_vable_*` reads
-    /// and any `synchronize_virtualizable` write-back see up-to-date values.
+    /// heap between opcodes.  The refresh must run BEFORE
+    /// `capture_pre_opcode_state` reads from `virtualizable_boxes`
+    /// (`trace_opcode.rs:1014`) — otherwise guard fail_args would snapshot a
+    /// stale shadow whenever the prior opcode ran through trait dispatch.
     ///
     /// Inline-frame guard: when `self.parent_frames` is non-empty we are
     /// running `trace_code_step_inline` on a callee MIFrame.  The shared
@@ -2318,11 +2315,21 @@ impl MIFrame {
     /// When dispatch unification retires `execute_opcode_step`, this hook
     /// becomes a no-op (every mutation already lands in shadow) and can
     /// be removed.
-    fn refresh_vable_shadow_before_walker(&mut self) {
-        if !self.parent_frames.is_empty() {
-            return;
+    pub(crate) fn set_orgpc(&mut self, pc: usize) {
+        self.orgpc = pc;
+        // Refresh gating: only frames that own the vable shadow read
+        // through it in `capture_pre_opcode_state` (line 1055) and in the
+        // walker's `vable_getfield_*` arm bodies; non-owner frames snapshot
+        // `s.registers_r` (line 1072) instead, so a stale shadow cannot
+        // contaminate their guard fail_args.  Inline frames inherit the
+        // portal's shadow and must not refresh — the portal's preceding
+        // opcode boundary already ran the refresh and the inline body
+        // may have pushed walker-side updates that have not yet
+        // synchronized back to heap (refresh would clobber them).
+        if self.parent_frames.is_empty() && self.sym().owns_virtualizable_shadow() {
+            self.with_ctx(|_, ctx| ctx.refresh_virtualizable_shadow_from_heap());
         }
-        self.with_ctx(|_, ctx| ctx.refresh_virtualizable_shadow_from_heap());
+        self.publish_last_instr_to_vable(pc);
     }
 
     /// pyopcode.py:170-172 `dispatch_bytecode` parity (Slice 3a, Task #115):
@@ -6513,9 +6520,11 @@ impl MIFrame {
     /// trait-driven Python-opcode interpreter while
     /// `jitcode_dispatch::dispatch_via_miframe` walks the codewriter-
     /// emitted jitcode arm.  Phase 5 retires the trait path opcode-by-
-    /// opcode; this helper is the per-opcode walker entry that production
-    /// dispatch (`trace_code_step` / `trace_code_step_inline`) calls for
-    /// allow-listed instructions.
+    /// opcode; this helper is the per-opcode walker entry that root-frame
+    /// production dispatch (`trace_code_step`) calls for allow-listed
+    /// instructions.  Inline dispatch (`trace_code_step_inline`) remains
+    /// on the trait path until walker snapshot capture can represent the
+    /// full parent-frame chain.
     ///
     /// `is_top_level=false` so the arm's `ref_return/r` terminator
     /// surfaces as `DispatchOutcome::SubReturn` rather than emitting a
@@ -6778,7 +6787,6 @@ impl MIFrame {
                 // dispatch in inline frames.
                 let in_inline_frame = !self.parent_frames.is_empty();
                 if production_walker_handles(&instruction) && !in_inline_frame {
-                    self.refresh_vable_shadow_before_walker();
                     self.dispatch_via_walker_for_opcode(&instruction)
                 } else {
                     let shadow_outcome =
@@ -7499,11 +7507,13 @@ unsafe fn trace_check_exc_match_against(
 /// RPython parity: `pyjitpl.py:1892 MetaInterp._interpret` dispatches
 /// every opcode through the single jitcode-bytecode path; there is no
 /// dual trait/walker split upstream.  This predicate names the Python
-/// instructions for which pyre has already retired the trait dispatch
-/// — for those, `trace_code_step{,_inline}` route directly through
-/// `MIFrame::dispatch_via_walker_for_opcode` and the trait path is
-/// dead code at runtime (Phase 6 removes the trait impl once every
-/// opcode is in this set).
+/// instructions for which pyre has already retired the root-frame trait
+/// dispatch — for those, `trace_code_step` routes directly through
+/// `MIFrame::dispatch_via_walker_for_opcode` and the root-frame trait
+/// path is dead code at runtime.  `trace_code_step_inline` intentionally
+/// stays on the trait path until walker snapshots can encode the full
+/// parent-frame chain.  Phase 6 removes the trait impl once every opcode
+/// is in this set and the inline-frame snapshot gap is closed.
 ///
 /// Phase 5.A initial set: the Nop family of 5 zero-op opcodes
 /// (`Nop`, `ExtendedArg`, `Resume`, `Cache`, `NotTaken`).  All share

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2295,34 +2295,34 @@ impl MIFrame {
     /// All guards within this opcode will use orgpc as their resume PC.
     pub(crate) fn set_orgpc(&mut self, pc: usize) {
         self.orgpc = pc;
-        // Pyre-only shadow refresh.  RPython's metainterp owns every opcode
-        // boundary so `metainterp.virtualizable_boxes` stays in lockstep with
-        // heap automatically.  Pyre splits dispatch between the walker (which
-        // mirrors via `vable_setfield → synchronize_virtualizable`) and
-        // `execute_opcode_step` (which mutates the heap PyFrame directly via
-        // `PyFrame::push` / `PyFrame::pop` etc.), so the shadow can lag the
-        // heap between opcodes.  Pull the heap values into the shadow at the
-        // opcode boundary so any walker arm body that reads `getfield_vable_*`
-        // or that triggers `synchronize_virtualizable` sees the up-to-date
-        // values rather than a seed-time stale copy.  When dispatch unification
-        // retires `execute_opcode_step`, this call becomes a no-op and can be
-        // removed.
-        //
-        // Inline-frame guard: when `self.parent_frames` is non-empty we are
-        // running `trace_code_step_inline` on a callee MIFrame.  The shared
-        // `TraceCtx.virtualizable_boxes` shadow still belongs to the portal
-        // (caller) frame; refreshing it from heap mid-inline would overwrite
-        // any caller-side updates that the walker pushed into the shadow
-        // before the inline call but has not yet written back to heap, and a
-        // guard raised in the callee would then capture stale caller state
-        // for `materialize_parent_snapshot_state` /
-        // `get_list_of_active_boxes`.  Skip the refresh for inline frames —
-        // the caller's last opcode boundary already ran the refresh from its
-        // own `set_orgpc` call.
-        if self.parent_frames.is_empty() {
-            self.with_ctx(|_, ctx| ctx.refresh_virtualizable_shadow_from_heap());
-        }
         self.publish_last_instr_to_vable(pc);
+    }
+
+    /// Pyre-only shadow refresh hook.  RPython's metainterp owns every opcode
+    /// boundary so `metainterp.virtualizable_boxes` stays in lockstep with
+    /// heap automatically.  Pyre splits dispatch between the walker (which
+    /// mirrors via `vable_setfield → synchronize_virtualizable`) and
+    /// `execute_opcode_step` (which mutates the heap PyFrame directly via
+    /// `PyFrame::push` / `PyFrame::pop` etc.), so the shadow can lag the
+    /// heap between opcodes.  Pull the heap values into the shadow before
+    /// entering walker dispatch so the arm body's `getfield_vable_*` reads
+    /// and any `synchronize_virtualizable` write-back see up-to-date values.
+    ///
+    /// Inline-frame guard: when `self.parent_frames` is non-empty we are
+    /// running `trace_code_step_inline` on a callee MIFrame.  The shared
+    /// `TraceCtx.virtualizable_boxes` shadow still belongs to the portal
+    /// (caller) frame; refreshing it from heap mid-inline would overwrite
+    /// any caller-side updates that the walker pushed into the shadow
+    /// before the inline call but has not yet written back to heap.
+    ///
+    /// When dispatch unification retires `execute_opcode_step`, this hook
+    /// becomes a no-op (every mutation already lands in shadow) and can
+    /// be removed.
+    fn refresh_vable_shadow_before_walker(&mut self) {
+        if !self.parent_frames.is_empty() {
+            return;
+        }
+        self.with_ctx(|_, ctx| ctx.refresh_virtualizable_shadow_from_heap());
     }
 
     /// pyopcode.py:170-172 `dispatch_bytecode` parity (Slice 3a, Task #115):
@@ -6778,6 +6778,7 @@ impl MIFrame {
                 // dispatch in inline frames.
                 let in_inline_frame = !self.parent_frames.is_empty();
                 if production_walker_handles(&instruction) && !in_inline_frame {
+                    self.refresh_vable_shadow_before_walker();
                     self.dispatch_via_walker_for_opcode(&instruction)
                 } else {
                     let shadow_outcome =


### PR DESCRIPTION
#73

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer


  1. Patch Regressions vs Main

  No confirmed PyPy/RPython parity regressions.

  The earlier PopTop issue is fixed in the current files. pyre/pyre-jit-trace/src/trace_opcode.rs:7558 no longer includes PopTop in
  production_walker_handles, and the surrounding comment now matches the code.

  2. Other Patch-Introduced Mismatches

  No clear new parity mismatches introduced by this patch.

  The main non-1:1 changes look justified:

  - majit/majit-translate/src/jit_codewriter/call.rs:3613 only accepts elidable_cannot_raise / elidable_or_memerror assertions when a real
    fnaddr exists. That preserves the RPython invariant that executable elidable calls have a real callable target.
  - pyre/pyre-jit-trace/src/jitcode_dispatch.rs:3131 now requires allboxes[0] to be constant before pure-call folding, matching RPython’s
    residual-call path where only Const function boxes are looked up as JIT code.
  - pyre/pyre-jit-trace/src/trace_opcode.rs:6775 keeps walker dispatch root-frame only and leaves inline frames on the trait path, which
    matches the current snapshot/parent-chain limitation.

  3. Pre-Existing Mismatches

  There is one stale pre-existing mismatch in tests/comments:

  - pyre/pyre-jit-trace/src/jitcode_dispatch.rs:11222 and pyre/pyre-jit-trace/src/jitcode_dispatch.rs:11325 still say getfield_vable_i/rd>i
    has no walker handler.
  - But the handler exists at pyre/pyre-jit-trace/src/jitcode_dispatch.rs:5296, with a non-ignored test at pyre/pyre-jit-trace/src/
    jitcode_dispatch.rs:12181.
  - This was already present on origin/main, so it is not a regression from this patch.

  4. Structural Adaptations

  These are intentional structural differences rather than porting errors:

  - pyre/pyre-interpreter/src/pyframe.rs:555 uses npure_cellvars / ncells helpers with annotations. PyPy’s _stack_start is a direct
    co_nlocals + len(co_cellvars) + len(co_freevars), but Pyre must account for Python 3.11+ localsplus layout.
  - pyre/pyre-interpreter/src/jit_fnaddr.rs:1 registers real fnaddrs so Rust executor paths do not treat synthetic hashes as callable
    pointers.
  - majit/majit-translate/src/lib.rs:1 / majit/majit-translate/src/front/ast.rs:1 preserve module-qualified hints and aliases, standing in
    for RPython’s Python function-object attributes and graph identity.
  - majit/majit-metainterp/src/trace_ctx.rs:1 rewrites virtualizable shadow refresh to direct reads while keeping the same statics-then-
    arrays layout.
  - majit/majit-metainterp/src/history.rs:1 only improves snapshot panic diagnostics.



<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics for snapshot/active-box failures
  * Fixed Windows path handling for consistent module derivation

* **Performance**
  * Reduced intermediate allocations when refreshing virtualizable shadows
  * Improved opcode/inline-frame dispatch to avoid stale folding of calls

* **New Features**
  * JIT hint support extended to recognize two additional elidable assertions, improving elision classification and matching behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->