### PR TITLE
 Strict PyPy parity: profiler thread-claim, ExportedState    box_pool, InputArg fixture

### DIFF
--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -292,7 +292,19 @@ impl OpRef {
     /// the type test by coincidence but trips any identity-based
     /// dispatch (resoperation.py:699 `AbstractInputArg` vs :250
     /// `AbstractResOp`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `types` contains `Type::Void`. RPython has no
+    /// `InputArgVoid` class — only `InputArgInt`/`InputArgFloat`/`InputArgRef`
+    /// exist (resoperation.py:719/727/739) — so a Void slot here is a
+    /// structural bookkeeping error in the caller.
     pub fn inputarg_refs(types: &[Type]) -> Vec<OpRef> {
+        debug_assert!(
+            types.iter().all(|t| *t != Type::Void),
+            "inputarg_refs: Type::Void is not a valid InputArg type \
+             (resoperation.py:719/727/739 has no InputArgVoid)"
+        );
         types
             .iter()
             .enumerate()

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -284,6 +284,22 @@ impl OpRef {
         }
     }
 
+    /// Build the `[InputArg*(0), InputArg*(1), ...]` vector for a trace
+    /// whose inputarg types are `types`.  Position is the slot index.
+    /// Used by test fixtures so inputarg slots get the `InputArg*`
+    /// variant tag PyPy's `isinstance(x, InputArgInt)` dispatch reads —
+    /// `IntOp` / `VoidOp` masquerading at inputarg positions matches
+    /// the type test by coincidence but trips any identity-based
+    /// dispatch (resoperation.py:699 `AbstractInputArg` vs :250
+    /// `AbstractResOp`).
+    pub fn inputarg_refs(types: &[Type]) -> Vec<OpRef> {
+        types
+            .iter()
+            .enumerate()
+            .map(|(i, t)| OpRef::input_arg_typed(i as u32, *t))
+            .collect()
+    }
+
     /// Allocate a typed `*Op` OpRef from a position. The type tag picks
     /// the matching mixin variant (resoperation.py:564-638).
     /// `Type::Void` lands on `VoidOp` — `AbstractResOp.type = 'v'`

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -219,6 +219,13 @@ impl JitProfiler {
         let mut state = self.timing.lock().expect("JitProfiler timing poisoned");
         state.t1 = Some(Instant::now());
         state.current.clear();
+        // `current` is now empty — release the debug-only thread claim
+        // so the next push from any thread can re-acquire it.  Without
+        // this reset, a previous owner_thread set during the old
+        // session would persist and trip the cross-thread guard in
+        // `check_or_claim_owner_thread` on the next push from a
+        // different thread, even though the stack itself is empty.
+        state.owner_thread = None;
     }
 
     /// jitprof.py:95 `Profiler.start_tracing`.
@@ -523,6 +530,11 @@ impl JitProfiler {
             t0 = state.t1;
             state.t1 = Some(now);
             let Some(ev1) = state.current.pop() else {
+                // Stack was already empty on entry — no owner state to
+                // keep.  Clear the debug-only thread claim so the
+                // broken-data path does not leave dangling ownership
+                // behind for the next push.
+                state.owner_thread = None;
                 crate::debug::log_one("jit-profiler", "BROKEN PROFILER DATA!");
                 return;
             };
@@ -892,6 +904,35 @@ mod tests {
         let snap = prof_arc.snapshot();
         assert_eq!(snap.tracing, 1);
         assert_eq!(snap.backend, 1);
+    }
+
+    #[test]
+    fn start_resets_owner_thread_so_other_threads_can_push_after_a_reset() {
+        // `Profiler.start()` is the global reset entry point
+        // (`jitprof.py:55-61` clears `self.current = []`).  Pyre's
+        // debug-only `owner_thread` claim must clear alongside the
+        // stack — otherwise an in-flight session that gets reset by
+        // `start()` would leave the owner field set on an empty stack,
+        // and a fresh push from a different thread would falsely
+        // trigger `check_or_claim_owner_thread`.
+        let prof = Arc::new(JitProfiler::default());
+        prof.start();
+        // Push a frame on this thread, then reset without popping —
+        // mirrors the "abandon the in-flight session and start over"
+        // case `_setup_once` would not normally exercise but `start()`
+        // contract supports.
+        prof.start_tracing();
+        prof.start();
+        // After `start()`, a worker thread must be able to claim
+        // ownership.  In debug builds this is the meaningful coverage;
+        // in release it merely confirms the API does not regress.
+        let prof_clone = Arc::clone(&prof);
+        std::thread::spawn(move || {
+            prof_clone.start_backend();
+            prof_clone.end_backend();
+        })
+        .join()
+        .expect("worker should claim a freshly-reset stack without panic");
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -1421,7 +1421,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         // Overflow guards and IntMulOvf work on Int-typed args — override
         // the test default so renamed_inputarg_types sees Int, not Ref.
-        opt.trace_inputarg_types = vec![majit_ir::Type::Int; 1024];
+        opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result = opt.optimize_with_constants_and_inputs(

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3949,7 +3949,7 @@ mod tests {
         for &idx in int_slots {
             types[idx as usize] = Type::Int;
         }
-        opt.trace_inputarg_types = types;
+        opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
         opt.optimize_with_constants_and_inputs(

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -4427,7 +4427,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         // IntLt/IntAddOvf operate on Int-typed inputs — override the
         // test default (Ref) used by `optimize_with_constants_and_inputs_at`.
-        opt.trace_inputarg_types = vec![majit_ir::Type::Int; 1024];
+        opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
         constants.insert(200u32, majit_ir::Value::Int(1));
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -727,11 +727,15 @@ pub struct OptContext {
     pub snapshot_vref_boxes: SnapshotBoxes,
     /// Per-guard per-frame (jitcode_index, pc) from tracing-time snapshots.
     pub snapshot_frame_pcs: SnapshotFramePcs,
-    /// Inputarg types indexed by slot, mirroring `Optimizer.trace_inputarg_types`
-    /// (recorder side `InputArg{Int,Ref,Float}.tp`). Slot `i` corresponds to
-    /// `OpRef(inputarg_base + i)`. Populated in `setup_optimizations` so
-    /// readers can resolve inputarg `box.type` (history.py:220 parity).
-    pub inputarg_types: Vec<majit_ir::Type>,
+    /// Inputarg list as typed `OpRef::InputArg{Int,Ref,Float}` variants
+    /// (recorder side `InputArg{Int,Ref,Float}` objects). Slot `i` of
+    /// this Vec corresponds to the `OpRef` at position `inputarg_base + i`
+    /// in the current trace's namespace. `box.type` (history.py:220) is
+    /// derived from each entry's variant tag via `OpRef::ty()`, mirroring
+    /// PyPy's `self.inputargs = inputargs` pattern (optimizer.py:34) where
+    /// the optimizer carries the Box list and reads `.type` per Box.
+    /// Populated by `setup_optimizations`; emptied initially.
+    pub inputargs: Vec<majit_ir::OpRef>,
     /// Phase 1 emit ops carried into Phase 2's lookup surface.
     ///
     /// In RPython, a Box referenced cross-phase keeps its `.type` attribute
@@ -1596,7 +1600,7 @@ impl OptContext {
             snapshot_vref_boxes: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
 
-            inputarg_types: Vec::new(),
+            inputargs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
@@ -1646,14 +1650,15 @@ impl OptContext {
         }
         ctx.box_pool = seed;
         // Mirror the production wiring at `setup_optimizations`
-        // (optimizer.rs `ctx.inputarg_types = self.trace_inputarg_types
-        // .clone()`): seed `ctx.inputarg_types` in lockstep with the
-        // `box_pool` so the typed-Box parity contract holds — strict
-        // accessors like `inputarg_type_at_strict` (and `inputarg_type_at`)
-        // return `Some(tp)` matching `box.type` for slot i. Test fixtures
-        // that call `with_inputarg_types` no longer need to set
-        // `inputarg_types` separately.
-        ctx.inputarg_types = inputarg_types.to_vec();
+        // (optimizer.rs `ctx.inputargs = self.trace_inputargs.clone()`):
+        // seed `ctx.inputargs` in lockstep with the `box_pool` so the
+        // typed-Box parity contract holds — strict accessors like
+        // `inputarg_type_at_strict` (and `inputarg_type_at`) return
+        // `Some(tp)` matching `box.type` for slot i. Test fixtures that
+        // call `with_inputarg_types` no longer need to set `inputargs`
+        // separately. Each entry is `OpRef::input_arg_typed(i, tp)` so
+        // the variant tag IS the type (resoperation.py:719/727/739).
+        ctx.inputargs = majit_ir::OpRef::inputarg_refs(inputarg_types);
         ctx
     }
 
@@ -1722,7 +1727,7 @@ impl OptContext {
             snapshot_vref_boxes: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
 
-            inputarg_types: Vec::new(),
+            inputargs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
@@ -5710,9 +5715,9 @@ impl OptContext {
         } else if self.inputarg_base > 0 && raw < self.num_inputs {
             // Phase 1 inputarg slot accessed from a non-Phase-1 context
             // (Phase 2 / bridge).  RPython resolves these through Box
-            // identity; flat-OpRef pyre uses the shared `inputarg_types`
-            // Vec — no materialization, just the recorder-seeded type
-            // table.
+            // identity; flat-OpRef pyre uses the shared `inputargs` list
+            // — no materialization, just the recorder-seeded Box list
+            // (optimizer.py:34 self.inputargs).
             raw as usize
         } else {
             return None;
@@ -5720,32 +5725,26 @@ impl OptContext {
         if idx >= ni {
             return None;
         }
-        let tp = *self.inputarg_types.get(idx)?;
-        if tp == majit_ir::Type::Void {
-            None
-        } else {
-            Some(tp)
-        }
+        self.inputarg_type_at(idx)
     }
 
-    /// Look up the declared type of inputarg slot `idx` (zero-based) from
-    /// the `inputarg_types` Vec seeded by `setup_optimizations`. Returns
-    /// `None` if the slot is out of range, the type is `Void`, or the Vec
-    /// has not been populated. Mirrors the per-Box `box.type` lookup that
-    /// `init_virtualizable` and other consumers use to mint typed
-    /// `OpRef::input_arg_*` matching the producer side.
+    /// Look up the declared type of inputarg slot `idx` (zero-based) by
+    /// reading the variant tag of `self.inputargs[idx]`. Returns `None`
+    /// if the slot is out of range, the variant tag yields `Void`, or
+    /// the Vec has not been populated. Mirrors the per-Box `box.type`
+    /// lookup (history.py:220) that `init_virtualizable` and other
+    /// consumers use to mint typed `OpRef::input_arg_*` matching the
+    /// producer side.
     pub fn inputarg_type_at(&self, idx: usize) -> Option<majit_ir::Type> {
-        let tp = *self.inputarg_types.get(idx)?;
-        if tp == majit_ir::Type::Void {
-            None
-        } else {
-            Some(tp)
+        match self.inputargs.get(idx)?.ty()? {
+            majit_ir::Type::Void => None,
+            tp => Some(tp),
         }
     }
 
     /// Strict counterpart to `inputarg_type_at`. Panics when the slot is
-    /// out of range, the type is `Void`, or `inputarg_types` was not
-    /// populated by `setup_optimizations`. Mirrors RPython's
+    /// out of range, the variant tag yields `Void`, or `inputargs` was
+    /// not populated by `setup_optimizations`. Mirrors RPython's
     /// `box.type` invariant (history.py:220) — every InputArg always
     /// carries a `.type`, so a miss here is a structural bookkeeping
     /// bug.
@@ -5753,19 +5752,28 @@ impl OptContext {
     /// Used by Slice P5 sites that mint `OpRef::input_arg_typed(...)`
     /// for Phase 2 inputargs and have no legitimate untyped fallback.
     pub fn inputarg_type_at_strict(&self, idx: usize) -> majit_ir::Type {
-        match self.inputarg_types.get(idx).copied() {
-            Some(majit_ir::Type::Void) => panic!(
-                "inputarg_type_at_strict: slot {idx} is Void; \
-                 RPython invariant violated (history.py:220 box.type)"
-            ),
-            Some(tp) => tp,
+        match self.inputargs.get(idx).copied() {
+            Some(op) => match op.ty() {
+                Some(majit_ir::Type::Void) | None => panic!(
+                    "inputarg_type_at_strict: slot {idx} ({op:?}) is Void / untyped; \
+                     RPython invariant violated (history.py:220 box.type)"
+                ),
+                Some(tp) => tp,
+            },
             None => panic!(
                 "inputarg_type_at_strict: slot {idx} out of range \
-                 (inputarg_types.len() = {}); setup_optimizations did not \
-                 seed the parallel type vector",
-                self.inputarg_types.len()
+                 (inputargs.len() = {}); setup_optimizations did not \
+                 seed the inputarg list",
+                self.inputargs.len()
             ),
         }
+    }
+
+    /// Read-only access to the inputarg slot's typed `OpRef` (variant tag
+    /// is `box.type`). Returns `None` when the slot is out of range.
+    /// Mirrors PyPy `self.inputargs[idx]` (optimizer.py:34).
+    pub fn inputarg_at(&self, idx: usize) -> Option<majit_ir::OpRef> {
+        self.inputargs.get(idx).copied()
     }
 
     /// `Box.type` strict accessor. Panics when no source carries a type for

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -90,6 +90,20 @@ pub struct Optimizer {
     /// Types of the original trace inputargs (from LABEL or inputarg_types).
     /// RPython Boxes carry type intrinsically; we store it here so
     /// export_state can propagate to ExportedState.renamed_inputarg_types.
+    ///
+    /// Production redundancy: `OpRef::ty()` (resoperation.rs:133-135)
+    /// already derives `Type::Int` / `Float` / `Ref` from the
+    /// `InputArg*` variant tag, mirroring PyPy `isinstance(x,
+    /// InputArgInt)` class-derived type lookup.  This field carries the
+    /// same information and survives as a compatibility shim for the
+    /// test-only auto-seed at
+    /// [`Self::optimize_with_constants_and_inputs_at`] — many fixtures
+    /// still use `OpRef::int_op(N)` (`AbstractResOp::IntOp` mixin) at
+    /// inputarg slots, where `OpRef::ty()` returns the IntOp type
+    /// regardless of whether the slot is genuinely an inputarg.  Once
+    /// fixtures are migrated to `InputArg*` variants (via
+    /// [`OpRef::inputarg_refs`]) this field can be dropped in favour of
+    /// per-slot `OpRef::ty()` resolution.
     pub trace_inputarg_types: Vec<majit_ir::Type>,
     /// unroll.py / compile.py parity: original live values at the jump
     /// point, threaded into export_state as `runtime_boxes`. Dormant

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1905,14 +1905,30 @@ impl Optimizer {
         box_pool: crate::r#box::BoxPool,
     ) -> Vec<Op> {
         use majit_ir::OpRef;
-        // Test-only: auto-seed `trace_inputarg_types` when unit tests
-        // pass bare `num_inputs` without staging a recorder. Production
-        // callers always populate `trace_inputarg_types` from the
-        // recorder's InputArg{Int,Ref,Float} entries before calling —
-        // the guard never fires outside `#[cfg(test)]`.
+        // Test-only auto-seed of `trace_inputarg_types` from the variant
+        // tags of any InputArg*/IntOp/FloatOp/RefOp OpRef that references
+        // a slot index in `[0, num_inputs)`. Production callers populate
+        // the side table from the recorder's InputArg{Int,Ref,Float}
+        // entries via `setup_optimizations` before calling
+        // (history.py:220 box.type).
+        //
+        // Falls back to `Type::Ref` for slots that no arg references —
+        // RPython never sees that case (every InputArg flows through some
+        // op), but unit fixtures can omit references to unused slots.
         #[cfg(test)]
         if self.trace_inputarg_types.is_empty() && num_inputs > 0 {
-            self.trace_inputarg_types = vec![majit_ir::Type::Ref; num_inputs];
+            let mut types = vec![majit_ir::Type::Ref; num_inputs];
+            for op in ops.iter() {
+                for arg in op.getarglist().iter() {
+                    let idx = arg.raw() as usize;
+                    if idx < num_inputs {
+                        if let Some(tp) = arg.ty() {
+                            types[idx] = tp;
+                        }
+                    }
+                }
+            }
+            self.trace_inputarg_types = types;
         }
         self.imported_label_args = None;
         self.terminal_op = None;

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4971,10 +4971,10 @@ mod tests {
         opt.add_pass(Box::new(AddVirtualInputsOnce { added: false }));
 
         let mut ops = vec![
-            Op::new(OpCode::GetfieldRawI, &[OpRef::int_op(0)]),
-            Op::new(OpCode::GetfieldRawI, &[OpRef::int_op(0)]),
+            Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_int(0)]),
+            Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_int(0)]),
             Op::new(OpCode::GetfieldRawI, &[OpRef::int_op(4)]),
-            Op::new(OpCode::IntGt, &[OpRef::int_op(5), OpRef::int_op(1)]),
+            Op::new(OpCode::IntGt, &[OpRef::int_op(5), OpRef::input_arg_int(1)]),
         ];
         ops[0].pos.set(OpRef::int_op(3));
         ops[1].pos.set(OpRef::int_op(4));
@@ -5013,10 +5013,10 @@ mod tests {
         }));
 
         let mut ops = vec![
-            Op::new(OpCode::GetfieldRawI, &[OpRef::int_op(0)]),
-            Op::new(OpCode::GetfieldRawI, &[OpRef::int_op(0)]),
-            Op::new(OpCode::GetfieldRawI, &[OpRef::int_op(0)]),
-            Op::new(OpCode::IntGt, &[OpRef::int_op(3), OpRef::int_op(1)]),
+            Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_int(0)]),
+            Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_int(0)]),
+            Op::new(OpCode::GetfieldRawI, &[OpRef::input_arg_int(0)]),
+            Op::new(OpCode::IntGt, &[OpRef::int_op(3), OpRef::input_arg_int(1)]),
         ];
         ops[0].pos.set(OpRef::int_op(3));
         ops[1].pos.set(OpRef::int_op(4));
@@ -5049,7 +5049,7 @@ mod tests {
 
         let mut ops = vec![Op::new(
             OpCode::IntGt,
-            &[OpRef::int_op(0), OpRef::int_op(1)],
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
         )];
         ops[0].pos.set(OpRef::int_op(3));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -5073,7 +5073,7 @@ mod tests {
 
         let mut ops = vec![Op::new(
             OpCode::IntGt,
-            &[OpRef::int_op(0), OpRef::int_op(1)],
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
         )];
         ops[0].pos.set(OpRef::int_op(3));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -5099,7 +5099,10 @@ mod tests {
         opt.skip_flush = true;
 
         let mut ops = vec![
-            Op::new(OpCode::IntAdd, &[OpRef::int_op(0), OpRef::int_op(1)]),
+            Op::new(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
             Op::new(OpCode::Jump, &[OpRef::int_op(2)]),
         ];
         ops[0].pos.set(OpRef::int_op(2));
@@ -5214,8 +5217,14 @@ mod tests {
         opt.add_pass(Box::new(crate::optimizeopt::unroll::OptUnroll::new()));
 
         let mut ops = vec![
-            Op::new(OpCode::IntAdd, &[OpRef::int_op(0), OpRef::int_op(1)]),
-            Op::new(OpCode::Jump, &[OpRef::int_op(0), OpRef::int_op(1)]),
+            Op::new(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
+            Op::new(
+                OpCode::Jump,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
         ];
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
@@ -5285,8 +5294,14 @@ mod tests {
         opt.add_pass(Box::new(OptHeap::new()));
 
         let mut ops = vec![
-            Op::new(OpCode::IntAdd, &[OpRef::int_op(0), OpRef::int_op(1)]),
-            Op::new(OpCode::Jump, &[OpRef::int_op(0), OpRef::int_op(1)]),
+            Op::new(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
+            Op::new(
+                OpCode::Jump,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
         ];
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
@@ -5338,8 +5353,14 @@ mod tests {
         opt.add_pass(Box::new(OptHeap::new()));
 
         let mut ops = vec![
-            Op::new(OpCode::IntAdd, &[OpRef::int_op(0), OpRef::int_op(1)]),
-            Op::new(OpCode::Jump, &[OpRef::int_op(0), OpRef::int_op(1)]),
+            Op::new(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
+            Op::new(
+                OpCode::Jump,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
         ];
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
@@ -5390,8 +5411,14 @@ mod tests {
         opt.add_pass(Box::new(OptHeap::new()));
 
         let mut ops = vec![
-            Op::new(OpCode::IntAdd, &[OpRef::int_op(0), OpRef::int_op(1)]),
-            Op::new(OpCode::Jump, &[OpRef::int_op(0), OpRef::int_op(1)]),
+            Op::new(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
+            Op::new(
+                OpCode::Jump,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            ),
         ];
         ops[0].pos.set(OpRef::int_op(66));
         ops[1].pos.set(OpRef::void_op(67));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -87,24 +87,17 @@ pub struct Optimizer {
     /// Maps the original loop-carried input slot to a recursive abstract
     /// description of the virtual's field values.
     pub imported_virtuals: Vec<ImportedVirtual>,
-    /// Types of the original trace inputargs (from LABEL or inputarg_types).
-    /// RPython Boxes carry type intrinsically; we store it here so
-    /// export_state can propagate to ExportedState.renamed_inputarg_types.
+    /// Original trace inputargs as typed `OpRef::InputArg{Int,Ref,Float}`
+    /// variants. Mirrors PyPy `Optimizer.__init__: self.inputargs = inputargs`
+    /// (optimizer.py:34) where the optimizer carries the recorder's Box
+    /// list verbatim and reads `.type` per Box (history.py:220). Each
+    /// entry's variant tag IS `box.type` (resoperation.py:719/727/739),
+    /// so there is no parallel `Vec<Type>` side table — the OpRef is the
+    /// single source of truth.
     ///
-    /// Production redundancy: `OpRef::ty()` (resoperation.rs:133-135)
-    /// already derives `Type::Int` / `Float` / `Ref` from the
-    /// `InputArg*` variant tag, mirroring PyPy `isinstance(x,
-    /// InputArgInt)` class-derived type lookup.  This field carries the
-    /// same information and survives as a compatibility shim for the
-    /// test-only auto-seed at
-    /// [`Self::optimize_with_constants_and_inputs_at`] — many fixtures
-    /// still use `OpRef::int_op(N)` (`AbstractResOp::IntOp` mixin) at
-    /// inputarg slots, where `OpRef::ty()` returns the IntOp type
-    /// regardless of whether the slot is genuinely an inputarg.  Once
-    /// fixtures are migrated to `InputArg*` variants (via
-    /// [`OpRef::inputarg_refs`]) this field can be dropped in favour of
-    /// per-slot `OpRef::ty()` resolution.
-    pub trace_inputarg_types: Vec<majit_ir::Type>,
+    /// `export_state` propagates these into
+    /// `ExportedState.renamed_inputarg_types` (Phase 1 → Phase 2 carry).
+    pub trace_inputargs: Vec<OpRef>,
     /// unroll.py / compile.py parity: original live values at the jump
     /// point, threaded into export_state as `runtime_boxes`. Dormant
     /// until the export/import pair starts reading it.
@@ -1081,7 +1074,7 @@ impl Optimizer {
             can_replace_guards: true,
             quasi_immutable_deps: Vec::new(),
             imported_virtuals: Vec::new(),
-            trace_inputarg_types: Vec::new(),
+            trace_inputargs: Vec::new(),
             runtime_boxes: Vec::new(),
             exported_loop_state: None,
             imported_loop_state: None,
@@ -1905,30 +1898,35 @@ impl Optimizer {
         box_pool: crate::r#box::BoxPool,
     ) -> Vec<Op> {
         use majit_ir::OpRef;
-        // Test-only auto-seed of `trace_inputarg_types` from the variant
+        // Test-only auto-seed of `trace_inputargs` from the variant
         // tags of any InputArg*/IntOp/FloatOp/RefOp OpRef that references
         // a slot index in `[0, num_inputs)`. Production callers populate
-        // the side table from the recorder's InputArg{Int,Ref,Float}
-        // entries via `setup_optimizations` before calling
-        // (history.py:220 box.type).
+        // the list from the recorder's InputArg{Int,Ref,Float} objects
+        // via `setup_optimizations` (optimizer.py:34 self.inputargs).
         //
         // Falls back to `Type::Ref` for slots that no arg references —
         // RPython never sees that case (every InputArg flows through some
         // op), but unit fixtures can omit references to unused slots.
         #[cfg(test)]
-        if self.trace_inputarg_types.is_empty() && num_inputs > 0 {
+        if self.trace_inputargs.is_empty() && num_inputs > 0 {
+            // RPython InputArg variants are Int/Ref/Float only
+            // (resoperation.py:719/727/739) — Void inputargs do not exist.
+            // VoidOp args at inputarg slots leave the slot at the Ref
+            // fallback because the actual inputarg-side Box would have
+            // been Int/Ref/Float per producer-side typing.
             let mut types = vec![majit_ir::Type::Ref; num_inputs];
             for op in ops.iter() {
                 for arg in op.getarglist().iter() {
                     let idx = arg.raw() as usize;
                     if idx < num_inputs {
-                        if let Some(tp) = arg.ty() {
-                            types[idx] = tp;
+                        match arg.ty() {
+                            Some(majit_ir::Type::Void) | None => {}
+                            Some(tp) => types[idx] = tp,
                         }
                     }
                 }
             }
-            self.trace_inputarg_types = types;
+            self.trace_inputargs = OpRef::inputarg_refs(&types);
         }
         self.imported_label_args = None;
         self.terminal_op = None;
@@ -1971,11 +1969,12 @@ impl Optimizer {
         // 1. Phase 1 → Phase 2 carry: `phase1_emit_ops` below; `op_at`
         //    resolves cross-phase OpRefs through `op.type_` directly
         //    (history.py:220 box.type parity).
-        // 2. Inputarg types (from recorder — RPython InputArgInt/Ref/Float).
-        //    Slice 0.5: inputarg slot lookups live on the dedicated
-        //    `ctx.inputarg_types` Vec exclusively, mirroring RPython's
-        //    `InputArg{Int,Ref,Float}.type` (history.py:220 parity).
-        ctx.inputarg_types = self.trace_inputarg_types.clone();
+        // 2. Inputarg list (from recorder — RPython InputArgInt/Ref/Float).
+        //    Each entry is a typed `OpRef::InputArg{Int,Ref,Float}` so
+        //    `box.type` is the variant tag (resoperation.py:719/727/739).
+        //    Mirrors `PyPy Optimizer.__init__: self.inputargs = inputargs`
+        //    (optimizer.py:34).
+        ctx.inputargs = self.trace_inputargs.clone();
         // Phase 1 emit ops: single source of truth for cross-phase OpRef →
         // `op.type_` lookup (history.py:220 parity).
         ctx.phase1_emit_ops = std::mem::take(&mut self.phase1_emit_ops);
@@ -2309,7 +2308,7 @@ impl Optimizer {
             // Additionally, in majit OpRef forwarding is typeless, so a Ref
             // virtual can forward to a Float (SameAsF). When that happens,
             // force_box materializes the virtual to preserve Ref type.
-            let inputarg_types = self.trace_inputarg_types.clone();
+            let inputargs = self.trace_inputargs.clone();
             // Phase 1: resolve and call force_at_the_end_of_preamble on all args
             let resolved_args: Vec<OpRef> = terminal_op
                 .getarglist()
@@ -2328,12 +2327,12 @@ impl Optimizer {
                 let arg = terminal_op.arg(i);
                 let resolved = ctx.get_box_replacement(arg);
                 let expected_ref =
-                    i < inputarg_types.len() && inputarg_types[i] == majit_ir::Type::Ref;
-                // setup_optimizations seeds `trace_inputarg_types` into
-                // ctx.inputarg_types (this fn, line 1837), and `opref_type`
-                // consults it via the inputarg-slot fallback after the
-                // op/value_types chain. PtrInfo presence is an additional
-                // Ref-only side channel for inputargs not in `new_operations`.
+                    inputargs.get(i).and_then(|op| op.ty()) == Some(majit_ir::Type::Ref);
+                // setup_optimizations seeds `trace_inputargs` into
+                // ctx.inputargs (this fn), and `opref_type` consults it
+                // via the inputarg-slot fallback after the op/value_types
+                // chain. PtrInfo presence is an additional Ref-only side
+                // channel for inputargs not in `new_operations`.
                 let resolved_has_ptr_info = ctx
                     .get_box_replacement_box(arg)
                     .as_ref()
@@ -3230,14 +3229,18 @@ impl Optimizer {
                     // opencoder.py:259 inputarg_from_tp parity — seed inputarg
                     // BoxRefs with the producer-side types when available; the
                     // Ref fallback covers the rare case the recorder hasn't
-                    // populated `trace_inputarg_types` (e.g. test-only entry
-                    // paths) and matches the historical Type::Void behaviour
-                    // for ptr-handle slots.
+                    // populated `trace_inputargs` (e.g. test-only entry paths)
+                    // and matches the historical Type::Void behaviour for
+                    // ptr-handle slots.
                     let ni = self.final_num_inputs();
                     let types: Vec<majit_ir::Type> = self
-                        .trace_inputarg_types
+                        .trace_inputargs
                         .get(..ni)
-                        .map(|s| s.to_vec())
+                        .map(|s| {
+                            s.iter()
+                                .map(|op| op.ty().unwrap_or(majit_ir::Type::Ref))
+                                .collect()
+                        })
                         .unwrap_or_else(|| vec![majit_ir::Type::Ref; ni]);
                     OptContext::with_inputarg_types(32, &types)
                 });
@@ -3263,9 +3266,13 @@ impl Optimizer {
             // as the inline_short_preamble path above.
             let ni = self.final_num_inputs();
             let types: Vec<majit_ir::Type> = self
-                .trace_inputarg_types
+                .trace_inputargs
                 .get(..ni)
-                .map(|s| s.to_vec())
+                .map(|s| {
+                    s.iter()
+                        .map(|op| op.ty().unwrap_or(majit_ir::Type::Ref))
+                        .collect()
+                })
                 .unwrap_or_else(|| vec![majit_ir::Type::Ref; ni]);
             OptContext::with_inputarg_types(32, &types)
         });
@@ -4716,7 +4723,7 @@ mod tests {
     fn test_restart_from_extra_operation_rediscovers_first_pass() {
         let hits = Rc::new(Cell::new(0));
         let mut opt = Optimizer::new();
-        opt.trace_inputarg_types = vec![majit_ir::Type::Int; 8];
+        opt.trace_inputargs = OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 8]);
         opt.add_pass(Box::new(QueueRestartCandidate { queued: false }));
         opt.add_pass(Box::new(RestartIntAddAsSub));
         opt.add_pass(Box::new(CountRestartedIntSub { hits: hits.clone() }));
@@ -4956,7 +4963,7 @@ mod tests {
     fn test_default_pipeline_processes_trace() {
         let mut opt = Optimizer::default_pipeline();
         // IntAdd operates on Int-typed inputs — override the test default.
-        opt.trace_inputarg_types = vec![majit_ir::Type::Int; 1024];
+        opt.trace_inputargs = OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
         // A simple trace: two INT_ADD with identical args. The Pure pass (CSE)
         // should eliminate the duplicate.
         let mut ops = vec![
@@ -5148,7 +5155,7 @@ mod tests {
         // This test only exercises the ops/guard counter; each inputarg
         // is read by at least one Int-shape consumer (GuardTrue, IntAdd),
         // so seed Int to keep intbounds' type asserts happy.
-        opt.trace_inputarg_types = vec![majit_ir::Type::Int; 1024];
+        opt.trace_inputargs = OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
         // optimizer.py:691 `assert isinstance(last_descr, ResumeGuardDescr)`:
         // the first GuardTrue becomes the sharing donor for the
         // descrless GuardNonnull below — give it a real descr so
@@ -5573,10 +5580,13 @@ mod tests {
         // `ctx.new_operations` filtered by non-NONE pos and non-Void type
         // (resoperation.py:1693 parity). Phase 1 inputarg slot OpRefs are
         // resolved from Phase 2 through `OptContext::inputarg_type`
-        // (history.py:220 parity) against the shared `inputarg_types`
-        // Vec, so they are NOT carried here.
+        // (history.py:220 parity) against the shared `inputargs` list,
+        // so they are NOT carried here.
         let mut opt = Optimizer::new();
-        opt.trace_inputarg_types = vec![Type::Void, Type::Int, Type::Ref];
+        // resoperation.py:719/727/739 — InputArg type is always
+        // Int/Ref/Float (no Void inputargs). Slot 0 unused by this
+        // fixture; Int picked arbitrarily.
+        opt.trace_inputargs = OpRef::inputarg_refs(&[Type::Int, Type::Int, Type::Ref]);
         opt.phase1_emit_ops.push(std::rc::Rc::new(majit_ir::Op::new(
             majit_ir::OpCode::SameAsI,
             &[OpRef::int_op(50)],
@@ -5603,10 +5613,10 @@ mod tests {
         // Slice 0.6 step 1: from a Phase-2-like context (`inputarg_base > 0`)
         // `OptContext::inputarg_type` must resolve low OpRefs in
         // `[0, num_inputs)` as Phase 1 inputarg slot lookups against the
-        // shared `inputarg_types` Vec (history.py:220 parity for
-        // `box.type` reads through `imported_label_args`).
+        // shared `inputargs` list (history.py:220 parity for `box.type`
+        // reads through `imported_label_args`).
         let mut ctx = OptContext::with_num_inputs_and_start_pos(8, 3, 100, 103);
-        ctx.inputarg_types = vec![Type::Int, Type::Ref, Type::Float];
+        ctx.inputargs = OpRef::inputarg_refs(&[Type::Int, Type::Ref, Type::Float]);
         // Phase 2's own inputargs at [100..103) — own range still resolves.
         assert_eq!(ctx.inputarg_type(OpRef::int_op(100)), Some(Type::Int));
         assert_eq!(ctx.inputarg_type(OpRef::int_op(101)), Some(Type::Ref));
@@ -5628,7 +5638,7 @@ mod tests {
         // In Phase 1 (`inputarg_base == 0`) the low-range fallback must
         // NOT trigger — only the canonical own-range path applies.
         let mut ctx = OptContext::with_inputarg_types(8, &[Type::Ref, Type::Ref, Type::Ref]);
-        ctx.inputarg_types = vec![Type::Int, Type::Ref, Type::Float];
+        ctx.inputargs = OpRef::inputarg_refs(&[Type::Int, Type::Ref, Type::Float]);
         // OpRefs in [0..3) resolve through the own range (inputarg_base=0).
         assert_eq!(ctx.inputarg_type(OpRef::int_op(0)), Some(Type::Int));
         assert_eq!(ctx.inputarg_type(OpRef::int_op(2)), Some(Type::Float));
@@ -5889,12 +5899,12 @@ mod tests {
     fn test_resumedata_memo_encodes_rd_numb_on_guard() {
         let mut opt = Optimizer::default_pipeline();
         // OptIntBound (mod.rs:2624 getintbound) requires IntAdd's args to be
-        // Type::Int.  trace_inputarg_types defaults to all-Ref, so we must
+        // Type::Int.  trace_inputargs defaults to all-Ref, so we must
         // override slots 100 and 101.
         let mut input_types = vec![Type::Ref; 1024];
         input_types[100] = Type::Int;
         input_types[101] = Type::Int;
-        opt.trace_inputarg_types = input_types;
+        opt.trace_inputargs = OpRef::inputarg_refs(&input_types);
 
         let mut ops = vec![
             Op::new(OpCode::IntAdd, &[OpRef::int_op(100), OpRef::int_op(101)]),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -41,25 +41,29 @@ fn is_trace_runtime_ref(
     !opref.is_none() && !is_trace_constant_ref(opref, constants)
 }
 
-/// Reconstruct Phase 1's `box_pool` prefix from the exported snapshot
-/// so a Phase 2 retrace observes the same `_forwarded` chain Phase 1
-/// produced. The `BoxPool::clone` here is intentionally shallow:
-/// `BoxRef` is `Rc<Box>`, so cloning shares the same `Box` cells —
-/// matching `unroll.py` Phase 2's behaviour of seeing Phase 1's
-/// `_forwarded` mutations through Python object identity
-/// (resoperation.py:233-240).
+/// Reconstruct Phase 1's `box_pool` prefix for a Phase 2 retrace.
 ///
+/// The `BoxPool::clone` here is intentionally shallow: `BoxRef` is
+/// `Rc<Box>`, so cloning shares the same `Box` cells — matching
+/// `unroll.py` Phase 2's behaviour of seeing Phase 1's `_forwarded`
+/// mutations through Python object identity (resoperation.py:233-240).
 /// A "deep" snapshot (cloning each `Box` so Phase 2 cannot reach into
 /// `phase1_out`) would diverge from upstream: PyPy explicitly relies on
 /// shared identity to read Phase 1 forwarding from Phase 2 — see
-/// `unroll.py:55-64` `setinfo_from_preamble`. The defensive copy is the
-/// wrong direction for parity. The GcRef-rooting bookkeeping that
-/// `ExportedState::root_all_gcrefs` does is the canonical safety net,
-/// not snapshot copying.
-fn p1_full_prefix_from_box_pool_snapshot(
-    snapshot: Option<&crate::r#box::BoxPool>,
+/// `unroll.py:55-64` `setinfo_from_preamble`.
+///
+/// Returns `None` for an empty pool so callers feed the iterator the
+/// same `None`/`Some` distinction the `p1_full_prefix` argument
+/// expects.  GcRef rooting via `ExportedState::root_all_gcrefs` is the
+/// canonical safety net, not snapshot copying.
+fn p1_full_prefix_from_box_pool(
+    pool: &crate::r#box::BoxPool,
 ) -> Option<crate::r#box::BoxPool> {
-    snapshot.cloned()
+    if pool.is_empty() {
+        None
+    } else {
+        Some(pool.clone())
+    }
 }
 
 /// unroll.py: UnrollOptimizer — high-level loop optimization controller.
@@ -336,8 +340,8 @@ impl UnrollOptimizer {
                 }
                 // compile_retrace has no `opt_p1.final_ctx` (Phase 1 was
                 // skipped), but the failed attempt's Phase 1 captured its full
-                // `box_pool` into `ExportedState.box_pool_snapshot` at export
-                // time (`export_state_with_bounds`). TraceIterator's
+                // `box_pool` into `ExportedState.box_pool` at export time
+                // (`export_state_with_bounds`). TraceIterator's
                 // `p1_full_prefix` contract: deliver the full Phase 1 box_pool
                 // including inputarg BoxRefs at `[0..num_inputs)`, so
                 // `import_state` setting `Forwarded::Box(target)` for
@@ -346,8 +350,7 @@ impl UnrollOptimizer {
                 // `_forwarded` through shared Box identity; preserving the full
                 // raw position alignment (inputargs + emit ops) reproduces
                 // that identity here.
-                let prefix =
-                    p1_full_prefix_from_box_pool_snapshot(pre_imported.box_pool_snapshot.as_ref());
+                let prefix = p1_full_prefix_from_box_pool(&pre_imported.box_pool);
                 (pre_imported, constants.clone(), Vec::new(), prefix)
             } else {
                 // ── Phase 1: PreambleCompileData.optimize() ──
@@ -528,8 +531,7 @@ impl UnrollOptimizer {
                             short_inputargs: Vec::new(),
                             runtime_boxes: Vec::new(),
                             patchguardop: None,
-                            phase1_emit_high_water: state.phase1_emit_high_water,
-                            box_pool_snapshot: None,
+                            box_pool: state.box_pool.clone(),
                             rooted_refs: Vec::new(),
                             shadow_stack_base: 0,
                         });
@@ -1714,25 +1716,25 @@ pub struct ExportedState {
     /// Phase 2's extra_guards (from virtualstate) need rd_resume_position
     /// from this patchguardop (unroll.py:333-336).
     pub patchguardop: Option<majit_ir::Op>,
-    /// Smallest fresh OpRef strictly above every Phase 1 emit position
-    /// (i.e. `max(op.pos.raw()) + 1` over `phase1_emit_ops`). Used by
-    /// `opref_high_water` so retrace's Phase 2 namespace stays disjoint
-    /// from intermediate Phase 1 emit OpRefs that were forwarded /
-    /// folded and never survive as an end_arg / short_op source.
-    /// `0` when there are no Phase 1 emit positions to track.
-    pub phase1_emit_high_water: u32,
-    /// Snapshot of Phase 1's `OptContext::box_pool` taken at export time.
-    /// Used by `compile_retrace`'s Phase 2 TraceIterator as the
-    /// `p1_full_prefix` (inputarg + emit BoxRefs) so chain walks via
-    /// `Forwarded::Box(rc)` observe the failed attempt's accumulated
-    /// `_forwarded` info on every Phase 1 position — `unroll.py` Phase 2
-    /// reading Phase 1 box.\_forwarded through Python identity parity.
+    /// Phase 1's `OptContext::box_pool` slot table at export time — the
+    /// raw OpRef position → `Rc<Box>` lookup table Phase 2 consults when
+    /// chain-walking a Phase 1 OpRef.  Carries `Rc::clone`d handles, so
+    /// `Forwarded::Box(rc)` walks land on the same cells Phase 1 mutated
+    /// during its run — `unroll.py` Phase 2 reading Phase 1
+    /// `box._forwarded` through Python object identity parity.
     ///
-    /// `None` for ExportedStates produced by paths that do not feed into a
-    /// retrace attempt (test fixtures, in-flight construction). Populated
-    /// only by `export_state_with_bounds` at the canonical Phase 1 export
-    /// site.
-    pub(crate) box_pool_snapshot: Option<crate::r#box::BoxPool>,
+    /// Empty when no Phase 1 ran (test fixtures, fresh constructor) or
+    /// when Phase 1 forced-returned without producing a chain.  Always
+    /// populated by `export_state_with_bounds` at the canonical Phase 1
+    /// export site.  PyPy has no analog because Box references pass by
+    /// Python identity end-to-end; pyre's numeric `OpRef` indirection
+    /// makes this table the explicit lookup.  Doubles as the
+    /// `opref_high_water` ceiling (`box_pool.len()` covers every
+    /// Phase 1 emit position, including intermediates that were
+    /// forwarded/folded and never survive as an end_arg / short_op
+    /// source — `reserve_pos` extends `box_pool` even when the resulting
+    /// op is later dropped).
+    pub(crate) box_pool: crate::r#box::BoxPool,
     /// Shadow stack rooting for GcRef values in exported_infos.
     /// (OpRef key, field kind, shadow stack index).
     rooted_refs: Vec<(OpRef, ExportedGcRefField, usize)>,
@@ -1765,11 +1767,11 @@ enum ExportedGcRefField {
     VirtualStateConstantRef(usize),
     /// short_box_const_values[OpRef] = Value::Ref(...)
     ShortBoxConstValue(OpRef),
-    /// box_pool_snapshot[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Constant(_)))
+    /// box_pool[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Constant(_)))
     BoxPoolInfoPtrInfoConstant(usize),
-    /// box_pool_snapshot[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Instance{known_class: Some(_)}))
+    /// box_pool[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Instance{known_class: Some(_)}))
     BoxPoolInfoPtrInfoKnownClass(usize),
-    /// box_pool_snapshot[index].forwarded = Box(target) where target is
+    /// box_pool[index].forwarded = Box(target) where target is
     /// `BoxKind::Const(Value::Ref(_))` — `make_constant` /
     /// `make_equal_to(... const ...)` writer mirror shape.
     BoxPoolBoxConstRef(usize),
@@ -1815,8 +1817,7 @@ impl ExportedState {
             short_inputargs,
             runtime_boxes: Vec::new(),
             patchguardop: None,
-            phase1_emit_high_water: 0,
-            box_pool_snapshot: None,
+            box_pool: crate::r#box::BoxPool::default(),
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -1910,23 +1911,19 @@ impl ExportedState {
             }
         }
 
-        // `phase1_emit_high_water` covers Phase 1 emit positions that are
-        // not reachable via any of the structure-stored OpRef fields above
-        // (e.g. intermediate ops that were forwarded and never survive as
-        // an end_arg / short_op source). Retrace must keep its Phase 2
-        // namespace disjoint from every one of those.
-        high = high.max(self.phase1_emit_high_water);
-        // `box_pool_snapshot.len()` covers every Phase 1 BoxRef the failed
-        // attempt allocated, including positions whose only carrier is the
-        // pool itself (no end_arg / short_op / phase1_emit_op trace). When
+        // `box_pool.len()` covers every Phase 1 BoxRef the failed
+        // attempt allocated — inputargs, emitted ops, and intermediates
+        // that were forwarded/folded and never survive as an end_arg /
+        // short_op source.  `OptContext::reserve_pos` extends `box_pool`
+        // even when the resulting op is later dropped, so this is the
+        // raw position ceiling Phase 2's namespace must clear.  When
         // retrace's Phase 2 `start_fresh` is below that ceiling, the
-        // `TraceIterator::new` `p1_prefix.len().min(start_fresh)` truncation
-        // would drop the tail of the snapshot and re-issue the same raw
-        // positions for Phase 2 input/result OpRefs — a numeric collision
-        // PyPy's object-identity Boxes structurally cannot have.
-        if let Some(snapshot) = &self.box_pool_snapshot {
-            high = high.max(snapshot.len() as u32);
-        }
+        // `TraceIterator::new` `p1_prefix.len().min(start_fresh)`
+        // truncation would drop the tail of the pool and re-issue the
+        // same raw positions for Phase 2 input/result OpRefs — a numeric
+        // collision PyPy's object-identity Boxes structurally cannot
+        // have.
+        high = high.max(self.box_pool.len() as u32);
 
         high
     }
@@ -2035,49 +2032,47 @@ impl ExportedState {
                     .push((key, ExportedGcRefField::ShortBoxConstValue(key), ss_idx));
             }
         }
-        // ── box_pool_snapshot Forwarded::Info GcRef fields ──
+        // ── box_pool Forwarded::Info GcRef fields ──
         // Phase 2 chain walks land on these BoxRef cells and read their
         // _forwarded info; if GC moves a Ref between Phase 1 export and
         // retrace those reads see a stale handle.
-        if let Some(snapshot) = &self.box_pool_snapshot {
-            for (i, b) in snapshot.iter_indexed() {
-                let forwarded = b.get_forwarded();
-                if let crate::r#box::Forwarded::Info(OpInfo::Ptr(rc)) = &forwarded {
-                    let info = rc.borrow();
-                    match &*info {
-                        PtrInfo::Constant(gcref) if !gcref.is_null() => {
-                            let ss_idx = majit_gc::shadow_stack::push(*gcref);
-                            self.rooted_refs.push((
-                                dummy_key,
-                                ExportedGcRefField::BoxPoolInfoPtrInfoConstant(i),
-                                ss_idx,
-                            ));
-                        }
-                        PtrInfo::Instance(iinfo) => {
-                            if let Some(gcref) = iinfo.known_class {
-                                if !gcref.is_null() {
-                                    let ss_idx = majit_gc::shadow_stack::push(gcref);
-                                    self.rooted_refs.push((
-                                        dummy_key,
-                                        ExportedGcRefField::BoxPoolInfoPtrInfoKnownClass(i),
-                                        ss_idx,
-                                    ));
-                                }
-                            }
-                        }
-                        _ => {}
+        for (i, b) in self.box_pool.iter_indexed() {
+            let forwarded = b.get_forwarded();
+            if let crate::r#box::Forwarded::Info(OpInfo::Ptr(rc)) = &forwarded {
+                let info = rc.borrow();
+                match &*info {
+                    PtrInfo::Constant(gcref) if !gcref.is_null() => {
+                        let ss_idx = majit_gc::shadow_stack::push(*gcref);
+                        self.rooted_refs.push((
+                            dummy_key,
+                            ExportedGcRefField::BoxPoolInfoPtrInfoConstant(i),
+                            ss_idx,
+                        ));
                     }
-                } else if let crate::r#box::Forwarded::Box(target) = &forwarded {
-                    if target.is_constant() {
-                        if let Some(Value::Ref(gcref)) = target.const_value() {
+                    PtrInfo::Instance(iinfo) => {
+                        if let Some(gcref) = iinfo.known_class {
                             if !gcref.is_null() {
                                 let ss_idx = majit_gc::shadow_stack::push(gcref);
                                 self.rooted_refs.push((
                                     dummy_key,
-                                    ExportedGcRefField::BoxPoolBoxConstRef(i),
+                                    ExportedGcRefField::BoxPoolInfoPtrInfoKnownClass(i),
                                     ss_idx,
                                 ));
                             }
+                        }
+                    }
+                    _ => {}
+                }
+            } else if let crate::r#box::Forwarded::Box(target) = &forwarded {
+                if target.is_constant() {
+                    if let Some(Value::Ref(gcref)) = target.const_value() {
+                        if !gcref.is_null() {
+                            let ss_idx = majit_gc::shadow_stack::push(gcref);
+                            self.rooted_refs.push((
+                                dummy_key,
+                                ExportedGcRefField::BoxPoolBoxConstRef(i),
+                                ss_idx,
+                            ));
                         }
                     }
                 }
@@ -2178,9 +2173,7 @@ impl ExportedState {
                     }
                 }
                 ExportedGcRefField::BoxPoolInfoPtrInfoConstant(i) => {
-                    if let Some(snapshot) = self.box_pool_snapshot.as_ref()
-                        && let Some(b) = snapshot.get_at_position(*i)
-                    {
+                    if let Some(b) = self.box_pool.get_at_position(*i) {
                         // RPython object identity: mutate the live Rc<RefCell<PtrInfo>>
                         // in place so any other handle sharing it sees the post-GC
                         // address. Matches PyPy's `_forwarded` Python object reference
@@ -2199,9 +2192,7 @@ impl ExportedState {
                     }
                 }
                 ExportedGcRefField::BoxPoolInfoPtrInfoKnownClass(i) => {
-                    if let Some(snapshot) = self.box_pool_snapshot.as_ref()
-                        && let Some(b) = snapshot.get_at_position(*i)
-                    {
+                    if let Some(b) = self.box_pool.get_at_position(*i) {
                         let rc = match &b.get_forwarded() {
                             crate::r#box::Forwarded::Info(OpInfo::Ptr(rc))
                                 if matches!(&*rc.borrow(), PtrInfo::Instance(_)) =>
@@ -2218,9 +2209,7 @@ impl ExportedState {
                     }
                 }
                 ExportedGcRefField::BoxPoolBoxConstRef(i) => {
-                    if let Some(snapshot) = self.box_pool_snapshot.as_ref()
-                        && let Some(b) = snapshot.get_at_position(*i)
-                    {
+                    if let Some(b) = self.box_pool.get_at_position(*i) {
                         // BoxKind::Const is immutable, so swap in a fresh
                         // ConstRef BoxRef carrying the updated handle.
                         // `set_forwarded_box` enforces the AbstractValue
@@ -2317,8 +2306,7 @@ impl Clone for ExportedState {
             short_inputargs: self.short_inputargs.clone(),
             runtime_boxes: self.runtime_boxes.clone(),
             patchguardop: self.patchguardop.clone(),
-            phase1_emit_high_water: self.phase1_emit_high_water,
-            box_pool_snapshot: self.box_pool_snapshot.clone(),
+            box_pool: self.box_pool.clone(),
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -2725,26 +2713,20 @@ impl OptUnroll {
             renamed_inputarg_types,
             short_args,
         );
-        // Smallest fresh OpRef strictly above every Phase 1 emit position.
-        // Retrace's `opref_high_water` consults this so Phase 2's namespace
-        // stays disjoint from intermediate Phase 1 ops that were forwarded
-        // and never survive as an end_arg / short_op source. `op.pos.0`
-        // is already non-NONE / non-Void by the rebuild filter.
-        state.phase1_emit_high_water = optimizer
-            .phase1_emit_ops
-            .iter()
-            .map(|op| op.pos.get().raw().saturating_add(1))
-            .max()
-            .unwrap_or(0);
         // Capture the full Phase 1 BoxRef pool so a subsequent
         // `compile_retrace` attempt can hand it back to Phase 2 as
-        // `p1_full_prefix` (`unroll.rs:282-303`). PyPy `unroll.py` Phase 2
-        // observes Phase 1's `_forwarded` mutations through Python identity
-        // on the same Box objects; pyre needs the Rc::cloned BoxRef vector
-        // to recreate that observation across the in-memory ExportedState
-        // hand-off. Each entry is `Rc::clone` cheap; vec retention is
-        // bounded by `ExportedState` lifetime.
-        state.box_pool_snapshot = Some(ctx.box_pool.clone());
+        // `p1_full_prefix` (`unroll.rs:282-303`).  Doubles as the
+        // `opref_high_water` ceiling — `reserve_pos` extends `box_pool`
+        // for every Phase 1 emit position, including intermediates that
+        // were forwarded/folded and never survive as an end_arg /
+        // short_op source, so retrace's Phase 2 namespace must clear
+        // `box_pool.len()` to stay disjoint.  PyPy `unroll.py` Phase 2
+        // observes Phase 1's `_forwarded` mutations through Python
+        // identity on the same Box objects; pyre needs the Rc::cloned
+        // BoxRef vector to recreate that observation across the
+        // in-memory ExportedState hand-off.  Each entry is `Rc::clone`
+        // cheap; vec retention is bounded by `ExportedState` lifetime.
+        state.box_pool = ctx.box_pool.clone();
         // PRE-EXISTING-ADAPTATION: snapshot producer-side const values for
         // any const-namespace OpRef referenced by `short_boxes` op args.
         // Phase B.2 `ProducedShortOp::produce_op` reads raw OpRefs (not the
@@ -5026,7 +5008,7 @@ mod tests {
     }
 
     #[test]
-    fn test_retrace_box_pool_snapshot_preserves_inputargs_for_p1_full_prefix() {
+    fn test_retrace_box_pool_preserves_inputargs_for_p1_full_prefix() {
         let input0 = crate::r#box::BoxRef::new_inputarg(Type::Ref, 0);
         let input1 = crate::r#box::BoxRef::new_inputarg(Type::Int, 1);
         let emit2 = crate::r#box::BoxRef::new_resop(Type::Ref, 2);
@@ -5038,8 +5020,7 @@ mod tests {
             Some(emit3.clone()),
         ]);
 
-        let prefix =
-            p1_full_prefix_from_box_pool_snapshot(Some(&snapshot)).expect("snapshot exists");
+        let prefix = p1_full_prefix_from_box_pool(&snapshot).expect("non-empty pool");
 
         let prefix_slots: Vec<Option<crate::r#box::BoxRef>> = (0..prefix.len())
             .map(|i| prefix.get_at_position(i).cloned())
@@ -5047,6 +5028,11 @@ mod tests {
         assert_eq!(
             prefix_slots,
             vec![Some(input0), Some(input1), Some(emit2), Some(emit3)]
+        );
+
+        assert!(
+            p1_full_prefix_from_box_pool(&crate::r#box::BoxPool::default()).is_none(),
+            "empty pool maps to None for TraceIterator p1_full_prefix"
         );
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5627,21 +5627,19 @@ mod tests {
     #[test]
     fn test_unroll_optimizer_optimize_trace() {
         let mut unroll_opt = UnrollOptimizer::new();
-        // IntAdd operates on Int-typed inputs — seed the inner phase1/2
-        // optimizers' trace_inputarg_types via UnrollOptimizer so the
-        // intbounds pass sees Int on the two inputargs.
+        // Two Int inputargs.  Use `InputArgInt` variants via
+        // `OpRef::inputarg_refs` to match resoperation.py:719
+        // `AbstractInputArg` class identity — the prior fixture used
+        // `OpRef::int_op` (`AbstractResOp` mixin) at inputarg slots, so
+        // the type check passed but the variant tag PyPy's
+        // `isinstance(x, InputArgInt)` reads diverged.  Seeding
+        // `trace_inputarg_types` mirrors the same intent for the
+        // intbounds pass / `with_inputarg_types` BoxRef planter.
+        let inputargs = OpRef::inputarg_refs(&[majit_ir::Type::Int, majit_ir::Type::Int]);
         unroll_opt.trace_inputarg_types = vec![majit_ir::Type::Int; 2];
-        // Use optimize_trace_with_constants_and_inputs to properly set
-        // num_inputs so input args don't collide with op positions. Args
-        // address inputarg slots via `InputArg*` OpRef variants so the
-        // BoxRef shape (`with_inputarg_types` plants `BoxRef::new_inputarg`)
-        // and the orthodox `_forwarded` mirror agree on the namespace.
         let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
-            ),
-            Op::new(OpCode::Jump, &[OpRef::input_arg_int(0)]),
+            Op::new(OpCode::IntAdd, &[inputargs[0], inputargs[1]]),
+            Op::new(OpCode::Jump, &[inputargs[0]]),
         ];
         assign_positions(&mut ops, 2);
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1777,6 +1777,13 @@ enum ExportedGcRefField {
 
 impl ExportedState {
     /// unroll.py: ExportedState.__init__
+    ///
+    /// `box_pool` must be supplied at construction so the synthetic vs
+    /// canonical-export distinction is explicit at every callsite — PyPy
+    /// passes the same Box objects by identity end-to-end, so the
+    /// "no pool" / "fresh pool" case has to be a conscious choice (test
+    /// fixture, retrace base) rather than a silent default that misses
+    /// `_forwarded` chain coverage.
     pub fn new(
         end_args: Vec<OpRef>,
         next_iteration_args: Vec<OpRef>,
@@ -1789,6 +1796,7 @@ impl ExportedState {
         renamed_inputargs: Vec<OpRef>,
         renamed_inputarg_types: Vec<Type>,
         short_inputargs: Vec<OpRef>,
+        box_pool: crate::r#box::BoxPool,
     ) -> Self {
         // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
         // pre-derives the per-OpRef ProducedShortOp view (with label-arg
@@ -1815,7 +1823,7 @@ impl ExportedState {
             short_inputargs,
             runtime_boxes: Vec::new(),
             patchguardop: None,
-            box_pool: crate::r#box::BoxPool::default(),
+            box_pool,
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -2701,16 +2709,6 @@ impl OptUnroll {
         // via `produced_short_boxes_from_exported_boxes`
         // (`shortpreamble.rs:2100`). Storing both shapes on
         // `ExportedState` would risk drift across mutations.
-        let mut state = ExportedState::new(
-            label_args.clone(),
-            resolved_next_iteration_args,
-            virtual_state,
-            infos,
-            exported_short_boxes,
-            renamed_inputargs.to_vec(),
-            renamed_inputarg_types,
-            short_args,
-        );
         // Capture the full Phase 1 BoxRef pool so a subsequent
         // `compile_retrace` attempt can hand it back to Phase 2 as
         // `p1_full_prefix` (`unroll.rs:282-303`).  Doubles as the
@@ -2724,7 +2722,17 @@ impl OptUnroll {
         // BoxRef vector to recreate that observation across the
         // in-memory ExportedState hand-off.  Each entry is `Rc::clone`
         // cheap; vec retention is bounded by `ExportedState` lifetime.
-        state.box_pool = ctx.box_pool.clone();
+        let mut state = ExportedState::new(
+            label_args.clone(),
+            resolved_next_iteration_args,
+            virtual_state,
+            infos,
+            exported_short_boxes,
+            renamed_inputargs.to_vec(),
+            renamed_inputarg_types,
+            short_args,
+            ctx.box_pool.clone(),
+        );
         // PRE-EXISTING-ADAPTATION: snapshot producer-side const values for
         // any const-namespace OpRef referenced by `short_boxes` op args.
         // Phase B.2 `ProducedShortOp::produce_op` reads raw OpRefs (not the
@@ -5045,6 +5053,7 @@ mod tests {
             vec![OpRef::int_op(14)],
             Vec::new(),
             vec![OpRef::int_op(23)],
+            crate::r#box::BoxPool::default(),
         );
 
         assert_eq!(exported.opref_high_water(), 110);
@@ -5918,6 +5927,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             vec![source],
+            crate::r#box::BoxPool::default(),
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
             8,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -522,7 +522,14 @@ impl UnrollOptimizer {
                         // so the backend can see the reduced LABEL's declared
                         // types. Clone only the field we need to avoid keeping
                         // Phase 1 short preamble data alive longer than before.
-                        self.final_exported_state = Some(ExportedState {
+                        // GC parity (gcreftracer.py): `virtual_state` and
+                        // `box_pool` both carry GcRefs that the shadow stack
+                        // must pin between this store and any later read.
+                        // Match the rooting pattern at
+                        // `imported_loop_state = ...` / `phase1_out = ...`
+                        // (this file, ~line 666) — root after construction,
+                        // before placing into long-lived storage.
+                        let mut final_exported_state = ExportedState {
                             end_args: Vec::new(),
                             next_iteration_args: Vec::new(),
                             end_arg_types: Vec::new(),
@@ -538,9 +545,12 @@ impl UnrollOptimizer {
                             runtime_boxes: Vec::new(),
                             patchguardop: None,
                             box_pool: state.box_pool.clone(),
+                            phase1_emit_high_water: self.next_global_opref,
                             rooted_refs: Vec::new(),
                             shadow_stack_base: 0,
-                        });
+                        };
+                        final_exported_state.root_all_gcrefs();
+                        self.final_exported_state = Some(final_exported_state);
                         // Codex plan step 3: snapshot Phase 1 emit-op slice as
                         // Rc::clone vector. Phase 2's TraceIterator embeds these
                         // BoxRefs at its placeholder prefix `[num_inputs..end)`
@@ -1742,13 +1752,21 @@ pub struct ExportedState {
     /// populated by `export_state_with_bounds` at the canonical Phase 1
     /// export site.  PyPy has no analog because Box references pass by
     /// Python identity end-to-end; pyre's numeric `OpRef` indirection
-    /// makes this table the explicit lookup.  Doubles as the
-    /// `opref_high_water` ceiling (`box_pool.len()` covers every
-    /// Phase 1 emit position, including intermediates that were
-    /// forwarded/folded and never survive as an end_arg / short_op
-    /// source — `reserve_pos` extends `box_pool` even when the resulting
-    /// op is later dropped).
+    /// makes this table the explicit lookup.
     pub(crate) box_pool: crate::r#box::BoxPool,
+    /// `OptContext::next_pos` at end of Phase 1 — strict upper bound of
+    /// every OpRef Phase 1 allocated, including intermediates folded /
+    /// forwarded away before any structure-stored field could observe
+    /// them.  `box_pool.len()` is *almost* the same value, but
+    /// `reserve_pos_typed` skips `ensure_box` when `box_pool` is empty
+    /// (zero-inputarg / retrace baselines, `optimizeopt/mod.rs:2026`),
+    /// so the pool length under-reports the emit allocations in that
+    /// case.  Phase 2 / retrace seed their TraceIterator namespace
+    /// strictly above this watermark via `opref_high_water()` to keep
+    /// the OpRef set disjoint — RPython's object-identity Boxes get
+    /// disjointness from Python identity for free; pyre's numeric
+    /// OpRefs need an explicit position floor.
+    pub phase1_emit_high_water: u32,
     /// Shadow stack rooting for GcRef values in exported_infos.
     /// (OpRef key, field kind, shadow stack index).
     rooted_refs: Vec<(OpRef, ExportedGcRefField, usize)>,
@@ -1840,6 +1858,7 @@ impl ExportedState {
             runtime_boxes: Vec::new(),
             patchguardop: None,
             box_pool,
+            phase1_emit_high_water: 0,
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -1934,18 +1953,25 @@ impl ExportedState {
         }
 
         // `box_pool.len()` covers every Phase 1 BoxRef the failed
-        // attempt allocated — inputargs, emitted ops, and intermediates
-        // that were forwarded/folded and never survive as an end_arg /
-        // short_op source.  `OptContext::reserve_pos` extends `box_pool`
-        // even when the resulting op is later dropped, so this is the
-        // raw position ceiling Phase 2's namespace must clear.  When
-        // retrace's Phase 2 `start_fresh` is below that ceiling, the
+        // attempt materialized — inputargs and emit ops the recorder /
+        // optimizer extended the pool for.  When retrace's Phase 2
+        // `start_fresh` is below that ceiling, the
         // `TraceIterator::new` `p1_prefix.len().min(start_fresh)`
         // truncation would drop the tail of the pool and re-issue the
         // same raw positions for Phase 2 input/result OpRefs — a numeric
         // collision PyPy's object-identity Boxes structurally cannot
         // have.
         high = high.max(self.box_pool.len() as u32);
+
+        // `phase1_emit_high_water` covers Phase 1 emit positions when
+        // `box_pool` was not extended (zero-inputarg / retrace baselines
+        // where `reserve_pos_typed` skips `ensure_box` — see
+        // `optimizeopt/mod.rs:2026`).  Intermediate OpRefs that were
+        // allocated then forwarded/folded never make it into any
+        // structure-stored field above, so the explicit watermark from
+        // Phase 1's `OptContext::next_pos` is the only signal that keeps
+        // Phase 2's namespace disjoint from those positions.
+        high = high.max(self.phase1_emit_high_water);
 
         high
     }
@@ -2329,6 +2355,7 @@ impl Clone for ExportedState {
             runtime_boxes: self.runtime_boxes.clone(),
             patchguardop: self.patchguardop.clone(),
             box_pool: self.box_pool.clone(),
+            phase1_emit_high_water: self.phase1_emit_high_water,
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -2749,6 +2776,12 @@ impl OptUnroll {
             short_args,
             ctx.box_pool.clone(),
         );
+        // `OptContext::next_pos` is the strict upper bound on raw OpRefs
+        // Phase 1 allocated.  Captured here so `opref_high_water()` can
+        // floor Phase 2 / retrace's `start_fresh` above every Phase 1
+        // emit position even when `box_pool` was not extended (zero-
+        // inputarg / retrace baselines — `optimizeopt/mod.rs:2026`).
+        state.phase1_emit_high_water = ctx.next_pos;
         // PRE-EXISTING-ADAPTATION: snapshot producer-side const values for
         // any const-namespace OpRef referenced by `short_boxes` op args.
         // Phase B.2 `ProducedShortOp::produce_op` reads raw OpRefs (not the

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -118,11 +118,13 @@ pub struct UnrollOptimizer {
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
     /// Threaded through inner Optimizer instances for inline registration.
     pub all_descrs: Vec<majit_ir::descr::DescrRef>,
-    /// RPython Box type parity: trace inputarg types from recorder.
-    /// Each RPython Box carries its type; in majit OpRef is untyped u32.
-    /// Propagated to Phase 1 and Phase 2 Optimizer.trace_inputarg_types
-    /// so value_types covers inputarg OpRefs.
-    pub trace_inputarg_types: Vec<majit_ir::Type>,
+    /// Recorder-side trace inputargs as typed `OpRef::InputArg{Int,Ref,Float}`
+    /// variants. `box.type` (history.py:220) is the variant tag —
+    /// resoperation.py:719/727/739 `InputArg{Int,Ref,Float}.type`.
+    /// Propagated to the inner Phase 1 / Phase 2 `Optimizer.trace_inputargs`
+    /// so each phase carries the same Box list (optimizer.py:34
+    /// `self.inputargs = inputargs`).
+    pub trace_inputargs: Vec<majit_ir::OpRef>,
     /// Phase 1 emit ops (filtered to non-NONE pos, non-Void type) carried
     /// into Phase 2 so that `OptContext::op_at` resolves Phase 1 OpRefs
     /// directly via `op.type_` (history.py:220 box.type parity).
@@ -183,7 +185,7 @@ impl UnrollOptimizer {
             snapshot_vref_boxes: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
             all_descrs: Vec::new(),
-            trace_inputarg_types: Vec::new(),
+            trace_inputargs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             phase1_patchguardop: None,
             next_global_opref: 0,
@@ -365,7 +367,7 @@ impl UnrollOptimizer {
                 opt_p1.all_descrs = std::mem::take(&mut self.all_descrs);
                 opt_p1.callinfocollection = self.callinfocollection.clone();
                 opt_p1.cpu = self.cpu.clone();
-                opt_p1.trace_inputarg_types = self.trace_inputarg_types.clone();
+                opt_p1.trace_inputargs = self.trace_inputargs.clone();
                 opt_p1.snapshot_boxes = self.snapshot_boxes.clone();
                 opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
                 opt_p1.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
@@ -394,10 +396,16 @@ impl UnrollOptimizer {
                 // structural alignment with RPython's `trace.get_iter()`
                 // call site, not a functional change.
                 // opencoder.py:264 `inputarg_from_tp(arg.type)` — fresh inputargs
-                // are typed via `self.trace_inputarg_types`, the recorder-supplied
-                // per-arg type list (length must equal `num_inputs`).
-                let p1_inputarg_types: &[majit_ir::Type] = &self.trace_inputarg_types;
-                debug_assert_eq!(p1_inputarg_types.len(), num_inputs);
+                // are typed via `self.trace_inputargs`, the recorder-supplied
+                // Box list (length must equal `num_inputs`). Derive the &[Type]
+                // surface TraceIterator expects from each Box's variant tag
+                // (resoperation.py:719/727/739).
+                debug_assert_eq!(self.trace_inputargs.len(), num_inputs);
+                let p1_inputarg_types: Vec<majit_ir::Type> = self
+                    .trace_inputargs
+                    .iter()
+                    .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
+                    .collect();
                 // Wrap input ops as `Vec<OpRc>` so TraceIterator's `&[OpRc]`
                 // surface receives shared identity (history.py:528). The
                 // deep-clone here corresponds to PyPy's `cls()` per-op fresh
@@ -409,7 +417,7 @@ impl UnrollOptimizer {
                     0,
                     ops_oprc.len(),
                     None,
-                    p1_inputarg_types,
+                    &p1_inputarg_types,
                     0,    // start_fresh = 0 — inputargs at [0..num_inputs)
                     None, // p1_full_prefix — Phase 1 has no prior phase
                 );
@@ -628,7 +636,7 @@ impl UnrollOptimizer {
         opt_p2.all_descrs = std::mem::take(&mut self.all_descrs);
         opt_p2.callinfocollection = self.callinfocollection.clone();
         opt_p2.cpu = self.cpu.clone();
-        opt_p2.trace_inputarg_types = self.trace_inputarg_types.clone();
+        opt_p2.trace_inputargs = self.trace_inputargs.clone();
         opt_p2.phase1_emit_ops = self.phase1_emit_ops.clone();
         opt_p2.snapshot_boxes = self.snapshot_boxes.clone();
         opt_p2.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
@@ -722,8 +730,12 @@ impl UnrollOptimizer {
         let phase2_inputarg_base = self.next_global_opref.max(body_num_inputs as u32);
         // opencoder.py:264 `inputarg_from_tp(arg.type)` — same per-arg types
         // as Phase 1 (Phase 2 walks the body half of the same trace).
-        let p2_inputarg_types: &[majit_ir::Type] = &self.trace_inputarg_types;
-        debug_assert_eq!(p2_inputarg_types.len(), body_num_inputs);
+        debug_assert_eq!(self.trace_inputargs.len(), body_num_inputs);
+        let p2_inputarg_types: Vec<majit_ir::Type> = self
+            .trace_inputargs
+            .iter()
+            .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
+            .collect();
         // Wrap into `Vec<OpRc>` for TraceIterator's `&[OpRc]` surface.
         let ops_oprc: Vec<majit_ir::OpRc> =
             ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
@@ -732,7 +744,7 @@ impl UnrollOptimizer {
             0,
             ops_oprc.len(),
             None,
-            p2_inputarg_types,
+            &p2_inputarg_types,
             phase2_inputarg_base, // fresh inputargs at [phase2_inputarg_base..)
             p1_full_prefix, // Codex plan step 3 slice B: full Phase 1 box_pool (inputargs + emit ops)
         );
@@ -1202,7 +1214,7 @@ impl UnrollOptimizer {
                         // equivalent (resoperation.py:29
                         // `AbstractValue.type`); legacy untyped paths fall
                         // through to Phase 2's `final_ctx.opref_type` and
-                        // the recorder's `trace_inputarg_types`.
+                        // the recorder's `trace_inputargs` Box list.
                         let tp = ub
                             .ty()
                             .or_else(|| {
@@ -1210,7 +1222,7 @@ impl UnrollOptimizer {
                             })
                             .or_else(|| {
                                 let raw = ub.raw() as usize;
-                                opt_p2.trace_inputarg_types.get(raw).copied()
+                                opt_p2.trace_inputargs.get(raw).and_then(|op| op.ty())
                             })
                             .unwrap_or_else(|| {
                                 panic!(
@@ -1241,9 +1253,13 @@ impl UnrollOptimizer {
                 // carry the same producer-side types as Phase 1's; fall back
                 // to Ref when types are unavailable.
                 let types: Vec<majit_ir::Type> = opt_p2
-                    .trace_inputarg_types
+                    .trace_inputargs
                     .get(..body_num_inputs)
-                    .map(|s| s.to_vec())
+                    .map(|s| {
+                        s.iter()
+                            .map(|op| op.ty().unwrap_or(majit_ir::Type::Ref))
+                            .collect()
+                    })
                     .unwrap_or_else(|| vec![majit_ir::Type::Ref; body_num_inputs]);
                 crate::optimizeopt::OptContext::with_inputarg_types(32, &types)
             });
@@ -5066,7 +5082,7 @@ mod tests {
         // rationale — the preamble exporter needs an intrinsic type
         // for every renamed inputarg, which production derives from
         // the recorder's trace_inputarg_types.
-        opt.trace_inputarg_types = vec![majit_ir::Type::Ref; 1024];
+        opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Ref; 1024]);
         // Production trace iteration gets rd_resume_position from
         // opencoder.py:399-401.  Direct unit-test guards must seed the
         // corresponding snapshot explicitly before store_final_boxes_in_guard.
@@ -5522,7 +5538,7 @@ mod tests {
 
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptUnroll::new()));
-        opt.trace_inputarg_types = vec![majit_ir::Type::Ref; 1024];
+        opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Ref; 1024]);
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result = opt.optimize_with_constants_and_inputs(
@@ -5640,10 +5656,10 @@ mod tests {
         // `OpRef::int_op` (`AbstractResOp` mixin) at inputarg slots, so
         // the type check passed but the variant tag PyPy's
         // `isinstance(x, InputArgInt)` reads diverged.  Seeding
-        // `trace_inputarg_types` mirrors the same intent for the
+        // `trace_inputargs` mirrors the same intent for the
         // intbounds pass / `with_inputarg_types` BoxRef planter.
         let inputargs = OpRef::inputarg_refs(&[majit_ir::Type::Int, majit_ir::Type::Int]);
-        unroll_opt.trace_inputarg_types = vec![majit_ir::Type::Int; 2];
+        unroll_opt.trace_inputargs = inputargs.clone();
         let mut ops = vec![
             Op::new(OpCode::IntAdd, &[inputargs[0], inputargs[1]]),
             Op::new(OpCode::Jump, &[inputargs[0]]),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -56,9 +56,7 @@ fn is_trace_runtime_ref(
 /// same `None`/`Some` distinction the `p1_full_prefix` argument
 /// expects.  GcRef rooting via `ExportedState::root_all_gcrefs` is the
 /// canonical safety net, not snapshot copying.
-fn p1_full_prefix_from_box_pool(
-    pool: &crate::r#box::BoxPool,
-) -> Option<crate::r#box::BoxPool> {
+fn p1_full_prefix_from_box_pool(pool: &crate::r#box::BoxPool) -> Option<crate::r#box::BoxPool> {
     if pool.is_empty() {
         None
     } else {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2604,7 +2604,7 @@ mod tests {
         for &idx in int_slots {
             types[idx as usize] = Type::Int;
         }
-        opt.trace_inputarg_types = types;
+        opt.trace_inputargs = OpRef::inputarg_refs(&types);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
         opt.optimize_with_constants_and_inputs(
@@ -2617,7 +2617,7 @@ mod tests {
 
     fn run_default_pipeline(ops: &[Op]) -> Vec<Op> {
         let mut opt = Optimizer::default_pipeline();
-        opt.trace_inputarg_types = vec![Type::Ref; 1024];
+        opt.trace_inputargs = OpRef::inputarg_refs(&vec![Type::Ref; 1024]);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
         opt.optimize_with_constants_and_inputs(
@@ -2637,7 +2637,7 @@ mod tests {
         for &idx in float_slots {
             types[idx as usize] = Type::Float;
         }
-        opt.trace_inputarg_types = types;
+        opt.trace_inputargs = OpRef::inputarg_refs(&types);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
         opt.optimize_with_constants_and_inputs(

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -3052,12 +3052,20 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::Label,
-                &[OpRef::input_arg_ref(0), OpRef::int_op(1), OpRef::int_op(2)],
+                &[
+                    OpRef::input_arg_ref(0),
+                    OpRef::input_arg_int(1),
+                    OpRef::input_arg_int(2),
+                ],
             ),
-            Op::new(OpCode::GuardTrue, &[OpRef::int_op(1)]),
+            Op::new(OpCode::GuardTrue, &[OpRef::input_arg_int(1)]),
             Op::new(
                 OpCode::Jump,
-                &[OpRef::input_arg_ref(0), OpRef::int_op(1), OpRef::int_op(2)],
+                &[
+                    OpRef::input_arg_ref(0),
+                    OpRef::input_arg_int(1),
+                    OpRef::input_arg_int(2),
+                ],
             ),
         ];
         ops[1].setfailargs(Default::default());

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4603,12 +4603,15 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.cpu = self.cpu.clone();
         unroll_opt.call_pure_results = preamble_data.call_pure_results.clone();
         // RPython Box type parity: each InputArg carries its type from
-        // tracing. Propagate to optimizer so value_types covers inputargs.
-        unroll_opt.trace_inputarg_types = preamble_data
+        // tracing. Mint typed `OpRef::input_arg_{int,float,ref}` per
+        // recorder Box so the optimizer's `trace_inputargs` IS the Box
+        // list (optimizer.py:34 `self.inputargs = inputargs`).
+        unroll_opt.trace_inputargs = preamble_data
             .base
             .inputargs()
             .iter()
-            .map(|ia| ia.tp)
+            .enumerate()
+            .map(|(i, ia)| majit_ir::OpRef::input_arg_typed(i as u32, ia.tp))
             .collect();
         // resume.py parity: convert tracing-time snapshots to flat OpRef
         // vectors so the optimizer can rebuild fail_args from snapshot in
@@ -4673,9 +4676,12 @@ impl<M: Clone> MetaInterp<M> {
                         // `InputArg.type` are intrinsic on the box;
                         // no raw-u32 type side-table propagation is
                         // needed (callers read via `OpRef::ty()`).
-                        let inputarg_types: Vec<majit_ir::Type> =
-                            trace.inputargs.iter().map(|ia| ia.tp).collect();
-                        simple_opt.trace_inputarg_types = inputarg_types.clone();
+                        simple_opt.trace_inputargs = trace
+                            .inputargs
+                            .iter()
+                            .enumerate()
+                            .map(|(i, ia)| majit_ir::OpRef::input_arg_typed(i as u32, ia.tp))
+                            .collect();
                         simple_opt.snapshot_boxes = snapshot_map.clone();
                         simple_opt.snapshot_frame_sizes = snapshot_frame_size_map.clone();
                         simple_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
@@ -6150,8 +6156,12 @@ impl<M: Clone> MetaInterp<M> {
         // history.py:_make_op parity: every InputArg carries its type
         // from the recorder. Propagate those raw recorder types to the
         // optimizer without further reconciliation.
-        let inputarg_types: Vec<majit_ir::Type> = trace.inputargs.iter().map(|ia| ia.tp).collect();
-        optimizer.trace_inputarg_types = inputarg_types.clone();
+        optimizer.trace_inputargs = trace
+            .inputargs
+            .iter()
+            .enumerate()
+            .map(|(i, ia)| majit_ir::OpRef::input_arg_typed(i as u32, ia.tp))
+            .collect();
         // history.py:220/261/307 — `Const.type` / `InputArg.type` are
         // intrinsic on the box itself; no raw-u32 type side-table
         // propagation is needed.
@@ -8564,7 +8574,11 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_vable_boxes = prepared.snapshot_vable_boxes;
         optimizer.snapshot_vref_boxes = prepared.snapshot_vref_boxes;
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
-        optimizer.trace_inputarg_types = bridge_inputargs.iter().map(|ia| ia.tp).collect();
+        optimizer.trace_inputargs = bridge_inputargs
+            .iter()
+            .enumerate()
+            .map(|(i, ia)| majit_ir::OpRef::input_arg_typed(i as u32, ia.tp))
+            .collect();
 
         // RPython-orthodox: bridgeopt.py / unroll.py have no source→bridge
         // constant pool merge. Const objects flow via rd_consts + fresh
@@ -9068,7 +9082,6 @@ impl<M: Clone> MetaInterp<M> {
             pending_bridge_rd,
             bridge_inputarg_base,
         );
-        let bridge_inputarg_types = prepared.inputargs.iter().map(|ia| ia.tp).collect();
         let bridge_inputargs = prepared.inputargs.as_slice();
         let bridge_ops = prepared.ops.as_slice();
         let pending_bridge_rd = prepared.pending_bridge_rd;
@@ -9095,9 +9108,14 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_vable_boxes = prepared.snapshot_vable_boxes;
         optimizer.snapshot_vref_boxes = prepared.snapshot_vref_boxes;
         optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
-        // Store bridge inputarg types so export_state can propagate them
-        // to ExportedState.renamed_inputarg_types (RPython Box type parity).
-        optimizer.trace_inputarg_types = bridge_inputarg_types;
+        // Store bridge inputargs as typed `OpRef::input_arg_*` Boxes so
+        // export_state can propagate them to
+        // `ExportedState.renamed_inputarg_types` (history.py:220 box.type).
+        optimizer.trace_inputargs = bridge_inputargs
+            .iter()
+            .enumerate()
+            .map(|(i, ia)| majit_ir::OpRef::input_arg_typed(i as u32, ia.tp))
+            .collect();
 
         // RPython-orthodox: no source→bridge constant_types merge.
         // bridgeopt.py / unroll.py do not copy the source loop's constant


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper to build typed input-argument references for seeding/tracing.

* **Bug Fixes**
  * Fixed thread-ownership clearing in the JIT profiler to avoid stale ownership after resets or aborted events.

* **Documentation**
  * Clarified optimizer trace/input type handling and compatibility shim behavior.

* **Refactor**
  * Restructured loop-unrolling/retrace state and pool management for more consistent export/import behavior.

* **Tests**
  * Added unit tests covering profiler reset behavior and retrace/pool reconstruction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->