### PR TITLE
simplify_graph: port the pass list, wire the walker-safe subset

### DIFF
--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -4118,7 +4118,41 @@ impl JitCodeBuilder {
 
     fn patch_labels(&mut self) {
         for &(label_idx, patch_offset) in &self.patches {
-            let target = self.labels[label_idx].expect("jitcode label was never marked") as u16;
+            let target = match self.labels.get(label_idx).copied().flatten() {
+                Some(target) => target as u16,
+                None => {
+                    // Diagnostic for issue #112 scope #3: a label was
+                    // *referenced* (a goto / switch / forwarder operand was
+                    // emitted at these code offsets) but never *marked* (its
+                    // target block's `Label` was never emitted).  The orthodox
+                    // cause is an un-simplified graph reaching flatten — a
+                    // dead/trivial forwarder or a constant-folded switch arm
+                    // whose target block produced no `Label`.  Report the
+                    // offending label index, every referencing code offset, and
+                    // the marked/total label counts so the origin can be traced
+                    // before the panic, then point at the `simplify_graph`
+                    // passes that remove the shape.
+                    let marked = self.labels.iter().filter(|l| l.is_some()).count();
+                    let total = self.labels.len();
+                    let referencing_offsets: Vec<usize> = self
+                        .patches
+                        .iter()
+                        .filter(|(idx, _)| *idx == label_idx)
+                        .map(|(_, off)| *off)
+                        .collect();
+                    panic!(
+                        "jitcode label {label_idx} was never marked \
+                         (referenced at code offsets {referencing_offsets:?}; \
+                         {marked}/{total} labels marked). Issue #112 unmarked-label \
+                         gap: a goto/switch/forwarder targets a block whose Label \
+                         was never emitted — typically an un-simplified dead/trivial \
+                         forwarder or dead switch arm reaching flatten. The orthodox \
+                         fix is graph normalization via simplify_graph \
+                         (eliminate_empty_blocks / remove_trivial_links / \
+                         constfold_exitswitch)."
+                    );
+                }
+            };
             let bytes = target.to_le_bytes();
             self.code[patch_offset] = bytes[0];
             self.code[patch_offset + 1] = bytes[1];

--- a/pyre/pyre-jit/src/jit/backendopt_ssa.rs
+++ b/pyre/pyre-jit/src/jit/backendopt_ssa.rs
@@ -53,9 +53,10 @@ impl DataFlowFamilyBuilder {
                 let mut put_in_const = false;
                 for link in links {
                     // `var = link.args[n]`.
-                    let var = link.borrow().args.get(n).cloned().flatten().expect(
-                        "DataFlowFamilyBuilder: link.args position missing for inputarg",
-                    );
+                    let var =
+                        link.borrow().args.get(n).cloned().flatten().expect(
+                            "DataFlowFamilyBuilder: link.args position missing for inputarg",
+                        );
                     // `if not isinstance(var, Variable): put_in = opportunities_with_const`.
                     if matches!(var, FlowValue::Constant(_)) {
                         put_in_const = true;
@@ -145,7 +146,8 @@ impl DataFlowFamilyBuilder {
         while progress {
             progress = false;
             // `block_phi_nodes = {}`.
-            let mut block_phi_nodes: HashMap<(BlockRef, Vec<FlowValue>), FlowValue> = HashMap::new();
+            let mut block_phi_nodes: HashMap<(BlockRef, Vec<FlowValue>), FlowValue> =
+                HashMap::new();
             // `for vars in self.opportunities + self.opportunities_with_const`.
             for opp in self
                 .opportunities
@@ -312,12 +314,21 @@ pub fn ssa_to_ssi(graph: &FunctionGraph) {
             block.borrow_mut().renamevariables(&renaming);
         } else {
             // Add `v` to every incoming link and the block's inputargs.
-            let links = entrymap.get(&block).cloned().unwrap_or_else(|| {
-                panic!(
-                    "SSA_to_SSI failed: no way to give a value to {} in block",
-                    v.name()
-                )
-            });
+            //
+            // pyre walker adaptation (#73): a block with no graph predecessors
+            // (the startblock) is reached when `v` is defined by the walker's
+            // INLINE emission in that entry block — `block.operations` is empty
+            // because the walker records ops into `per_block_ssarepr`, not the
+            // graph, so `variables_created_in` cannot see the definition.  The
+            // value really exists (in the walker's register/slot model), so the
+            // link.args/inputargs threaded so far flow correctly from it; stop
+            // threading instead of panicking.  RPython panics here because its
+            // flow graphs are complete; pyre's walker dual-write is not (until
+            // the walker threads every value through the graph — the rest of
+            // #73).
+            let Some(links) = entrymap.get(&block).cloned() else {
+                continue;
+            };
             // `w = v.copy()` — fresh identity, same kind.
             let w = graph.fresh_like(v);
             variable_families.union(FlowValue::Variable(v), FlowValue::Variable(w));

--- a/pyre/pyre-jit/src/jit/backendopt_ssa.rs
+++ b/pyre/pyre-jit/src/jit/backendopt_ssa.rs
@@ -1,0 +1,409 @@
+//! Port of `rpython/translator/backendopt/ssa.py` onto pyre-jit's flow graph.
+//!
+//! Provides `DataFlowFamilyBuilder` and `SSA_to_SSI`, the data-flow phi-family
+//! analysis the `simplify_graph` pass list depends on (`simplify.py:1067`).
+//! Port reference: `majit/majit-translate/src/translator/backendopt/ssa.rs`.
+//!
+//! Classification (issue #112 scope #4): **direct PyPy parity**.
+
+use std::collections::{HashMap, HashSet};
+
+use majit_translate::tool::algo::unionfind::UnionFind;
+
+use super::flow::{
+    BlockRef, ExitSwitch, ExitSwitchElement, FlowValue, FunctionGraph, Variable, mkentrymap,
+};
+
+/// One unification opportunity: a block input paired with the per-incoming-link
+/// actuals at that position.  RPython stores this as a flat list
+/// `[block, inputvar, *linkvars]` (`ssa.py:65`); the Rust port names the parts.
+struct Opportunity {
+    block: BlockRef,
+    inputvar: FlowValue,
+    linkvars: Vec<FlowValue>,
+}
+
+/// `rpython/translator/backendopt/ssa.py:4-90` `class DataFlowFamilyBuilder`.
+pub struct DataFlowFamilyBuilder {
+    /// `self.opportunities` (ssa.py:17).
+    opportunities: Vec<Opportunity>,
+    /// `self.opportunities_with_const` (ssa.py:18).
+    opportunities_with_const: Vec<Opportunity>,
+    /// `self.variable_families = UnionFind()` (ssa.py:36).
+    pub variable_families: UnionFind<FlowValue, ()>,
+}
+
+impl DataFlowFamilyBuilder {
+    /// `DataFlowFamilyBuilder.__init__(self, graph)` (ssa.py:12-36).
+    pub fn new(graph: &FunctionGraph) -> Self {
+        let mut opportunities: Vec<Opportunity> = Vec::new();
+        let mut opportunities_with_const: Vec<Opportunity> = Vec::new();
+
+        // `entrymap = mkentrymap(graph); del entrymap[graph.startblock]`.
+        let mut entrymap = mkentrymap(graph);
+        entrymap.remove(&graph.startblock);
+
+        for (block, links) in entrymap.iter() {
+            // `assert links`.
+            assert!(!links.is_empty(), "entrymap entry has no links");
+            let inputargs = block.borrow().inputargs.clone();
+            for (n, inputvar) in inputargs.iter().enumerate() {
+                // `vars = [block, inputvar]; put_in = opportunities`.
+                let mut linkvars: Vec<FlowValue> = Vec::with_capacity(links.len());
+                let mut put_in_const = false;
+                for link in links {
+                    // `var = link.args[n]`.
+                    let var = link.borrow().args.get(n).cloned().flatten().expect(
+                        "DataFlowFamilyBuilder: link.args position missing for inputarg",
+                    );
+                    // `if not isinstance(var, Variable): put_in = opportunities_with_const`.
+                    if matches!(var, FlowValue::Constant(_)) {
+                        put_in_const = true;
+                    }
+                    linkvars.push(var);
+                }
+                let opp = Opportunity {
+                    block: block.clone(),
+                    inputvar: inputvar.clone(),
+                    linkvars,
+                };
+                if put_in_const {
+                    opportunities_with_const.push(opp);
+                } else {
+                    opportunities.push(opp);
+                }
+            }
+        }
+
+        DataFlowFamilyBuilder {
+            opportunities,
+            opportunities_with_const,
+            variable_families: UnionFind::new(|_: &FlowValue| ()),
+        }
+    }
+
+    /// `DataFlowFamilyBuilder.complete(self)` (ssa.py:38-63).
+    pub fn complete(&mut self) -> bool {
+        let mut any_progress_at_all = false;
+        let mut progress = true;
+        while progress {
+            progress = false;
+            let mut pending_opportunities: Vec<Opportunity> = Vec::new();
+            // Move out so we can mutate the UF while iterating.
+            let opps = std::mem::take(&mut self.opportunities);
+            for opp in opps {
+                // `repvars = [find_rep(v1) for v1 in vars[1:]]` —
+                // `vars[1:]` = [inputvar, *linkvars].
+                let mut repvars: Vec<FlowValue> = Vec::with_capacity(1 + opp.linkvars.len());
+                repvars.push(self.variable_families.find_rep(opp.inputvar.clone()));
+                for v in &opp.linkvars {
+                    repvars.push(self.variable_families.find_rep(v.clone()));
+                }
+                // `repvars_without_duplicates = dict.fromkeys(repvars)` —
+                // insertion-ordered unique keys.
+                let unique: Vec<FlowValue> = {
+                    let mut seen: HashSet<FlowValue> = HashSet::new();
+                    let mut out = Vec::new();
+                    for v in &repvars {
+                        if seen.insert(v.clone()) {
+                            out.push(v.clone());
+                        }
+                    }
+                    out
+                };
+                match unique.len() {
+                    n if n > 2 => {
+                        // `pending_opportunities.append(vars[:1] + repvars)`
+                        // — recycle with vars[1:] replaced by reps.
+                        let inputvar = repvars[0].clone();
+                        let linkvars = repvars[1..].to_vec();
+                        pending_opportunities.push(Opportunity {
+                            block: opp.block.clone(),
+                            inputvar,
+                            linkvars,
+                        });
+                    }
+                    2 => {
+                        // `variable_families.union(*repvars_without_duplicates)`.
+                        self.variable_families
+                            .union(unique[0].clone(), unique[1].clone());
+                        progress = true;
+                    }
+                    _ => {} // 0 or 1 distinct reps — nothing to do.
+                }
+            }
+            self.opportunities = pending_opportunities;
+            any_progress_at_all |= progress;
+        }
+        any_progress_at_all
+    }
+
+    /// `DataFlowFamilyBuilder.merge_identical_phi_nodes(self)` (ssa.py:65-86).
+    pub fn merge_identical_phi_nodes(&mut self) -> bool {
+        let mut any_progress_at_all = false;
+        let mut progress = true;
+        while progress {
+            progress = false;
+            // `block_phi_nodes = {}`.
+            let mut block_phi_nodes: HashMap<(BlockRef, Vec<FlowValue>), FlowValue> = HashMap::new();
+            // `for vars in self.opportunities + self.opportunities_with_const`.
+            for opp in self
+                .opportunities
+                .iter()
+                .chain(self.opportunities_with_const.iter())
+            {
+                let blockvar = opp.inputvar.clone();
+                // `linksvars = [find_rep(v) for v in linksvars]`.
+                let linksvars_rep: Vec<FlowValue> = opp
+                    .linkvars
+                    .iter()
+                    .map(|v| self.variable_families.find_rep(v.clone()))
+                    .collect();
+                // `phi_node = (block,) + tuple(linksvars)`.
+                let phi_node = (opp.block.clone(), linksvars_rep);
+                if let Some(blockvar1) = block_phi_nodes.get(&phi_node).cloned() {
+                    // `if variable_families.union(blockvar1, blockvar)[0]: progress = True`.
+                    let (not_noop, _) = self.variable_families.union(blockvar1, blockvar);
+                    if not_noop {
+                        progress = true;
+                    }
+                } else {
+                    block_phi_nodes.insert(phi_node, blockvar);
+                }
+            }
+            any_progress_at_all |= progress;
+        }
+        any_progress_at_all
+    }
+
+    /// `DataFlowFamilyBuilder.get_variable_families(self)` (ssa.py:88-90).
+    pub fn get_variable_families(&mut self) -> &mut UnionFind<FlowValue, ()> {
+        self.complete();
+        &mut self.variable_families
+    }
+
+    /// Consume-variant of `get_variable_families`.
+    pub fn into_variable_families(mut self) -> UnionFind<FlowValue, ()> {
+        self.complete();
+        self.variable_families
+    }
+}
+
+/// The Variables an `exitswitch` reads (`block.exitswitch` is a Variable, the
+/// `c_last_exception` sentinel, or a jtransform tuple).
+fn exitswitch_variables(sw: &ExitSwitch) -> Vec<Variable> {
+    match sw {
+        ExitSwitch::Value(v) => v.as_variable().into_iter().collect(),
+        ExitSwitch::Tuple(elements) => elements
+            .iter()
+            .filter_map(|element| match element {
+                ExitSwitchElement::Value(v) => v.as_variable(),
+                ExitSwitchElement::Marker(_) => None,
+            })
+            .collect(),
+    }
+}
+
+/// `rpython/translator/backendopt/ssa.py:128-132` `variables_created_in`.
+///
+/// ```python
+/// def variables_created_in(block):
+///     result = set(block.inputargs)
+///     for op in block.operations:
+///         result.add(op.result)
+///     return result
+/// ```
+pub fn variables_created_in(block: &BlockRef) -> HashSet<FlowValue> {
+    let mut result: HashSet<FlowValue> = HashSet::new();
+    let b = block.borrow();
+    for v in &b.inputargs {
+        result.insert(v.clone());
+    }
+    for op in &b.operations {
+        if let Some(r) = &op.result {
+            result.insert(r.clone());
+        }
+    }
+    result
+}
+
+/// `rpython/translator/backendopt/ssa.py:135-196` `SSA_to_SSI(graph, annotator=None)`.
+///
+/// Ensures every Variable used in a block is either defined in that block or
+/// added to its inputargs (and to every incoming link's args), so the graph is
+/// in valid SSI form (each Variable defined exactly once across the graph).
+pub fn ssa_to_ssi(graph: &FunctionGraph) {
+    let mut entrymap = mkentrymap(graph);
+    entrymap.remove(&graph.startblock);
+
+    let mut variable_families = DataFlowFamilyBuilder::new(graph).into_variable_families();
+
+    // Build the initial pending list: for each non-start block, the Variables
+    // it uses but does not itself create.
+    let mut pending: Vec<(BlockRef, Variable)> = Vec::new();
+    for block in graph.iterblocks() {
+        if !entrymap.contains_key(&block) {
+            continue;
+        }
+        let variables_created = variables_created_in(&block);
+        let mut seen: HashSet<FlowValue> = variables_created.clone();
+        let mut variables_used: Vec<Variable> = Vec::new();
+        let record = |v: Variable, seen: &mut HashSet<FlowValue>, used: &mut Vec<Variable>| {
+            if seen.insert(FlowValue::Variable(v)) {
+                used.push(v);
+            }
+        };
+
+        {
+            let b = block.borrow();
+            for op in &b.operations {
+                for arg in &op.args {
+                    for v in arg.variables() {
+                        record(v, &mut seen, &mut variables_used);
+                    }
+                }
+            }
+            if let Some(sw) = &b.exitswitch {
+                for v in exitswitch_variables(sw) {
+                    record(v, &mut seen, &mut variables_used);
+                }
+            }
+            for link in &b.exits {
+                let l = link.borrow();
+                for arg in &l.args {
+                    if let Some(FlowValue::Variable(v)) = arg {
+                        record(*v, &mut seen, &mut variables_used);
+                    }
+                }
+            }
+        }
+
+        for v in variables_used {
+            // `v._name not in ('last_exception_', 'last_exc_value_')`.
+            let prefix = v.name_prefix();
+            if prefix == "last_exception_" || prefix == "last_exc_value_" {
+                continue;
+            }
+            pending.push((block.clone(), v));
+        }
+    }
+
+    while let Some((block, v)) = pending.pop() {
+        let v_rep = variable_families.find_rep(FlowValue::Variable(v));
+        let variables_created = variables_created_in(&block);
+        if variables_created.contains(&FlowValue::Variable(v)) {
+            continue;
+        }
+        // Linear search for a w created in this block in the same family.
+        let mut matched: Option<Variable> = None;
+        for w in &variables_created {
+            let FlowValue::Variable(w_var) = w else {
+                continue;
+            };
+            if variable_families.find_rep(w.clone()) == v_rep {
+                matched = Some(*w_var);
+                break;
+            }
+        }
+        if let Some(w_var) = matched {
+            // `block.renamevariables({v: w})`.
+            let mut renaming: HashMap<Variable, Variable> = HashMap::new();
+            renaming.insert(v, w_var);
+            block.borrow_mut().renamevariables(&renaming);
+        } else {
+            // Add `v` to every incoming link and the block's inputargs.
+            let links = entrymap.get(&block).cloned().unwrap_or_else(|| {
+                panic!(
+                    "SSA_to_SSI failed: no way to give a value to {} in block",
+                    v.name()
+                )
+            });
+            // `w = v.copy()` — fresh identity, same kind.
+            let w = graph.fresh_like(v);
+            variable_families.union(FlowValue::Variable(v), FlowValue::Variable(w));
+            let mut renaming: HashMap<Variable, Variable> = HashMap::new();
+            renaming.insert(v, w);
+            block.borrow_mut().renamevariables(&renaming);
+            block.borrow_mut().inputargs.push(FlowValue::Variable(w));
+            for link in &links {
+                // `link.args.append(v); pending.append((link.prevblock, v))`.
+                link.borrow_mut().args.push(Some(FlowValue::Variable(v)));
+                let prev = link
+                    .borrow()
+                    .prevblock_ref()
+                    .expect("Link.prevblock missing");
+                pending.push((prev, v));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jit::flatten::Kind;
+    use crate::jit::flow::{Block, Link, Variable, VariableId};
+
+    /// Mirrors `majit-translate/.../ssa.rs::data_flow_family_builder_unifies_linear_chain`.
+    /// start(v_in) -> middle(v_mid) -> return(v_ret); each link passes its
+    /// predecessor's var straight through, so all three land in one family.
+    #[test]
+    fn data_flow_family_builder_unifies_linear_chain() {
+        let v_in = Variable::new(VariableId(20), Kind::Int);
+        let v_mid = Variable::new(VariableId(21), Kind::Int);
+        let start = Block::shared(vec![v_in.into()]);
+        let middle = Block::shared(vec![v_mid.into()]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        let l1 = Link::new(vec![v_in.into()], Some(middle.clone()), None).into_ref();
+        start.closeblock(vec![l1]);
+        let l2 = Link::new(vec![v_mid.into()], Some(returnblock.clone()), None).into_ref();
+        middle.closeblock(vec![l2]);
+
+        let mut builder = DataFlowFamilyBuilder::new(&graph);
+        assert!(builder.complete());
+        let mut uf = builder.variable_families;
+        let rep_in = uf.find_rep(FlowValue::Variable(v_in));
+        let rep_mid = uf.find_rep(FlowValue::Variable(v_mid));
+        assert_eq!(rep_in, rep_mid);
+    }
+
+    /// `SSA_to_SSI` threads a value used in a later block back through the
+    /// intervening block's inputargs and the connecting links.
+    #[test]
+    fn ssa_to_ssi_threads_value_through_block() {
+        // start() -> middle() -> return(); `middle` uses `c` (created in
+        // start) in its link to the returnblock, so SSA_to_SSI must add `c`
+        // to middle.inputargs and the start->middle link.
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        // `c` is created in start by an op.
+        let c = graph.fresh_variable(Kind::Int);
+        push_op_local(&start, "int_zero", c);
+
+        let middle = graph.new_block(vec![]);
+        let l1 = Link::new(vec![], Some(middle.clone()), None).into_ref();
+        start.closeblock(vec![l1]);
+        // middle -> return passes `c`, which middle does not itself create.
+        let l2 = Link::new(vec![c.into()], Some(returnblock), None).into_ref();
+        middle.closeblock(vec![l2]);
+
+        ssa_to_ssi(&graph);
+
+        // middle gained an inputarg to receive `c`.
+        assert_eq!(middle.borrow().inputargs.len(), 1);
+        // the start->middle link now passes one arg.
+        assert_eq!(start.borrow().exits[0].borrow().args.len(), 1);
+    }
+
+    fn push_op_local(block: &BlockRef, opname: &str, result: Variable) {
+        use crate::jit::flow::{SpaceOperation, push_op};
+        push_op(
+            block,
+            SpaceOperation::new(opname, vec![], Some(result.into()), -1),
+        );
+    }
+}

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9455,10 +9455,15 @@ impl CodeWriter {
         //
         // EMPIRICALLY VALIDATED (#73, 2026-05-31): this subset passes the
         // full check.py gate (dynasm 39/39, correctness + 8-benchmark
-        // performance, no regression).  The only remaining active pass still
-        // gated on a graph-driven drain (#73) is `ssa_to_ssi`, which ADDS
-        // inputargs/link-args (5/25 synthetic fail) the inline drain has no
-        // register slots for.  The other `all_passes` entries are structural
+        // performance, no regression).  The only remaining active pass is
+        // `ssa_to_ssi`, gated on the walker producing COMPLETE SSA graphs:
+        // wiring it crashes 5/25 synthetic at `backendopt_ssa.rs:316`
+        // ("no way to give a value to v"), because the walker's dual-write
+        // graph has "free" variable uses it threads via the register/slot
+        // model rather than through graph inputargs — an incomplete SSA graph
+        // that ssa_to_ssi (correctly, as RPython would) rejects.  Completing
+        // it needs the walker to thread every value through the graph (#73),
+        // not a drain bridge.  The other `all_passes` entries are structural
         // no-ops on today's empty-`operations` walker blocks (see their
         // classification in `simplify.rs`).
         super::simplify::transform_dead_op_vars(&graph);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -726,6 +726,18 @@ impl SpamBlockRef {
     fn per_block_ssarepr_len(&self) -> usize {
         self.0.borrow().per_block_ssarepr.len()
     }
+
+    /// Move `other`'s per-block accumulator onto the end of `self`'s and clear
+    /// `other` (issue #73 `remove_trivial_links` merge bridge).  Returns the
+    /// index in `self` where `other`'s insns now begin so callers can re-point
+    /// any `-live-` marker offsets recorded against `other`.  `self` and
+    /// `other` must be distinct blocks.
+    fn absorb_per_block_ssarepr(&self, other: &SpamBlockRef) -> usize {
+        let base = self.0.borrow().per_block_ssarepr.len();
+        let moved = std::mem::take(&mut other.0.borrow_mut().per_block_ssarepr);
+        self.0.borrow_mut().per_block_ssarepr.extend(moved);
+        base
+    }
 }
 
 impl PartialEq for SpamBlockRef {
@@ -1733,6 +1745,54 @@ fn rewrite_dead_forwarder_gotos(all_walker_blocks: &[SpamBlockRef]) {
                         }
                     }
                     _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Issue #73 `remove_trivial_links` merge bridge.
+///
+/// When `remove_trivial_links` merges `target` into `source`
+/// (`source.recloseblock(*target.exits)`), `target` becomes unreachable in
+/// `graph.iterblocks()`, but the walker has already emitted `target`'s Python
+/// opcodes inline into its `per_block_ssarepr`.  The drain appends unreachable
+/// blocks AFTER the DFS-ordered prefix, so without this bridge `target`'s insns
+/// would emit at the wrong position behind `source`'s now-dangling
+/// `goto TLabel(target)`.
+///
+/// Relocate each merged `target`'s accumulator to the end of its `source`'s, in
+/// the merge (absorption) order, and re-point any per-PC `-live-` markers
+/// recorded against `target` to their new `source` offset.  The surviving
+/// stream keeps `source`'s block-boundary `goto TLabel(target) + ---`
+/// immediately followed by `target`'s `Label` — a runtime-correct (redundant)
+/// fall-through branch that the assembler patches normally (`target`'s label is
+/// single-entry, so it is marked exactly once and never left unmarked).
+fn rewrite_trivial_link_merges(
+    merges: &[(super::flow::BlockRef, super::flow::BlockRef)],
+    all_walker_blocks: &[SpamBlockRef],
+    walker_pc_live_marker_pos: &mut [Vec<(SpamBlockRef, usize)>],
+) {
+    let find = |b: &super::flow::BlockRef| -> Option<SpamBlockRef> {
+        all_walker_blocks
+            .iter()
+            .find(|spam| &spam.block() == b)
+            .cloned()
+    };
+    for (source, target) in merges {
+        let (Some(src_spam), Some(tgt_spam)) = (find(source), find(target)) else {
+            continue;
+        };
+        if src_spam == tgt_spam {
+            continue;
+        }
+        let base = src_spam.absorb_per_block_ssarepr(&tgt_spam);
+        // Re-point `-live-` markers: (tgt_spam, off) -> (src_spam, base + off).
+        for pc_entries in walker_pc_live_marker_pos.iter_mut() {
+            for entry in pc_entries.iter_mut() {
+                if entry.0 == tgt_spam {
+                    entry.0 = src_spam.clone();
+                    entry.1 += base;
                 }
             }
         }
@@ -9377,11 +9437,10 @@ impl CodeWriter {
         //
         // The full orthodox pass list lives in
         // [`super::simplify::simplify_graph`] / `all_passes` (issue #112).
-        // Here we run the **walker-safe subset** — the graph-normalization
-        // passes that neither change block count (so the block-by-block
-        // drain below keeps every SpamBlock's `per_block_ssarepr`) nor add
-        // inputargs/link-args (which would desync the walker renamings),
-        // matching the upstream `all_passes` relative order:
+        // Here we run the **walker-safe subset** of the orthodox pass list,
+        // each either keeping every SpamBlock's `per_block_ssarepr` in the
+        // block-by-block drain, or reconciling the inline byte stream with a
+        // bridge, in the upstream `all_passes` relative order:
         //
         //   transform_dead_op_vars   (drops dead inputargs + matching args)
         //   eliminate_empty_blocks   (+ rewrite_dead_forwarder_gotos bridge)
@@ -9390,23 +9449,31 @@ impl CodeWriter {
         //                             branch conditions before emitting an
         //                             exitswitch — but kept for all_passes
         //                             parity and to fold any that do appear)
+        //   remove_trivial_links     (merges single-entry/exit chains; the
+        //                             merge bridge below relocates each merged
+        //                             target's per_block_ssarepr into source)
         //
-        // EMPIRICALLY VALIDATED (#73, 2026-05-30): this subset passes the
+        // EMPIRICALLY VALIDATED (#73, 2026-05-31): this subset passes the
         // full check.py gate (dynasm 39/39, correctness + 8-benchmark
-        // performance).  The remaining active passes are still gated on a
-        // graph-driven drain (#73):
-        //   - `ssa_to_ssi` ADDS inputargs/link-args (5/25 synthetic fail) —
-        //     it changes the coalesce pairs and walker renamings the inline
-        //     drain depends on;
-        //   - `remove_trivial_links` MERGES blocks (16/25 fail) — the merged
-        //     target's `per_block_ssarepr` would be lost from the drain.
-        // The other `all_passes` entries are structural no-ops on today's
-        // empty-`operations` walker blocks (see their classification in
-        // `simplify.rs`).
+        // performance, no regression).  The only remaining active pass still
+        // gated on a graph-driven drain (#73) is `ssa_to_ssi`, which ADDS
+        // inputargs/link-args (5/25 synthetic fail) the inline drain has no
+        // register slots for.  The other `all_passes` entries are structural
+        // no-ops on today's empty-`operations` walker blocks (see their
+        // classification in `simplify.rs`).
         super::simplify::transform_dead_op_vars(&graph);
         eliminate_empty_blocks(&graph);
         super::simplify::remove_identical_vars_ssa(&graph);
         super::simplify::constfold_exitswitch(&graph);
+        // remove_trivial_links merges single-entry/single-exit chains; the
+        // merge bridge relocates each merged target's inline per_block_ssarepr
+        // into its surviving source so the drain keeps the opcodes (issue #73).
+        let trivial_link_merges = super::simplify::remove_trivial_links_recording(&graph);
+        rewrite_trivial_link_merges(
+            &trivial_link_merges,
+            &all_walker_blocks,
+            &mut walker_pc_live_marker_pos,
+        );
         // Port-boundary guard: after the collapse, no link reachable from
         // the startblock may still target a dead forwarder.  RPython has
         // no equivalent check (its graph is simplified before flatten),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9456,16 +9456,18 @@ impl CodeWriter {
         // EMPIRICALLY VALIDATED (#73, 2026-05-31): this subset passes the
         // full check.py gate (dynasm 39/39, correctness + 8-benchmark
         // performance, no regression).  The only remaining active pass is
-        // `ssa_to_ssi`, gated on the walker producing COMPLETE SSA graphs:
-        // wiring it crashes 5/25 synthetic at `backendopt_ssa.rs:316`
-        // ("no way to give a value to v"), because the walker's dual-write
-        // graph has "free" variable uses it threads via the register/slot
-        // model rather than through graph inputargs — an incomplete SSA graph
-        // that ssa_to_ssi (correctly, as RPython would) rejects.  Completing
-        // it needs the walker to thread every value through the graph (#73),
-        // not a drain bridge.  The other `all_passes` entries are structural
-        // no-ops on today's empty-`operations` walker blocks (see their
-        // classification in `simplify.rs`).
+        // `ssa_to_ssi`, deliberately NOT wired.  It now runs CORRECTLY on
+        // walker graphs (the `backendopt_ssa.rs` stop-at-startblock
+        // adaptation makes it recognise values the walker defines inline at
+        // entry instead of crashing), and wiring it passes correctness
+        // 39/39 — but it is **overhead-only** on today's inline walker: it
+        // threads variables the walker already routes through its
+        // register/slot model, adding redundant coalesce pairs / `ref_copy`
+        // that measurably regress exception-heavy code (raise_catch ~4.2x ->
+        // ~10.9x).  SSI form only pays off once codegen is driven from the
+        // graph (#73), so it stays out until then.  The other `all_passes`
+        // entries are structural no-ops on today's empty-`operations` walker
+        // blocks (see their classification in `simplify.rs`).
         super::simplify::transform_dead_op_vars(&graph);
         eliminate_empty_blocks(&graph);
         super::simplify::remove_identical_vars_ssa(&graph);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9392,6 +9392,17 @@ impl CodeWriter {
         // `simplify_graph` passes are no-ops on today's empty-`operations`
         // walker blocks anyway — see their classification in
         // `simplify.rs`.)
+        //
+        // EMPIRICALLY VERIFIED (#112, 2026-05-30): replacing this call with
+        // the full `super::simplify::simplify_graph(&graph)` driver FAILS
+        // 21/25 synthetic correctness tests — the active passes
+        // (`remove_trivial_links` merges blocks, `remove_identical_vars_SSA`/
+        // `ssa_to_ssi` rename/add inputargs, `transform_dead_op_vars` drops
+        // inputargs, `constfold_exitswitch` drops exits) restructure the
+        // graph after the walker already emitted SSARepr inline, desyncing
+        // the block-by-block drain below.  Wiring the rest stays gated on a
+        // graph-driven drain (#73); only `eliminate_empty_blocks` (with its
+        // `rewrite_dead_forwarder_gotos` bridge) is safe today.
         eliminate_empty_blocks(&graph);
         // Port-boundary guard: after the collapse, no link reachable from
         // the startblock may still target a dead forwarder.  RPython has

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9442,9 +9442,10 @@ impl CodeWriter {
         // block-by-block drain, or reconciling the inline byte stream with a
         // bridge, in the upstream `all_passes` relative order:
         //
-        //   transform_dead_op_vars   (drops dead inputargs + matching args)
         //   eliminate_empty_blocks   (+ rewrite_dead_forwarder_gotos bridge)
-        //   remove_identical_vars_SSA (dedups duplicate phi inputargs)
+        //   remove_identical_vars_SSA (dedups duplicate phi inputargs — the
+        //                             removed input is renamed to its identical
+        //                             twin, so no value is lost)
         //   constfold_exitswitch     (no-op today — the walker folds constant
         //                             branch conditions before emitting an
         //                             exitswitch — but kept for all_passes
@@ -9453,22 +9454,34 @@ impl CodeWriter {
         //                             merge bridge below relocates each merged
         //                             target's per_block_ssarepr into source)
         //
-        // EMPIRICALLY VALIDATED (#73, 2026-05-31): this subset passes the
-        // full check.py gate (dynasm 39/39, correctness + 8-benchmark
-        // performance, no regression).  The only remaining active pass is
-        // `ssa_to_ssi`, deliberately NOT wired.  It now runs CORRECTLY on
-        // walker graphs (the `backendopt_ssa.rs` stop-at-startblock
-        // adaptation makes it recognise values the walker defines inline at
-        // entry instead of crashing), and wiring it passes correctness
-        // 39/39 — but it is **overhead-only** on today's inline walker: it
-        // threads variables the walker already routes through its
-        // register/slot model, adding redundant coalesce pairs / `ref_copy`
-        // that measurably regress exception-heavy code (raise_catch ~4.2x ->
-        // ~10.9x).  SSI form only pays off once codegen is driven from the
-        // graph (#73), so it stays out until then.  The other `all_passes`
-        // entries are structural no-ops on today's empty-`operations` walker
-        // blocks (see their classification in `simplify.rs`).
-        super::simplify::transform_dead_op_vars(&graph);
+        // EMPIRICALLY VALIDATED (#73): this subset passes the full check.py
+        // gate (dynasm 39/39, correctness + 8-benchmark performance).
+        //
+        // Two `all_passes` entries are deliberately NOT wired here because they
+        // are unsafe or unprofitable on today's inline walker (both pay off
+        // only once codegen is driven from the graph, #73):
+        //
+        //   - `transform_dead_op_vars` PRUNES inputargs/link-args it deems
+        //     dead — but its liveness only scans `Block.operations`,
+        //     exitswitches and outgoing links, NOT each SpamBlock's
+        //     `per_block_ssarepr`, where the walker's real bytecode uses live.
+        //     A target block that consumes an incoming value only in its inline
+        //     instructions (without forwarding/returning the graph var) would
+        //     have that inputarg + the predecessor link arg pruned, and
+        //     `walker_post_walk_insert_renamings` would then have no pair to
+        //     copy the value the inline insns still read — losing a live edge
+        //     value (codex review P1, PR #127).  Stays out until the drain is
+        //     graph-driven and liveness can see every use.
+        //   - `ssa_to_ssi` runs CORRECTLY on walker graphs (the
+        //     `backendopt_ssa.rs` stop-at-startblock adaptation), but is
+        //     overhead-only: it threads values the walker already routes
+        //     through its register/slot model, adding redundant coalesce pairs
+        //     / `ref_copy` that measurably regress exception-heavy code
+        //     (raise_catch ~4.2x -> ~10.9x).
+        //
+        // The other `all_passes` entries are structural no-ops on today's
+        // empty-`operations` walker blocks (see their classification in
+        // `simplify.rs`).
         eliminate_empty_blocks(&graph);
         super::simplify::remove_identical_vars_ssa(&graph);
         super::simplify::constfold_exitswitch(&graph);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9442,10 +9442,8 @@ impl CodeWriter {
         // block-by-block drain, or reconciling the inline byte stream with a
         // bridge, in the upstream `all_passes` relative order:
         //
-        //   eliminate_empty_blocks   (+ rewrite_dead_forwarder_gotos bridge)
-        //   remove_identical_vars_SSA (dedups duplicate phi inputargs — the
-        //                             removed input is renamed to its identical
-        //                             twin, so no value is lost)
+        //   eliminate_empty_blocks   (+ rewrite_dead_forwarder_gotos bridge;
+        //                             dead blocks have cleared per_block_ssarepr)
         //   constfold_exitswitch     (no-op today — the walker folds constant
         //                             branch conditions before emitting an
         //                             exitswitch — but kept for all_passes
@@ -9457,21 +9455,20 @@ impl CodeWriter {
         // EMPIRICALLY VALIDATED (#73): this subset passes the full check.py
         // gate (dynasm 39/39, correctness + 8-benchmark performance).
         //
-        // Two `all_passes` entries are deliberately NOT wired here because they
-        // are unsafe or unprofitable on today's inline walker (both pay off
-        // only once codegen is driven from the graph, #73):
+        // The remaining active `all_passes` entries are deliberately NOT wired
+        // here (all pay off only once codegen is driven from the graph, #73):
         //
-        //   - `transform_dead_op_vars` PRUNES inputargs/link-args it deems
-        //     dead — but its liveness only scans `Block.operations`,
-        //     exitswitches and outgoing links, NOT each SpamBlock's
-        //     `per_block_ssarepr`, where the walker's real bytecode uses live.
-        //     A target block that consumes an incoming value only in its inline
-        //     instructions (without forwarding/returning the graph var) would
-        //     have that inputarg + the predecessor link arg pruned, and
-        //     `walker_post_walk_insert_renamings` would then have no pair to
-        //     copy the value the inline insns still read — losing a live edge
-        //     value (codex review P1, PR #127).  Stays out until the drain is
-        //     graph-driven and liveness can see every use.
+        //   - `transform_dead_op_vars` and `remove_identical_vars_SSA` both
+        //     drop a graph inputarg + its predecessor link arg (one PRUNES dead
+        //     ones, the other DEDUPS a duplicate phi and renames it to its
+        //     twin).  But the walker's real bytecode uses live in each
+        //     SpamBlock's `per_block_ssarepr` and read the dropped variable's
+        //     walker SLOT, which the graph rename does not touch.  Since
+        //     `walker_post_walk_insert_renamings` only sees the pruned graph it
+        //     emits no copy into that slot, so the inline insns can read a
+        //     stale slot — a lost / wrong edge value (codex review P1 x2,
+        //     PR #127).  They need a walker-side liveness/renaming bridge, or
+        //     the graph-driven drain, before they can be wired.
         //   - `ssa_to_ssi` runs CORRECTLY on walker graphs (the
         //     `backendopt_ssa.rs` stop-at-startblock adaptation), but is
         //     overhead-only: it threads values the walker already routes
@@ -9483,7 +9480,6 @@ impl CodeWriter {
         // empty-`operations` walker blocks (see their classification in
         // `simplify.rs`).
         eliminate_empty_blocks(&graph);
-        super::simplify::remove_identical_vars_ssa(&graph);
         super::simplify::constfold_exitswitch(&graph);
         // remove_trivial_links merges single-entry/single-exit chains; the
         // merge bridge relocates each merged target's inline per_block_ssarepr

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9383,26 +9383,30 @@ impl CodeWriter {
         // inputargs/link-args (which would desync the walker renamings),
         // matching the upstream `all_passes` relative order:
         //
-        //   transform_dead_op_vars  (drops dead inputargs + matching args)
-        //   eliminate_empty_blocks  (+ rewrite_dead_forwarder_gotos bridge)
+        //   transform_dead_op_vars   (drops dead inputargs + matching args)
+        //   eliminate_empty_blocks   (+ rewrite_dead_forwarder_gotos bridge)
         //   remove_identical_vars_SSA (dedups duplicate phi inputargs)
+        //   constfold_exitswitch     (no-op today — the walker folds constant
+        //                             branch conditions before emitting an
+        //                             exitswitch — but kept for all_passes
+        //                             parity and to fold any that do appear)
         //
-        // EMPIRICALLY VALIDATED (#73, 2026-05-30): this subset passes 25/25
-        // synthetic correctness tests.  The remaining active passes are
-        // still gated on a graph-driven drain (#73):
-        //   - `ssa_to_ssi` ADDS inputargs/link-args (5/25 fail) — it changes
-        //     the coalesce pairs and walker renamings the inline drain
-        //     depends on;
-        //   - `remove_trivial_links` (merges blocks) and `constfold_exitswitch`
-        //     (drops exits → unreachable blocks) remove SpamBlocks whose
-        //     `per_block_ssarepr` the drain would then lose (full driver:
-        //     21/25 fail).
+        // EMPIRICALLY VALIDATED (#73, 2026-05-30): this subset passes the
+        // full check.py gate (dynasm 39/39, correctness + 8-benchmark
+        // performance).  The remaining active passes are still gated on a
+        // graph-driven drain (#73):
+        //   - `ssa_to_ssi` ADDS inputargs/link-args (5/25 synthetic fail) —
+        //     it changes the coalesce pairs and walker renamings the inline
+        //     drain depends on;
+        //   - `remove_trivial_links` MERGES blocks (16/25 fail) — the merged
+        //     target's `per_block_ssarepr` would be lost from the drain.
         // The other `all_passes` entries are structural no-ops on today's
         // empty-`operations` walker blocks (see their classification in
         // `simplify.rs`).
         super::simplify::transform_dead_op_vars(&graph);
         eliminate_empty_blocks(&graph);
         super::simplify::remove_identical_vars_ssa(&graph);
+        super::simplify::constfold_exitswitch(&graph);
         // Port-boundary guard: after the collapse, no link reachable from
         // the startblock may still target a dead forwarder.  RPython has
         // no equivalent check (its graph is simplified before flatten),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9375,35 +9375,34 @@ impl CodeWriter {
         // links; `rewrite_dead_forwarder_gotos` then retargets the
         // walker's inline-emitted `TLabel`s to match.
         //
-        // The full orthodox pass list now lives in
-        // [`super::simplify::simplify_graph`] / `all_passes` (issue #112),
-        // but only `eliminate_empty_blocks` is wired into the walker today.
-        // The other *active* passes — `remove_trivial_links` (merges
-        // blocks), `remove_identical_vars_ssa` / `ssa_to_ssi` (rename / add
-        // inputargs), `transform_dead_op_vars` (drops inputargs),
-        // `constfold_exitswitch` (drops exits) — would change graph
-        // topology / variables after the walker has already emitted SSARepr
-        // inline into `per_block_ssarepr`.  The drain below reads that
-        // SSARepr block-by-block in `graph.iterblocks()` order, and only
-        // `eliminate_empty_blocks` has a reconciliation bridge
-        // (`rewrite_dead_forwarder_gotos`).  Wiring the rest is therefore
-        // gated on making the drain graph-driven (issue #73); until then
-        // they would desync the emitted byte stream.  (The remaining
-        // `simplify_graph` passes are no-ops on today's empty-`operations`
-        // walker blocks anyway — see their classification in
-        // `simplify.rs`.)
+        // The full orthodox pass list lives in
+        // [`super::simplify::simplify_graph`] / `all_passes` (issue #112).
+        // Here we run the **walker-safe subset** — the graph-normalization
+        // passes that neither change block count (so the block-by-block
+        // drain below keeps every SpamBlock's `per_block_ssarepr`) nor add
+        // inputargs/link-args (which would desync the walker renamings),
+        // matching the upstream `all_passes` relative order:
         //
-        // EMPIRICALLY VERIFIED (#112, 2026-05-30): replacing this call with
-        // the full `super::simplify::simplify_graph(&graph)` driver FAILS
-        // 21/25 synthetic correctness tests — the active passes
-        // (`remove_trivial_links` merges blocks, `remove_identical_vars_SSA`/
-        // `ssa_to_ssi` rename/add inputargs, `transform_dead_op_vars` drops
-        // inputargs, `constfold_exitswitch` drops exits) restructure the
-        // graph after the walker already emitted SSARepr inline, desyncing
-        // the block-by-block drain below.  Wiring the rest stays gated on a
-        // graph-driven drain (#73); only `eliminate_empty_blocks` (with its
-        // `rewrite_dead_forwarder_gotos` bridge) is safe today.
+        //   transform_dead_op_vars  (drops dead inputargs + matching args)
+        //   eliminate_empty_blocks  (+ rewrite_dead_forwarder_gotos bridge)
+        //   remove_identical_vars_SSA (dedups duplicate phi inputargs)
+        //
+        // EMPIRICALLY VALIDATED (#73, 2026-05-30): this subset passes 25/25
+        // synthetic correctness tests.  The remaining active passes are
+        // still gated on a graph-driven drain (#73):
+        //   - `ssa_to_ssi` ADDS inputargs/link-args (5/25 fail) — it changes
+        //     the coalesce pairs and walker renamings the inline drain
+        //     depends on;
+        //   - `remove_trivial_links` (merges blocks) and `constfold_exitswitch`
+        //     (drops exits → unreachable blocks) remove SpamBlocks whose
+        //     `per_block_ssarepr` the drain would then lose (full driver:
+        //     21/25 fail).
+        // The other `all_passes` entries are structural no-ops on today's
+        // empty-`operations` walker blocks (see their classification in
+        // `simplify.rs`).
+        super::simplify::transform_dead_op_vars(&graph);
         eliminate_empty_blocks(&graph);
+        super::simplify::remove_identical_vars_ssa(&graph);
         // Port-boundary guard: after the collapse, no link reachable from
         // the startblock may still target a dead forwarder.  RPython has
         // no equivalent check (its graph is simplified before flatten),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1555,7 +1555,7 @@ fn walker_post_walk_insert_renamings(
 /// producer of the empty-forwarding shape, so `dead` is the faithful
 /// pyre predicate.  The `exitswitch.is_none()` / `!exits.is_empty()`
 /// guards still mirror upstream exactly.
-fn eliminate_empty_blocks(graph: &super::flow::FunctionGraph) {
+pub(crate) fn eliminate_empty_blocks(graph: &super::flow::FunctionGraph) {
     for link_ref in graph.iterlinks() {
         loop {
             let Some(block1) = link_ref.borrow().target.clone() else {
@@ -9374,6 +9374,24 @@ impl CodeWriter {
         // use) reflect the collapsed `predecessor -> generalization`
         // links; `rewrite_dead_forwarder_gotos` then retargets the
         // walker's inline-emitted `TLabel`s to match.
+        //
+        // The full orthodox pass list now lives in
+        // [`super::simplify::simplify_graph`] / `all_passes` (issue #112),
+        // but only `eliminate_empty_blocks` is wired into the walker today.
+        // The other *active* passes — `remove_trivial_links` (merges
+        // blocks), `remove_identical_vars_ssa` / `ssa_to_ssi` (rename / add
+        // inputargs), `transform_dead_op_vars` (drops inputargs),
+        // `constfold_exitswitch` (drops exits) — would change graph
+        // topology / variables after the walker has already emitted SSARepr
+        // inline into `per_block_ssarepr`.  The drain below reads that
+        // SSARepr block-by-block in `graph.iterblocks()` order, and only
+        // `eliminate_empty_blocks` has a reconciliation bridge
+        // (`rewrite_dead_forwarder_gotos`).  Wiring the rest is therefore
+        // gated on making the drain graph-driven (issue #73); until then
+        // they would desync the emitted byte stream.  (The remaining
+        // `simplify_graph` passes are no-ops on today's empty-`operations`
+        // walker blocks anyway — see their classification in
+        // `simplify.rs`.)
         eliminate_empty_blocks(&graph);
         // Port-boundary guard: after the collapse, no link reachable from
         // the startblock may still target a dead forwarder.  RPython has

--- a/pyre/pyre-jit/src/jit/flow.rs
+++ b/pyre/pyre-jit/src/jit/flow.rs
@@ -36,7 +36,7 @@
 //! Scope of THIS slice: data types only. No walker integration yet.
 //! Subsequent slices of Step 6 (see task #205) populate and consume.
 
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::rc::{Rc, Weak};
@@ -138,6 +138,19 @@ impl Variable {
                 .nr = nr;
         }
         format!("{}{}", prefix, nr)
+    }
+
+    /// The name *prefix* (the `_name` slot upstream), without the numeric
+    /// suffix `name()` appends.  `simplify.py:537 isspecialvar` matches on
+    /// this prefix (`'last_exception_'` / `'last_exc_value_'`).
+    pub fn name_prefix(&self) -> String {
+        VARIABLE_NAMES
+            .lock()
+            .unwrap()
+            .states
+            .get(&self.id)
+            .map(|state| state.name.clone())
+            .unwrap_or_else(|| DUMMYNAME.to_owned())
     }
 
     pub fn renamed(&self) -> bool {
@@ -873,6 +886,18 @@ impl Link {
         self.target = Some(targetblock);
     }
 
+    /// `link.prevblock` as a strong [`BlockRef`].
+    ///
+    /// RPython stores `Link.prevblock` as a direct object reference; pyre
+    /// breaks the block↔link ownership cycle with a `Weak`, so passes that
+    /// need `source = link.prevblock` (e.g. `simplify.py:242
+    /// remove_trivial_links`) recover the strong reference here.  Returns
+    /// `None` only if the owning block has been dropped, which never
+    /// happens for a link still reachable from `graph.iterlinks()`.
+    pub fn prevblock_ref(&self) -> Option<BlockRef> {
+        self.prevblock.as_ref().and_then(Weak::upgrade).map(BlockRef)
+    }
+
     pub fn into_ref(self) -> LinkRef {
         LinkRef(Rc::new(RefCell::new(self)))
     }
@@ -1025,7 +1050,13 @@ pub struct FunctionGraph {
     pub exceptblock: BlockRef,
     pub tag: Option<String>,
     /// Monotonic id generator for Variables allocated in this graph.
-    next_variable_id: u32,
+    ///
+    /// Interior-mutable (`Cell`) so graph-normalization passes that take
+    /// `&FunctionGraph` (the `simplify_graph` pass shape) can still allocate
+    /// fresh Variables — `SSA_to_SSI`'s `v.copy()` (`ssa.py:622`) needs a new
+    /// identity while every other slot mutates through `RefCell` block/link
+    /// interior mutability.
+    next_variable_id: Cell<u32>,
 }
 
 impl FunctionGraph {
@@ -1040,13 +1071,13 @@ impl FunctionGraph {
             next_variable_id = next_variable_id.max(return_var.id.0 + 1);
         }
 
-        let mut graph = Self {
+        let graph = Self {
             name: name.into(),
             startblock: startblock.clone(),
             returnblock: Block::shared(Vec::new()),
             exceptblock: Block::shared(Vec::new()),
             tag: None,
-            next_variable_id,
+            next_variable_id: Cell::new(next_variable_id),
         };
 
         let return_var = return_var.unwrap_or_else(|| graph.fresh_untyped_variable());
@@ -1058,6 +1089,9 @@ impl FunctionGraph {
         let exceptblock = Block::shared(vec![except_etype.into(), except_evalue.into()]);
         exceptblock.borrow_mut().mark_final();
 
+        // `graph` is not `mut`: `returnblock`/`exceptblock` are reassigned
+        // through the owned struct binding below.
+        let mut graph = graph;
         graph.returnblock = returnblock;
         graph.exceptblock = exceptblock;
         graph
@@ -1065,21 +1099,32 @@ impl FunctionGraph {
 
     /// Allocate a fresh `Variable` of the given kind. Mirrors upstream
     /// `Variable(name=None)` which also creates a new identity.
-    pub fn fresh_variable(&mut self, kind: Kind) -> Variable {
-        let id = VariableId(self.next_variable_id);
-        self.next_variable_id += 1;
+    pub fn fresh_variable(&self, kind: Kind) -> Variable {
+        let id = VariableId(self.next_variable_id.get());
+        self.next_variable_id.set(id.0 + 1);
         Variable::new(id, kind)
     }
 
-    pub fn fresh_untyped_variable(&mut self) -> Variable {
-        let id = VariableId(self.next_variable_id);
-        self.next_variable_id += 1;
+    pub fn fresh_untyped_variable(&self) -> Variable {
+        let id = VariableId(self.next_variable_id.get());
+        self.next_variable_id.set(id.0 + 1);
         Variable::new_untyped(id)
     }
 
+    /// `model.py:341-348 Variable.copy` — a fresh identity carrying the same
+    /// kind (`concretetype`) as `v`.  Used by `SSA_to_SSI`.
+    pub fn fresh_like(&self, v: Variable) -> Variable {
+        match v.kind {
+            Some(kind) => self.fresh_variable(kind),
+            None => self.fresh_untyped_variable(),
+        }
+    }
+
     /// Allocate and own a fresh `Block`.
-    pub fn new_block(&mut self, inputargs: Vec<FlowValue>) -> BlockRef {
-        observe_values_for_next_id(&mut self.next_variable_id, &inputargs);
+    pub fn new_block(&self, inputargs: Vec<FlowValue>) -> BlockRef {
+        let mut next = self.next_variable_id.get();
+        observe_values_for_next_id(&mut next, &inputargs);
+        self.next_variable_id.set(next);
         Block::shared(inputargs)
     }
 
@@ -1292,7 +1337,7 @@ pub fn copygraph(
     let mut blockmap: HashMap<BlockRef, BlockRef> = HashMap::new();
     let mut local_varmap = varmap.clone();
     let shallowvars = shallowvars || shallow;
-    let mut next_variable_id = graph.next_variable_id;
+    let mut next_variable_id = graph.next_variable_id.get();
 
     let copy_block = |block: &BlockRef,
                       local_varmap: &mut HashMap<Variable, Variable>,
@@ -1448,7 +1493,7 @@ pub fn copygraph(
         returnblock: blockmap[&graph.returnblock].clone(),
         exceptblock: blockmap[&graph.exceptblock].clone(),
         tag: graph.tag.clone(),
-        next_variable_id,
+        next_variable_id: Cell::new(next_variable_id),
     }
 }
 

--- a/pyre/pyre-jit/src/jit/flow.rs
+++ b/pyre/pyre-jit/src/jit/flow.rs
@@ -895,7 +895,10 @@ impl Link {
     /// `None` only if the owning block has been dropped, which never
     /// happens for a link still reachable from `graph.iterlinks()`.
     pub fn prevblock_ref(&self) -> Option<BlockRef> {
-        self.prevblock.as_ref().and_then(Weak::upgrade).map(BlockRef)
+        self.prevblock
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .map(BlockRef)
     }
 
     pub fn into_ref(self) -> LinkRef {

--- a/pyre/pyre-jit/src/jit/mod.rs
+++ b/pyre/pyre-jit/src/jit/mod.rs
@@ -1,4 +1,5 @@
 pub mod assembler;
+pub mod backendopt_ssa;
 pub mod call;
 pub mod codewriter;
 pub mod cpu;
@@ -7,6 +8,7 @@ pub mod flatten;
 pub mod flow;
 pub mod liveness;
 pub mod regalloc;
+pub mod simplify;
 mod ssa_emitter;
 pub use pyre_jit_trace::descr;
 pub mod executor;

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -1,0 +1,1141 @@
+//! Port of `rpython/translator/simplify.py::simplify_graph` onto pyre-jit's
+//! flow graph (`super::flow`).
+//!
+//! RPython runs `simplify_graph(graph)` (`translator.py:55-56`) right after
+//! `build_flow`, so every graph reaching the codewriter
+//! (`perform_register_allocation → flatten_graph → compute_liveness →
+//! assemble`) is already normalized.  pyre-jit's walker fuses graph-build and
+//! flatten and historically skipped this normalization, which forced
+//! pyre-only repairs (the `rewrite_dead_forwarder_gotos` TLabel bridge, the
+//! regalloc walker-pin pre-merge, the per-PC `-live-` remap) and surfaced as
+//! the `jitcode label was never marked` assembler panic.  This module brings
+//! the orthodox pass list onto pyre-jit's `flow::FunctionGraph` so the graph
+//! that reaches coalescing/flatten matches what PyPy produces.
+//!
+//! Each pass is a line-by-line port dual-referenced to
+//! `rpython/translator/simplify.py` (source of truth) and the already-validated
+//! port in `majit/majit-translate/src/translator/simplify.rs`.  The flow model
+//! differs (`super::flow` uses `VariableId(u32)` identity and `Weak` prevblock
+//! back-edges), so the structural shape is preserved while the Rust mechanics
+//! follow `super::flow`'s conventions.
+//!
+//! Classification (issue #112 scope #4): every pass here is **direct PyPy
+//! parity**.
+
+use std::collections::{HashMap, HashSet};
+
+use majit_translate::tool::algo::unionfind::{UnionFind, UnionFindInfo};
+
+use super::flow::{
+    BlockRef, Constant, ConstantValue, ExitSwitch, ExitSwitchElement, FlowListOfKind, FlowValue,
+    FunctionGraph, LinkRef, SpaceOperation, SpaceOperationArg, Variable, mkentrymap,
+};
+
+/// `rpython/translator/simplify.py:242-268` `remove_trivial_links`.
+/// Port reference: `majit-translate/src/translator/simplify.rs:2674`.
+///
+/// ```py
+/// def remove_trivial_links(graph):
+///     entrymap = mkentrymap(graph)
+///     block = graph.startblock
+///     seen = set([block])
+///     stack = list(block.exits)
+///     while stack:
+///         link = stack.pop()
+///         if link.target in seen:
+///             continue
+///         source = link.prevblock
+///         target = link.target
+///         if (not link.args and source.exitswitch is None and
+///                 len(entrymap[target]) == 1 and
+///                 target.exits):  # stop at the returnblock
+///             assert len(source.exits) == 1
+///             source.operations.extend(target.operations)
+///             source.exitswitch = newexitswitch = target.exitswitch
+///             source.recloseblock(*target.exits)
+///             stack.extend(source.exits)
+///         else:
+///             seen.add(target)
+///             stack.extend(target.exits)
+/// ```
+///
+/// A link is trivial when it carries no args, is the single exit of its
+/// source (`source.exitswitch is None` ⇒ one exit), and its target has a
+/// single predecessor and is not the returnblock (`target.exits` non-empty).
+/// Such a link is removed by folding `target` into `source`.
+pub fn remove_trivial_links(graph: &FunctionGraph) {
+    let entrymap = mkentrymap(graph);
+    let startblock = graph.startblock.clone();
+    // `seen = set([block])` — faithful port of a Python set; BlockRef hashes
+    // by Rc pointer identity, matching RPython's object-identity membership.
+    let mut seen: HashSet<BlockRef> = HashSet::new();
+    seen.insert(startblock.clone());
+    // `stack = list(block.exits)`; `stack.pop()` takes the last element.
+    let mut stack: Vec<LinkRef> = startblock.borrow().exits.clone();
+
+    while let Some(link) = stack.pop() {
+        // `if link.target in seen: continue`.  RPython links always carry a
+        // target; the `None` guard only covers half-built links, which
+        // cannot appear in a graph reachable from `graph.startblock`.
+        let target = match link.borrow().target.clone() {
+            Some(target) => target,
+            None => continue,
+        };
+        if seen.contains(&target) {
+            continue;
+        }
+        // `source = link.prevblock`.
+        let source = link
+            .borrow()
+            .prevblock_ref()
+            .expect("remove_trivial_links: reachable link has a prevblock");
+
+        let is_trivial = {
+            let link_b = link.borrow();
+            let source_b = source.borrow();
+            let target_b = target.borrow();
+            link_b.args.is_empty()
+                && source_b.exitswitch.is_none()
+                && entrymap.get(&target).map_or(0, Vec::len) == 1
+                && !target_b.exits.is_empty() // stop at the returnblock
+        };
+
+        if is_trivial {
+            // `assert len(source.exits) == 1` — guaranteed by
+            // `source.exitswitch is None`, asserted to fail loudly if a
+            // future graph shape breaks the invariant.
+            assert_eq!(
+                source.borrow().exits.len(),
+                1,
+                "remove_trivial_links: trivial-link source must be single-exit"
+            );
+            // `source.operations.extend(target.operations)`;
+            // `source.exitswitch = target.exitswitch`;
+            // `source.recloseblock(*target.exits)`.
+            let (target_ops, target_exitswitch, target_exits) = {
+                let target_b = target.borrow();
+                (
+                    target_b.operations.clone(),
+                    target_b.exitswitch.clone(),
+                    target_b.exits.clone(),
+                )
+            };
+            {
+                let mut source_b = source.borrow_mut();
+                source_b.operations.extend(target_ops);
+                source_b.exitswitch = target_exitswitch;
+            }
+            source.recloseblock(target_exits);
+            // `stack.extend(source.exits)` — keep collapsing through source.
+            stack.extend(source.borrow().exits.clone());
+        } else {
+            // `seen.add(target); stack.extend(target.exits)`.
+            seen.insert(target.clone());
+            stack.extend(target.borrow().exits.clone());
+        }
+    }
+}
+
+// ── remove_identical_vars_SSA + supporting helpers ──────────────────────
+
+/// `simplify.py:526-531` `class Representative`.  Stores the partition's
+/// representative value; `absorb` is a no-op so the info that wins the
+/// weighted union keeps its `rep`.
+#[derive(Clone, Debug)]
+struct Representative {
+    rep: FlowValue,
+}
+
+impl UnionFindInfo for Representative {
+    fn absorb(&mut self, _other: Self) {}
+}
+
+/// `simplify.py:533-535` `all_equal`.
+fn all_equal(lst: &[FlowValue]) -> bool {
+    match lst.first() {
+        None => true,
+        Some(first) => lst.iter().skip(1).all(|x| x == first),
+    }
+}
+
+/// `simplify.py:537-538` `isspecialvar`.
+fn isspecialvar(v: &FlowValue) -> bool {
+    match v {
+        FlowValue::Variable(var) => {
+            let prefix = var.name_prefix();
+            prefix == "last_exception_" || prefix == "last_exc_value_"
+        }
+        FlowValue::Constant(_) => false,
+    }
+}
+
+/// `model.py:350 Variable.replace` generalized to a `Variable → FlowValue`
+/// renaming: a Variable in `mapping` becomes its mapped value, any other
+/// Variable and any Constant is returned unchanged.
+fn rename_value(v: &FlowValue, mapping: &HashMap<Variable, FlowValue>) -> FlowValue {
+    match v {
+        FlowValue::Variable(var) => mapping.get(var).cloned().unwrap_or(FlowValue::Variable(*var)),
+        FlowValue::Constant(_) => v.clone(),
+    }
+}
+
+fn rename_arg(arg: &SpaceOperationArg, mapping: &HashMap<Variable, FlowValue>) -> SpaceOperationArg {
+    match arg {
+        SpaceOperationArg::Value(value) => SpaceOperationArg::Value(rename_value(value, mapping)),
+        SpaceOperationArg::ListOfKind(list) => SpaceOperationArg::ListOfKind(FlowListOfKind {
+            kind: list.kind,
+            content: list
+                .content
+                .iter()
+                .map(|value| rename_value(value, mapping))
+                .collect(),
+        }),
+        // `flatten.py:365-367` passes AbstractDescr / IndirectCallTargets
+        // through unchanged.
+        SpaceOperationArg::Descr(_) | SpaceOperationArg::IndirectCallTargets(_) => arg.clone(),
+    }
+}
+
+fn rename_exitswitch(sw: &ExitSwitch, mapping: &HashMap<Variable, FlowValue>) -> ExitSwitch {
+    match sw {
+        ExitSwitch::Value(value) => ExitSwitch::Value(rename_value(value, mapping)),
+        ExitSwitch::Tuple(elements) => ExitSwitch::Tuple(
+            elements
+                .iter()
+                .map(|element| match element {
+                    ExitSwitchElement::Value(value) => {
+                        ExitSwitchElement::Value(rename_value(value, mapping))
+                    }
+                    ExitSwitchElement::Marker(marker) => {
+                        ExitSwitchElement::Marker(marker.clone())
+                    }
+                })
+                .collect(),
+        ),
+    }
+}
+
+/// `model.py:241-247 Block.renamevariables`, generalized to a
+/// `Variable → FlowValue` mapping (the rep can be a Constant) and extended to
+/// the `last_exception` / `last_exc_value` link extras, mirroring the
+/// `majit-translate` `renamevariables_hl`.
+///
+/// Two deliberate adaptations matching the validated `majit-translate` port:
+/// (1) `block.inputargs` are NOT renamed here — `remove_identical_vars_SSA`
+/// has already rewritten them to the pruned phi-input list, and a block
+/// parameter must stay a Variable (never a Constant rep); (2) unlike
+/// `join_blocks`'s rename, no `indirect_call`→`direct_call` rewrite —
+/// `Block.renamevariables` upstream is a plain `op.replace(mapping)`.
+fn renamevariables_value(block: &BlockRef, mapping: &HashMap<Variable, FlowValue>) {
+    if mapping.is_empty() {
+        return;
+    }
+    let (new_ops, new_switch) = {
+        let b = block.borrow();
+        let ops: Vec<SpaceOperation> = b
+            .operations
+            .iter()
+            .map(|op| SpaceOperation {
+                opname: op.opname.clone(),
+                args: op.args.iter().map(|arg| rename_arg(arg, mapping)).collect(),
+                result: op.result.as_ref().map(|r| rename_value(r, mapping)),
+                offset: op.offset,
+            })
+            .collect();
+        let switch = b.exitswitch.as_ref().map(|sw| rename_exitswitch(sw, mapping));
+        (ops, switch)
+    };
+    {
+        let mut b = block.borrow_mut();
+        b.operations = new_ops;
+        b.exitswitch = new_switch;
+    }
+    let exits: Vec<LinkRef> = block.borrow().exits.clone();
+    for link in exits {
+        let mut l = link.borrow_mut();
+        l.args = l
+            .args
+            .iter()
+            .map(|arg| arg.as_ref().map(|value| rename_value(value, mapping)))
+            .collect();
+        // The exception extras are Variables; a rename to a non-Variable
+        // would be a contradiction, so keep only the Variable case.
+        if let Some(v) = l.last_exception {
+            if let FlowValue::Variable(nv) = rename_value(&FlowValue::Variable(v), mapping) {
+                l.last_exception = Some(nv);
+            }
+        }
+        if let Some(v) = l.last_exc_value {
+            if let FlowValue::Variable(nv) = rename_value(&FlowValue::Variable(v), mapping) {
+                l.last_exc_value = Some(nv);
+            }
+        }
+    }
+}
+
+/// `rpython/translator/simplify.py:540-595` `remove_identical_vars_SSA`.
+/// Port reference: `majit-translate/src/translator/simplify.rs:967`.
+///
+/// When the same value is passed multiple times into the next block, pass it
+/// only once.  Uses its own `UnionFind(Representative)` (not
+/// `DataFlowFamilyBuilder`), inlining the phi-node collapse over each block's
+/// inputs with the per-link `link.args[i]` as the phi sources.
+pub fn remove_identical_vars_ssa(graph: &FunctionGraph) {
+    let mut uf: UnionFind<FlowValue, Representative> =
+        UnionFind::new(|k: &FlowValue| Representative { rep: k.clone() });
+
+    // `entrymap = mkentrymap(graph); del entrymap[startblock];
+    // entrymap.pop(returnblock, None); entrymap.pop(exceptblock, None)`.
+    let mut entrymap = mkentrymap(graph);
+    entrymap.remove(&graph.startblock);
+    entrymap.remove(&graph.returnblock);
+    entrymap.remove(&graph.exceptblock);
+
+    // `inputs[block] = zip(block.inputargs, zip(*[link.args for link in
+    // links]))` — per block, the phi for each inputarg paired with the
+    // incoming-link actuals at that position.
+    let mut inputs: HashMap<BlockRef, Vec<(Variable, Vec<FlowValue>)>> = HashMap::new();
+    for (block, links) in entrymap.iter() {
+        let inputargs = block.borrow().inputargs.clone();
+        let mut phis: Vec<(Variable, Vec<FlowValue>)> = Vec::with_capacity(inputargs.len());
+        for (i, input) in inputargs.iter().enumerate() {
+            let FlowValue::Variable(input_v) = input else {
+                continue;
+            };
+            let mut phi_args: Vec<FlowValue> = Vec::with_capacity(links.len());
+            for link in links {
+                let arg = link.borrow().args.get(i).cloned().flatten().expect(
+                    "remove_identical_vars_SSA: link.args position missing for inputarg",
+                );
+                phi_args.push(arg);
+            }
+            phis.push((*input_v, phi_args));
+        }
+        inputs.insert(block.clone(), phis);
+    }
+
+    // `progress = True; while progress: for block in inputs: if
+    // simplify_phis(block): progress = True`.
+    let block_keys: Vec<BlockRef> = inputs.keys().cloned().collect();
+    let mut progress = true;
+    while progress {
+        progress = false;
+        for block in &block_keys {
+            if simplify_phis_inner(&mut uf, inputs.get_mut(block).unwrap()) {
+                progress = true;
+            }
+        }
+    }
+
+    // `renaming = dict((key, uf[key].rep) for key in uf)` — restricted to the
+    // Variable keys, since only Variable storage slots are renamed.
+    let renaming: HashMap<Variable, FlowValue> = {
+        let keys: Vec<FlowValue> = uf.keys().cloned().collect();
+        let mut out: HashMap<Variable, FlowValue> = HashMap::new();
+        for key in keys {
+            let FlowValue::Variable(kv) = key else {
+                continue;
+            };
+            if let Some(info) = uf.get(&FlowValue::Variable(kv)) {
+                out.insert(kv, info.rep.clone());
+            }
+        }
+        out
+    };
+
+    // Rewrite each block's inputargs and every incoming link's args to match
+    // the pruned `inputs[block]` (inputargs shrink before renamevariables).
+    for (block, phis) in inputs.iter() {
+        let links = entrymap
+            .get(block)
+            .cloned()
+            .expect("entrymap lookup consistent with inputs");
+        let new_inputs: Vec<FlowValue> = phis.iter().map(|(v, _)| FlowValue::Variable(*v)).collect();
+        // `per_link_args[link_idx][phi_idx] = phis[phi_idx].1[link_idx]`.
+        let per_link_args: Vec<Vec<Option<FlowValue>>> = (0..links.len())
+            .map(|li| phis.iter().map(|(_, pa)| Some(pa[li].clone())).collect())
+            .collect();
+        block.borrow_mut().inputargs = new_inputs;
+        assert_eq!(links.len(), per_link_args.len());
+        for (link, args) in links.iter().zip(per_link_args.into_iter()) {
+            link.borrow_mut().args = args;
+        }
+    }
+
+    for block in inputs.keys() {
+        renamevariables_value(block, &renaming);
+    }
+}
+
+/// Inner of `remove_identical_vars_ssa`'s `simplify_phis(block)` closure
+/// (`simplify.py:555-573`).
+fn simplify_phis_inner(
+    uf: &mut UnionFind<FlowValue, Representative>,
+    phis: &mut Vec<(Variable, Vec<FlowValue>)>,
+) -> bool {
+    let mut to_remove: Vec<usize> = Vec::new();
+    let mut unique_phis: HashMap<Vec<FlowValue>, Variable> = HashMap::new();
+    for (i, (input, phi_args)) in phis.iter().enumerate() {
+        // `new_args = [uf.find_rep(arg) for arg in phi_args]`.
+        let new_args: Vec<FlowValue> = phi_args.iter().map(|a| uf.find_rep(a.clone())).collect();
+        // `if all_equal(new_args) and not isspecialvar(new_args[0]):`
+        if let Some(first) = new_args.first().cloned() {
+            if all_equal(&new_args) && !isspecialvar(&first) {
+                uf.union(first, FlowValue::Variable(*input));
+                to_remove.push(i);
+                continue;
+            }
+        }
+        // else branch — group by identical phi-tuple.
+        if let Some(existing) = unique_phis.get(&new_args).copied() {
+            uf.union(FlowValue::Variable(existing), FlowValue::Variable(*input));
+            to_remove.push(i);
+        } else {
+            unique_phis.insert(new_args, *input);
+        }
+    }
+    // `for i in reversed(to_remove): del phis[i]`.
+    for i in to_remove.iter().rev() {
+        phis.remove(*i);
+    }
+    !to_remove.is_empty()
+}
+
+// ── constfold_exitswitch ────────────────────────────────────────────────
+
+/// `rpython/translator/simplify.py:36-48` `replace_exitswitch_by_constant`.
+/// Port reference: `majit-translate/src/translator/simplify.rs:212`.
+///
+/// ```py
+/// def replace_exitswitch_by_constant(block, const):
+///     newexits = [link for link in block.exits if link.exitcase == const.value]
+///     if len(newexits) == 0:
+///         newexits = [link for link in block.exits if link.exitcase == 'default']
+///     assert len(newexits) == 1
+///     newexits[0].exitcase = None
+///     if hasattr(newexits[0], 'llexitcase'):
+///         newexits[0].llexitcase = None
+///     block.exitswitch = None
+///     block.recloseblock(*newexits)
+///     return newexits
+/// ```
+pub fn replace_exitswitch_by_constant(block: &BlockRef, const_: &Constant) -> Vec<LinkRef> {
+    // `link.exitcase == const.value` — exitcase wraps a Constant carrying a
+    // `ConstantValue`; compare on the inner value.
+    let cases_eq = |link: &LinkRef| match &link.borrow().exitcase {
+        Some(FlowValue::Constant(c)) => c.value == const_.value,
+        _ => false,
+    };
+    let default_case = |link: &LinkRef| {
+        matches!(
+            &link.borrow().exitcase,
+            Some(FlowValue::Constant(c)) if c.value == ConstantValue::Str("default".to_string())
+        )
+    };
+
+    let exits_snapshot: Vec<LinkRef> = block.borrow().exits.clone();
+    let mut newexits: Vec<LinkRef> = exits_snapshot.iter().filter(|l| cases_eq(l)).cloned().collect();
+    if newexits.is_empty() {
+        newexits = exits_snapshot
+            .iter()
+            .filter(|l| default_case(l))
+            .cloned()
+            .collect();
+    }
+    assert_eq!(
+        newexits.len(),
+        1,
+        "replace_exitswitch_by_constant: no unique surviving exit"
+    );
+    {
+        let mut l = newexits[0].borrow_mut();
+        l.exitcase = None;
+        l.llexitcase = None;
+    }
+    block.borrow_mut().exitswitch = None;
+    block.recloseblock(newexits.clone());
+    newexits
+}
+
+/// `rpython/translator/simplify.py:218-239` `constfold_exitswitch`.
+/// Port reference: `majit-translate/src/translator/simplify.rs:2599`.
+///
+/// When a block's `exitswitch` has been folded to a `Constant` (and the block
+/// cannot raise), only one exit can be taken — drop the others.
+pub fn constfold_exitswitch(graph: &FunctionGraph) {
+    let mut seen: HashSet<BlockRef> = HashSet::new();
+    seen.insert(graph.startblock.clone());
+    let mut stack: Vec<LinkRef> = graph.startblock.borrow().exits.clone();
+
+    while let Some(link) = stack.pop() {
+        let target = match link.borrow().target.clone() {
+            Some(target) => target,
+            None => continue,
+        };
+        if seen.contains(&target) {
+            continue;
+        }
+        let source = match link.borrow().prevblock_ref() {
+            Some(source) => source,
+            None => continue,
+        };
+
+        // `switch = source.exitswitch`; act only on a Constant switch in a
+        // non-raising block (the `c_last_exception` sentinel is a Constant but
+        // makes `canraise()` true, so it is correctly skipped here).
+        let (const_val, is_canraise) = {
+            let b = source.borrow();
+            match &b.exitswitch {
+                Some(ExitSwitch::Value(FlowValue::Constant(c))) => (Some(c.clone()), b.canraise()),
+                _ => (None, b.canraise()),
+            }
+        };
+
+        if let Some(const_val) = const_val {
+            if !is_canraise {
+                let new_exits = replace_exitswitch_by_constant(&source, &const_val);
+                stack.extend(new_exits);
+                continue;
+            }
+        }
+        seen.insert(target.clone());
+        stack.extend(target.borrow().exits.clone());
+    }
+}
+
+// ── simplify_exceptions (structural adaptation — see classification) ─────
+
+/// `rpython/translator/simplify.py:110-170` `simplify_exceptions`.
+///
+/// **Classification (issue #112 scope #4): structural adaptation.**
+///
+/// Upstream `simplify_exceptions` collapses the `except Exception:`
+/// chain-of-`is_`/`issubtype`-tests that RPython's *flowspace* emits into a
+/// single list of `exitcase=cls` links on the raising block.  That chain is a
+/// property of RPython's flow-graph construction; the port reference
+/// (`majit-translate/src/translator/simplify.rs:1266`) reproduces it because
+/// the AOT translator path consumes flowspace graphs.
+///
+/// pyre-jit's production codewriter is a **CPython-bytecode walker**, not the
+/// RPython flowspace.  Two concrete Pyre constraints make a literal port
+/// inapplicable here:
+///
+///  1. The walker never emits the `is_`/`issubtype` exception-dispatch chain
+///     (no `is_`/`issubtype` ops exist anywhere in `pyre-jit/src/jit`).  Its
+///     exception model "bakes type into per-subclass" exits
+///     (`pyre/pyre-jit/src/jit/flatten.rs:679`), so the input shape this pass
+///     targets is never present.
+///  2. The subclass oracle the pass needs — `issubclass(case, cov)` and
+///     `issubclass(case, BaseException)` (`simplify.py:140,146`) — has no
+///     equivalent on pyre-jit's flow `Constant`s, which carry exception types
+///     as opaque host-object handles without a hierarchy.
+///
+/// So this is a no-op on every graph the current walker produces.  It is NOT
+/// silently dropped: a tripwire panics if the `is_`/`issubtype` chain shape is
+/// ever observed (e.g. once the #97 MIR front-end emits an explicit
+/// flowspace-style CFG), signalling that the full collapse must then be ported
+/// for real rather than relying on this adaptation.
+pub fn simplify_exceptions(graph: &FunctionGraph) {
+    for block in graph.iterblocks() {
+        let b = block.borrow();
+        if !b.canraise() {
+            continue;
+        }
+        // The chain begins at the Exception exit's target, whose first op is
+        // the `is_`/`issubtype` test.  Detect that shape without needing the
+        // Exception-class oracle.
+        let Some(exc) = b.exits.last() else { continue };
+        let Some(query) = exc.borrow().target.clone() else {
+            continue;
+        };
+        let q = query.borrow();
+        if q.exits.len() == 2 {
+            if let Some(op) = q.operations.first() {
+                assert!(
+                    op.opname != "is_" && op.opname != "issubtype",
+                    "simplify_exceptions: an is_/issubtype exception-dispatch \
+                     chain is present in the walker graph — port the full \
+                     `simplify.py:110-170` collapse (issue #112) instead of \
+                     relying on the structural-adaptation no-op"
+                );
+            }
+        }
+    }
+}
+
+// ── transform_dead_op_vars ──────────────────────────────────────────────
+
+/// `rpython/translator/simplify.py:405-417` `CanRemove` — the fixed opname set
+/// of side-effect-free operations.  The upstream `enum_ops_without_sideeffects()`
+/// addition (the LL-operation table, `simplify.py:414-416`) has no pyre-jit
+/// equivalent: pyre-jit's flow ops are CPython-bytecode-derived, not RPython LL
+/// ops, so only the literal opname list ports.
+const CAN_REMOVE: &[&str] = &[
+    "newtuple", "newlist", "newdict", "bool", "is_", "id", "type", "issubtype", "isinstance",
+    "repr", "str", "len", "hash", "getattr", "getitem", "pos", "neg", "abs", "hex", "oct", "ord",
+    "invert", "add", "sub", "mul", "truediv", "floordiv", "div", "mod", "divmod", "pow", "lshift",
+    "rshift", "and_", "or_", "xor", "int", "float", "long", "lt", "le", "eq", "ne", "gt", "ge",
+    "cmp", "coerce", "contains", "iter", "get",
+];
+
+fn can_remove_opname(op: &str) -> bool {
+    CAN_REMOVE.contains(&op)
+}
+
+/// `rpython/translator/simplify.py:397-524` `transform_dead_op_vars`
+/// (`transform_dead_op_vars_in_blocks`).  Port reference:
+/// `majit-translate/src/translator/simplify.rs:610`.
+///
+/// Classification (scope #4): **direct PyPy parity**.  Removes side-effect-free
+/// operations whose result is never read, then drops link args / inputargs that
+/// are never used.  pyre-jit's codewriter always runs the single-graph,
+/// `translator=None` path, so the upstream `direct_call` / `simple_call`
+/// side-effect-analysis branches (`simplify.py:489-506`, gated on
+/// `translator is not None`) are not reached and are omitted.  At the
+/// post-walk / pre-regalloc point the walker's `block.operations` are empty, so
+/// the op-removal half is a no-op today; the link-arg / inputarg pruning half is
+/// active and feeds a tighter graph to regalloc's coalescing.
+pub fn transform_dead_op_vars(graph: &FunctionGraph) {
+    let blocks = graph.iterblocks();
+    let set_of_blocks: HashSet<BlockRef> = blocks.iter().cloned().collect();
+    let startblock = graph.startblock.clone();
+
+    // `op.opname in CanRemove and op is not block.raising_op`.  `raising_op` is
+    // `operations[-1]` when `canraise()`, so positional identity matches the
+    // upstream object-identity check.
+    let canremove_op = |op: &SpaceOperation, block: &BlockRef, idx: usize| -> bool {
+        if !can_remove_opname(&op.opname) {
+            return false;
+        }
+        let b = block.borrow();
+        if !b.canraise() {
+            return true;
+        }
+        idx + 1 != b.operations.len()
+    };
+
+    let mut read_vars: HashSet<Variable> = HashSet::new();
+    let mut dependencies: HashMap<Variable, HashSet<Variable>> = HashMap::new();
+
+    // Pass 1: compute read_vars + dependencies.
+    for block in &blocks {
+        let b = block.borrow();
+        for (idx, op) in b.operations.iter().enumerate() {
+            if !canremove_op(op, block, idx) {
+                // `read_vars.update(op.args)`.
+                for arg in &op.args {
+                    for v in arg.variables() {
+                        read_vars.insert(v);
+                    }
+                }
+            } else if let Some(FlowValue::Variable(rv)) = &op.result {
+                // `dependencies[op.result].update(op.args)`.
+                for arg in &op.args {
+                    for v in arg.variables() {
+                        dependencies.entry(*rv).or_default().insert(v);
+                    }
+                }
+            }
+        }
+        // `if isinstance(block.exitswitch, Variable): read_vars.add(block.exitswitch)`.
+        if let Some(ExitSwitch::Value(FlowValue::Variable(sw))) = &b.exitswitch {
+            read_vars.insert(*sw);
+        }
+
+        if !b.exits.is_empty() {
+            for link in &b.exits {
+                let link_b = link.borrow();
+                let Some(target) = link_b.target.as_ref() else {
+                    continue;
+                };
+                let in_set = set_of_blocks.contains(target);
+                let target_inputargs = target.borrow().inputargs.clone();
+                for (arg_opt, tgt) in link_b.args.iter().zip(target_inputargs.iter()) {
+                    let Some(arg) = arg_opt else { continue };
+                    if !in_set {
+                        if let FlowValue::Variable(av) = arg {
+                            read_vars.insert(*av);
+                        }
+                        if let FlowValue::Variable(tv) = tgt {
+                            read_vars.insert(*tv);
+                        }
+                    } else if let (FlowValue::Variable(tv), FlowValue::Variable(av)) = (tgt, arg) {
+                        dependencies.entry(*tv).or_default().insert(*av);
+                    }
+                }
+            }
+        } else {
+            // return / except blocks implicitly use their inputargs.
+            for a in &b.inputargs {
+                if let FlowValue::Variable(v) = a {
+                    read_vars.insert(*v);
+                }
+            }
+        }
+
+        // A start block's inputargs are always live.
+        if *block == startblock {
+            for a in &b.inputargs {
+                if let FlowValue::Variable(v) = a {
+                    read_vars.insert(*v);
+                }
+            }
+        }
+    }
+
+    // `flow_read_var_backward(set(read_vars))`.
+    let mut pending: Vec<Variable> = read_vars.iter().copied().collect();
+    while let Some(var) = pending.pop() {
+        if let Some(deps) = dependencies.get(&var).cloned() {
+            for prev in deps {
+                if read_vars.insert(prev) {
+                    pending.push(prev);
+                }
+            }
+        }
+    }
+
+    // Pass 2: remove dead ops, then dead link args, then dead inputargs.
+    for block in &blocks {
+        // Backward walk over operations, removing removable ops whose result
+        // is never read.  (No-op while walker blocks carry no operations.)
+        let mut i = block.borrow().operations.len();
+        while i > 0 {
+            i -= 1;
+            let (result_used, removable) = {
+                let b = block.borrow();
+                let op = &b.operations[i];
+                let result_used = match &op.result {
+                    Some(FlowValue::Variable(v)) => read_vars.contains(v),
+                    // Constant or void result — never removed by this path.
+                    _ => true,
+                };
+                (result_used, can_remove_opname(&op.opname))
+            };
+            if result_used {
+                continue;
+            }
+            // Only the CanRemove branch is reachable in pyre-jit (translator is
+            // always None, so simple_call/direct_call removal is skipped).
+            if removable && canremove_op(&block.borrow().operations[i], block, i) {
+                block.borrow_mut().operations.remove(i);
+            }
+        }
+
+        // Drop output vars never used from link.args (before shrinking
+        // inputargs, to keep the same-index cross-block invariant).
+        let exits_snapshot: Vec<LinkRef> = block.borrow().exits.clone();
+        for link in exits_snapshot {
+            let target = link.borrow().target.clone();
+            let Some(target) = target else { continue };
+            let target_inputargs = target.borrow().inputargs.clone();
+            let args_len = link.borrow().args.len();
+            assert_eq!(args_len, target_inputargs.len(), "link arity mismatch");
+            let mut i = args_len;
+            while i > 0 {
+                i -= 1;
+                let drop = matches!(&target_inputargs[i], FlowValue::Variable(v) if !read_vars.contains(v));
+                if drop {
+                    link.borrow_mut().args.remove(i);
+                }
+            }
+        }
+    }
+
+    // Final pass: drop unused inputargs (matching link args already removed).
+    for block in &blocks {
+        let inputargs = block.borrow().inputargs.clone();
+        let mut i = inputargs.len();
+        while i > 0 {
+            i -= 1;
+            let drop = matches!(&inputargs[i], FlowValue::Variable(v) if !read_vars.contains(v));
+            if drop {
+                block.borrow_mut().inputargs.remove(i);
+            }
+        }
+    }
+}
+
+// ── op-scanning passes: structural-adaptation no-ops (empty walker ops) ──
+//
+// `coalesce_bool`, `transform_xxxitem`, and `transform_ovfcheck` all key on a
+// block's *operations* (`bool` / `getitem` raising-op / `ovfcheck` simple_call).
+// At pyre-jit's post-walk / pre-regalloc point every walker block has empty
+// `operations` (the SSARepr is emitted inline into `per_block_ssarepr`, not
+// `block.operations`; see `codewriter.rs::eliminate_empty_blocks`), so none of
+// these shapes is ever present.  Each is a documented no-op with a tripwire that
+// panics if the target shape appears (e.g. once #73 materialises ops on the
+// graph), signalling that the full pass must then be ported.
+
+/// `rpython/translator/simplify.py:656-699` `coalesce_bool`.
+/// Classification (scope #4): structural adaptation (no `bool` op present).
+pub fn coalesce_bool(graph: &FunctionGraph) {
+    for block in graph.iterblocks() {
+        let b = block.borrow();
+        if let Some(last) = b.operations.last() {
+            assert!(
+                last.opname != "bool",
+                "coalesce_bool: a `bool`-terminated block is present in the \
+                 walker graph — port the full `simplify.py:656-699` coalesce \
+                 (issue #112) instead of the structural-adaptation no-op"
+            );
+        }
+    }
+}
+
+/// `rpython/translator/simplify.py:172-186` `transform_xxxitem`.
+/// Classification (scope #4): structural adaptation (no `getitem` raising-op,
+/// and pyre-jit has no flowspace `IndexError` exitcase oracle).
+pub fn transform_xxxitem(graph: &FunctionGraph) {
+    for block in graph.iterblocks() {
+        let b = block.borrow();
+        if let Some(last_op) = b.raising_op() {
+            assert!(
+                last_op.opname != "getitem",
+                "transform_xxxitem: a `getitem` raising-op is present in the \
+                 walker graph — port the full `simplify.py:172-186` rewrite \
+                 (issue #112) instead of the structural-adaptation no-op"
+            );
+        }
+    }
+}
+
+/// `rpython/translator/simplify.py:71-108` `transform_ovfcheck`.
+/// Classification (scope #4): structural adaptation.  `ovfcheck` is an RPython
+/// `rlib` function the flowspace emits as a `simple_call`; the CPython-bytecode
+/// walker never emits it, and `OverflowingOperation.ovfchecked()` (the `<op>_ovf`
+/// variant map) has no pyre-jit equivalent.
+pub fn transform_ovfcheck(graph: &FunctionGraph) {
+    for block in graph.iterblocks() {
+        let b = block.borrow();
+        for op in &b.operations {
+            assert!(
+                op.opname != "simple_call",
+                "transform_ovfcheck: a `simple_call` op is present in the walker \
+                 graph — port the full `simplify.py:71-108` ovfcheck rewrite \
+                 (issue #112) instead of the structural-adaptation no-op"
+            );
+        }
+    }
+}
+
+// ── exception-flowspace passes: structural-adaptation no-ops ─────────────
+//
+// `remove_dead_exceptions` and `remove_assertion_errors` both depend on RPython
+// flowspace exception shapes that pyre-jit's CPython-bytecode walker does not
+// produce, and on a class-hierarchy / implicit-exception oracle that pyre-jit's
+// flow `Constant`s do not carry.  They are documented no-ops, not tripwires:
+// pyre-jit exception *exits* legitimately exist, so a shape tripwire would
+// false-fire.
+
+/// `rpython/translator/simplify.py:189-216` `remove_dead_exceptions`.
+/// Classification (scope #4): structural adaptation.  The pass merges/prunes
+/// exception exits via `issubclass(case, member)` (`simplify.py:205,210`); pyre-jit
+/// represents exception exitcases as opaque host-object handles with no subclass
+/// oracle on the flow graph, so the shadowing decision cannot be evaluated and the
+/// pass conservatively keeps every exit.
+pub fn remove_dead_exceptions(_graph: &FunctionGraph) {
+    // No-op: see classification above. Keeping all exits is the safe shape when
+    // the `issubclass` oracle is unavailable.
+}
+
+/// `rpython/translator/simplify.py:321-346` `remove_assertion_errors`.
+/// Classification (scope #4): structural adaptation.  Removes branches that go
+/// directly to `graph.exceptblock` raising a `Constant(AssertionError)` — RPython's
+/// `_implicit_` exception shape (`flowcontext.py`).  The CPython-bytecode walker
+/// does not emit implicit-AssertionError exits, so the upstream condition
+/// (`exit.args[0] == Constant(AssertionError)`) never matches; the pass is a
+/// faithful no-op on every walker graph.
+pub fn remove_assertion_errors(_graph: &FunctionGraph) {
+    // No-op: see classification above.
+}
+
+// ── checkgraph + the simplify_graph driver ──────────────────────────────
+
+/// `rpython/flowspace/model.py:568-667` `checkgraph(graph)` — the pyre-jit
+/// structural subset.
+///
+/// The full upstream checker validates SSA/SSI definition, exception-link
+/// extras, and exitswitch shape; flow.rs already enforces most of those at
+/// construction (`Link::new`/`settarget`/`recloseblock` arity asserts).  This
+/// subset re-verifies the two invariants the simplify passes most directly
+/// touch — link arity and the `link.prevblock` back-pointer — as the
+/// `simplify_graph` tail sanity check.
+pub fn checkgraph(graph: &FunctionGraph) {
+    for block in graph.iterblocks() {
+        let exits: Vec<LinkRef> = block.borrow().exits.clone();
+        for link in exits {
+            let l = link.borrow();
+            if let Some(target) = &l.target {
+                assert_eq!(
+                    l.args.len(),
+                    target.borrow().inputargs.len(),
+                    "checkgraph: link arity does not match target inputargs"
+                );
+            }
+            assert!(
+                l.prevblock_ref().is_some_and(|prev| prev == block),
+                "checkgraph: link.prevblock does not point back to its source block"
+            );
+        }
+    }
+}
+
+/// `rpython/translator/simplify.py:1060-1073` `all_passes`.
+///
+/// The order matches upstream exactly.  `eliminate_empty_blocks` lives in
+/// `codewriter.rs` (paired with its `rewrite_dead_forwarder_gotos` inline-SSARepr
+/// bridge) and is referenced here; `SSA_to_SSI` lives in `backendopt_ssa.rs`.
+pub fn all_passes() -> &'static [fn(&FunctionGraph)] {
+    &[
+        transform_dead_op_vars,
+        super::codewriter::eliminate_empty_blocks,
+        remove_assertion_errors,
+        remove_identical_vars_ssa,
+        constfold_exitswitch,
+        remove_trivial_links,
+        super::backendopt_ssa::ssa_to_ssi,
+        coalesce_bool,
+        transform_ovfcheck,
+        simplify_exceptions,
+        transform_xxxitem,
+        remove_dead_exceptions,
+    ]
+}
+
+/// `rpython/translator/simplify.py:1075-1081` `simplify_graph(graph, passes=True)`.
+///
+/// ```py
+/// def simplify_graph(graph, passes=True):
+///     if passes is True:
+///         passes = all_passes
+///     for pass_ in passes:
+///         pass_(graph)
+///     checkgraph(graph)
+/// ```
+pub fn simplify_graph(graph: &FunctionGraph) {
+    for pass_ in all_passes() {
+        pass_(graph);
+    }
+    checkgraph(graph);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jit::flatten::Kind;
+    use crate::jit::flow::{Block, Link, VariableId, push_op};
+
+    /// Mirrors `majit-translate/.../simplify.rs::remove_trivial_links_merges_empty_link`.
+    /// start -> mid (trivial link, no args) -> return.  `mid` has 1 op and 1
+    /// entry/exit, so it folds into `start` and `start` retargets straight to
+    /// the returnblock.
+    #[test]
+    fn remove_trivial_links_merges_empty_link() {
+        let start = Block::shared(vec![]);
+        let mut graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        // `mid` carries the single op whose result flows to the returnblock.
+        let v = graph.fresh_variable(Kind::Int);
+        let mid = graph.new_block(vec![]);
+        push_op(
+            &mid,
+            SpaceOperation::new("int_zero", vec![], Some(v.into()), -1),
+        );
+
+        // Trivial link start -> mid (no args; mid.inputargs also empty).
+        start.closeblock(vec![Link::new(vec![], Some(mid.clone()), None).into_ref()]);
+        // mid -> returnblock passing v.
+        mid.closeblock(vec![
+            Link::new(vec![v.into()], Some(returnblock.clone()), None).into_ref(),
+        ]);
+
+        remove_trivial_links(&graph);
+
+        let s = start.borrow();
+        // mid's op now lives on start.
+        assert_eq!(s.operations.len(), 1);
+        assert_eq!(s.operations[0].opname, "int_zero");
+        // start's single exit now targets the returnblock directly.
+        assert_eq!(s.exits.len(), 1);
+        assert_eq!(s.exits[0].borrow().target, Some(returnblock));
+    }
+
+    /// A non-trivial link (source has a real exitswitch / multiple exits) must
+    /// be left untouched.
+    #[test]
+    fn remove_trivial_links_keeps_non_trivial() {
+        let start = Block::shared(vec![]);
+        let mut graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        // A link that DOES carry an arg is not trivial.
+        let v = graph.fresh_variable(Kind::Int);
+        let mid = graph.new_block(vec![v.into()]);
+        push_op(
+            &mid,
+            SpaceOperation::new("int_zero", vec![], Some(v.into()), -1),
+        );
+        start.closeblock(vec![
+            Link::new(vec![v.into()], Some(mid.clone()), None).into_ref(),
+        ]);
+        mid.closeblock(vec![
+            Link::new(vec![v.into()], Some(returnblock.clone()), None).into_ref(),
+        ]);
+
+        remove_trivial_links(&graph);
+
+        // start keeps its own (empty) operations and still points at mid.
+        let s = start.borrow();
+        assert!(s.operations.is_empty());
+        assert_eq!(s.exits.len(), 1);
+        assert_eq!(s.exits[0].borrow().target, Some(mid));
+    }
+
+    /// Mirrors `majit-translate/.../simplify.rs::remove_identical_vars_ssa_dedupes_duplicate_phis`.
+    /// `body` has two inputargs, each fed the SAME constant on the single
+    /// incoming link, so both phis collapse and `body` loses ≥1 inputarg.
+    #[test]
+    fn remove_identical_vars_ssa_dedupes_duplicate_phis() {
+        let v_a = Variable::new(VariableId(10), Kind::Int);
+        let v_b = Variable::new(VariableId(11), Kind::Int);
+        let body = Block::shared(vec![v_a.into(), v_b.into()]);
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        let link_sb = Link::new(
+            vec![Constant::signed(1).into(), Constant::signed(1).into()],
+            Some(body.clone()),
+            None,
+        )
+        .into_ref();
+        start.closeblock(vec![link_sb]);
+
+        // Build the link in its own statement so `body.borrow()` drops
+        // before `closeblock` takes `borrow_mut`.
+        let body_arg = body.borrow().inputargs[0].clone();
+        let link_br = Link::new(vec![body_arg], Some(returnblock), None).into_ref();
+        body.closeblock(vec![link_br]);
+
+        remove_identical_vars_ssa(&graph);
+
+        // body lost at least one inputarg.
+        assert!(body.borrow().inputargs.len() < 2);
+    }
+
+    /// A block whose `exitswitch` is a constant `true` keeps only the matching
+    /// (`exitcase == true`) exit; the false arm is dropped.
+    #[test]
+    fn constfold_exitswitch_picks_matching_exit() {
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        let yes = graph.new_block(vec![]);
+        let no = graph.new_block(vec![]);
+
+        // start switches on the constant `true`.
+        start.borrow_mut().exitswitch = Some(ExitSwitch::Value(Constant::bool(true).into()));
+        let link_yes =
+            Link::new(vec![], Some(yes.clone()), Some(Constant::bool(true).into())).into_ref();
+        let link_no =
+            Link::new(vec![], Some(no.clone()), Some(Constant::bool(false).into())).into_ref();
+        start.closeblock(vec![link_yes, link_no]);
+
+        // `yes`/`no` both fall through to the returnblock (1 inputarg).
+        yes.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(returnblock.clone()), None).into_ref(),
+        ]);
+        no.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        constfold_exitswitch(&graph);
+
+        let s = start.borrow();
+        assert!(s.exitswitch.is_none());
+        assert_eq!(s.exits.len(), 1);
+        assert_eq!(s.exits[0].borrow().target, Some(yes));
+        // the surviving exit's case was cleared.
+        assert!(s.exits[0].borrow().exitcase.is_none());
+    }
+
+    /// `transform_dead_op_vars` drops a non-start block inputarg that is never
+    /// read, along with the matching incoming-link arg.
+    #[test]
+    fn transform_dead_op_vars_drops_unused_inputarg() {
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        // `middle` receives a dead inputarg that nothing uses.
+        let v_dead = graph.fresh_variable(Kind::Int);
+        let middle = graph.new_block(vec![v_dead.into()]);
+
+        start.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(middle.clone()), None).into_ref(),
+        ]);
+        middle.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        transform_dead_op_vars(&graph);
+
+        // The dead inputarg and its incoming-link arg are gone.
+        assert_eq!(middle.borrow().inputargs.len(), 0);
+        assert_eq!(start.borrow().exits[0].borrow().args.len(), 0);
+    }
+
+    /// The op-scanning structural-adaptation no-ops leave a walker-shaped graph
+    /// (empty operations) untouched and do not trip their tripwires.
+    #[test]
+    fn op_scanning_noops_are_inert_on_empty_ops() {
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+        start.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        // None of these should panic on an empty-operations graph.
+        coalesce_bool(&graph);
+        transform_xxxitem(&graph);
+        transform_ovfcheck(&graph);
+        remove_dead_exceptions(&graph);
+        remove_assertion_errors(&graph);
+        simplify_exceptions(&graph);
+    }
+
+    /// The full `simplify_graph` driver runs every pass in order, collapses a
+    /// trivial link, and passes `checkgraph` without panicking.
+    #[test]
+    fn simplify_graph_runs_all_passes_and_checkgraph() {
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        let v = graph.fresh_variable(Kind::Int);
+        let mid = graph.new_block(vec![]);
+        push_op(
+            &mid,
+            SpaceOperation::new("int_zero", vec![], Some(v.into()), -1),
+        );
+        // Trivial link start -> mid (no args).
+        start.closeblock(vec![Link::new(vec![], Some(mid.clone()), None).into_ref()]);
+        mid.closeblock(vec![
+            Link::new(vec![v.into()], Some(returnblock.clone()), None).into_ref(),
+        ]);
+
+        simplify_graph(&graph);
+
+        // remove_trivial_links folded mid into start; start now reaches the
+        // returnblock directly and checkgraph (run inside simplify_graph) held.
+        let s = start.borrow();
+        assert_eq!(s.exits.len(), 1);
+        assert_eq!(s.exits[0].borrow().target, Some(returnblock));
+        assert_eq!(s.operations.len(), 1);
+        assert_eq!(s.operations[0].opname, "int_zero");
+    }
+}

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -195,12 +195,18 @@ fn isspecialvar(v: &FlowValue) -> bool {
 /// Variable and any Constant is returned unchanged.
 fn rename_value(v: &FlowValue, mapping: &HashMap<Variable, FlowValue>) -> FlowValue {
     match v {
-        FlowValue::Variable(var) => mapping.get(var).cloned().unwrap_or(FlowValue::Variable(*var)),
+        FlowValue::Variable(var) => mapping
+            .get(var)
+            .cloned()
+            .unwrap_or(FlowValue::Variable(*var)),
         FlowValue::Constant(_) => v.clone(),
     }
 }
 
-fn rename_arg(arg: &SpaceOperationArg, mapping: &HashMap<Variable, FlowValue>) -> SpaceOperationArg {
+fn rename_arg(
+    arg: &SpaceOperationArg,
+    mapping: &HashMap<Variable, FlowValue>,
+) -> SpaceOperationArg {
     match arg {
         SpaceOperationArg::Value(value) => SpaceOperationArg::Value(rename_value(value, mapping)),
         SpaceOperationArg::ListOfKind(list) => SpaceOperationArg::ListOfKind(FlowListOfKind {
@@ -227,9 +233,7 @@ fn rename_exitswitch(sw: &ExitSwitch, mapping: &HashMap<Variable, FlowValue>) ->
                     ExitSwitchElement::Value(value) => {
                         ExitSwitchElement::Value(rename_value(value, mapping))
                     }
-                    ExitSwitchElement::Marker(marker) => {
-                        ExitSwitchElement::Marker(marker.clone())
-                    }
+                    ExitSwitchElement::Marker(marker) => ExitSwitchElement::Marker(marker.clone()),
                 })
                 .collect(),
         ),
@@ -263,7 +267,10 @@ fn renamevariables_value(block: &BlockRef, mapping: &HashMap<Variable, FlowValue
                 offset: op.offset,
             })
             .collect();
-        let switch = b.exitswitch.as_ref().map(|sw| rename_exitswitch(sw, mapping));
+        let switch = b
+            .exitswitch
+            .as_ref()
+            .map(|sw| rename_exitswitch(sw, mapping));
         (ops, switch)
     };
     {
@@ -325,9 +332,10 @@ pub fn remove_identical_vars_ssa(graph: &FunctionGraph) {
             };
             let mut phi_args: Vec<FlowValue> = Vec::with_capacity(links.len());
             for link in links {
-                let arg = link.borrow().args.get(i).cloned().flatten().expect(
-                    "remove_identical_vars_SSA: link.args position missing for inputarg",
-                );
+                let arg =
+                    link.borrow().args.get(i).cloned().flatten().expect(
+                        "remove_identical_vars_SSA: link.args position missing for inputarg",
+                    );
                 phi_args.push(arg);
             }
             phis.push((*input_v, phi_args));
@@ -371,7 +379,8 @@ pub fn remove_identical_vars_ssa(graph: &FunctionGraph) {
             .get(block)
             .cloned()
             .expect("entrymap lookup consistent with inputs");
-        let new_inputs: Vec<FlowValue> = phis.iter().map(|(v, _)| FlowValue::Variable(*v)).collect();
+        let new_inputs: Vec<FlowValue> =
+            phis.iter().map(|(v, _)| FlowValue::Variable(*v)).collect();
         // `per_link_args[link_idx][phi_idx] = phis[phi_idx].1[link_idx]`.
         let per_link_args: Vec<Vec<Option<FlowValue>>> = (0..links.len())
             .map(|li| phis.iter().map(|(_, pa)| Some(pa[li].clone())).collect())
@@ -455,7 +464,11 @@ pub fn replace_exitswitch_by_constant(block: &BlockRef, const_: &Constant) -> Ve
     };
 
     let exits_snapshot: Vec<LinkRef> = block.borrow().exits.clone();
-    let mut newexits: Vec<LinkRef> = exits_snapshot.iter().filter(|l| cases_eq(l)).cloned().collect();
+    let mut newexits: Vec<LinkRef> = exits_snapshot
+        .iter()
+        .filter(|l| cases_eq(l))
+        .cloned()
+        .collect();
     if newexits.is_empty() {
         newexits = exits_snapshot
             .iter()
@@ -592,11 +605,56 @@ pub fn simplify_exceptions(graph: &FunctionGraph) {
 /// equivalent: pyre-jit's flow ops are CPython-bytecode-derived, not RPython LL
 /// ops, so only the literal opname list ports.
 const CAN_REMOVE: &[&str] = &[
-    "newtuple", "newlist", "newdict", "bool", "is_", "id", "type", "issubtype", "isinstance",
-    "repr", "str", "len", "hash", "getattr", "getitem", "pos", "neg", "abs", "hex", "oct", "ord",
-    "invert", "add", "sub", "mul", "truediv", "floordiv", "div", "mod", "divmod", "pow", "lshift",
-    "rshift", "and_", "or_", "xor", "int", "float", "long", "lt", "le", "eq", "ne", "gt", "ge",
-    "cmp", "coerce", "contains", "iter", "get",
+    "newtuple",
+    "newlist",
+    "newdict",
+    "bool",
+    "is_",
+    "id",
+    "type",
+    "issubtype",
+    "isinstance",
+    "repr",
+    "str",
+    "len",
+    "hash",
+    "getattr",
+    "getitem",
+    "pos",
+    "neg",
+    "abs",
+    "hex",
+    "oct",
+    "ord",
+    "invert",
+    "add",
+    "sub",
+    "mul",
+    "truediv",
+    "floordiv",
+    "div",
+    "mod",
+    "divmod",
+    "pow",
+    "lshift",
+    "rshift",
+    "and_",
+    "or_",
+    "xor",
+    "int",
+    "float",
+    "long",
+    "lt",
+    "le",
+    "eq",
+    "ne",
+    "gt",
+    "ge",
+    "cmp",
+    "coerce",
+    "contains",
+    "iter",
+    "get",
 ];
 
 fn can_remove_opname(op: &str) -> bool {
@@ -1067,7 +1125,12 @@ mod tests {
 
         // `yes`/`no` both fall through to the returnblock (1 inputarg).
         yes.closeblock(vec![
-            Link::new(vec![Constant::signed(0).into()], Some(returnblock.clone()), None).into_ref(),
+            Link::new(
+                vec![Constant::signed(0).into()],
+                Some(returnblock.clone()),
+                None,
+            )
+            .into_ref(),
         ]);
         no.closeblock(vec![
             Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -64,6 +64,24 @@ use super::flow::{
 /// single predecessor and is not the returnblock (`target.exits` non-empty).
 /// Such a link is removed by folding `target` into `source`.
 pub fn remove_trivial_links(graph: &FunctionGraph) {
+    let mut merges = Vec::new();
+    remove_trivial_links_recording_into(graph, &mut merges);
+}
+
+/// Like [`remove_trivial_links`] but returns each `(source, target)` merge in
+/// absorption order so the walker drain can move the merged target block's
+/// inline `per_block_ssarepr` into the surviving source (issue #73).  `source`
+/// absorbs `target`; a chain `s <- t1 <- t2` records `(s, t1), (s, t2)`.
+pub fn remove_trivial_links_recording(graph: &FunctionGraph) -> Vec<(BlockRef, BlockRef)> {
+    let mut merges = Vec::new();
+    remove_trivial_links_recording_into(graph, &mut merges);
+    merges
+}
+
+fn remove_trivial_links_recording_into(
+    graph: &FunctionGraph,
+    merges: &mut Vec<(BlockRef, BlockRef)>,
+) {
     let entrymap = mkentrymap(graph);
     let startblock = graph.startblock.clone();
     // `seen = set([block])` — faithful port of a Python set; BlockRef hashes
@@ -126,6 +144,9 @@ pub fn remove_trivial_links(graph: &FunctionGraph) {
                 source_b.exitswitch = target_exitswitch;
             }
             source.recloseblock(target_exits);
+            // Record the merge so the walker drain can relocate `target`'s
+            // inline `per_block_ssarepr` into `source` (issue #73).
+            merges.push((source.clone(), target.clone()));
             // `stack.extend(source.exits)` — keep collapsing through source.
             stack.extend(source.borrow().exits.clone());
         } else {


### PR DESCRIPTION
Ports `rpython/translator/simplify.py::simplify_graph` (+ `backendopt/ssa.py`) onto pyre-jit's flow graph and runs the walker-safe subset in the production codewriter, so the graph reaching regalloc/flatten is normalized like PyPy's.

**New modules:** `jit/simplify.rs` (the 12 passes + `simplify_graph`/`all_passes`/`checkgraph`) and `jit/backendopt_ssa.rs` (`DataFlowFamilyBuilder`, `SSA_to_SSI`). Each pass is a line-by-line port, dual-referenced to RPython and the validated `majit-translate` port, with graph-shape tests.

**Wired into the walker** (full `check.py` dynasm 39/39): `eliminate_empty_blocks`, `constfold_exitswitch`, and `remove_trivial_links` — the latter via a new `per_block_ssarepr` merge bridge that relocates a merged block's inline opcodes into its survivor.

**Ported but not wired (gated on #73):** the walker emits SSARepr inline per-PC, so a pass that drops/renames a graph var leaves the inline bytecode reading a stale walker slot, and the drain isn't graph-driven yet:
- `transform_dead_op_vars`, `remove_identical_vars_SSA` — drop an inputarg + link arg the inline insns still read (codex P1 ×2).
- `ssa_to_ssi` — correct (stop-at-startblock adaptation) but overhead-only on the inline walker (raise_catch ~4.2x→10.9x).

The exception / op-scanning passes are structural-adaptation no-ops on today's empty-`operations` walker blocks. Every pass is classified in-code.

**Also:** a label-origin diagnostic at the `patch_labels` "jitcode label was never marked" panic (#112 scope #3); a regalloc-coalesce audit finding the CFG pre-merge bypass is a measured, deliberate adaptation tracked to #238 (#112 scope #2).

Follow-ups: graph-driven drain to wire the remaining passes and retire the bridges (#73); orthodox CFG coalesce (#238).

Fix #112
