### PR TITLE
Retire Box.forwarded slot; canonical box identity via Op/InputArg _forwarded

### DIFF
--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -731,6 +731,11 @@ impl BoxRef {
     /// per `set_forwarded_*` — `Forwarded` is `Clone`, payloads are
     /// `Rc`/`Copy` handles.
     fn write_forwarded(&self, value: Forwarded) {
+        debug_assert!(
+            self.bound_op().is_some() || self.bound_inputarg().is_some(),
+            "BoxRef::write_forwarded on unbound BoxRef — bind the box to its \
+             Op/InputArg before writing forwarded (S-0 box identity precondition)"
+        );
         if let Some(weak) = self.0.op_handle.borrow().as_ref() {
             if let Some(op) = weak.upgrade() {
                 *op.forwarded.borrow_mut() = value.clone();
@@ -1059,6 +1064,36 @@ mod tests {
     use crate::intbound::IntBound;
     use crate::op_info::OpInfo;
     use crate::ptr_info::PtrInfo;
+    use crate::resoperation::{Op, OpCode, OpRc};
+    use crate::value::{InputArg, InputArgRc};
+
+    /// Bind a fresh ResOp BoxRef to a synthetic `SameAs*`/`Jump` OpRc so
+    /// `set_forwarded_*` writes land on `op.forwarded` (the canonical
+    /// `_forwarded` host per resoperation.py:233). The OpRc must outlive
+    /// every write through the returned BoxRef.
+    fn bound_resop(tp: Type, position: u32) -> (BoxRef, OpRc) {
+        let b = BoxRef::new_resop(tp, position);
+        let opcode = match tp {
+            Type::Int => OpCode::SameAsI,
+            Type::Float => OpCode::SameAsF,
+            Type::Ref => OpCode::SameAsR,
+            Type::Void => OpCode::Jump,
+        };
+        let op = std::rc::Rc::new(Op::new(opcode, &[]));
+        op.pos.set(OpRef::op_typed(position, tp));
+        b.bind_op(&op);
+        (b, op)
+    }
+
+    /// InputArg counterpart of `bound_resop` — binds a fresh `BoxRef::new_inputarg`
+    /// to a fresh `InputArgRc` so writes land on `inputarg.forwarded`
+    /// (resoperation.py:700).
+    fn bound_inputarg(tp: Type, index: u32) -> (BoxRef, InputArgRc) {
+        let b = BoxRef::new_inputarg(tp, index);
+        let ia = std::rc::Rc::new(InputArg::from_type(tp, index));
+        b.bind_inputarg(&ia);
+        (b, ia)
+    }
 
     #[test]
     fn box_ref_identity_is_pointer_equality() {
@@ -1071,9 +1106,9 @@ mod tests {
 
     #[test]
     fn forwarded_chain_walk_returns_terminal() {
-        let a = BoxRef::new_resop(Type::Int, 0);
-        let b = BoxRef::new_resop(Type::Int, 1);
-        let c = BoxRef::new_resop(Type::Int, 2);
+        let (a, _ao) = bound_resop(Type::Int, 0);
+        let (b, _bo) = bound_resop(Type::Int, 1);
+        let (c, _co) = bound_resop(Type::Int, 2);
         a.set_forwarded_box(b.clone());
         b.set_forwarded_box(c.clone());
         assert_eq!(a.get_box_replacement(false), c);
@@ -1083,8 +1118,8 @@ mod tests {
 
     #[test]
     fn forwarded_chain_stops_at_info() {
-        let a = BoxRef::new_resop(Type::Int, 0);
-        let b = BoxRef::new_resop(Type::Int, 1);
+        let (a, _ao) = bound_resop(Type::Int, 0);
+        let (b, _bo) = bound_resop(Type::Int, 1);
         a.set_forwarded_box(b.clone());
         b.set_forwarded_info(OpInfo::Unknown);
         assert_eq!(a.get_box_replacement(false), b);
@@ -1092,8 +1127,8 @@ mod tests {
 
     #[test]
     fn forwarded_chain_not_const_stops_before_const() {
-        let a = BoxRef::new_resop(Type::Int, 0);
-        let b = BoxRef::new_resop(Type::Int, 1);
+        let (a, _ao) = bound_resop(Type::Int, 0);
+        let (b, _bo) = bound_resop(Type::Int, 1);
         let c = BoxRef::new_const(Value::Int(42));
         a.set_forwarded_box(b.clone());
         b.set_forwarded_box(c.clone());
@@ -1149,8 +1184,8 @@ mod tests {
 
     #[test]
     fn clear_forwarded_resets_slot() {
-        let a = BoxRef::new_resop(Type::Int, 0);
-        let b = BoxRef::new_resop(Type::Int, 0);
+        let (a, _ao) = bound_resop(Type::Int, 0);
+        let (b, _bo) = bound_resop(Type::Int, 0);
         a.set_forwarded_box(b.clone());
         a.clear_forwarded();
         assert_eq!(a.get_box_replacement(false), a);
@@ -1197,7 +1232,7 @@ mod tests {
 
     #[test]
     fn ptr_info_returns_inner_when_forwarded_is_ptr_info() {
-        let a = BoxRef::new_resop(Type::Ref, 0);
+        let (a, _ao) = bound_resop(Type::Ref, 0);
         a.set_forwarded_info(OpInfo::ptr(PtrInfo::nonnull()));
         let pi = a.ptr_info().expect("ptr_info should return Some");
         assert!(pi.is_nonnull());
@@ -1211,22 +1246,22 @@ mod tests {
 
     #[test]
     fn ptr_info_returns_none_for_box_forwarded() {
-        let a = BoxRef::new_resop(Type::Ref, 0);
-        let b = BoxRef::new_resop(Type::Ref, 0);
+        let (a, _ao) = bound_resop(Type::Ref, 0);
+        let (b, _bo) = bound_resop(Type::Ref, 0);
         a.set_forwarded_box(b.clone());
         assert!(a.ptr_info().is_none());
     }
 
     #[test]
     fn ptr_info_returns_none_for_intbound_forwarded() {
-        let a = BoxRef::new_resop(Type::Int, 0);
+        let (a, _ao) = bound_resop(Type::Int, 0);
         a.set_forwarded_info(OpInfo::int_bound(IntBound::from_constant(7)));
         assert!(a.ptr_info().is_none());
     }
 
     #[test]
     fn int_bound_returns_inner_when_forwarded_is_intbound() {
-        let a = BoxRef::new_resop(Type::Int, 0);
+        let (a, _ao) = bound_resop(Type::Int, 0);
         a.set_forwarded_info(OpInfo::int_bound(IntBound::from_constant(42)));
         let ib = a.int_bound().expect("int_bound should return Some");
         assert!(ib.is_constant());
@@ -1241,22 +1276,22 @@ mod tests {
 
     #[test]
     fn int_bound_returns_none_for_box_forwarded() {
-        let a = BoxRef::new_resop(Type::Int, 0);
-        let b = BoxRef::new_resop(Type::Int, 0);
+        let (a, _ao) = bound_resop(Type::Int, 0);
+        let (b, _bo) = bound_resop(Type::Int, 0);
         a.set_forwarded_box(b.clone());
         assert!(a.int_bound().is_none());
     }
 
     #[test]
     fn int_bound_returns_none_for_ptrinfo_forwarded() {
-        let a = BoxRef::new_resop(Type::Ref, 0);
+        let (a, _ao) = bound_resop(Type::Ref, 0);
         a.set_forwarded_info(OpInfo::ptr(PtrInfo::nonnull()));
         assert!(a.int_bound().is_none());
     }
 
     #[test]
     fn ptr_info_mut_mutates_inner_in_place() {
-        let a = BoxRef::new_resop(Type::Ref, 0);
+        let (a, _ao) = bound_resop(Type::Ref, 0);
         a.set_forwarded_info(OpInfo::ptr(PtrInfo::nonnull()));
         {
             let mut pi = a.ptr_info_mut().expect("ptr_info_mut should return Some");
@@ -1270,14 +1305,14 @@ mod tests {
 
     #[test]
     fn ptr_info_mut_returns_none_for_intbound_forwarded() {
-        let a = BoxRef::new_resop(Type::Int, 0);
+        let (a, _ao) = bound_resop(Type::Int, 0);
         a.set_forwarded_info(OpInfo::int_bound(IntBound::from_constant(7)));
         assert!(a.ptr_info_mut().is_none());
     }
 
     #[test]
     fn int_bound_mut_mutates_inner_in_place() {
-        let a = BoxRef::new_resop(Type::Int, 0);
+        let (a, _ao) = bound_resop(Type::Int, 0);
         a.set_forwarded_info(OpInfo::int_bound(IntBound::unbounded()));
         {
             let mut ib = a.int_bound_mut().expect("int_bound_mut should return Some");
@@ -1292,7 +1327,7 @@ mod tests {
 
     #[test]
     fn int_bound_mut_returns_none_for_ptrinfo_forwarded() {
-        let a = BoxRef::new_resop(Type::Ref, 0);
+        let (a, _ao) = bound_resop(Type::Ref, 0);
         a.set_forwarded_info(OpInfo::ptr(PtrInfo::nonnull()));
         assert!(a.int_bound_mut().is_none());
     }
@@ -1332,47 +1367,6 @@ mod tests {
         }
     }
 
-    /// `bind_op` stores `Weak<Op>`; once the `Rc<Op>` is dropped, the
-    /// dual-write becomes a no-op (Weak::upgrade returns None) without
-    /// panicking. Safety net.
-    #[test]
-    fn dropped_op_makes_dual_write_a_noop() {
-        use crate::resoperation::{Op, OpCode};
-        let b = BoxRef::new_resop(Type::Int, 0);
-        {
-            let op = std::rc::Rc::new(Op::new(OpCode::IntAdd, &[]));
-            b.bind_op(&op);
-            // op drops here.
-        }
-        // Dual-write target is gone; set_forwarded should not panic.
-        b.set_forwarded_info(OpInfo::Unknown);
-        assert!(matches!(b.get_forwarded(), Forwarded::Info(_)));
-    }
-
-    /// CodeRabbit mod.rs:2204 scenario: `ensure_box` materializes an
-    /// unbound ResOp placeholder; subsequent code writes Info / IntBound
-    /// / PtrInfo onto it through `BoxRef::set_forwarded_*` (which lands
-    /// in `Box.forwarded` for unbound boxes). When the producer is
-    /// emitted and `bind_op` runs, the pre-emit state must reach
-    /// `op.forwarded` so reads routed through the bound op see it.
-    #[test]
-    fn bind_op_carries_pre_emit_forwarded_to_new_op() {
-        use crate::resoperation::{Op, OpCode};
-        let placeholder = BoxRef::new_resop(Type::Int, 5);
-        placeholder.set_forwarded_info(OpInfo::int_bound(IntBound::from_constant(13)));
-
-        let producer = std::rc::Rc::new(Op::new(OpCode::IntAdd, &[]));
-        placeholder.bind_op(&producer);
-
-        // The pre-emit Info forwarding is reachable on the bound op.
-        match &*producer.forwarded.borrow() {
-            Forwarded::Info(_) => {}
-            other => panic!("bind_op dropped the pre-emit forwarding: {other:?}"),
-        }
-        // And via the BoxRef accessor too.
-        assert!(matches!(placeholder.get_forwarded(), Forwarded::Info(_)));
-    }
-
     /// `bind_inputarg` panics on a non-InputArg box (same contract as
     /// `bind_op`'s ResOp-only check).
     #[test]
@@ -1382,23 +1376,6 @@ mod tests {
         let b = BoxRef::new_resop(Type::Int, 0);
         let ia = InputArg::new_int_rc(0);
         b.bind_inputarg(&ia);
-    }
-
-    /// `bind_inputarg` carries pre-bind `Box.forwarded` state into
-    /// `inputarg.forwarded`, mirroring `bind_op`'s carry-over.
-    #[test]
-    fn bind_inputarg_carries_pre_bind_forwarded_to_inputarg() {
-        use crate::value::InputArg;
-        let b = BoxRef::new_inputarg(Type::Int, 3);
-        b.set_forwarded_info(OpInfo::int_bound(IntBound::from_constant(7)));
-
-        let ia = InputArg::new_int_rc(3);
-        b.bind_inputarg(&ia);
-
-        // The pre-bind Info forwarding survives on the InputArg slot.
-        assert!(matches!(*ia.forwarded.borrow(), Forwarded::Info(_)));
-        // bound_inputarg upgrades the Weak.
-        assert!(b.bound_inputarg().is_some());
     }
 
     /// `bound_inputarg` returns `None` for unbound boxes (no Weak set)
@@ -1443,43 +1420,6 @@ mod tests {
         b.clear_forwarded();
         assert!(matches!(b.get_forwarded(), Forwarded::None));
         assert!(matches!(*ia.forwarded.borrow(), Forwarded::None));
-    }
-
-    /// If the bound `InputArgRc` is dropped, `write_forwarded` falls back
-    /// to `Box.forwarded` instead of panicking — symmetric to
-    /// `dropped_op_makes_dual_write_a_noop`.
-    #[test]
-    fn dropped_inputarg_makes_write_fall_back_to_box() {
-        use crate::value::InputArg;
-        let b = BoxRef::new_inputarg(Type::Int, 0);
-        {
-            let ia = InputArg::new_int_rc(0);
-            b.bind_inputarg(&ia);
-            // ia drops here.
-        }
-        b.set_forwarded_info(OpInfo::Unknown);
-        assert!(matches!(b.get_forwarded(), Forwarded::Info(_)));
-    }
-
-    /// Cross-pass snapshots (e.g. test fixtures cloning a BoxRef whose
-    /// originating `OpRc` then drops) outlive the `Weak<Op>` referent.
-    /// Writes done while the Op is alive must also land in `Box.forwarded`
-    /// so the snapshot keeps the latest forwarding once `Weak::upgrade`
-    /// fails.
-    #[test]
-    fn write_forwarded_mirrors_to_box_so_snapshot_survives_op_drop() {
-        use crate::resoperation::{Op, OpCode};
-        let b = BoxRef::new_resop(Type::Int, 0);
-        let snapshot = b.clone();
-        {
-            let op = std::rc::Rc::new(Op::new(OpCode::IntAdd, &[]));
-            b.bind_op(&op);
-            b.set_forwarded_info(OpInfo::int_bound(IntBound::from_constant(7)));
-            // op drops at the end of this block.
-        }
-        // The snapshot still sees the Info forwarding because the writer
-        // mirrored to Box.forwarded alongside op.forwarded.
-        assert!(matches!(snapshot.get_forwarded(), Forwarded::Info(_)));
     }
 
     /// Reviewer scenario: `bind A → set_forwarded(X) → bind B`. PyPy's

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -5,22 +5,27 @@
 //! `AbstractResOpOrInputArg` / `AbstractResOp` / `AbstractInputArg` /
 //! `Const*` (`history.py:182`), expressed as `Rc<Box>`.
 //!
-//! Hosted in `majit-ir` so the `forwarded: RefCell<Forwarded>` slot
-//! eventually lifted onto `Op` / `InputArg` can carry the type without a
-//! `majit-metainterp → majit-ir` circular dep. The `BoxPool` side-table
-//! that addresses these objects by `OpRef` index stays in metainterp.
+//! Hosted in `majit-ir` so `BoxRef` can carry `Weak<Op>` / `Weak<InputArg>`
+//! without a `majit-metainterp → majit-ir` circular dep. The canonical
+//! `_forwarded` slot lives on `Op` / `InputArg` themselves
+//! (`resoperation.py:233` / `:700`); `BoxRef` is a thin wrapper that
+//! routes `get_forwarded` / `set_forwarded_*` through the bound handle.
+//! The `BoxPool` side-table that addresses these objects by `OpRef`
+//! index stays in metainterp.
 //!
 //! # Design decisions
 //!
-//! - The `forwarded` slot is a `RefCell<Forwarded>`. `Cell` is not used
-//!   because `Forwarded` carries `OpInfo` / `BoxRef`, neither of which is
-//!   `Copy`. Helpers terminate the borrow scope immediately after reading.
+//! - The canonical `forwarded` slot is a `RefCell<Forwarded>` on
+//!   `Op` / `InputArg`. `Cell` is not used because `Forwarded` carries
+//!   `OpInfo` / `BoxRef`, neither of which is `Copy`. Helpers terminate
+//!   the borrow scope immediately after reading.
 //! - `BoxRef`'s `Eq` / `Hash` use `Rc::ptr_eq` / `Rc::as_ptr` — equivalent
 //!   to RPython's use of object identity as a dict key.
 //! - When `Forwarded::Box(BoxRef)` carries a BoxRef whose kind is
 //!   `BoxKind::Const(...)`, that mirrors RPython's
-//!   `box.set_forwarded(constbox)`. We do not introduce a separate `Const`
-//!   variant: RPython stores everything in a single `_forwarded` slot.
+//!   `box.set_forwarded(constbox)`. Constants are split into
+//!   `Forwarded::Const(Const)` separately so chain walkers terminate on
+//!   the inline value without needing a `BoxKind::Const` carrier.
 
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
@@ -49,14 +54,6 @@ fn default_value_for(type_: Type) -> Value {
 /// `AbstractValue` mirror — unified representation of RPython's
 /// op/inputarg/const objects.
 pub struct Box {
-    /// `resoperation.py:233-243 AbstractResOpOrInputArg._forwarded`.
-    ///
-    /// Const boxes also carry the slot, but in RPython `Const` is not a
-    /// subclass of `AbstractResOpOrInputArg`, so its `_forwarded` is
-    /// always `None`. Rust unifies the layout into a single struct
-    /// shape while preserving the same invariant.
-    pub forwarded: RefCell<Forwarded>,
-
     /// `resoperation.py:260 type` (`'i'` / `'r'` / `'f'` / `'v'`).
     /// Absorbs the frontend semantic portion that majit currently spreads
     /// across `value_types` / `inputarg_types` / `constant_types`.
@@ -75,26 +72,28 @@ pub struct Box {
     /// `BoxKind::Const { value, .. }` instead.
     pub value: Cell<Option<Value>>,
 
-    /// Dual-write backref to the `Op` this Box stands in for.
-    /// `Weak` to avoid an Rc cycle (Op.forwarded may carry a `BoxRef`
-    /// holding an `Rc<Box>` whose `op_handle` could otherwise loop back
-    /// through the trace). Empty for `BoxKind::InputArg` / `Const`
-    /// (those have their own backref strategy or no Op counterpart);
-    /// for `BoxKind::ResOp` it is filled by `BoxRef::bind_op` at the
-    /// recorder→TreeLoop handoff. When `Some`, `set_forwarded_box` /
-    /// `set_forwarded_info` / `clear_forwarded` also write through to
-    /// `op.forwarded`, establishing the invariant
-    /// `Box.forwarded == op.forwarded`.
+    /// Canonical `_forwarded` host backref for `BoxKind::ResOp`
+    /// (`resoperation.py:233 AbstractResOpOrInputArg._forwarded` —
+    /// the slot lives on the `Op` itself, not on this wrapper).
+    /// `Weak` to avoid an `Rc` cycle (`Op.forwarded` may carry a
+    /// `BoxRef` holding an `Rc<Box>` whose `op_handle` could
+    /// otherwise loop back through the trace). Empty for
+    /// `BoxKind::InputArg` / `Const`; filled by `BoxRef::bind_op` at
+    /// the recorder→TreeLoop handoff (`history.rs::with_box_pool`)
+    /// and during emit's `bound_is_synthetic` rebind path
+    /// (`mod.rs::emit`). `BoxRef::get_forwarded` /
+    /// `set_forwarded_*` route through this handle exclusively for
+    /// ResOp boxes — there is no `Box`-side mirror to consult.
     pub op_handle: RefCell<Option<Weak<Op>>>,
 
-    /// Parity: backref to the `InputArg` this Box stands in
-    /// for, mirroring `op_handle` for the `BoxKind::InputArg` variant.
-    /// Empty for `BoxKind::ResOp` / `Const`; filled by
-    /// `BoxRef::bind_inputarg` at the recorder→TreeLoop handoff so the
-    /// authoritative `_forwarded` slot lives on the `InputArg` itself
-    /// (RPython `resoperation.py:700 AbstractInputArg._forwarded`).
-    /// Without this, `InputArg.forwarded` would remain a dead field and
-    /// readers migrating off `BoxRef.forwarded` would see stale `None`.
+    /// Canonical `_forwarded` host backref for `BoxKind::InputArg`
+    /// (`resoperation.py:700 AbstractInputArg._forwarded`). Empty for
+    /// `BoxKind::ResOp` / `Const`; filled by `BoxRef::bind_inputarg`
+    /// at the recorder→TreeLoop handoff and by
+    /// `OptContext::ensure_inputarg_bindings` /
+    /// `bind_input_resops` for per-iter TraceIterator pools.
+    /// `set_forwarded_*` route through this handle exclusively for
+    /// InputArg boxes.
     pub inputarg_handle: RefCell<Option<Weak<InputArg>>>,
 }
 
@@ -218,7 +217,6 @@ impl BoxRef {
     /// `Trace.record()`.
     pub fn new_resop(type_: Type, position: u32) -> Self {
         Self(Rc::new(Box {
-            forwarded: RefCell::new(Forwarded::None),
             type_,
             kind: BoxKind::ResOp {
                 position: std::cell::Cell::new(position),
@@ -242,10 +240,6 @@ impl BoxRef {
         let type_ = opref.ty().unwrap_or(Type::Void);
         let position = opref.raw();
         Self(Rc::new(Box {
-            // `Box.forwarded` is the legacy mirror — the bound op's
-            // own slot is canonical so this stays None; `get_forwarded`
-            // returns op.forwarded via the `bound_op()` fastpath.
-            forwarded: RefCell::new(Forwarded::None),
             type_,
             kind: BoxKind::ResOp {
                 position: std::cell::Cell::new(position),
@@ -263,7 +257,6 @@ impl BoxRef {
         let type_ = ia.tp;
         let position = ia.index;
         Self(Rc::new(Box {
-            forwarded: RefCell::new(Forwarded::None),
             type_,
             kind: BoxKind::InputArg { position },
             value: Cell::new(None),
@@ -275,7 +268,6 @@ impl BoxRef {
     /// New `AbstractInputArg` Box.
     pub fn new_inputarg(type_: Type, position: u32) -> Self {
         Self(Rc::new(Box {
-            forwarded: RefCell::new(Forwarded::None),
             type_,
             kind: BoxKind::InputArg { position },
             value: Cell::new(None),
@@ -290,7 +282,6 @@ impl BoxRef {
     pub fn new_const(value: Value) -> Self {
         let type_ = value.get_type();
         Self(Rc::new(Box {
-            forwarded: RefCell::new(Forwarded::None),
             type_,
             kind: BoxKind::Const {
                 value,
@@ -309,7 +300,6 @@ impl BoxRef {
     pub fn new_const_with_index(value: Value, const_index: u32) -> Self {
         let type_ = value.get_type();
         Self(Rc::new(Box {
-            forwarded: RefCell::new(Forwarded::None),
             type_,
             kind: BoxKind::Const {
                 value,
@@ -494,11 +484,15 @@ impl BoxRef {
     }
 
     /// `resoperation.py:50 get_forwarded`. Returns a clone of the
-    /// current slot. For bound ResOp boxes the read is routed
-    /// through `op.forwarded`; extends this to InputArg via
-    /// `inputarg.forwarded`. Unbound boxes (Const / lazy-allocated) fall
-    /// back to `Box.forwarded`. The clone is cheap — every `Forwarded`
-    /// payload is an `Rc`/`Copy` handle.
+    /// canonical `_forwarded` slot. For bound ResOp boxes the read is
+    /// routed through `op.forwarded` (`resoperation.py:233`); for
+    /// bound InputArg boxes through `inputarg.forwarded`
+    /// (`resoperation.py:700`). Const boxes and unbound non-Const
+    /// boxes return `Forwarded::None` (RPython `Const._forwarded` is
+    /// permanently `None`, and unbound non-Consts are an invariant
+    /// violation that `write_forwarded`'s precondition assert
+    /// catches on the writer side). The clone is cheap — every
+    /// `Forwarded` payload is an `Rc`/`Copy` handle.
     pub fn get_forwarded(&self) -> Forwarded {
         if let Some(op) = self.bound_op() {
             return op.forwarded.borrow().clone();
@@ -506,7 +500,7 @@ impl BoxRef {
         if let Some(ia) = self.bound_inputarg() {
             return ia.forwarded.borrow().clone();
         }
-        self.0.forwarded.borrow().clone()
+        Forwarded::None
     }
 
     /// `resoperation.py:53 set_forwarded(forwarded_to)` — Box variant.
@@ -721,32 +715,32 @@ impl BoxRef {
         self.write_forwarded(Forwarded::None);
     }
 
-    /// Dual-write to `op.forwarded` / `inputarg.forwarded` (the canonical
-    /// `_forwarded` host, resoperation.py:233-242 / :700) AND
-    /// `Box.forwarded`. Snapshot consumers (`compile_retrace` partial
-    /// trace import, test fixtures) clone the `BoxRef` by value and may
-    /// outlive the originating `OpRc` / `InputArgRc`; once the `Weak`
-    /// upgrade fails, `get_forwarded` falls back to `Box.forwarded`, so
-    /// that slot must stay current. The cost is one extra `RefCell` write
-    /// per `set_forwarded_*` — `Forwarded` is `Clone`, payloads are
-    /// `Rc`/`Copy` handles.
+    /// Write to the canonical `_forwarded` host — `op.forwarded`
+    /// (`resoperation.py:233-242`) for ResOp boxes,
+    /// `inputarg.forwarded` (`resoperation.py:700`) for InputArg
+    /// boxes. `BoxKind::ResOp` and `BoxKind::InputArg` are mutually
+    /// exclusive so at most one branch fires per call.
+    ///
+    /// Asserts that at least one handle is bound and upgradable; an
+    /// unbound or dropped-target write would silently lose data
+    /// since there is no `Box`-side mirror to catch it. Production
+    /// pre-binds every chain-walker-reachable slot via
+    /// `OptContext::ensure_inputarg_bindings` and
+    /// `bind_input_resops`; recorder→TreeLoop handoff binds via
+    /// `BoxPool::bind_inputargs` / `bind_ops`.
     fn write_forwarded(&self, value: Forwarded) {
-        debug_assert!(
-            self.bound_op().is_some() || self.bound_inputarg().is_some(),
+        if let Some(op) = self.bound_op() {
+            *op.forwarded.borrow_mut() = value;
+            return;
+        }
+        if let Some(ia) = self.bound_inputarg() {
+            *ia.forwarded.borrow_mut() = value;
+            return;
+        }
+        panic!(
             "BoxRef::write_forwarded on unbound BoxRef — bind the box to its \
-             Op/InputArg before writing forwarded (S-0 box identity precondition)"
+             Op/InputArg before writing forwarded (box identity precondition)"
         );
-        if let Some(weak) = self.0.op_handle.borrow().as_ref() {
-            if let Some(op) = weak.upgrade() {
-                *op.forwarded.borrow_mut() = value.clone();
-            }
-        }
-        if let Some(weak) = self.0.inputarg_handle.borrow().as_ref() {
-            if let Some(ia) = weak.upgrade() {
-                *ia.forwarded.borrow_mut() = value.clone();
-            }
-        }
-        *self.0.forwarded.borrow_mut() = value;
     }
 
     /// `resoperation.py:57-68 get_box_replacement(not_const=False)`.
@@ -867,9 +861,10 @@ impl BoxRef {
     ///
     /// Holds the inner `RefCell` borrow for the lifetime of the returned
     /// guard; callers must drop the guard before any other access to the
-    /// same handle.  The outer `forwarded` `RefCell` is released as soon
-    /// as the `Rc` clone is captured, so other consumers can still take
-    /// non-conflicting borrows of `self.0.forwarded`.
+    /// same handle.  The canonical `forwarded` `RefCell` (on the bound
+    /// `Op` / `InputArg`) is released as soon as the `Rc` clone is
+    /// captured, so other consumers can still take non-conflicting
+    /// borrows of it.
     pub fn ptr_info_mut(&self) -> Option<PtrInfoBorrowMut> {
         let rc = match self.get_forwarded() {
             Forwarded::Info(OpInfo::Ptr(rc)) => rc,
@@ -1470,20 +1465,5 @@ mod tests {
             Forwarded::Info(OpInfo::Unknown) => {}
             other => panic!("inputarg rebind dropped the latest forwarding: {other:?}"),
         }
-    }
-
-    /// Same invariant for InputArg-bound boxes.
-    #[test]
-    fn write_forwarded_mirrors_to_box_so_snapshot_survives_inputarg_drop() {
-        use crate::value::InputArg;
-        let b = BoxRef::new_inputarg(Type::Int, 0);
-        let snapshot = b.clone();
-        {
-            let ia = InputArg::new_int_rc(0);
-            b.bind_inputarg(&ia);
-            b.set_forwarded_info(OpInfo::Unknown);
-            // ia drops here.
-        }
-        assert!(matches!(snapshot.get_forwarded(), Forwarded::Info(_)));
     }
 }

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -28,7 +28,7 @@ use std::rc::{Rc, Weak};
 use crate::intbound::IntBound;
 use crate::op_info::OpInfo;
 use crate::ptr_info::PtrInfo;
-use crate::resoperation::{Op, VectorizationInfo};
+use crate::resoperation::Op;
 use crate::value::{Const, InputArg};
 use crate::{GcRef, OpRef, Type, Value};
 
@@ -190,12 +190,6 @@ pub enum Forwarded {
     /// `optimizeopt/info.py:17 AbstractInfo (is_info_class = True)` family —
     /// `PtrInfo`, `IntBound`, `FloatConstInfo`, `EmptyInfo`, etc.
     Info(OpInfo),
-
-    /// `resoperation.py:156 VectorizationInfo(AbstractValue)` written by
-    /// `schedule.py:20-28 forwarded_vecinfo`.  Separate from `Info`
-    /// because vectorizer metadata is not an `OpInfo` semantic class —
-    /// it's per-op codegen state.
-    VectorInfo(VectorizationInfo),
 }
 
 /// `Rc<Box>` newtype.
@@ -636,28 +630,6 @@ impl BoxRef {
         self.write_forwarded(next);
     }
 
-    /// `schedule.py:20-28 forwarded_vecinfo` — set the per-op vectorizer
-    /// metadata into the `_forwarded` slot via the dedicated
-    /// `VectorInfo` variant.
-    pub fn set_forwarded_vector_info(&self, info: VectorizationInfo) {
-        assert!(
-            !matches!(self.0.kind, BoxKind::Const { .. }),
-            "set_forwarded_vector_info on Const violates RPython AbstractValue \
-             invariant (Const has no _forwarded slot)"
-        );
-        *self.0.forwarded.borrow_mut() = Forwarded::VectorInfo(info);
-    }
-
-    /// `schedule.py:30-36 forwarded_vecinfo` reader — return a clone of the
-    /// `VectorizationInfo` currently in the `_forwarded` slot, or `None`
-    /// if the slot does not hold `VectorInfo`.
-    pub fn vector_info(&self) -> Option<VectorizationInfo> {
-        match &*self.0.forwarded.borrow() {
-            Forwarded::VectorInfo(info) => Some(info.clone()),
-            _ => None,
-        }
-    }
-
     /// Per-type mixin slot read — `_resint` / `_resref` / `_resfloat`
     /// (resoperation.py:566/612/582).  Returns the cached runtime value
     /// for `ResOp` / `InputArg` boxes; the variant default for `Const`
@@ -780,7 +752,7 @@ impl BoxRef {
         let mut cur = self.clone();
         loop {
             match cur.get_forwarded() {
-                Forwarded::None | Forwarded::Info(_) | Forwarded::VectorInfo(_) => return cur,
+                Forwarded::None | Forwarded::Info(_) => return cur,
                 Forwarded::Box(b) => {
                     if not_const && b.is_constant() {
                         return cur;

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4150,17 +4150,6 @@ impl OptContext {
         op.get_box_replacement(false).ptr_info().map(|p| p.clone())
     }
 
-    /// Live `Rc<RefCell<PtrInfo>>` handle for `info.py:865-894
-    /// getrawptrinfo`/`getptrinfo` semantics — RPython `return fw`
-    /// object identity.  Returns `None` if the chain terminal does
-    /// not currently carry `Forwarded::Info(OpInfo::Ptr(_))`.
-    pub fn peek_ptr_info_handle(
-        &self,
-        op: &crate::r#box::BoxRef,
-    ) -> Option<std::rc::Rc<std::cell::RefCell<crate::optimizeopt::info::PtrInfo>>> {
-        op.get_box_replacement(false).ptr_info_handle()
-    }
-
     /// info.py: getptrinfo(op) — mutable variant. Walks the chain on `op`
     /// and runs the closure against the terminal BoxRef's `_forwarded`
     /// PtrInfo via `ptr_info_mut()`. The BoxRef slot is the authoritative

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3989,6 +3989,30 @@ impl OptContext {
                     .cloned();
                 if let Some(op_rc) = op_rc {
                     cloned.bind_op(&op_rc);
+                } else {
+                    // Producer not yet emitted: bind to a synthetic stand-in
+                    // (mirrors the lazy-alloc miss path below at line 4044).
+                    // `emit()` swaps the binding to the real producer when
+                    // it arrives, with `bind_op`'s carry-over migrating the
+                    // forwarded state. Required so every BoxRef returned
+                    // from `ensure_box` is bound to an `Op` whose
+                    // `forwarded` slot is the canonical `_forwarded` host
+                    // (resoperation.py:233).
+                    use majit_ir::resoperation::{Op, OpCode};
+                    let opcode = match cloned.type_() {
+                        majit_ir::Type::Int => OpCode::SameAsI,
+                        majit_ir::Type::Float => OpCode::SameAsF,
+                        majit_ir::Type::Ref => OpCode::SameAsR,
+                        majit_ir::Type::Void => OpCode::Jump,
+                    };
+                    let synthetic = std::rc::Rc::new(Op::new(opcode, &[]));
+                    synthetic.pos.set(opref);
+                    let idx = opref.raw() as usize;
+                    if idx >= self.resop_refs.len() {
+                        self.resop_refs.resize_with(idx + 1, || None);
+                    }
+                    self.resop_refs[idx] = Some(synthetic.clone());
+                    cloned.bind_op(&synthetic);
                 }
             }
             return Some(cloned);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1787,11 +1787,7 @@ impl OptContext {
         if opref.is_none() || opref.is_constant() {
             return None;
         }
-        if let Some(op) = self
-            .new_operations
-            .iter()
-            .rfind(|op| op.pos.get() == opref)
-        {
+        if let Some(op) = self.new_operations.iter().rfind(|op| op.pos.get() == opref) {
             return Some(op.clone());
         }
         if let Some(op) = self
@@ -4099,24 +4095,17 @@ impl OptContext {
     /// without an upstream pool). Callers in that case fall back to the
     /// `OpRef`-returning walker.
     pub fn get_box_replacement_box(&self, opref: OpRef) -> Option<crate::r#box::BoxRef> {
-        if opref.is_none() {
-            return None;
-        }
-        let start = if opref.is_constant() {
-            let ci = opref.const_index();
-            let value = self.const_pool.get(&ci).copied()?;
-            crate::r#box::BoxRef::new_const_with_index(value, ci)
-        } else {
-            // RPython invariant: every non-const `AbstractResOpOrInputArg`
-            // carries a Box (`resoperation.py:233-248`). pyre's `box_pool`
-            // is the Rust-side embodiment; a miss here means the producer
-            // failed to materialize the Box (production should always
-            // populate via `ensure_box`). The `None` fallthrough is
-            // tolerated for test fixtures that bypass the recorder; READ
-            // sites that need the materialize-always invariant should use
-            // `ensure_box` instead. Phase D-2.g audit pending.
-            self.box_pool.get(opref).cloned()?
-        };
+        // S-8.A.4: resolve the chain root through `resolve_to_boxref`, the
+        // variant-aware canonical-host resolver (producer `Op` for ResOp
+        // variants, `inputarg_refs` for InputArg, `const_pool` for Const),
+        // rather than `box_pool.get` whose position-collapse merges a ResOp
+        // and an InputArg sharing a raw slot index. Production `ensure_box`
+        // binds every resop slot to the same producer `Op`, so reads here
+        // and writes through `ensure_box` agree by hitting the identical
+        // `Op.forwarded` / `InputArg.forwarded` host. A `None` resolve
+        // (sentinel, or a position with no producer / inputarg / const)
+        // leaves callers on the OpRef-returning walker fallback.
+        let start = self.resolve_to_boxref(opref)?;
         Some(start.get_box_replacement(false))
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1773,6 +1773,69 @@ impl OptContext {
         }
     }
 
+    /// S-8.A.1 lookup primitive: find the canonical producer `OpRc`
+    /// for `opref` by scanning the current phase's `new_operations`
+    /// first, then cross-phase `phase1_emit_ops` (`history.py:220`
+    /// box.type parity for Phase 1 emit OpRefs visible from Phase 2),
+    /// then synthetic stand-ins / pre-bound input ops in
+    /// `resop_refs`. Reverse scan on the first two lists mirrors
+    /// `op_at`'s ordering so a later replacement at the same `pos`
+    /// wins. Returns `None` for inputargs, constants, OpRefs without
+    /// a producer in any of the three stores, and sentinel
+    /// `OpRef::none()`.
+    pub(crate) fn find_producer_op(&self, opref: OpRef) -> Option<majit_ir::OpRc> {
+        if opref.is_none() || opref.is_constant() {
+            return None;
+        }
+        if let Some(op) = self
+            .new_operations
+            .iter()
+            .rfind(|op| op.pos.get() == opref)
+        {
+            return Some(op.clone());
+        }
+        if let Some(op) = self
+            .phase1_emit_ops
+            .iter()
+            .rfind(|op| op.pos.get() == opref)
+        {
+            return Some(op.clone());
+        }
+        self.resop_refs
+            .get(opref.raw() as usize)
+            .and_then(|slot| slot.clone())
+    }
+
+    /// S-8.A.1: mint a `SameAsI/F/R` (or `Jump` for `Void`) synthetic
+    /// stand-in `OpRc` for `opref` with the correct result type and
+    /// stash it in `resop_refs[idx]` so `emit()`'s
+    /// `bound_is_synthetic` rebind path later upgrades the binding to
+    /// the real producer via `bind_op`'s carry-over. The synthetic
+    /// stays referenced from `resop_refs` for the OptContext's
+    /// lifetime so lingering `Forwarded::Op(_)` `Weak<Op>` upgrades
+    /// stay valid until rebind.
+    pub(crate) fn mint_synthetic_resop(
+        &mut self,
+        opref: OpRef,
+        ty: majit_ir::Type,
+    ) -> majit_ir::OpRc {
+        use majit_ir::resoperation::{Op, OpCode};
+        let opcode = match ty {
+            majit_ir::Type::Int => OpCode::SameAsI,
+            majit_ir::Type::Float => OpCode::SameAsF,
+            majit_ir::Type::Ref => OpCode::SameAsR,
+            majit_ir::Type::Void => OpCode::Jump,
+        };
+        let synthetic = std::rc::Rc::new(Op::new(opcode, &[]));
+        synthetic.pos.set(opref);
+        let idx = opref.raw() as usize;
+        if idx >= self.resop_refs.len() {
+            self.resop_refs.resize_with(idx + 1, || None);
+        }
+        self.resop_refs[idx] = Some(synthetic.clone());
+        synthetic
+    }
+
     /// S-1: bind every input op's resop `BoxRef` in `box_pool` to a
     /// fresh `OpRc` of the input op so any `Forwarded::Op(_)` chain
     /// step targeting the slot has an upgradable `Weak<Op>` from the
@@ -4020,41 +4083,18 @@ impl OptContext {
             // host) and `make_equal_to`'s strict bound-target invariant
             // holds.
             if cloned.is_resop() && cloned.bound_op().is_none() {
-                let op_rc = self
-                    .new_operations
-                    .iter()
-                    .rfind(|op| op.pos.get() == opref)
-                    .or_else(|| {
-                        self.phase1_emit_ops
-                            .iter()
-                            .rfind(|op| op.pos.get() == opref)
-                    })
-                    .cloned();
-                if let Some(op_rc) = op_rc {
+                if let Some(op_rc) = self.find_producer_op(opref) {
                     cloned.bind_op(&op_rc);
                 } else {
-                    // Producer not yet emitted: bind to a synthetic stand-in
-                    // (mirrors the lazy-alloc miss path below at line 4044).
-                    // `emit()` swaps the binding to the real producer when
-                    // it arrives, with `bind_op`'s carry-over migrating the
-                    // forwarded state. Required so every BoxRef returned
-                    // from `ensure_box` is bound to an `Op` whose
-                    // `forwarded` slot is the canonical `_forwarded` host
-                    // (resoperation.py:233).
-                    use majit_ir::resoperation::{Op, OpCode};
-                    let opcode = match cloned.type_() {
-                        majit_ir::Type::Int => OpCode::SameAsI,
-                        majit_ir::Type::Float => OpCode::SameAsF,
-                        majit_ir::Type::Ref => OpCode::SameAsR,
-                        majit_ir::Type::Void => OpCode::Jump,
-                    };
-                    let synthetic = std::rc::Rc::new(Op::new(opcode, &[]));
-                    synthetic.pos.set(opref);
-                    let idx = opref.raw() as usize;
-                    if idx >= self.resop_refs.len() {
-                        self.resop_refs.resize_with(idx + 1, || None);
-                    }
-                    self.resop_refs[idx] = Some(synthetic.clone());
+                    // Producer not yet emitted: bind to a synthetic
+                    // stand-in. `emit()` swaps the binding to the
+                    // real producer when it arrives, with `bind_op`'s
+                    // carry-over migrating the forwarded state.
+                    // Required so every BoxRef returned from
+                    // `ensure_box` is bound to an `Op` whose
+                    // `forwarded` slot is the canonical `_forwarded`
+                    // host (resoperation.py:233).
+                    let synthetic = self.mint_synthetic_resop(opref, cloned.type_());
                     cloned.bind_op(&synthetic);
                 }
             }
@@ -4097,21 +4137,10 @@ impl OptContext {
             }
             _ => {
                 let p = crate::r#box::BoxRef::new_resop(placeholder_type, idx as u32);
-                // Bind to the producing OpRc when present so `box.set_forwarded`
-                // dual-writes to `op.forwarded` (resoperation.py:233 `_forwarded`
-                // host). Searches the current phase's `new_operations` first,
-                // then cross-phase `phase1_emit_ops`.
-                let op_rc = self
-                    .new_operations
-                    .iter()
-                    .rfind(|op| op.pos.get() == opref)
-                    .or_else(|| {
-                        self.phase1_emit_ops
-                            .iter()
-                            .rfind(|op| op.pos.get() == opref)
-                    })
-                    .cloned();
-                if let Some(op_rc) = op_rc {
+                // Bind to the producing OpRc when present so
+                // `box.set_forwarded` dual-writes to `op.forwarded`
+                // (resoperation.py:233 `_forwarded` host).
+                if let Some(op_rc) = self.find_producer_op(opref) {
                     p.bind_op(&op_rc);
                 } else {
                     // No producer Op yet — synthesise a `SameAsI/F/R`
@@ -4119,24 +4148,11 @@ impl OptContext {
                     // result type and bind so chain steps targeting
                     // this BoxRef route through `Forwarded::Op(_)`
                     // (`optimizer.py:394 op.set_forwarded(newop)`
-                    // where `newop` is an `AbstractResOp`) instead of
-                    // the deprecated `Forwarded::Box(_)` fallback.
-                    // `emit()` re-binds to the real producer when it
-                    // arrives, carrying the forwarded state across via
+                    // where `newop` is an `AbstractResOp`). `emit()`
+                    // re-binds to the real producer when it arrives,
+                    // carrying the forwarded state across via
                     // `BoxRef::bind_op`'s carry-over.
-                    use majit_ir::resoperation::{Op, OpCode};
-                    let opcode = match placeholder_type {
-                        majit_ir::Type::Int => OpCode::SameAsI,
-                        majit_ir::Type::Float => OpCode::SameAsF,
-                        majit_ir::Type::Ref => OpCode::SameAsR,
-                        majit_ir::Type::Void => OpCode::Jump,
-                    };
-                    let synthetic = std::rc::Rc::new(Op::new(opcode, &[]));
-                    synthetic.pos.set(opref);
-                    if idx >= self.resop_refs.len() {
-                        self.resop_refs.resize_with(idx + 1, || None);
-                    }
-                    self.resop_refs[idx] = Some(synthetic.clone());
+                    let synthetic = self.mint_synthetic_resop(opref, placeholder_type);
                     p.bind_op(&synthetic);
                 }
                 p

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6068,21 +6068,6 @@ impl OptContext {
     ///     return None
     /// ```
     ///
-    /// The `IntBound` branch maps onto `peek_ptr_info` returning `None`
-    /// when the forwarded slot is `Forwarded::IntBound` (rather than
-    /// `Forwarded::Info(PtrInfo)`), which already corresponds to
-    /// upstream's `isinstance(fw, IntBound): return None` early-out.
-    ///
-    /// The two `assert op.type == 'i'` are kept as `debug_assert_eq!`s
-    /// against `BoxRef::type_()` — strict `Type::Int` only, matching
-    /// upstream. Callers that materialize boxes via `ensure_box`
-    /// (which defaults to `Type::Void` for un-typed OpRef variants)
-    /// must thread the correct `Type::Int` at the fixture boundary
-    /// instead of relaxing this helper.
-    pub fn getrawptrinfo(&self, op: &crate::r#box::BoxRef) -> Option<PtrInfo> {
-        self.getrawptrinfo_handle(op).map(|h| h.snapshot())
-    }
-
     /// info.py:865-878 `getrawptrinfo(op)` parity — orthodox return
     /// shape that preserves RPython `_forwarded` object identity.
     /// `PtrInfoHandle::Const(_)` for the `isinstance(op, ConstInt)`

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1836,6 +1836,58 @@ impl OptContext {
         synthetic
     }
 
+    /// S-8.A: read `_forwarded` for `opref` directly off the canonical
+    /// host (`op.forwarded` / `inputarg.forwarded`) without going
+    /// through `box_pool`. Mirrors `BoxRef::get_forwarded` semantics
+    /// but bypasses the wrapper allocation. Returns `Forwarded::None`
+    /// for constants (`resoperation.py:50` `Const._forwarded` is
+    /// permanently `None`), `None` for sentinel `OpRef::none()` and
+    /// for ResOp positions whose producer is not in any canonical
+    /// store (`new_operations` / `phase1_emit_ops` / `resop_refs`).
+    pub(crate) fn read_forwarded(&self, opref: OpRef) -> Option<crate::r#box::Forwarded> {
+        if opref.is_none() {
+            return None;
+        }
+        if opref.is_constant() {
+            return Some(crate::r#box::Forwarded::None);
+        }
+        match opref {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let idx = opref.raw() as usize;
+                self.inputarg_refs
+                    .get(idx)
+                    .map(|ia| ia.forwarded.borrow().clone())
+            }
+            _ => self
+                .find_producer_op(opref)
+                .map(|op| op.forwarded.borrow().clone()),
+        }
+    }
+
+    /// S-8.A: write `Forwarded::None` to the canonical host for
+    /// `opref` (`resoperation.py:240` `set_forwarded(None)` /
+    /// `:50` clear semantics). No-op for sentinel `OpRef::none()`,
+    /// constants (whose `_forwarded` is permanently `None`), and
+    /// positions without a canonical Op/InputArg.
+    pub(crate) fn clear_forwarded(&self, opref: OpRef) {
+        if opref.is_none() || opref.is_constant() {
+            return;
+        }
+        match opref {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let idx = opref.raw() as usize;
+                if let Some(ia) = self.inputarg_refs.get(idx) {
+                    *ia.forwarded.borrow_mut() = crate::r#box::Forwarded::None;
+                }
+            }
+            _ => {
+                if let Some(op) = self.find_producer_op(opref) {
+                    *op.forwarded.borrow_mut() = crate::r#box::Forwarded::None;
+                }
+            }
+        }
+    }
+
     /// S-1: bind every input op's resop `BoxRef` in `box_pool` to a
     /// fresh `OpRc` of the input op so any `Forwarded::Op(_)` chain
     /// step targeting the slot has an upgradable `Weak<Op>` from the
@@ -3027,14 +3079,14 @@ impl OptContext {
         let snapshot_forwarded = |ctx: &Self, arg: OpRef| -> Option<ForwardedInfo> {
             // shortpreamble.py:387 `info = arg.get_forwarded()` — PyPy
             // returns the AbstractInfo subtype stored in `_forwarded`.
-            // Pyre's BoxRef carries:
+            // Pyre's canonical `_forwarded` host carries:
             //   `Forwarded::Info(OpInfo::Ptr(_))` — info.py:600 PtrInfo
             //   `Forwarded::Info(OpInfo::IntBound(_))` — intutils.py
             //   `Forwarded::Info(OpInfo::FloatConst(_))` — info.py:851
             //       FloatConstInfo planted via set_preamble_forwarded_info.
-            let b = ctx.box_pool.get(arg)?;
+            let forwarded = ctx.read_forwarded(arg)?;
             use crate::optimizeopt::info::OpInfo;
-            match &b.get_forwarded() {
+            match &forwarded {
                 crate::r#box::Forwarded::Info(OpInfo::Ptr(info)) => {
                     Some(ForwardedInfo::Ptr(info.borrow().clone()))
                 }
@@ -3188,9 +3240,8 @@ impl OptContext {
         // Const targets can still appear from legacy bridge/fixture replay
         // paths; normalize them to the OpInfo shape consumed by
         // `setinfo_from_preamble_item_option`.
-        let b = self.box_pool.get(source).cloned()?;
         let result = {
-            let fwd = b.get_forwarded();
+            let fwd = self.read_forwarded(source)?;
             match &fwd {
                 crate::r#box::Forwarded::Info(OpInfo::Ptr(p)) => Some(OpInfo::Ptr(p.clone())),
                 crate::r#box::Forwarded::Info(OpInfo::IntBound(ib)) => {
@@ -3220,8 +3271,10 @@ impl OptContext {
             }
         };
         if result.is_some() {
-            // shortpreamble.py:401 preamble_op.set_forwarded(None).
-            b.clear_forwarded();
+            // shortpreamble.py:401 preamble_op.set_forwarded(None) —
+            // write directly to the canonical host so we don't
+            // re-fetch the BoxRef wrapper.
+            self.clear_forwarded(source);
         }
         result
     }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4161,45 +4161,6 @@ impl OptContext {
         op.get_box_replacement(false).ptr_info_handle()
     }
 
-    /// `optimizer.py:99-113 getintbound(op)` orthodox identity reader.
-    ///
-    /// Returns `IntBoundHandle::Const(from_constant(v))` for a
-    /// `ConstInt` terminal (line 102-103) and
-    /// `IntBoundHandle::Live(rc)` when the terminal's `_forwarded`
-    /// slot already holds an `OpInfo::IntBound(rc)` (line 105-108
-    /// `if cur is not None and isinstance(cur, IntBound): return cur`).
-    /// Returns `None` when the slot carries any other `Forwarded`
-    /// variant — caller decides whether to lazy-install via
-    /// [`Self::getintbound`].
-    ///
-    /// This is the IntBound counterpart of `peek_ptr_info_handle`;
-    /// two handles cloned from the same `Live` cell observe each
-    /// other's `.intersect(...)` / `.make_ge(...)` mutations
-    /// (`Rc::ptr_eq` ≡ `is`).
-    pub fn peek_intbound_handle(&self, op: &crate::r#box::BoxRef) -> Option<IntBoundHandle> {
-        // optimizer.py:100 `assert op.type == 'i'`. Void admitted as the
-        // pyre placeholder-box tolerance noted in `setintbound`'s comment
-        // (convergence path: D-3 box_pool retirement).
-        assert!(
-            matches!(op.type_(), majit_ir::Type::Int | majit_ir::Type::Void),
-            "peek_intbound_handle: expected 'i'-typed BoxRef, got {:?}",
-            op.type_()
-        );
-        let resolved = op.get_box_replacement(false);
-        // optimizer.py:107 `assert op.type == 'i'` — re-check post-walker.
-        assert!(
-            matches!(resolved.type_(), majit_ir::Type::Int | majit_ir::Type::Void),
-            "peek_intbound_handle: chain terminal lost 'i' type, got {:?}",
-            resolved.type_()
-        );
-        if let Some(Value::Int(v)) = resolved.const_value() {
-            return Some(IntBoundHandle::const_(
-                crate::optimizeopt::intutils::IntBound::from_constant(v as i64),
-            ));
-        }
-        resolved.int_bound_handle().map(IntBoundHandle::live)
-    }
-
     /// info.py: getptrinfo(op) — mutable variant. Walks the chain on `op`
     /// and runs the closure against the terminal BoxRef's `_forwarded`
     /// PtrInfo via `ptr_info_mut()`. The BoxRef slot is the authoritative

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7806,7 +7806,7 @@ mod boxref_forwarding_tests {
     fn h3_1_set_ptr_info_mirrors_box_info() {
         // PtrInfo applies to ref-typed boxes.
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let b = BoxRef::new_inputarg(Type::Ref, 0);
+        let (b, _ia) = bound_inputarg_box(Type::Ref, 0);
         ctx.box_pool = vec![b.clone()].into();
         let info = PtrInfo::NonNull { last_guard_pos: -1 };
         ctx.set_ptr_info(&b, info);
@@ -7825,7 +7825,7 @@ mod boxref_forwarding_tests {
     fn audit_a_make_nonnull_preserves_box_constant_slot() {
         use majit_ir::GcRef;
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let b = BoxRef::new_inputarg(Type::Ref, 0);
+        let (b, _ia) = bound_inputarg_box(Type::Ref, 0);
         ctx.box_pool = vec![b.clone()].into();
         let opref = OpRef::input_arg_typed(0, Type::Ref);
         ctx.make_constant(opref, Value::Ref(GcRef(0xdead_beef)));
@@ -7863,8 +7863,8 @@ mod boxref_forwarding_tests {
     #[test]
     fn audit_a_chain_walker_reaches_constant_through_forwarded_box() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
-        let b0 = BoxRef::new_inputarg(Type::Int, 0);
-        let b1 = BoxRef::new_inputarg(Type::Int, 1);
+        let (b0, _ia0) = bound_inputarg_box(Type::Int, 0);
+        let (b1, _ia1) = bound_inputarg_box(Type::Int, 1);
         ctx.box_pool = vec![b0, b1.clone()].into();
         // (a) Const-namespace OpRef terminates at a Const box.
         let const_opref = OpRef::const_int(0);
@@ -7884,7 +7884,7 @@ mod boxref_forwarding_tests {
         ctx.const_pool.insert(1, Value::Int(42));
         assert!(b1.get_box_replacement(false).is_constant());
         // Negative case: BoxRef with no constant forwarding.
-        let nb = BoxRef::new_inputarg(Type::Int, 0);
+        let (nb, _ia_nb) = bound_inputarg_box(Type::Int, 0);
         assert!(!nb.get_box_replacement(false).is_constant());
     }
 
@@ -8245,8 +8245,11 @@ mod boxref_forwarding_tests {
 
     fn ctx_with_one_ref_box() -> (OptContext, BoxRef) {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let b = BoxRef::new_inputarg(Type::Ref, 0);
+        let (b, ia) = bound_inputarg_box(Type::Ref, 0);
         ctx.box_pool = vec![b.clone()].into();
+        // Keep the InputArgRc alive in ctx so the Weak<InputArg> in
+        // `b.inputarg_handle` upgrades across the test body.
+        ctx.inputarg_refs = vec![ia];
         (ctx, b)
     }
 
@@ -8491,11 +8494,10 @@ mod boxref_forwarding_tests {
     /// `_forwarded` cell carrying the ConstPtrInfo-equivalent payload.
     #[test]
     fn ptr_info_handle_const_and_live_constant_use_constptr_same_info() {
-        use crate::r#box::BoxRef;
         use crate::optimizeopt::info::OpInfo;
         use majit_ir::{GcRef, Type};
 
-        let b = BoxRef::new_resop(Type::Ref, 0);
+        let (b, _op) = bound_resop_box(Type::Ref, 0);
         b.set_forwarded_info(OpInfo::ptr(PtrInfo::Constant(GcRef(0x1000))));
         let live = PtrInfoHandle::Live(
             b.ptr_info_handle()
@@ -8515,11 +8517,10 @@ mod boxref_forwarding_tests {
     /// holds and mutation through one handle propagates to the other.
     #[test]
     fn int_bound_handle_live_identity_propagates_mutation() {
-        use crate::r#box::BoxRef;
         use majit_ir::Type;
 
         let mut ctx = OptContext::with_num_inputs(0, 0);
-        let b = BoxRef::new_resop(Type::Int, 0);
+        let (b, _op) = bound_resop_box(Type::Int, 0);
         let h1 = ctx.getintbound_handle(&b);
         let h2 = ctx.getintbound_handle(&b);
         assert!(
@@ -8763,8 +8764,9 @@ mod boxref_forwarding_tests {
     #[test]
     fn clear_forwarded_drops_int_bound() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
-        let old_box = BoxRef::new_inputarg(Type::Int, 0);
+        let (old_box, ia) = bound_inputarg_box(Type::Int, 0);
         ctx.box_pool = vec![old_box.clone()].into();
+        ctx.inputarg_refs = vec![ia];
         ctx.setintbound(
             &old_box,
             &crate::optimizeopt::intutils::IntBound::unbounded(),

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1892,13 +1892,23 @@ impl OptContext {
         if let Some(op) = self.find_producer_op(opref) {
             return Some(crate::r#box::BoxRef::from_bound_op(&op));
         }
+        // Match `ensure_box`'s resolution order exactly so the write host
+        // (a `set_forwarded_*` through `ensure_box`'s BoxRef) and the read
+        // host (this resolver, behind `get_box_replacement_box`) coincide:
+        // consult the authoritative `box_pool` slot before the
+        // `inputarg_refs` mirror. `ensure_box` returns the `box_pool` slot
+        // for an existing entry and only falls to `inputarg_refs` when it
+        // must lazy-allocate; without this ordering an InputArg whose
+        // `box_pool` slot is bound to a different `InputArgRc` than
+        // `inputarg_refs[idx]` would read its forwarded state from the wrong
+        // host. Both are transitional and retire with `BoxPool` in S-9.
         let idx = opref.raw() as usize;
-        if let Some(ia) = self.inputarg_refs.get(idx) {
-            return Some(crate::r#box::BoxRef::from_bound_inputarg(ia));
+        if let Some(b) = self.box_pool.get(opref) {
+            return Some(b.clone());
         }
-        // Transitional `BoxPool` fallback — see doc above. Retired
-        // alongside `BoxPool` in S-9.
-        self.box_pool.get(opref).cloned()
+        self.inputarg_refs
+            .get(idx)
+            .map(crate::r#box::BoxRef::from_bound_inputarg)
     }
 
     /// S-8.A: write `Forwarded::None` to the canonical host for
@@ -4142,6 +4152,20 @@ impl OptContext {
                 )
             });
             return Some(crate::r#box::BoxRef::new_const_with_index(value, ci));
+        }
+        // S-8.A.4: align the write-path host with `resolve_to_boxref`
+        // (the read path behind `get_box_replacement_box`). For ResOp
+        // variants, resolve to the producing `Op`'s canonical `_forwarded`
+        // host first. `find_producer_op` distinguishes the ResOp namespace
+        // from the InputArg namespace by full `OpRef` (`op.pos == opref`),
+        // so a `Box.value`-style position-collapse — where this raw slot
+        // also holds an InputArg box (`box_pool[idx]`) — no longer routes a
+        // ResOp write to `inputarg_refs[idx].forwarded` while the matching
+        // read routes to `op.forwarded`. Returns `None` for InputArg / input
+        // positions (no producing op), falling through to the InputArg /
+        // box_pool / lazy-alloc paths below unchanged.
+        if let Some(op_rc) = self.find_producer_op(opref) {
+            return Some(crate::r#box::BoxRef::from_bound_op(&op_rc));
         }
         // Existing entries keep their construction-time shape (the recorder
         // / `with_inputarg_types` plant authoritative BoxRefs upstream);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6297,10 +6297,6 @@ impl OptContext {
                  (info.py:876), got {:?}",
                 std::mem::discriminant(other),
             ),
-            Forwarded::VectorInfo(_) => panic!(
-                "getrawptrinfo: forwarded must be IntBound or AbstractRawPtrInfo \
-                 (info.py:876), got VectorizationInfo",
-            ),
             // Terminal of `get_box_replacement(false)` can only be `None`
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
@@ -6391,9 +6387,6 @@ impl OptContext {
                 "getptrinfo: forwarded must be PtrInfo (info.py:892), got {:?}",
                 std::mem::discriminant(other),
             ),
-            Forwarded::VectorInfo(_) => {
-                panic!("getptrinfo: forwarded must be PtrInfo (info.py:892), got VectorizationInfo",)
-            }
             // Terminal of `get_box_replacement(false)` can only be `None`
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
@@ -6766,10 +6759,8 @@ impl OptContext {
                     Forwarded::Info(OpInfo::IntBound(rc)) => return rc.borrow().getnullness(),
                     // optimizer.py:108-109: rare case (fw is RawBufferPtrInfo).
                     // optimizer.py:104-109 reads anything that is not an
-                    // IntBound through the same "return unbounded" path,
-                    // including a stray VectorizationInfo that survived
-                    // the vector pass teardown.
-                    Forwarded::Info(_) | Forwarded::VectorInfo(_) => {
+                    // IntBound through the same "return unbounded" path.
+                    Forwarded::Info(_) => {
                         return crate::optimizeopt::intutils::IntBound::unbounded().getnullness();
                     }
                     Forwarded::Box(_)

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1773,6 +1773,49 @@ impl OptContext {
         }
     }
 
+    /// S-1: bind every input op's resop `BoxRef` in `box_pool` to a
+    /// fresh `OpRc` of the input op so any `Forwarded::Op(_)` chain
+    /// step targeting the slot has an upgradable `Weak<Op>` from the
+    /// start of the optimization run. `TraceIterator::next()`
+    /// (opencoder.rs:500) plants unbound `BoxRef::new_resop` slots for
+    /// every visited op; absent this pre-pass, `getintbound_box` →
+    /// `get_box_replacement_box` (a `&self` reader) can land on the
+    /// unbound terminal and a subsequent `set_forwarded_info` write
+    /// trips `BoxRef::write_forwarded`'s bound-precondition assert.
+    ///
+    /// The bound `OpRc` is stashed in `resop_refs[pos]` so `emit()`'s
+    /// `bound_is_synthetic` check (`mod.rs::emit` rebind path) later
+    /// upgrades the binding to the emitted post-pass producer `OpRc`
+    /// via `bind_op`'s carry-over (forwarded state preserved).
+    ///
+    /// Inherited Phase 1 slots (already bound by Phase 1's end-of-pass
+    /// orphan binding at `optimizer.rs:2431-2460`) skip — the
+    /// `bound_op().is_some()` guard preserves their phase-1 identity.
+    pub(crate) fn bind_input_resops(&mut self, ops: &[Op]) {
+        if self.box_pool.is_empty() {
+            return;
+        }
+        for op in ops {
+            let pos = op.pos.get();
+            if pos.is_none() || pos.is_constant() {
+                continue;
+            }
+            let Some(b) = self.box_pool.get(pos) else {
+                continue;
+            };
+            if !b.is_resop() || b.bound_op().is_some() {
+                continue;
+            }
+            let op_rc = std::rc::Rc::new(op.clone());
+            b.bind_op(&op_rc);
+            let idx = pos.raw() as usize;
+            if idx >= self.resop_refs.len() {
+                self.resop_refs.resize_with(idx + 1, || None);
+            }
+            self.resop_refs[idx] = Some(op_rc);
+        }
+    }
+
     /// Construct an `OptContext` whose inputarg / fresh-OpRef numbering is
     /// shifted to start above a parent trace's high water mark.
     ///

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1864,6 +1864,47 @@ impl OptContext {
         }
     }
 
+    /// S-8.A: resolve `opref` to a `BoxRef` bound to its canonical
+    /// `_forwarded` host (`Op` / `InputArg`). Materialises a fresh
+    /// `BoxRef::from_bound_op` / `from_bound_inputarg` per call; the
+    /// bound handle ensures every `set_forwarded_*` / `get_forwarded`
+    /// routes through the same `Op.forwarded` / `InputArg.forwarded`
+    /// slot, so two calls for the same `opref` observe each other's
+    /// writes via the canonical host even though the `BoxRef` wrapper
+    /// identities differ (the wrapper carries no state post-S-0.C).
+    /// Const variants return `BoxRef::new_const_with_index`. Returns
+    /// `None` for sentinel `OpRef::none()` and for ResOp positions
+    /// without a producer in any canonical store.
+    ///
+    /// Transitional fallback: synthetic test fixtures (`ctx.box_pool =
+    /// vec![...]`) bypass the production canonical-store population
+    /// path. While `BoxPool` survives (until S-9), consult it after
+    /// the canonical stores so those fixtures continue resolving to
+    /// the same bound `BoxRef`. Production paths populate `inputarg_refs`
+    /// via S-1's `bind_input_resops` plus emit-time `bind_op`, so the
+    /// fallback is dead outside synthetic fixtures and disappears with
+    /// `BoxPool` in S-9.
+    pub(crate) fn resolve_to_boxref(&self, opref: OpRef) -> Option<crate::r#box::BoxRef> {
+        if opref.is_none() {
+            return None;
+        }
+        if opref.is_constant() {
+            let ci = opref.const_index();
+            let value = self.const_pool.get(&ci).copied()?;
+            return Some(crate::r#box::BoxRef::new_const_with_index(value, ci));
+        }
+        if let Some(op) = self.find_producer_op(opref) {
+            return Some(crate::r#box::BoxRef::from_bound_op(&op));
+        }
+        let idx = opref.raw() as usize;
+        if let Some(ia) = self.inputarg_refs.get(idx) {
+            return Some(crate::r#box::BoxRef::from_bound_inputarg(ia));
+        }
+        // Transitional `BoxPool` fallback — see doc above. Retired
+        // alongside `BoxPool` in S-9.
+        self.box_pool.get(opref).cloned()
+    }
+
     /// S-8.A: write `Forwarded::None` to the canonical host for
     /// `opref` (`resoperation.py:240` `set_forwarded(None)` /
     /// `:50` clear semantics). No-op for sentinel `OpRef::none()`,
@@ -3962,7 +4003,7 @@ impl OptContext {
         if opref.is_constant() || opref.is_none() {
             return opref;
         }
-        let Some(start) = self.box_pool.get(opref).cloned() else {
+        let Some(start) = self.resolve_to_boxref(opref) else {
             return opref;
         };
         // resoperation.py:57-68: walk box._forwarded on the box itself.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1980,6 +1980,15 @@ impl Optimizer {
         // per-iter pool with fresh unbound `BoxRef::new_inputarg(tp, _)`;
         // the TreeLoop-owned strong `InputArgRc`s never reach it.
         ctx.ensure_inputarg_bindings();
+        // S-1: bind every input op's resop BoxRef so chain-walker
+        // terminals are guaranteed bound before any `&self` reader
+        // (e.g. `OptIntBounds::getintbound_box`) reaches a
+        // `set_forwarded_*` write. `TraceIterator::next()`
+        // (opencoder.rs:500) plants unbound resop slots; without this
+        // pre-pass, `get_box_replacement_box(&self)` could return an
+        // unbound terminal that fails `write_forwarded`'s bound-
+        // precondition assert.
+        ctx.bind_input_resops(ops);
         // Phase 1 emit ops: single source of truth for cross-phase OpRef →
         // `op.type_` lookup (history.py:220 parity).
         ctx.phase1_emit_ops = std::mem::take(&mut self.phase1_emit_ops);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2881,7 +2881,8 @@ impl Optimizer {
             .map(|op| !Self::is_constant_placeholder_op(op, &ctx))
             .collect();
         let mut keep_iter = keep.into_iter();
-        ctx.new_operations.retain(|_| keep_iter.next().unwrap_or(true));
+        ctx.new_operations
+            .retain(|_| keep_iter.next().unwrap_or(true));
 
         // Drain remaining extra ops.
         self.drain_extra_operations_from(0, &mut ctx);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -335,17 +335,17 @@ pub enum ImportedVirtualKind {
 }
 
 impl Optimizer {
-    fn is_constant_placeholder_op(op: &Op, box_pool: &crate::r#box::BoxPool) -> bool {
+    fn is_constant_placeholder_op(op: &Op, ctx: &OptContext) -> bool {
         if !matches!(
             op.opcode,
             OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF
         ) {
             return false;
         }
-        let Some(b) = box_pool.get(op.pos.get()) else {
+        let Some(forwarded) = ctx.read_forwarded(op.pos.get()) else {
             return false;
         };
-        if !matches!(b.get_forwarded(), crate::r#box::Forwarded::Const(_, _)) {
+        if !matches!(forwarded, crate::r#box::Forwarded::Const(_, _)) {
             return false;
         }
         op.num_args() == 0 || op.getarglist().iter().all(|arg| arg.is_none())
@@ -2872,8 +2872,16 @@ impl Optimizer {
         // the final trace. Drop constant-only SameAs placeholders before the
         // backend sees the trace; their OpRefs remain available through the
         // constants table.
-        ctx.new_operations
-            .retain(|op| !Self::is_constant_placeholder_op(op, &ctx.box_pool));
+        // Manual filter (instead of `.retain`) because the predicate
+        // borrows `ctx` while `ctx.new_operations` would be borrowed
+        // mutably by `retain`.
+        let keep: Vec<bool> = ctx
+            .new_operations
+            .iter()
+            .map(|op| !Self::is_constant_placeholder_op(op, &ctx))
+            .collect();
+        let mut keep_iter = keep.into_iter();
+        ctx.new_operations.retain(|_| keep_iter.next().unwrap_or(true));
 
         // Drain remaining extra ops.
         self.drain_extra_operations_from(0, &mut ctx);

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -5,7 +5,6 @@
 
 use majit_ir::{Op, OpCode, OpRef, Type};
 
-use crate::r#box::BoxRef;
 use crate::optimizeopt::dependency::DependencyGraph;
 
 // ── vector.py:670-678: isomorphic ─────────────────────────────────────
@@ -790,17 +789,14 @@ pub struct VecScheduleState {
     pub accumulation: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, AccumEntry>,
     /// Next OpRef counter for newly created vector ops.
     next_pos: u32,
-    /// RPython `box._forwarded` storage used by the vectorizer for
-    /// `VectorizationInfo`. This is local to scheduling because upstream
-    /// clears the vectorization `_forwarded` state after the vector pass
-    /// (`vector.py:58-60`, `finaloplist`:88-90).
-    ///
-    /// Keyed by full `OpRef` (variant + payload) so the
-    /// `InputArg*` and `*Op` namespaces stay disjoint — PyPy uses Box
-    /// object identity (`AbstractValue` `is`), so e.g. an inputarg at
-    /// slot 0 and an op at position 0 cannot collide upstream and must
-    /// not collide here either.
-    box_pool: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, BoxRef>,
+    /// `schedule.py:20-28 forwarded_vecinfo(op)` cache. PyPy reads
+    /// `op._forwarded` as the `VectorizationInfo` carrier; pyre splits
+    /// the slot — `Op.vecinfo` is the per-op canonical (cleared by
+    /// `vector.py:58-60 teardown_vectorization`) and this cache holds
+    /// the schedule-local stamps for InputArg/transient OpRefs that
+    /// don't own an Op. Keyed by full `OpRef` so InputArg/op namespaces
+    /// don't collide.
+    vecinfo_cache: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::VectorizationInfo>,
 }
 
 impl VecScheduleState {
@@ -816,7 +812,7 @@ impl VecScheduleState {
             invariant_oplist: Vec::new(),
             accumulation: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             next_pos: start_pos,
-            box_pool: crate::optimizeopt::vec_assoc::VecAssoc::new(),
+            vecinfo_cache: crate::optimizeopt::vec_assoc::VecAssoc::new(),
         }
     }
 
@@ -837,9 +833,7 @@ impl VecScheduleState {
             } else {
                 self.vectorization_info_for_op(op)
             };
-            if let Some(b) = self.ensure_box_for_opref(op.pos.get()) {
-                b.set_forwarded_vector_info(info);
-            }
+            self.set_forwarded_vecinfo(op.pos.get(), info);
         }
     }
 
@@ -867,38 +861,18 @@ impl VecScheduleState {
         self.vectorization_info_for_op(op)
     }
 
-    fn ensure_box_for_opref(&mut self, opref: OpRef) -> Option<BoxRef> {
-        if opref.is_none() || opref.is_constant() {
-            return None;
-        }
-        if let Some(existing) = self.box_pool.get(&opref) {
-            return Some(existing.clone());
-        }
-        let tp = opref.ty().unwrap_or(Type::Void);
-        let raw = opref.raw();
-        let b = if matches!(
-            opref,
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
-        ) {
-            BoxRef::new_inputarg(tp, raw)
-        } else {
-            BoxRef::new_resop(tp, raw)
-        };
-        self.box_pool.insert(opref, b.clone());
-        Some(b)
-    }
-
     fn get_forwarded_vecinfo(&self, opref: OpRef) -> Option<majit_ir::VectorizationInfo> {
         if opref.is_none() || opref.is_constant() {
             return None;
         }
-        self.box_pool.get(&opref).and_then(|b| b.vector_info())
+        self.vecinfo_cache.get(&opref).cloned()
     }
 
     fn set_forwarded_vecinfo(&mut self, opref: OpRef, info: majit_ir::VectorizationInfo) {
-        if let Some(b) = self.ensure_box_for_opref(opref) {
-            b.set_forwarded_vector_info(info);
+        if opref.is_none() || opref.is_constant() {
+            return;
         }
+        self.vecinfo_cache.insert(opref, info);
     }
 
     /// schedule.py:20-28 `forwarded_vecinfo(op)`.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2948,11 +2948,14 @@ impl OptUnroll {
                         return rc;
                     }
                 }
-                if let Some(b) = ctx.box_pool.get(*ia_opref) {
-                    if let Some(ia_rc) = b.bound_inputarg() {
-                        return ia_rc;
-                    }
-                }
+                // S-0.C: `box_pool[*ia_opref].bound_inputarg()` resolves
+                // to the same `InputArgRc` as `inputarg_refs[idx]` after
+                // `ensure_inputarg_bindings` / `ensure_box`'s InputArg
+                // placeholder arm have run (both write the canonical
+                // `InputArgRc` matching the OpRef's type). Drop the
+                // box_pool fallback — fall through to a fresh `InputArg`
+                // allocation, matching the original last-resort behaviour
+                // for the type-mismatch edge case.
                 std::rc::Rc::new(majit_ir::InputArg::from_type(want_ty, idx as u32))
             })
             .collect();

--- a/majit/majit-translate/src/front/ast.rs
+++ b/majit/majit-translate/src/front/ast.rs
@@ -1384,6 +1384,7 @@ fn build_graphs_from_items(
     options: &AstGraphOptions,
     struct_fields: &StructFieldRegistry,
     fn_return_types: &HashMap<String, String>,
+    method_suffix_index: &MethodSuffixIndex,
     use_imports: &HashMap<String, String>,
     // Program-wide `pub const` / `pub static` table aggregated by the
     // caller (`build_semantic_program_*_with_options`).  Empty for
@@ -1412,6 +1413,7 @@ fn build_graphs_from_items(
                         None,
                         struct_fields,
                         fn_return_types,
+                        method_suffix_index,
                         prefix,
                         source_module,
                         use_imports,
@@ -1456,6 +1458,7 @@ fn build_graphs_from_items(
                                 self_ty_root.clone(),
                                 struct_fields,
                                 fn_return_types,
+                                method_suffix_index,
                                 prefix,
                                 source_module,
                                 use_imports,
@@ -1482,6 +1485,7 @@ fn build_graphs_from_items(
                         options,
                         struct_fields,
                         fn_return_types,
+                        method_suffix_index,
                         use_imports,
                         module_statics,
                         known_struct_names,
@@ -1536,6 +1540,7 @@ pub fn build_semantic_program_with_options(
         module_statics.insert((module, name.clone()), decl.clone());
     }
     let start_len = functions.len();
+    let method_suffix_index = MethodSuffixIndex::from_fn_return_types(&fn_return_types);
     build_graphs_from_items(
         &parsed.file.items,
         "",
@@ -1543,6 +1548,7 @@ pub fn build_semantic_program_with_options(
         options,
         &struct_fields,
         &fn_return_types,
+        &method_suffix_index,
         &parsed.use_imports,
         &module_statics,
         &known_struct_names,
@@ -1624,6 +1630,7 @@ pub fn build_semantic_program_from_parsed_files_with_options(
     // Pass 2: build function graphs with merged struct_fields + fn_return_types visible.
     // Field types already module-qualified at source (qualified_full_type_string).
     let mut functions = Vec::new();
+    let method_suffix_index = MethodSuffixIndex::from_fn_return_types(&fn_return_types);
     for parsed in parsed_files {
         let functions_before = functions.len();
         build_graphs_from_items(
@@ -1633,6 +1640,7 @@ pub fn build_semantic_program_from_parsed_files_with_options(
             options,
             &struct_fields,
             &fn_return_types,
+            &method_suffix_index,
             &parsed.use_imports,
             &module_statics,
             &known_struct_names,
@@ -1709,11 +1717,13 @@ pub fn lower_expr_into_graph_with_signature(
     let mut block = graph.startblock;
     let empty_registry = StructFieldRegistry::default();
     let empty_fn_ret = HashMap::new();
+    let empty_suffix_index = MethodSuffixIndex::default();
     let empty_names = std::collections::HashSet::new();
     let empty_trait_names = std::collections::HashSet::new();
     let mut ctx = GraphBuildContext::new(
         &empty_registry,
         &empty_fn_ret,
+        &empty_suffix_index,
         "",
         HashMap::new(),
         &empty_names,
@@ -1780,6 +1790,7 @@ pub fn lower_expr_into_graph_with_signature(
 pub fn build_function_graph_pub(func: &ItemFn) -> Result<SemanticFunction, FlowingError> {
     let empty_registry = StructFieldRegistry::default();
     let empty_fn_ret = HashMap::new();
+    let empty_suffix_index = MethodSuffixIndex::default();
     let empty_names = std::collections::HashSet::new();
     let empty_trait_names = std::collections::HashSet::new();
     let empty_use_imports = HashMap::new();
@@ -1790,6 +1801,7 @@ pub fn build_function_graph_pub(func: &ItemFn) -> Result<SemanticFunction, Flowi
         None,
         &empty_registry,
         &empty_fn_ret,
+        &empty_suffix_index,
         "",
         "",
         &empty_use_imports,
@@ -1810,12 +1822,14 @@ pub fn build_function_graph_with_self_ty_pub(
     known_trait_names: &std::collections::HashSet<String>,
 ) -> Result<SemanticFunction, FlowingError> {
     let empty_module_statics = HashMap::new();
+    let method_suffix_index = MethodSuffixIndex::from_fn_return_types(fn_return_types);
     build_function_graph(
         func,
         &AstGraphOptions::default(),
         self_ty_root,
         struct_fields,
         fn_return_types,
+        &method_suffix_index,
         module_prefix,
         "",
         use_imports,
@@ -1842,6 +1856,66 @@ pub fn collect_jit_hints_pub(attrs: &[syn::Attribute]) -> Vec<String> {
 /// slots in the spec's `(...)` pattern to `Index(n)` placeholders.
 pub fn collect_jit_hints_with_sig(attrs: &[syn::Attribute], sig: &syn::Signature) -> Vec<String> {
     collect_jit_hints(attrs, Some(sig))
+}
+
+/// Resolution of a `(receiver_leaf, method)` suffix against the
+/// `fn_return_types` keys: either the single unique key carrying that
+/// suffix or `Ambiguous` when two distinct keys share it.
+#[derive(Debug, Clone)]
+enum SuffixMatch {
+    Unique(String),
+    Ambiguous,
+}
+
+/// Compile-time resolver for `lookup_method_return_type`'s leaf-suffix
+/// fallback. Maps `(receiver_leaf, method)` to the unique `fn_return_types`
+/// key with that suffix (or `Ambiguous`). Built once per whole-program
+/// build from the frozen `fn_return_types` map and borrowed into every
+/// per-function `GraphBuildContext`, so the fallback is an O(1) lookup
+/// instead of a linear scan over every registered return type. pyre-only
+/// resolution aid — RPython carries the callee's `concretetype` on the
+/// annotated op, so there is no name-suffix resolution upstream.
+#[derive(Debug, Clone, Default)]
+struct MethodSuffixIndex {
+    by_suffix: HashMap<(String, String), SuffixMatch>,
+}
+
+impl MethodSuffixIndex {
+    fn from_fn_return_types(map: &HashMap<String, String>) -> Self {
+        let mut by_suffix: HashMap<(String, String), SuffixMatch> = HashMap::new();
+        for key in map.keys() {
+            let Some((owner, method)) = key.rsplit_once("::") else {
+                continue;
+            };
+            let leaf = owner.rsplit("::").next().unwrap_or(owner);
+            match by_suffix.entry((leaf.to_string(), method.to_string())) {
+                std::collections::hash_map::Entry::Vacant(v) => {
+                    v.insert(SuffixMatch::Unique(key.clone()));
+                }
+                std::collections::hash_map::Entry::Occupied(mut o) => {
+                    if let SuffixMatch::Unique(existing) = o.get()
+                        && existing != key
+                    {
+                        o.insert(SuffixMatch::Ambiguous);
+                    }
+                }
+            }
+        }
+        Self { by_suffix }
+    }
+
+    /// The unique `fn_return_types` key whose last two segments are
+    /// `(receiver_leaf, method)`, or `None` when no key or more than one
+    /// key carries that suffix.
+    fn unique_key(&self, receiver_leaf: &str, method: &str) -> Option<&str> {
+        match self
+            .by_suffix
+            .get(&(receiver_leaf.to_string(), method.to_string()))?
+        {
+            SuffixMatch::Unique(key) => Some(key.as_str()),
+            SuffixMatch::Ambiguous => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1890,6 +1964,11 @@ struct GraphBuildContext<'a> {
     /// Maps function name (or "Type::method") → return type string.
     /// Used by array_type_id_from_expr to resolve Call/MethodCall expressions.
     fn_return_types: &'a HashMap<String, String>,
+    /// O(1) leaf-suffix resolver over `fn_return_types`, built once per
+    /// whole-program build and shared across every per-function context.
+    /// Consulted by `lookup_method_return_type` when the exact
+    /// `receiver::method` key misses.
+    method_suffix_index: &'a MethodSuffixIndex,
     /// Module path prefix for qualifying bare type names.
     /// RPython: lltype identity is globally unique — bare "Foo" in mod "a"
     /// must resolve to "a::Foo" in struct_fields lookups.
@@ -2524,6 +2603,7 @@ impl<'a> GraphBuildContext<'a> {
     fn new(
         struct_fields: &'a StructFieldRegistry,
         fn_return_types: &'a HashMap<String, String>,
+        method_suffix_index: &'a MethodSuffixIndex,
         module_prefix: &str,
         use_imports: HashMap<String, String>,
         known_struct_names: &'a std::collections::HashSet<String>,
@@ -2541,6 +2621,7 @@ impl<'a> GraphBuildContext<'a> {
             local_closure_returns: HashMap::new(),
             struct_fields,
             fn_return_types,
+            method_suffix_index,
             module_prefix: module_prefix.to_string(),
             source_module: String::new(),
             use_imports,
@@ -3773,6 +3854,7 @@ fn build_function_graph(
     self_ty_root: Option<String>,
     struct_fields: &StructFieldRegistry,
     fn_return_types: &HashMap<String, String>,
+    method_suffix_index: &MethodSuffixIndex,
     module_prefix: &str,
     source_module: &str,
     use_imports: &HashMap<String, String>,
@@ -3793,6 +3875,7 @@ fn build_function_graph(
     let mut ctx = GraphBuildContext::new(
         struct_fields,
         fn_return_types,
+        method_suffix_index,
         module_prefix,
         use_imports.clone(),
         known_struct_names,
@@ -4163,11 +4246,13 @@ pub fn lower_stmt_pub(
     let mut block = block;
     let empty_registry = StructFieldRegistry::default();
     let empty_fn_ret = HashMap::new();
+    let empty_suffix_index = MethodSuffixIndex::default();
     let empty_names = std::collections::HashSet::new();
     let empty_trait_names = std::collections::HashSet::new();
     let mut ctx = GraphBuildContext::new(
         &empty_registry,
         &empty_fn_ret,
+        &empty_suffix_index,
         "",
         HashMap::new(),
         &empty_names,
@@ -9638,26 +9723,14 @@ fn lookup_method_return_type<'a>(
         return Some(ret);
     }
 
-    let method_name = method.to_string();
-    let receiver_leaf = receiver_root.rsplit("::").next().unwrap_or(receiver_root);
     // Rust imports can make the call-site owner path shorter or longer
     // than the impl key. Use the leaf owner only when it is unambiguous.
-    let mut matches = ctx.fn_return_types.iter().filter_map(|(key, ret)| {
-        let (owner, candidate_method) = key.rsplit_once("::")?;
-        if candidate_method == method_name.as_str()
-            && owner.rsplit("::").next().unwrap_or(owner) == receiver_leaf
-        {
-            Some(ret)
-        } else {
-            None
-        }
-    });
-    let first = matches.next()?;
-    if matches.next().is_none() {
-        Some(first)
-    } else {
-        None
-    }
+    let method_name = method.to_string();
+    let receiver_leaf = receiver_root.rsplit("::").next().unwrap_or(receiver_root);
+    let key = ctx
+        .method_suffix_index
+        .unique_key(receiver_leaf, &method_name)?;
+    ctx.fn_return_types.get(key)
 }
 
 /// Extract the trait root from a type-string when the type is a trait
@@ -14094,11 +14167,13 @@ mod tests {
 
         let empty_registry = StructFieldRegistry::default();
         let empty_fn_ret = HashMap::new();
+        let empty_suffix_index = MethodSuffixIndex::default();
         let empty_names = std::collections::HashSet::new();
         let empty_trait_names = std::collections::HashSet::new();
         let mut ctx = GraphBuildContext::new(
             &empty_registry,
             &empty_fn_ret,
+            &empty_suffix_index,
             "",
             HashMap::new(),
             &empty_names,
@@ -15211,9 +15286,12 @@ mod tests {
         known_struct_names: &'a std::collections::HashSet<String>,
         known_trait_names: &'a std::collections::HashSet<String>,
     ) -> GraphBuildContext<'a> {
+        static EMPTY_SUFFIX_INDEX: std::sync::OnceLock<MethodSuffixIndex> =
+            std::sync::OnceLock::new();
         GraphBuildContext::new(
             struct_fields,
             fn_return_types,
+            EMPTY_SUFFIX_INDEX.get_or_init(MethodSuffixIndex::default),
             "",
             HashMap::new(),
             known_struct_names,

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -469,10 +469,28 @@ pub struct JitDriverStaticData {
 /// Instead, callee graphs are collected from parsed Rust source files
 /// (free functions via `collect_function_graphs` and trait impl methods
 /// via `extract_trait_impls`).
+/// Resolution of a `(receiver, method)` last-two-segment suffix against the
+/// registered `function_graphs` keys: either a single unique key or an
+/// ambiguous suffix shared by more than one key.
+enum SuffixMatch {
+    Unique(CallPath),
+    Ambiguous,
+}
+
 pub struct CallControl {
     /// Free function graphs: CallPath → FunctionGraph.
     /// RPython: `funcptr._obj.graph` linkage.
     function_graphs: HashMap<CallPath, FunctionGraph>,
+
+    /// O(1) index over `function_graphs` keyed by their last two segments
+    /// `(receiver, method)`, mirroring the suffix-match in `target_to_path`'s
+    /// `self.method()` fallback. Maintained incrementally on registration so
+    /// the fallback is a single lookup instead of a linear scan over every
+    /// registered graph (the analysis runs that fallback tens of thousands of
+    /// times during effect inference). pyre-only resolution aid — RPython
+    /// carries the callee graph pointer on the call op, so there is no
+    /// suffix-scan upstream.
+    method_suffix_index: HashMap<(String, String), SuffixMatch>,
 
     /// Per-graph hint set, mirroring RPython `func._jit_*_` / `_elidable_function_`.
     /// Populated by `register_function_graph_with_hints` and
@@ -1030,6 +1048,7 @@ impl CallControl {
     pub fn new() -> Self {
         Self {
             function_graphs: HashMap::new(),
+            method_suffix_index: HashMap::new(),
             function_hints: HashMap::new(),
             trait_method_impls: HashMap::new(),
             candidate_graphs: HashSet::new(),
@@ -1797,9 +1816,34 @@ impl CallControl {
         Some(descr as majit_ir::descr::DescrRef)
     }
 
+    /// Maintain [`Self::method_suffix_index`] for a newly registered key.
+    /// Records the last two segments `(receiver, method)`; a second distinct
+    /// key with the same suffix marks the suffix `Ambiguous` (so the
+    /// `target_to_path` fallback declines to guess, matching the old scan).
+    fn index_method_suffix(&mut self, path: &CallPath) {
+        let segs = &path.segments;
+        if segs.len() < 2 {
+            return;
+        }
+        let key = (segs[segs.len() - 2].clone(), segs[segs.len() - 1].clone());
+        match self.method_suffix_index.entry(key) {
+            std::collections::hash_map::Entry::Vacant(v) => {
+                v.insert(SuffixMatch::Unique(path.clone()));
+            }
+            std::collections::hash_map::Entry::Occupied(mut o) => {
+                if let SuffixMatch::Unique(existing) = o.get() {
+                    if existing != path {
+                        o.insert(SuffixMatch::Ambiguous);
+                    }
+                }
+            }
+        }
+    }
+
     /// Register a free function graph.
     /// RPython: graphs are discovered via funcptr linkage.
     pub fn register_function_graph(&mut self, path: CallPath, graph: FunctionGraph) {
+        self.index_method_suffix(&path);
         self.function_graphs.insert(path, graph);
     }
 
@@ -1813,6 +1857,7 @@ impl CallControl {
         graph: FunctionGraph,
         hints: Vec<String>,
     ) {
+        self.index_method_suffix(&path);
         self.function_graphs.insert(path.clone(), graph);
         if !hints.is_empty() {
             self.function_hints.insert(path, hints);
@@ -1952,7 +1997,10 @@ impl CallControl {
         // `for_impl_method` so PyFrame's `push_value` and MIFrame's
         // `push_value` stay separate.
         let qualified_path = CallPath::for_impl_method(impl_type, method_name);
-        self.function_graphs.entry(qualified_path).or_insert(graph);
+        if !self.function_graphs.contains_key(&qualified_path) {
+            self.index_method_suffix(&qualified_path);
+            self.function_graphs.insert(qualified_path, graph);
+        }
     }
 
     /// Mark a target as the portal entry point.
@@ -3052,32 +3100,19 @@ impl CallControl {
                     // emission whenever the BFS would have inlined the
                     // method body otherwise.
                     //
-                    // Scan `function_graphs` for keys whose last 2 segments
-                    // match `[receiver, name]`.  Accept the match only if it
-                    // is unique: an ambiguous suffix (e.g. two crates both
-                    // exposing a `PyFrame::pop`) falls through to the trait
-                    // resolution path, which mirrors Rust's name-resolution
-                    // ambiguity error rather than silently picking one.
-                    let needle = (receiver, name.as_str());
-                    let mut matched: Option<&CallPath> = None;
-                    let mut multi = false;
-                    for key in self.function_graphs.keys() {
-                        let segs = &key.segments;
-                        if segs.len() >= 2
-                            && segs[segs.len() - 2] == needle.0
-                            && segs[segs.len() - 1] == needle.1
-                        {
-                            if matched.is_some() {
-                                multi = true;
-                                break;
-                            }
-                            matched = Some(key);
-                        }
-                    }
-                    if !multi {
-                        if let Some(path) = matched {
-                            return Some(path.clone());
-                        }
+                    // Look up `function_graphs` keys whose last 2 segments
+                    // match `[receiver, name]` via `method_suffix_index`.
+                    // Accept the match only if it is unique: an ambiguous
+                    // suffix (e.g. two crates both exposing a `PyFrame::pop`)
+                    // falls through to the trait resolution path, which mirrors
+                    // Rust's name-resolution ambiguity error rather than
+                    // silently picking one.
+                    match self
+                        .method_suffix_index
+                        .get(&(receiver.to_string(), name.to_string()))
+                    {
+                        Some(SuffixMatch::Unique(path)) => return Some(path.clone()),
+                        Some(SuffixMatch::Ambiguous) | None => {}
                     }
                 }
                 // Fall back to trait method resolution for polymorphic calls.

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -508,6 +508,18 @@ pub struct CallControl {
     /// they use `function_graphs` directly via `[impl_type, method_name]`.
     trait_method_impls: HashMap<(String, String), Vec<String>>,
 
+    /// O(1) index over `trait_method_impls` keyed by method name alone:
+    /// `method_name → [impl_type, …]` across every declaring trait.
+    /// Maintained incrementally in `register_trait_method` so
+    /// `impls_for_method_name` is a single lookup instead of a linear scan
+    /// over every `(trait_root, method_name)` entry (the effect analysis
+    /// runs that scan tens of thousands of times via `target_to_path`'s
+    /// trait-resolution fallback). Each entry mirrors the exact push order
+    /// into `trait_method_impls`, so the resolved multiset is identical.
+    /// pyre-only resolution aid — RPython keys candidate lookup on the
+    /// call op's exact candidate-graph list, not on a method-name global.
+    method_to_impl_types: HashMap<String, Vec<String>>,
+
     /// Candidate targets — graphs we will inline.
     /// RPython: `CallControl.candidate_graphs`.
     candidate_graphs: HashSet<CallPath>,
@@ -1051,6 +1063,7 @@ impl CallControl {
             method_suffix_index: HashMap::new(),
             function_hints: HashMap::new(),
             trait_method_impls: HashMap::new(),
+            method_to_impl_types: HashMap::new(),
             candidate_graphs: HashSet::new(),
             portal_targets: HashSet::new(),
             jitdrivers_sd: Vec::new(),
@@ -1989,6 +2002,10 @@ impl CallControl {
         if let Some(trait_root) = trait_root {
             self.trait_method_impls
                 .entry((trait_root.to_string(), method_name.to_string()))
+                .or_default()
+                .push(impl_type.to_string());
+            self.method_to_impl_types
+                .entry(method_name.to_string())
                 .or_default()
                 .push(impl_type.to_string());
         }
@@ -3396,10 +3413,10 @@ impl CallControl {
     /// lookup uses the exact `(trait_root, method_name)` key via
     /// `all_impls_for_indirect` instead.
     fn impls_for_method_name<'b>(&'b self, method_name: &str) -> Vec<&'b String> {
-        self.trait_method_impls
-            .iter()
-            .filter(|((_, m), _)| m == method_name)
-            .flat_map(|(_, impls)| impls.iter())
+        self.method_to_impl_types
+            .get(method_name)
+            .into_iter()
+            .flatten()
             .collect()
     }
 


### PR DESCRIPTION
Partially fix #47

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized forwarded-state handling to use canonical hosts, enforcing write-through-only semantics for forwarded writes.
  * Replaced per-item vectorization storage with a single schedule-local cache for vector info.
  * Improved producer-chain resolution and earlier binding of input/result slots for consistent optimization behavior.
* **Performance**
  * Faster and more deterministic method resolution and return-type lookups via precomputed suffix indices.
* **Tests**
  * Updated unit tests to match the new forwarding semantics and stricter write-through invariants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->