### PR TITLE
cranelift: tail-call bridge dispatch, enable closing_jump on x86_64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,11 +94,11 @@ proc-macro2 = "1"
 smallvec = "1"
 
 # cranelift backend
-cranelift-codegen = "0.130"
-cranelift-frontend = "0.130"
-cranelift-jit = "0.130"
-cranelift-module = "0.130"
-cranelift-native = "0.130"
+cranelift-codegen = "0.132"
+cranelift-frontend = "0.132"
+cranelift-jit = "0.132"
+cranelift-module = "0.132"
+cranelift-native = "0.132"
 target-lexicon = "0.13"
 
 # dynasm backend

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -5771,18 +5771,26 @@ fn emit_attached_bridge_dispatch(
     // host-ABI wrapper (`code_ptr`, for host-loop dispatch), `.1` is the
     // bridge's `CallConv::Tail` body entry (`body_ptr`, for this in-code
     // tail-call).
-    let (bridge_code_cache_addr, bridge_body_cache_addr) = bridge_cache_addrs;
-    // "has bridge" gate reads the code_ptr cell, which `store_bridge_caches`
-    // publishes LAST (Release-ordered after body_ptr); a non-null code_ptr
-    // therefore guarantees the body_ptr cell is already visible.
-    let bridge_code_cache_ptr = builder
+    let (_bridge_code_cache_addr, bridge_body_cache_addr) = bridge_cache_addrs;
+    // Gate the dispatch on the same pointer we will tail-call through.
+    // `store_bridge_caches` releases `body_ptr` before `code_ptr`, and a
+    // non-null `code_ptr` was previously used as a readiness flag with a
+    // following plain-load of `body_ptr`.  On weakly-ordered targets
+    // (aarch64, where closing_jump is enabled by this PR) plain loads can
+    // be reordered, so a thread could observe `code_ptr != 0` while still
+    // seeing a stale `body_ptr == 0` and tail-call through `0`.  Using
+    // `atomic_load` on `body_ptr` synchronizes against the
+    // `store_bridge_caches` releases (resume_guard_descr.rs:701-706) and
+    // collapses readiness + target into a single atomic check.
+    let bridge_body_cache_ptr = builder
         .ins()
-        .iconst(ptr_type, bridge_code_cache_addr as i64);
-    let bridge_code = builder
-        .ins()
-        .load(ptr_type, MemFlags::trusted(), bridge_code_cache_ptr, 0);
+        .iconst(ptr_type, bridge_body_cache_addr as i64);
+    let bridge_body =
+        builder
+            .ins()
+            .atomic_load(ptr_type, MemFlags::trusted(), bridge_body_cache_ptr);
     let null_ptr = builder.ins().iconst(ptr_type, 0);
-    let has_bridge = builder.ins().icmp(IntCC::NotEqual, bridge_code, null_ptr);
+    let has_bridge = builder.ins().icmp(IntCC::NotEqual, bridge_body, null_ptr);
     let bridge_block = builder.create_block();
     let miss_block = builder.create_block();
     builder
@@ -5801,12 +5809,6 @@ fn emit_attached_bridge_dispatch(
     // dispatch under closing_jump, growing the stack until the JIT prologue
     // stack check raises RecursionError.  The host-ABI wrapper in the
     // code_ptr cell is unusable here — its call conv is not tail-callable.
-    let bridge_body_cache_ptr = builder
-        .ins()
-        .iconst(ptr_type, bridge_body_cache_addr as i64);
-    let bridge_body = builder
-        .ins()
-        .load(ptr_type, MemFlags::trusted(), bridge_body_cache_ptr, 0);
     // Dynasm patches the guard branch into a jump to the bridge, so the
     // parent trace no longer contributes a separate shadowstack entry while
     // the bridge runs.  Pop before the transfer; the bridge prologue pushes
@@ -5847,12 +5849,22 @@ fn emit_attached_loop_dispatch(
     jf_ptr: CValue,
     ll_loop_code_addr: usize,
     label_block_id_addr: usize,
+    target_frame_depth_addr: usize,
     ptr_type: cranelift_codegen::ir::Type,
 ) {
+    // `LoopTargetDescr::set_dispatch_target` (descr.rs:1308-1318)
+    // releases `target_frame_depth` and `label_block_id` BEFORE
+    // `ll_loop_code`; an `atomic_load` on `ll_loop_code` synchronizes
+    // against those releases so the subsequent plain loads observe
+    // matching companion values.  Without the acquire ordering, on
+    // weakly-ordered targets (aarch64) the CPU could reorder the
+    // companion loads ahead of the readiness check and tail-call
+    // through a non-null `ll_loop_code` while still seeing stale
+    // `label_block_id == 0` or `target_frame_depth == 0`.
     let cell_ptr = builder.ins().iconst(ptr_type, ll_loop_code_addr as i64);
     let entry = builder
         .ins()
-        .load(ptr_type, MemFlags::trusted(), cell_ptr, 0);
+        .atomic_load(ptr_type, MemFlags::trusted(), cell_ptr);
     let null = builder.ins().iconst(ptr_type, 0);
     let has_entry = builder.ins().icmp(IntCC::NotEqual, entry, null);
     let check_block_id = builder.create_block();
@@ -5886,10 +5898,52 @@ fn emit_attached_loop_dispatch(
         .load(cl_types::I32, MemFlags::trusted(), lbid_ptr, 0);
     let zero_i32 = builder.ins().iconst(cl_types::I32, 0);
     let is_first_label = builder.ins().icmp(IntCC::Equal, lbid, zero_i32);
+    let check_depth_block = builder.create_block();
+    builder.append_block_param(check_depth_block, ptr_type);
+    builder.ins().brif(
+        is_first_label,
+        check_depth_block,
+        &[BlockArg::from(target_code_ptr)],
+        miss_block,
+        &[],
+    );
+
+    builder.switch_to_block(check_depth_block);
+    builder.seal_block(check_depth_block);
+    let target_code_ptr = builder.block_params(check_depth_block)[0];
+    // `assembler.py:927 _check_frame_depth_bridge` parity, deferred for
+    // closing-jump: bridges insert this check in their own prologue
+    // (compiler.rs:8060), but loops reached via closing-jump skip the
+    // bridge prologue entirely.  `run_compiled_code_inner` only sized
+    // the JITFRAME for the originally entered loop, so a tail-call
+    // into a target whose `max_output_slots + num_ref_roots` exceeds
+    // the current frame's length would overrun the allocation when
+    // the target writes guard outputs or ref roots.  Read the target
+    // depth from the descr's `target_frame_depth` cell (published with
+    // Release ordering before `ll_loop_code` — see
+    // `LoopTargetDescr::set_dispatch_target`) and compare against the
+    // current frame's `JF_FRAME_LENGTH` word; fall back to the
+    // deadframe exit when the frame is too small so the host loop can
+    // re-enter via `execute_token`, which reallocates for the target.
+    let depth_cell_ptr = builder
+        .ins()
+        .iconst(ptr_type, target_frame_depth_addr as i64);
+    let target_depth = builder
+        .ins()
+        .load(cl_types::I64, MemFlags::trusted(), depth_cell_ptr, 0);
+    let frame_len = builder.ins().load(
+        cl_types::I64,
+        MemFlags::trusted(),
+        jf_ptr,
+        JF_FRAME_LENGTH_OFS,
+    );
+    let frame_fits = builder
+        .ins()
+        .icmp(IntCC::SignedGreaterThanOrEqual, frame_len, target_depth);
     let take_block = builder.create_block();
     builder.append_block_param(take_block, ptr_type);
     builder.ins().brif(
-        is_first_label,
+        frame_fits,
         take_block,
         &[BlockArg::from(target_code_ptr)],
         miss_block,
@@ -6037,7 +6091,9 @@ fn emit_guard_exit(
     // zero drift, nbody_50k matches the reference exactly, and the full
     // bench suite is correct.  `PYRE_CL_NO_CLOSING_JUMP` is an opt-out
     // hatch for A/B and rollback.
-    if let Some((ll_loop_code_addr, label_block_id_addr)) = info.external_jump_ll_loop_code_addr {
+    if let Some((ll_loop_code_addr, label_block_id_addr, target_frame_depth_addr)) =
+        info.external_jump_ll_loop_code_addr
+    {
         let enabled = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
             && std::env::var_os("PYRE_CL_NO_CLOSING_JUMP").is_none();
         if enabled {
@@ -6046,6 +6102,7 @@ fn emit_guard_exit(
                 jf_ptr,
                 ll_loop_code_addr,
                 label_block_id_addr,
+                target_frame_depth_addr,
                 ptr_type,
             );
         }
@@ -6941,7 +6998,7 @@ struct GuardInfo {
     /// per-LABEL `JMP imm(target._ll_loop_code)`).  Anything else falls
     /// through to the standard deadframe exit so the host loop can
     /// dispatch via `execute_token` to the right wrapper.
-    external_jump_ll_loop_code_addr: Option<(usize, usize)>,
+    external_jump_ll_loop_code_addr: Option<(usize, usize, usize)>,
 }
 
 fn identity_recovery_layout(
@@ -13273,6 +13330,17 @@ impl CraneliftBackend {
             num_ref_roots: ref_root_slots.len(),
             max_output_slots,
         };
+        // Publish target_frame_depth alongside the dispatch pointer so
+        // an external JUMP's closing-jump dispatcher can verify the
+        // source loop's already-allocated JITFRAME has enough capacity
+        // for THIS target before tail-calling into it.  Without the
+        // companion publish, a source loop with a smaller
+        // `max_output_slots + num_ref_roots` than this target could
+        // closing-jump in and overrun the frame writing guard outputs
+        // / ref roots past the allocation (assembler.py:927 bridge
+        // `_check_frame_depth` only fires for bridges, not for loop
+        // bodies entered via tail-call).
+        let target_frame_depth = max_output_slots + ref_root_slots.len();
         let mut label_block_id: u32 = 0;
         for op in ops.iter() {
             if op.opcode != OpCode::Label {
@@ -13280,7 +13348,11 @@ impl CraneliftBackend {
             }
             if let Some(descr_ref) = op.getdescr() {
                 if let Some(target) = descr_ref.as_loop_target_descr() {
-                    target.set_dispatch_target(body_ptr as usize, label_block_id);
+                    target.set_dispatch_target(
+                        body_ptr as usize,
+                        label_block_id,
+                        target_frame_depth,
+                    );
                 }
                 register_loop_target(&descr_ref, entry.clone());
             }
@@ -14134,6 +14206,7 @@ fn collect_guards(
                     (
                         ltd.ll_loop_code_ptr() as usize,
                         ltd.label_block_id_ptr() as usize,
+                        ltd.target_frame_depth_ptr() as usize,
                     )
                 })
         } else {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6025,24 +6025,25 @@ fn emit_guard_exit(
     // steady-state speedup over the legacy deadframe→`run_compiled_code`
     // dispatch.
     //
-    // Enabled by default on x86_64.  The cranelift x86_64 Tail-conv
-    // lowering (`return_call_indirect`) is balanced — verified by
-    // `tests/tail_sp_leak.rs`, which tail-calls 5M times with zero SP
-    // drift.  The historical "gate off" note blamed a ~12.5 bytes/take SP
-    // leak in `emit_return_call_common_sequence`; that diagnosis was wrong
-    // for x86_64.  The real stack growth came from
+    // Enabled by default on x86_64 and aarch64.  The cranelift Tail-conv
+    // lowering (`return_call_indirect`) is balanced — verified on both
+    // arches by `tests/tail_sp_leak.rs`, which tail-calls 5M times with
+    // zero SP drift.  The historical "gate off" note blamed a
+    // ~12.5 bytes/take SP leak in `emit_return_call_common_sequence`; that
+    // diagnosis was wrong.  The real stack growth came from
     // `emit_attached_bridge_dispatch` doing a nested call+return into the
     // bridge: under closing_jump the bridge tail-calls forward and never
     // returns, stranding one return frame per dispatch until the prologue
     // stack check raised RecursionError.  Fixed by making the bridge
     // dispatch a tail-call too (see `emit_attached_bridge_dispatch`); with
-    // that, nbody/spectral/fannkuch match dynasm exactly under the gate.
+    // that, nbody/spectral/fannkuch match dynasm exactly on both arches.
     //
-    // aarch64 stays off: the Tail-conv lowering concerns documented above
-    // were observed there and have not been re-verified post-fix.
-    // `PYRE_CL_NO_CLOSING_JUMP` is an opt-out hatch for A/B and rollback.
+    // aarch64 re-verified post-fix (cranelift 0.132): tail_sp_leak.rs has
+    // zero drift, nbody_50k matches the reference exactly, and the full
+    // bench suite is correct.  `PYRE_CL_NO_CLOSING_JUMP` is an opt-out
+    // hatch for A/B and rollback.
     if let Some((ll_loop_code_addr, label_block_id_addr)) = info.external_jump_ll_loop_code_addr {
-        let enabled = cfg!(target_arch = "x86_64")
+        let enabled = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
             && std::env::var_os("PYRE_CL_NO_CLOSING_JUMP").is_none();
         if enabled {
             emit_attached_loop_dispatch(

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -5899,19 +5899,14 @@ fn emit_attached_loop_dispatch(
     builder.switch_to_block(take_block);
     builder.seal_block(take_block);
     let target_code_ptr = builder.block_params(take_block)[0];
-    // 2026-05-18 hypothesis tests (all reverted, none affect nbody_50k
-    // corruption -0.03513214049650899 vs. dynasm -0.035132020348426815):
-    //   - probe 1: per-LABEL `label_block_id == 0` gate
-    //   - probe 2: zero jf_gcmap / jf_descr / jf_guard_exc
-    //   - probe 3: zero source body's ref_root area
-    //   - probe 4: always-on frame-realloc check at main-loop prologue
-    //   - probe 5: wholesale zero of entire jf_frame tail beyond inputs
-    // The corruption is NOT in jf_frame heap state.  Both
-    // `return_call_indirect` and `call_indirect + return` transit
-    // cranelift's aarch64 Tail-conv function entry/exit lowering and
-    // both corrupt, pointing at the documented ~12.5 bytes/take SP
-    // leak in `emit_return_call_common_sequence` as the same root
-    // cause.  Pyre-side workarounds are exhausted.
+    // The earlier nbody_50k corruption (-0.03513214049650899 vs. the
+    // reference -0.035132020348426815) and the per-dispatch SP growth were
+    // both consequences of `emit_attached_bridge_dispatch` doing a nested
+    // call+return into the bridge, not a cranelift Tail-conv defect: under
+    // closing_jump the bridge tail-calls forward and never returns, so each
+    // dispatch stranded a return frame.  With the bridge dispatch itself
+    // now a tail-call, this loop dispatch is balanced on both x86_64 and
+    // aarch64 (tail_sp_leak.rs: zero drift over 5M tail-calls).
     emit_call_footer_shadowstack(builder, ptr_type);
     // Both this body and the target body were compiled with
     // `CallConv::Tail`, so `return_call_indirect` replaces the current
@@ -14832,12 +14827,12 @@ impl majit_backend::Backend for CraneliftBackend {
         // surface (resume-trace builder via `[`crate::pyre`]`) needs the
         // exit-slot bytes BEFORE virtual reconstruction.
         //
-        // External JUMP fallback: cranelift's
-        // in-code `closing_jump` dispatch (`emit_attached_loop_dispatch`)
-        // stays gated off pending the aarch64 Tail-conv defect fix
-        // (`project_cranelift_wrapper_body_tail_leak.md`).  Until then a
-        // guard exit may legitimately surface an `is_external_jump` descr
-        // here, and the host loop re-enters the target trace exactly as
+        // External JUMP fallback: the in-code `closing_jump` dispatch
+        // (`emit_attached_loop_dispatch`) is on by default for x86_64 and
+        // aarch64, but stays off on other arches and whenever
+        // `PYRE_CL_NO_CLOSING_JUMP` is set.  In those cases a guard exit may
+        // legitimately surface an `is_external_jump` descr here, and the
+        // host loop re-enters the target trace exactly as
         // `execute_with_inputs` (compiler.rs:7357) does.  This block
         // mirrors that dispatch loop with one additional raw-output
         // termination per `execute_token_ints_raw`'s contract.
@@ -14943,10 +14938,10 @@ impl majit_backend::Backend for CraneliftBackend {
             // llgraph/runner.py:1130-1140 cross-loop JUMP: switch to the
             // target trace identified by the TargetToken stored on the
             // fail descriptor and continue dispatch, mirroring
-            // `execute_with_inputs`.  Required until in-code `closing_jump`
-            // lands — see
-            // `project_cranelift_wrapper_body_tail_leak.md` for the
-            // upstream cranelift aarch64 Tail-conv blocker.
+            // `execute_with_inputs`.  Reached when in-code `closing_jump` is
+            // disabled (non-x86_64/non-aarch64 arch, or
+            // `PYRE_CL_NO_CLOSING_JUMP`); otherwise the JUMP transfers
+            // entirely inside generated code.
             if fail_descr_fd.is_external_jump() {
                 slice_x2_probe::record_execute_with_inputs_hit();
                 let target_entry = fail_descr_fd
@@ -21142,7 +21137,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "dispatch site gated off: enabling `emit_attached_loop_dispatch` triggers cranelift 0.130/0.131 aarch64 Tail-conv leak + jf_frame-slot corruption (project_cranelift_wrapper_body_tail_leak.md). Test passes the moment the gate at compiler.rs `emit_guard_exit` flips on."]
     fn test_execute_bridge_follows_external_jump_to_compiled_target() {
         let mut backend = CraneliftBackend::new();
         let loop_descr = make_label_descr(1500_260);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -5748,7 +5748,6 @@ fn emit_attached_bridge_dispatch(
     jf_ptr: CValue,
     bridge_cache_addrs: (usize, usize),
     ptr_type: cranelift_codegen::ir::Type,
-    call_conv: cranelift_codegen::isa::CallConv,
 ) {
     // dynasm/x86 patches the failing guard's jump to the attached bridge.
     // Cranelift cannot patch finalized code, so guard exits do the
@@ -5764,15 +5763,18 @@ fn emit_attached_bridge_dispatch(
     // read here — the bridge prologue (compiler.rs:7585) bakes the
     // expected size as an iconst at compile time.
     //
-    // Bridge code_ptr cell lives on the descr as
-    // `Box<AtomicUsize>`.  Box gives it a heap-pinned address that
-    // survives the descr being moved into `Arc::new(...)`, so the
-    // address is stable for the descr's lifetime and safe to bake
-    // into machine code as an immediate.  The caller
-    // pre-computes the address pair via `fail_descr_bridge_cache_addrs`
-    // and passes it directly, since `jf_descr` now embeds the meta
-    // Arc rather than the backend wrapper that owns the cells.
-    let (bridge_code_cache_addr, _bridge_frame_depth_cache_addr) = bridge_cache_addrs;
+    // Bridge cache cells live on the descr as `Box<AtomicUsize>`.  Box
+    // gives them heap-pinned addresses that survive the descr being moved
+    // into `Arc::new(...)`, so they are stable for the descr's lifetime and
+    // safe to bake into machine code as immediates.  The caller pre-computes
+    // the address pair via `fail_descr_bridge_cache_addrs`: `.0` is the
+    // host-ABI wrapper (`code_ptr`, for host-loop dispatch), `.1` is the
+    // bridge's `CallConv::Tail` body entry (`body_ptr`, for this in-code
+    // tail-call).
+    let (bridge_code_cache_addr, bridge_body_cache_addr) = bridge_cache_addrs;
+    // "has bridge" gate reads the code_ptr cell, which `store_bridge_caches`
+    // publishes LAST (Release-ordered after body_ptr); a non-null code_ptr
+    // therefore guarantees the body_ptr cell is already visible.
     let bridge_code_cache_ptr = builder
         .ins()
         .iconst(ptr_type, bridge_code_cache_addr as i64);
@@ -5782,33 +5784,41 @@ fn emit_attached_bridge_dispatch(
     let null_ptr = builder.ins().iconst(ptr_type, 0);
     let has_bridge = builder.ins().icmp(IntCC::NotEqual, bridge_code, null_ptr);
     let bridge_block = builder.create_block();
-    builder.append_block_param(bridge_block, ptr_type);
     let miss_block = builder.create_block();
-    builder.ins().brif(
-        has_bridge,
-        bridge_block,
-        &[BlockArg::from(bridge_code)],
-        miss_block,
-        &[],
-    );
+    builder
+        .ins()
+        .brif(has_bridge, bridge_block, &[], miss_block, &[]);
 
     builder.switch_to_block(bridge_block);
     builder.seal_block(bridge_block);
-    let bridge_code_ptr = builder.block_params(bridge_block)[0];
+    // assembler.py:987 `patch_jump_for_descr`: the failing guard's JMP is
+    // rewritten to jump straight into the bridge — a tail transfer, not a
+    // call.  The cranelift analogue is `return_call_indirect` into the
+    // bridge's `CallConv::Tail` body: the parent trace's frame is torn down
+    // and replaced by the bridge's, so no return frame is stranded on the
+    // machine stack when the bridge later tail-calls forward (closing_jump).
+    // A nested call+return here would leak one return frame per bridge
+    // dispatch under closing_jump, growing the stack until the JIT prologue
+    // stack check raises RecursionError.  The host-ABI wrapper in the
+    // code_ptr cell is unusable here — its call conv is not tail-callable.
+    let bridge_body_cache_ptr = builder
+        .ins()
+        .iconst(ptr_type, bridge_body_cache_addr as i64);
+    let bridge_body = builder
+        .ins()
+        .load(ptr_type, MemFlags::trusted(), bridge_body_cache_ptr, 0);
     // Dynasm patches the guard branch into a jump to the bridge, so the
     // parent trace no longer contributes a separate shadowstack entry while
-    // the bridge runs.  Pop before the call; the bridge prologue pushes the
-    // same jitframe for its own execution and pops it on return.
+    // the bridge runs.  Pop before the transfer; the bridge prologue pushes
+    // the same jitframe for its own execution and pops it on exit.
     emit_call_footer_shadowstack(builder, ptr_type);
-    let mut bridge_sig = Signature::new(call_conv);
+    let mut bridge_sig = Signature::new(cranelift_codegen::isa::CallConv::Tail);
     bridge_sig.params.push(AbiParam::new(ptr_type));
     bridge_sig.returns.push(AbiParam::new(ptr_type));
     let bridge_sig_ref = builder.import_signature(bridge_sig);
-    let bridge_call = builder
+    builder
         .ins()
-        .call_indirect(bridge_sig_ref, bridge_code_ptr, &[jf_ptr]);
-    let bridge_result_jf = builder.inst_results(bridge_call)[0];
-    builder.ins().return_(&[bridge_result_jf]);
+        .return_call_indirect(bridge_sig_ref, bridge_body, &[jf_ptr]);
 
     builder.switch_to_block(miss_block);
     builder.seal_block(miss_block);
@@ -6007,45 +6017,43 @@ fn emit_guard_exit(
     // Store FailDescr POINTER (not index) to jf_descr on the deadframe path.
     let descr_val = builder.ins().iconst(cl_types::I64, info.fail_descr_ptr);
 
-    // `assembler.py:2456-2462 closing_jump` parity is wired through
-    // `emit_attached_loop_dispatch` but the call site stays gated.
-    // Enabling it has two independent failure modes on cranelift
-    // 0.130 *and* 0.131 aarch64 (re-verified after 0.131 upgrade
-    // attempt 2026-05-18):
+    // `assembler.py:2456-2462 closing_jump` parity: external JUMP exits
+    // tail-call straight into the target loop body via
+    // `emit_attached_loop_dispatch` (`return_call_indirect`), the
+    // cranelift analogue of PyPy's raw `JMP imm(target._ll_loop_code)`.
+    // This avoids a host-loop round-trip per loop edge and is the main
+    // steady-state speedup over the legacy deadframe→`run_compiled_code`
+    // dispatch.
     //
-    //   - `nbody` produces `-0.03513214049650899` instead of the
-    //     dynasm-reference `-0.035132020348426815` (8th-decimal
-    //     divergence — meaningful, not ULP).  Hypothesis per
-    //     `project_cranelift_wrapper_body_tail_leak.md`: target
-    //     body's prologue reads jf_frame slots (ref-root area,
-    //     force-token slots, gcmap) that source `emit_guard_exit`
-    //     doesn't refresh at the in-code tail call.  Surfaced
-    //     before the orthodox argloc remap (task #114 option (ii))
-    //     lands; bench-only since lib/integration tests don't
-    //     exercise long enough traces to expose the slot mismatch.
+    // Enabled by default on x86_64.  The cranelift x86_64 Tail-conv
+    // lowering (`return_call_indirect`) is balanced — verified by
+    // `tests/tail_sp_leak.rs`, which tail-calls 5M times with zero SP
+    // drift.  The historical "gate off" note blamed a ~12.5 bytes/take SP
+    // leak in `emit_return_call_common_sequence`; that diagnosis was wrong
+    // for x86_64.  The real stack growth came from
+    // `emit_attached_bridge_dispatch` doing a nested call+return into the
+    // bridge: under closing_jump the bridge tail-calls forward and never
+    // returns, stranding one return frame per dispatch until the prologue
+    // stack check raised RecursionError.  Fixed by making the bridge
+    // dispatch a tail-call too (see `emit_attached_bridge_dispatch`); with
+    // that, nbody/spectral/fannkuch match dynasm exactly under the gate.
     //
-    //   - raise_catch_loop / fannkuch crash or time out via the
-    //     ~12.5 bytes/take stack leak inside cranelift's
-    //     `emit_return_call_common_sequence` (Tail conv aarch64) —
-    //     unchanged between 0.130.2 and 0.131.1.
-    //
-    // Gate stays off — 5 hypotheses tested + ruled out:
-    //   - probe 1: per-LABEL `label_block_id == 0` gate
-    //   - probe 2: zero jf_gcmap / jf_descr / jf_guard_exc
-    //   - probe 3: zero source body's ref_root area
-    //   - probe 4: always-on frame-realloc check at main-loop prologue
-    //   - probe 5: wholesale zero of entire jf_frame tail beyond inputs
-    // None affect the deterministic nbody_50k corruption
-    // (-0.03513214049650899 vs. dynasm -0.035132020348426815),
-    // confirming the corruption is NOT in jf_frame heap state.
-    // Empirical conclusion: source is the cranelift aarch64 Tail-conv
-    // lowering itself (consistent with the documented ~12.5 bytes/take
-    // SP leak in `emit_return_call_common_sequence`).  Both
-    // `return_call_indirect` and `call_indirect + return` shapes
-    // corrupt because both transit cranelift's aarch64 Tail-conv
-    // function entry/exit lowering.  Pyre-side workarounds cannot
-    // address upstream stack-frame accounting defects.
-    let _ = info.external_jump_ll_loop_code_addr;
+    // aarch64 stays off: the Tail-conv lowering concerns documented above
+    // were observed there and have not been re-verified post-fix.
+    // `PYRE_CL_NO_CLOSING_JUMP` is an opt-out hatch for A/B and rollback.
+    if let Some((ll_loop_code_addr, label_block_id_addr)) = info.external_jump_ll_loop_code_addr {
+        let enabled = cfg!(target_arch = "x86_64")
+            && std::env::var_os("PYRE_CL_NO_CLOSING_JUMP").is_none();
+        if enabled {
+            emit_attached_loop_dispatch(
+                builder,
+                jf_ptr,
+                ll_loop_code_addr,
+                label_block_id_addr,
+                ptr_type,
+            );
+        }
+    }
 
     if info.can_have_bridge && !info.must_save_exception {
         // RPython/dynasm patched guards enter the bridge before failure
@@ -6058,7 +6066,6 @@ fn emit_guard_exit(
             info.bridge_cache_addrs
                 .expect("can_have_bridge=true GuardInfo must carry bridge_cache_addrs"),
             ptr_type,
-            call_conv,
         );
     }
 
@@ -6122,7 +6129,6 @@ fn emit_guard_exit(
             info.bridge_cache_addrs
                 .expect("can_have_bridge=true GuardInfo must carry bridge_cache_addrs"),
             ptr_type,
-            call_conv,
         );
     }
     builder
@@ -6148,6 +6154,10 @@ struct CompiledLoop {
     caller_prefix_layout: Option<ExitRecoveryLayout>,
     _func_id: FuncId,
     code_ptr: *const u8,
+    /// `CallConv::Tail` body entry (the wrapper-bypassing in-code target).
+    /// `ll_loop_code` for loops; the tail-call target when this trace is a
+    /// bridge dispatched from a parent guard.
+    body_ptr: *const u8,
     code_size: usize,
     fail_descrs: Box<[DescrRef]>,
     /// Position-aligned `FailDescrCell` wrappers (see
@@ -6304,11 +6314,7 @@ pub(crate) fn fail_descr_bridge_ref(fd: &dyn FailDescr) -> Option<Arc<BridgeData
 /// test-scaffold path via the synthesis at compiler.rs:12884.
 pub(crate) fn fail_descr_attach_bridge(fd: &dyn FailDescr, bridge: BridgeData) {
     let code_ptr = bridge.code_ptr as usize;
-    let frame_depth = bridge
-        .max_output_slots
-        .max(bridge.num_inputs)
-        .max(1)
-        .saturating_add(bridge.num_ref_roots);
+    let body_ptr = bridge.body_ptr as usize;
     // assembler.py:987 patch_jump_for_descr ordering parity: publish the
     // dispatch cache BEFORE the BridgeData Arc swap so any JIT execution
     // observing a non-null `bridge_dispatch` cell also sees a populated
@@ -6316,7 +6322,11 @@ pub(crate) fn fail_descr_attach_bridge(fd: &dyn FailDescr, bridge: BridgeData) {
     // loop bridge fallback at compiler.rs:7287 fires with a freshly
     // published Arc but a still-null cache, which the in-code dispatch
     // (`emit_attached_bridge_dispatch`) cannot reach.
-    fd.store_bridge_caches(code_ptr, frame_depth);
+    //
+    // `store_bridge_caches` writes the body_ptr cell first, then the
+    // code_ptr cell (Release), so a dispatch that observes a non-null
+    // code_ptr is guaranteed to also see the body_ptr it tail-calls.
+    fd.store_bridge_caches(code_ptr, body_ptr);
     let new_ptr = Arc::into_raw(Arc::new(bridge)) as *mut ();
     let old_ptr = fd.bridge_dispatch_swap(new_ptr, drop_bridge_payload);
     if !old_ptr.is_null() {
@@ -7279,6 +7289,7 @@ impl CraneliftBackend {
                                             source_guard: b.source_guard,
                                             caller_prefix_layout: b.caller_prefix_layout.clone(),
                                             code_ptr: b.code_ptr,
+                                            body_ptr: b.body_ptr,
                                             fail_descrs: b.fail_descrs.clone(),
                                             fail_descr_cells: b.fail_descr_cells.clone(),
                                             num_inputs: b.num_inputs,
@@ -7303,6 +7314,15 @@ impl CraneliftBackend {
     pub fn new() -> Self {
         let mut flag_builder = settings::builder();
         flag_builder.set("opt_level", "speed").unwrap();
+        // cranelift 0.132 x86_64 `emit_return_call_common_sequence` panics
+        // when `preserve_frame_pointers=false`:
+        //   "frame pointers aren't fundamentally required for tail calls,
+        //    but the current implementation relies on them being present"
+        // We need frame pointers for the in-code `closing_jump` dispatch
+        // (`emit_attached_loop_dispatch`) regardless of whether the env
+        // var enables it at the call site — bridges/wrappers still get
+        // compiled with these flags.
+        flag_builder.set("preserve_frame_pointers", "true").unwrap();
 
         let isa_builder = cranelift_native::builder().expect("host ISA not supported");
         let isa = isa_builder
@@ -13278,6 +13298,7 @@ impl CraneliftBackend {
             caller_prefix_layout: caller_layout.cloned(),
             _func_id: func_id,
             code_ptr,
+            body_ptr,
             code_size: 0,
             fail_descrs,
             fail_descr_cells,
@@ -14560,6 +14581,7 @@ impl majit_backend::Backend for CraneliftBackend {
                     source_guard: (source_trace_id, fail_descr.fail_index_per_trace()),
                     caller_prefix_layout: compiled.caller_prefix_layout.clone(),
                     code_ptr: compiled.code_ptr,
+                    body_ptr: compiled.body_ptr,
                     fail_descrs: compiled.fail_descrs,
                     fail_descr_cells: compiled.fail_descr_cells,
                     terminal_exit_layouts: compiled.terminal_exit_layouts,
@@ -14600,6 +14622,7 @@ impl majit_backend::Backend for CraneliftBackend {
                                         source_guard: b.source_guard,
                                         caller_prefix_layout: b.caller_prefix_layout.clone(),
                                         code_ptr: b.code_ptr,
+                                        body_ptr: b.body_ptr,
                                         fail_descrs: b.fail_descrs.clone(),
                                         fail_descr_cells: b.fail_descr_cells.clone(),
                                         num_inputs: b.num_inputs,
@@ -14737,6 +14760,7 @@ impl majit_backend::Backend for CraneliftBackend {
                             source_guard: b.source_guard,
                             caller_prefix_layout: b.caller_prefix_layout.clone(),
                             code_ptr: b.code_ptr,
+                            body_ptr: b.body_ptr,
                             fail_descrs: b.fail_descrs.clone(),
                             fail_descr_cells: b.fail_descr_cells.clone(),
                             num_inputs: b.num_inputs,

--- a/majit/majit-backend-cranelift/src/guard.rs
+++ b/majit/majit-backend-cranelift/src/guard.rs
@@ -52,6 +52,11 @@ pub struct BridgeData {
     /// Same calling convention as a compiled loop:
     ///   fn(inputs_ptr: *const i64, outputs_ptr: *mut i64, roots_ptr: *mut i64) -> i64
     pub code_ptr: *const u8,
+    /// `CallConv::Tail` body entry of the bridge (wrapper-bypassing).
+    /// `emit_attached_bridge_dispatch` tail-calls this on guard failure so
+    /// the transfer leaves no machine-stack return frame — the cranelift
+    /// analogue of PyPy `patch_jump_for_descr`'s raw JMP into the bridge.
+    pub body_ptr: *const u8,
     /// Fail descriptors within the bridge (guards + finish).
     /// Frozen after compile — `Box<[T]>` reflects RPython's no-mutation
     /// contract (compile.py:183-203 record_loop_or_bridge). Position

--- a/majit/majit-backend-cranelift/tests/tail_sp_leak.rs
+++ b/majit/majit-backend-cranelift/tests/tail_sp_leak.rs
@@ -1,0 +1,229 @@
+// Minimal reproducer for the cranelift x86_64 tail-call SP-drift hypothesis.
+//
+// Builds two functions:
+//   - body(CallConv::Tail): if arg < N, return_call_indirect itself with arg+1;
+//                            else return arg.
+//   - wrapper(host call_conv): forwards arg to body via normal call.
+//
+// Calls wrapper several times in a tight loop and measures the host RSP
+// between invocations.  If the body's tail-call epilogue leaks, the host
+// RSP value either drifts or the OS terminates the test with a stack
+// overflow.
+
+use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::types as cl_types;
+use cranelift_codegen::ir::{AbiParam, Function, InstBuilder, MemFlags, Signature, UserFuncName};
+use cranelift_codegen::isa::CallConv;
+use cranelift_codegen::settings::{self, Configurable};
+use cranelift_codegen::Context;
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{Linkage, Module};
+use target_lexicon::Triple;
+
+fn current_sp() -> usize {
+    let probe: usize = 0;
+    &probe as *const usize as usize
+}
+
+// Counter probe so we can call from JIT with WindowsFastcall ABI without
+// worrying about how MSVC mangles a Rust extern "C" symbol.
+static PROBE_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+extern "C" fn host_probe(_jf: usize) {
+    PROBE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+// Chain cap, read by the body each tail-call so we can vary chain length
+// at runtime without recompiling.
+static CHAIN_CAP: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(2000);
+
+#[test]
+fn tail_call_sp_drift_repro() {
+    let mut flag_builder = settings::builder();
+    flag_builder.set("preserve_frame_pointers", "true").unwrap();
+    flag_builder.set("opt_level", "speed").unwrap();
+    let isa_builder =
+        cranelift_native::builder().expect("host machine is not a supported target");
+    let isa = isa_builder
+        .finish(settings::Flags::new(flag_builder))
+        .unwrap();
+    let host_call_conv = isa.default_call_conv();
+    let triple: Triple = isa.triple().clone();
+    println!("host triple={triple} call_conv={host_call_conv:?}");
+
+    let jit_builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+    let mut module = JITModule::new(jit_builder);
+    let ptr_type = cl_types::I64;
+
+    // body signature: (i64) -> i64 (Tail conv)
+    let mut body_sig = Signature::new(CallConv::Tail);
+    body_sig.params.push(AbiParam::new(ptr_type));
+    body_sig.returns.push(AbiParam::new(ptr_type));
+    let body_id = module
+        .declare_function("body", Linkage::Local, &body_sig)
+        .unwrap();
+    // body2 has the SAME signature but a different declared frame.
+    let body2_id = module
+        .declare_function("body2", Linkage::Local, &body_sig)
+        .unwrap();
+
+    // wrapper signature: (i64) -> i64 (host conv)
+    let mut wrapper_sig = Signature::new(host_call_conv);
+    wrapper_sig.params.push(AbiParam::new(ptr_type));
+    wrapper_sig.returns.push(AbiParam::new(ptr_type));
+    let wrapper_id = module
+        .declare_function("wrapper", Linkage::Local, &wrapper_sig)
+        .unwrap();
+
+    // Build the body.
+    let mut fbcx = FunctionBuilderContext::new();
+    let mut body_func = Function::with_name_signature(
+        UserFuncName::user(0, body_id.as_u32()),
+        body_sig.clone(),
+    );
+    {
+        let mut bx = FunctionBuilder::new(&mut body_func, &mut fbcx);
+        let entry = bx.create_block();
+        bx.append_block_params_for_function_params(entry);
+        bx.switch_to_block(entry);
+        bx.seal_block(entry);
+        let arg = bx.block_params(entry)[0];
+
+        let cap_addr = bx
+            .ins()
+            .iconst(ptr_type, &CHAIN_CAP as *const _ as i64);
+        let cap = bx.ins().load(ptr_type, MemFlags::trusted(), cap_addr, 0);
+        let cont = bx.ins().icmp(IntCC::SignedLessThan, arg, cap);
+        let tail = bx.create_block();
+        let exit = bx.create_block();
+        bx.ins().brif(cont, tail, &[], exit, &[]);
+
+        bx.switch_to_block(tail);
+        bx.seal_block(tail);
+        let one = bx.ins().iconst(ptr_type, 1);
+        let next = bx.ins().iadd(arg, one);
+
+        // Replicate pyre's tail-call epilogue: emit a windows_fastcall
+        // call to a host probe AND a shadow-stack-like in-memory pop.
+        let host_addr = bx
+            .ins()
+            .iconst(ptr_type, host_probe as *const () as i64);
+        let mut probe_sig = Signature::new(CallConv::WindowsFastcall);
+        probe_sig.params.push(AbiParam::new(ptr_type));
+        let probe_sig_ref = bx.import_signature(probe_sig);
+        bx.ins().call_indirect(probe_sig_ref, host_addr, &[next]);
+
+        // Tail-call body2 via INDIRECT (different declared frame size).
+        let body2_ref = module.declare_func_in_func(body2_id, bx.func);
+        let body2_addr = bx.ins().func_addr(ptr_type, body2_ref);
+        let mut tail_sig = Signature::new(CallConv::Tail);
+        tail_sig.params.push(AbiParam::new(ptr_type));
+        tail_sig.returns.push(AbiParam::new(ptr_type));
+        let tail_sig_ref = bx.import_signature(tail_sig);
+        bx.ins().return_call_indirect(tail_sig_ref, body2_addr, &[next]);
+
+        bx.switch_to_block(exit);
+        bx.seal_block(exit);
+        bx.ins().return_(&[arg]);
+        bx.finalize();
+    }
+    let mut ctx = Context::for_function(body_func);
+    module.define_function(body_id, &mut ctx).unwrap();
+    module.clear_context(&mut ctx);
+
+    // Build body2 — tail-calls back to body, with a different frame size
+    // (larger local-slot usage to differentiate the prologue).
+    let mut body2_func = Function::with_name_signature(
+        UserFuncName::user(0, body2_id.as_u32()),
+        body_sig.clone(),
+    );
+    {
+        let mut bx = FunctionBuilder::new(&mut body2_func, &mut fbcx);
+        let entry = bx.create_block();
+        bx.append_block_params_for_function_params(entry);
+        bx.switch_to_block(entry);
+        bx.seal_block(entry);
+        let arg = bx.block_params(entry)[0];
+
+        // Force a much larger frame so body and body2 have different sizes.
+        use cranelift_codegen::ir::stackslot::{StackSlotData, StackSlotKind};
+        let big_slot = bx.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            128,
+            3,
+        ));
+        let big_addr = bx.ins().stack_addr(ptr_type, big_slot, 0);
+        bx.ins().store(MemFlags::trusted(), arg, big_addr, 0);
+
+        // Always tail-call back to body with arg+1.
+        let one = bx.ins().iconst(ptr_type, 1);
+        let next = bx.ins().iadd(arg, one);
+        let body_ref = module.declare_func_in_func(body_id, bx.func);
+        let body_addr = bx.ins().func_addr(ptr_type, body_ref);
+        let mut tail_sig = Signature::new(CallConv::Tail);
+        tail_sig.params.push(AbiParam::new(ptr_type));
+        tail_sig.returns.push(AbiParam::new(ptr_type));
+        let tail_sig_ref = bx.import_signature(tail_sig);
+        bx.ins().return_call_indirect(tail_sig_ref, body_addr, &[next]);
+        bx.finalize();
+    }
+    let mut ctx = Context::for_function(body2_func);
+    module.define_function(body2_id, &mut ctx).unwrap();
+    module.clear_context(&mut ctx);
+
+    // Build the wrapper.
+    let mut wrapper_func = Function::with_name_signature(
+        UserFuncName::user(0, wrapper_id.as_u32()),
+        wrapper_sig.clone(),
+    );
+    {
+        let mut bx = FunctionBuilder::new(&mut wrapper_func, &mut fbcx);
+        let entry = bx.create_block();
+        bx.append_block_params_for_function_params(entry);
+        bx.switch_to_block(entry);
+        bx.seal_block(entry);
+        let arg = bx.block_params(entry)[0];
+        let body_ref = module.declare_func_in_func(body_id, bx.func);
+        let call = bx.ins().call(body_ref, &[arg]);
+        let r = bx.inst_results(call)[0];
+        bx.ins().return_(&[r]);
+        bx.finalize();
+    }
+    let mut ctx = Context::for_function(wrapper_func);
+    module.define_function(wrapper_id, &mut ctx).unwrap();
+    module.clear_context(&mut ctx);
+
+    module.finalize_definitions().unwrap();
+
+    let wrapper_ptr = module.get_finalized_function(wrapper_id);
+    let wrapper: extern "C" fn(usize) -> usize = unsafe { std::mem::transmute(wrapper_ptr) };
+
+    use std::sync::atomic::Ordering::Relaxed;
+    // Measure drift for short vs long chains. If cranelift's tail-call
+    // leaks per take, drift scales with chain length. If drift is a
+    // constant (test-harness noise), it doesn't.
+    CHAIN_CAP.store(1000, Relaxed);
+    let sp0 = current_sp();
+    let r = wrapper(0);
+    assert_eq!(r, 1000);
+    let sp1 = current_sp();
+    let drift_short = sp0.wrapping_sub(sp1) as i64;
+
+    CHAIN_CAP.store(5_000_000, Relaxed);
+    let sp2 = current_sp();
+    let r = wrapper(0);
+    assert_eq!(r, 5_000_000);
+    let sp3 = current_sp();
+    let drift_long = sp2.wrapping_sub(sp3) as i64;
+
+    println!("drift 1k-chain = {drift_short} bytes, 5M-chain = {drift_long} bytes");
+    let per_call = (drift_long - drift_short) as f64 / (5_000_000.0 - 1000.0);
+    println!("per-call leak estimate: {per_call} bytes");
+    // A genuine per-take leak makes drift scale with chain length, so the
+    // 5M chain would dwarf the 1k chain.  A balanced epilogue leaves both
+    // drifts as small, comparable, chain-length-independent harness noise.
+    assert!(
+        per_call.abs() < 1.0,
+        "tail-call leaks {per_call} bytes/take (drift scales with chain length)"
+    );
+}

--- a/majit/majit-backend-cranelift/tests/tail_sp_leak.rs
+++ b/majit/majit-backend-cranelift/tests/tail_sp_leak.rs
@@ -10,12 +10,12 @@
 // RSP value either drifts or the OS terminates the test with a stack
 // overflow.
 
+use cranelift_codegen::Context;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::types as cl_types;
 use cranelift_codegen::ir::{AbiParam, Function, InstBuilder, MemFlags, Signature, UserFuncName};
 use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings::{self, Configurable};
-use cranelift_codegen::Context;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{Linkage, Module};
@@ -26,8 +26,8 @@ fn current_sp() -> usize {
     &probe as *const usize as usize
 }
 
-// Counter probe so we can call from JIT with WindowsFastcall ABI without
-// worrying about how MSVC mangles a Rust extern "C" symbol.
+// Counter probe so we can call from JIT with the host ABI without
+// worrying about how the linker mangles a Rust extern "C" symbol.
 static PROBE_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 extern "C" fn host_probe(_jf: usize) {
     PROBE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -42,8 +42,7 @@ fn tail_call_sp_drift_repro() {
     let mut flag_builder = settings::builder();
     flag_builder.set("preserve_frame_pointers", "true").unwrap();
     flag_builder.set("opt_level", "speed").unwrap();
-    let isa_builder =
-        cranelift_native::builder().expect("host machine is not a supported target");
+    let isa_builder = cranelift_native::builder().expect("host machine is not a supported target");
     let isa = isa_builder
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
@@ -77,10 +76,8 @@ fn tail_call_sp_drift_repro() {
 
     // Build the body.
     let mut fbcx = FunctionBuilderContext::new();
-    let mut body_func = Function::with_name_signature(
-        UserFuncName::user(0, body_id.as_u32()),
-        body_sig.clone(),
-    );
+    let mut body_func =
+        Function::with_name_signature(UserFuncName::user(0, body_id.as_u32()), body_sig.clone());
     {
         let mut bx = FunctionBuilder::new(&mut body_func, &mut fbcx);
         let entry = bx.create_block();
@@ -89,9 +86,7 @@ fn tail_call_sp_drift_repro() {
         bx.seal_block(entry);
         let arg = bx.block_params(entry)[0];
 
-        let cap_addr = bx
-            .ins()
-            .iconst(ptr_type, &CHAIN_CAP as *const _ as i64);
+        let cap_addr = bx.ins().iconst(ptr_type, &CHAIN_CAP as *const _ as i64);
         let cap = bx.ins().load(ptr_type, MemFlags::trusted(), cap_addr, 0);
         let cont = bx.ins().icmp(IntCC::SignedLessThan, arg, cap);
         let tail = bx.create_block();
@@ -103,12 +98,10 @@ fn tail_call_sp_drift_repro() {
         let one = bx.ins().iconst(ptr_type, 1);
         let next = bx.ins().iadd(arg, one);
 
-        // Replicate pyre's tail-call epilogue: emit a windows_fastcall
-        // call to a host probe AND a shadow-stack-like in-memory pop.
-        let host_addr = bx
-            .ins()
-            .iconst(ptr_type, host_probe as *const () as i64);
-        let mut probe_sig = Signature::new(CallConv::WindowsFastcall);
+        // Replicate pyre's tail-call epilogue: emit a host-ABI call to a
+        // host probe AND a shadow-stack-like in-memory pop.
+        let host_addr = bx.ins().iconst(ptr_type, host_probe as *const () as i64);
+        let mut probe_sig = Signature::new(host_call_conv);
         probe_sig.params.push(AbiParam::new(ptr_type));
         let probe_sig_ref = bx.import_signature(probe_sig);
         bx.ins().call_indirect(probe_sig_ref, host_addr, &[next]);
@@ -120,7 +113,8 @@ fn tail_call_sp_drift_repro() {
         tail_sig.params.push(AbiParam::new(ptr_type));
         tail_sig.returns.push(AbiParam::new(ptr_type));
         let tail_sig_ref = bx.import_signature(tail_sig);
-        bx.ins().return_call_indirect(tail_sig_ref, body2_addr, &[next]);
+        bx.ins()
+            .return_call_indirect(tail_sig_ref, body2_addr, &[next]);
 
         bx.switch_to_block(exit);
         bx.seal_block(exit);
@@ -133,10 +127,8 @@ fn tail_call_sp_drift_repro() {
 
     // Build body2 — tail-calls back to body, with a different frame size
     // (larger local-slot usage to differentiate the prologue).
-    let mut body2_func = Function::with_name_signature(
-        UserFuncName::user(0, body2_id.as_u32()),
-        body_sig.clone(),
-    );
+    let mut body2_func =
+        Function::with_name_signature(UserFuncName::user(0, body2_id.as_u32()), body_sig.clone());
     {
         let mut bx = FunctionBuilder::new(&mut body2_func, &mut fbcx);
         let entry = bx.create_block();
@@ -147,11 +139,8 @@ fn tail_call_sp_drift_repro() {
 
         // Force a much larger frame so body and body2 have different sizes.
         use cranelift_codegen::ir::stackslot::{StackSlotData, StackSlotKind};
-        let big_slot = bx.create_sized_stack_slot(StackSlotData::new(
-            StackSlotKind::ExplicitSlot,
-            128,
-            3,
-        ));
+        let big_slot =
+            bx.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 128, 3));
         let big_addr = bx.ins().stack_addr(ptr_type, big_slot, 0);
         bx.ins().store(MemFlags::trusted(), arg, big_addr, 0);
 
@@ -164,7 +153,8 @@ fn tail_call_sp_drift_repro() {
         tail_sig.params.push(AbiParam::new(ptr_type));
         tail_sig.returns.push(AbiParam::new(ptr_type));
         let tail_sig_ref = bx.import_signature(tail_sig);
-        bx.ins().return_call_indirect(tail_sig_ref, body_addr, &[next]);
+        bx.ins()
+            .return_call_indirect(tail_sig_ref, body_addr, &[next]);
         bx.finalize();
     }
     let mut ctx = Context::for_function(body2_func);

--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -12,7 +12,7 @@
 //!
 //! Several slots — `trace_info` (`AtomicPtr<CompiledTraceInfo>`),
 //! `bridge_dispatch_cell` (`AtomicPtr<()>`), and `bridge_code_ptr_cache`
-//! / `bridge_frame_depth_cache` — are accessed through atomics so that
+//! / `bridge_body_ptr_cache` — are accessed through atomics so that
 //! JIT-baked machine code can read them without a Mutex.  The
 //! `Arc::into_raw` / `Arc::increment_strong_count` / `Arc::from_raw`
 //! protocol used on the dispatch / trace_info cells has a textbook
@@ -218,11 +218,15 @@ pub struct ResumeGuardDescr {
     /// `emit_attached_bridge_dispatch` (compiler.rs:5347) embeds this
     /// address as an immediate.  `0` = no bridge attached.
     pub bridge_code_ptr_cache: Box<AtomicUsize>,
-    /// Bridge frame-depth cache.  Same shape as
-    /// `bridge_code_ptr_cache`; baked into the dispatch path so the
-    /// runtime can verify the JIT frame can fit the bridge inputs
-    /// before re-entering.
-    pub bridge_frame_depth_cache: Box<AtomicUsize>,
+    /// Bridge body-pointer cache.  Same shape as
+    /// `bridge_code_ptr_cache`, but holds the bridge's `CallConv::Tail`
+    /// body entry (not the host-ABI wrapper).  The in-code dispatch
+    /// (`emit_attached_bridge_dispatch`) tail-calls this so a guard
+    /// failure transfers into the bridge without leaving a return frame
+    /// on the machine stack — the cranelift analogue of PyPy's
+    /// `patch_jump_for_descr` raw JMP.  The wrapper in
+    /// `bridge_code_ptr_cache` stays for the host-loop fallback dispatch.
+    pub bridge_body_ptr_cache: Box<AtomicUsize>,
     /// Bridge dispatch cell (cranelift-only TODO: PyPy patches guard
     /// JMP targets in place).  PyPy's `assembler.py:987 patch_jump_for_descr`
     /// rewrites the guard JMP target in place; cranelift cannot patch
@@ -291,7 +295,7 @@ impl Descr for ResumeGuardDescr {
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
             bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
         }))
@@ -489,15 +493,15 @@ impl FailDescr for ResumeGuardDescr {
     fn bridge_cache_addrs(&self) -> Option<(usize, usize)> {
         Some((
             self.bridge_code_ptr_cache.as_ref() as *const _ as usize,
-            self.bridge_frame_depth_cache.as_ref() as *const _ as usize,
+            self.bridge_body_ptr_cache.as_ref() as *const _ as usize,
         ))
     }
     fn bridge_code_ptr(&self) -> usize {
         self.bridge_code_ptr_cache.load(Ordering::Acquire)
     }
-    fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        self.bridge_frame_depth_cache
-            .store(frame_depth, Ordering::Release);
+    fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        self.bridge_body_ptr_cache
+            .store(body_ptr, Ordering::Release);
         self.bridge_code_ptr_cache
             .store(code_ptr, Ordering::Release);
     }
@@ -564,7 +568,7 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
         external_jump_target: OnceLock::new(),
         bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+        bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
         bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
         bridge_dispatch_drop_fn: OnceLock::new(),
     })
@@ -683,20 +687,20 @@ impl ResumeGuardDescr {
 
     /// Heap-pinned addresses of the two bridge-cache atomic cells
     /// suitable for baking into JIT machine code as
-    /// immediates.  Returns `(code_ptr_addr, frame_depth_addr)`.
+    /// immediates.  Returns `(code_ptr_addr, body_ptr_addr)`.
     pub fn bridge_cache_addrs(&self) -> (usize, usize) {
         (
             self.bridge_code_ptr_cache.as_ref() as *const _ as usize,
-            self.bridge_frame_depth_cache.as_ref() as *const _ as usize,
+            self.bridge_body_ptr_cache.as_ref() as *const _ as usize,
         )
     }
 
     /// Atomically store the bridge code-pointer + frame-depth caches
     /// Called from cranelift `attach_bridge` after
     /// the bridge has been compiled.
-    pub fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        self.bridge_frame_depth_cache
-            .store(frame_depth, Ordering::Release);
+    pub fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        self.bridge_body_ptr_cache
+            .store(body_ptr, Ordering::Release);
         self.bridge_code_ptr_cache
             .store(code_ptr, Ordering::Release);
     }

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -2183,11 +2183,11 @@ pub trait FailDescr: Descr {
     }
 
     /// Pyre-only cranelift bridge cache publish.  Atomic-stores
-    /// `(code_ptr, frame_depth)` into the cells whose addresses
+    /// `(code_ptr, body_ptr)` into the cells whose addresses
     /// `bridge_cache_addrs` reported.  Default panics — only
     /// Resume-family guards carry bridge cache cells.  Callers
     /// gate by `is_resume_guard() || is_resume_guard_copied()`.
-    fn store_bridge_caches(&self, _code_ptr: usize, _frame_depth: usize) {
+    fn store_bridge_caches(&self, _code_ptr: usize, _body_ptr: usize) {
         panic!(
             "store_bridge_caches invoked on a FailDescr that does not \
              carry the per-emission bridge cache cells (only \

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1297,15 +1297,41 @@ pub trait LoopTargetDescr: Descr {
         );
     }
 
-    /// Publish `(ll_loop_code, label_block_id)` as one coherent dispatch
-    /// target.  Readers gate on `ll_loop_code != 0` (Acquire) and then
-    /// read `label_block_id` via baked address, so `label_block_id` MUST
-    /// become visible before `ll_loop_code` is non-zero — otherwise a
-    /// reader can observe the new code pointer alongside the stale
-    /// initial `label_block_id = 0` and route into the wrong block.
-    /// Default impl stores `label_block_id` first, then `ll_loop_code`,
-    /// matching the readiness ordering.
-    fn set_dispatch_target(&self, loop_code: usize, block_id: u32) {
+    /// Target loop's frame depth (`max_output_slots + num_ref_roots`).
+    /// Read by the closing-jump dispatcher to verify the source loop's
+    /// already-allocated JITFRAME has enough capacity for the target
+    /// before tail-calling into it.  `0` until the target has been
+    /// registered.
+    fn target_frame_depth(&self) -> usize {
+        0
+    }
+    fn set_target_frame_depth(&self, _depth: usize) {
+        panic!(
+            "set_target_frame_depth requires an AtomicUsize-backed slot \
+             (LoopTargetDescr impl: {})",
+            std::any::type_name::<Self>(),
+        );
+    }
+    fn target_frame_depth_ptr(&self) -> *const std::sync::atomic::AtomicUsize {
+        panic!(
+            "target_frame_depth_ptr requires an AtomicUsize-backed slot \
+             (LoopTargetDescr impl: {})",
+            std::any::type_name::<Self>(),
+        );
+    }
+
+    /// Publish `(ll_loop_code, label_block_id, target_frame_depth)` as
+    /// one coherent dispatch target.  Readers gate on
+    /// `ll_loop_code != 0` (Acquire) and then read `label_block_id` and
+    /// `target_frame_depth` via baked addresses, so both companion
+    /// cells MUST become visible before `ll_loop_code` is non-zero —
+    /// otherwise a reader can observe the new code pointer alongside a
+    /// stale companion (0 block-id routing into the wrong LABEL, or 0
+    /// depth bypassing the frame-capacity check).  Default impl stores
+    /// the companions first, then `ll_loop_code`, matching the
+    /// readiness ordering.
+    fn set_dispatch_target(&self, loop_code: usize, block_id: u32, frame_depth: usize) {
+        self.set_target_frame_depth(frame_depth);
         self.set_label_block_id(block_id);
         self.set_ll_loop_code(loop_code);
     }
@@ -1355,6 +1381,12 @@ struct BasicLoopTargetDescr {
     /// codegen; default 0 covers single-LABEL traces and dynasm (which
     /// ignores the slot and uses raw LABEL addresses in `_ll_loop_code`).
     label_block_id: std::sync::atomic::AtomicU32,
+    /// `max_output_slots + num_ref_roots` for the target loop.
+    /// Published with the dispatch target so the cranelift in-code
+    /// closing-jump dispatch can compare against the source frame's
+    /// `JF_FRAME_LENGTH` and fall back to the host loop when the
+    /// already-allocated frame is too small for the target.
+    target_frame_depth: std::sync::atomic::AtomicUsize,
     state: Mutex<BasicLoopTargetDescrState>,
 }
 
@@ -1365,6 +1397,7 @@ impl BasicLoopTargetDescr {
             is_preamble_target,
             ll_loop_code: std::sync::atomic::AtomicUsize::new(0),
             label_block_id: std::sync::atomic::AtomicU32::new(0),
+            target_frame_depth: std::sync::atomic::AtomicUsize::new(0),
             state: Mutex::new(BasicLoopTargetDescrState::default()),
         }
     }
@@ -1422,6 +1455,20 @@ impl LoopTargetDescr for BasicLoopTargetDescr {
 
     fn label_block_id_ptr(&self) -> *const std::sync::atomic::AtomicU32 {
         &self.label_block_id as *const _
+    }
+
+    fn target_frame_depth(&self) -> usize {
+        self.target_frame_depth
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn set_target_frame_depth(&self, depth: usize) {
+        self.target_frame_depth
+            .store(depth, std::sync::atomic::Ordering::Release);
+    }
+
+    fn target_frame_depth_ptr(&self) -> *const std::sync::atomic::AtomicUsize {
+        &self.target_frame_depth as *const _
     }
 
     fn target_arglocs(&self) -> Vec<TargetArgLoc> {

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2922,7 +2922,7 @@ pub fn make_fail_descr_with_index(fail_index: u32, num_live: usize) -> DescrRef 
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
         external_jump_target: OnceLock::new(),
         bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+        bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
         bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
         bridge_dispatch_drop_fn: OnceLock::new(),
     })
@@ -3013,7 +3013,7 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
         external_jump_target: OnceLock::new(),
         bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+        bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
         bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
         bridge_dispatch_drop_fn: OnceLock::new(),
     })
@@ -3225,8 +3225,8 @@ impl FailDescr for ResumeAtPositionDescr {
     fn bridge_code_ptr(&self) -> usize {
         FailDescr::bridge_code_ptr(&self.inner)
     }
-    fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        FailDescr::store_bridge_caches(&self.inner, code_ptr, frame_depth);
+    fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        FailDescr::store_bridge_caches(&self.inner, code_ptr, body_ptr);
     }
     fn bridge_dispatch_load(&self) -> *mut () {
         FailDescr::bridge_dispatch_load(&self.inner)
@@ -3273,7 +3273,7 @@ pub fn make_resume_at_position_descr_typed(types: Vec<Type>) -> DescrRef {
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
             bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
         },
@@ -3491,8 +3491,8 @@ impl FailDescr for ResumeGuardForcedDescr {
     fn bridge_code_ptr(&self) -> usize {
         FailDescr::bridge_code_ptr(&self.inner)
     }
-    fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        FailDescr::store_bridge_caches(&self.inner, code_ptr, frame_depth);
+    fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        FailDescr::store_bridge_caches(&self.inner, code_ptr, body_ptr);
     }
     fn bridge_dispatch_load(&self) -> *mut () {
         FailDescr::bridge_dispatch_load(&self.inner)
@@ -3539,7 +3539,7 @@ pub fn make_resume_guard_forced_descr_typed(types: Vec<Type>) -> DescrRef {
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
             bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
         },
@@ -3741,8 +3741,8 @@ impl FailDescr for ResumeGuardExcDescr {
     fn bridge_code_ptr(&self) -> usize {
         FailDescr::bridge_code_ptr(&self.inner)
     }
-    fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        FailDescr::store_bridge_caches(&self.inner, code_ptr, frame_depth);
+    fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        FailDescr::store_bridge_caches(&self.inner, code_ptr, body_ptr);
     }
     fn bridge_dispatch_load(&self) -> *mut () {
         FailDescr::bridge_dispatch_load(&self.inner)
@@ -3789,7 +3789,7 @@ pub fn make_resume_guard_exc_descr_typed(types: Vec<Type>) -> DescrRef {
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
             bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
         },
@@ -3897,11 +3897,12 @@ pub struct ResumeGuardCopiedDescr {
     /// ResumeGuardDescr and ResumeGuardCopiedDescr).  `0` means no
     /// bridge attached.
     bridge_code_ptr_cache: Box<std::sync::atomic::AtomicUsize>,
-    /// Pyre-only per-emission cranelift bridge frame-depth cache.
-    /// Same shape as `bridge_code_ptr_cache`; baked into the dispatch
-    /// path so the runtime verifies the JIT frame can fit the
-    /// bridge inputs before re-entering.
-    bridge_frame_depth_cache: Box<std::sync::atomic::AtomicUsize>,
+    /// Pyre-only per-emission cranelift bridge body-pointer cache.
+    /// Same shape as `bridge_code_ptr_cache`, but holds the bridge's
+    /// `CallConv::Tail` body entry; the in-code dispatch tail-calls it
+    /// so a guard failure transfers into the bridge without leaving a
+    /// machine-stack return frame (PyPy `patch_jump_for_descr` JMP).
+    bridge_body_ptr_cache: Box<std::sync::atomic::AtomicUsize>,
     /// Pyre-only per-emission cranelift bridge dispatch cell.
     /// Type-erased to `*mut ()` because `BridgeData` lives in
     /// `majit-backend-cranelift` (downstream); the cleanup function
@@ -4022,7 +4023,7 @@ impl majit_ir::Descr for ResumeGuardCopiedDescr {
             fail_count: AtomicU32::new(0),
             trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
             bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-            bridge_frame_depth_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
+            bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
             bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
             external_jump_target: std::sync::OnceLock::new(),
@@ -4252,15 +4253,15 @@ impl FailDescr for ResumeGuardCopiedDescr {
     fn bridge_cache_addrs(&self) -> Option<(usize, usize)> {
         Some((
             self.bridge_code_ptr_cache.as_ref() as *const _ as usize,
-            self.bridge_frame_depth_cache.as_ref() as *const _ as usize,
+            self.bridge_body_ptr_cache.as_ref() as *const _ as usize,
         ))
     }
     fn bridge_code_ptr(&self) -> usize {
         self.bridge_code_ptr_cache.load(Ordering::Acquire)
     }
-    fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        self.bridge_frame_depth_cache
-            .store(frame_depth, Ordering::Release);
+    fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        self.bridge_body_ptr_cache
+            .store(body_ptr, Ordering::Release);
         self.bridge_code_ptr_cache
             .store(code_ptr, Ordering::Release);
     }
@@ -4338,7 +4339,7 @@ impl majit_ir::Descr for ResumeGuardCopiedExcDescr {
                 fail_count: AtomicU32::new(0),
                 trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
                 bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-                bridge_frame_depth_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
+                bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
                 bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
                 bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
                 external_jump_target: std::sync::OnceLock::new(),
@@ -4480,8 +4481,8 @@ impl FailDescr for ResumeGuardCopiedExcDescr {
     fn bridge_code_ptr(&self) -> usize {
         self.inner.bridge_code_ptr()
     }
-    fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        self.inner.store_bridge_caches(code_ptr, frame_depth);
+    fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        self.inner.store_bridge_caches(code_ptr, body_ptr);
     }
     fn bridge_dispatch_load(&self) -> *mut () {
         self.inner.bridge_dispatch_load()
@@ -4542,7 +4543,7 @@ pub fn make_resume_guard_copied_descr(prev: DescrRef) -> DescrRef {
         fail_count: AtomicU32::new(0),
         trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
         bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-        bridge_frame_depth_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
+        bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
         bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
         bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
         external_jump_target: std::sync::OnceLock::new(),
@@ -4582,7 +4583,7 @@ pub fn make_resume_guard_copied_exc_descr(prev: DescrRef) -> DescrRef {
             fail_count: AtomicU32::new(0),
             trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
             bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-            bridge_frame_depth_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
+            bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
             bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
             external_jump_target: std::sync::OnceLock::new(),
@@ -4747,7 +4748,7 @@ impl majit_ir::Descr for CompileLoopVersionDescr {
                 trace_info: AtomicPtr::new(std::ptr::null_mut()),
                 external_jump_target: OnceLock::new(),
                 bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-                bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+                bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
                 bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
                 bridge_dispatch_drop_fn: OnceLock::new(),
             },
@@ -4920,8 +4921,8 @@ impl FailDescr for CompileLoopVersionDescr {
     fn bridge_code_ptr(&self) -> usize {
         FailDescr::bridge_code_ptr(&self.inner)
     }
-    fn store_bridge_caches(&self, code_ptr: usize, frame_depth: usize) {
-        FailDescr::store_bridge_caches(&self.inner, code_ptr, frame_depth);
+    fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
+        FailDescr::store_bridge_caches(&self.inner, code_ptr, body_ptr);
     }
     fn bridge_dispatch_load(&self) -> *mut () {
         FailDescr::bridge_dispatch_load(&self.inner)
@@ -5022,7 +5023,7 @@ pub fn make_compile_loop_version_descr_from(source_op: &majit_ir::Op) -> DescrRe
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
             bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
             bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
             bridge_dispatch_drop_fn: OnceLock::new(),
         },
@@ -5416,7 +5417,7 @@ mod fail_descr_tests {
                 trace_info: AtomicPtr::new(std::ptr::null_mut()),
                 external_jump_target: OnceLock::new(),
                 bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-                bridge_frame_depth_cache: Box::new(AtomicUsize::new(0)),
+                bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
                 bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
                 bridge_dispatch_drop_fn: OnceLock::new(),
             },

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2688,6 +2688,10 @@ struct LoopTargetDescr {
     /// for second, ...) so cranelift's `br_table` body-entry dispatch
     /// can route to the right per-LABEL entry block.
     label_block_id: std::sync::atomic::AtomicU32,
+    /// Target loop's `max_output_slots + num_ref_roots`, published
+    /// alongside `ll_loop_code` so the closing-jump dispatcher can
+    /// gate on the source's already-allocated frame being big enough.
+    target_frame_depth: std::sync::atomic::AtomicUsize,
     state: Mutex<LoopTargetDescrState>,
 }
 
@@ -2698,6 +2702,7 @@ impl LoopTargetDescr {
             is_preamble_target,
             ll_loop_code: std::sync::atomic::AtomicUsize::new(0),
             label_block_id: std::sync::atomic::AtomicU32::new(0),
+            target_frame_depth: std::sync::atomic::AtomicUsize::new(0),
             state: Mutex::new(LoopTargetDescrState::default()),
         }
     }
@@ -2755,6 +2760,20 @@ impl majit_ir::LoopTargetDescr for LoopTargetDescr {
 
     fn label_block_id_ptr(&self) -> *const std::sync::atomic::AtomicU32 {
         &self.label_block_id as *const _
+    }
+
+    fn target_frame_depth(&self) -> usize {
+        self.target_frame_depth
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn set_target_frame_depth(&self, depth: usize) {
+        self.target_frame_depth
+            .store(depth, std::sync::atomic::Ordering::Release);
+    }
+
+    fn target_frame_depth_ptr(&self) -> *const std::sync::atomic::AtomicUsize {
+        &self.target_frame_depth as *const _
     }
 
     fn target_arglocs(&self) -> Vec<majit_ir::TargetArgLoc> {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -398,6 +398,41 @@ fn collect_snapshot_const_ptr_slots(maps: &mut [&mut SnapshotBoxes]) -> Vec<usiz
     slots
 }
 
+/// RAII guard that empties `MetaInterp.compile_snapshot_refs` when
+/// dropped. Every compile entry point that calls
+/// `collect_snapshot_const_ptr_slots` stores raw `*mut OpRef`
+/// pointers into local `SnapshotBoxes` storage; once the enclosing
+/// compile returns, those locals are dropped and the raw pointers
+/// are dangling. Holding this guard at the top of every such entry
+/// point forces the vector to be cleared before any subsequent GC
+/// walk (driven by `compile_snapshot_root_walker`) can observe the
+/// stale pointers.
+pub(crate) struct CompileSnapshotRootsGuard {
+    refs: *mut Vec<usize>,
+}
+
+impl CompileSnapshotRootsGuard {
+    pub(crate) fn new(refs: &mut Vec<usize>) -> Self {
+        Self {
+            refs: refs as *mut _,
+        }
+    }
+}
+
+impl Drop for CompileSnapshotRootsGuard {
+    fn drop(&mut self) {
+        // SAFETY: the guard is constructed from a `&mut Vec<usize>`
+        // and lives no longer than the enclosing `&mut self` borrow
+        // of `MetaInterp`. The raw pointer therefore stays valid for
+        // the guard's entire scope; nothing else mutates the vector
+        // through a competing reference, because the borrow checker
+        // observed the original `&mut` at construction.
+        unsafe {
+            (*self.refs).clear();
+        }
+    }
+}
+
 fn snapshot_map_from_trace_snapshots(
     trace_snapshots: &[crate::recorder::Snapshot],
     constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
@@ -4427,6 +4462,7 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     fn compile_loop_body(&mut self, jump_args: &[OpRef], meta: M) -> CompileOutcome {
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
         // pyjitpl.py:2995 `assert len(self.virtualref_boxes) == 0,
         // "missing virtual_ref_finish()?"` — every `opimpl_virtual_ref`
         // must have a matching `opimpl_virtual_ref_finish` before the
@@ -5408,6 +5444,7 @@ impl<M: Clone> MetaInterp<M> {
         finish_descr: Option<majit_ir::DescrRef>,
         entry_bridge: Option<(u64, M)>,
     ) -> CompileOutcome {
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
         let ends_with_jump = finish_descr.is_none();
         let ctx = match self.tracing.as_mut() {
             Some(ctx) => ctx,
@@ -5628,6 +5665,7 @@ impl<M: Clone> MetaInterp<M> {
     ///
     /// Returns true if compilation succeeded.
     pub fn compile_retrace(&mut self, jump_args: &[OpRef], meta: M) -> bool {
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
         // compile.py:355-359: resolve `loop_jitcell_token` before recording
         // the closing JUMP.  Keep this lookup before any state is consumed so
         // the rare missing-token path does not drain the active retrace.
@@ -6198,6 +6236,7 @@ impl<M: Clone> MetaInterp<M> {
         meta: M,
         exit_with_exception: bool,
     ) -> Result<(), SwitchToBlackhole> {
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
         // Cache vable_config before take() clears self.tracing.
         let vable_config = self.current_virtualizable_optimizer_config();
         // Cache driver descriptor before ctx is partially consumed below.
@@ -6654,6 +6693,7 @@ impl<M: Clone> MetaInterp<M> {
     /// Returns the green_key on success (caller must call
     /// attach_procedure_to_interp), None on failure.
     pub fn compile_simple_loop(&mut self, meta: M) -> Option<u64> {
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
         let vable_config = self.current_virtualizable_optimizer_config();
         self.force_finish_trace = false;
         let mut ctx = match self.tracing.take() {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6143,30 +6143,27 @@ impl JitState for PyreJitState {
             first_vable_scalar_idx + crate::virtualizable_gen::NUM_VABLE_SCALARS;
         let mut oprefs: Vec<OpRef> = Vec::with_capacity(vvals.len());
         let mut concrete_values: Vec<majit_ir::Value> = Vec::with_capacity(vvals.len());
-        // virtualizable_gen.rs PyFrame layout: the resume payload prefix is
-        //   [vable, last_instr:Int, pycode:Ref, valuestackdepth:Int,
-        //    debugdata:Ref, lastblock:Ref, w_globals:Ref, locals_cells_stack_w...].
-        // virtualizable.py:139 read_boxes consumes typed boxes per declared
-        // field type, so decode_box's `kind` must be the field type — not a
-        // uniform Ref. last_instr/valuestackdepth are signed ints (matching
-        // publish_last_instr_to_vable's const_int), the rest Ref.
-        const VABLE_VALUE_TYPES: &[Type] = &[
-            Type::Ref, // vable pointer
-            Type::Int, // last_instr
-            Type::Ref, // pycode
-            Type::Int, // valuestackdepth
-            Type::Ref, // debugdata
-            Type::Ref, // lastblock
-            Type::Ref, // w_globals
-        ];
-        for (i, v) in vvals.iter().enumerate() {
-            // locals_cells_stack_w array items (index ≥ scalar prefix) are
-            // Ref (W_Root array).
-            let expected = VABLE_VALUE_TYPES.get(i).copied().unwrap_or(Type::Ref);
+        // resume.py:1264 `assert box.type == kind`: the vable payload is
+        // NOT uniformly Ref — the static fields carry their declared
+        // kinds (interp_jit.py:25-31: last_instr/valuestackdepth are Int).
+        // `virt_live_value_types` yields the full live layout WITH the
+        // extra reds ([frame, <NUM_EXTRA_REDS>, <NUM_VABLE_SCALARS>,
+        // array...]); the vvals stream omits the extra reds, so strip them
+        // to recover the per-slot kind for each payload position.
+        let array_item_count = vvals
+            .len()
+            .saturating_sub(1 + crate::virtualizable_gen::NUM_VABLE_SCALARS);
+        let full_types = crate::virtualizable_gen::virt_live_value_types(array_item_count);
+        let nreds = crate::virtualizable_gen::NUM_EXTRA_REDS;
+        let mut vvals_types: Vec<Type> = Vec::with_capacity(vvals.len());
+        vvals_types.push(full_types.first().copied().unwrap_or(Type::Ref));
+        vvals_types.extend_from_slice(&full_types[(1 + nreds).min(full_types.len())..]);
+        for (idx, v) in vvals.iter().enumerate() {
+            let expected_kind = vvals_types.get(idx).copied().unwrap_or(Type::Ref);
             let (op, val) = bridge_decode_box(
                 ctx,
                 v,
-                expected,
+                expected_kind,
                 rd_virtuals,
                 resume_data,
                 fail_values,


### PR DESCRIPTION
emit_attached_bridge_dispatch now return_call_indirect's the bridge's CallConv::Tail body instead of call_indirect + return, so a guard failure transfers into the bridge without leaving a return frame on the machine stack. BridgeData and CompiledLoop gain a body_ptr field; the per-emission cache cell bridge_frame_depth_cache becomes bridge_body_ptr_cache and store_bridge_caches publishes (code_ptr, body_ptr).

emit_attached_loop_dispatch (closing_jump) is enabled by default on x86_64, opt-out via PYRE_CL_NO_CLOSING_JUMP. CraneliftBackend::new sets preserve_frame_pointers=true, required by the 0.132 Tail-conv lowering.

setup_bridge_sym decodes the virtualizable payload with per-slot kinds from virt_live_value_types instead of a blanket Type::Ref, so the Int static fields (last_instr, valuestackdepth) decode as Int.

cranelift 0.130 -> 0.132. Add tests/tail_sp_leak.rs.

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External-jump optimization for loops enabled by default on x86_64 and aarch64.
  * New mechanism to track loop target frame depth for safer in-code dispatch.
  * RAII guard to clear compilation snapshot roots after compilation.

* **Bug Fixes**
  * Strengthened bridge/guard dispatch synchronization and switched to tail-transfer semantics to avoid stack-frame leaks and races.
  * Fixed and re-enabled a regression related to bridge/external-jump behavior.

* **Tests**
  * Added a regression test validating tail-call stack-pointer behavior.

* **Chores**
  * Upgraded Cranelift backend dependencies 0.130 → 0.132.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/youknowone/pyre/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->