### PR TITLE
fix x86

### DIFF
--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -774,6 +774,10 @@ impl ModuleDictStrategy {
 /// callers, but the canonical surface going forward is the
 /// trait dispatch below.
 impl crate::dictstrategy::DictStrategy for ModuleDictStrategy {
+    fn strategy_kind(&self) -> crate::dictstrategy::StrategyKind {
+        crate::dictstrategy::StrategyKind::Module
+    }
+
     /// `celldict.py:46-49 get_empty_storage` — pyre owns the
     /// `ModuleDictStorage` directly (no `rerased` indirection); return
     /// the storage as an erased `*mut u8` so the trait surface stays

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -138,10 +138,7 @@ fn strategy_is(
     current: &'static dyn crate::dictstrategy::DictStrategy,
     expected: &'static dyn crate::dictstrategy::DictStrategy,
 ) -> bool {
-    std::ptr::eq(
-        current as *const _ as *const u8,
-        expected as *const _ as *const u8,
-    )
+    current.strategy_kind() == expected.strategy_kind()
 }
 
 #[inline]

--- a/pyre/pyre-object/src/dictstrategy.rs
+++ b/pyre/pyre-object/src/dictstrategy.rs
@@ -28,7 +28,30 @@ use crate::pyobject::PyObjectRef;
 /// has no `ObjSpace` shim, so callers that need str-wrapping
 /// (`getitem_str`'s default → `getitem(space.newtext(key))`) call
 /// `crate::w_str_new` directly.
+/// Identifies a concrete `DictStrategy` impl.  Used by
+/// `dictmultiobject::strategy_is` to discriminate strategies that share
+/// the same data pointer because each `*_DICT_STRATEGY` static is a
+/// unit-struct ZST (Rust collapses ZST static addresses, so
+/// pointer/`std::ptr::eq` checks cannot tell them apart reliably).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StrategyKind {
+    Empty,
+    EmptyKwargs,
+    Object,
+    Bytes,
+    Unicode,
+    Int,
+    Identity,
+    Kwargs,
+    Module,
+}
+
 pub trait DictStrategy {
+    /// Discriminate strategies by concrete impl — see [`StrategyKind`]
+    /// for the rationale.  Required because pointer comparison on the
+    /// `&'static dyn DictStrategy` slot is unreliable for ZST strategies.
+    fn strategy_kind(&self) -> StrategyKind;
+
     /// `dictmultiobject.py:466-467 get_empty_storage` — return a
     /// freshly-allocated erased storage for this strategy.  Required.
     fn get_empty_storage(&self) -> *mut u8;
@@ -547,6 +570,10 @@ impl EmptyKwargsDictStrategy {
 }
 
 impl DictStrategy for EmptyKwargsDictStrategy {
+    fn strategy_kind(&self) -> StrategyKind {
+        StrategyKind::EmptyKwargs
+    }
+
     /// `kwargsdict.py:13-14` inherits `EmptyDictStrategy.get_empty_storage`.
     fn get_empty_storage(&self) -> *mut u8 {
         EMPTY_DICT_STRATEGY.get_empty_storage()
@@ -630,6 +657,10 @@ impl DictStrategy for EmptyKwargsDictStrategy {
 }
 
 impl DictStrategy for EmptyDictStrategy {
+    fn strategy_kind(&self) -> StrategyKind {
+        StrategyKind::Empty
+    }
+
     fn get_empty_storage(&self) -> *mut u8 {
         // `erased(None)` — null is the only inhabitant of "empty
         // storage" before a switch installs a real backing.  Pyre's
@@ -791,6 +822,10 @@ impl DictStrategy for EmptyDictStrategy {
 pub struct ObjectDictStrategy;
 
 impl DictStrategy for ObjectDictStrategy {
+    fn strategy_kind(&self) -> StrategyKind {
+        StrategyKind::Object
+    }
+
     fn get_empty_storage(&self) -> *mut u8 {
         // `dictmultiobject.py:1209-1212`: erased `r_dict(dict_keys_equal,
         // hash_w)`.  Pyre's typed map is
@@ -941,6 +976,10 @@ impl DictStrategy for ObjectDictStrategy {
 pub struct BytesDictStrategy;
 
 impl DictStrategy for BytesDictStrategy {
+    fn strategy_kind(&self) -> StrategyKind {
+        StrategyKind::Bytes
+    }
+
     /// `dictmultiobject.py:1143-1150 AbstractTypedStrategy.switch_to_object_strategy`
     /// instantiation for BytesDictStrategy — `wrap = newbytes` (`:1234`).
     /// Walks the typed `IndexMap<Vec<u8>, _>`, rebuilds
@@ -1107,6 +1146,10 @@ impl DictStrategy for BytesDictStrategy {
 pub struct UnicodeDictStrategy;
 
 impl DictStrategy for UnicodeDictStrategy {
+    fn strategy_kind(&self) -> StrategyKind {
+        StrategyKind::Unicode
+    }
+
     fn get_empty_storage(&self) -> *mut u8 {
         // `dictmultiobject.py:1302-1304 create_empty_unicode_key_dict`
         // returns an empty `r_dict(unicode_eq, unicode_hash)`.  Pyre
@@ -1288,6 +1331,10 @@ impl IntDictStrategy {
 }
 
 impl DictStrategy for IntDictStrategy {
+    fn strategy_kind(&self) -> StrategyKind {
+        StrategyKind::Int
+    }
+
     /// `dictmultiobject.py:1143-1150 AbstractTypedStrategy.switch_to_object_strategy`:
     /// wraps each i64 key via `wrap = newint` (`:1342`), produces a
     /// fresh `IndexMap<ObjectKey, PyObjectRef>` and drops the old typed

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -113,6 +113,10 @@ impl IdentityDictStrategy {
 }
 
 impl DictStrategy for IdentityDictStrategy {
+    fn strategy_kind(&self) -> crate::dictstrategy::StrategyKind {
+        crate::dictstrategy::StrategyKind::Identity
+    }
+
     /// `dictmultiobject.py:1143-1150 AbstractTypedStrategy.switch_to_object_strategy`
     /// instantiation for IdentityDictStrategy — `wrap` is identity
     /// (`:26-27`), so the migration ports each `IdentityKey(obj)` into

--- a/pyre/pyre-object/src/kwargsdict.rs
+++ b/pyre/pyre-object/src/kwargsdict.rs
@@ -102,6 +102,10 @@ impl KwargsDictStrategy {
 }
 
 impl DictStrategy for KwargsDictStrategy {
+    fn strategy_kind(&self) -> crate::dictstrategy::StrategyKind {
+        crate::dictstrategy::StrategyKind::Kwargs
+    }
+
     /// `kwargsdict.py:30-32 get_empty_storage` — erased `([], [])`.
     fn get_empty_storage(&self) -> *mut u8 {
         let v: Box<(Vec<PyObjectRef>, Vec<PyObjectRef>)> = Box::new((Vec::new(), Vec::new()));


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dictionary strategy identification mechanism to use explicit strategy classification rather than pointer-based comparison, enabling more reliable strategy discrimination throughout the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->