### PR TITLE
Add Forwarded::{Const,Op,InputArg} variants; retire ExportedState.box_pool_snapshot via partial_trace

### DIFF
--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -588,14 +588,15 @@ impl BoxRef {
         self.write_forwarded(Forwarded::None);
     }
 
-    /// Slice 8.D writer: dual-write to `op.forwarded` / `inputarg.forwarded`
-    /// AND `Box.forwarded`. Snapshot consumers (`ExportedState.box_pool_snapshot`,
-    /// retrace import) clone the `BoxRef` by value and may outlive the
-    /// originating `OpRc` / `InputArgRc`; once the `Weak` upgrade fails,
-    /// `get_forwarded` falls back to `Box.forwarded`, so that slot must
-    /// stay current. The cost is one extra `RefCell` write per
-    /// `set_forwarded_*` — `Forwarded` is `Clone`, payloads are `Rc`/`Copy`
-    /// handles.
+    /// Dual-write to `op.forwarded` / `inputarg.forwarded` (the canonical
+    /// `_forwarded` host, resoperation.py:233-242 / :700) AND
+    /// `Box.forwarded`. Snapshot consumers (`compile_retrace` partial
+    /// trace import, test fixtures) clone the `BoxRef` by value and may
+    /// outlive the originating `OpRc` / `InputArgRc`; once the `Weak`
+    /// upgrade fails, `get_forwarded` falls back to `Box.forwarded`, so
+    /// that slot must stay current. The cost is one extra `RefCell` write
+    /// per `set_forwarded_*` — `Forwarded` is `Clone`, payloads are
+    /// `Rc`/`Copy` handles.
     fn write_forwarded(&self, value: Forwarded) {
         if let Some(weak) = self.0.op_handle.borrow().as_ref() {
             if let Some(op) = weak.upgrade() {
@@ -1343,10 +1344,11 @@ mod tests {
         assert!(matches!(b.get_forwarded(), Forwarded::Info(_)));
     }
 
-    /// PR #93 review (Codex P1): `ExportedState.box_pool_snapshot` clones
-    /// `BoxRef`s by value and lives past the originating `OpRc`. Writes
-    /// done while the Op is alive must also land in `Box.forwarded` so the
-    /// snapshot keeps the latest forwarding once `Weak::upgrade` fails.
+    /// Cross-pass snapshots (e.g. test fixtures cloning a BoxRef whose
+    /// originating `OpRc` then drops) outlive the `Weak<Op>` referent.
+    /// Writes done while the Op is alive must also land in `Box.forwarded`
+    /// so the snapshot keeps the latest forwarding once `Weak::upgrade`
+    /// fails.
     #[test]
     fn write_forwarded_mirrors_to_box_so_snapshot_survives_op_drop() {
         use crate::resoperation::{Op, OpCode};

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -138,7 +138,16 @@ pub enum Forwarded {
     /// inline. Chain walkers stop on this variant (`not_const=true`
     /// returns the pre-Const box; `not_const=false` materializes a
     /// terminal const-bearing `BoxRef` for legacy callers).
-    Const(Const),
+    ///
+    /// The trailing `Option<u32>` is the pyre-only `const_pool`
+    /// constant-namespace index that lets `box_to_opref` reconstruct
+    /// an `OpRef::Const{Int,Float,Ptr}(idx)` from a chain-walked-to-
+    /// Const terminal. PyPy has no analog (callers hold the Python
+    /// `Const` object directly). Sidecar to be retired alongside the
+    /// broader OpRef-reverse-lookup machinery; tagged `None` for
+    /// indexless seed_constant plantings (`optimizer.py:432` body
+    /// arm) and test plantings.
+    Const(Const, Option<u32>),
 
     /// `optimizeopt/info.py:17 AbstractInfo (is_info_class = True)` family —
     /// `PtrInfo`, `IntBound`, `FloatConstInfo`, `EmptyInfo`, etc.
@@ -408,8 +417,10 @@ impl BoxRef {
     /// `Const` is an `AbstractValue` subclass (`history.py:220`), so PyPy
     /// `box.set_forwarded(constbox)` is well-typed; here it terminates
     /// the chain in a value-typed payload rather than allocating a
-    /// `BoxKind::Const` carrier.
-    pub fn set_forwarded_const(&self, value: Const) {
+    /// `BoxKind::Const` carrier. `const_index` is the pyre-side sidecar
+    /// for `box_to_opref` OpRef reconstruction; pass `None` when the
+    /// const has no const-namespace OpRef (PyPy parity site).
+    pub fn set_forwarded_const(&self, value: Const, const_index: Option<u32>) {
         // Same Const-as-source invariant as the other set_forwarded_*
         // variants — Const has no `_forwarded` slot per PyPy.
         assert!(
@@ -417,7 +428,7 @@ impl BoxRef {
             "set_forwarded_const on Const violates RPython AbstractValue \
              invariant (Const has no _forwarded slot)"
         );
-        self.write_forwarded(Forwarded::Const(value));
+        self.write_forwarded(Forwarded::Const(value, const_index));
     }
 
     /// `resoperation.py:53 set_forwarded(forwarded_to)` — Info variant.
@@ -525,7 +536,7 @@ impl BoxRef {
                     }
                     cur = b;
                 }
-                Forwarded::Const(c) => {
+                Forwarded::Const(c, idx) => {
                     if not_const {
                         return cur;
                     }
@@ -533,8 +544,13 @@ impl BoxRef {
                     // legacy callers that expect `.const_value()` /
                     // `BoxKind::Const` on the walker output keep
                     // working until the BoxRef return type itself is
-                    // retired.
-                    return BoxRef::new_const(c.to_value());
+                    // retired. Index sidecar round-trips so
+                    // `box_to_opref` can rebuild
+                    // `OpRef::Const{Int,Float,Ptr}(idx)`.
+                    return match idx {
+                        Some(i) => BoxRef::new_const_with_index(c.to_value(), i),
+                        None => BoxRef::new_const(c.to_value()),
+                    };
                 }
             }
         }

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -143,6 +143,14 @@ pub enum Forwarded {
     /// underlying object alive through the trace `operations` list).
     Op(Weak<Op>),
 
+    /// `resoperation.py:699 AbstractInputArg` forwarding — direct
+    /// `Weak<InputArg>` reference, no `BoxRef`/`BoxKind::InputArg`
+    /// carrier. Same chain-walk semantics as `Op` (transient BoxRef
+    /// materialization via `BoxRef::from_bound_inputarg`). RPython
+    /// uses this for inputarg→inputarg redirects in bridge import and
+    /// retrace remap (compile.py:478 / unroll.py:497).
+    InputArg(Weak<InputArg>),
+
     /// `history.py:220 ConstInt` / `:261 ConstFloat` / `:307 ConstPtr`
     /// — forwarding terminates here; the constant value is carried
     /// inline. Chain walkers stop on this variant (`not_const=true`
@@ -231,6 +239,22 @@ impl BoxRef {
             value: Cell::new(None),
             op_handle: RefCell::new(Some(Rc::downgrade(op))),
             inputarg_handle: RefCell::new(None),
+        }))
+    }
+
+    /// Transient `AbstractInputArg` Box wrapping an already-bound
+    /// `InputArgRc`. Mirror of `from_bound_op` for the chain walker's
+    /// `Forwarded::InputArg` terminal materialization.
+    pub fn from_bound_inputarg(ia: &crate::value::InputArgRc) -> Self {
+        let type_ = ia.tp;
+        let position = ia.index;
+        Self(Rc::new(Box {
+            forwarded: RefCell::new(Forwarded::None),
+            type_,
+            kind: BoxKind::InputArg { position },
+            value: Cell::new(None),
+            op_handle: RefCell::new(None),
+            inputarg_handle: RefCell::new(Some(Rc::downgrade(ia))),
         }))
     }
 
@@ -450,6 +474,19 @@ impl BoxRef {
         self.write_forwarded(next);
     }
 
+    /// `optimizer.py:394 op.set_forwarded(newop)` — InputArg variant.
+    /// Targets an `AbstractInputArg` identity directly via
+    /// `Weak<InputArg>`. Mirror of `set_forwarded_op` for the InputArg
+    /// chain-step case (compile.py:478, unroll.py:497).
+    pub fn set_forwarded_inputarg(&self, target: &crate::value::InputArgRc) {
+        assert!(
+            !matches!(self.0.kind, BoxKind::Const { .. }),
+            "set_forwarded_inputarg on Const violates RPython AbstractValue \
+             invariant (Const has no _forwarded slot)"
+        );
+        self.write_forwarded(Forwarded::InputArg(Rc::downgrade(target)));
+    }
+
     /// `optimizer.py:394 op.set_forwarded(newop)` — Op variant.
     /// Targets an `AbstractResOp` identity directly via `Weak<Op>`,
     /// retiring the `BoxKind::ResOp`-as-chain-target carrier. The
@@ -597,6 +634,12 @@ impl BoxRef {
                         return cur;
                     };
                     cur = BoxRef::from_bound_op(&op_rc);
+                }
+                Forwarded::InputArg(weak) => {
+                    let Some(ia_rc) = weak.upgrade() else {
+                        return cur;
+                    };
+                    cur = BoxRef::from_bound_inputarg(&ia_rc);
                 }
                 Forwarded::Const(c, idx) => {
                     if not_const {

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -29,7 +29,7 @@ use crate::intbound::IntBound;
 use crate::op_info::OpInfo;
 use crate::ptr_info::PtrInfo;
 use crate::resoperation::{Op, VectorizationInfo};
-use crate::value::InputArg;
+use crate::value::{Const, InputArg};
 use crate::{OpRef, Type, Value};
 
 /// `AbstractValue` mirror — unified representation of RPython's
@@ -120,15 +120,25 @@ pub enum BoxKind {
 
 /// Variant of the `_forwarded` slot.
 ///
-/// RPython's `_forwarded` is `None | another AbstractResOpOrInputArg |
-/// AbstractInfo`. Const forwarding is one case of "another box", so we
-/// represent it as `Box(BoxRef)` carrying a `BoxKind::Const(...)`.
+/// `Const` is an `AbstractValue` subclass too (`history.py:220
+/// ConstInt`), so forwarding to a constant is its own shape: `Const`
+/// is a value-typed `Copy` payload with no `_forwarded` slot of its
+/// own, unlike `ResOp`/`InputArg`. Keeping it as a separate variant
+/// retires the dedicated `BoxKind::Const`-as-chain-target carrier.
 #[derive(Clone, Debug)]
 pub enum Forwarded {
     None,
 
-    /// Forwarding to another `AbstractResOpOrInputArg` or `Const`.
+    /// Forwarding to another `AbstractResOpOrInputArg`. Const targets
+    /// route through [`Forwarded::Const`] instead.
     Box(BoxRef),
+
+    /// `history.py:220 ConstInt` / `:261 ConstFloat` / `:307 ConstPtr`
+    /// — forwarding terminates here; the constant value is carried
+    /// inline. Chain walkers stop on this variant (`not_const=true`
+    /// returns the pre-Const box; `not_const=false` materializes a
+    /// terminal const-bearing `BoxRef` for legacy callers).
+    Const(Const),
 
     /// `optimizeopt/info.py:17 AbstractInfo (is_info_class = True)` family —
     /// `PtrInfo`, `IntBound`, `FloatConstInfo`, `EmptyInfo`, etc.
@@ -394,6 +404,22 @@ impl BoxRef {
         self.write_forwarded(next);
     }
 
+    /// `optimizer.py:432 make_constant(box, constbox)` — Const variant.
+    /// `Const` is an `AbstractValue` subclass (`history.py:220`), so PyPy
+    /// `box.set_forwarded(constbox)` is well-typed; here it terminates
+    /// the chain in a value-typed payload rather than allocating a
+    /// `BoxKind::Const` carrier.
+    pub fn set_forwarded_const(&self, value: Const) {
+        // Same Const-as-source invariant as the other set_forwarded_*
+        // variants — Const has no `_forwarded` slot per PyPy.
+        assert!(
+            !matches!(self.0.kind, BoxKind::Const { .. }),
+            "set_forwarded_const on Const violates RPython AbstractValue \
+             invariant (Const has no _forwarded slot)"
+        );
+        self.write_forwarded(Forwarded::Const(value));
+    }
+
     /// `resoperation.py:53 set_forwarded(forwarded_to)` — Info variant.
     pub fn set_forwarded_info(&self, info: OpInfo) {
         // PyPy `AbstractValue.set_forwarded` raises unconditionally on
@@ -498,6 +524,17 @@ impl BoxRef {
                         return cur;
                     }
                     cur = b;
+                }
+                Forwarded::Const(c) => {
+                    if not_const {
+                        return cur;
+                    }
+                    // Materialize a terminal Const-bearing BoxRef so
+                    // legacy callers that expect `.const_value()` /
+                    // `BoxKind::Const` on the walker output keep
+                    // working until the BoxRef return type itself is
+                    // retired.
+                    return BoxRef::new_const(c.to_value());
                 }
             }
         }

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -458,7 +458,25 @@ impl BoxRef {
         // `assert forwarded_to is not self` (resoperation.py:241).
         // Always-on assert so a release build can't accept a one-node
         // forwarding cycle that would make `get_box_replacement()` spin.
+        // After `bind_op` / `bind_inputarg` two distinct `Rc<Box>`
+        // wrappers can share the same canonical bound `OpRc`/`InputArgRc`;
+        // the `Rc::ptr_eq` on `self.0` alone misses that case, so also
+        // compare the bound handles when both sides carry one.
         assert!(!Rc::ptr_eq(&self.0, &target.0));
+        if let (Some(self_op), Some(target_op)) = (self.bound_op(), target.bound_op()) {
+            assert!(
+                !Rc::ptr_eq(&self_op, &target_op),
+                "set_forwarded_box on a BoxRef that wraps the same bound \
+                 Op as the target creates a one-node chain cycle"
+            );
+        }
+        if let (Some(self_ia), Some(target_ia)) = (self.bound_inputarg(), target.bound_inputarg()) {
+            assert!(
+                !Rc::ptr_eq(&self_ia, &target_ia),
+                "set_forwarded_box on a BoxRef that wraps the same bound \
+                 InputArg as the target creates a one-node chain cycle"
+            );
+        }
         // RPython AbstractValue invariant: `Const` is not a subclass of
         // `AbstractResOpOrInputArg` (history.py:182), so `set_forwarded`
         // is undefined on Const objects (resoperation.py:50 default
@@ -479,6 +497,17 @@ impl BoxRef {
     /// `Weak<InputArg>`. Mirror of `set_forwarded_op` for the InputArg
     /// chain-step case (compile.py:478, unroll.py:497).
     pub fn set_forwarded_inputarg(&self, target: &crate::value::InputArgRc) {
+        // `resoperation.py:241 assert forwarded_to is not self` —
+        // compare against this BoxRef's bound InputArg so a chain step
+        // targeting the box's own identity panics instead of spinning
+        // the walker.
+        if let Some(self_ia) = self.bound_inputarg() {
+            assert!(
+                !Rc::ptr_eq(&self_ia, target),
+                "set_forwarded_inputarg on the same InputArg creates a \
+                 one-node chain cycle"
+            );
+        }
         assert!(
             !matches!(self.0.kind, BoxKind::Const { .. }),
             "set_forwarded_inputarg on Const violates RPython AbstractValue \
@@ -494,6 +523,17 @@ impl BoxRef {
     /// entry) — chain walkers upgrade the `Weak` and continue from
     /// there.
     pub fn set_forwarded_op(&self, target: &crate::resoperation::OpRc) {
+        // `resoperation.py:241 assert forwarded_to is not self` —
+        // compare against this BoxRef's bound Op so a chain step
+        // targeting the box's own identity panics instead of spinning
+        // the walker.
+        if let Some(self_op) = self.bound_op() {
+            assert!(
+                !Rc::ptr_eq(&self_op, target),
+                "set_forwarded_op on the same Op creates a one-node chain \
+                 cycle"
+            );
+        }
         assert!(
             !matches!(self.0.kind, BoxKind::Const { .. }),
             "set_forwarded_op on Const violates RPython AbstractValue \

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -130,8 +130,18 @@ pub enum Forwarded {
     None,
 
     /// Forwarding to another `AbstractResOpOrInputArg`. Const targets
-    /// route through [`Forwarded::Const`] instead.
+    /// route through [`Forwarded::Const`] instead; `ResOp` targets route
+    /// through [`Forwarded::Op`] once C.5 retires this variant.
     Box(BoxRef),
+
+    /// `resoperation.py:250 AbstractResOp` forwarding — direct
+    /// `Weak<Op>` reference, no `BoxRef`/`BoxKind::ResOp` carrier.
+    /// Chain walker upgrades the `Weak`, wraps the `Op` in a transient
+    /// `BoxRef` (via `BoxRef::from_bound_op`), and continues from
+    /// there. A dropped `Weak` terminates the chain at the predecessor
+    /// (PyPy never observes a dropped target — RPython keeps the
+    /// underlying object alive through the trace `operations` list).
+    Op(Weak<Op>),
 
     /// `history.py:220 ConstInt` / `:261 ConstFloat` / `:307 ConstPtr`
     /// — forwarding terminates here; the constant value is carried
@@ -193,6 +203,33 @@ impl BoxRef {
             },
             value: Cell::new(None),
             op_handle: RefCell::new(None),
+            inputarg_handle: RefCell::new(None),
+        }))
+    }
+
+    /// Transient `AbstractResOp` Box wrapping an already-bound
+    /// `OpRc`. Used by the chain walker to materialize a `BoxRef`
+    /// terminal from a `Forwarded::Op(Weak<Op>)` payload without
+    /// going through the pool; the new box does not live in
+    /// `BoxPool`, but its `bound_op` immediately answers with the
+    /// same `Rc<Op>` and its `_forwarded` slot reads via the bound op
+    /// per `get_forwarded`. Type and position are mirrored from
+    /// `op.pos.get()`.
+    pub fn from_bound_op(op: &crate::resoperation::OpRc) -> Self {
+        let opref = op.pos.get();
+        let type_ = opref.ty().unwrap_or(Type::Void);
+        let position = opref.raw();
+        Self(Rc::new(Box {
+            // `Box.forwarded` is the legacy mirror — the bound op's
+            // own slot is canonical so this stays None; `get_forwarded`
+            // returns op.forwarded via the `bound_op()` fastpath.
+            forwarded: RefCell::new(Forwarded::None),
+            type_,
+            kind: BoxKind::ResOp {
+                position: std::cell::Cell::new(position),
+            },
+            value: Cell::new(None),
+            op_handle: RefCell::new(Some(Rc::downgrade(op))),
             inputarg_handle: RefCell::new(None),
         }))
     }
@@ -413,6 +450,21 @@ impl BoxRef {
         self.write_forwarded(next);
     }
 
+    /// `optimizer.py:394 op.set_forwarded(newop)` — Op variant.
+    /// Targets an `AbstractResOp` identity directly via `Weak<Op>`,
+    /// retiring the `BoxKind::ResOp`-as-chain-target carrier. The
+    /// caller passes the canonical `OpRc` (typically a `TreeLoop.ops`
+    /// entry) — chain walkers upgrade the `Weak` and continue from
+    /// there.
+    pub fn set_forwarded_op(&self, target: &crate::resoperation::OpRc) {
+        assert!(
+            !matches!(self.0.kind, BoxKind::Const { .. }),
+            "set_forwarded_op on Const violates RPython AbstractValue \
+             invariant (Const has no _forwarded slot)"
+        );
+        self.write_forwarded(Forwarded::Op(Rc::downgrade(target)));
+    }
+
     /// `optimizer.py:432 make_constant(box, constbox)` — Const variant.
     /// `Const` is an `AbstractValue` subclass (`history.py:220`), so PyPy
     /// `box.set_forwarded(constbox)` is well-typed; here it terminates
@@ -535,6 +587,16 @@ impl BoxRef {
                         return cur;
                     }
                     cur = b;
+                }
+                Forwarded::Op(weak) => {
+                    let Some(op_rc) = weak.upgrade() else {
+                        // Dropped target: PyPy has no analog (Python
+                        // GC keeps targets alive through `operations`).
+                        // Terminate the chain at `cur` to avoid a
+                        // dangling read.
+                        return cur;
+                    };
+                    cur = BoxRef::from_bound_op(&op_rc);
                 }
                 Forwarded::Const(c, idx) => {
                     if not_const {

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -184,6 +184,17 @@ impl Const {
         }
     }
 
+    /// Inverse of [`Const::to_value`]. Panics on `Value::Void` since
+    /// PyPy has no void-typed `Const` (`history.py:182`).
+    pub fn from_value(value: Value) -> Self {
+        match value {
+            Value::Int(v) => Const::Int(v),
+            Value::Float(v) => Const::Float(v),
+            Value::Ref(v) => Const::Ref(v),
+            Value::Void => panic!("Const::from_value: Void has no Const counterpart"),
+        }
+    }
+
     /// history.py:225 ConstInt.getint — unsigned/signed integer value.
     /// Method belongs to ConstInt upstream; Rust single-enum collapses
     /// all variants, so assert variant at call time instead of

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -238,3 +238,48 @@ impl From<Vec<BoxRef>> for BoxPool {
 // `OpRef::raw() as usize` index lookups against the result. Callers
 // that need the raw slot table must use `BoxPool::into_slots()` and
 // keep working in `Vec<Option<BoxRef>>` shape.
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    //! Shared test helpers for constructing **bound** BoxRefs. Production
+    //! recorder→TreeLoop handoff binds every `AbstractInputArg` /
+    //! `AbstractResOp` BoxRef to its `InputArg` / `Op` identity (per
+    //! `BoxPool::bind_inputargs` / `BoxPool::bind_ops`), so tests that
+    //! seed `OptContext::box_pool` directly must do the same to match
+    //! `make_equal_to`'s `Forwarded::Op` / `Forwarded::InputArg` chain
+    //! shape and avoid the deprecated `Forwarded::Box` fallback.
+    use majit_ir::box_ref::BoxRef;
+    use majit_ir::resoperation::{Op, OpCode, OpRc};
+    use majit_ir::{InputArg, InputArgRc, OpRef, Type};
+
+    /// Bind a fresh `BoxRef::new_inputarg(tp, index)` to a fresh
+    /// `InputArgRc` (`box_ref.rs:354 bind_inputarg`). The returned
+    /// `InputArgRc` must outlive every read of `box.get_forwarded()`
+    /// for the bound `Weak<InputArg>` upgrade to stay live.
+    pub(crate) fn bound_inputarg_box(tp: Type, index: u32) -> (BoxRef, InputArgRc) {
+        let b = BoxRef::new_inputarg(tp, index);
+        let ia = std::rc::Rc::new(InputArg::from_type(tp, index));
+        b.bind_inputarg(&ia);
+        (b, ia)
+    }
+
+    /// Bind a fresh `BoxRef::new_resop(tp, position)` to a fresh
+    /// `OpRc` (`box_ref.rs:322 bind_op`). The Op carries `SameAsI/F/R`
+    /// (or `Jump` for `Type::Void`) so its `opcode.result_type()`
+    /// matches `tp`; `pos` is seeded with the typed OpRef so
+    /// `BoxRef::from_bound_op` materialises a transient terminal box
+    /// of the correct type during chain walks.
+    pub(crate) fn bound_resop_box(tp: Type, position: u32) -> (BoxRef, OpRc) {
+        let b = BoxRef::new_resop(tp, position);
+        let opcode = match tp {
+            Type::Int => OpCode::SameAsI,
+            Type::Float => OpCode::SameAsF,
+            Type::Ref => OpCode::SameAsR,
+            Type::Void => OpCode::Jump,
+        };
+        let op = std::rc::Rc::new(Op::new(opcode, &[]));
+        op.pos.set(OpRef::op_typed(position, tp));
+        b.bind_op(&op);
+        (b, op)
+    }
+}

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2640,6 +2640,15 @@ impl OptHeap {
                     }
                 });
             }
+            // heap.py:703 `make_nonnull(op.getarg(0))` runs in the
+            // fallthrough default of `optimize_GETARRAYITEM_GC_I`. PyPy's
+            // constant-index branch only short-circuits on a cache hit;
+            // when it falls through to record the new value (matching
+            // pyre's `arrayinfo_setitem` below), `make_nonnull` still
+            // fires.
+            if let Some(array_box) = ctx.ensure_box(array_ref) {
+                ctx.make_nonnull(&array_box);
+            }
             ctx.arrayinfo_setitem(op, const_index as usize, op.pos.get());
             return OptimizationResult::Emit(op.clone());
         }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -721,7 +721,6 @@ pub struct OptHeap {
     // ── Aliasing analysis state — RPython: PtrInfo flags ──
     seen_allocation: Vec<bool>,
     unescaped: Vec<bool>,
-    known_nonnull: Vec<bool>,
     /// heapcache.py:209/298-307/453-455 `box._heapc_deps` — per-Box
     /// dependency list. RPython attaches `_heapc_deps: list | None`
     /// as an attribute on the `RefFrontendOp` Box object itself;
@@ -772,7 +771,6 @@ impl OptHeap {
             postponed_op: None,
             seen_allocation: Vec::new(),
             unescaped: Vec::new(),
-            known_nonnull: Vec::new(),
             heapc_deps: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             last_emitted_removed: false,
             cached_dict_reads: crate::optimizeopt::vec_assoc::VecAssoc::new(),
@@ -2059,18 +2057,9 @@ impl OptHeap {
         }
 
         // Cache miss: emit the load and cache the result.
-        // heap.py line 652: make_nonnull(op.getarg(0))
-        // optimizer.py:437-448: only set NonNull if no existing PtrInfo.
         // heap.py postprocess_GETFIELD_GC_I:
         //     structinfo = self.ensure_ptr_info_arg0(op)
         //     structinfo.setfield(descr, op.getarg(0), op, ...)
-        //
-        // The PyPy primitive returns the same structinfo regardless of
-        // whether it was newly installed or already present, so the
-        // line-by-line port reuses the EnsuredPtrInfo handle for both
-        // the nonnull bookkeeping and the field write.
-        let struct_ref = ctx.get_box_replacement(op.arg(0));
-        vb_set(&mut self.known_nonnull, struct_ref.raw());
         self.cache_field(obj, &descr);
         // heap.py postprocess_GETFIELD_GC_I: structinfo.setfield(descr, op)
         //
@@ -2639,7 +2628,6 @@ impl OptHeap {
             //      `const_infos[gcref]` and regular arg0 through
             //      `ensure_ptr_info_arg0(op).as_mut().setitem(...)`.
             let array_ref = ctx.get_box_replacement(op.arg(0));
-            vb_set(&mut self.known_nonnull, array_ref.raw());
             if const_index >= 0 {
                 ctx.with_ensured_ptr_info_arg0(op, |mut arrayinfo| {
                     if let Some(mut bound) = arrayinfo.getlenbound(None) {
@@ -2684,9 +2672,7 @@ impl OptHeap {
                 .cache_varindex_read(arrayinfo, indexbox, op.pos.get());
         }
 
-        // heap.py line 701: make_nonnull(op.getarg(0))
-        vb_set(&mut self.known_nonnull, array_ref.raw());
-        // OpRef → BoxRef shim until this caller migrates (Phase D-2).
+        // heap.py line 701: make_nonnull(op.getarg(0)) (optimizer.py:440-451).
         if let Some(arg0_box) = ctx.ensure_box(op.arg(0)) {
             ctx.make_nonnull(&arg0_box);
         }
@@ -2743,7 +2729,6 @@ impl OptHeap {
         if opcode.is_malloc() {
             vb_set(&mut self.seen_allocation, op.pos.get().raw());
             vb_set(&mut self.unescaped, op.pos.get().raw());
-            vb_set(&mut self.known_nonnull, op.pos.get().raw());
             return OptimizationResult::Emit(op.clone());
         }
 
@@ -2756,20 +2741,6 @@ impl OptHeap {
         // RPython heap.py does NOT handle GuardNonnull — that is handled
         // exclusively by rewrite.py. Only track nullity for cache purposes.
         if opcode.is_guard() {
-            if opcode == OpCode::GuardNonnull {
-                vb_set(&mut self.known_nonnull, op.arg(0).raw());
-            }
-
-            // GuardClass / GuardNonnullClass imply non-null.
-            // GuardValue does NOT imply non-null: the guarded constant
-            // may be NULL (rewrite.py:320 handles GUARD_VALUE(..., NULL)).
-            match opcode {
-                OpCode::GuardClass | OpCode::GuardNonnullClass => {
-                    vb_set(&mut self.known_nonnull, op.arg(0).raw());
-                }
-                _ => {}
-            }
-
             // force_lazy_sets_for_guard is now called via emitting_operation
             // callback (which runs for ALL guards regardless of which pass emits
             // them). No need to force here — it was already done.
@@ -2904,7 +2875,6 @@ impl OptHeap {
             OpCode::New | OpCode::NewWithVtable | OpCode::NewArray | OpCode::NewArrayClear => {
                 vb_set(&mut self.seen_allocation, op.pos.get().raw());
                 vb_set(&mut self.unescaped, op.pos.get().raw());
-                vb_set(&mut self.known_nonnull, op.pos.get().raw());
                 OptimizationResult::PassOn
             }
 
@@ -3102,7 +3072,6 @@ impl OptHeap {
             | OpCode::GcLoadIndexedF => {
                 self.force_all_lazy_setfields(ctx.current_pass_idx, ctx);
                 self.force_all_lazy_setarrayitems(ctx.current_pass_idx, ctx);
-                vb_set(&mut self.known_nonnull, op.arg(0).raw());
                 OptimizationResult::Emit(op.clone())
             }
 
@@ -3167,7 +3136,6 @@ impl Optimization for OptHeap {
         self.postponed_op = None;
         self.seen_allocation.clear();
         self.unescaped.clear();
-        self.known_nonnull.clear();
         self.last_emitted_removed = false;
         self.cached_dict_reads.clear();
         self.corresponding_array_descrs.clear();

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2054,7 +2054,7 @@ impl OptContext {
             .box_pool
             .get_at_position(self.next_pos as usize)
             .is_some_and(|b| {
-                matches!(b.get_forwarded(), crate::r#box::Forwarded::Box(ref t) if t.const_value().is_some())
+                matches!(b.get_forwarded(), crate::r#box::Forwarded::Const(_, _))
             })
         {
             self.next_pos += 1;
@@ -2971,20 +2971,19 @@ impl OptContext {
                 crate::r#box::Forwarded::Info(OpInfo::FloatConst(f)) => {
                     Some(OpInfo::FloatConst(*f))
                 }
-                crate::r#box::Forwarded::Box(target) if target.is_constant() => {
+                crate::r#box::Forwarded::Const(c, _) => {
                     // optimizer.py:329-338 `getinfo` parity for the Const
                     // terminal — Refs surface as `ConstPtrInfo`, Floats as
                     // `FloatConstInfo`, Ints as `IntBound::from_constant`.
-                    target.const_value().and_then(|v| match v {
-                        Value::Ref(gcref) => Some(OpInfo::ptr(
+                    match *c {
+                        majit_ir::Const::Ref(gcref) => Some(OpInfo::ptr(
                             crate::optimizeopt::info::PtrInfo::Constant(gcref),
                         )),
-                        Value::Float(f) => Some(OpInfo::FloatConst(f)),
-                        Value::Int(i) => Some(OpInfo::int_bound(
+                        majit_ir::Const::Float(f) => Some(OpInfo::FloatConst(f)),
+                        majit_ir::Const::Int(i) => Some(OpInfo::int_bound(
                             crate::optimizeopt::intutils::IntBound::from_constant(i),
                         )),
-                        Value::Void => None,
-                    })
+                    }
                 }
                 _ => None,
             }
@@ -3416,12 +3415,10 @@ impl OptContext {
                 // value and the downstream `ExtendedShortPreambleBuilder::setup`
                 // `constants_set` check accepts them as resolved deps.
                 for (idx, b) in self.box_pool.iter_indexed() {
-                    if let crate::r#box::Forwarded::Box(target) = &b.get_forwarded() {
-                        if let Some(val) = target.const_value() {
-                            if !loop_constants.contains_key(&(idx as u32)) {
-                                loop_constants.insert(idx as u32, val.to_const());
-                            }
-                        }
+                    if let crate::r#box::Forwarded::Const(c, _) = b.get_forwarded()
+                        && !loop_constants.contains_key(&(idx as u32))
+                    {
+                        loop_constants.insert(idx as u32, c);
                     }
                 }
                 builder.build_short_preamble_struct(&loop_constants)
@@ -4652,12 +4649,10 @@ impl OptContext {
         if opref.is_constant() {
             return self.const_pool.get(&opref.const_index()).copied();
         }
-        if let Some(b) = self.box_pool.get(opref) {
-            if let crate::r#box::Forwarded::Box(target) = &b.get_forwarded() {
-                if let Some(value) = target.const_value() {
-                    return Some(value);
-                }
-            }
+        if let Some(b) = self.box_pool.get(opref)
+            && let crate::r#box::Forwarded::Const(c, _) = b.get_forwarded()
+        {
+            return Some(c.to_value());
         }
         None
     }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -744,6 +744,17 @@ pub struct OptContext {
     /// the optimizer carries the Box list and reads `.type` per Box.
     /// Populated by `setup_optimizations`; emptied initially.
     pub inputargs: Vec<majit_ir::OpRef>,
+    /// Strong `InputArgRc` ownership for the BoxRefs seeded by
+    /// `with_inputarg_types`. Production traces own their `InputArgRc`s
+    /// via `TreeLoop.inputargs` and re-bind the optimizer's `box_pool`
+    /// via `BoxPool::bind_inputargs`; the test-and-fallback helper
+    /// `with_inputarg_types` has no upstream `TreeLoop`, so it stashes
+    /// fresh `InputArgRc`s here to keep the `Weak<InputArg>` stored
+    /// inside each `BoxRef.inputarg_handle` upgradable. `make_equal_to`
+    /// then routes the chain step through `Forwarded::InputArg(_)`
+    /// (`optimizer.py:394 op.set_forwarded(newop)`) instead of the
+    /// deprecated `Forwarded::Box(_)` fallback.
+    pub(crate) inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// Phase 1 emit ops carried into Phase 2's lookup surface.
     ///
     /// In RPython, a Box referenced cross-phase keeps its `.type` attribute
@@ -1609,6 +1620,7 @@ impl OptContext {
             snapshot_frame_pcs: Vec::new(),
 
             inputargs: Vec::new(),
+            inputarg_refs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
@@ -1653,10 +1665,25 @@ impl OptContext {
         let mut ctx =
             Self::with_num_inputs_and_start_pos(estimated_ops, num_inputs, 0, num_inputs as u32);
         let mut seed = crate::r#box::BoxPool::with_capacity(inputarg_types.len());
+        let mut refs: Vec<majit_ir::InputArgRc> = Vec::with_capacity(inputarg_types.len());
         for (i, &tp) in inputarg_types.iter().enumerate() {
-            seed.push(crate::r#box::BoxRef::new_inputarg(tp, i as u32));
+            let b = crate::r#box::BoxRef::new_inputarg(tp, i as u32);
+            // Bind each seeded BoxRef to a fresh `InputArgRc` so the
+            // optimizer's `make_equal_to` routes a chain step that
+            // targets one of these BoxRefs through
+            // `Forwarded::InputArg(_)`, matching the production
+            // recorder→TreeLoop handoff invariant
+            // (`BoxPool::bind_inputargs`). The strong `InputArgRc`s
+            // are stashed in `ctx.inputarg_refs` so the bound
+            // `Weak<InputArg>` stays upgradable for the OptContext's
+            // lifetime.
+            let ia = std::rc::Rc::new(majit_ir::InputArg::from_type(tp, i as u32));
+            b.bind_inputarg(&ia);
+            seed.push(b);
+            refs.push(ia);
         }
         ctx.box_pool = seed;
+        ctx.inputarg_refs = refs;
         // Mirror the production wiring at `setup_optimizations`
         // (optimizer.rs `ctx.inputargs = self.trace_inputargs.clone()`):
         // seed `ctx.inputargs` in lockstep with the `box_pool` so the
@@ -1736,6 +1763,7 @@ impl OptContext {
             snapshot_frame_pcs: Vec::new(),
 
             inputargs: Vec::new(),
+            inputarg_refs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
@@ -3545,13 +3573,12 @@ impl OptContext {
             // InputArg-target chain step (compile.py:478, unroll.py:497).
             op.set_forwarded_inputarg(&target_ia);
         } else {
-            // Unbound non-const BoxRef target — only constructible
-            // from test fixtures that build `BoxRef::new_resop` /
-            // `BoxRef::new_inputarg` without calling `bind_op` /
-            // `bind_inputarg`. Production paths bind every BoxRef at
-            // the recorder→TreeLoop handoff. Keep the legacy path for
-            // those callers; migrating each test individually is
-            // C.8's scope.
+            // Unbound non-const BoxRef target — remaining test fixtures
+            // that flow custom BoxRef constructions through
+            // `make_equal_to` without binding. Probe 2026-05-25 (post
+            // with_inputarg_types bind) counts 40 such tests across
+            // heap / pure / unroll / virtualize / jitdriver, migrated
+            // incrementally per [[box-pool-v2 C.6]].
             op.set_forwarded_box(newop.clone());
         }
         // optimizer.py:395-396

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7344,25 +7344,46 @@ mod boxref_forwarding_tests {
     use crate::r#box::{BoxRef, Forwarded as BoxForwarded};
     use crate::optimizeopt::info::{OpInfo, PtrInfo};
     use crate::optimizeopt::intutils::IntBound;
-    use majit_ir::{OpRef, Type, Value};
+    use majit_ir::{InputArg, InputArgRc, OpRef, Type, Value};
 
-    fn ctx_with_two_int_boxes() -> (OptContext, BoxRef, BoxRef) {
-        let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let b0 = BoxRef::new_inputarg(Type::Int, 0);
-        let b1 = BoxRef::new_inputarg(Type::Int, 1);
-        ctx.box_pool = vec![b0.clone(), b1.clone()].into();
-        (ctx, b0, b1)
+    /// Create a `BoxRef::new_inputarg(tp, index)` already bound to a fresh
+    /// `InputArgRc` (`box_ref.rs:354 bind_inputarg`), matching the
+    /// recorder→TreeLoop production handoff invariant that every
+    /// `AbstractInputArg` BoxRef has an `inputarg.forwarded` target. The
+    /// returned `InputArgRc` must outlive every read of `box.get_forwarded()`
+    /// so the bound `Weak<InputArg>` stays upgradable.
+    fn bound_inputarg_box(tp: Type, index: u32) -> (BoxRef, InputArgRc) {
+        let b = BoxRef::new_inputarg(tp, index);
+        let ia = std::rc::Rc::new(InputArg::from_type(tp, index));
+        b.bind_inputarg(&ia);
+        (b, ia)
     }
 
-    /// `make_equal_to(old, new)` mirrors `old_box.set_forwarded_box(new_box)`.
+    fn ctx_with_two_int_boxes() -> (OptContext, BoxRef, BoxRef, Vec<InputArgRc>) {
+        let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
+        let (b0, ia0) = bound_inputarg_box(Type::Int, 0);
+        let (b1, ia1) = bound_inputarg_box(Type::Int, 1);
+        ctx.box_pool = vec![b0.clone(), b1.clone()].into();
+        (ctx, b0, b1, vec![ia0, ia1])
+    }
+
+    /// `make_equal_to(old, new)` plants an `InputArg`-target chain step on
+    /// `old`'s `_forwarded` slot (`optimizer.py:394 op.set_forwarded(newop)`
+    /// — `newop` is an `AbstractInputArg` here), and `get_box_replacement`
+    /// (`resoperation.py:57-68`) walks to a BoxRef bound to `new`'s
+    /// `AbstractInputArg` identity. The walker materialises a transient
+    /// BoxRef wrapping the same `InputArgRc`, so identity is checked via
+    /// the bound handle, not outer `Rc<Box>` pointer equality.
     #[test]
     fn h3_1_replace_op_mirrors_box_forward() {
-        let (mut ctx, b0, b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, b1, ia_holder) = ctx_with_two_int_boxes();
         ctx.make_equal_to(&b0, &b1);
-        match &b0.get_forwarded() {
-            BoxForwarded::Box(target) => assert_eq!(target, &b1),
-            other => panic!("expected Forwarded::Box, got {:?}", other),
-        }
+        assert!(matches!(b0.get_forwarded(), BoxForwarded::InputArg(_)));
+        let walked = b0.get_box_replacement(false);
+        assert!(std::rc::Rc::ptr_eq(
+            &walked.bound_inputarg().expect("walked terminal carries bound InputArg"),
+            &ia_holder[1],
+        ));
     }
 
     /// `box.clear_forwarded()` resets a previously-set forwarding slot
@@ -7370,7 +7391,7 @@ mod boxref_forwarding_tests {
     /// path; chain reset happens on the box directly.
     #[test]
     fn h3_1_clear_forwarded_resets_box_forward() {
-        let (mut ctx, b0, b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, b1, _ia_holder) = ctx_with_two_int_boxes();
         ctx.make_equal_to(&b0, &b1);
         b0.clear_forwarded();
         assert!(matches!(b0.get_forwarded(), BoxForwarded::None));
@@ -7381,7 +7402,7 @@ mod boxref_forwarding_tests {
     /// non-constant `new`, the IntBound moves to `new`'s slot.
     #[test]
     fn h3_1_replace_op_transfers_int_bound_to_new() {
-        let (mut ctx, b0, b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, b1, ia_holder) = ctx_with_two_int_boxes();
         let bound = IntBound::from_constant(7);
         ctx.setintbound(&b0, &bound);
         ctx.make_equal_to(&b0, &b1);
@@ -7391,18 +7412,23 @@ mod boxref_forwarding_tests {
             BoxForwarded::Info(OpInfo::IntBound(b)) => assert_eq!(b.borrow().lower, 7),
             other => panic!("BoxRef[1] should carry IntBound, got {:?}", other),
         }
-        // old's slot now points to new (forwarding chain head).
-        match &b0.get_forwarded() {
-            BoxForwarded::Box(target) => assert_eq!(target, &b1),
-            other => panic!("expected b0 to forward to b1, got {:?}", other),
-        }
+        // old's slot now points to new. Bound-InputArg target routes through
+        // `set_forwarded_inputarg`, so the slot carries
+        // `Forwarded::InputArg(Weak<InputArg>)`; chain walk lands on a
+        // transient BoxRef sharing `ia_holder[1]`'s identity.
+        assert!(matches!(b0.get_forwarded(), BoxForwarded::InputArg(_)));
+        let walked = b0.get_box_replacement(false);
+        assert!(std::rc::Rc::ptr_eq(
+            &walked.bound_inputarg().expect("walked terminal carries bound InputArg"),
+            &ia_holder[1],
+        ));
     }
 
     /// `optimizer.py:400` guard: transfer is **skipped** when `new` is
     /// constant. PyPy short-circuits via `not newop.is_constant()`.
     #[test]
     fn h3_1_replace_op_skips_info_transfer_when_new_is_constant() {
-        let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         // Seed an IntBound on old.
         let bound = IntBound::from_constant(42);
         ctx.setintbound(&b0, &bound);
@@ -7510,7 +7536,7 @@ mod boxref_forwarding_tests {
     /// `box.set_forwarded(constbox)` — Const variant.
     #[test]
     fn h3_1_make_constant_mirrors_box_info_constant() {
-        let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         ctx.make_constant(OpRef::int_op(0), Value::Int(42));
         match &b0.get_forwarded() {
             BoxForwarded::Const(majit_ir::Const::Int(v), _) => {
@@ -7523,7 +7549,7 @@ mod boxref_forwarding_tests {
     /// `setintbound(opref, bound)` mirrors `box.set_forwarded(IntBound)`.
     #[test]
     fn h3_1_setintbound_mirrors_box_info() {
-        let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         let bound = IntBound::from_constant(7);
         ctx.setintbound(&b0, &bound);
         match &b0.get_forwarded() {
@@ -7544,7 +7570,7 @@ mod boxref_forwarding_tests {
     /// BoxRef carrying the same Value as the seeded constant.
     #[test]
     fn h3_4_replace_op_const_target_mirrors_value_box() {
-        let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         let const_opref = OpRef::const_int(0);
         ctx.const_pool
             .insert(const_opref.const_index(), Value::Int(42));
@@ -7566,7 +7592,7 @@ mod boxref_forwarding_tests {
     /// keep the runtime Box identity.
     #[test]
     fn get_box_replacement_not_const_stops_before_const_target() {
-        let (mut ctx, b0, b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, b1, _ia_holder) = ctx_with_two_int_boxes();
         let const_opref = OpRef::const_int(0);
         ctx.const_pool
             .insert(const_opref.const_index(), Value::Int(42));
@@ -7599,7 +7625,7 @@ mod boxref_forwarding_tests {
     #[test]
     #[should_panic(expected = "missing from const_pool")]
     fn h3_4_replace_op_const_target_without_const_pool_panics() {
-        let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         // const_pool is empty — bug in caller.
         let const_opref = OpRef::const_int(0);
         let b_const = ctx
@@ -7775,7 +7801,7 @@ mod boxref_forwarding_tests {
     /// `resoperation.py:57-68` walker terminates on `None` immediately.
     #[test]
     fn h3_2b_get_box_replacement_box_returns_pool_entry_when_no_forward() {
-        let (ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         let got = ctx
             .get_box_replacement_box(OpRef::int_op(0))
             .expect("pool entry exists");
@@ -7786,16 +7812,21 @@ mod boxref_forwarding_tests {
     /// H-3.2b: with a forwarding chain installed via `make_equal_to`, the
     /// BoxRef walker reaches the terminal Box (`b1`). RPython parity:
     /// `optimizer.py:393 box.set_forwarded(newop)` → reader walks until
-    /// `Forwarded::None` and returns the last Box.
+    /// `Forwarded::None` and returns the last Box. The walker materialises
+    /// a transient BoxRef wrapping `b1`'s bound `InputArgRc`, so terminal
+    /// identity is checked via the shared `InputArg` handle rather than
+    /// outer `Rc<Box>` pointer equality.
     #[test]
     fn h3_2b_get_box_replacement_box_walks_forwarded_chain() {
-        let (mut ctx, b0, b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, b1, ia_holder) = ctx_with_two_int_boxes();
         ctx.make_equal_to(&b0, &b1);
         let got = ctx
             .get_box_replacement_box(OpRef::int_op(0))
             .expect("pool entry exists");
-        // b0 → b1 through the BoxRef `_forwarded` slot; terminal is b1.
-        assert_eq!(got, b1);
+        assert!(std::rc::Rc::ptr_eq(
+            &got.bound_inputarg().expect("walked terminal carries bound InputArg"),
+            &ia_holder[1],
+        ));
         // b0 itself is not the terminal.
         assert_ne!(got, b0);
     }
@@ -7816,7 +7847,7 @@ mod boxref_forwarding_tests {
     /// the sentinel independently by returning it unchanged.
     #[test]
     fn h3_2b_get_box_replacement_box_handles_none_sentinel() {
-        let (ctx, _b0, _b1) = ctx_with_two_int_boxes();
+        let (ctx, _b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         assert!(ctx.get_box_replacement_box(OpRef::NONE).is_none());
     }
 
@@ -7826,7 +7857,7 @@ mod boxref_forwarding_tests {
     /// construction. Identity is irrelevant; readers compare via Value.
     #[test]
     fn h3_4_get_box_replacement_box_materializes_const_from_const_pool() {
-        let (mut ctx, _b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, _b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         let const_opref = OpRef::const_int(0);
         ctx.const_pool
             .insert(const_opref.const_index(), Value::Int(42));
@@ -7843,7 +7874,7 @@ mod boxref_forwarding_tests {
     /// PyPy `resoperation.py:60 isinstance(next, AbstractInfo)`.
     #[test]
     fn h3_2b_get_box_replacement_box_stops_at_info_terminal() {
-        let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         ctx.setintbound(&b0, &IntBound::from_constant(7));
         let got = ctx
             .get_box_replacement_box(OpRef::int_op(0))
@@ -7911,7 +7942,7 @@ mod boxref_forwarding_tests {
 
     #[test]
     fn h3_2c_peek_intbound_box_matches_legacy_when_pool_plumbed() {
-        let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         ctx.setintbound(&b0, &IntBound::from_constant(42));
         let legacy = ctx
             .peek_intbound(OpRef::input_arg_int(0))
@@ -7925,7 +7956,7 @@ mod boxref_forwarding_tests {
 
     #[test]
     fn h3_2c_peek_intbound_box_returns_none_for_unset() {
-        let (ctx, b0, _b1) = ctx_with_two_int_boxes();
+        let (ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         assert!(ctx.peek_intbound_box(&b0).is_none());
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1712,6 +1712,54 @@ impl OptContext {
         ctx
     }
 
+    /// Walk every materialized `box_pool` slot and bind any InputArg BoxRef
+    /// whose `bound_inputarg()` is None to a fresh `InputArgRc` carrying
+    /// the BoxRef's intrinsic type. Strong refs are stashed in
+    /// `inputarg_refs` so the bound `Weak<InputArg>` stays upgradable for
+    /// the OptContext's lifetime.
+    ///
+    /// `TraceIterator::new` (opencoder.rs) builds the per-iter pool by
+    /// pushing fresh `BoxRef::new_inputarg(tp, _fresh)` for each inputarg
+    /// without calling `bind_inputarg`; the TreeLoop-owned strong
+    /// `InputArgRc`s never reach this freshly-built pool. Phase 2 inherits
+    /// Phase 1's box_pool snapshot via `iter.box_pool.clone()`, so Phase 1
+    /// inputarg slots reappear at Phase 2 entry with their earlier
+    /// `Weak<InputArg>` dangling (the previous OptContext's
+    /// `inputarg_refs` strong owners were dropped). Re-binding here
+    /// restores `Forwarded::InputArg(_)` reachability for every
+    /// InputArg BoxRef the optimizer will hand to `make_equal_to`
+    /// (`optimizer.py:394 op.set_forwarded(newop)`, unroll.py:497).
+    /// Idempotent — already-bound entries skip.
+    pub(crate) fn ensure_inputarg_bindings(&mut self) {
+        if self.box_pool.is_empty() {
+            return;
+        }
+        // Walk every materialized slot; any InputArg BoxRef whose
+        // `bound_inputarg()` is None gets a fresh `InputArgRc` and bind.
+        // Cross-phase: Phase 2 inherits Phase 1's box_pool snapshot, so
+        // Phase 1 inputarg slots reappear at Phase 2 entry with their
+        // earlier `Weak<InputArg>` dangling (the previous OptContext's
+        // `inputarg_refs` strong owners were dropped). Re-binding here
+        // restores `Forwarded::InputArg(_)` reachability across phases.
+        let needs: Vec<(usize, majit_ir::Type)> = self
+            .box_pool
+            .iter_indexed()
+            .filter_map(|(pos, b)| {
+                if !b.is_inputarg() || b.bound_inputarg().is_some() {
+                    return None;
+                }
+                Some((pos, b.type_()))
+            })
+            .collect();
+        for (pos, tp) in needs {
+            let ia = std::rc::Rc::new(majit_ir::InputArg::from_type(tp, pos as u32));
+            if let Some(b) = self.box_pool.get_at_position(pos) {
+                b.bind_inputarg(&ia);
+            }
+            self.inputarg_refs.push(ia);
+        }
+    }
+
     /// Construct an `OptContext` whose inputarg / fresh-OpRef numbering is
     /// shifted to start above a parent trace's high water mark.
     ///

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3534,7 +3534,17 @@ impl OptContext {
                 .const_value()
                 .expect("is_constant() implies const_value() Some");
             op.set_forwarded_const(majit_ir::Const::from_value(value), newop.const_index());
+        } else if let Some(target_op) = newop.bound_op() {
+            // Op-target chain step: route through Forwarded::Op(Weak<Op>)
+            // so the chain refers to the canonical Rc<Op> (PyPy
+            // resoperation.py:240 set_forwarded(forwarded_to) where
+            // forwarded_to is an AbstractResOp), retiring the
+            // BoxKind::ResOp-as-chain-target carrier.
+            op.set_forwarded_op(&target_op);
         } else {
+            // Unbound non-const target: legacy InputArg / pre-bind
+            // path; keep BoxRef-based Forwarded::Box until those
+            // sources are migrated in C.4.b / C.5.
             op.set_forwarded_box(newop.clone());
         }
         // optimizer.py:395-396
@@ -5983,7 +5993,7 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_, _) => unreachable!(
+            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) => unreachable!(
                 "getrawptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6073,7 +6083,7 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_, _) => unreachable!(
+            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) => unreachable!(
                 "getptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6399,7 +6409,7 @@ impl OptContext {
                     Forwarded::Info(_) | Forwarded::VectorInfo(_) => {
                         return crate::optimizeopt::intutils::IntBound::unbounded().getnullness();
                     }
-                    Forwarded::Box(_) | Forwarded::Const(_, _) => {
+                    Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) => {
                         unreachable!("chain walker terminal")
                     }
                     Forwarded::None => {}
@@ -7400,8 +7410,8 @@ mod boxref_forwarding_tests {
         // The IntBound on old is gone (overwritten by Forwarded::Op(const)).
         // Const targets do not carry transferred info — PyPy skips this case.
         match &b0.get_forwarded() {
-            BoxForwarded::Box(target) => assert!(target.is_constant()),
-            other => panic!("expected b0 to forward to const_box, got {:?}", other),
+            BoxForwarded::Const(majit_ir::Const::Int(v), _) => assert_eq!(*v, 42),
+            other => panic!("expected b0 to forward to Const, got {:?}", other),
         }
     }
 
@@ -7422,9 +7432,9 @@ mod boxref_forwarding_tests {
     }
 
     /// PyPy optimizer.py:432 parity: after
-    /// `make_constant(opref, Value::Ref(_))` writes `Forwarded::Box(constbox)`
-    /// on the InputArg's BoxRef, a subsequent `make_nonnull(opref)` MUST NOT
-    /// overwrite the Const slot with `OpInfo::Ptr(NonNull)`.
+    /// `make_constant(opref, Value::Ref(_))` writes the constant onto
+    /// the InputArg's `_forwarded` slot, a subsequent `make_nonnull(opref)`
+    /// MUST NOT overwrite the Const with `OpInfo::Ptr(NonNull)`.
     #[test]
     fn audit_a_make_nonnull_preserves_box_constant_slot() {
         use majit_ir::GcRef;
@@ -7434,22 +7444,22 @@ mod boxref_forwarding_tests {
         let opref = OpRef::input_arg_typed(0, Type::Ref);
         ctx.make_constant(opref, Value::Ref(GcRef(0xdead_beef)));
         match &b.get_forwarded() {
-            BoxForwarded::Box(target) => {
-                assert_eq!(target.const_value(), Some(Value::Ref(GcRef(0xdead_beef))));
+            BoxForwarded::Const(majit_ir::Const::Ref(g), _) => {
+                assert_eq!(*g, GcRef(0xdead_beef));
             }
-            other => panic!("expected Box(ConstRef) post make_constant, got {:?}", other),
+            other => panic!("expected Forwarded::Const(Ref) post make_constant, got {:?}", other),
         }
         // OpRef → BoxRef shim until this caller migrates (Phase D-2).
         ctx.make_nonnull(&b);
         match &b.get_forwarded() {
-            BoxForwarded::Box(target) => {
+            BoxForwarded::Const(majit_ir::Const::Ref(g), _) => {
                 assert_eq!(
-                    target.const_value(),
-                    Some(Value::Ref(GcRef(0xdead_beef))),
-                    "make_nonnull must not overwrite the Const Box slot"
+                    *g,
+                    GcRef(0xdead_beef),
+                    "make_nonnull must not overwrite the Const slot"
                 );
             }
-            other => panic!("make_nonnull clobbered Const Box slot — got {:?}", other),
+            other => panic!("make_nonnull clobbered Const slot — got {:?}", other),
         }
     }
 
@@ -7490,16 +7500,16 @@ mod boxref_forwarding_tests {
     }
 
     /// `make_constant` mirrors PyPy optimizer.py:432
-    /// `box.set_forwarded(constbox)` as `Forwarded::Box(Const)`.
+    /// `box.set_forwarded(constbox)` — Const variant.
     #[test]
     fn h3_1_make_constant_mirrors_box_info_constant() {
         let (mut ctx, b0, _b1) = ctx_with_two_int_boxes();
         ctx.make_constant(OpRef::int_op(0), Value::Int(42));
         match &b0.get_forwarded() {
-            BoxForwarded::Box(target) => {
-                assert_eq!(target.const_value(), Some(Value::Int(42)));
+            BoxForwarded::Const(majit_ir::Const::Int(v), _) => {
+                assert_eq!(*v, 42);
             }
-            other => panic!("expected Forwarded::Box(ConstInt 42), got {:?}", other),
+            other => panic!("expected Forwarded::Const(Int 42), got {:?}", other),
         }
     }
 
@@ -7536,11 +7546,10 @@ mod boxref_forwarding_tests {
             .expect("const_pool seeded above");
         ctx.make_equal_to(&b0, &b_const);
         match &b0.get_forwarded() {
-            BoxForwarded::Box(target) => {
-                assert!(target.is_constant());
-                assert_eq!(target.const_value(), Some(Value::Int(42)));
+            BoxForwarded::Const(majit_ir::Const::Int(v), _) => {
+                assert_eq!(*v, 42);
             }
-            other => panic!("expected Forwarded::Box(Const), got {:?}", other),
+            other => panic!("expected Forwarded::Const(Int 42), got {:?}", other),
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7341,47 +7341,11 @@ mod boxref_forwarding_tests {
     //! `setintbound`, `make_constant`, `make_equal_to`) install PyPy-style
     //! forwarding state on the authoritative BoxRef slot.
     use super::*;
+    use crate::r#box::test_support::{bound_inputarg_box, bound_resop_box};
     use crate::r#box::{BoxRef, Forwarded as BoxForwarded};
     use crate::optimizeopt::info::{OpInfo, PtrInfo};
     use crate::optimizeopt::intutils::IntBound;
-    use majit_ir::resoperation::{Op, OpCode, OpRc};
-    use majit_ir::{InputArg, InputArgRc, OpRef, Type, Value};
-
-    /// Create a `BoxRef::new_inputarg(tp, index)` already bound to a fresh
-    /// `InputArgRc` (`box_ref.rs:354 bind_inputarg`), matching the
-    /// recorder→TreeLoop production handoff invariant that every
-    /// `AbstractInputArg` BoxRef has an `inputarg.forwarded` target. The
-    /// returned `InputArgRc` must outlive every read of `box.get_forwarded()`
-    /// so the bound `Weak<InputArg>` stays upgradable.
-    fn bound_inputarg_box(tp: Type, index: u32) -> (BoxRef, InputArgRc) {
-        let b = BoxRef::new_inputarg(tp, index);
-        let ia = std::rc::Rc::new(InputArg::from_type(tp, index));
-        b.bind_inputarg(&ia);
-        (b, ia)
-    }
-
-    /// Create a `BoxRef::new_resop(tp, position)` already bound to a fresh
-    /// `OpRc` (`box_ref.rs:322 bind_op`), matching the
-    /// recorder→TreeLoop handoff for `AbstractResOp` BoxRefs. The Op's
-    /// `pos` is seeded to a typed OpRef matching `(position, tp)` so
-    /// `BoxRef::from_bound_op` (`box_ref.rs:226`) materialises a
-    /// transient terminal box of the same type during chain walks.
-    /// `OpCode::SameAsI/F/R` is a no-op placeholder result for the
-    /// requested type (`resoperation.py:600+`); `Type::Void` lands on
-    /// `OpCode::Guard` which has Void result.
-    fn bound_resop_box(tp: Type, position: u32) -> (BoxRef, OpRc) {
-        let b = BoxRef::new_resop(tp, position);
-        let opcode = match tp {
-            Type::Int => OpCode::SameAsI,
-            Type::Float => OpCode::SameAsF,
-            Type::Ref => OpCode::SameAsR,
-            Type::Void => OpCode::Jump,
-        };
-        let op = std::rc::Rc::new(Op::new(opcode, &[]));
-        op.pos.set(OpRef::op_typed(position, tp));
-        b.bind_op(&op);
-        (b, op)
-    }
+    use majit_ir::{InputArgRc, OpRef, Type, Value};
 
     fn ctx_with_two_int_boxes() -> (OptContext, BoxRef, BoxRef, Vec<InputArgRc>) {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3532,7 +3532,14 @@ impl OptContext {
             _ => None,
         };
         // optimizer.py:394 op.set_forwarded(newop)
-        op.set_forwarded_box(newop.clone());
+        if newop.is_constant() {
+            let value = newop
+                .const_value()
+                .expect("is_constant() implies const_value() Some");
+            op.set_forwarded_const(majit_ir::Const::from_value(value), newop.const_index());
+        } else {
+            op.set_forwarded_box(newop.clone());
+        }
         // optimizer.py:395-396
         //   if opinfo is not None and not newop.is_constant():
         //       newop.set_forwarded(opinfo)
@@ -4116,7 +4123,7 @@ impl OptContext {
                 .ensure_box(opref)
                 .expect("body-namespace OpRef must have a BoxRef slot");
             if matches!(box_at.get_forwarded(), crate::r#box::Forwarded::None) {
-                box_at.set_forwarded_box(crate::r#box::BoxRef::new_const(value));
+                box_at.set_forwarded_const(majit_ir::Const::from_value(value), None);
             }
         }
     }
@@ -4459,10 +4466,7 @@ impl OptContext {
         let b = self
             .ensure_box(replaced)
             .expect("body-namespace OpRef must have a BoxRef slot");
-        b.set_forwarded_box(crate::r#box::BoxRef::new_const_with_index(
-            value,
-            new_const_idx,
-        ));
+        b.set_forwarded_const(majit_ir::Const::from_value(value), Some(new_const_idx));
     }
 
     /// info.py:194-198 (AbstractStructPtrInfo) + info.py:533-538 (ArrayPtrInfo)
@@ -5984,7 +5988,7 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_) => unreachable!(
+            Forwarded::Box(_) | Forwarded::Const(_, _) => unreachable!(
                 "getrawptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6074,7 +6078,7 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_) => unreachable!(
+            Forwarded::Box(_) | Forwarded::Const(_, _) => unreachable!(
                 "getptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6400,7 +6404,7 @@ impl OptContext {
                     Forwarded::Info(_) | Forwarded::VectorInfo(_) => {
                         return crate::optimizeopt::intutils::IntBound::unbounded().getnullness();
                     }
-                    Forwarded::Box(_) | Forwarded::Const(_) => {
+                    Forwarded::Box(_) | Forwarded::Const(_, _) => {
                         unreachable!("chain walker terminal")
                     }
                     Forwarded::None => {}

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3646,19 +3646,23 @@ impl OptContext {
             // forwarded_to is an AbstractResOp), retiring the
             // BoxKind::ResOp-as-chain-target carrier.
             op.set_forwarded_op(&target_op);
-        } else {
+        } else if let Some(target_ia) = newop.bound_inputarg() {
             // InputArg-target chain step (compile.py:478, unroll.py:497).
-            // Const / Op / InputArg are the only `newop` shapes
-            // make_equal_to ever receives — InputArg BoxRefs are bound at
-            // OptContext entry via `ensure_inputarg_bindings`, ResOp
-            // BoxRefs at `ensure_box` (lazy stand-in synthesis when the
-            // producer has not yet emitted).
-            let target_ia = newop.bound_inputarg().expect(
-                "make_equal_to: non-Const target carries neither bound Op \
-                 nor bound InputArg — every BoxRef reaching this point \
-                 must be bound (resoperation.py:233-242 _forwarded host)",
-            );
             op.set_forwarded_inputarg(&target_ia);
+        } else {
+            // Orphan unbound non-Const BoxRef target. Phase 1's per-iter
+            // `TraceIterator::next()` (opencoder.rs:500) plants
+            // `BoxRef::new_resop` slots in the pool *without* binding to
+            // an `OpRc`; when Phase 1 folds/drops the op before it lands
+            // in `new_operations` / `phase1_emit_ops`, the pool slot stays
+            // unbound. Chain walks via `Forwarded::Box(...)` can still
+            // reach it through `Box.forwarded` (the mirror is canonical
+            // for unbound slots), so the chain step terminates safely on
+            // a `Forwarded::Box(newop)` write — `get_box_replacement` will
+            // continue reading Phase 1's forwarded state off the same
+            // `Box`. Test fixtures that build `BoxRef::new_resop` /
+            // `new_inputarg` without binding also rely on this path.
+            op.set_forwarded_box(newop.clone());
         }
         // optimizer.py:395-396
         //   if opinfo is not None and not newop.is_constant():
@@ -3912,7 +3916,32 @@ impl OptContext {
         // would round-trip to `op_at(pos)` (None) instead of
         // `inputargs[i]`.
         if let Some(existing) = self.box_pool.get(opref) {
-            return Some(existing.clone());
+            let cloned = existing.clone();
+            // Phase 1's per-iter BoxPool plants unbound `BoxRef::new_resop`
+            // slots in `TraceIterator::next()` (opencoder.rs:500) without a
+            // producer OpRc to bind to. When Phase 2 (or a retrace) sees
+            // those slots via `p1_full_prefix` carry-over and the
+            // corresponding producer arrives via `phase1_emit_ops` or
+            // `new_operations`, late-bind here so the chain-walk reads
+            // through to `op.forwarded` (resoperation.py:233 `_forwarded`
+            // host) and `make_equal_to`'s strict bound-target invariant
+            // holds.
+            if cloned.is_resop() && cloned.bound_op().is_none() {
+                let op_rc = self
+                    .new_operations
+                    .iter()
+                    .rfind(|op| op.pos.get() == opref)
+                    .or_else(|| {
+                        self.phase1_emit_ops
+                            .iter()
+                            .rfind(|op| op.pos.get() == opref)
+                    })
+                    .cloned();
+                if let Some(op_rc) = op_rc {
+                    cloned.bind_op(&op_rc);
+                }
+            }
+            return Some(cloned);
         }
         let idx = opref.raw() as usize;
         let placeholder_type = opref.ty().unwrap_or(majit_ir::Type::Void);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7344,6 +7344,7 @@ mod boxref_forwarding_tests {
     use crate::r#box::{BoxRef, Forwarded as BoxForwarded};
     use crate::optimizeopt::info::{OpInfo, PtrInfo};
     use crate::optimizeopt::intutils::IntBound;
+    use majit_ir::resoperation::{Op, OpCode, OpRc};
     use majit_ir::{InputArg, InputArgRc, OpRef, Type, Value};
 
     /// Create a `BoxRef::new_inputarg(tp, index)` already bound to a fresh
@@ -7357,6 +7358,29 @@ mod boxref_forwarding_tests {
         let ia = std::rc::Rc::new(InputArg::from_type(tp, index));
         b.bind_inputarg(&ia);
         (b, ia)
+    }
+
+    /// Create a `BoxRef::new_resop(tp, position)` already bound to a fresh
+    /// `OpRc` (`box_ref.rs:322 bind_op`), matching the
+    /// recorder→TreeLoop handoff for `AbstractResOp` BoxRefs. The Op's
+    /// `pos` is seeded to a typed OpRef matching `(position, tp)` so
+    /// `BoxRef::from_bound_op` (`box_ref.rs:226`) materialises a
+    /// transient terminal box of the same type during chain walks.
+    /// `OpCode::SameAsI/F/R` is a no-op placeholder result for the
+    /// requested type (`resoperation.py:600+`); `Type::Void` lands on
+    /// `OpCode::Guard` which has Void result.
+    fn bound_resop_box(tp: Type, position: u32) -> (BoxRef, OpRc) {
+        let b = BoxRef::new_resop(tp, position);
+        let opcode = match tp {
+            Type::Int => OpCode::SameAsI,
+            Type::Float => OpCode::SameAsF,
+            Type::Ref => OpCode::SameAsR,
+            Type::Void => OpCode::Jump,
+        };
+        let op = std::rc::Rc::new(Op::new(opcode, &[]));
+        op.pos.set(OpRef::op_typed(position, tp));
+        b.bind_op(&op);
+        (b, op)
     }
 
     fn ctx_with_two_int_boxes() -> (OptContext, BoxRef, BoxRef, Vec<InputArgRc>) {
@@ -7659,10 +7683,10 @@ mod boxref_forwarding_tests {
         // so place Ref-typed boxes on both sides — the test models a
         // Phase 1 RefOp result acting as the import target.
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 4, 0, 4);
-        let placeholder_target = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 0);
-        let placeholder_other = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 1);
-        let source_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 2);
-        let other_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 3);
+        let (placeholder_target, _op_target) = bound_resop_box(Type::Ref, 0);
+        let (placeholder_other, _op_other) = bound_resop_box(Type::Ref, 1);
+        let (source_box, _ia_source) = bound_inputarg_box(Type::Ref, 2);
+        let (other_box, _ia_other) = bound_inputarg_box(Type::Ref, 3);
         ctx.box_pool = vec![
             placeholder_target.clone(),
             placeholder_other,
@@ -7733,10 +7757,10 @@ mod boxref_forwarding_tests {
         // Same Ref-typed alignment as the sibling test: forwarding a Ref
         // source to the placeholder requires placeholder type to match
         // (PyPy `box.type` invariant; `make_equal_to` cross-type assertion).
-        let placeholder_target = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 0);
-        let placeholder_other = crate::r#box::BoxRef::new_resop(majit_ir::Type::Ref, 1);
-        let source_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 2);
-        let other_box = crate::r#box::BoxRef::new_inputarg(majit_ir::Type::Ref, 3);
+        let (placeholder_target, _op_target) = bound_resop_box(Type::Ref, 0);
+        let (placeholder_other, _op_other) = bound_resop_box(Type::Ref, 1);
+        let (source_box, _ia_source) = bound_inputarg_box(Type::Ref, 2);
+        let (other_box, _ia_other) = bound_inputarg_box(Type::Ref, 3);
         ctx.box_pool = vec![
             placeholder_target.clone(),
             placeholder_other,
@@ -8254,9 +8278,9 @@ mod boxref_forwarding_tests {
     #[test]
     fn chain_walk_preserves_ptr_info_rc_identity_across_two_hops() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 3, 0, 3);
-        let a = BoxRef::new_inputarg(Type::Ref, 0);
-        let b = BoxRef::new_inputarg(Type::Ref, 1);
-        let c = BoxRef::new_inputarg(Type::Ref, 2);
+        let (a, _ia_a) = bound_inputarg_box(Type::Ref, 0);
+        let (b, _ia_b) = bound_inputarg_box(Type::Ref, 1);
+        let (c, _ia_c) = bound_inputarg_box(Type::Ref, 2);
         ctx.box_pool = vec![a.clone(), b.clone(), c.clone()].into();
         ctx.set_ptr_info(&a, PtrInfo::NonNull { last_guard_pos: 7 });
 
@@ -8286,8 +8310,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn replace_op_preserves_int_bound_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Int, 0);
-        let new_box = BoxRef::new_inputarg(Type::Int, 1);
+        let (old_box, _ia_old) = bound_inputarg_box(Type::Int, 0);
+        let (new_box, _ia_new) = bound_inputarg_box(Type::Int, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.setintbound(
             &old_box,
@@ -8323,8 +8347,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn replace_op_preserves_ptr_info_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Ref, 0);
-        let new_box = BoxRef::new_inputarg(Type::Ref, 1);
+        let (old_box, _ia_old) = bound_inputarg_box(Type::Ref, 0);
+        let (new_box, _ia_new) = bound_inputarg_box(Type::Ref, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.set_ptr_info(&old_box, PtrInfo::NonNull { last_guard_pos: 0 });
 
@@ -8358,8 +8382,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn make_equal_to_preserves_int_bound_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Int, 0);
-        let new_box = BoxRef::new_inputarg(Type::Int, 1);
+        let (old_box, _ia_old) = bound_inputarg_box(Type::Int, 0);
+        let (new_box, _ia_new) = bound_inputarg_box(Type::Int, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.setintbound(
             &old_box,
@@ -8382,8 +8406,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn make_equal_to_preserves_ptr_info_rc_identity() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let old_box = BoxRef::new_inputarg(Type::Ref, 0);
-        let new_box = BoxRef::new_inputarg(Type::Ref, 1);
+        let (old_box, _ia_old) = bound_inputarg_box(Type::Ref, 0);
+        let (new_box, _ia_new) = bound_inputarg_box(Type::Ref, 1);
         ctx.box_pool = vec![old_box.clone(), new_box.clone()].into();
         ctx.set_ptr_info(&old_box, PtrInfo::NonNull { last_guard_pos: 0 });
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5981,9 +5981,11 @@ impl OptContext {
                  (info.py:876), got VectorizationInfo",
             ),
             // Terminal of `get_box_replacement(false)` can only be `None`
-            // or `Info(_)` per the chain walker (box.rs:295-322).
-            Forwarded::Box(_) => unreachable!(
-                "getrawptrinfo: chain terminal must not carry Forwarded::Box \
+            // or `Info(_)` per the chain walker (box.rs:295-322); a
+            // `Forwarded::Const` terminal is materialized inline by the
+            // walker into a fresh BoxRef whose own slot is None.
+            Forwarded::Box(_) | Forwarded::Const(_) => unreachable!(
+                "getrawptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
         }
@@ -6069,9 +6071,11 @@ impl OptContext {
                 panic!("getptrinfo: forwarded must be PtrInfo (info.py:892), got VectorizationInfo",)
             }
             // Terminal of `get_box_replacement(false)` can only be `None`
-            // or `Info(_)` per the chain walker (box.rs:295-322).
-            Forwarded::Box(_) => unreachable!(
-                "getptrinfo: chain terminal must not carry Forwarded::Box \
+            // or `Info(_)` per the chain walker (box.rs:295-322); a
+            // `Forwarded::Const` terminal is materialized inline by the
+            // walker into a fresh BoxRef whose own slot is None.
+            Forwarded::Box(_) | Forwarded::Const(_) => unreachable!(
+                "getptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
         }
@@ -6396,7 +6400,9 @@ impl OptContext {
                     Forwarded::Info(_) | Forwarded::VectorInfo(_) => {
                         return crate::optimizeopt::intutils::IntBound::unbounded().getnullness();
                     }
-                    Forwarded::Box(_) => unreachable!("chain walker terminal"),
+                    Forwarded::Box(_) | Forwarded::Const(_) => {
+                        unreachable!("chain walker terminal")
+                    }
                     Forwarded::None => {}
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3646,16 +3646,19 @@ impl OptContext {
             // forwarded_to is an AbstractResOp), retiring the
             // BoxKind::ResOp-as-chain-target carrier.
             op.set_forwarded_op(&target_op);
-        } else if let Some(target_ia) = newop.bound_inputarg() {
-            // InputArg-target chain step (compile.py:478, unroll.py:497).
-            op.set_forwarded_inputarg(&target_ia);
         } else {
-            // C.6 panic probe to identify residual fixtures.
-            panic!(
-                "make_equal_to.C6 PROBE: unbound non-Const target \
-                 {newop:?} (position={:?})",
-                newop.position(),
+            // InputArg-target chain step (compile.py:478, unroll.py:497).
+            // Const / Op / InputArg are the only `newop` shapes
+            // make_equal_to ever receives — InputArg BoxRefs are bound at
+            // OptContext entry via `ensure_inputarg_bindings`, ResOp
+            // BoxRefs at `ensure_box` (lazy stand-in synthesis when the
+            // producer has not yet emitted).
+            let target_ia = newop.bound_inputarg().expect(
+                "make_equal_to: non-Const target carries neither bound Op \
+                 nor bound InputArg — every BoxRef reaching this point \
+                 must be bound (resoperation.py:233-242 _forwarded host)",
             );
+            op.set_forwarded_inputarg(&target_ia);
         }
         // optimizer.py:395-396
         //   if opinfo is not None and not newop.is_constant():

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -755,6 +755,20 @@ pub struct OptContext {
     /// (`optimizer.py:394 op.set_forwarded(newop)`) instead of the
     /// deprecated `Forwarded::Box(_)` fallback.
     pub(crate) inputarg_refs: Vec<majit_ir::InputArgRc>,
+    /// Synthetic `OpRc` stand-ins for ResOp BoxRef placeholders whose
+    /// real producer has not been (and may never be) emitted, indexed
+    /// sparsely by `OpRef::raw()`. `ensure_box` falls back to
+    /// synthesising a `SameAsI/F/R` (or `Jump`) Op with the requested
+    /// type and binding the BoxRef to it so `make_equal_to` routes a
+    /// chain step that targets such a placeholder through
+    /// `Forwarded::Op(_)`. When a real producer Op is later emitted at
+    /// the same OpRef position, `emit()` re-binds the BoxRef to that
+    /// Op (carrying forwarded state across) and the synthetic stand-in
+    /// becomes unreferenced from the BoxRef but is still retained here
+    /// for the OptContext's lifetime so any lingering `Weak<Op>`
+    /// upgrades (e.g. in already-installed `Forwarded::Op` chains)
+    /// stay valid.
+    pub(crate) resop_refs: Vec<Option<majit_ir::resoperation::OpRc>>,
     /// Phase 1 emit ops carried into Phase 2's lookup surface.
     ///
     /// In RPython, a Box referenced cross-phase keeps its `.type` attribute
@@ -1621,6 +1635,7 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
+            resop_refs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
@@ -1764,6 +1779,7 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
+            resop_refs: Vec::new(),
             phase1_emit_ops: Vec::new(),
             last_guard_idx: None,
             last_seen_snapshot_pos: None,
@@ -2081,9 +2097,7 @@ impl OptContext {
         while self
             .box_pool
             .get_at_position(self.next_pos as usize)
-            .is_some_and(|b| {
-                matches!(b.get_forwarded(), crate::r#box::Forwarded::Const(_, _))
-            })
+            .is_some_and(|b| matches!(b.get_forwarded(), crate::r#box::Forwarded::Const(_, _)))
         {
             self.next_pos += 1;
         }
@@ -2255,14 +2269,29 @@ impl OptContext {
         Self::debug_assert_box_type_invariant(&op);
         let op_pos = op.pos.get();
         let op_rc = std::rc::Rc::new(op);
-        // Catch up any unbound BoxRef placeholder that ensure_box created
-        // for `op_pos` ahead of this emit (forward-reference path).
-        // resoperation.py:233 `_forwarded` lives on the operation object;
-        // late binding establishes that connection so subsequent
-        // `box.set_forwarded` reaches `op.forwarded`.
+        // Catch up any BoxRef placeholder that `ensure_box` created for
+        // `op_pos` ahead of this emit (forward-reference path).
+        // `resoperation.py:233 _forwarded` lives on the operation
+        // object; late binding establishes that connection so
+        // subsequent `box.set_forwarded` reaches `op.forwarded`.
+        //
+        // Re-bind unconditionally when a ResOp BoxRef is already bound
+        // to a synthetic stand-in (`OptContext::resop_refs[op_pos]`):
+        // `BoxRef::bind_op`'s carry-over reads the current
+        // `get_forwarded()` (via the stand-in's slot) and writes it
+        // into `op_rc.forwarded` before re-pointing the handle, so
+        // forwarded state migrates to the real producer Op.
         if let Some(b) = self.box_pool.get(op_pos) {
-            if b.bound_op().is_none() && b.is_resop() {
-                b.bind_op(&op_rc);
+            if b.is_resop() {
+                let bound_is_synthetic = b.bound_op().is_some_and(|bound| {
+                    self.resop_refs
+                        .get(op_pos.raw() as usize)
+                        .and_then(|slot| slot.as_ref())
+                        .is_some_and(|synth| std::rc::Rc::ptr_eq(&bound, synth))
+                });
+                if b.bound_op().is_none() || bound_is_synthetic {
+                    b.bind_op(&op_rc);
+                }
             }
         }
         self.new_operations.push(op_rc);
@@ -3573,12 +3602,12 @@ impl OptContext {
             // InputArg-target chain step (compile.py:478, unroll.py:497).
             op.set_forwarded_inputarg(&target_ia);
         } else {
-            // Probe 2026-05-25 (post lazy InputArg bind) counts 36 test
-            // fixtures still hitting this arm — predominantly ResOp
-            // BoxRef placeholders whose producer Op is never emitted in
-            // the test (forward-reference-only targets). Migrated
-            // incrementally per [[box-pool-v2 C.6]] in follow-up slices.
-            op.set_forwarded_box(newop.clone());
+            // C.6 panic probe to identify residual fixtures.
+            panic!(
+                "make_equal_to.C6 PROBE: unbound non-Const target \
+                 {newop:?} (position={:?})",
+                newop.position(),
+            );
         }
         // optimizer.py:395-396
         //   if opinfo is not None and not newop.is_constant():
@@ -3848,26 +3877,23 @@ impl OptContext {
                 // where `newop` is an `AbstractInputArg`) reachable for
                 // lazy-allocated InputArg placeholders too.
                 if idx >= self.inputarg_refs.len() {
-                    self.inputarg_refs.resize_with(idx + 1, || {
-                        std::rc::Rc::new(majit_ir::InputArg::new_int(0))
-                    });
+                    self.inputarg_refs
+                        .resize_with(idx + 1, || std::rc::Rc::new(majit_ir::InputArg::new_int(0)));
                     // Replace the placeholder filler at this exact slot
                     // with one matching the OpRef's true type/index.
-                    self.inputarg_refs[idx] =
-                        std::rc::Rc::new(majit_ir::InputArg::from_type(
-                            placeholder_type,
-                            idx as u32,
-                        ));
+                    self.inputarg_refs[idx] = std::rc::Rc::new(majit_ir::InputArg::from_type(
+                        placeholder_type,
+                        idx as u32,
+                    ));
                 } else if self.inputarg_refs[idx].tp != placeholder_type
                     || self.inputarg_refs[idx].index != idx as u32
                 {
                     // Replace a mismatched filler (e.g. `new_int(0)` set
                     // by an earlier resize-fill on a different slot).
-                    self.inputarg_refs[idx] =
-                        std::rc::Rc::new(majit_ir::InputArg::from_type(
-                            placeholder_type,
-                            idx as u32,
-                        ));
+                    self.inputarg_refs[idx] = std::rc::Rc::new(majit_ir::InputArg::from_type(
+                        placeholder_type,
+                        idx as u32,
+                    ));
                 }
                 p.bind_inputarg(&self.inputarg_refs[idx]);
                 p
@@ -3877,9 +3903,7 @@ impl OptContext {
                 // Bind to the producing OpRc when present so `box.set_forwarded`
                 // dual-writes to `op.forwarded` (resoperation.py:233 `_forwarded`
                 // host). Searches the current phase's `new_operations` first,
-                // then cross-phase `phase1_emit_ops`. Search reaches a value
-                // for every emitted ResOp; unbound only when the producer Op
-                // has not yet been pushed (forward reference inside a pass).
+                // then cross-phase `phase1_emit_ops`.
                 let op_rc = self
                     .new_operations
                     .iter()
@@ -3892,6 +3916,31 @@ impl OptContext {
                     .cloned();
                 if let Some(op_rc) = op_rc {
                     p.bind_op(&op_rc);
+                } else {
+                    // No producer Op yet — synthesise a `SameAsI/F/R`
+                    // (or `Jump` for Void) stand-in with the correct
+                    // result type and bind so chain steps targeting
+                    // this BoxRef route through `Forwarded::Op(_)`
+                    // (`optimizer.py:394 op.set_forwarded(newop)`
+                    // where `newop` is an `AbstractResOp`) instead of
+                    // the deprecated `Forwarded::Box(_)` fallback.
+                    // `emit()` re-binds to the real producer when it
+                    // arrives, carrying the forwarded state across via
+                    // `BoxRef::bind_op`'s carry-over.
+                    use majit_ir::resoperation::{Op, OpCode};
+                    let opcode = match placeholder_type {
+                        majit_ir::Type::Int => OpCode::SameAsI,
+                        majit_ir::Type::Float => OpCode::SameAsF,
+                        majit_ir::Type::Ref => OpCode::SameAsR,
+                        majit_ir::Type::Void => OpCode::Jump,
+                    };
+                    let synthetic = std::rc::Rc::new(Op::new(opcode, &[]));
+                    synthetic.pos.set(opref);
+                    if idx >= self.resop_refs.len() {
+                        self.resop_refs.resize_with(idx + 1, || None);
+                    }
+                    self.resop_refs[idx] = Some(synthetic.clone());
+                    p.bind_op(&synthetic);
                 }
                 p
             }
@@ -6058,7 +6107,10 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) | Forwarded::InputArg(_) => unreachable!(
+            Forwarded::Box(_)
+            | Forwarded::Const(_, _)
+            | Forwarded::Op(_)
+            | Forwarded::InputArg(_) => unreachable!(
                 "getrawptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6148,7 +6200,10 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) | Forwarded::InputArg(_) => unreachable!(
+            Forwarded::Box(_)
+            | Forwarded::Const(_, _)
+            | Forwarded::Op(_)
+            | Forwarded::InputArg(_) => unreachable!(
                 "getptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6474,7 +6529,10 @@ impl OptContext {
                     Forwarded::Info(_) | Forwarded::VectorInfo(_) => {
                         return crate::optimizeopt::intutils::IntBound::unbounded().getnullness();
                     }
-                    Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) | Forwarded::InputArg(_) => {
+                    Forwarded::Box(_)
+                    | Forwarded::Const(_, _)
+                    | Forwarded::Op(_)
+                    | Forwarded::InputArg(_) => {
                         unreachable!("chain walker terminal")
                     }
                     Forwarded::None => {}
@@ -7427,7 +7485,9 @@ mod boxref_forwarding_tests {
         assert!(matches!(b0.get_forwarded(), BoxForwarded::InputArg(_)));
         let walked = b0.get_box_replacement(false);
         assert!(std::rc::Rc::ptr_eq(
-            &walked.bound_inputarg().expect("walked terminal carries bound InputArg"),
+            &walked
+                .bound_inputarg()
+                .expect("walked terminal carries bound InputArg"),
             &ia_holder[1],
         ));
     }
@@ -7465,7 +7525,9 @@ mod boxref_forwarding_tests {
         assert!(matches!(b0.get_forwarded(), BoxForwarded::InputArg(_)));
         let walked = b0.get_box_replacement(false);
         assert!(std::rc::Rc::ptr_eq(
-            &walked.bound_inputarg().expect("walked terminal carries bound InputArg"),
+            &walked
+                .bound_inputarg()
+                .expect("walked terminal carries bound InputArg"),
             &ia_holder[1],
         ));
     }
@@ -7526,7 +7588,10 @@ mod boxref_forwarding_tests {
             BoxForwarded::Const(majit_ir::Const::Ref(g), _) => {
                 assert_eq!(*g, GcRef(0xdead_beef));
             }
-            other => panic!("expected Forwarded::Const(Ref) post make_constant, got {:?}", other),
+            other => panic!(
+                "expected Forwarded::Const(Ref) post make_constant, got {:?}",
+                other
+            ),
         }
         // OpRef → BoxRef shim until this caller migrates (Phase D-2).
         ctx.make_nonnull(&b);
@@ -7870,7 +7935,8 @@ mod boxref_forwarding_tests {
             .get_box_replacement_box(OpRef::int_op(0))
             .expect("pool entry exists");
         assert!(std::rc::Rc::ptr_eq(
-            &got.bound_inputarg().expect("walked terminal carries bound InputArg"),
+            &got.bound_inputarg()
+                .expect("walked terminal carries bound InputArg"),
             &ia_holder[1],
         ));
         // b0 itself is not the terminal.

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3545,9 +3545,13 @@ impl OptContext {
             // InputArg-target chain step (compile.py:478, unroll.py:497).
             op.set_forwarded_inputarg(&target_ia);
         } else {
-            // Unbound non-const target: pre-bind / test fixture
-            // path; keep BoxRef-based Forwarded::Box until those
-            // sources are migrated in C.5.
+            // Unbound non-const BoxRef target — only constructible
+            // from test fixtures that build `BoxRef::new_resop` /
+            // `BoxRef::new_inputarg` without calling `bind_op` /
+            // `bind_inputarg`. Production paths bind every BoxRef at
+            // the recorder→TreeLoop handoff. Keep the legacy path for
+            // those callers; migrating each test individually is
+            // C.8's scope.
             op.set_forwarded_box(newop.clone());
         }
         // optimizer.py:395-396

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3541,10 +3541,13 @@ impl OptContext {
             // forwarded_to is an AbstractResOp), retiring the
             // BoxKind::ResOp-as-chain-target carrier.
             op.set_forwarded_op(&target_op);
+        } else if let Some(target_ia) = newop.bound_inputarg() {
+            // InputArg-target chain step (compile.py:478, unroll.py:497).
+            op.set_forwarded_inputarg(&target_ia);
         } else {
-            // Unbound non-const target: legacy InputArg / pre-bind
+            // Unbound non-const target: pre-bind / test fixture
             // path; keep BoxRef-based Forwarded::Box until those
-            // sources are migrated in C.4.b / C.5.
+            // sources are migrated in C.5.
             op.set_forwarded_box(newop.clone());
         }
         // optimizer.py:395-396
@@ -5993,7 +5996,7 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) => unreachable!(
+            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) | Forwarded::InputArg(_) => unreachable!(
                 "getrawptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6083,7 +6086,7 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) => unreachable!(
+            Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) | Forwarded::InputArg(_) => unreachable!(
                 "getptrinfo: chain terminal must not carry Forwarded::Box / Const \
                  (box.rs:295 get_box_replacement walker invariant)",
             ),
@@ -6409,7 +6412,7 @@ impl OptContext {
                     Forwarded::Info(_) | Forwarded::VectorInfo(_) => {
                         return crate::optimizeopt::intutils::IntBound::unbounded().getnullness();
                     }
-                    Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) => {
+                    Forwarded::Box(_) | Forwarded::Const(_, _) | Forwarded::Op(_) | Forwarded::InputArg(_) => {
                         unreachable!("chain walker terminal")
                     }
                     Forwarded::None => {}

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3573,12 +3573,11 @@ impl OptContext {
             // InputArg-target chain step (compile.py:478, unroll.py:497).
             op.set_forwarded_inputarg(&target_ia);
         } else {
-            // Unbound non-const BoxRef target — remaining test fixtures
-            // that flow custom BoxRef constructions through
-            // `make_equal_to` without binding. Probe 2026-05-25 (post
-            // with_inputarg_types bind) counts 40 such tests across
-            // heap / pure / unroll / virtualize / jitdriver, migrated
-            // incrementally per [[box-pool-v2 C.6]].
+            // Probe 2026-05-25 (post lazy InputArg bind) counts 36 test
+            // fixtures still hitting this arm — predominantly ResOp
+            // BoxRef placeholders whose producer Op is never emitted in
+            // the test (forward-reference-only targets). Migrated
+            // incrementally per [[box-pool-v2 C.6]] in follow-up slices.
             op.set_forwarded_box(newop.clone());
         }
         // optimizer.py:395-396
@@ -3839,7 +3838,39 @@ impl OptContext {
         let placeholder_type = opref.ty().unwrap_or(majit_ir::Type::Void);
         let placeholder = match opref {
             OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                crate::r#box::BoxRef::new_inputarg(placeholder_type, idx as u32)
+                let p = crate::r#box::BoxRef::new_inputarg(placeholder_type, idx as u32);
+                // Bind to the canonical `InputArgRc` for this slot. When
+                // `inputarg_refs[idx]` is already populated (e.g. by
+                // `with_inputarg_types`), use it; otherwise allocate a
+                // fresh `InputArgRc`, stash it in `inputarg_refs`, and
+                // bind. This keeps the `Forwarded::InputArg(_)` chain
+                // shape (`optimizer.py:394 op.set_forwarded(newop)`
+                // where `newop` is an `AbstractInputArg`) reachable for
+                // lazy-allocated InputArg placeholders too.
+                if idx >= self.inputarg_refs.len() {
+                    self.inputarg_refs.resize_with(idx + 1, || {
+                        std::rc::Rc::new(majit_ir::InputArg::new_int(0))
+                    });
+                    // Replace the placeholder filler at this exact slot
+                    // with one matching the OpRef's true type/index.
+                    self.inputarg_refs[idx] =
+                        std::rc::Rc::new(majit_ir::InputArg::from_type(
+                            placeholder_type,
+                            idx as u32,
+                        ));
+                } else if self.inputarg_refs[idx].tp != placeholder_type
+                    || self.inputarg_refs[idx].index != idx as u32
+                {
+                    // Replace a mismatched filler (e.g. `new_int(0)` set
+                    // by an earlier resize-fill on a different slot).
+                    self.inputarg_refs[idx] =
+                        std::rc::Rc::new(majit_ir::InputArg::from_type(
+                            placeholder_type,
+                            idx as u32,
+                        ));
+                }
+                p.bind_inputarg(&self.inputarg_refs[idx]);
+                p
             }
             _ => {
                 let p = crate::r#box::BoxRef::new_resop(placeholder_type, idx as u32);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4052,13 +4052,11 @@ impl OptContext {
 
     /// True only when opref has a non-const forwarding redirect.
     ///
-    /// `make_equal_to(_, non_const)` writes `Forwarded::Box(target)` where
-    /// `target` is a non-Const box. Both `make_equal_to(_, const_target)`
-    /// and `make_constant` write `Forwarded::Box(const_box)` per
-    /// `optimizer.py:432 box.set_forwarded(constbox)`. Splitting on
-    /// `target.is_constant()` excludes the const-target shape so this
-    /// returns true only for the inputarg-redirect case used by
-    /// `import_state`.
+    /// `make_equal_to(_, non_const)` writes either `Forwarded::Op(_)` or
+    /// `Forwarded::InputArg(_)`; the const branches go through
+    /// `Forwarded::Const`. Splitting on the variant excludes the
+    /// const-target shape so this returns true only for the AbstractValue
+    /// redirect case used by `import_state`.
     ///
     /// `Const.get_forwarded()` returns `None` upstream
     /// (`resoperation.py:1162`); short-circuit on the const-namespace
@@ -4070,7 +4068,9 @@ impl OptContext {
         }
         matches!(
             &op.get_forwarded(),
-            crate::r#box::Forwarded::Box(target) if !target.is_constant()
+            crate::r#box::Forwarded::Op(_)
+                | crate::r#box::Forwarded::InputArg(_)
+                | crate::r#box::Forwarded::Box(_)
         )
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3654,9 +3654,33 @@ impl OptContext {
             // resoperation.py:240 set_forwarded(forwarded_to) where
             // forwarded_to is an AbstractResOp), retiring the
             // BoxKind::ResOp-as-chain-target carrier.
+            //
+            // `optimizer.py:392 if op is newop: return` — PyPy's
+            // identity check uses Python `is`; after `bind_op`, two
+            // separate `Rc<Box>` wrappers can share the same canonical
+            // `OpRc`, so `&op == newop` (which compares the `Rc<Box>`)
+            // misses that case and falls through to `set_forwarded_op`,
+            // tripping `set_forwarded_op`'s self-cycle assert. Honour
+            // the upstream `is` semantics by comparing the bound `Op`
+            // identities first.
+            if op
+                .bound_op()
+                .is_some_and(|o| std::rc::Rc::ptr_eq(&o, &target_op))
+            {
+                return;
+            }
             op.set_forwarded_op(&target_op);
         } else if let Some(target_ia) = newop.bound_inputarg() {
             // InputArg-target chain step (compile.py:478, unroll.py:497).
+            // Same `optimizer.py:392` idempotent gate as the
+            // `bound_op` arm above, against the bound `InputArg`
+            // identities.
+            if op
+                .bound_inputarg()
+                .is_some_and(|i| std::rc::Rc::ptr_eq(&i, &target_ia))
+            {
+                return;
+            }
             op.set_forwarded_inputarg(&target_ia);
         } else {
             // Orphan unbound non-Const BoxRef target. Phase 1's per-iter

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1756,7 +1756,16 @@ impl OptContext {
             if let Some(b) = self.box_pool.get_at_position(pos) {
                 b.bind_inputarg(&ia);
             }
-            self.inputarg_refs.push(ia);
+            // `inputarg_refs` is keyed by raw OpRef position so
+            // `ensure_box(InputArg{Int,Ref,Float}(idx))` finds the
+            // canonical `InputArgRc` at `inputarg_refs[idx]`. Pushing
+            // would scramble the position→Rc mapping (bridges/Phase 2
+            // see scattered inputarg positions, not a dense 0..N range).
+            if pos >= self.inputarg_refs.len() {
+                self.inputarg_refs
+                    .resize_with(pos + 1, || std::rc::Rc::new(majit_ir::InputArg::new_int(0)));
+            }
+            self.inputarg_refs[pos] = ia;
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2407,15 +2407,38 @@ impl Optimizer {
         //
         // pyre's per-iter `TraceIterator::next()` (opencoder.rs:500)
         // pushes a fresh `BoxRef::new_resop` slot for every visited op
-        // BEFORE the optimizer pipeline decides whether to emit. When
-        // the pipeline drops the op no `ctx.emit` is called and the
-        // slot stays unbound; the BoxRef is then an orphan with no
-        // producer `OpRc`. Seal each orphan now by synthesising a
-        // SameAs stand-in OpRc, binding the slot, and appending the
-        // stand-in to the emit-op carry list so the retrace
-        // `ensure_box` existing-pool-slot late-bind reaches it.
+        // BEFORE the optimizer pipeline decides whether to emit. Two
+        // categories of slot escape the `new_operations` carry above
+        // and need explicit handling so `Forwarded::Op(Weak<Op>)`
+        // upgrades stay live after Phase 1 context drop:
+        //
+        //   - Unbound orphan: the pipeline folded/dropped the op so
+        //     `ctx.emit` never ran. Synthesize a `SameAs` stand-in
+        //     and bind the slot.
+        //   - Synthetic-bound: a forward reference reached `ensure_box`
+        //     first; `ensure_box` minted a `SameAs` stand-in into
+        //     `ctx.resop_refs[idx]` and `bind_op`'ed it. When `emit`
+        //     never arrived to upgrade the binding to a real producer,
+        //     the stand-in itself is the chain target carrier.
+        //
+        // In both cases the stand-in OpRc must travel into
+        // `phase1_emit_ops` (and from there into
+        // `ExportedState.partial_trace_operations`) so retrace's
+        // `Weak<Op>` upgrade succeeds.
         for (idx, b) in ctx.box_pool.iter_indexed() {
-            if !b.is_resop() || b.bound_op().is_some() {
+            if !b.is_resop() {
+                continue;
+            }
+            let synth_stand_in = ctx.resop_refs.get(idx).and_then(|slot| slot.as_ref());
+            let bound = b.bound_op();
+            let bound_is_synthetic = match (&bound, synth_stand_in) {
+                (Some(boxed), Some(synth)) => std::rc::Rc::ptr_eq(boxed, synth),
+                _ => false,
+            };
+            if let Some(bound_rc) = bound {
+                if bound_is_synthetic {
+                    self.phase1_emit_ops.push(bound_rc);
+                }
                 continue;
             }
             use majit_ir::resoperation::Op;

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1970,6 +1970,13 @@ impl Optimizer {
         //    Mirrors `PyPy Optimizer.__init__: self.inputargs = inputargs`
         //    (optimizer.py:34).
         ctx.inputargs = self.trace_inputargs.clone();
+        // Bind inputarg BoxRefs handed in via `box_pool` so
+        // `make_equal_to` routes InputArg-targeted chain steps through
+        // `Forwarded::InputArg(_)` rather than the deprecated
+        // `Forwarded::Box(_)` fallback. `TraceIterator::new` builds the
+        // per-iter pool with fresh unbound `BoxRef::new_inputarg(tp, _)`;
+        // the TreeLoop-owned strong `InputArgRc`s never reach it.
+        ctx.ensure_inputarg_bindings();
         // Phase 1 emit ops: single source of truth for cross-phase OpRef →
         // `op.type_` lookup (history.py:220 parity).
         ctx.phase1_emit_ops = std::mem::take(&mut self.phase1_emit_ops);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2872,10 +2872,7 @@ impl Optimizer {
                 if old_idx < num_inputs as u32 {
                     continue;
                 }
-                if !matches!(
-                    b.get_forwarded(),
-                    crate::r#box::Forwarded::Const(_, _)
-                ) {
+                if !matches!(b.get_forwarded(), crate::r#box::Forwarded::Const(_, _)) {
                     continue;
                 }
                 remap.insert(old_idx, next_const_pos);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2400,6 +2400,39 @@ impl Optimizer {
                 self.phase1_emit_ops.push(op.clone());
             }
         }
+        // PyPy parity: a folded ResOperation keeps its Python identity
+        // through `_forwarded` links; Phase 2 chain walks via
+        // `partial_trace.operations` reach it directly
+        // (resoperation.py:233 `_forwarded` host).
+        //
+        // pyre's per-iter `TraceIterator::next()` pushes a fresh
+        // `BoxRef::new_resop` slot for every visited op
+        // (opencoder.rs:500) BEFORE the optimizer pipeline decides
+        // whether to emit it. When the pipeline drops the op, no
+        // `ctx.emit` is called and the slot stays unbound; the BoxRef
+        // is then a phase-1 orphan with no producer `OpRc`. Seal each
+        // orphan now by synthesising a SameAs stand-in OpRc, binding
+        // the slot, and appending the stand-in to `phase1_emit_ops`
+        // so Phase 2 / retrace `ensure_box` can late-bind through it
+        // (mod.rs::ensure_box existing-pool-slot path).
+        for (idx, b) in ctx.box_pool.iter_indexed() {
+            if !b.is_resop() || b.bound_op().is_some() {
+                continue;
+            }
+            use majit_ir::resoperation::Op;
+            let opcode = match b.type_() {
+                majit_ir::Type::Int => OpCode::SameAsI,
+                majit_ir::Type::Float => OpCode::SameAsF,
+                majit_ir::Type::Ref => OpCode::SameAsR,
+                majit_ir::Type::Void => continue,
+            };
+            let stand_in = std::rc::Rc::new(Op::new(opcode, &[]));
+            stand_in
+                .pos
+                .set(majit_ir::OpRef::op_typed(idx as u32, b.type_()));
+            b.bind_op(&stand_in);
+            self.phase1_emit_ops.push(stand_in);
+        }
         // Transfer exported virtual state from context to optimizer
         // RPython BasicLoopInfo: quasi_immutable_deps collected during optimization
         self.quasi_immutable_deps = std::mem::take(&mut ctx.quasi_immutable_deps);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -297,11 +297,9 @@ pub(crate) fn merge_backend_constants_from_ctx(
         if b.is_inputarg() {
             continue;
         }
-        let crate::r#box::Forwarded::Box(target) = &b.get_forwarded() else {
-            continue;
-        };
-        let Some(value) = target.const_value() else {
-            continue;
+        let value = match b.get_forwarded() {
+            crate::r#box::Forwarded::Const(c, _) => c.to_value(),
+            _ => continue,
         };
         if idx < live_positions.len() && live_positions[idx] {
             continue;
@@ -354,10 +352,7 @@ impl Optimizer {
         let Some(b) = box_pool.get(op.pos.get()) else {
             return false;
         };
-        let crate::r#box::Forwarded::Box(target) = &b.get_forwarded() else {
-            return false;
-        };
-        if target.const_value().is_none() {
+        if !matches!(b.get_forwarded(), crate::r#box::Forwarded::Const(_, _)) {
             return false;
         }
         op.num_args() == 0 || op.getarglist().iter().all(|arg| arg.is_none())
@@ -2877,10 +2872,10 @@ impl Optimizer {
                 if old_idx < num_inputs as u32 {
                     continue;
                 }
-                let crate::r#box::Forwarded::Box(target) = &b.get_forwarded() else {
-                    continue;
-                };
-                if target.const_value().is_none() {
+                if !matches!(
+                    b.get_forwarded(),
+                    crate::r#box::Forwarded::Const(_, _)
+                ) {
                     continue;
                 }
                 remap.insert(old_idx, next_const_pos);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2400,21 +2400,20 @@ impl Optimizer {
                 self.phase1_emit_ops.push(op.clone());
             }
         }
-        // PyPy parity: a folded ResOperation keeps its Python identity
-        // through `_forwarded` links; Phase 2 chain walks via
-        // `partial_trace.operations` reach it directly
-        // (resoperation.py:233 `_forwarded` host).
+        // PyPy parity: a folded `ResOperation` keeps its Python identity
+        // through `_forwarded` links (resoperation.py:233-242); the
+        // `optimize_peeled_loop` (compile.py:291) chain walk reaches it
+        // via `partial_trace.operations`.
         //
-        // pyre's per-iter `TraceIterator::next()` pushes a fresh
-        // `BoxRef::new_resop` slot for every visited op
-        // (opencoder.rs:500) BEFORE the optimizer pipeline decides
-        // whether to emit it. When the pipeline drops the op, no
-        // `ctx.emit` is called and the slot stays unbound; the BoxRef
-        // is then a phase-1 orphan with no producer `OpRc`. Seal each
-        // orphan now by synthesising a SameAs stand-in OpRc, binding
-        // the slot, and appending the stand-in to `phase1_emit_ops`
-        // so Phase 2 / retrace `ensure_box` can late-bind through it
-        // (mod.rs::ensure_box existing-pool-slot path).
+        // pyre's per-iter `TraceIterator::next()` (opencoder.rs:500)
+        // pushes a fresh `BoxRef::new_resop` slot for every visited op
+        // BEFORE the optimizer pipeline decides whether to emit. When
+        // the pipeline drops the op no `ctx.emit` is called and the
+        // slot stays unbound; the BoxRef is then an orphan with no
+        // producer `OpRc`. Seal each orphan now by synthesising a
+        // SameAs stand-in OpRc, binding the slot, and appending the
+        // stand-in to the emit-op carry list so the retrace
+        // `ensure_box` existing-pool-slot late-bind reaches it.
         for (idx, b) in ctx.box_pool.iter_indexed() {
             if !b.is_resop() || b.bound_op().is_some() {
                 continue;

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2325,26 +2325,18 @@ impl ExportedState {
                         // index, so the `None` arm is reachable for
                         // body-position keys whose forwarded slot points
                         // at an index-less Const.
-                        let swap: Option<(bool, Option<u32>)> = {
-                            let f = b.get_forwarded();
-                            if let crate::r#box::Forwarded::Box(target) = &f
-                                && target.is_constant()
-                                && matches!(target.const_value(), Some(Value::Ref(_)))
-                            {
-                                Some((true, target.const_index()))
-                            } else {
-                                None
-                            }
+                        let swap: Option<(bool, Option<u32>)> = match b.get_forwarded() {
+                            crate::r#box::Forwarded::Const(
+                                majit_ir::Const::Ref(_),
+                                idx,
+                            ) => Some((true, idx)),
+                            _ => None,
                         };
                         if let Some((_present, orig_idx)) = swap {
-                            let new_target = match orig_idx {
-                                Some(idx) => crate::r#box::BoxRef::new_const_with_index(
-                                    Value::Ref(updated),
-                                    idx,
-                                ),
-                                None => crate::r#box::BoxRef::new_const(Value::Ref(updated)),
-                            };
-                            b.set_forwarded_box(new_target);
+                            b.set_forwarded_const(
+                                majit_ir::Const::Ref(updated),
+                                orig_idx,
+                            );
                         }
                     }
                 }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -734,7 +734,6 @@ impl UnrollOptimizer {
                             short_inputargs: Vec::new(),
                             runtime_boxes: Vec::new(),
                             patchguardop: None,
-                            box_pool: state.box_pool.clone(),
                             phase1_emit_high_water: self.next_global_opref,
                             partial_trace_inputargs: Vec::new(),
                             partial_trace_operations: Vec::new(),
@@ -1937,28 +1936,12 @@ pub struct ExportedState {
     /// Phase 2's extra_guards (from virtualstate) need rd_resume_position
     /// from this patchguardop (unroll.py:333-336).
     pub patchguardop: Option<majit_ir::Op>,
-    /// Phase 1's `OptContext::box_pool` slot table at export time — the
-    /// raw OpRef position → `Rc<Box>` lookup table Phase 2 consults when
-    /// chain-walking a Phase 1 OpRef.  Carries `Rc::clone`d handles, so
-    /// `Forwarded::Box(rc)` walks land on the same cells Phase 1 mutated
-    /// during its run — `unroll.py` Phase 2 reading Phase 1
-    /// `box._forwarded` through Python object identity parity.
-    ///
-    /// Empty when no Phase 1 ran (test fixtures, fresh constructor) or
-    /// when Phase 1 forced-returned without producing a chain.  Always
-    /// populated by `export_state_with_bounds` at the canonical Phase 1
-    /// export site.  PyPy has no analog because Box references pass by
-    /// Python identity end-to-end; pyre's numeric `OpRef` indirection
-    /// makes this table the explicit lookup.
-    pub(crate) box_pool: crate::r#box::BoxPool,
     /// `OptContext::next_pos` at end of Phase 1 — strict upper bound of
     /// every OpRef Phase 1 allocated, including intermediates folded /
-    /// forwarded away before any structure-stored field could observe
-    /// them.  `box_pool.len()` is *almost* the same value, but
-    /// `reserve_pos_typed` skips `ensure_box` when `box_pool` is empty
-    /// (zero-inputarg / retrace baselines, `optimizeopt/mod.rs:2026`),
-    /// so the pool length under-reports the emit allocations in that
-    /// case.  Phase 2 / retrace seed their TraceIterator namespace
+    /// forwarded away. `reserve_pos_typed` skips `ensure_box` on the
+    /// zero-inputarg / retrace baselines (`optimizeopt/mod.rs:2026`),
+    /// so capturing `ctx.next_pos` at export is the only reliable
+    /// floor. Phase 2 / retrace seed their TraceIterator namespace
     /// strictly above this watermark via `opref_high_water()` to keep
     /// the OpRef set disjoint — RPython's object-identity Boxes get
     /// disjointness from Python identity for free; pyre's numeric
@@ -2048,7 +2031,6 @@ impl ExportedState {
         renamed_inputargs: Vec<OpRef>,
         renamed_inputarg_types: Vec<Type>,
         short_inputargs: Vec<OpRef>,
-        box_pool: crate::r#box::BoxPool,
     ) -> Self {
         // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
         // pre-derives the per-OpRef ProducedShortOp view (with label-arg
@@ -2075,7 +2057,6 @@ impl ExportedState {
             short_inputargs,
             runtime_boxes: Vec::new(),
             patchguardop: None,
-            box_pool,
             phase1_emit_high_water: 0,
             partial_trace_inputargs: Vec::new(),
             partial_trace_operations: Vec::new(),
@@ -2172,26 +2153,27 @@ impl ExportedState {
             }
         }
 
-        // `box_pool.len()` covers every Phase 1 BoxRef the failed
-        // attempt materialized — inputargs and emit ops the recorder /
-        // optimizer extended the pool for.  When retrace's Phase 2
-        // `start_fresh` is below that ceiling, the
-        // `TraceIterator::new` `p1_prefix.len().min(start_fresh)`
-        // truncation would drop the tail of the pool and re-issue the
-        // same raw positions for Phase 2 input/result OpRefs — a numeric
-        // collision PyPy's object-identity Boxes structurally cannot
-        // have.
-        high = high.max(self.box_pool.len() as u32);
-
-        // `phase1_emit_high_water` covers Phase 1 emit positions when
-        // `box_pool` was not extended (zero-inputarg / retrace baselines
-        // where `reserve_pos_typed` skips `ensure_box` — see
-        // `optimizeopt/mod.rs:2026`).  Intermediate OpRefs that were
-        // allocated then forwarded/folded never make it into any
-        // structure-stored field above, so the explicit watermark from
-        // Phase 1's `OptContext::next_pos` is the only signal that keeps
-        // Phase 2's namespace disjoint from those positions.
+        // `phase1_emit_high_water` is `OptContext::next_pos` at end of
+        // Phase 1 — covers every emit OpRef the recorder / optimizer
+        // allocated, including intermediates forwarded/folded before
+        // they could reach a structure-stored field. Phase 2 / retrace
+        // must seed `start_fresh` strictly above this watermark to keep
+        // the OpRef set disjoint.
         high = high.max(self.phase1_emit_high_water);
+        // `partial_trace.inputargs` / `partial_trace.operations` cover
+        // every preamble-pass `AbstractValue` whose `_forwarded` must
+        // survive into `compile_retrace`; raise the high-water mark
+        // above any position they reference so the retrace's fresh
+        // OpRef namespace cannot collide with them.
+        for ia in &self.partial_trace_inputargs {
+            high = high.max((ia.index as u32).saturating_add(1));
+        }
+        for op in &self.partial_trace_operations {
+            let pos = op.pos.get();
+            if !pos.is_none() && !pos.is_constant() {
+                high = high.max(pos.raw().saturating_add(1));
+            }
+        }
 
         high
     }
@@ -2513,7 +2495,6 @@ impl Clone for ExportedState {
             short_inputargs: self.short_inputargs.clone(),
             runtime_boxes: self.runtime_boxes.clone(),
             patchguardop: self.patchguardop.clone(),
-            box_pool: self.box_pool.clone(),
             phase1_emit_high_water: self.phase1_emit_high_water,
             partial_trace_inputargs: self.partial_trace_inputargs.clone(),
             partial_trace_operations: self.partial_trace_operations.clone(),
@@ -2935,13 +2916,14 @@ impl OptUnroll {
             renamed_inputargs.to_vec(),
             renamed_inputarg_types,
             short_args,
-            ctx.box_pool.clone(),
         );
         // `OptContext::next_pos` is the strict upper bound on raw OpRefs
-        // Phase 1 allocated.  Captured here so `opref_high_water()` can
-        // floor Phase 2 / retrace's `start_fresh` above every Phase 1
-        // emit position even when `box_pool` was not extended (zero-
-        // inputarg / retrace baselines — `optimizeopt/mod.rs:2026`).
+        // Phase 1 allocated, including intermediates folded / forwarded
+        // away before any structure-stored field could observe them.
+        // `reserve_pos_typed` skips `ensure_box` on the zero-inputarg /
+        // retrace baselines (`optimizeopt/mod.rs:2026`), so capturing
+        // `ctx.next_pos` at export is the only reliable floor for
+        // `opref_high_water()` to feed retrace's `start_fresh`.
         state.phase1_emit_high_water = ctx.next_pos;
         // `partial_trace.inputargs` / `partial_trace.operations`
         // (compile.py:362) identity carriage: snapshot the InputArgRc /
@@ -5272,7 +5254,6 @@ mod tests {
             vec![OpRef::int_op(14)],
             Vec::new(),
             vec![OpRef::int_op(23)],
-            crate::r#box::BoxPool::default(),
         );
 
         assert_eq!(exported.opref_high_water(), 110);
@@ -6146,7 +6127,6 @@ mod tests {
             Vec::new(),
             Vec::new(),
             vec![source],
-            crate::r#box::BoxPool::default(),
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
             8,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2323,17 +2323,13 @@ impl ExportedState {
                         // body-position keys whose forwarded slot points
                         // at an index-less Const.
                         let swap: Option<(bool, Option<u32>)> = match b.get_forwarded() {
-                            crate::r#box::Forwarded::Const(
-                                majit_ir::Const::Ref(_),
-                                idx,
-                            ) => Some((true, idx)),
+                            crate::r#box::Forwarded::Const(majit_ir::Const::Ref(_), idx) => {
+                                Some((true, idx))
+                            }
                             _ => None,
                         };
                         if let Some((_present, orig_idx)) = swap {
-                            b.set_forwarded_const(
-                                majit_ir::Const::Ref(updated),
-                                orig_idx,
-                            );
+                            b.set_forwarded_const(majit_ir::Const::Ref(updated), orig_idx);
                         }
                     }
                 }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -595,6 +595,8 @@ impl UnrollOptimizer {
                             patchguardop: None,
                             box_pool: state.box_pool.clone(),
                             phase1_emit_high_water: self.next_global_opref,
+                            phase1_inputargs_snapshot: Vec::new(),
+                            phase1_emit_ops_snapshot: Vec::new(),
                             rooted_refs: Vec::new(),
                             shadow_stack_base: 0,
                         };
@@ -1821,6 +1823,21 @@ pub struct ExportedState {
     /// disjointness from Python identity for free; pyre's numeric
     /// OpRefs need an explicit position floor.
     pub phase1_emit_high_water: u32,
+    /// Snapshot of Phase 1's `OptContext::inputarg_refs` taken at export
+    /// time. PyPy parity: `partial_trace.inputargs` (history.py:528) keeps
+    /// the inputarg `AbstractValue` instances alive so a follow-up
+    /// `compile_retrace` Phase 2 reads `_forwarded` off the same objects
+    /// (resoperation.py:700 `AbstractInputArg._forwarded`). Each entry is
+    /// `Rc::clone` cheap; the vec is bounded by `ExportedState` lifetime.
+    /// Populated only by `export_state_with_bounds`.
+    pub(crate) phase1_inputargs_snapshot: Vec<majit_ir::InputArgRc>,
+    /// Snapshot of Phase 1's emit ops (the same `Optimizer.phase1_emit_ops`
+    /// `Vec<OpRc>` Phase 2 already receives at spawn; mirrored here so
+    /// `compile_retrace`'s Phase 2 — which spawns a *new* Optimizer and
+    /// only sees the imported `ExportedState` — can reach Phase 1's
+    /// `_forwarded` through the same OpRc identities. Companion to
+    /// `phase1_inputargs_snapshot`.
+    pub(crate) phase1_emit_ops_snapshot: Vec<majit_ir::OpRc>,
     /// Shadow stack rooting for GcRef values in exported_infos.
     /// (OpRef key, field kind, shadow stack index).
     rooted_refs: Vec<(OpRef, ExportedGcRefField, usize)>,
@@ -1913,6 +1930,8 @@ impl ExportedState {
             patchguardop: None,
             box_pool,
             phase1_emit_high_water: 0,
+            phase1_inputargs_snapshot: Vec::new(),
+            phase1_emit_ops_snapshot: Vec::new(),
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -2395,6 +2414,8 @@ impl Clone for ExportedState {
             patchguardop: self.patchguardop.clone(),
             box_pool: self.box_pool.clone(),
             phase1_emit_high_water: self.phase1_emit_high_water,
+            phase1_inputargs_snapshot: self.phase1_inputargs_snapshot.clone(),
+            phase1_emit_ops_snapshot: self.phase1_emit_ops_snapshot.clone(),
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -2821,6 +2842,16 @@ impl OptUnroll {
         // emit position even when `box_pool` was not extended (zero-
         // inputarg / retrace baselines — `optimizeopt/mod.rs:2026`).
         state.phase1_emit_high_water = ctx.next_pos;
+        // PyPy `partial_trace.inputargs` / `partial_trace.operations` identity
+        // carriage (compile.py:362, history.py:528): snapshot the InputArgRc /
+        // OpRc lists Phase 1 mutated `_forwarded` on. Cross-call
+        // `compile_retrace` Phase 2 reads `Op.forwarded` / `InputArg.forwarded`
+        // directly off the same objects (resoperation.py:233-242 `_forwarded`
+        // host), the PyPy-orthodox identity carry that replaces the
+        // BoxPool-snapshot indirection. Populated here only; consumer
+        // migration follows.
+        state.phase1_inputargs_snapshot = ctx.inputarg_refs.clone();
+        state.phase1_emit_ops_snapshot = optimizer.phase1_emit_ops.clone();
         // PRE-EXISTING-ADAPTATION: snapshot producer-side const values for
         // any const-namespace OpRef referenced by `short_boxes` op args.
         // Phase B.2 `ProducedShortOp::produce_op` reads raw OpRefs (not the

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2165,19 +2165,16 @@ impl ExportedState {
                     }
                     _ => {}
                 }
-            } else if let crate::r#box::Forwarded::Box(target) = &forwarded {
-                if target.is_constant() {
-                    if let Some(Value::Ref(gcref)) = target.const_value() {
-                        if !gcref.is_null() {
-                            let ss_idx = majit_gc::shadow_stack::push(gcref);
-                            self.rooted_refs.push((
-                                dummy_key,
-                                ExportedGcRefField::BoxPoolBoxConstRef(i),
-                                ss_idx,
-                            ));
-                        }
-                    }
-                }
+            } else if let crate::r#box::Forwarded::Const(majit_ir::Const::Ref(gcref), _) =
+                &forwarded
+                && !gcref.is_null()
+            {
+                let ss_idx = majit_gc::shadow_stack::push(*gcref);
+                self.rooted_refs.push((
+                    dummy_key,
+                    ExportedGcRefField::BoxPoolBoxConstRef(i),
+                    ss_idx,
+                ));
             }
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2933,24 +2933,39 @@ impl OptUnroll {
         // the PyPy-orthodox identity carry.
         //
         // Walk `ctx.inputargs` (the canonical inputarg-order OpRef list)
-        // and pick up the `InputArgRc` at each inputarg's raw OpRef
-        // position out of `ctx.inputarg_refs`. The raw-position table
-        // can carry placeholder fillers for slots outside the active
-        // inputarg range (bridges open at `inputarg_base > 0`, so
-        // positions `[0, inputarg_base)` are unused); the indexed copy
-        // here yields exactly the partial trace's inputargs in PyPy
-        // `partial_trace.inputargs` order.
+        // and pick up the `InputArgRc` for each inputarg's raw OpRef
+        // position. The bound `InputArgRc` lives on the `box_pool` slot
+        // already, populated by either `with_inputarg_types`,
+        // `ensure_inputarg_bindings`, or retrace prefix import; reading
+        // it directly preserves any `_forwarded` state the Phase 1
+        // passes wrote on the original `InputArg` object
+        // (resoperation.py:700 `_forwarded` host). `inputarg_refs[idx]`
+        // is the strong-owner mirror — read it first, but only when
+        // it actually matches the inputarg's type and index (the
+        // `ensure_inputarg_bindings` resize fills gaps with
+        // `new_int(0)` placeholders that would otherwise leak in here);
+        // fall back to the bound BoxRef in `box_pool` for retrace paths
+        // where the prefix slot was bound before this OptContext was
+        // built, so `inputarg_refs` has no entry. Last-resort fresh
+        // allocation only when neither carries an Rc (test fixtures
+        // with empty box_pool).
         state.partial_trace_inputargs = ctx
             .inputargs
             .iter()
             .map(|ia_opref| {
                 let idx = ia_opref.raw() as usize;
-                ctx.inputarg_refs.get(idx).cloned().unwrap_or_else(|| {
-                    std::rc::Rc::new(majit_ir::InputArg::from_type(
-                        ia_opref.ty().unwrap_or(majit_ir::Type::Void),
-                        idx as u32,
-                    ))
-                })
+                let want_ty = ia_opref.ty().unwrap_or(majit_ir::Type::Void);
+                if let Some(rc) = ctx.inputarg_refs.get(idx).cloned() {
+                    if rc.tp == want_ty && rc.index == idx as u32 {
+                        return rc;
+                    }
+                }
+                if let Some(b) = ctx.box_pool.get(*ia_opref) {
+                    if let Some(ia_rc) = b.bound_inputarg() {
+                        return ia_rc;
+                    }
+                }
+                std::rc::Rc::new(majit_ir::InputArg::from_type(want_ty, idx as u32))
             })
             .collect();
         state.partial_trace_operations = optimizer.phase1_emit_ops.clone();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2931,7 +2931,28 @@ impl OptUnroll {
         // `compile_retrace` reads `Op.forwarded` / `InputArg.forwarded`
         // directly off the same objects (resoperation.py:233-242 / :700),
         // the PyPy-orthodox identity carry.
-        state.partial_trace_inputargs = ctx.inputarg_refs.clone();
+        //
+        // Walk `ctx.inputargs` (the canonical inputarg-order OpRef list)
+        // and pick up the `InputArgRc` at each inputarg's raw OpRef
+        // position out of `ctx.inputarg_refs`. The raw-position table
+        // can carry placeholder fillers for slots outside the active
+        // inputarg range (bridges open at `inputarg_base > 0`, so
+        // positions `[0, inputarg_base)` are unused); the indexed copy
+        // here yields exactly the partial trace's inputargs in PyPy
+        // `partial_trace.inputargs` order.
+        state.partial_trace_inputargs = ctx
+            .inputargs
+            .iter()
+            .map(|ia_opref| {
+                let idx = ia_opref.raw() as usize;
+                ctx.inputarg_refs.get(idx).cloned().unwrap_or_else(|| {
+                    std::rc::Rc::new(majit_ir::InputArg::from_type(
+                        ia_opref.ty().unwrap_or(majit_ir::Type::Void),
+                        idx as u32,
+                    ))
+                })
+            })
+            .collect();
         state.partial_trace_operations = optimizer.phase1_emit_ops.clone();
         // PRE-EXISTING-ADAPTATION: snapshot producer-side const values for
         // any const-namespace OpRef referenced by `short_boxes` op args.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -74,27 +74,65 @@ fn is_trace_runtime_ref(
     !opref.is_none() && !is_trace_constant_ref(opref, constants)
 }
 
-/// Reconstruct Phase 1's `box_pool` prefix for a Phase 2 retrace.
+/// Reconstruct Phase 1's `box_pool` prefix directly from the snapshotted
+/// `InputArgRc` / `OpRc` lists. PyPy parity: `partial_trace.inputargs`
+/// and `partial_trace.operations` (compile.py:362, history.py:528) hold the
+/// AbstractValue instances Phase 1 mutated `_forwarded` on; chain walks via
+/// the bound handles read `inputarg.forwarded` / `op.forwarded` directly
+/// (resoperation.py:233-242 `_forwarded` host, `:700
+/// AbstractInputArg._forwarded`).
 ///
-/// The `BoxPool::clone` here is intentionally shallow: `BoxRef` is
-/// `Rc<Box>`, so cloning shares the same `Box` cells — matching
-/// `unroll.py` Phase 2's behaviour of seeing Phase 1's `_forwarded`
-/// mutations through Python object identity (resoperation.py:233-240).
-/// A "deep" snapshot (cloning each `Box` so Phase 2 cannot reach into
-/// `phase1_out`) would diverge from upstream: PyPy explicitly relies on
-/// shared identity to read Phase 1 forwarding from Phase 2 — see
-/// `unroll.py:55-64` `setinfo_from_preamble`.
+/// Each slot uses `BoxRef::from_bound_{op,inputarg}` so the box handle is
+/// installed *without* the carry-over that `bind_*` performs — Phase 1's
+/// state already lives on the bound `Op` / `InputArg`, and we want
+/// `Box.get_forwarded()` to read through to it, not overwrite it from the
+/// fresh box's empty mirror.
 ///
-/// Returns `None` for an empty pool so callers feed the iterator the
-/// same `None`/`Some` distinction the `p1_full_prefix` argument
-/// expects.  GcRef rooting via `ExportedState::root_all_gcrefs` is the
-/// canonical safety net, not snapshot copying.
-fn p1_full_prefix_from_box_pool(pool: &crate::r#box::BoxPool) -> Option<crate::r#box::BoxPool> {
-    if pool.is_empty() {
-        None
-    } else {
-        Some(pool.clone())
+/// Phase 1 export seals orphan unbound ResOp pool slots with synthesized
+/// SameAs OpRc stand-ins (`optimizer.rs::optimize_with_constants_and_inputs_at`),
+/// so every Phase 1 BoxRef position is reachable through one of the two
+/// snapshot lists here.
+fn build_p1_full_prefix(
+    inputargs: &[majit_ir::InputArgRc],
+    emit_ops: &[majit_ir::OpRc],
+) -> Option<crate::r#box::BoxPool> {
+    if inputargs.is_empty() && emit_ops.is_empty() {
+        return None;
     }
+    let max_inputarg_pos = inputargs
+        .iter()
+        .map(|ia| ia.index as usize + 1)
+        .max()
+        .unwrap_or(0);
+    let max_op_pos = emit_ops
+        .iter()
+        .filter_map(|op| {
+            let pos = op.pos.get();
+            if pos.is_none() || pos.is_constant() {
+                None
+            } else {
+                Some(pos.raw() as usize + 1)
+            }
+        })
+        .max()
+        .unwrap_or(0);
+    let size = max_inputarg_pos.max(max_op_pos);
+    let mut slots: Vec<Option<crate::r#box::BoxRef>> = vec![None; size];
+    for ia in inputargs {
+        let idx = ia.index as usize;
+        slots[idx] = Some(crate::r#box::BoxRef::from_bound_inputarg(ia));
+    }
+    for op in emit_ops {
+        let pos = op.pos.get();
+        if pos.is_none() || pos.is_constant() {
+            continue;
+        }
+        let raw = pos.raw() as usize;
+        if raw < slots.len() {
+            slots[raw] = Some(crate::r#box::BoxRef::from_bound_op(op));
+        }
+    }
+    Some(crate::r#box::BoxPool::from_slots(slots))
 }
 
 /// unroll.py: UnrollOptimizer — high-level loop optimization controller.
@@ -382,18 +420,24 @@ impl UnrollOptimizer {
                     self.phase1_patchguardop = pre_imported.patchguardop.clone();
                 }
                 // compile_retrace has no `opt_p1.final_ctx` (Phase 1 was
-                // skipped), but the failed attempt's Phase 1 captured its full
-                // `box_pool` into `ExportedState.box_pool` at export time
+                // skipped), but the failed attempt's Phase 1 captured its
+                // inputarg + emit-op identity into
+                // `ExportedState.phase1_inputargs_snapshot` /
+                // `phase1_emit_ops_snapshot` at export time
                 // (`export_state_with_bounds`). TraceIterator's
                 // `p1_full_prefix` contract: deliver the full Phase 1 box_pool
                 // including inputarg BoxRefs at `[0..num_inputs)`, so
                 // `import_state` setting `Forwarded::Box(target)` for
                 // `target.raw() < num_inputs` lands the chain on the same
                 // Phase 1 inputarg cell — PyPy Phase 2 reads Phase 1
-                // `_forwarded` through shared Box identity; preserving the full
-                // raw position alignment (inputargs + emit ops) reproduces
-                // that identity here.
-                let prefix = p1_full_prefix_from_box_pool(&pre_imported.box_pool);
+                // `_forwarded` through shared `AbstractValue` identity
+                // (resoperation.py:233-242), and `build_p1_full_prefix`
+                // reproduces that by installing `BoxRef::from_bound_*` handles
+                // pointing at the snapshotted `InputArgRc` / `OpRc` objects.
+                let prefix = build_p1_full_prefix(
+                    &pre_imported.phase1_inputargs_snapshot,
+                    &pre_imported.phase1_emit_ops_snapshot,
+                );
                 (pre_imported, constants.clone(), Vec::new(), prefix)
             } else {
                 // ── Phase 1: PreambleCompileData.optimize() ──
@@ -5133,32 +5177,33 @@ mod tests {
     }
 
     #[test]
-    fn test_retrace_box_pool_preserves_inputargs_for_p1_full_prefix() {
-        let input0 = crate::r#box::BoxRef::new_inputarg(Type::Ref, 0);
-        let input1 = crate::r#box::BoxRef::new_inputarg(Type::Int, 1);
-        let emit2 = crate::r#box::BoxRef::new_resop(Type::Ref, 2);
-        let emit3 = crate::r#box::BoxRef::new_resop(Type::Int, 3);
-        let snapshot = crate::r#box::BoxPool::from_slots(vec![
-            Some(input0.clone()),
-            Some(input1.clone()),
-            Some(emit2.clone()),
-            Some(emit3.clone()),
-        ]);
+    fn test_build_p1_full_prefix_carries_forwarded_state_via_bound_handles() {
+        // Phase 1 InputArg / Op carry `_forwarded` mutations on the
+        // AbstractValue object itself (resoperation.py:233-242 / :700);
+        // a retrace's Phase 2 must read that state through the same
+        // identity. The builder installs `BoxRef::from_bound_*` so
+        // `Box.get_forwarded()` routes through the bound handle.
+        let ia0 = std::rc::Rc::new(majit_ir::InputArg::from_type(Type::Int, 0));
+        let ia1 = std::rc::Rc::new(majit_ir::InputArg::from_type(Type::Ref, 1));
+        *ia1.forwarded.borrow_mut() =
+            majit_ir::box_ref::Forwarded::Const(majit_ir::Const::Int(42), None);
+        let op2 = std::rc::Rc::new(majit_ir::Op::new(
+            OpCode::IntAdd,
+            &[OpRef::int_op(0), OpRef::int_op(1)],
+        ));
+        op2.pos.set(OpRef::int_op(2));
 
-        let prefix = p1_full_prefix_from_box_pool(&snapshot).expect("non-empty pool");
+        let prefix = build_p1_full_prefix(&[ia0.clone(), ia1.clone()], &[op2.clone()])
+            .expect("non-empty inputs build a prefix");
+        assert_eq!(prefix.len(), 3);
 
-        let prefix_slots: Vec<Option<crate::r#box::BoxRef>> = (0..prefix.len())
-            .map(|i| prefix.get_at_position(i).cloned())
-            .collect();
-        assert_eq!(
-            prefix_slots,
-            vec![Some(input0), Some(input1), Some(emit2), Some(emit3)]
-        );
-
-        assert!(
-            p1_full_prefix_from_box_pool(&crate::r#box::BoxPool::default()).is_none(),
-            "empty pool maps to None for TraceIterator p1_full_prefix"
-        );
+        let slot1 = prefix.get_at_position(1).expect("ia1 slot present");
+        match slot1.get_forwarded() {
+            majit_ir::box_ref::Forwarded::Const(majit_ir::Const::Int(42), _) => {}
+            other => panic!("expected Const(42), got {other:?}"),
+        }
+        let slot2 = prefix.get_at_position(2).expect("op2 slot present");
+        assert!(slot2.bound_op().is_some(), "op2 slot binds the OpRc");
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -74,25 +74,128 @@ fn is_trace_runtime_ref(
     !opref.is_none() && !is_trace_constant_ref(opref, constants)
 }
 
-/// Reconstruct Phase 1's `box_pool` prefix directly from the snapshotted
-/// `InputArgRc` / `OpRc` lists. PyPy parity: `partial_trace.inputargs`
-/// and `partial_trace.operations` (compile.py:362, history.py:528) hold the
-/// AbstractValue instances Phase 1 mutated `_forwarded` on; chain walks via
-/// the bound handles read `inputarg.forwarded` / `op.forwarded` directly
+/// Root any GcRef payload reachable from a single `_forwarded` slot (the
+/// `AbstractInputArg.forwarded` / `AbstractResOp.forwarded` host,
+/// resoperation.py:233-242 / :700). PyPy's Python GC walks `_forwarded`
+/// transitively; pyre pins each GcRef on the shadow stack instead.
+/// Used by `ExportedState::root_all_gcrefs` to keep
+/// `PtrInfo::Constant` / `PtrInfo::Instance.known_class` / `Const::Ref`
+/// payloads live across GC pauses.
+fn root_forwarded_gcref(
+    forwarded: &crate::r#box::Forwarded,
+    info_constant_field: ExportedGcRefField,
+    info_known_class_field: ExportedGcRefField,
+    const_ref_field: ExportedGcRefField,
+    dummy_key: OpRef,
+    rooted_refs: &mut Vec<(OpRef, ExportedGcRefField, usize)>,
+) {
+    use crate::optimizeopt::info::{OpInfo, PtrInfo};
+    if let crate::r#box::Forwarded::Info(OpInfo::Ptr(rc)) = forwarded {
+        let info = rc.borrow();
+        match &*info {
+            PtrInfo::Constant(gcref) if !gcref.is_null() => {
+                let ss_idx = majit_gc::shadow_stack::push(*gcref);
+                rooted_refs.push((dummy_key, info_constant_field, ss_idx));
+            }
+            PtrInfo::Instance(iinfo) => {
+                if let Some(gcref) = iinfo.known_class {
+                    if !gcref.is_null() {
+                        let ss_idx = majit_gc::shadow_stack::push(gcref);
+                        rooted_refs.push((dummy_key, info_known_class_field, ss_idx));
+                    }
+                }
+            }
+            _ => {}
+        }
+    } else if let crate::r#box::Forwarded::Const(majit_ir::Const::Ref(gcref), _) = forwarded
+        && !gcref.is_null()
+    {
+        let ss_idx = majit_gc::shadow_stack::push(*gcref);
+        rooted_refs.push((dummy_key, const_ref_field, ss_idx));
+    }
+}
+
+/// Mutate the `PtrInfo::Constant` payload of a `Forwarded::Info` cell in
+/// place so any other handle sharing the `Rc<RefCell<PtrInfo>>` sees the
+/// post-GC GcRef. Matches PyPy `_forwarded` Python object reference
+/// semantics — the cell stays, only its content updates.
+fn refresh_forwarded_ptrinfo_constant(
+    forwarded: &std::cell::RefCell<crate::r#box::Forwarded>,
+    updated: majit_ir::GcRef,
+) {
+    use crate::optimizeopt::info::{OpInfo, PtrInfo};
+    let rc = match &*forwarded.borrow() {
+        crate::r#box::Forwarded::Info(OpInfo::Ptr(rc))
+            if matches!(&*rc.borrow(), PtrInfo::Constant(_)) =>
+        {
+            Some(rc.clone())
+        }
+        _ => None,
+    };
+    if let Some(rc) = rc {
+        *rc.borrow_mut() = PtrInfo::Constant(updated);
+    }
+}
+
+fn refresh_forwarded_ptrinfo_known_class(
+    forwarded: &std::cell::RefCell<crate::r#box::Forwarded>,
+    updated: majit_ir::GcRef,
+) {
+    use crate::optimizeopt::info::{OpInfo, PtrInfo};
+    let rc = match &*forwarded.borrow() {
+        crate::r#box::Forwarded::Info(OpInfo::Ptr(rc))
+            if matches!(&*rc.borrow(), PtrInfo::Instance(_)) =>
+        {
+            Some(rc.clone())
+        }
+        _ => None,
+    };
+    if let Some(rc) = rc {
+        if let PtrInfo::Instance(iinfo) = &mut *rc.borrow_mut() {
+            iinfo.known_class = Some(updated);
+        }
+    }
+}
+
+/// Overwrite a `Forwarded::Const(Const::Ref(_), idx)` payload in place with
+/// the post-GC GcRef, preserving the `const_index` sidecar so chain walkers
+/// keep reconstructing the original `OpRef::const_ptr(idx)` (per
+/// `seed_constant` body-namespace arm `optimizer.py:432`).
+fn refresh_forwarded_const_ref(
+    forwarded: &std::cell::RefCell<crate::r#box::Forwarded>,
+    updated: majit_ir::GcRef,
+) {
+    let orig_idx = match &*forwarded.borrow() {
+        crate::r#box::Forwarded::Const(majit_ir::Const::Ref(_), idx) => Some(*idx),
+        _ => None,
+    };
+    if let Some(idx) = orig_idx {
+        *forwarded.borrow_mut() =
+            crate::r#box::Forwarded::Const(majit_ir::Const::Ref(updated), idx);
+    }
+}
+
+/// Reconstruct the preamble's `box_pool` prefix directly from the
+/// `partial_trace.inputargs` / `partial_trace.operations` snapshots
+/// (compile.py:362, where `optimize_peeled_loop` receives the partial
+/// trace from a prior `optimize_preamble`). PyPy parity: those lists
+/// hold the AbstractValue instances `optimize_preamble` mutated
+/// `_forwarded` on; chain walks via the bound handles read
+/// `inputarg.forwarded` / `op.forwarded` directly
 /// (resoperation.py:233-242 `_forwarded` host, `:700
 /// AbstractInputArg._forwarded`).
 ///
 /// Each slot uses `BoxRef::from_bound_{op,inputarg}` so the box handle is
-/// installed *without* the carry-over that `bind_*` performs — Phase 1's
-/// state already lives on the bound `Op` / `InputArg`, and we want
-/// `Box.get_forwarded()` to read through to it, not overwrite it from the
-/// fresh box's empty mirror.
+/// installed *without* the carry-over that `bind_*` performs — the
+/// preamble's state already lives on the bound `Op` / `InputArg`, and
+/// `Box.get_forwarded()` reads through to it instead of overwriting it
+/// from the fresh box's empty mirror.
 ///
-/// Phase 1 export seals orphan unbound ResOp pool slots with synthesized
-/// SameAs OpRc stand-ins (`optimizer.rs::optimize_with_constants_and_inputs_at`),
-/// so every Phase 1 BoxRef position is reachable through one of the two
-/// snapshot lists here.
-fn build_p1_full_prefix(
+/// `optimize_with_constants_and_inputs_at` seals orphan unbound ResOp
+/// pool slots with synthesized `SameAs` stand-ins at preamble export,
+/// so every preamble BoxRef position is reachable through one of the
+/// two snapshot lists here.
+fn build_partial_trace_box_prefix(
     inputargs: &[majit_ir::InputArgRc],
     emit_ops: &[majit_ir::OpRc],
 ) -> Option<crate::r#box::BoxPool> {
@@ -419,24 +522,18 @@ impl UnrollOptimizer {
                 if self.phase1_patchguardop.is_none() {
                     self.phase1_patchguardop = pre_imported.patchguardop.clone();
                 }
-                // compile_retrace has no `opt_p1.final_ctx` (Phase 1 was
-                // skipped), but the failed attempt's Phase 1 captured its
-                // inputarg + emit-op identity into
-                // `ExportedState.phase1_inputargs_snapshot` /
-                // `phase1_emit_ops_snapshot` at export time
-                // (`export_state_with_bounds`). TraceIterator's
-                // `p1_full_prefix` contract: deliver the full Phase 1 box_pool
-                // including inputarg BoxRefs at `[0..num_inputs)`, so
-                // `import_state` setting `Forwarded::Box(target)` for
-                // `target.raw() < num_inputs` lands the chain on the same
-                // Phase 1 inputarg cell — PyPy Phase 2 reads Phase 1
-                // `_forwarded` through shared `AbstractValue` identity
-                // (resoperation.py:233-242), and `build_p1_full_prefix`
-                // reproduces that by installing `BoxRef::from_bound_*` handles
-                // pointing at the snapshotted `InputArgRc` / `OpRc` objects.
-                let prefix = build_p1_full_prefix(
-                    &pre_imported.phase1_inputargs_snapshot,
-                    &pre_imported.phase1_emit_ops_snapshot,
+                // `optimize_peeled_loop` from `compile_retrace` (compile.py:362)
+                // skips the preamble pass, so reconstruct the box prefix
+                // from `partial_trace.inputargs` / `partial_trace.operations`
+                // — those AbstractValue instances carry the preamble's
+                // `_forwarded` mutations (resoperation.py:233-242 / :700).
+                // `import_state` (unroll.py:483) writes a chain step from
+                // each peeled-loop inputarg onto the matching partial-trace
+                // box; routing through `BoxRef::from_bound_*` lands the
+                // chain on the same handle.
+                let prefix = build_partial_trace_box_prefix(
+                    &pre_imported.partial_trace_inputargs,
+                    &pre_imported.partial_trace_operations,
                 );
                 (pre_imported, constants.clone(), Vec::new(), prefix)
             } else {
@@ -639,8 +736,8 @@ impl UnrollOptimizer {
                             patchguardop: None,
                             box_pool: state.box_pool.clone(),
                             phase1_emit_high_water: self.next_global_opref,
-                            phase1_inputargs_snapshot: Vec::new(),
-                            phase1_emit_ops_snapshot: Vec::new(),
+                            partial_trace_inputargs: Vec::new(),
+                            partial_trace_operations: Vec::new(),
                             rooted_refs: Vec::new(),
                             shadow_stack_base: 0,
                         };
@@ -1867,21 +1964,21 @@ pub struct ExportedState {
     /// disjointness from Python identity for free; pyre's numeric
     /// OpRefs need an explicit position floor.
     pub phase1_emit_high_water: u32,
-    /// Snapshot of Phase 1's `OptContext::inputarg_refs` taken at export
-    /// time. PyPy parity: `partial_trace.inputargs` (history.py:528) keeps
-    /// the inputarg `AbstractValue` instances alive so a follow-up
-    /// `compile_retrace` Phase 2 reads `_forwarded` off the same objects
-    /// (resoperation.py:700 `AbstractInputArg._forwarded`). Each entry is
-    /// `Rc::clone` cheap; the vec is bounded by `ExportedState` lifetime.
-    /// Populated only by `export_state_with_bounds`.
-    pub(crate) phase1_inputargs_snapshot: Vec<majit_ir::InputArgRc>,
-    /// Snapshot of Phase 1's emit ops (the same `Optimizer.phase1_emit_ops`
-    /// `Vec<OpRc>` Phase 2 already receives at spawn; mirrored here so
-    /// `compile_retrace`'s Phase 2 — which spawns a *new* Optimizer and
-    /// only sees the imported `ExportedState` — can reach Phase 1's
-    /// `_forwarded` through the same OpRc identities. Companion to
-    /// `phase1_inputargs_snapshot`.
-    pub(crate) phase1_emit_ops_snapshot: Vec<majit_ir::OpRc>,
+    /// `partial_trace.inputargs` (compile.py:362, history.py:509).
+    /// Keeps the preamble's `AbstractInputArg` instances alive so that
+    /// `compile_retrace`'s `optimize_peeled_loop` reads `_forwarded` off
+    /// the same objects (resoperation.py:700
+    /// `AbstractInputArg._forwarded`). Each entry is `Rc::clone` cheap;
+    /// the vec is bounded by `ExportedState` lifetime. Populated only by
+    /// `export_state_with_bounds`.
+    pub(crate) partial_trace_inputargs: Vec<majit_ir::InputArgRc>,
+    /// `partial_trace.operations` (compile.py:362, history.py:528).
+    /// Keeps the preamble's emit `AbstractResOp` instances alive — a
+    /// follow-up `compile_retrace` spawns a fresh optimizer that only
+    /// sees the imported `ExportedState`, so the OpRc identities the
+    /// preamble mutated `_forwarded` on must travel through here
+    /// (resoperation.py:233-242 `_forwarded` host).
+    pub(crate) partial_trace_operations: Vec<majit_ir::OpRc>,
     /// Shadow stack rooting for GcRef values in exported_infos.
     /// (OpRef key, field kind, shadow stack index).
     rooted_refs: Vec<(OpRef, ExportedGcRefField, usize)>,
@@ -1914,14 +2011,20 @@ enum ExportedGcRefField {
     VirtualStateConstantRef(usize),
     /// short_box_const_values[OpRef] = Value::Ref(...)
     ShortBoxConstValue(OpRef),
-    /// box_pool[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Constant(_)))
-    BoxPoolInfoPtrInfoConstant(usize),
-    /// box_pool[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Instance{known_class: Some(_)}))
-    BoxPoolInfoPtrInfoKnownClass(usize),
-    /// box_pool[index].forwarded = Box(target) where target is
-    /// `BoxKind::Const(Value::Ref(_))` — `make_constant` /
-    /// `make_equal_to(... const ...)` writer mirror shape.
-    BoxPoolBoxConstRef(usize),
+    /// `partial_trace_inputargs[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Constant(_)))`.
+    /// PyPy `InputArg._forwarded` host (resoperation.py:700).
+    PartialTraceInputArgInfoPtrInfoConstant(usize),
+    /// `partial_trace_inputargs[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Instance{known_class: Some(_)}))`.
+    PartialTraceInputArgInfoPtrInfoKnownClass(usize),
+    /// `partial_trace_inputargs[index].forwarded = Const(Const::Ref(_), _)`.
+    PartialTraceInputArgConstRef(usize),
+    /// `partial_trace_operations[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Constant(_)))`.
+    /// PyPy `AbstractResOp._forwarded` host (resoperation.py:233-242).
+    PartialTraceOpInfoPtrInfoConstant(usize),
+    /// `partial_trace_operations[index].forwarded = Info(OpInfo::Ptr(PtrInfo::Instance{known_class: Some(_)}))`.
+    PartialTraceOpInfoPtrInfoKnownClass(usize),
+    /// `partial_trace_operations[index].forwarded = Const(Const::Ref(_), _)`.
+    PartialTraceOpConstRef(usize),
 }
 
 impl ExportedState {
@@ -1974,8 +2077,8 @@ impl ExportedState {
             patchguardop: None,
             box_pool,
             phase1_emit_high_water: 0,
-            phase1_inputargs_snapshot: Vec::new(),
-            phase1_emit_ops_snapshot: Vec::new(),
+            partial_trace_inputargs: Vec::new(),
+            partial_trace_operations: Vec::new(),
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -2197,48 +2300,34 @@ impl ExportedState {
                     .push((key, ExportedGcRefField::ShortBoxConstValue(key), ss_idx));
             }
         }
-        // ── box_pool Forwarded::Info GcRef fields ──
-        // Phase 2 chain walks land on these BoxRef cells and read their
-        // _forwarded info; if GC moves a Ref between Phase 1 export and
-        // retrace those reads see a stale handle.
-        for (i, b) in self.box_pool.iter_indexed() {
-            let forwarded = b.get_forwarded();
-            if let crate::r#box::Forwarded::Info(OpInfo::Ptr(rc)) = &forwarded {
-                let info = rc.borrow();
-                match &*info {
-                    PtrInfo::Constant(gcref) if !gcref.is_null() => {
-                        let ss_idx = majit_gc::shadow_stack::push(*gcref);
-                        self.rooted_refs.push((
-                            dummy_key,
-                            ExportedGcRefField::BoxPoolInfoPtrInfoConstant(i),
-                            ss_idx,
-                        ));
-                    }
-                    PtrInfo::Instance(iinfo) => {
-                        if let Some(gcref) = iinfo.known_class {
-                            if !gcref.is_null() {
-                                let ss_idx = majit_gc::shadow_stack::push(gcref);
-                                self.rooted_refs.push((
-                                    dummy_key,
-                                    ExportedGcRefField::BoxPoolInfoPtrInfoKnownClass(i),
-                                    ss_idx,
-                                ));
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            } else if let crate::r#box::Forwarded::Const(majit_ir::Const::Ref(gcref), _) =
-                &forwarded
-                && !gcref.is_null()
-            {
-                let ss_idx = majit_gc::shadow_stack::push(*gcref);
-                self.rooted_refs.push((
-                    dummy_key,
-                    ExportedGcRefField::BoxPoolBoxConstRef(i),
-                    ss_idx,
-                ));
-            }
+        // ── partial_trace `_forwarded` GcRef fields ──
+        // `partial_trace.inputargs` / `partial_trace.operations`
+        // (compile.py:362) keep every preamble-pass `AbstractValue`
+        // instance alive; their `_forwarded` slots may carry GcRef
+        // payloads (`PtrInfo::Constant`, `PtrInfo::Instance.known_class`,
+        // or `Const::Ref`). Root each so `compile_retrace` chain walks
+        // observe live handles.
+        for (i, ia) in self.partial_trace_inputargs.iter().enumerate() {
+            let forwarded = ia.forwarded.borrow().clone();
+            root_forwarded_gcref(
+                &forwarded,
+                ExportedGcRefField::PartialTraceInputArgInfoPtrInfoConstant(i),
+                ExportedGcRefField::PartialTraceInputArgInfoPtrInfoKnownClass(i),
+                ExportedGcRefField::PartialTraceInputArgConstRef(i),
+                dummy_key,
+                &mut self.rooted_refs,
+            );
+        }
+        for (i, op) in self.partial_trace_operations.iter().enumerate() {
+            let forwarded = op.forwarded.borrow().clone();
+            root_forwarded_gcref(
+                &forwarded,
+                ExportedGcRefField::PartialTraceOpInfoPtrInfoConstant(i),
+                ExportedGcRefField::PartialTraceOpInfoPtrInfoKnownClass(i),
+                ExportedGcRefField::PartialTraceOpConstRef(i),
+                dummy_key,
+                &mut self.rooted_refs,
+            );
         }
     }
 
@@ -2334,66 +2423,34 @@ impl ExportedState {
                         *value = Value::Ref(updated);
                     }
                 }
-                ExportedGcRefField::BoxPoolInfoPtrInfoConstant(i) => {
-                    if let Some(b) = self.box_pool.get_at_position(*i) {
-                        // RPython object identity: mutate the live Rc<RefCell<PtrInfo>>
-                        // in place so any other handle sharing it sees the post-GC
-                        // address. Matches PyPy's `_forwarded` Python object reference
-                        // semantics — the cell stays, only its content updates.
-                        let rc = match &b.get_forwarded() {
-                            crate::r#box::Forwarded::Info(OpInfo::Ptr(rc))
-                                if matches!(&*rc.borrow(), PtrInfo::Constant(_)) =>
-                            {
-                                Some(rc.clone())
-                            }
-                            _ => None,
-                        };
-                        if let Some(rc) = rc {
-                            *rc.borrow_mut() = PtrInfo::Constant(updated);
-                        }
+                ExportedGcRefField::PartialTraceInputArgInfoPtrInfoConstant(i) => {
+                    if let Some(ia) = self.partial_trace_inputargs.get(*i) {
+                        refresh_forwarded_ptrinfo_constant(&ia.forwarded, updated);
                     }
                 }
-                ExportedGcRefField::BoxPoolInfoPtrInfoKnownClass(i) => {
-                    if let Some(b) = self.box_pool.get_at_position(*i) {
-                        let rc = match &b.get_forwarded() {
-                            crate::r#box::Forwarded::Info(OpInfo::Ptr(rc))
-                                if matches!(&*rc.borrow(), PtrInfo::Instance(_)) =>
-                            {
-                                Some(rc.clone())
-                            }
-                            _ => None,
-                        };
-                        if let Some(rc) = rc {
-                            if let PtrInfo::Instance(iinfo) = &mut *rc.borrow_mut() {
-                                iinfo.known_class = Some(updated);
-                            }
-                        }
+                ExportedGcRefField::PartialTraceInputArgInfoPtrInfoKnownClass(i) => {
+                    if let Some(ia) = self.partial_trace_inputargs.get(*i) {
+                        refresh_forwarded_ptrinfo_known_class(&ia.forwarded, updated);
                     }
                 }
-                ExportedGcRefField::BoxPoolBoxConstRef(i) => {
-                    if let Some(b) = self.box_pool.get_at_position(*i) {
-                        // BoxKind::Const is immutable, so swap in a fresh
-                        // ConstRef BoxRef carrying the updated handle.
-                        // `set_forwarded_box` enforces the AbstractValue
-                        // invariant (Const has no _forwarded slot of its
-                        // own) for the source, which is a non-Const ResOp
-                        // / InputArg here. Preserve the original Const's
-                        // `const_index` (if any) so the chain walker keeps
-                        // reconstructing `OpRef::const_ptr(idx)` after GC;
-                        // `seed_constant` (optimizer.py:432 body-namespace
-                        // arm) plants `BoxRef::new_const(value)` without an
-                        // index, so the `None` arm is reachable for
-                        // body-position keys whose forwarded slot points
-                        // at an index-less Const.
-                        let swap: Option<(bool, Option<u32>)> = match b.get_forwarded() {
-                            crate::r#box::Forwarded::Const(majit_ir::Const::Ref(_), idx) => {
-                                Some((true, idx))
-                            }
-                            _ => None,
-                        };
-                        if let Some((_present, orig_idx)) = swap {
-                            b.set_forwarded_const(majit_ir::Const::Ref(updated), orig_idx);
-                        }
+                ExportedGcRefField::PartialTraceInputArgConstRef(i) => {
+                    if let Some(ia) = self.partial_trace_inputargs.get(*i) {
+                        refresh_forwarded_const_ref(&ia.forwarded, updated);
+                    }
+                }
+                ExportedGcRefField::PartialTraceOpInfoPtrInfoConstant(i) => {
+                    if let Some(op) = self.partial_trace_operations.get(*i) {
+                        refresh_forwarded_ptrinfo_constant(&op.forwarded, updated);
+                    }
+                }
+                ExportedGcRefField::PartialTraceOpInfoPtrInfoKnownClass(i) => {
+                    if let Some(op) = self.partial_trace_operations.get(*i) {
+                        refresh_forwarded_ptrinfo_known_class(&op.forwarded, updated);
+                    }
+                }
+                ExportedGcRefField::PartialTraceOpConstRef(i) => {
+                    if let Some(op) = self.partial_trace_operations.get(*i) {
+                        refresh_forwarded_const_ref(&op.forwarded, updated);
                     }
                 }
             }
@@ -2458,8 +2515,8 @@ impl Clone for ExportedState {
             patchguardop: self.patchguardop.clone(),
             box_pool: self.box_pool.clone(),
             phase1_emit_high_water: self.phase1_emit_high_water,
-            phase1_inputargs_snapshot: self.phase1_inputargs_snapshot.clone(),
-            phase1_emit_ops_snapshot: self.phase1_emit_ops_snapshot.clone(),
+            partial_trace_inputargs: self.partial_trace_inputargs.clone(),
+            partial_trace_operations: self.partial_trace_operations.clone(),
             rooted_refs: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
         }
@@ -2886,16 +2943,14 @@ impl OptUnroll {
         // emit position even when `box_pool` was not extended (zero-
         // inputarg / retrace baselines — `optimizeopt/mod.rs:2026`).
         state.phase1_emit_high_water = ctx.next_pos;
-        // PyPy `partial_trace.inputargs` / `partial_trace.operations` identity
-        // carriage (compile.py:362, history.py:528): snapshot the InputArgRc /
-        // OpRc lists Phase 1 mutated `_forwarded` on. Cross-call
-        // `compile_retrace` Phase 2 reads `Op.forwarded` / `InputArg.forwarded`
-        // directly off the same objects (resoperation.py:233-242 `_forwarded`
-        // host), the PyPy-orthodox identity carry that replaces the
-        // BoxPool-snapshot indirection. Populated here only; consumer
-        // migration follows.
-        state.phase1_inputargs_snapshot = ctx.inputarg_refs.clone();
-        state.phase1_emit_ops_snapshot = optimizer.phase1_emit_ops.clone();
+        // `partial_trace.inputargs` / `partial_trace.operations`
+        // (compile.py:362) identity carriage: snapshot the InputArgRc /
+        // OpRc lists the preamble pass mutated `_forwarded` on. A later
+        // `compile_retrace` reads `Op.forwarded` / `InputArg.forwarded`
+        // directly off the same objects (resoperation.py:233-242 / :700),
+        // the PyPy-orthodox identity carry.
+        state.partial_trace_inputargs = ctx.inputarg_refs.clone();
+        state.partial_trace_operations = optimizer.phase1_emit_ops.clone();
         // PRE-EXISTING-ADAPTATION: snapshot producer-side const values for
         // any const-namespace OpRef referenced by `short_boxes` op args.
         // Phase B.2 `ProducedShortOp::produce_op` reads raw OpRefs (not the
@@ -5177,7 +5232,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_p1_full_prefix_carries_forwarded_state_via_bound_handles() {
+    fn test_build_partial_trace_box_prefix_carries_forwarded_state_via_bound_handles() {
         // Phase 1 InputArg / Op carry `_forwarded` mutations on the
         // AbstractValue object itself (resoperation.py:233-242 / :700);
         // a retrace's Phase 2 must read that state through the same
@@ -5193,7 +5248,7 @@ mod tests {
         ));
         op2.pos.set(OpRef::int_op(2));
 
-        let prefix = build_p1_full_prefix(&[ia0.clone(), ia1.clone()], &[op2.clone()])
+        let prefix = build_partial_trace_box_prefix(&[ia0.clone(), ia1.clone()], &[op2.clone()])
             .expect("non-empty inputs build a prefix");
         assert_eq!(prefix.len(), 3);
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3580,19 +3580,28 @@ fn collect_outer_active_boxes(
     }
     for &idx in &banks.ref_ {
         let reg_idx = idx as usize;
-        // Vable-first read for portal frames (see comment at function top).
-        let mut v = sym
-            .registers_r
-            .get(reg_idx)
-            .copied()
-            .unwrap_or_else(|| panic!("{}", dump_ctx("ref", idx)));
-        if v == OpRef::NONE && portal_vable_owner {
-            if let Some(vable_box) = trace_ctx.virtualizable_box_at(nvs + reg_idx) {
-                if vable_box != OpRef::NONE {
-                    v = vable_box;
-                }
+        // Vable-first read for portal frames.  The trait dispatch path
+        // intentionally stops mutating `registers_r` once the portal owns
+        // the vable shadow, so a non-`NONE` slot there can be stale.
+        // Reading `virtualizable_box_at(nvs + reg_idx)` first keeps the
+        // outer snapshot in lockstep with the live shadow; fall back to
+        // `registers_r` only when the vable lookup misses (non-portal
+        // sub-frames, or out-of-range indices the vable info doesn't
+        // cover).
+        let registers_r_slot = || {
+            sym.registers_r
+                .get(reg_idx)
+                .copied()
+                .unwrap_or_else(|| panic!("{}", dump_ctx("ref", idx)))
+        };
+        let v = if portal_vable_owner {
+            match trace_ctx.virtualizable_box_at(nvs + reg_idx) {
+                Some(vable_box) if vable_box != OpRef::NONE => vable_box,
+                _ => registers_r_slot(),
             }
-        }
+        } else {
+            registers_r_slot()
+        };
         if v == OpRef::NONE {
             panic!("{}", dump_ctx("ref", idx));
         }


### PR DESCRIPTION
partially fix #47 

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->

 1. Cases Where Our Patch Regressed PyPy Parity Compared To Main

  None found.

  The main change replaces origin/main’s shallow BoxPool identity carry with stronger OpRc / InputArgRc identity preservation. That matches PyPy’s _forwarded object-
  identity model more closely for phase 2 and retrace paths.

  2. Other Mismatches Introduced By Our Patch

  None found.

  Key checked areas:

  - majit/majit-ir/src/box_ref.rs: Forwarded::Op, Forwarded::InputArg, and Forwarded::Const are reasonable Rust representations of PyPy _forwarded = AbstractResOp/
    InputArg/Const/Info.
  - majit/majit-metainterp/src/optimizeopt/mod.rs: make_equal_to, make_constant, ensure_box, and inputarg binding match the intent of RPython optimizer.py.
  - majit/majit-metainterp/src/optimizeopt/unroll.rs: retaining partial_trace_inputargs / partial_trace_operations matches PyPy retrace behavior, where the partial trace
    keeps the same objects alive.
  - majit/majit-metainterp/src/optimizeopt/heap.rs: removing the separate known_nonnull side table moves closer to PyPy’s PtrInfo-based make_nonnull.

  3. Mismatches That Already Existed Before This Patch

  No clear pre-existing incorrect port was identified within this diff scope.

  There are some stale comments still referring to older Forwarded::Box(Const) terminology. That is documentation drift, not a behavioral mismatch.

  4. Structural Adaptations

  - Rust must explicitly root GcRefs; PyPy’s GC traces Python object graphs automatically.
  - Weak<Op> / Weak<InputArg> plus strong ownership in exported state is a Rust lifetime adaptation.
  - Synthetic SameAs* stand-ins preserve identity for folded/orphan ResOps; PyPy keeps the original ResOperation object.
  - The virtualizable liveness read in jitcode_dispatch.rs is not a 1:1 PyPy register read, but appears necessary for Pyre’s virtualizable shadow/register split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled forwarding/identity representation for ops, input slots, and constants; strengthened cycle prevention and constant handling across phases.
  * Redesigned phase-boundary snapshot/retrace and optimizer bookkeeping; revised allocation / null-escape tracking and related heap handling.

* **Bug Fixes**
  * Fixed portal-frame snapshot selection to prefer up-to-date virtualizable values when present.

* **Tests**
  * Added test helpers and updated unit tests to validate forwarding, snapshot, and GC behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->