### PR TITLE
Builtin-leaf subclass / dict / deque / operator interpreter machinery + simplify_graph (#127) and canonical-flatten (#73) JIT passes

### DIFF
--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -4160,7 +4160,13 @@ impl JitCodeBuilder {
                     // offending label index, every referencing code offset, and
                     // the marked/total label counts so the origin can be traced
                     // before the panic, then point at the `simplify_graph`
-                    // passes that remove the shape.
+                    // passes that remove the shape.  Scope #3 concluded that the
+                    // walker-safe subset wired ahead of flatten
+                    // (`eliminate_empty_blocks` + `constfold_exitswitch` +
+                    // `remove_trivial_links`, see `pyre-jit/src/jit/simplify.rs`
+                    // module doc) already removes every shape that produces an
+                    // unmarked label, so this panic is a fail-loud backstop, not
+                    // a live failure mode.
                     let marked = self.labels.iter().filter(|l| l.is_some()).count();
                     let total = self.labels.len();
                     let referencing_offsets: Vec<usize> = self

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -773,15 +773,28 @@ pub struct VecScheduleState {
     pub accumulation: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, AccumEntry>,
     /// Next OpRef counter for newly created vector ops.
     next_pos: u32,
-    /// `schedule.py:20-28 forwarded_vecinfo(op)` cache — pyre's stand-in
-    /// for PyPy's `op._forwarded` `VectorizationInfo` carrier. It is the
-    /// canonical store for the vector pass: `VectorLoop::setup_vectorization`
-    /// stamps every loop op here through `VectorizationInfo(op)`, and
-    /// `forwarded_vecinfo` / `isomorphic` read it back. Living on the state
-    /// (not on the op) means it is dropped when the state is, and
-    /// `VectorLoop::teardown_vectorization` clears it per op
-    /// (`vector.py:58-60 set_forwarded(None)`). Keyed by full `OpRef` so
-    /// InputArg/op namespaces don't collide.
+    /// `schedule.py:20-28 forwarded_vecinfo(op)` cache, keyed by full
+    /// `OpRef` (InputArg and op namespaces never collide).
+    ///
+    /// PyPy carries this scheduling scratch in `op._forwarded`. pyre cannot
+    /// store it there: `Op::clone` resets `forwarded` to `None`
+    /// (resoperation.rs:1352) while preserving `pos` (resoperation.rs:1344),
+    /// and the scheduler reads vecinfo off CLONED ops — the dependency graph
+    /// clones every op into its nodes (dependency.rs:221) and the
+    /// unroll/schedule paths clone `loop_.operations`. A clone-reset
+    /// `forwarded` would drop the stamp, and recompute-on-miss is NOT safe
+    /// for `INT_SIGNEXT`: its bytesize is the dynamic value of `arg1`
+    /// (`cast_to_bytesize_static` returns `None`, resoperation.rs:2310),
+    /// recoverable only through `int_signext_vecinfo`'s setup-time
+    /// box-replacement/const-pool resolver, which needs the optimizer
+    /// context that `vectorization_info_for_op(&Op)` does not hold. So a
+    /// `pos`-keyed cache — clone-stable because `OpRef`/`pos` survives a
+    /// clone — is required for correctness; it is not a stylistic split.
+    ///
+    /// `Op.vecinfo` is the SEPARATE permanent carrier: the
+    /// `resoperation.py:111-127 VecOperationNew` datatype/bytesize/signed/count
+    /// that survives `copy_and_change`, cleared for non-vector ops by
+    /// `vector.py:58-60 teardown_vectorization`.
     vecinfo_cache: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::VectorizationInfo>,
 }
 

--- a/pyre/bench/list_reverse.py
+++ b/pyre/bench/list_reverse.py
@@ -3,11 +3,13 @@
 # PYPYLOG confirms: guard_class(IntegerListStrategy) + setarrayitem(ArrayS 8) swaps.
 # On main, reverse() called items_to_vec() → Object strategy first.
 # On this branch, reverse() stays in Integer strategy (no boxing overhead).
-# REPS=15 (odd): final list is reversed, so lst[0]=N-1, lst[-1]=0.
+# REPS is large and odd: the one-time build loop and the trace warmup are
+# amortised over many reverse() iterations so the measurement reflects
+# reverse() itself, and the final list is reversed (lst[0]=N-1, lst[-1]=0).
 #
 def main():
     N = 700000
-    REPS = 15
+    REPS = 401
 
     lst = []
     i = 0

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -882,7 +882,11 @@ def main():
         #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py  skip
         chk.run_bench("int_loop",       f"{B}/int_loop.py",             5,       None,    2,       None,    2)
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
-        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       4,       2,       4)
+        # fib_loop is bignum-add bound; windows pyre runs markedly slower than
+        # macos/ubuntu for the same codegen (no PGO, MSVC), pushing cranelift
+        # past a 2x vs-cpython bound there while it is ~0.8x cpython locally —
+        # so cranelift gets 3x headroom; a real regression still trips it.
+        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       4,       3,       4)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       10,      2,       10)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -882,11 +882,7 @@ def main():
         #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py  skip
         chk.run_bench("int_loop",       f"{B}/int_loop.py",             5,       None,    2,       None,    2)
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
-        # fib_loop is bignum-add bound; windows pyre runs markedly slower than
-        # macos/ubuntu for the same codegen (no PGO, MSVC), pushing cranelift
-        # past a 2x vs-cpython bound there while it is ~0.8x cpython locally —
-        # so cranelift gets 3x headroom; a real regression still trips it.
-        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       4,       3,       4)
+        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       4,       2,       4)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       10,      2,       10)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6835,12 +6835,12 @@ pub fn contains(haystack: PyObjectRef, needle: PyObjectRef) -> Result<bool, PyEr
         if is_instance(haystack) {
             let w_type = w_instance_get_type(haystack);
             if let Some(method) = lookup_in_type_where(w_type, "__contains__") {
-                let result = crate::call_function(method, &[haystack, needle]);
+                let result = crate::builtins::call_and_check(method, &[haystack, needle])?;
                 return Ok(is_true(result));
             }
             // Also check per-instance attributes (ATTR_TABLE)
             if let Ok(method) = getattr(haystack, "__contains__") {
-                let result = crate::call_function(method, &[haystack, needle]);
+                let result = crate::builtins::call_and_check(method, &[haystack, needle])?;
                 return Ok(is_true(result));
             }
         }
@@ -6855,7 +6855,7 @@ pub fn contains(haystack: PyObjectRef, needle: PyObjectRef) -> Result<bool, PyEr
     unsafe {
         if let Some(w_type) = crate::typedef::r#type(haystack) {
             if let Some(method) = lookup_in_type_where(w_type, "__contains__") {
-                let result = crate::call_function(method, &[haystack, needle]);
+                let result = crate::builtins::call_and_check(method, &[haystack, needle])?;
                 return Ok(is_true(result));
             }
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1005,6 +1005,16 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
 
 #[inline(never)]
 unsafe fn getitem_type(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
+    // A metaclass `__getitem__` (resolved on `type(cls)`'s MRO, e.g.
+    // `EnumMeta.__getitem__`) applies before the PEP 560
+    // `__class_getitem__` fallback: `Color['RED']` is `type(Color)
+    // .__getitem__(Color, 'RED')`.  `type` itself defines no `__getitem__`,
+    // so an ordinary class still takes the `__class_getitem__` path below.
+    if let Some(w_meta) = crate::typedef::r#type(obj) {
+        if let Some(method) = lookup_in_type_where(w_meta, "__getitem__") {
+            return crate::call::call_function_impl_result(method, &[obj, index]);
+        }
+    }
     // Python 3.9+ generic subscript: type[X] → __class_getitem__(X)
     // typeobject.py type.__class_getitem__
     if let Some(method) = lookup_in_type_where(obj, "__class_getitem__") {
@@ -1481,6 +1491,16 @@ pub fn len(obj: PyObjectRef) -> PyResult {
                 w_type_get_name(w_instance_get_type(obj)),
             )))
         } else {
+            // A metaclass `__len__` (e.g. `EnumMeta.__len__`) applies when
+            // the receiver is a class; `type` itself defines none, so an
+            // ordinary class still falls through to the error below.
+            if is_type(obj) {
+                if let Some(w_meta) = crate::typedef::r#type(obj) {
+                    if let Some(method) = lookup_in_type_where(w_meta, "__len__") {
+                        return crate::builtins::call_and_check(method, &[obj]);
+                    }
+                }
+            }
             Err(PyError::type_error(format!(
                 "object of type '{}' has no len()",
                 (*(*obj).ob_type).name,
@@ -6820,6 +6840,21 @@ pub fn contains(haystack: PyObjectRef, needle: PyObjectRef) -> Result<bool, PyEr
             }
             // Also check per-instance attributes (ATTR_TABLE)
             if let Ok(method) = getattr(haystack, "__contains__") {
+                let result = crate::call_function(method, &[haystack, needle]);
+                return Ok(is_true(result));
+            }
+        }
+    }
+    // A `__contains__` resolved on the receiver's dynamic type applies
+    // before the getitem scan: covers a metaclass `__contains__` when the
+    // haystack is a class (`x in Color` → `type(Color).__contains__(Color,
+    // x)`; `type` defines none, so an ordinary class falls through) and a
+    // builtin-leaf subclass instance (`x in flag` where the flag's ob_type
+    // is the int storage type but its w_class carries `__contains__`).  The
+    // is_instance receivers are already handled above.
+    unsafe {
+        if let Some(w_type) = crate::typedef::r#type(haystack) {
+            if let Some(method) = lookup_in_type_where(w_type, "__contains__") {
                 let result = crate::call_function(method, &[haystack, needle]);
                 return Ok(is_true(result));
             }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -766,7 +766,7 @@ unsafe fn get_and_call_function(
 }
 
 #[majit_macros::dont_look_inside]
-fn dict_missing_or_key_error(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
+pub(crate) fn dict_missing_or_key_error(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     if let Some(w_type_obj) = crate::typedef::r#type(obj) {
         let dict_type = crate::typedef::gettypeobject(&pyre_object::DICT_TYPE);
         if dict_type.is_null() == false && std::ptr::eq(w_type_obj, dict_type) == false {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1466,10 +1466,21 @@ fn type_descr_new_with_metaclass(
         // walks correctly.
         let mut class_ns = Box::new(crate::DictStorage::new());
         class_ns.fix_ptr();
+        // type_new_classcell — capture the `__classcell__` cell and keep
+        // both explicit class cells out of the new type's `__dict__`
+        // (CPython consumes them here rather than storing them).
+        let mut classcell = pyre_object::PY_NULL;
         if unsafe { is_dict(w_namespace_dict) } {
             for (k, v) in unsafe { pyre_object::w_dict_items(w_namespace_dict) } {
                 if unsafe { is_str(k) } {
                     let key = unsafe { pyre_object::w_str_get_value(k) };
+                    if key == "__classcell__" {
+                        classcell = v;
+                        continue;
+                    }
+                    if key == "__classdictcell__" {
+                        continue;
+                    }
                     crate::dict_storage_store(&mut class_ns, key, v);
                 }
             }
@@ -1531,6 +1542,13 @@ fn type_descr_new_with_metaclass(
         // `weak_subclasses` so `mutated()` and `__subclasses__()`
         // observe this class.
         unsafe { pyre_object::typeobject::w_type_ready(w_type) };
+
+        // type_new_classcell — bind the captured `__classcell__` to the
+        // new type so `__class__` / zero-arg `super()` in the methods
+        // resolve; the key was already dropped from the namespace above.
+        if !classcell.is_null() && unsafe { pyre_object::is_cell(classcell) } {
+            unsafe { pyre_object::w_cell_set(classcell, w_type) };
+        }
 
         // __set_name__ protocol — CPython: type_new_set_names
         // PyPy: typeobject.py type_new → call __set_name__(owner, name) on each descriptor.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1551,8 +1551,7 @@ fn type_descr_new_with_metaclass(
         // (the check is `PyDict_Check`, not `PyDict_CheckExact`); resolve
         // the dict backing so e.g. an `enum._EnumDict` class body is
         // walked instead of dropped.
-        let w_ns_backing =
-            unsafe { crate::type_methods::resolve_dict_backing(w_namespace_dict) };
+        let w_ns_backing = unsafe { crate::type_methods::resolve_dict_backing(w_namespace_dict) };
         if !w_ns_backing.is_null() {
             for (k, v) in unsafe { pyre_object::w_dict_items(w_ns_backing) } {
                 if unsafe { is_str(k) } {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1470,8 +1470,14 @@ fn type_descr_new_with_metaclass(
         // both explicit class cells out of the new type's `__dict__`
         // (CPython consumes them here rather than storing them).
         let mut classcell = pyre_object::PY_NULL;
-        if unsafe { is_dict(w_namespace_dict) } {
-            for (k, v) in unsafe { pyre_object::w_dict_items(w_namespace_dict) } {
+        // `type.__new__` accepts any `dict` subclass as the namespace
+        // (the check is `PyDict_Check`, not `PyDict_CheckExact`); resolve
+        // the dict backing so e.g. an `enum._EnumDict` class body is
+        // walked instead of dropped.
+        let w_ns_backing =
+            unsafe { crate::type_methods::resolve_dict_backing(w_namespace_dict) };
+        if !w_ns_backing.is_null() {
+            for (k, v) in unsafe { pyre_object::w_dict_items(w_ns_backing) } {
                 if unsafe { is_str(k) } {
                     let key = unsafe { pyre_object::w_str_get_value(k) };
                     if key == "__classcell__" {
@@ -1550,11 +1556,10 @@ fn type_descr_new_with_metaclass(
             unsafe { pyre_object::w_cell_set(classcell, w_type) };
         }
 
-        // __set_name__ protocol — CPython: type_new_set_names
-        // PyPy: typeobject.py type_new → call __set_name__(owner, name) on each descriptor.
-        // `w_dict_items` dispatches through `is_module_dict`.
-        if unsafe { is_dict(w_namespace_dict) } {
-            let entries = unsafe { pyre_object::w_dict_items(w_namespace_dict) };
+        // __set_name__ protocol — type_new_set_names
+        // typeobject.py type_new → call __set_name__(owner, name) on each descriptor.
+        if !w_ns_backing.is_null() {
+            let entries = unsafe { pyre_object::w_dict_items(w_ns_backing) };
             for (k, v) in entries {
                 if unsafe { is_str(k) } {
                     if let Ok(set_name) = crate::baseobjspace::getattr(v, "__set_name__") {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1557,6 +1557,15 @@ fn type_descr_new_with_metaclass(
                 if unsafe { is_str(k) } {
                     let key = unsafe { pyre_object::w_str_get_value(k) };
                     if key == "__classcell__" {
+                        if !unsafe { pyre_object::is_cell(v) } {
+                            let tp_name = match unsafe { crate::typedef::r#type(v) } {
+                                Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+                                None => "object".to_string(),
+                            };
+                            return Err(crate::PyError::type_error(format!(
+                                "__classcell__ must be a nonlocal cell, not {tp_name}"
+                            )));
+                        }
                         classcell = v;
                         continue;
                     }
@@ -1640,8 +1649,8 @@ fn type_descr_new_with_metaclass(
                 if unsafe { is_str(k) } {
                     if let Ok(set_name) = crate::baseobjspace::getattr(v, "__set_name__") {
                         // getattr returns a bound method, so self is already bound.
-                        // Call: bound_set_name(owner, name)
-                        let _ = crate::call_function(set_name, &[w_type, k]);
+                        // Call: bound_set_name(owner, name); propagate a raise.
+                        call_and_check(set_name, &[w_type, k])?;
                     }
                 }
             }
@@ -2329,6 +2338,13 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let obj = args[0];
     unsafe {
         if is_str(obj) {
+            // A `str` subclass keeps `ob_type` at STR_TYPE but carries the
+            // Python class in `w_class`; honor its `__str__` override before
+            // returning the raw value.
+            let tp = (*obj).ob_type;
+            if let Some(s) = crate::display::builtin_subclass_dunder(obj, tp, "__str__") {
+                return Ok(w_str_new(&s));
+            }
             return Ok(obj);
         }
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1197,6 +1197,83 @@ pub(crate) fn kwarg_reject_unknown(
     Ok(())
 }
 
+/// `true` when the last argument is the `__pyre_kw__`-tagged dict the
+/// CALL_KW builtin dispatch appends — i.e. the call carried keywords.
+pub(crate) fn has_builtin_kwargs(args: &[PyObjectRef]) -> bool {
+    matches!(args.last(), Some(&last) if unsafe {
+        is_dict(last) && pyre_object::w_dict_lookup(last, w_str_new("__pyre_kw__")).is_some()
+    })
+}
+
+/// Bind positional + `__pyre_kw__` keyword arguments into a resolved
+/// scope of length `names.len()`, mirroring the gateway's
+/// `Arguments._match_signature` (`pypy/interpreter/argument.py`). Each
+/// slot is filled by a positional, then by a keyword of the matching
+/// name; an absent optional slot becomes `PY_NULL` (the generated
+/// `#[pyre_function]` unwrap reads that as "argument omitted"). An absent
+/// required slot, an unknown keyword, a keyword duplicating a positional,
+/// or too many positionals raises `TypeError`.
+///
+/// This is the consumer-side counterpart that lets a builtin resolve
+/// keywords by parameter name without a per-function `Signature`; the
+/// `#[pyre_function]` wrapper supplies the name/required tables it knows
+/// at expansion time.
+pub(crate) fn bind_builtin_kwargs(
+    args: &[PyObjectRef],
+    names: &[&str],
+    required: &[bool],
+    fn_name: &str,
+) -> Result<Vec<PyObjectRef>, crate::PyError> {
+    let (positional, kwargs) = split_builtin_kwargs(args);
+    if positional.len() > names.len() {
+        return Err(crate::PyError::type_error(format!(
+            "{fn_name}() takes at most {} positional argument{} ({} given)",
+            names.len(),
+            if names.len() == 1 { "" } else { "s" },
+            positional.len(),
+        )));
+    }
+    let mut scope: Vec<PyObjectRef> = vec![PY_NULL; names.len()];
+    let mut filled: Vec<bool> = vec![false; names.len()];
+    for (i, &v) in positional.iter().enumerate() {
+        scope[i] = v;
+        filled[i] = true;
+    }
+    if let Some(dict) = kwargs {
+        let entries = unsafe { pyre_object::w_dict_str_entries(dict) };
+        for (key, val) in entries.iter() {
+            if key == "__pyre_kw__" {
+                continue;
+            }
+            match names.iter().position(|n| *n == key.as_str()) {
+                Some(idx) => {
+                    if filled[idx] {
+                        return Err(crate::PyError::type_error(format!(
+                            "{fn_name}() got multiple values for argument '{key}'"
+                        )));
+                    }
+                    scope[idx] = *val;
+                    filled[idx] = true;
+                }
+                None => {
+                    return Err(crate::PyError::type_error(format!(
+                        "{fn_name}() got an unexpected keyword argument '{key}'"
+                    )));
+                }
+            }
+        }
+    }
+    for i in 0..names.len() {
+        if !filled[i] && required[i] {
+            return Err(crate::PyError::type_error(format!(
+                "{fn_name}() missing required argument: '{}'",
+                names[i]
+            )));
+        }
+    }
+    Ok(scope)
+}
+
 /// Reject `f(x, name=...)` when `name` already arrived positionally.
 /// The flat builtin ABI leaves this validation to each kw-aware method.
 pub(crate) fn kwarg_reject_duplicate(

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2227,7 +2227,12 @@ fn build_class_inner(
     let classcell = {
         let class_ns = unsafe { &mut *class_ns_ptr };
         let cell = class_ns.get("__classcell__").copied();
-        for key in ["__class__", "__classdict__", "__classcell__", "__classdictcell__"] {
+        for key in [
+            "__class__",
+            "__classdict__",
+            "__classcell__",
+            "__classdictcell__",
+        ] {
             class_ns.remove(key);
         }
         cell

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2217,6 +2217,22 @@ fn build_class_inner(
 
     frame.execute_frame(None, None)?;
 
+    // type_new_classcell (typeobject.c) — capture the `__classcell__` cell
+    // so its content can be set to the new class below, then drop the
+    // compiler-internal scaffolding from the namespace so it never reaches
+    // the class `__dict__`.  `__class__` / `__classdict__` are cellvar
+    // names that `fast2locals` mirrors in; `__classcell__` /
+    // `__classdictcell__` are the cells the class body stores explicitly.
+    // CPython leaves none of them in the class dict.
+    let classcell = {
+        let class_ns = unsafe { &mut *class_ns_ptr };
+        let cell = class_ns.get("__classcell__").copied();
+        for key in ["__class__", "__classdict__", "__classcell__", "__classdictcell__"] {
+            class_ns.remove(key);
+        }
+        cell
+    };
+
     // Create W_TypeObject from the class namespace
     // PyPy: type.__new__(type, name, bases, dict_w) + compute_mro + ready()
     // PyPy: typeobject.py — if not bases_w: bases_w = [space.w_object]
@@ -2343,10 +2359,11 @@ fn build_class_inner(
         w
     };
 
-    // CPython: if __classcell__ is in the namespace, set the cell's content
-    // to the newly created class. This enables `__class__` references in methods.
-    let class_ns = unsafe { &*class_ns_ptr };
-    if let Some(&classcell) = class_ns.get("__classcell__") {
+    // type_new_classcell — set the captured `__classcell__` cell's content
+    // to the newly created class so `__class__` / zero-arg `super()`
+    // references in the methods resolve.  The namespace key was already
+    // removed above.
+    if let Some(classcell) = classcell {
         if !classcell.is_null() && unsafe { pyre_object::is_cell(classcell) } {
             unsafe { pyre_object::w_cell_set(classcell, w_type) };
         }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2218,23 +2218,20 @@ fn build_class_inner(
     frame.execute_frame(None, None)?;
 
     // type_new_classcell (typeobject.c) — capture the `__classcell__` cell
-    // so its content can be set to the new class below, then drop the
-    // compiler-internal scaffolding from the namespace so it never reaches
-    // the class `__dict__`.  `__class__` / `__classdict__` are cellvar
-    // names that `fast2locals` mirrors in; `__classcell__` /
-    // `__classdictcell__` are the cells the class body stores explicitly.
-    // CPython leaves none of them in the class dict.
+    // so its content can be set to the new class below.  `__class__` /
+    // `__classdict__` are cellvar names that `fast2locals` mirrors into
+    // the namespace; CPython never exposes them as namespace keys, so drop
+    // them now before a metaclass or the class dict ever sees them.
+    // `__classcell__` / `__classdictcell__` ARE real namespace entries the
+    // class body stores explicitly: a custom metaclass observes them
+    // (type.__new__ receives the full namespace) and `type.__new__`
+    // (type_new_classcell) consumes them, so they are dropped per
+    // construction path below rather than up front.
     let classcell = {
         let class_ns = unsafe { &mut *class_ns_ptr };
         let cell = class_ns.get("__classcell__").copied();
-        for key in [
-            "__class__",
-            "__classdict__",
-            "__classcell__",
-            "__classdictcell__",
-        ] {
-            class_ns.remove(key);
-        }
+        class_ns.remove("__class__");
+        class_ns.remove("__classdict__");
         cell
     };
 
@@ -2324,6 +2321,15 @@ fn build_class_inner(
         }
         result
     } else {
+        // No metaclass observes the namespace on the default path, so
+        // consume the explicit class cells here (type_new_classcell leaves
+        // them out of the class `__dict__`); the captured `classcell` is
+        // bound to the new type below.
+        unsafe {
+            let class_ns = &mut *class_ns_ptr;
+            class_ns.remove("__classcell__");
+            class_ns.remove("__classdictcell__");
+        }
         let w = pyre_object::w_type_new(name, w_effective_bases, class_ns_ptr as *mut u8);
         // typeobject.py:1143-1204 create_all_slots parity.
         unsafe {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2241,6 +2241,9 @@ fn build_class_inner(
         let backing = crate::type_methods::resolve_dict_backing(w_ns);
         if !backing.is_null() && unsafe { pyre_object::is_dict(backing) } {
             let class_ns = unsafe { &mut *class_ns_ptr };
+            // Rebuild from the final backing so names `del`eted from the
+            // mapping during body execution don't survive in class_ns.
+            class_ns.clear();
             for (key, value) in unsafe { pyre_object::w_dict_items(backing) } {
                 if !value.is_null() && unsafe { pyre_object::is_str(key) } {
                     crate::dict_storage_store(
@@ -2309,6 +2312,15 @@ fn build_class_inner(
                         // Use setitem to trigger __setitem__ on EnumDict etc.
                         let _ = crate::baseobjspace::setitem(w_prepared_dict, key, v);
                     }
+                }
+            } else {
+                // The body wrote directly into the mapping, so the prepared
+                // dict already holds every store — but `fast2locals` may have
+                // synced the `__class__` / `__classdict__` cellvars into it.
+                // Drop that scaffolding before the metaclass observes it.
+                for scaffold in ["__class__", "__classdict__"] {
+                    let _ =
+                        crate::baseobjspace::delitem(w_prepared_dict, pyre_object::w_str_new(scaffold));
                 }
             }
             w_prepared_dict
@@ -2403,10 +2415,10 @@ fn build_class_inner(
             for (attr_name, value) in entries {
                 if !value.is_null() {
                     if let Ok(set_name) = crate::baseobjspace::getattr(value, "__set_name__") {
-                        let _ = crate::call_function(
+                        crate::builtins::call_and_check(
                             set_name,
                             &[w, pyre_object::w_str_new(&attr_name)],
-                        );
+                        )?;
                     }
                 }
             }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2205,6 +2205,19 @@ fn build_class_inner(
         }
     }
 
+    // When `__prepare__` returned a custom mapping (a dict subclass such as
+    // enum._EnumDict), the class body must execute against it directly so its
+    // `__setitem__`/`__getitem__` fire mid-body — e.g. `WHITE = RED | GREEN`
+    // reads the values `_EnumDict.__setitem__` resolved on assignment, not the
+    // stale `auto()` sentinels.  Route the frame's name binding through it via
+    // setdictscope_object; an absent or plain-dict namespace keeps the
+    // DictStorage fast path.  Restricted to a dict-subclass instance with a
+    // resolvable backing so the post-execution mirror below can recover its
+    // entries — an exotic non-dict mapping keeps the legacy path unchanged.
+    let mapping_namespace = w_namespace.filter(|&w| unsafe {
+        pyre_object::is_instance(w) && !crate::type_methods::resolve_dict_backing(w).is_null()
+    });
+
     let mut frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
         w_code,
         &[],
@@ -2213,9 +2226,33 @@ fn build_class_inner(
         exec_ctx,
         closure,
     )?;
-    frame.setdictscope(class_ns_ptr)?;
+    if let Some(w_ns) = mapping_namespace {
+        frame.setdictscope_object(w_ns)?;
+    } else {
+        frame.setdictscope(class_ns_ptr)?;
+    }
 
     frame.execute_frame(None, None)?;
+
+    // The body wrote through the custom mapping; mirror its final contents
+    // into class_ns for the downstream type construction (classcell capture,
+    // create_all_slots, __set_name__), which read class_ns.
+    if let Some(w_ns) = mapping_namespace {
+        let backing = crate::type_methods::resolve_dict_backing(w_ns);
+        if !backing.is_null() && unsafe { pyre_object::is_dict(backing) } {
+            let class_ns = unsafe { &mut *class_ns_ptr };
+            for (key, value) in unsafe { pyre_object::w_dict_items(backing) } {
+                if !value.is_null() && unsafe { pyre_object::is_str(key) } {
+                    crate::dict_storage_store(
+                        class_ns,
+                        unsafe { pyre_object::w_str_get_value(key) },
+                        value,
+                    );
+                }
+            }
+            unsafe { (*class_ns_ptr).fix_ptr() };
+        }
+    }
 
     // type_new_classcell (typeobject.c) — capture the `__classcell__` cell
     // so its content can be set to the new class below.  `__class__` /
@@ -2258,13 +2295,20 @@ fn build_class_inner(
         // If __prepare__ returned a custom dict, replay stores into it
         // so that __setitem__ side effects (e.g. EnumDict tracking) fire.
         let w_namespace_dict = if let Some(w_prepared_dict) = w_namespace {
-            // Replay class body stores into prepared dict
-            let ns = unsafe { &*class_ns_ptr };
-            for (k, &v) in ns.entries() {
-                if !v.is_null() {
-                    let key = pyre_object::w_str_new(k);
-                    // Use setitem to trigger __setitem__ on EnumDict etc.
-                    let _ = crate::baseobjspace::setitem(w_prepared_dict, key, v);
+            // Replay class body stores into the prepared dict so __setitem__
+            // side effects (EnumDict tracking) fire — but only on the legacy
+            // path where the body wrote into class_ns.  When the body executed
+            // directly against the mapping (setdictscope_object above) it
+            // already holds every store; replaying would re-run __setitem__
+            // and, for _EnumDict, reject the duplicate member keys.
+            if mapping_namespace.is_none() {
+                let ns = unsafe { &*class_ns_ptr };
+                for (k, &v) in ns.entries() {
+                    if !v.is_null() {
+                        let key = pyre_object::w_str_new(k);
+                        // Use setitem to trigger __setitem__ on EnumDict etc.
+                        let _ = crate::baseobjspace::setitem(w_prepared_dict, key, v);
+                    }
                 }
             }
             w_prepared_dict

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2319,8 +2319,10 @@ fn build_class_inner(
                 // synced the `__class__` / `__classdict__` cellvars into it.
                 // Drop that scaffolding before the metaclass observes it.
                 for scaffold in ["__class__", "__classdict__"] {
-                    let _ =
-                        crate::baseobjspace::delitem(w_prepared_dict, pyre_object::w_str_new(scaffold));
+                    let _ = crate::baseobjspace::delitem(
+                        w_prepared_dict,
+                        pyre_object::w_str_new(scaffold),
+                    );
                 }
             }
             w_prepared_dict

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -194,6 +194,73 @@ pub unsafe fn dict_repr(obj: PyObjectRef) -> String {
 ///
 /// # Safety
 /// `obj` must be a valid pointer to a known Python object type.
+/// Format an `int`/`long`/`float`/`bool` storage object with its builtin
+/// `repr` (which equals its `str` for these types).  Returns `None` for
+/// any other storage type.  Shared by `py_repr`'s leaf path and `py_str`'s
+/// fallback so a builtin leaf subclass that overrides only `__repr__`
+/// still `str()`s via the inherited builtin `tp_str`.
+unsafe fn builtin_leaf_repr_string(obj: PyObjectRef, tp: *const PyType) -> Option<String> {
+    unsafe {
+        if std::ptr::eq(tp, &INT_TYPE as *const PyType) {
+            let int_obj = obj as *const pyre_object::intobject::W_IntObject;
+            Some(format!("{}", (*int_obj).intval))
+        } else if std::ptr::eq(tp, &FLOAT_TYPE as *const PyType) {
+            let float_obj = obj as *const pyre_object::floatobject::W_FloatObject;
+            Some(format_float_repr((*float_obj).floatval))
+        } else if std::ptr::eq(tp, &LONG_TYPE as *const PyType) {
+            let long_obj = obj as *const pyre_object::longobject::W_LongObject;
+            Some(format!("{}", &*(*long_obj).value))
+        } else if std::ptr::eq(tp, &BOOL_TYPE as *const PyType) {
+            let bool_obj = obj as *const pyre_object::boolobject::W_BoolObject;
+            Some(if (*bool_obj).boolval { "True" } else { "False" }.to_string())
+        } else {
+            None
+        }
+    }
+}
+
+/// Dispatch a user-defined `__repr__`/`__str__` override for a builtin leaf
+/// subclass instance.  `int`/`float`/`str`/... keep `ob_type` at the
+/// canonical storage type and carry the Python class in `w_class`, so the
+/// `ob_type`-keyed formatters ignore a subclass override.  Returns `Some`
+/// only when the dunder resolves above `object` (whose inherited default
+/// must fall through to the builtin formatting instead of re-entering).
+unsafe fn builtin_subclass_dunder(
+    obj: PyObjectRef,
+    tp: *const PyType,
+    name: &str,
+) -> Option<String> {
+    unsafe {
+        let is_leaf = std::ptr::eq(tp, &INT_TYPE as *const PyType)
+            || std::ptr::eq(tp, &LONG_TYPE as *const PyType)
+            || std::ptr::eq(tp, &FLOAT_TYPE as *const PyType)
+            || std::ptr::eq(tp, &BOOL_TYPE as *const PyType)
+            || std::ptr::eq(tp, &STR_TYPE as *const PyType);
+        if !is_leaf {
+            return None;
+        }
+        let w_class = (*obj).w_class;
+        if w_class.is_null() || !pyre_object::is_type(w_class) {
+            return None;
+        }
+        let found = crate::baseobjspace::lookup_in_type_where(w_class, name)?;
+        // `object`'s inherited default is not a leaf override — fall through
+        // so the builtin formatting runs (and `object.__repr__` does not
+        // re-enter through this path).
+        let w_object = crate::typedef::w_object();
+        if let Some(default) = crate::baseobjspace::lookup_in_type_where(w_object, name) {
+            if std::ptr::eq(found, default) {
+                return None;
+            }
+        }
+        let r = crate::call_function(found, &[obj]);
+        if !r.is_null() && pyre_object::is_str(r) {
+            return Some(pyre_object::w_str_get_value(r).to_string());
+        }
+        None
+    }
+}
+
 pub unsafe fn py_repr(obj: PyObjectRef) -> String {
     let obj = crate::baseobjspace::unwrap_cell(obj);
     if obj.is_null() {
@@ -201,23 +268,14 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> String {
     }
     unsafe {
         let tp = (*obj).ob_type;
-        if std::ptr::eq(tp, &INT_TYPE as *const PyType) {
-            let int_obj = obj as *const pyre_object::intobject::W_IntObject;
-            format!("{}", (*int_obj).intval)
-        } else if std::ptr::eq(tp, &FLOAT_TYPE as *const PyType) {
-            let float_obj = obj as *const pyre_object::floatobject::W_FloatObject;
-            let val = (*float_obj).floatval;
-            format_float_repr(val)
-        } else if std::ptr::eq(tp, &LONG_TYPE as *const PyType) {
-            let long_obj = obj as *const pyre_object::longobject::W_LongObject;
-            format!("{}", &*(*long_obj).value)
-        } else if std::ptr::eq(tp, &BOOL_TYPE as *const PyType) {
-            let bool_obj = obj as *const pyre_object::boolobject::W_BoolObject;
-            if (*bool_obj).boolval {
-                "True".to_string()
-            } else {
-                "False".to_string()
-            }
+        // A builtin leaf subclass keeps `ob_type` at the canonical storage
+        // type but carries the Python class in `w_class`; dispatch its
+        // `__repr__` override before the `ob_type`-keyed formatting below.
+        if let Some(s) = builtin_subclass_dunder(obj, tp, "__repr__") {
+            return s;
+        }
+        if let Some(s) = builtin_leaf_repr_string(obj, tp) {
+            s
         } else if std::ptr::eq(tp, &pyre_object::pyobject::LIST_TYPE as *const PyType) {
             let Some(_guard) = ReprGuard::enter(obj) else {
                 return "[...]".to_string();
@@ -521,6 +579,9 @@ pub unsafe fn py_str(obj: PyObjectRef) -> String {
         let tp = (*obj).ob_type;
         // For strings, return the value directly (no quotes).
         if std::ptr::eq(tp, &STR_TYPE as *const PyType) {
+            if let Some(s) = builtin_subclass_dunder(obj, tp, "__str__") {
+                return s;
+            }
             return pyre_object::w_str_get_value(obj).to_string();
         }
         if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
@@ -602,6 +663,14 @@ pub unsafe fn py_str(obj: PyObjectRef) -> String {
                 return py_str(first);
             }
             return py_str(args);
+        }
+        // `int`/`float`/... define no `tp_str`, so `str()` falls back to
+        // `repr()` (a `__str__` override wins, otherwise the `__repr__`
+        // override or builtin formatting from `py_repr`).  `str` itself
+        // has its own `tp_str` and is handled by the `STR_TYPE` branch
+        // above, so this fallthrough never reaches a bare-`str` subclass.
+        if let Some(s) = builtin_subclass_dunder(obj, tp, "__str__") {
+            return s;
         }
         py_repr(obj)
     }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -225,7 +225,7 @@ unsafe fn builtin_leaf_repr_string(obj: PyObjectRef, tp: *const PyType) -> Optio
 /// `ob_type`-keyed formatters ignore a subclass override.  Returns `Some`
 /// only when the dunder resolves above `object` (whose inherited default
 /// must fall through to the builtin formatting instead of re-entering).
-unsafe fn builtin_subclass_dunder(
+pub(crate) unsafe fn builtin_subclass_dunder(
     obj: PyObjectRef,
     tp: *const PyType,
     name: &str,

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -169,6 +169,27 @@ impl Drop for ReprGuard {
     }
 }
 
+/// `dictmultiobject.py:130-150 descr_repr` — `{k: v, ...}`.  Iterates
+/// `w_dict_items` (which routes through `is_module_dict`), guarded against
+/// self-recursion.  Shared by the `py_repr` dict fast path and the dict
+/// type's `__repr__` method (so dict-subclass instances and `super().
+/// __repr__()` format their backing the same way).
+///
+/// # Safety
+/// `obj` must be a real `W_DictObject` (caller resolves any subclass
+/// backing via `resolve_dict_backing` first).
+pub unsafe fn dict_repr(obj: PyObjectRef) -> String {
+    let Some(_guard) = ReprGuard::enter(obj) else {
+        return "{...}".to_string();
+    };
+    let entries = pyre_object::w_dict_items(obj);
+    let mut parts = Vec::with_capacity(entries.len());
+    for (k, v) in entries {
+        parts.push(format!("{}: {}", py_repr(k), py_repr(v)));
+    }
+    format!("{{{}}}", parts.join(", "))
+}
+
 /// Format a PyObjectRef for debug display.
 ///
 /// # Safety
@@ -259,21 +280,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> String {
                 format!("({})", parts.join(", "))
             }
         } else if unsafe { pyre_object::is_dict(obj) } {
-            // `pypy/objspace/std/dictmultiobject.py:130-150 descr_repr`
-            // iterates `self.iteritems()`, which dispatches to the
-            // strategy on both `W_DictObject` and `W_ModuleDictObject`.
-            // `w_dict_items` already routes through `is_module_dict`,
-            // so reach for the unified surface instead of casting
-            // through the W_DictObject layout.
-            let Some(_guard) = ReprGuard::enter(obj) else {
-                return "{...}".to_string();
-            };
-            let entries = pyre_object::w_dict_items(obj);
-            let mut parts = Vec::with_capacity(entries.len());
-            for (k, v) in entries {
-                parts.push(format!("{}: {}", py_repr(k), py_repr(v)));
-            }
-            format!("{{{}}}", parts.join(", "))
+            unsafe { dict_repr(obj) }
         } else if pyre_object::sliceobject::is_slice(obj) {
             // `pypy/objspace/std/sliceobject.py descr_repr` —
             // `slice(%r, %r, %r)`.

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -141,10 +141,10 @@ thread_local! {
 /// RAII cycle guard.  `enter` returns `None` when `obj` is already being
 /// repr'd on this thread — the caller emits the `...` placeholder — and
 /// otherwise records `obj`, removing it again when the guard drops.
-struct ReprGuard(usize);
+pub(crate) struct ReprGuard(usize);
 
 impl ReprGuard {
-    fn enter(obj: PyObjectRef) -> Option<ReprGuard> {
+    pub(crate) fn enter(obj: PyObjectRef) -> Option<ReprGuard> {
         let key = obj as usize;
         REPR_ACTIVE.with(|active| {
             let mut active = active.borrow_mut();

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3505,6 +3505,33 @@ mod tests {
     }
 
     #[test]
+    fn test_make_cell_closure_over_parameter_not_double_wrapped() {
+        // An argument slot promoted to a cellvar (captured by an inner
+        // function) must wrap to a single cell, not a cell-of-cell, so the
+        // closure reads the value rather than an inner cell.
+        let (_result, frame) = run_exec_frame(
+            "def make_adder(n):\n    def add(x):\n        return x + n\n    return add\nresult = make_adder(10)(5)",
+        );
+        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let result = *w_globals.get("result").expect("missing result");
+        assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 15);
+    }
+
+    #[test]
+    fn test_make_cell_class_cell_super_not_double_wrapped() {
+        // The implicit `__class__` cellvar is never reassigned in the body,
+        // so MAKE_CELL must leave the pre-installed cell alone; a
+        // cell-of-cell would make zero-arg super() resolve an inner cell
+        // instead of the class.
+        let (_result, frame) = run_exec_frame(
+            "class A:\n    def f(self):\n        return 1\nclass B(A):\n    def f(self):\n        return 10 + super().f()\nresult = B().f()",
+        );
+        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let result = *w_globals.get("result").expect("missing result");
+        assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 11);
+    }
+
+    #[test]
     fn test_raise_invalid_cause_raises_typeerror() {
         let (result, _frame) = run_exec_frame("raise ValueError() from 1");
         let err = result.expect_err("invalid cause should fail");

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2847,10 +2847,24 @@ impl OpcodeStepExecutor for PyFrame {
                 // PyPy: LOOKUP_METHOD binds self for builtin type methods,
                 // except staticmethods (str.maketrans) and classmethods
                 // (dict.fromkeys), which getattr already unwrapped above.
+                //
+                // A builtin-storage subclass instance (`class MyInt(int)`,
+                // enum members) is not is_instance-shaped, so it reaches this
+                // branch too; its `w_type` is the subclass with a full MRO.
+                // Mirror the is_instance branch: non-method descriptors
+                // (type / property / member / getset such as `__class__`) do
+                // not prepend self, and an attribute not in the type MRO (a
+                // special attribute like `__class__`/`__dict__`, resolved
+                // directly in getattr, or an instance-dict entry) binds none.
                 match crate::baseobjspace::lookup_in_type(w_type, name) {
                     Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
                     Some(d) if pyre_object::is_classmethod(d) => w_type,
-                    _ => obj,
+                    Some(d) if pyre_object::is_type(d) => PY_NULL,
+                    Some(d) if pyre_object::is_property(d) => PY_NULL,
+                    Some(d) if pyre_object::is_member(d) => PY_NULL,
+                    Some(d) if pyre_object::getsetproperty::is_getset_property(d) => PY_NULL,
+                    Some(_) => obj,
+                    None => PY_NULL,
                 }
             } else {
                 PY_NULL

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2002,25 +2002,25 @@ impl OpcodeStepExecutor for PyFrame {
         Ok(())
     }
 
-    /// MAKE_CELL — no-op in pyre.
+    /// MAKE_CELL — wrap the slot value in a W_CellObject.
     ///
     /// CPython 3.13 / RustPython MAKE_CELL — create cell object in slot.
-    ///
-    /// PyPy: pyframe.py cell initialization.
     /// Wraps the current value (PY_NULL if uninitialized) in a W_CellObject.
     /// LoadFast on cell slots returns the cell object itself (needed for
     /// closure creation via BUILD_TUPLE + SET_FUNCTION_ATTRIBUTE).
+    ///
+    /// `initialize_frame_scopes` already installs an empty cell for every
+    /// pure cellvar (a cellvar not shadowing a parameter).  Only an
+    /// argument slot promoted to a cellvar still holds a raw value here,
+    /// so wrap solely when the slot is not already a cell — otherwise a
+    /// never-reassigned cellvar like `__class__` would become a
+    /// cell-wrapping-a-cell, and `fast2locals` / closure reads would
+    /// surface the inner cell instead of the value.
     fn make_cell(&mut self, idx: usize) -> Result<(), PyError> {
-        let code = unsafe { &*crate::pyframe_get_pycode(self) };
-        if std::env::var("PYRE_DEBUG_CELL").is_ok() {
-            eprintln!("  varnames: {:?}", code.varnames);
-            eprintln!("  cellvars: {:?}", code.cellvars);
-            for (i, instr) in code.instructions.iter().enumerate().take(25) {
-                eprintln!("  {i}: {:?}", instr);
-            }
-        }
         let current = self.locals_w()[idx];
-        self.locals_w_mut()[idx] = pyre_object::w_cell_new(current);
+        if current.is_null() || !unsafe { pyre_object::is_cell(current) } {
+            self.locals_w_mut()[idx] = pyre_object::w_cell_new(current);
+        }
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -972,6 +972,36 @@ pub fn jit_static_ref_addrs() -> Vec<(&'static str, i64)> {
             "kwargsdict::KWARGS_DICT_STRATEGY",
             kwargsdict::KWARGS_DICT_STRATEGY
         ),
+        // Prebuilt object singletons (`None` / `NotImplemented` /
+        // `Ellipsis` / `True` / `False`).  The accessors `w_none`,
+        // `w_ellipsis`, `w_not_implemented`, `w_bool_from` read these
+        // statics as a bare same-file `LOAD_GLOBAL` and return their
+        // address; supplying the captured address lets the front-end
+        // `Expr::Path` same-file fold emit `ConstRefAddr` with the real
+        // runtime identity instead of a cross-block body-`Input`.  The
+        // statics are private (callers route through the accessors), so
+        // the address is captured through the accessor rather than the
+        // `ref_addr!` `&pyre_object::X` path form.
+        (
+            "noneobject::NONE_SINGLETON",
+            pyre_object::w_none() as usize as i64,
+        ),
+        (
+            "noneobject::NOT_IMPLEMENTED_SINGLETON",
+            pyre_object::w_not_implemented() as usize as i64,
+        ),
+        (
+            "noneobject::ELLIPSIS_SINGLETON",
+            pyre_object::w_ellipsis() as usize as i64,
+        ),
+        (
+            "boolobject::TRUE_SINGLETON",
+            pyre_object::w_bool_from(true) as usize as i64,
+        ),
+        (
+            "boolobject::FALSE_SINGLETON",
+            pyre_object::w_bool_from(false) as usize as i64,
+        ),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -121,9 +121,11 @@ mod deque_class {
 
 /// `pypy/module/_collections/interp_defaultdict.py` — `W_DefaultDict`
 /// stub backed by an inner dict at `self.__data__` plus
-/// `self.default_factory`.  Factory invocation on missing key is
-/// short-circuited to `w_none()` because callable invocation needs
-/// frame-level plumbing the macro can't yet express.
+/// `self.default_factory`.  A missing key invokes `default_factory` and
+/// stores the result (`W_DefaultDict.missing`); a missing key with no
+/// factory raises `KeyError(key)`.  Still a stub vs upstream: this type
+/// subclasses `object`, not `dict`, so `isinstance(d, dict)` is False, and
+/// `__missing__`/`__repr__`/`copy`/`__reduce__` are absent.
 mod defaultdict_class {
     use super::*;
 

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -234,26 +234,35 @@ mod deque_class {
                 items.reverse();
                 store(self_obj, items);
             }
-            fn rotate(self_obj: PyObjectRef, n: Option<PyObjectRef>) {
-                // Rotate right by n (negative rotates left).
-                let n = n.map(|v| unsafe { w_int_get_value(v) }).unwrap_or(1);
+            fn rotate(self_obj: PyObjectRef, n: Option<PyObjectRef>) -> Result<(), crate::PyError> {
+                // Rotate right by n (negative rotates left).  The count goes
+                // through `__index__` so non-integers raise `TypeError`.
+                let n = match n {
+                    Some(v) => crate::builtins::getindex_w(v)?,
+                    None => 1,
+                };
                 let mut items = snapshot(self_obj);
                 let len = items.len() as i64;
                 if len <= 1 {
-                    return;
+                    return Ok(());
                 }
                 let shift = ((n % len) + len) % len;
                 if shift != 0 {
                     items.rotate_right(shift as usize);
                     store(self_obj, items);
                 }
+                Ok(())
             }
             fn index(self_obj: PyObjectRef, x: PyObjectRef, start: Option<PyObjectRef>, stop: Option<PyObjectRef>) -> Result<i64, crate::PyError> {
                 let items = snapshot(self_obj);
                 let len = items.len() as i64;
                 let clamp = |i: i64| if i < 0 { (i + len).max(0) } else { i.min(len) };
-                let start = clamp(start.map(|v| unsafe { w_int_get_value(v) }).unwrap_or(0));
-                let stop = clamp(stop.map(|v| unsafe { w_int_get_value(v) }).unwrap_or(len));
+                let start = clamp(
+                    start.map(|v| crate::builtins::getindex_w(v)).transpose()?.unwrap_or(0),
+                );
+                let stop = clamp(
+                    stop.map(|v| crate::builtins::getindex_w(v)).transpose()?.unwrap_or(len),
+                );
                 let mut i = start;
                 while i < stop {
                     if crate::baseobjspace::eq_w(items[i as usize], x) {

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -115,8 +115,9 @@ mod deque_class {
         let ty = unsafe { w_instance_get_type(self_obj) };
         let list = w_list_new(items);
         match crate::baseobjspace::getattr(self_obj, "__maxlen__") {
-            Ok(m) if !(m.is_null() || unsafe { is_none(m) }) =>
-                crate::call::call_function_impl_result(ty, &[list, m]),
+            Ok(m) if !(m.is_null() || unsafe { is_none(m) }) => {
+                crate::call::call_function_impl_result(ty, &[list, m])
+            }
             _ => crate::call::call_function_impl_result(ty, &[list]),
         }
     }

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -65,6 +65,24 @@ mod deque_class {
         }
     }
 
+    /// `space.decode_index4` index-only case — reject a slice with a
+    /// `TypeError`, route any `__index__`-able object through
+    /// `getindex_w`, apply the negative-index wrap and the in-range
+    /// check, and return the resolved element position.
+    fn deque_index(index: PyObjectRef, len: i64) -> Result<usize, crate::PyError> {
+        if unsafe { pyre_object::is_slice(index) } {
+            return Err(crate::PyError::type_error("deque[:] is not supported"));
+        }
+        let mut idx = crate::builtins::getindex_w(index)?;
+        if idx < 0 {
+            idx += len;
+        }
+        if idx < 0 || idx >= len {
+            return Err(crate::PyError::index_error("index out of range"));
+        }
+        Ok(idx as usize)
+    }
+
     /// `W_Deque.appendleft` + `trimright`: drop from the right once over the bound.
     fn do_appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
         let mut items = snapshot(self_obj);
@@ -229,36 +247,21 @@ mod deque_class {
                 }
             }
             fn __getitem__(self_obj: PyObjectRef, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                match data(self_obj) {
-                    Some(d) => crate::baseobjspace::getitem(d, index),
-                    None => Ok(w_none()),
-                }
+                let items = snapshot(self_obj);
+                let idx = deque_index(index, items.len() as i64)?;
+                Ok(items[idx])
             }
             fn __setitem__(self_obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> Result<(), crate::PyError> {
                 let mut items = snapshot(self_obj);
-                let len = items.len() as i64;
-                let mut idx = unsafe { w_int_get_value(index) };
-                if idx < 0 {
-                    idx += len;
-                }
-                if idx < 0 || idx >= len {
-                    return Err(crate::PyError::index_error("deque index out of range"));
-                }
-                items[idx as usize] = value;
+                let idx = deque_index(index, items.len() as i64)?;
+                items[idx] = value;
                 store(self_obj, items);
                 Ok(())
             }
             fn __delitem__(self_obj: PyObjectRef, index: PyObjectRef) -> Result<(), crate::PyError> {
                 let mut items = snapshot(self_obj);
-                let len = items.len() as i64;
-                let mut idx = unsafe { w_int_get_value(index) };
-                if idx < 0 {
-                    idx += len;
-                }
-                if idx < 0 || idx >= len {
-                    return Err(crate::PyError::index_error("deque index out of range"));
-                }
-                items.remove(idx as usize);
+                let idx = deque_index(index, items.len() as i64)?;
+                items.remove(idx);
                 store(self_obj, items);
                 Ok(())
             }

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -40,13 +40,15 @@ mod deque_class {
         let _ = crate::baseobjspace::setattr(self_obj, "__data__", w_list_new(items));
     }
 
-    /// `self.maxlen`: `None` (unbounded) or a non-negative bound.
+    /// `self.maxlen`: `None` (unbounded) or a non-negative bound.  The
+    /// bound is validated non-negative at construction, so the stored
+    /// value is read back directly.
     fn maxlen_bound(self_obj: PyObjectRef) -> Option<usize> {
         let w = crate::baseobjspace::getattr(self_obj, "__maxlen__").ok()?;
         if w.is_null() || unsafe { is_none(w) } {
             None
         } else {
-            Some(unsafe { w_int_get_value(w) }.max(0) as usize)
+            Some(unsafe { w_int_get_value(w) } as usize)
         }
     }
 
@@ -78,15 +80,33 @@ mod deque_class {
         methods: {
             // `init(iterable=None, maxlen=None)` — remember maxlen, then
             // extend so the bound is enforced while filling.
-            fn __init__(self_obj: PyObjectRef, iterable: Option<PyObjectRef>, maxlen: Option<PyObjectRef>) {
+            fn __init__(self_obj: PyObjectRef, iterable: Option<PyObjectRef>, maxlen: Option<PyObjectRef>) -> Result<(), crate::PyError> {
                 store(self_obj, vec![]);
-                let _ = crate::baseobjspace::setattr(
-                    self_obj, "__maxlen__", maxlen.unwrap_or(w_none()));
+                // `gateway_nonnegint_w(w_maxlen)` — None is unbounded; a
+                // non-integer is a TypeError and a negative bound is a
+                // ValueError, both raised here at construction rather than
+                // silently clamped when the bound is later read.
+                let w_maxlen = match maxlen {
+                    Some(m) if !unsafe { is_none(m) } => {
+                        if !unsafe { is_int(m) } {
+                            return Err(crate::PyError::type_error(
+                                "an integer is required"));
+                        }
+                        if unsafe { w_int_get_value(m) } < 0 {
+                            return Err(crate::PyError::value_error(
+                                "maxlen must be non-negative"));
+                        }
+                        m
+                    }
+                    _ => w_none(),
+                };
+                let _ = crate::baseobjspace::setattr(self_obj, "__maxlen__", w_maxlen);
                 if let Some(it) = iterable {
-                    for item in crate::builtins::collect_iterable(it).unwrap_or_default() {
+                    for item in crate::builtins::collect_iterable(it)? {
                         do_append(self_obj, item);
                     }
                 }
+                Ok(())
             }
             fn append(self_obj: PyObjectRef, item: PyObjectRef) {
                 do_append(self_obj, item);
@@ -243,6 +263,11 @@ mod deque_class {
                 Ok(())
             }
             fn __repr__(self_obj: PyObjectRef) -> String {
+                // `dequerepr` — a deque reachable from its own items renders
+                // the inner reference as `[...]` instead of recursing.
+                let Some(_guard) = crate::display::ReprGuard::enter(self_obj) else {
+                    return "[...]".to_string();
+                };
                 let name = unsafe { w_type_get_name(w_instance_get_type(self_obj)) };
                 let listrepr = snapshot(self_obj)
                     .into_iter()

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -83,6 +83,44 @@ mod deque_class {
         Ok(idx as usize)
     }
 
+    /// `W_Deque.compare` — element-wise (`compare_by_iteration`) ordering
+    /// against another deque, ignoring `maxlen`; `NotImplemented` when the
+    /// other operand is not a deque.  Delegates to list comparison over
+    /// snapshots of both backings.
+    fn deque_compare(
+        self_obj: PyObjectRef,
+        other: PyObjectRef,
+        op: crate::baseobjspace::CompareOp,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        if !crate::baseobjspace::isinstance(other, type_object())? {
+            return Ok(pyre_object::w_not_implemented());
+        }
+        let la = w_list_new(snapshot(self_obj));
+        let lb = w_list_new(snapshot(other));
+        crate::baseobjspace::compare(la, lb, op)
+    }
+
+    /// `W_Deque.mul` — repeat the elements `num` times, then re-bound by
+    /// `maxlen` by routing through the constructor (which trims).
+    fn deque_repeat(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        if !unsafe { is_int(n) } {
+            return Ok(pyre_object::w_not_implemented());
+        }
+        let num = unsafe { w_int_get_value(n) }.max(0);
+        let base = snapshot(self_obj);
+        let mut items = Vec::with_capacity(base.len().saturating_mul(num as usize));
+        for _ in 0..num {
+            items.extend_from_slice(&base);
+        }
+        let ty = unsafe { w_instance_get_type(self_obj) };
+        let list = w_list_new(items);
+        match crate::baseobjspace::getattr(self_obj, "__maxlen__") {
+            Ok(m) if !(m.is_null() || unsafe { is_none(m) }) =>
+                crate::call::call_function_impl_result(ty, &[list, m]),
+            _ => crate::call::call_function_impl_result(ty, &[list]),
+        }
+    }
+
     /// `W_Deque.appendleft` + `trimright`: drop from the right once over the bound.
     fn do_appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
         let mut items = snapshot(self_obj);
@@ -264,6 +302,57 @@ mod deque_class {
                 items.remove(idx);
                 store(self_obj, items);
                 Ok(())
+            }
+            fn __eq__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Eq)
+            }
+            fn __ne__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ne)
+            }
+            fn __lt__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Lt)
+            }
+            fn __le__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Le)
+            }
+            fn __gt__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Gt)
+            }
+            fn __ge__(self_obj: PyObjectRef, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ge)
+            }
+            fn __mul__(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_repeat(self_obj, n)
+            }
+            fn __rmul__(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                deque_repeat(self_obj, n)
+            }
+            fn __imul__(self_obj: PyObjectRef, n: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                // `W_Deque.imul` — empty or *1 is self; *<=0 clears; else
+                // repeat in place, trimmed by maxlen.
+                if !unsafe { is_int(n) } {
+                    return Ok(pyre_object::w_not_implemented());
+                }
+                let num = unsafe { w_int_get_value(n) };
+                let base = snapshot(self_obj);
+                if base.is_empty() || num == 1 {
+                    return Ok(self_obj);
+                }
+                if num <= 0 {
+                    store(self_obj, vec![]);
+                    return Ok(self_obj);
+                }
+                let mut items = Vec::with_capacity(base.len().saturating_mul(num as usize));
+                for _ in 0..num {
+                    items.extend_from_slice(&base);
+                }
+                if let Some(m) = maxlen_bound(self_obj) {
+                    if items.len() > m {
+                        items.drain(0..items.len() - m);
+                    }
+                }
+                store(self_obj, items);
+                Ok(self_obj)
             }
             fn __repr__(self_obj: PyObjectRef) -> String {
                 // `dequerepr` — a deque reachable from its own items renders

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -10,9 +10,12 @@
 
 use pyre_object::*;
 
-/// `pypy/module/_collections/interp_deque.py` — minimal `W_Deque`
-/// surface (append / appendleft / pop / popleft / clear / extend +
-/// container protocol) backed by an inner list at `self.__data__`.
+/// `pypy/module/_collections/interp_deque.py` — `W_Deque` surface
+/// (append / appendleft / pop / popleft / clear / extend / extendleft /
+/// rotate / count / remove / reverse / index / copy + container and repr
+/// protocols, with `maxlen` bounding) backed by an inner list at
+/// `self.__data__`.  The bound is kept in the private `self.__maxlen__`
+/// slot and surfaced read-only via the `maxlen` property.
 mod deque_class {
     use super::*;
 
@@ -20,83 +23,179 @@ mod deque_class {
         crate::baseobjspace::getattr(self_obj, "__data__").ok()
     }
 
+    /// Snapshot the backing list into a `Vec`.
+    fn snapshot(self_obj: PyObjectRef) -> Vec<PyObjectRef> {
+        match data(self_obj) {
+            Some(d) => unsafe {
+                (0..w_list_len(d))
+                    .filter_map(|i| w_list_getitem(d, i as i64))
+                    .collect()
+            },
+            None => Vec::new(),
+        }
+    }
+
+    /// Replace the backing list with `items`.
+    fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
+        let _ = crate::baseobjspace::setattr(self_obj, "__data__", w_list_new(items));
+    }
+
+    /// `self.maxlen`: `None` (unbounded) or a non-negative bound.
+    fn maxlen_bound(self_obj: PyObjectRef) -> Option<usize> {
+        let w = crate::baseobjspace::getattr(self_obj, "__maxlen__").ok()?;
+        if w.is_null() || unsafe { is_none(w) } {
+            None
+        } else {
+            Some(unsafe { w_int_get_value(w) }.max(0) as usize)
+        }
+    }
+
+    /// `W_Deque.append` + `trimleft`: drop from the left once over the bound.
+    fn do_append(self_obj: PyObjectRef, item: PyObjectRef) {
+        let Some(d) = data(self_obj) else { return };
+        unsafe { w_list_append(d, item) };
+        if let Some(m) = maxlen_bound(self_obj) {
+            let mut items = snapshot(self_obj);
+            if items.len() > m {
+                items.drain(0..items.len() - m);
+                store(self_obj, items);
+            }
+        }
+    }
+
+    /// `W_Deque.appendleft` + `trimright`: drop from the right once over the bound.
+    fn do_appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
+        let mut items = snapshot(self_obj);
+        items.insert(0, item);
+        if let Some(m) = maxlen_bound(self_obj) {
+            items.truncate(m);
+        }
+        store(self_obj, items);
+    }
+
     crate::py_class! {
         "deque",
         methods: {
-            // `__init__(iterable=(), maxlen=None)` — store items as
-            // `__data__` list, remember maxlen for future trimming.
+            // `init(iterable=None, maxlen=None)` — remember maxlen, then
+            // extend so the bound is enforced while filling.
             fn __init__(self_obj: PyObjectRef, iterable: Option<PyObjectRef>, maxlen: Option<PyObjectRef>) {
-                let items = iterable
-                    .map(|it| crate::builtins::collect_iterable(it).unwrap_or_default())
-                    .unwrap_or_default();
-                let _ = crate::baseobjspace::setattr(self_obj, "__data__", w_list_new(items));
-                let _ = crate::baseobjspace::setattr(self_obj, "maxlen", maxlen.unwrap_or(w_none()));
+                store(self_obj, vec![]);
+                let _ = crate::baseobjspace::setattr(
+                    self_obj, "__maxlen__", maxlen.unwrap_or(w_none()));
+                if let Some(it) = iterable {
+                    for item in crate::builtins::collect_iterable(it).unwrap_or_default() {
+                        do_append(self_obj, item);
+                    }
+                }
             }
             fn append(self_obj: PyObjectRef, item: PyObjectRef) {
-                if let Some(d) = data(self_obj) {
-                    unsafe { w_list_append(d, item) };
-                }
+                do_append(self_obj, item);
             }
             fn appendleft(self_obj: PyObjectRef, item: PyObjectRef) {
-                if let Some(d) = data(self_obj) {
-                    unsafe {
-                        let n = w_list_len(d);
-                        let mut items: Vec<_> = (0..n)
-                            .filter_map(|i| w_list_getitem(d, i as i64))
-                            .collect();
-                        items.insert(0, item);
-                        let _ = crate::baseobjspace::setattr(
-                            self_obj, "__data__", w_list_new(items));
-                    }
-                }
+                do_appendleft(self_obj, item);
             }
             fn pop(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `interp_deque.py W_Deque.pop` — empty raises IndexError.
-                let d = data(self_obj).ok_or_else(||
+                // `W_Deque.pop` — empty raises IndexError.
+                let mut items = snapshot(self_obj);
+                let item = items.pop().ok_or_else(||
                     crate::PyError::index_error("pop from an empty deque"))?;
-                unsafe {
-                    let n = w_list_len(d);
-                    if n == 0 {
-                        return Err(crate::PyError::index_error("pop from an empty deque"));
-                    }
-                    let item = w_list_getitem(d, (n - 1) as i64).unwrap_or(w_none());
-                    let items: Vec<_> = (0..n - 1)
-                        .filter_map(|i| w_list_getitem(d, i as i64))
-                        .collect();
-                    let _ = crate::baseobjspace::setattr(
-                        self_obj, "__data__", w_list_new(items));
-                    Ok(item)
-                }
+                store(self_obj, items);
+                Ok(item)
             }
             fn popleft(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `interp_deque.py W_Deque.popleft` — empty raises IndexError.
-                let d = data(self_obj).ok_or_else(||
-                    crate::PyError::index_error("pop from an empty deque"))?;
-                unsafe {
-                    let n = w_list_len(d);
-                    if n == 0 {
-                        return Err(crate::PyError::index_error("pop from an empty deque"));
-                    }
-                    let item = w_list_getitem(d, 0).unwrap_or(w_none());
-                    let items: Vec<_> = (1..n)
-                        .filter_map(|i| w_list_getitem(d, i as i64))
-                        .collect();
-                    let _ = crate::baseobjspace::setattr(
-                        self_obj, "__data__", w_list_new(items));
-                    Ok(item)
+                // `W_Deque.popleft` — empty raises IndexError.
+                let mut items = snapshot(self_obj);
+                if items.is_empty() {
+                    return Err(crate::PyError::index_error("pop from an empty deque"));
                 }
+                let item = items.remove(0);
+                store(self_obj, items);
+                Ok(item)
             }
             fn clear(self_obj: PyObjectRef) {
-                let _ = crate::baseobjspace::setattr(self_obj, "__data__", w_list_new(vec![]));
+                store(self_obj, vec![]);
             }
             fn extend(self_obj: PyObjectRef, iterable: PyObjectRef) -> Result<(), crate::PyError> {
-                let items = crate::builtins::collect_iterable(iterable)?;
-                if let Some(d) = data(self_obj) {
-                    for item in items {
-                        unsafe { w_list_append(d, item) };
-                    }
+                for item in crate::builtins::collect_iterable(iterable)? {
+                    do_append(self_obj, item);
                 }
                 Ok(())
+            }
+            fn extendleft(self_obj: PyObjectRef, iterable: PyObjectRef) -> Result<(), crate::PyError> {
+                // Each element is appended on the left, so the result is
+                // the reverse of `iterable`.
+                for item in crate::builtins::collect_iterable(iterable)? {
+                    do_appendleft(self_obj, item);
+                }
+                Ok(())
+            }
+            fn count(self_obj: PyObjectRef, x: PyObjectRef) -> i64 {
+                snapshot(self_obj)
+                    .into_iter()
+                    .filter(|&it| crate::baseobjspace::eq_w(it, x))
+                    .count() as i64
+            }
+            fn remove(self_obj: PyObjectRef, x: PyObjectRef) -> Result<(), crate::PyError> {
+                let mut items = snapshot(self_obj);
+                match items.iter().position(|&it| crate::baseobjspace::eq_w(it, x)) {
+                    Some(pos) => {
+                        items.remove(pos);
+                        store(self_obj, items);
+                        Ok(())
+                    }
+                    None => Err(crate::PyError::value_error(
+                        "deque.remove(x): x not in deque")),
+                }
+            }
+            fn __contains__(self_obj: PyObjectRef, x: PyObjectRef) -> bool {
+                snapshot(self_obj)
+                    .into_iter()
+                    .any(|it| crate::baseobjspace::eq_w(it, x))
+            }
+            fn reverse(self_obj: PyObjectRef) {
+                let mut items = snapshot(self_obj);
+                items.reverse();
+                store(self_obj, items);
+            }
+            fn rotate(self_obj: PyObjectRef, n: Option<PyObjectRef>) {
+                // Rotate right by n (negative rotates left).
+                let n = n.map(|v| unsafe { w_int_get_value(v) }).unwrap_or(1);
+                let mut items = snapshot(self_obj);
+                let len = items.len() as i64;
+                if len <= 1 {
+                    return;
+                }
+                let shift = ((n % len) + len) % len;
+                if shift != 0 {
+                    items.rotate_right(shift as usize);
+                    store(self_obj, items);
+                }
+            }
+            fn index(self_obj: PyObjectRef, x: PyObjectRef, start: Option<PyObjectRef>, stop: Option<PyObjectRef>) -> Result<i64, crate::PyError> {
+                let items = snapshot(self_obj);
+                let len = items.len() as i64;
+                let clamp = |i: i64| if i < 0 { (i + len).max(0) } else { i.min(len) };
+                let start = clamp(start.map(|v| unsafe { w_int_get_value(v) }).unwrap_or(0));
+                let stop = clamp(stop.map(|v| unsafe { w_int_get_value(v) }).unwrap_or(len));
+                let mut i = start;
+                while i < stop {
+                    if crate::baseobjspace::eq_w(items[i as usize], x) {
+                        return Ok(i);
+                    }
+                    i += 1;
+                }
+                Err(crate::PyError::value_error(
+                    format!("{} is not in deque", unsafe { crate::py_repr(x) })))
+            }
+            fn copy(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                // `type(self)(self)` or `type(self)(self, maxlen)`.
+                let ty = unsafe { w_instance_get_type(self_obj) };
+                let list = w_list_new(snapshot(self_obj));
+                match crate::baseobjspace::getattr(self_obj, "__maxlen__") {
+                    Ok(m) if !(m.is_null() || unsafe { is_none(m) }) =>
+                        crate::call::call_function_impl_result(ty, &[list, m]),
+                    _ => crate::call::call_function_impl_result(ty, &[list]),
+                }
             }
             fn __len__(self_obj: PyObjectRef) -> i64 {
                 data(self_obj)
@@ -114,6 +213,53 @@ mod deque_class {
                     Some(d) => crate::baseobjspace::getitem(d, index),
                     None => Ok(w_none()),
                 }
+            }
+            fn __setitem__(self_obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> Result<(), crate::PyError> {
+                let mut items = snapshot(self_obj);
+                let len = items.len() as i64;
+                let mut idx = unsafe { w_int_get_value(index) };
+                if idx < 0 {
+                    idx += len;
+                }
+                if idx < 0 || idx >= len {
+                    return Err(crate::PyError::index_error("deque index out of range"));
+                }
+                items[idx as usize] = value;
+                store(self_obj, items);
+                Ok(())
+            }
+            fn __delitem__(self_obj: PyObjectRef, index: PyObjectRef) -> Result<(), crate::PyError> {
+                let mut items = snapshot(self_obj);
+                let len = items.len() as i64;
+                let mut idx = unsafe { w_int_get_value(index) };
+                if idx < 0 {
+                    idx += len;
+                }
+                if idx < 0 || idx >= len {
+                    return Err(crate::PyError::index_error("deque index out of range"));
+                }
+                items.remove(idx as usize);
+                store(self_obj, items);
+                Ok(())
+            }
+            fn __repr__(self_obj: PyObjectRef) -> String {
+                let name = unsafe { w_type_get_name(w_instance_get_type(self_obj)) };
+                let listrepr = snapshot(self_obj)
+                    .into_iter()
+                    .map(|it| unsafe { crate::py_repr(it) })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                match maxlen_bound(self_obj) {
+                    Some(m) => format!("{name}([{listrepr}], maxlen={m})"),
+                    None => format!("{name}([{listrepr}])"),
+                }
+            }
+        },
+        properties: {
+            // GetSetProperty fget is invoked as `fget(descriptor, instance)`.
+            fn maxlen(_descr: PyObjectRef, self_obj: PyObjectRef) -> PyObjectRef {
+                crate::baseobjspace::getattr(self_obj, "__maxlen__")
+                    .unwrap_or_else(|_| w_none())
             }
         }
     }

--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -1,0 +1,114 @@
+# app_operator.py — app-level callable getters for the operator module.
+# Literal port of pypy/module/operator/app_operator.py (attrgetter,
+# itemgetter, methodcaller + the _resolve_attr_chain helper).  These are
+# app-level in upstream too; installed via the `appleveldefs:` arm in mod.rs.
+
+
+def _resolve_attr_chain(chain, obj, idx=0):
+    obj = getattr(obj, chain[idx])
+    if idx + 1 == len(chain):
+        return obj
+    else:
+        return _resolve_attr_chain(chain, obj, idx + 1)
+
+
+class attrgetter(object):
+    def __init__(self, attr, *attrs):
+        if (
+            not isinstance(attr, str) or
+            not all(isinstance(a, str) for a in attrs)
+        ):
+            raise TypeError("attribute name must be a string, not %r" %
+                        type(attr).__name__)
+        elif attrs:
+            self._multi_attrs = [
+                a.split(".") for a in [attr] + list(attrs)
+            ]
+            self._call = self._multi_attrgetter
+        elif "." not in attr:
+            self._simple_attr = attr
+            self._call = self._simple_attrgetter
+        else:
+            self._single_attr = attr.split(".")
+            self._call = self._single_attrgetter
+
+    def __call__(self, obj):
+        return self._call(obj)
+
+    def _simple_attrgetter(self, obj):
+        return getattr(obj, self._simple_attr)
+
+    def _single_attrgetter(self, obj):
+        return _resolve_attr_chain(self._single_attr, obj)
+
+    def _multi_attrgetter(self, obj):
+        return tuple([
+            _resolve_attr_chain(attrs, obj)
+            for attrs in self._multi_attrs
+        ])
+
+    def __reduce__(self):
+        try:
+            attrs = (self._simple_attr,)
+        except AttributeError:
+            try:
+                attrs = ('.'.join(self._single_attr),)
+            except AttributeError:
+                attrs = tuple('.'.join(a) for a in self._multi_attrs)
+        return (type(self), attrs)
+
+    def __repr__(self):
+        try:
+            a = repr(self._simple_attr)
+        except AttributeError:
+            try:
+                a = repr('.'.join(self._single_attr))
+            except AttributeError:
+                lst = self._multi_attrs
+                a = ', '.join([repr('.'.join(a1)) for a1 in lst])
+        return 'operator.attrgetter(%s)' % (a,)
+
+
+class itemgetter(object):
+    def __init__(self, item, *items):
+        self._single = not bool(items)
+        if self._single:
+            self._idx = item
+        else:
+            self._idx = [item] + list(items)
+
+    def __call__(self, obj):
+        if self._single:
+            return obj[self._idx]
+        else:
+            return tuple([obj[i] for i in self._idx])
+
+    def __repr__(self):
+        if self._single:
+            a = repr(self._idx)
+        else:
+            a = ', '.join([repr(i) for i in self._idx])
+        return 'operator.itemgetter(%s)' % (a,)
+
+
+class methodcaller(object):
+    def __init__(*args, **kwargs):
+        if len(args) < 2:
+            raise TypeError("methodcaller() called with not enough arguments")
+        self, method_name = args[:2]
+        if not isinstance(method_name, str):
+            raise TypeError("method name must be a string")
+        self._method_name = method_name
+        self._args = args[2:]
+        self._kwargs = kwargs
+
+    def __call__(self, obj):
+        return getattr(obj, self._method_name)(*self._args, **self._kwargs)
+
+    def __repr__(self):
+        args = [repr(self._method_name)]
+        for a in self._args:
+            args.append(repr(a))
+        for key, value in self._kwargs.items():
+            args.append('%s=%r' % (key, value))
+        return 'operator.methodcaller(%s)' % (', '.join(args),)

--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -1,7 +1,17 @@
-# app_operator.py — app-level callable getters for the operator module.
-# Literal port of pypy/module/operator/app_operator.py (attrgetter,
-# itemgetter, methodcaller + the _resolve_attr_chain helper).  These are
-# app-level in upstream too; installed via the `appleveldefs:` arm in mod.rs.
+# app_operator.py — app-level callables for the operator module.
+# Literal port of pypy/module/operator/app_operator.py (countOf,
+# attrgetter, itemgetter, methodcaller + the _resolve_attr_chain helper).
+# These are app-level in upstream too; installed via the `appleveldefs:`
+# arm in mod.rs.
+
+
+def countOf(a, b):
+    'countOf(a, b) -- Return the number of times b occurs in a.'
+    count = 0
+    for x in a:
+        if x is b or x == b:
+            count += 1
+    return count
 
 
 def _resolve_attr_chain(chain, obj, idx=0):

--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -93,6 +93,12 @@ class itemgetter(object):
         else:
             return tuple([obj[i] for i in self._idx])
 
+    def __reduce__(self):
+        if self._single:
+            return (type(self), (self._idx,))
+        else:
+            return (type(self), tuple(self._idx))
+
     def __repr__(self):
         if self._single:
             a = repr(self._idx)
@@ -114,6 +120,14 @@ class methodcaller(object):
 
     def __call__(self, obj):
         return getattr(obj, self._method_name)(*self._args, **self._kwargs)
+
+    def __reduce__(self):
+        if not self._kwargs:
+            return (type(self), (self._method_name,) + self._args)
+        else:
+            from functools import partial
+            return (partial(type(self), self._method_name, **self._kwargs),
+                    self._args)
 
     def __repr__(self):
         args = [repr(self._method_name)]

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -54,6 +54,11 @@ use crate::baseobjspace::{
 
 crate::py_module! {
     "operator",
+    // `itemgetter`/`attrgetter`/`methodcaller` are app-level callable
+    // classes (`pypy/module/operator/app_operator.py`), not interp-level.
+    appleveldefs: {
+        "app_operator.py" => ["itemgetter", "attrgetter", "methodcaller"],
+    },
     functions: {
         "index"    / 1 = op_index,
         "add"      / 2 = |args| { assert!(args.len() == 2); Ok(add(args[0], args[1]).unwrap_or(w_none())) },
@@ -91,10 +96,6 @@ crate::py_module! {
         "le" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Le),
         "ge" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Ge),
         "ne" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Ne),
-        // itemgetter / attrgetter / methodcaller stubs — return first arg.
-        "itemgetter"   / * = |args| Ok(if args.is_empty() { w_none() } else { args[0] }),
-        "attrgetter"   / * = |args| Ok(if args.is_empty() { w_none() } else { args[0] }),
-        "methodcaller" / * = |args| Ok(if args.is_empty() { w_none() } else { args[0] }),
         "length_hint"  / * = op_length_hint,
     },
 }

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -54,10 +54,11 @@ use crate::baseobjspace::{
 
 crate::py_module! {
     "operator",
-    // `itemgetter`/`attrgetter`/`methodcaller` are app-level callable
-    // classes (`pypy/module/operator/app_operator.py`), not interp-level.
+    // `countOf` + the `itemgetter`/`attrgetter`/`methodcaller` callable
+    // classes are app-level (`pypy/module/operator/app_operator.py`,
+    // `moduledef.py` `app_names`), not interp-level.
     appleveldefs: {
-        "app_operator.py" => ["itemgetter", "attrgetter", "methodcaller"],
+        "app_operator.py" => ["countOf", "itemgetter", "attrgetter", "methodcaller"],
     },
     functions: {
         "index"    / 1 = op_index,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1319,7 +1319,8 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let b = unwrap_cell(b);
     unsafe {
         if binop_dispatch_first(a, b, "__truediv__", "__rtruediv__") {
-            if let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")? {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")?
+            {
                 return Ok(result);
             }
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -955,10 +955,55 @@ unsafe fn try_instance_unaryop(a: PyObjectRef, dunder: &str) -> Option<PyResult>
     None
 }
 
+/// True when `obj`'s dynamic type (`w_class`) resolves `dunder` to a
+/// user-level Python function — a genuine override rather than the inherited
+/// builtin operator slot.  A builtin-storage instance keeps `ob_type` at the
+/// canonical storage type and carries its Python class in `w_class`, so a
+/// subclass `def __add__`/`__or__` is otherwise ignored by the storage fast
+/// paths.  The discriminator is the resolved method's kind, not a storage
+/// pointer: the builtin slots are fixed-code gateway functions that re-enter
+/// `add()`/`or_()`/…, so resolving to one must not trigger early dispatch —
+/// otherwise a plain `int`/`long` operand recurses forever (a `long` carries
+/// `w_class` = the `int` type object but `ob_type` = `LONG_TYPE`, so the two
+/// cannot be told apart by a storage-type comparison).  A user `def`
+/// (including one inherited from a Python mixin) is a `FUNCTION_TYPE` object
+/// with mutable code; `is_function_with_fixed_code` excludes the gateway
+/// builtins (`function_new_with_fixed_code`) that back the operator slots.
+unsafe fn operand_overrides(obj: PyObjectRef, dunder: &str) -> bool {
+    let w_class = (*obj).w_class;
+    if w_class.is_null() || !pyre_object::is_type(w_class) {
+        return false;
+    }
+    match lookup_in_type_where(w_class, dunder) {
+        Some(found) => {
+            pyre_object::py_type_check(found, &crate::function::FUNCTION_TYPE)
+                && !crate::function::is_function_with_fixed_code(found)
+        }
+        None => false,
+    }
+}
+
+/// Whether a binary operator should consult the dunder dispatch before its
+/// builtin storage fast path: when the left operand overrides the forward
+/// dunder or the right operand overrides the reflected one.
+unsafe fn binop_dispatch_first(
+    a: PyObjectRef,
+    b: PyObjectRef,
+    dunder: &str,
+    rdunder: &str,
+) -> bool {
+    operand_overrides(a, dunder) || operand_overrides(b, rdunder)
+}
+
 pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__add__", "__radd__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_add(a, b);
         }
@@ -1024,6 +1069,11 @@ pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__sub__", "__rsub__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__sub__", "__rsub__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_sub(a, b);
         }
@@ -1072,6 +1122,11 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__mul__", "__rmul__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__mul__", "__rmul__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_mul(a, b);
         }
@@ -1172,6 +1227,13 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__floordiv__", "__rfloordiv__") {
+            if let Some(result) =
+                try_dispatch_binary_special(a, b, "__floordiv__", "__rfloordiv__")?
+            {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_floordiv(a, b);
         }
@@ -1199,6 +1261,11 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__mod__", "__rmod__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__mod__", "__rmod__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_mod(a, b);
         }
@@ -1238,6 +1305,11 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__truediv__", "__rtruediv__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")? {
+                return Ok(result);
+            }
+        }
         let a_num = is_int(a) || is_float(a) || is_long(a);
         let b_num = is_int(b) || is_float(b) || is_long(b);
         if a_num && b_num {
@@ -1273,6 +1345,11 @@ pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__pow__", "__rpow__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__pow__", "__rpow__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_pow(a, b);
         }
@@ -1635,6 +1712,11 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__lshift__", "__rlshift__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__lshift__", "__rlshift__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_lshift(a, b);
         }
@@ -1661,6 +1743,11 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__rshift__", "__rrshift__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__rshift__", "__rrshift__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_rshift(a, b);
         }
@@ -1687,6 +1774,11 @@ pub fn and_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__and__", "__rand__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__and__", "__rand__")? {
+                return Ok(result);
+            }
+        }
         // boolobject.py:74 W_BoolObject.descr_and — both operands bool
         // → space.newbool(op(a, b)). MRO ensures this runs before the
         // W_IntObject.descr_and fallback in int_bitand.
@@ -1770,6 +1862,11 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         }
     };
     unsafe {
+        if binop_dispatch_first(a, b, "__or__", "__ror__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__or__", "__ror__")? {
+                return Ok(result);
+            }
+        }
         // boolobject.py:75 W_BoolObject.descr_or — both operands bool
         // → space.newbool(op(a, b)).
         if is_bool(a) && is_bool(b) {
@@ -1838,6 +1935,11 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if binop_dispatch_first(a, b, "__xor__", "__rxor__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__xor__", "__rxor__")? {
+                return Ok(result);
+            }
+        }
         if is_bool(a) && is_bool(b) {
             return Ok(pyre_object::bool_descr_xor(a, b));
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1989,12 +1989,70 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     }
 }
 
+/// Rich-comparison override dispatch for builtin-leaf subclasses, run before
+/// `compare`'s storage fast paths (which compare by value and ignore a
+/// subclass override).  Follows do_richcompare ordering — reflected-first
+/// when the right operand's type properly subtypes the left's and overrides
+/// the reflected comparison — but only ever invokes a genuine user override
+/// (`operand_overrides` gates each side).  The builtin comparison slots
+/// re-enter `compare`, so dispatching one here would recurse; instead, when
+/// no user override yields a result, `None` lets the caller fall through to
+/// the storage fast paths, which compute the same value comparison the
+/// builtin reflected slot would.
+unsafe fn try_compare_override(
+    a: PyObjectRef,
+    b: PyObjectRef,
+    dunder: &str,
+    rdunder: &str,
+) -> Result<Option<PyObjectRef>, PyError> {
+    let a_over = operand_overrides(a, dunder);
+    let b_over = operand_overrides(b, rdunder);
+    if !a_over && !b_over {
+        return Ok(None);
+    }
+    let reverse_first = b_over && should_try_reverse_first(a, b, rdunder);
+    if reverse_first {
+        if let Some(method) = lookup_type_special(b, rdunder) {
+            if let Some(result) = try_call_special(method, &[b, a])? {
+                return Ok(Some(result));
+            }
+        }
+    }
+    if a_over {
+        if let Some(method) = lookup_type_special(a, dunder) {
+            if let Some(result) = try_call_special(method, &[a, b])? {
+                return Ok(Some(result));
+            }
+        }
+    }
+    if b_over && !reverse_first {
+        if let Some(method) = lookup_type_special(b, rdunder) {
+            if let Some(result) = try_call_special(method, &[b, a])? {
+                return Ok(Some(result));
+            }
+        }
+    }
+    Ok(None)
+}
+
 /// Comparison operation dispatch.
 
 pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        let cmp_dunder = match op {
+            CompareOp::Lt => "__lt__",
+            CompareOp::Le => "__le__",
+            CompareOp::Gt => "__gt__",
+            CompareOp::Ge => "__ge__",
+            CompareOp::Eq => "__eq__",
+            CompareOp::Ne => "__ne__",
+        };
+        let cmp_rdunder = reverse_dunder(cmp_dunder).unwrap_or(cmp_dunder);
+        if let Some(result) = try_compare_override(a, b, cmp_dunder, cmp_rdunder)? {
+            return Ok(result);
+        }
         if is_int_like(a) && is_int_like(b) {
             return match op {
                 CompareOp::Lt => int_lt(a, b),

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -995,6 +995,19 @@ unsafe fn binop_dispatch_first(
     operand_overrides(a, dunder) || operand_overrides(b, rdunder)
 }
 
+/// Dispatch a builtin-leaf subclass's unary operator override (`__neg__`,
+/// `__pos__`, `__invert__`) before the storage fast paths, which operate on
+/// the value and ignore the override.  `try_instance_unaryop` only fires for
+/// is_instance-shaped objects, so a builtin-storage subclass needs the
+/// w_class-driven lookup here.
+unsafe fn try_unary_override(a: PyObjectRef, dunder: &str) -> Option<PyResult> {
+    if !operand_overrides(a, dunder) {
+        return None;
+    }
+    let method = lookup_type_special(a, dunder)?;
+    Some(crate::call::call_function_impl_result(method, &[a]))
+}
+
 pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
@@ -2398,6 +2411,9 @@ impl CompareOp {
 pub fn pos(a: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     unsafe {
+        if let Some(result) = try_unary_override(a, "__pos__") {
+            return result;
+        }
         if is_int(a) || is_bool(a) {
             return Ok(w_int_new(int_value(a)));
         }
@@ -2427,6 +2443,9 @@ pub fn pos(a: PyObjectRef) -> PyResult {
 pub fn neg(a: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     unsafe {
+        if let Some(result) = try_unary_override(a, "__neg__") {
+            return result;
+        }
         if is_int(a) || is_bool(a) {
             let v = int_value(a);
             return match v.checked_neg() {
@@ -2461,6 +2480,9 @@ pub fn neg(a: PyObjectRef) -> PyResult {
 pub fn invert(a: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     unsafe {
+        if let Some(result) = try_unary_override(a, "__invert__") {
+            return result;
+        }
         if is_int(a) || is_bool(a) {
             return Ok(w_int_new(!int_value(a)));
         }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -520,6 +520,11 @@ pub unsafe fn find_map_attr(self_node: MapRef, name: &str, attrkind: u16) -> Opt
 // W_Root into the untyped storage list) are the identity here.
 
 pub trait MapdictObject {
+    /// The object's own `W_Root` reference. `DevolvedDictTerminator` reaches the
+    /// instance dict through `obj.getdict(space)` (mapdict.py:386,393); pyre
+    /// threads the same identity so `_obj_getdict` can key the dict by object
+    /// address.
+    fn _mapdict_self_ref(&self) -> PyObjectRef;
     /// mapdict.py:905-906 `_get_mapdict_map` (`jit.promote(self.map)`).
     fn _get_mapdict_map(&self) -> MapRef;
     /// mapdict.py:907-908 `_set_mapdict_map`.
@@ -709,20 +714,18 @@ pub unsafe fn plain_direct_write<O: MapdictObject>(
 /// `term` must point to a live Terminator map node.
 unsafe fn terminator_read<O: MapdictObject>(
     term: MapRef,
-    _obj: &O,
-    _name: &str,
+    obj: &O,
+    name: &str,
     attrkind: u16,
 ) -> Option<PyObjectRef> {
     let t = unsafe { (*term).as_terminator() };
     match t.kind {
         TerminatorKind::Devolved if attrkind == DICT => {
-            // DevolvedDictTerminator reads from the instance dict
-            // (`space.finditem_str(obj.getdict(space), name)`). `getdict` and
-            // MapDictStrategy are not yet ported; a DevolvedDictTerminator only
-            // arises after the 80-attribute devolve (Slice 8), unreachable here.
-            unimplemented!(
-                "DevolvedDictTerminator._read_terminator (mapdict.py:387-391): needs getdict"
-            )
+            // DevolvedDictTerminator._read_terminator (mapdict.py:383-387):
+            // `w_dict = obj.getdict(space); return space.finditem_str(w_dict, name)`.
+            // `finditem_str` yields NULL (here `None`) when the key is absent.
+            let w_dict = _obj_getdict(obj._mapdict_self_ref());
+            unsafe { pyre_object::w_dict_getitem_str(w_dict, name) }
         }
         // Terminator / DictTerminator / NoDictTerminator read nothing.
         _ => None,
@@ -1043,13 +1046,12 @@ unsafe fn write_terminator<O: MapdictObject>(
     match kind {
         // NoDictTerminator: object without __dict__ rejects DICT writes.
         TerminatorKind::NoDict if attrkind == DICT => return false,
-        TerminatorKind::Devolved => {
-            // DevolvedDictTerminator writes to the instance dict
-            // (`space.setitem_str`). Needs getdict; only arises after the
-            // 80-attribute devolve (Slice 8). Unreachable here.
-            unimplemented!(
-                "DevolvedDictTerminator._write_terminator (mapdict.py:393-399): needs getdict"
-            )
+        TerminatorKind::Devolved if attrkind == DICT => {
+            // DevolvedDictTerminator._write_terminator (mapdict.py:390-395):
+            // `w_dict = obj.getdict(space); space.setitem_str(w_dict, name, w_value); return True`.
+            let w_dict = _obj_getdict(obj._mapdict_self_ref());
+            unsafe { pyre_object::w_dict_setitem_str(w_dict, name, w_value) };
+            return true;
         }
         _ => {}
     }
@@ -1058,9 +1060,16 @@ unsafe fn write_terminator<O: MapdictObject>(
     if attrkind == DICT
         && unsafe { (*obj._get_mapdict_map()).num_attributes() } >= LIMIT_MAP_ATTRIBUTES
     {
-        // Past LIMIT_MAP_ATTRIBUTES, switch the instance dict to a real dict
-        // strategy (`MapDictStrategy.switch_to_text_strategy`, mapdict.py:317-320).
-        // MapDictStrategy is deferred to Slice 8.
+        // mapdict.py:317-320 switches the instance __dict__ from the lazy
+        // MapDictStrategy view to an eager UnicodeDictStrategy and devolves the
+        // map to DevolvedDictTerminator via materialize_str_dict
+        // (`switch_to_text_strategy`, mapdict.py:1148-1155). pyre cannot port
+        // this yet: there is no MapDictStrategy (StrategyKind has no Map variant)
+        // and no materialize_str_dict / _make_devolved / _set_mapdict_storage_and_map,
+        // so `_obj_getdict` returns a separate eager dict rather than a view of
+        // the mapdict storage. Switching a strategy here would strand these
+        // attributes in mapdict storage with no devolve. Deferred to Slice 8
+        // together with the DevolvedDictTerminator devolve transition.
     }
     true
 }
@@ -1376,6 +1385,9 @@ mod tests {
     }
 
     impl MapdictObject for MockObj {
+        fn _mapdict_self_ref(&self) -> PyObjectRef {
+            self as *const Self as PyObjectRef
+        }
         fn _get_mapdict_map(&self) -> MapRef {
             self.map
         }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1511,7 +1511,10 @@ mod tests {
             assert!(obj.storage.is_empty());
             // The value is in `_obj_getdict`'s dict and node_read reads it back.
             let w_dict = _obj_getdict(obj._mapdict_self_ref());
-            assert_eq!(pyre_object::w_dict_getitem_str(w_dict, "dk"), Some(sentinel(0x55)));
+            assert_eq!(
+                pyre_object::w_dict_getitem_str(w_dict, "dk"),
+                Some(sentinel(0x55))
+            );
             assert_eq!(node_read(devolved, &obj, "dk", DICT), Some(sentinel(0x55)));
             // Absent key and non-DICT attrkind read nothing.
             assert_eq!(node_read(devolved, &obj, "absent_dk", DICT), None);

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1491,6 +1491,35 @@ mod tests {
     }
 
     #[test]
+    fn devolved_terminator_read_write_routes_through_obj_getdict() {
+        // mapdict.py:383-395 — a DevolvedDictTerminator reads and writes the
+        // DICT attrkind through the instance dict (`_obj_getdict`), not the
+        // map storage.  The branch is wired but not yet reachable in
+        // production (no MapDictStrategy devolve), so exercise it directly:
+        // root a MockObj at the paired devolved terminator and confirm both
+        // node_write and node_read go through `_obj_getdict`.
+        unsafe {
+            let dict_term = new_dict_terminator(std::ptr::null_mut());
+            let devolved = (*dict_term).as_terminator().devolved_dict_terminator.get();
+            assert!(!devolved.is_null());
+            let mut obj = MockObj {
+                map: devolved,
+                storage: vec![],
+            };
+            // Write lands in the instance dict, leaving map storage untouched.
+            assert!(node_write(devolved, &mut obj, "dk", DICT, sentinel(0x55)));
+            assert!(obj.storage.is_empty());
+            // The value is in `_obj_getdict`'s dict and node_read reads it back.
+            let w_dict = _obj_getdict(obj._mapdict_self_ref());
+            assert_eq!(pyre_object::w_dict_getitem_str(w_dict, "dk"), Some(sentinel(0x55)));
+            assert_eq!(node_read(devolved, &obj, "dk", DICT), Some(sentinel(0x55)));
+            // Absent key and non-DICT attrkind read nothing.
+            assert_eq!(node_read(devolved, &obj, "absent_dk", DICT), None);
+            assert_eq!(node_read(devolved, &obj, "dk", SPECIAL), None);
+        }
+    }
+
+    #[test]
     fn add_attr_via_write_grows_map_and_storage() {
         unsafe {
             // start empty: a DictTerminator, no storage

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1242,7 +1242,16 @@ impl PyFrame {
     #[inline]
     pub fn peekvalues(&self, n: usize) -> Vec<PyObjectRef> {
         let base = self.valuestackdepth - n;
-        self.assert_stack_index(base);
+        // Reads cover `[base, valuestackdepth)`; the highest index is
+        // `valuestackdepth - 1 < len`, so only the lower `base` bound needs
+        // guarding. When `n == 0` nothing is read and `base ==
+        // valuestackdepth` may equal `len` at peak depth, so skip the
+        // upper-bound `assert_stack_index` for the empty peek.
+        if n > 0 {
+            self.assert_stack_index(base);
+        } else {
+            debug_assert!(base >= self.stack_base());
+        }
         let mut values_w = vec![PY_NULL; n];
         let mut idx = n;
         while idx > 0 {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1183,7 +1183,38 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     )))
 }
 descr_new_wrapper!(list_descr_new, crate::builtins::builtin_list_ctor);
-descr_new_wrapper!(tuple_descr_new, crate::builtins::builtin_tuple);
+
+/// tuple.__new__(cls, iterable) — tupleobject.py descr__new__.
+///
+/// For a tuple subclass (e.g. `collections.namedtuple`), build a fresh
+/// tuple and set `w_class = cls` so `type(obj) == cls`, attribute lookup
+/// resolves the subclass's field descriptors, and `__repr__` dispatches.
+fn tuple_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = if args.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        args[0]
+    };
+    let value = crate::builtins::builtin_tuple(&args[1..])?;
+    if cls.is_null() || !unsafe { pyre_object::is_type(cls) } {
+        return Ok(value);
+    }
+    let tuple_typeobj = gettypefor(&pyre_object::pyobject::TUPLE_TYPE);
+    if tuple_typeobj.map_or(false, |t| std::ptr::eq(cls, t)) {
+        return Ok(value);
+    }
+    // Subclass path — copy into a fresh tuple so setting w_class does not
+    // clobber a shared/literal source tuple.
+    let n = unsafe { pyre_object::w_tuple_len(value) };
+    let items: Vec<_> = (0..n)
+        .filter_map(|i| unsafe { pyre_object::w_tuple_getitem(value, i as i64) })
+        .collect();
+    let obj = pyre_object::w_tuple_new(items);
+    unsafe {
+        (*obj).w_class = cls;
+    }
+    Ok(obj)
+}
 // dict_new handled by dict_descr_new above (supports dict subclasses)
 
 /// typeobject.py:511-524 W_TypeObject.check_user_subclass.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2277,9 +2277,17 @@ fn init_dict_type(ns: &mut DictStorage) {
                 if args.is_empty() {
                     return Ok(pyre_object::w_str_new("{}"));
                 }
-                let dict = crate::type_methods::resolve_dict_backing(args[0]);
+                let recv = args[0];
+                let dict = crate::type_methods::resolve_dict_backing(recv);
                 if dict.is_null() {
-                    return Ok(pyre_object::w_str_new("{}"));
+                    // Unbound `dict.__repr__(x)` on a non-dict receiver —
+                    // reject it like a builtin descriptor rather than
+                    // formatting an empty `{}`.
+                    let tp_name = unsafe { (*(*recv).ob_type).name };
+                    return Err(crate::PyError::type_error(format!(
+                        "descriptor '__repr__' for 'dict' objects \
+                         doesn't apply to a '{tp_name}' object"
+                    )));
                 }
                 unsafe { Ok(pyre_object::w_str_new(&crate::display::dict_repr(dict))) }
             },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2198,7 +2198,19 @@ fn init_dict_type(ns: &mut DictStorage) {
                         if let Ok(backing) = crate::baseobjspace::getattr(args[0], "__dict_data__")
                         {
                             if pyre_object::is_dict(backing) {
-                                return crate::baseobjspace::getitem(backing, args[1]);
+                                // `dictmultiobject.py:166-170` — on a miss,
+                                // dispatch `__missing__` against the SUBCLASS
+                                // instance's type, not the plain-`dict` backing
+                                // (so e.g. `defaultdict.__missing__` fires).
+                                return match pyre_object::dictmultiobject::w_dict_lookup_checked(
+                                    backing, args[1],
+                                ) {
+                                    Ok(Some(val)) => Ok(val),
+                                    Ok(None) => crate::baseobjspace::dict_missing_or_key_error(
+                                        args[0], args[1],
+                                    ),
+                                    Err(_) => Err(crate::baseobjspace::take_pending_hash_error()),
+                                };
                             }
                         }
                     }
@@ -2249,6 +2261,27 @@ fn init_dict_type(ns: &mut DictStorage) {
                     ));
                 }
                 crate::baseobjspace::len(args[0])
+            },
+            1,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__repr__",
+        make_builtin_function_with_arity(
+            "__repr__",
+            |args| {
+                // `dictmultiobject.py:130-150 descr_repr`.  Registered as a
+                // method (not only the `py_repr` fast path) so dict-subclass
+                // instances and `super().__repr__()` format their backing.
+                if args.is_empty() {
+                    return Ok(pyre_object::w_str_new("{}"));
+                }
+                let dict = crate::type_methods::resolve_dict_backing(args[0]);
+                if dict.is_null() {
+                    return Ok(pyre_object::w_str_new("{}"));
+                }
+                unsafe { Ok(pyre_object::w_str_new(&crate::display::dict_repr(dict))) }
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -4496,6 +4496,21 @@ fn init_type_type(ns: &mut DictStorage) {
     );
     dict_storage_store(ns, "__mro__", make_getset_descriptor(mro_getter));
 
+    // `type.mro(cls)` — typeobject.c `mro_external` / `type.mro`: the method
+    // form returns the MRO as a fresh list (the `__mro__` getset above
+    // returns the tuple).  Bound as a regular method, so `cls` is at args[0].
+    let mro_method = make_builtin_function("mro", |args| {
+        let cls = args[0];
+        unsafe {
+            let mro_ptr = pyre_object::w_type_get_mro(cls);
+            if mro_ptr.is_null() {
+                return Ok(pyre_object::w_list_new(vec![]));
+            }
+            Ok(pyre_object::w_list_new((*mro_ptr).clone()))
+        }
+    });
+    dict_storage_store(ns, "mro", mro_method);
+
     // `pypy/objspace/std/typeobject.py:614-624 get_module` /
     // `:1241-1247 descr_get__module` / `descr_set__module`.
     // For heaptype (user-defined classes) the value is read from /

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2322,7 +2322,20 @@ fn init_dict_type(ns: &mut DictStorage) {
                 if args.len() < 2 {
                     return Err(crate::PyError::type_error("__delitem__ requires 2 args"));
                 }
-                crate::baseobjspace::delitem(args[0], args[1])?;
+                // For plain dict: direct delete. For dict subclass instance: use backing dict.
+                unsafe {
+                    if pyre_object::is_dict(args[0]) {
+                        crate::baseobjspace::delitem(args[0], args[1])?;
+                    } else if pyre_object::is_instance(args[0]) {
+                        // dict subclass — delete from __dict_data__ backing dict
+                        if let Ok(backing) = crate::baseobjspace::getattr(args[0], "__dict_data__")
+                        {
+                            if pyre_object::is_dict(backing) {
+                                crate::baseobjspace::delitem(backing, args[1])?;
+                            }
+                        }
+                    }
+                }
                 Ok(pyre_object::w_none())
             },
             2,

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -290,6 +290,7 @@ impl Assembler {
                 // lands it must register onto the shared
                 // `BlackholeInterpBuilder.descrs` pool (`blackhole.py:
                 // 102-103 setup_descrs`), not a per-jitcode duplicate.
+                CURRENT_DISPATCH_OP.with(|cur| cur.borrow_mut().replace_range(.., opname));
                 dispatch_op(state, opname, args, result.as_ref());
             }
         }
@@ -1630,10 +1631,27 @@ fn expect_result_reg(result: Option<&Register>, kind: Kind, msg: &str) -> u16 {
     }
 }
 
+thread_local! {
+    /// Opname of the `Insn::Op` currently being lowered by `dispatch_op`,
+    /// so operand-shape panics (`expect_reg` etc.) can name the opcode
+    /// whose operand list violated the assembler's expectation instead
+    /// of forcing the reader to grep the SSARepr for the bad operand.
+    static CURRENT_DISPATCH_OP: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+}
+
+fn current_dispatch_op() -> String {
+    CURRENT_DISPATCH_OP.with(|op| op.borrow().clone())
+}
+
 fn expect_reg(op: &Operand, expected: Kind) -> u16 {
     match op {
         Operand::Register(Register { kind, index }) if *kind == expected => *index,
-        _ => panic!("expected Register({:?}, _), got {:?}", expected, op),
+        _ => panic!(
+            "expected Register({:?}, _), got {:?} (op={})",
+            expected,
+            op,
+            current_dispatch_op()
+        ),
     }
 }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -738,6 +738,47 @@ impl SpamBlockRef {
         self.0.borrow_mut().per_block_ssarepr.extend(moved);
         base
     }
+
+    /// Strip a trailing block-boundary `goto TLabel(<label>) + Unreachable`
+    /// pair from this block's `per_block_ssarepr`, if the goto targets `label`.
+    /// Returns whether a pair was removed.
+    ///
+    /// Used by the `remove_trivial_links` merge bridge: after absorbing
+    /// `target`'s bytecode, the source's OLD boundary goto would otherwise sit
+    /// in the middle of the merged stream, before the absorbed opcodes.
+    /// `emit_link_renamings_into_block`'s `SourceBeforeTerminator` splice
+    /// forward-scans for the FIRST terminator, so the absorbed link's renamings
+    /// would land before `target`'s opcodes and read stale slots (codex P1,
+    /// PR #127).  Removing the old boundary goto makes `target`'s own
+    /// terminator the first one, so renamings splice after its opcodes.
+    fn strip_trailing_boundary_goto(&self, label: &str) -> bool {
+        let mut b = self.0.borrow_mut();
+        let n = b.per_block_ssarepr.len();
+        if n < 2 {
+            return false;
+        }
+        let tail_unreachable =
+            matches!(b.per_block_ssarepr[n - 1], super::flatten::Insn::Unreachable);
+        let tail_goto = matches!(
+            &b.per_block_ssarepr[n - 2],
+            super::flatten::Insn::Op { opname, args, .. }
+                if opname == "goto"
+                    && args.len() == 1
+                    && matches!(&args[0], super::flatten::Operand::TLabel(tl) if tl.name == label)
+        );
+        if tail_unreachable && tail_goto {
+            b.per_block_ssarepr.truncate(n - 2);
+            // Keep the original-terminator anchor within bounds.
+            if let Some(end) = b.original_terminator_end {
+                if end > b.per_block_ssarepr.len() {
+                    b.original_terminator_end = Some(b.per_block_ssarepr.len());
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl PartialEq for SpamBlockRef {
@@ -1622,6 +1663,11 @@ fn rewrite_trivial_link_merges(
         if src_spam == tgt_spam {
             continue;
         }
+        // Drop source's old boundary `goto target + ---` before appending, so
+        // target's own terminator is the first terminator in the merged block
+        // and the single-exit renaming splice lands after target's opcodes
+        // (codex P1, PR #127).
+        src_spam.strip_trailing_boundary_goto(&super::flatten::block_label_name(target));
         let base = src_spam.absorb_per_block_ssarepr(&tgt_spam);
         // Re-point `-live-` markers: (tgt_spam, off) -> (src_spam, base + off).
         for pc_entries in walker_pc_live_marker_pos.iter_mut() {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9330,15 +9330,6 @@ impl CodeWriter {
         // `simplify.rs`).
         eliminate_empty_blocks(&graph);
         super::simplify::constfold_exitswitch(&graph);
-        // remove_trivial_links merges single-entry/single-exit chains; the
-        // merge bridge relocates each merged target's inline per_block_ssarepr
-        // into its surviving source so the drain keeps the opcodes (issue #73).
-        let trivial_link_merges = super::simplify::remove_trivial_links_recording(&graph);
-        rewrite_trivial_link_merges(
-            &trivial_link_merges,
-            &all_walker_blocks,
-            &mut walker_pc_live_marker_pos,
-        );
         // Port-boundary guard: after the collapse, no link reachable from
         // the startblock may still target a dead forwarder.  RPython has
         // no equivalent check (its graph is simplified before flatten),
@@ -9358,7 +9349,27 @@ impl CodeWriter {
                 );
             }
         }
+        // Byte-stream companion to `eliminate_empty_blocks`: retarget the
+        // walker's inline-emitted gotos that still name a collapsed dead
+        // forwarder to the surviving generalization.  MUST run before the
+        // merge bridge below: for a `source -> dead_forwarder -> target`
+        // shape `remove_trivial_links` records the merge `(source, target)`,
+        // but the source block's boundary terminator still reads
+        // `goto TLabel(dead_forwarder)` until this rewrite — so the merge
+        // strip (which looks for `block_label_name(target)`) would miss it
+        // and leave the stale terminator in front of the absorbed target
+        // opcodes, letting the single-exit renaming splice land before
+        // them (codex P2, PR #130).
         rewrite_dead_forwarder_gotos(&all_walker_blocks);
+        // remove_trivial_links merges single-entry/single-exit chains; the
+        // merge bridge relocates each merged target's inline per_block_ssarepr
+        // into its surviving source so the drain keeps the opcodes (issue #73).
+        let trivial_link_merges = super::simplify::remove_trivial_links_recording(&graph);
+        rewrite_trivial_link_merges(
+            &trivial_link_merges,
+            &all_walker_blocks,
+            &mut walker_pc_live_marker_pos,
+        );
 
         // Drain per-block accumulators into ssarepr.insns in
         // walker-block-creation order.  Mirrors `codewriter.py:53

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -757,8 +757,10 @@ impl SpamBlockRef {
         if n < 2 {
             return false;
         }
-        let tail_unreachable =
-            matches!(b.per_block_ssarepr[n - 1], super::flatten::Insn::Unreachable);
+        let tail_unreachable = matches!(
+            b.per_block_ssarepr[n - 1],
+            super::flatten::Insn::Unreachable
+        );
         let tail_goto = matches!(
             &b.per_block_ssarepr[n - 2],
             super::flatten::Insn::Op { opname, args, .. }

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -1368,8 +1368,7 @@ impl<'a> GraphFlattener<'a> {
         // no-op marker (the encoder never reads a PC with no guard).
         // Tightening to `EffectInfo::check_can_raise` waits until the
         // pc_map -> `-live-` wiring (A2) makes the distinction observable.
-        let trailing_live =
-            self.lowering_ctx.is_some() && insn_needs_trailing_live(&insn);
+        let trailing_live = self.lowering_ctx.is_some() && insn_needs_trailing_live(&insn);
         self.emitline(insn);
         if trailing_live {
             self.emitline(Insn::live(Vec::new()));
@@ -5447,9 +5446,9 @@ mod tests {
         let call_pos = ssarepr
             .insns
             .iter()
-            .position(|insn| {
-                matches!(insn, Insn::Op { opname, .. } if opname == "residual_call_ir_r")
-            })
+            .position(
+                |insn| matches!(insn, Insn::Op { opname, .. } if opname == "residual_call_ir_r"),
+            )
             .unwrap_or_else(|| panic!("expected residual_call_ir_r: {:?}", ssarepr.insns));
         assert!(
             ssarepr.insns[call_pos + 1].is_live(),

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -1347,7 +1347,33 @@ impl<'a> GraphFlattener<'a> {
             }
         }
         let insn = self.flatten_space_operation(op);
+        // `jtransform.py:467-482` appends a `-live-` AFTER a call op so the
+        // metainterp can snapshot the post-call resume state for
+        // `guard_no_exception` (residual) / inline-call boundaries:
+        //   handle_residual_call: `op1 = [op1, ('-live-', [], None)]`
+        //     emitted iff `may_call_jitcodes or calldescr_canraise(...)`.
+        //   handle_regular_call:  `[op0, ('-live-', [], None)]` — always.
+        // The walker covers this point incidentally via its per-PC `-live-`;
+        // the canonical driver must emit it explicitly so the encoder's
+        // FALLTHROUGH_pc read (`handle_possible_exception` ->
+        // `guard_no_exception`, trace_opcode.rs:7032) and the resume reader
+        // find a marker at the post-call position.  Gated on `lowering_ctx`
+        // so the production walker stream is untouched.
+        //
+        // Conservative superset: every `residual_call_*` gets the trailing
+        // `-live-`, not only the `calldescr_canraise` subset.  The retired
+        // HLOp families lowered here (add/lt/bool/setitem/...) all carry
+        // `EF_CAN_RAISE`, so the superset matches `calldescr_canraise` for
+        // the common case; an extra `-live-` after a non-raising call is a
+        // no-op marker (the encoder never reads a PC with no guard).
+        // Tightening to `EffectInfo::check_can_raise` waits until the
+        // pc_map -> `-live-` wiring (A2) makes the distinction observable.
+        let trailing_live =
+            self.lowering_ctx.is_some() && insn_needs_trailing_live(&insn);
         self.emitline(insn);
+        if trailing_live {
+            self.emitline(Insn::live(Vec::new()));
+        }
     }
 
     fn emitline(&mut self, insn: Insn) {
@@ -2344,6 +2370,22 @@ fn regalloc_color(
         )
     });
     Register::new(kind, color)
+}
+
+/// `true` iff a trailing `-live-` must follow this Insn in the canonical
+/// stream — the call ops that `jtransform.py:467-482` pairs with a
+/// post-op `-live-`.  `residual_call_*` (`handle_residual_call`) and
+/// `inline_call_*` (`handle_regular_call`) are the families; both produce
+/// a `guard_no_exception` / inline-boundary resume point that the encoder
+/// reads at the FALLTHROUGH position.  See `serialize_op` for the
+/// canraise-superset rationale.
+fn insn_needs_trailing_live(insn: &Insn) -> bool {
+    match insn {
+        Insn::Op { opname, .. } => {
+            opname.starts_with("residual_call") || opname.starts_with("inline_call")
+        }
+        _ => false,
+    }
 }
 
 fn is_bool_or_tuple_exitswitch(
@@ -5358,6 +5400,62 @@ mod tests {
                 ssarepr.insns
             );
         }
+    }
+
+    #[test]
+    fn lowering_emits_trailing_live_after_residual_call() {
+        // `jtransform.py:467-471 handle_residual_call` pairs a
+        // `residual_call_*` with a trailing `('-live-', [], None)` so the
+        // metainterp can snapshot the post-call `guard_no_exception`
+        // resume state.  The canonical driver (`serialize_op` under
+        // `lowering_ctx`) must emit that marker immediately AFTER the
+        // lowered call; the production walker covers the same point via
+        // its per-PC `-live-`.  A single `add` HLOp lowers to one
+        // `residual_call_ir_r` that must be followed by a `-live-`.
+        use crate::jit::flow::{Block, FunctionGraph};
+        let lhs = Variable::new(VariableId(0), Kind::Ref);
+        let rhs = Variable::new(VariableId(1), Kind::Ref);
+        let add_res = Variable::new(VariableId(2), Kind::Ref);
+        let start = Block::shared(vec![lhs.into(), rhs.into()]);
+        let graph = FunctionGraph::new("trailing_live", start.clone(), None);
+        super::super::flow::push_op(
+            &start,
+            SpaceOperation::new("add", vec![lhs.into(), rhs.into()], Some(add_res.into()), 0),
+        );
+        start.closeblock(vec![
+            super::super::flow::Link::new(
+                vec![add_res.into()],
+                Some(graph.returnblock.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+
+        let ctx = LoweringContext {
+            binary_op_fn_idx: 11,
+            compare_op_fn_idx: 13,
+            truth_fn_idx: 17,
+            store_subscr_fn_idx: 19,
+            build_list_fn_idx: 0,
+            call_fn_idx_by_nargs: [0; 9],
+            portal_frame_var: None,
+        };
+
+        let mut ssarepr = SSARepr::new("trailing_live");
+        flatten_graph_for_test_with_lowering(&graph, &mut ssarepr, ctx, None);
+
+        let call_pos = ssarepr
+            .insns
+            .iter()
+            .position(|insn| {
+                matches!(insn, Insn::Op { opname, .. } if opname == "residual_call_ir_r")
+            })
+            .unwrap_or_else(|| panic!("expected residual_call_ir_r: {:?}", ssarepr.insns));
+        assert!(
+            ssarepr.insns[call_pos + 1].is_live(),
+            "residual_call must be followed by a `-live-` marker, got {:?}",
+            &ssarepr.insns[call_pos..]
+        );
     }
 
     #[test]

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -695,8 +695,19 @@ pub fn slot_for_call_flavor(flavor: CallFlavor) -> majit_metainterp::EffectInfoS
 /// `getfield_gc_X(v, descr)` after rtyping; pyre's lack of rtyping
 /// keeps the HLOp unmodified, so eliding it under lowering_ctx is the
 /// production-safe path.
+///
+/// `setattr` — emitted by `codewriter.rs::emit_frontend_setattr`
+/// mirroring `flowcontext.py:1031-1036 op.setattr(w_obj,
+/// w_attributename, w_newvalue)`.  Same shape as `getattr`: the
+/// `StoreAttr` arm (codewriter.rs:8551) pairs it with an inline
+/// `emit_abort_permanent!`, so the compiled trace bails to the
+/// interpreter at the `abort_permanent` Insn canonical already emits.
+/// A literal `setattr` Insn would be unreachable at runtime and
+/// undispatchable by the assembler.  Upstream `rclass.py rtype_setattr`
+/// rewrites to `setfield_gc(v, descr, w_value)` after rtyping; pyre's
+/// lack of rtyping keeps the HLOp unmodified.
 fn is_pyre_canonical_elidable_hlop(opname: &str) -> bool {
-    matches!(opname, "type" | "getattr")
+    matches!(opname, "type" | "getattr" | "setattr")
 }
 
 pub fn effect_info_for_call_flavor(flavor: CallFlavor) -> majit_ir::EffectInfo {

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -1358,16 +1358,16 @@ impl<'a> GraphFlattener<'a> {
         // FALLTHROUGH_pc read (`handle_possible_exception` ->
         // `guard_no_exception`, trace_opcode.rs:7032) and the resume reader
         // find a marker at the post-call position.  Gated on `lowering_ctx`
-        // so the production walker stream is untouched.
-        //
-        // Conservative superset: every `residual_call_*` gets the trailing
-        // `-live-`, not only the `calldescr_canraise` subset.  The retired
-        // HLOp families lowered here (add/lt/bool/setitem/...) all carry
-        // `EF_CAN_RAISE`, so the superset matches `calldescr_canraise` for
-        // the common case; an extra `-live-` after a non-raising call is a
-        // no-op marker (the encoder never reads a PC with no guard).
-        // Tightening to `EffectInfo::check_can_raise` waits until the
-        // pc_map -> `-live-` wiring (A2) makes the distinction observable.
+        // so the production walker stream is untouched.  `may_call_jitcodes`
+        // has no analogue at this site: the canonical lowering emits only
+        // direct `residual_call_*` to fixed helper indices for the retired
+        // HLOp families, never the indirect call that is upstream's sole
+        // `may_call_jitcodes=True` caller — so the residual gate reduces to
+        // `calldescr_canraise`, read off each Insn's `CallDescrStub` operand
+        // (`insn_needs_trailing_live`).  Most retired families carry
+        // `EF_CAN_RAISE` / `EF_FORCES_*` so they keep the marker; the
+        // `get_current_exception` helper (`EF_CANNOT_RAISE`) does not, so it
+        // gets no trailing `-live-` — matching upstream's per-call gate.
         let trailing_live = self.lowering_ctx.is_some() && insn_needs_trailing_live(&insn);
         self.emitline(insn);
         if trailing_live {
@@ -2378,13 +2378,47 @@ fn regalloc_color(
 /// a `guard_no_exception` / inline-boundary resume point that the encoder
 /// reads at the FALLTHROUGH position.  See `serialize_op` for the
 /// canraise-superset rationale.
+/// `jtransform.py:469-470 handle_residual_call` /
+/// `jtransform.py:481 handle_regular_call`: a call op is followed by a
+/// trailing `('-live-', [], None)` marker, but the two call families gate
+/// it differently:
+///   * `inline_call_*` (handle_regular_call) — ALWAYS.
+///   * `residual_call_*` (handle_residual_call) — iff `may_call_jitcodes
+///     or calldescr_canraise(calldescr)`.
+/// The canonical lowering driver never emits the indirect call that is
+/// upstream's only `may_call_jitcodes=True` caller, so the residual gate
+/// is exactly `calldescr_canraise` = `effect_info.check_can_raise(false)`
+/// (`call.py:353-355 calldescr_canraise` -> `effectinfo.py:232
+/// check_can_raise`), read off the trailing `CallDescrStub` operand.
 fn insn_needs_trailing_live(insn: &Insn) -> bool {
-    match insn {
-        Insn::Op { opname, .. } => {
-            opname.starts_with("residual_call") || opname.starts_with("inline_call")
-        }
-        _ => false,
+    let Insn::Op { opname, args, .. } = insn else {
+        return false;
+    };
+    if opname.starts_with("inline_call") {
+        return true;
     }
+    if opname.starts_with("residual_call") {
+        return residual_call_can_raise(args);
+    }
+    false
+}
+
+/// `call.py:353-355 calldescr_canraise` — `calldescr.get_extra_info()
+/// .check_can_raise()` (default `ignore_memoryerror=False`).  Reads the
+/// `EffectInfo` off the residual call's trailing `CallDescrStub` operand;
+/// every `build_residual_call_*` appends exactly one.  A residual_call
+/// with no such operand is a malformed shape this measurement-only path
+/// treats as non-raising (no trailing `-live-`).
+fn residual_call_can_raise(args: &[Operand]) -> bool {
+    args.iter()
+        .find_map(|arg| match arg {
+            Operand::Descr(descr) => match descr.as_ref() {
+                DescrOperand::CallDescrStub(stub) => Some(stub.effect_info.check_can_raise(false)),
+                _ => None,
+            },
+            _ => None,
+        })
+        .unwrap_or(false)
 }
 
 fn is_bool_or_tuple_exitswitch(
@@ -5454,6 +5488,28 @@ mod tests {
             ssarepr.insns[call_pos + 1].is_live(),
             "residual_call must be followed by a `-live-` marker, got {:?}",
             &ssarepr.insns[call_pos..]
+        );
+    }
+
+    #[test]
+    fn insn_needs_trailing_live_gates_residual_call_on_calldescr_canraise() {
+        // `jtransform.py:469 handle_residual_call` emits the trailing
+        // `-live-` iff `may_call_jitcodes or calldescr_canraise(calldescr)`.
+        // The canonical driver has no `may_call_jitcodes` site, so the gate
+        // is `calldescr_canraise` = `effect_info.check_can_raise(false)`.
+        // A MayForce residual call (BINARY_OP, `EF_FORCES_*`) can raise →
+        // marker; the PlainCannotRaiseNoHeap `get_current_exception` helper
+        // (`EF_CANNOT_RAISE`) cannot raise → no marker.
+        let can_raise = build_binary_op_residual_call_ir_r_insn(11, 0, 0, 1, 2);
+        assert!(
+            insn_needs_trailing_live(&can_raise),
+            "MayForce residual_call (EF_FORCES_*) must take a trailing -live-"
+        );
+        let cannot_raise = build_get_current_exception_fn_residual_call_r_r_insn(7, 0);
+        assert!(
+            !insn_needs_trailing_live(&cannot_raise),
+            "PlainCannotRaiseNoHeap residual_call (EF_CANNOT_RAISE) must NOT \
+             take a trailing -live-"
         );
     }
 

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -31,6 +31,88 @@ use super::flow::{
     FunctionGraph, LinkRef, SpaceOperation, SpaceOperationArg, Variable, mkentrymap,
 };
 
+/// `rpython/translator/simplify.py:52-69` `eliminate_empty_blocks`.
+/// Port reference: `majit-translate/src/translator/simplify.rs:44`.
+///
+/// ```py
+/// def eliminate_empty_blocks(graph):
+///     for link in list(graph.iterlinks()):
+///         while not link.target.operations:
+///             block1 = link.target
+///             if block1.exitswitch is not None:
+///                 break
+///             if not block1.exits:
+///                 break
+///             exit = block1.exits[0]
+///             assert block1 is not exit.target
+///             subst = dict(zip(block1.inputargs, link.args))
+///             link.args = [v.replace(subst) for v in exit.args]
+///             link.target = exit.target
+/// ```
+///
+/// Collapses any empty forwarding block by retargeting each predecessor link
+/// through it — the faithful operations-based predicate the orthodox
+/// `simplify_graph` driver needs.  (The walker pipeline instead calls
+/// `codewriter::eliminate_empty_blocks`, whose `block.dead` predicate is the
+/// walker-only proxy: every walker block carries empty `operations` because the
+/// SSARepr is emitted inline, so a `not operations` predicate would collapse all
+/// of them.)
+pub fn eliminate_empty_blocks(graph: &FunctionGraph) {
+    for link in graph.iterlinks() {
+        loop {
+            let target = match link.borrow().target.clone() {
+                Some(target) => target,
+                None => break,
+            };
+            // `while not link.target.operations:` + the two guards
+            // (`exitswitch is not None` / `not exits`).
+            let exit_link = {
+                let tb = target.borrow();
+                if !tb.operations.is_empty() || tb.exitswitch.is_some() || tb.exits.is_empty() {
+                    break;
+                }
+                tb.exits[0].clone()
+            };
+            let (exit_args, exit_target) = {
+                let e = exit_link.borrow();
+                match e.target.clone() {
+                    Some(t) => (e.args.clone(), t),
+                    None => break,
+                }
+            };
+            assert!(
+                target != exit_target,
+                "eliminate_empty_blocks: the graph contains an empty infinite loop"
+            );
+            // `subst = dict(zip(block1.inputargs, link.args))`.
+            let inputargs = target.borrow().inputargs.clone();
+            let link_args = link.borrow().args.clone();
+            let mut subst: HashMap<Variable, Option<FlowValue>> = HashMap::new();
+            for (inputarg, arg) in inputargs.iter().zip(link_args.iter()) {
+                if let FlowValue::Variable(v) = inputarg {
+                    subst.insert(*v, arg.clone());
+                }
+            }
+            // `link.args = [v.replace(subst) for v in exit.args]`.
+            let new_args: Vec<Option<FlowValue>> = exit_args
+                .iter()
+                .map(|arg| match arg {
+                    Some(FlowValue::Variable(v)) => match subst.get(v) {
+                        Some(replacement) => replacement.clone(),
+                        None => arg.clone(),
+                    },
+                    _ => arg.clone(),
+                })
+                .collect();
+            // `link.target = exit.target`; the outer loop keeps collapsing
+            // through the new target if it too is an empty forwarder.
+            let mut l = link.borrow_mut();
+            l.args = new_args;
+            l.target = Some(exit_target);
+        }
+    }
+}
+
 /// `rpython/translator/simplify.py:242-268` `remove_trivial_links`.
 /// Port reference: `majit-translate/src/translator/simplify.rs:2674`.
 ///
@@ -962,13 +1044,15 @@ pub fn checkgraph(graph: &FunctionGraph) {
 
 /// `rpython/translator/simplify.py:1060-1073` `all_passes`.
 ///
-/// The order matches upstream exactly.  `eliminate_empty_blocks` lives in
-/// `codewriter.rs` (paired with its `rewrite_dead_forwarder_gotos` inline-SSARepr
-/// bridge) and is referenced here; `SSA_to_SSI` lives in `backendopt_ssa.rs`.
+/// The order matches upstream exactly.  This uses the faithful
+/// operations-based [`eliminate_empty_blocks`] above (NOT the walker-only
+/// `codewriter::eliminate_empty_blocks`, whose `block.dead` predicate suits the
+/// inline walker but would collapse every block of a normal flow graph).
+/// `SSA_to_SSI` lives in `backendopt_ssa.rs`.
 pub fn all_passes() -> &'static [fn(&FunctionGraph)] {
     &[
         transform_dead_op_vars,
-        super::codewriter::eliminate_empty_blocks,
+        eliminate_empty_blocks,
         remove_assertion_errors,
         remove_identical_vars_ssa,
         constfold_exitswitch,
@@ -1221,5 +1305,46 @@ mod tests {
         assert_eq!(s.exits[0].borrow().target, Some(returnblock));
         assert_eq!(s.operations.len(), 1);
         assert_eq!(s.operations[0].opname, "int_zero");
+    }
+
+    /// The faithful (operations-based) eliminate_empty_blocks collapses a
+    /// NON-dead empty forwarding block that carries args — the shape
+    /// `remove_trivial_links` cannot (its incoming link has args).  Codex P2,
+    /// PR #127.
+    #[test]
+    fn eliminate_empty_blocks_collapses_empty_forwarder_with_args() {
+        // start -> empty(ve) -> next(vn);  empty has no operations and forwards
+        // its inputarg.  start's link should retarget straight to `next`,
+        // substituting the constant it passed into `empty`.
+        let ve = Variable::new(VariableId(40), Kind::Int);
+        let vn = Variable::new(VariableId(41), Kind::Int);
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+        let empty = graph.new_block(vec![ve.into()]);
+        let next = graph.new_block(vec![vn.into()]);
+        // `next` carries a real op so it is NOT itself an empty forwarder
+        // (otherwise the faithful pass would collapse it too).
+        push_op(&next, SpaceOperation::new("keep_alive", vec![vn.into()], None, -1));
+
+        start.closeblock(vec![
+            Link::new(vec![Constant::signed(7).into()], Some(empty.clone()), None).into_ref(),
+        ]);
+        let empty_arg = empty.borrow().inputargs[0].clone();
+        empty.closeblock(vec![Link::new(vec![empty_arg], Some(next.clone()), None).into_ref()]);
+        next.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        eliminate_empty_blocks(&graph);
+
+        // start's link now skips `empty` and targets `next`, carrying the
+        // substituted constant.
+        let s = start.borrow();
+        assert_eq!(s.exits[0].borrow().target, Some(next));
+        assert_eq!(
+            s.exits[0].borrow().args,
+            vec![Some(Constant::signed(7).into())]
+        );
     }
 }

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -1325,13 +1325,18 @@ mod tests {
         let next = graph.new_block(vec![vn.into()]);
         // `next` carries a real op so it is NOT itself an empty forwarder
         // (otherwise the faithful pass would collapse it too).
-        push_op(&next, SpaceOperation::new("keep_alive", vec![vn.into()], None, -1));
+        push_op(
+            &next,
+            SpaceOperation::new("keep_alive", vec![vn.into()], None, -1),
+        );
 
         start.closeblock(vec![
             Link::new(vec![Constant::signed(7).into()], Some(empty.clone()), None).into_ref(),
         ]);
         let empty_arg = empty.borrow().inputargs[0].clone();
-        empty.closeblock(vec![Link::new(vec![empty_arg], Some(next.clone()), None).into_ref()]);
+        empty.closeblock(vec![
+            Link::new(vec![empty_arg], Some(next.clone()), None).into_ref(),
+        ]);
         next.closeblock(vec![
             Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),
         ]);

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -1407,14 +1407,22 @@ mod tests {
         start.borrow_mut().exitswitch = Some(ExitSwitch::Value(Constant::bool(true).into()));
         let link_true =
             Link::new(vec![], Some(fwd.clone()), Some(Constant::bool(true).into())).into_ref();
-        let link_false =
-            Link::new(vec![], Some(dead_arm.clone()), Some(Constant::bool(false).into()))
-                .into_ref();
+        let link_false = Link::new(
+            vec![],
+            Some(dead_arm.clone()),
+            Some(Constant::bool(false).into()),
+        )
+        .into_ref();
         start.closeblock(vec![link_true, link_false]);
 
         fwd.closeblock(vec![Link::new(vec![], Some(tail.clone()), None).into_ref()]);
         tail.closeblock(vec![
-            Link::new(vec![Constant::signed(0).into()], Some(returnblock.clone()), None).into_ref(),
+            Link::new(
+                vec![Constant::signed(0).into()],
+                Some(returnblock.clone()),
+                None,
+            )
+            .into_ref(),
         ]);
         dead_arm.closeblock(vec![
             Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),

--- a/pyre/pyre-jit/src/jit/simplify.rs
+++ b/pyre/pyre-jit/src/jit/simplify.rs
@@ -21,6 +21,30 @@
 //!
 //! Classification (issue #112 scope #4): every pass here is **direct PyPy
 //! parity**.
+//!
+//! ## Issue #112 scope #3 — unmarked-label investigation (concluded)
+//!
+//! The `jitcode label was never marked` panic (`majit-metainterp/src/jitcode/
+//! assembler.rs::patch_labels`) fires when flatten emits a goto/switch/forwarder
+//! operand referencing a block whose `Label` is never emitted.  The only graph
+//! shapes that produce it are a dead/trivial forwarder or a dead constant-switch
+//! arm reaching flatten.  The walker-safe subset wired in
+//! `codewriter.rs` (`eliminate_empty_blocks` + `constfold_exitswitch` +
+//! `remove_trivial_links`, in `all_passes` relative order) removes exactly
+//! those: `eliminate_empty_blocks` collapses dead forwarders — and the
+//! port-boundary guard fails loud if a reachable link still targets a `dead`
+//! block; `remove_trivial_links` merges single-entry/single-exit chains; and
+//! `constfold_exitswitch` drops the dead arm through `recloseblock`, so no link
+//! references it (a still-reachable arm target keeps its `Label`).
+//!
+//! The `all_passes` entries left unwired do **not** affect label structure:
+//! `transform_dead_op_vars` / `remove_identical_vars_ssa` / `ssa_to_ssi` only
+//! rename or dedup variables; `coalesce_bool` / `transform_ovfcheck` /
+//! `transform_xxxitem` are op-level rewrites; and `simplify_exceptions` /
+//! `remove_dead_exceptions` / `remove_assertion_errors` are documented no-ops
+//! that remove no block or link on a walker graph.  So the wired subset closes
+//! the gap and the assembler `never marked` panic is a fail-loud backstop, not a
+//! live failure mode — empirically unreached at check.py 41/41 both backends.
 
 use std::collections::{HashMap, HashSet};
 
@@ -1351,5 +1375,71 @@ mod tests {
             s.exits[0].borrow().args,
             vec![Some(Constant::signed(7).into())]
         );
+    }
+
+    /// Issue #112 scope #3 conclusion as a regression guard: the walker-safe
+    /// subset wired ahead of flatten (`eliminate_empty_blocks` +
+    /// `constfold_exitswitch` + `remove_trivial_links`) removes every shape that
+    /// yields an unmarked label.  A graph carrying BOTH a dead constant-switch
+    /// arm and a trivial empty forwarder must, after the subset, leave no
+    /// reachable link pointing at a dropped or dead block — the port-boundary
+    /// invariant the assembler `patch_labels` backstop guards.
+    #[test]
+    fn wired_subset_leaves_no_reachable_link_to_unmarked_block() {
+        let start = Block::shared(vec![]);
+        let graph = FunctionGraph::new("f", start.clone(), None);
+        let returnblock = graph.returnblock.clone();
+
+        // The live (true) arm goes through a trivial empty forwarder; the dead
+        // (false) arm reaches `dead_arm`, which only the folded-away case names.
+        let fwd = graph.new_block(vec![]);
+        let tail = graph.new_block(vec![]);
+        let dead_arm = graph.new_block(vec![]);
+
+        // `tail` carries a real op so it is not itself an empty forwarder.
+        let v = graph.fresh_variable(Kind::Int);
+        push_op(
+            &tail,
+            SpaceOperation::new("int_zero", vec![], Some(v.into()), -1),
+        );
+
+        // start switches on the constant `true`: true -> fwd, false -> dead_arm.
+        start.borrow_mut().exitswitch = Some(ExitSwitch::Value(Constant::bool(true).into()));
+        let link_true =
+            Link::new(vec![], Some(fwd.clone()), Some(Constant::bool(true).into())).into_ref();
+        let link_false =
+            Link::new(vec![], Some(dead_arm.clone()), Some(Constant::bool(false).into()))
+                .into_ref();
+        start.closeblock(vec![link_true, link_false]);
+
+        fwd.closeblock(vec![Link::new(vec![], Some(tail.clone()), None).into_ref()]);
+        tail.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(returnblock.clone()), None).into_ref(),
+        ]);
+        dead_arm.closeblock(vec![
+            Link::new(vec![Constant::signed(0).into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        // The wired subset, in the codewriter's relative order.
+        eliminate_empty_blocks(&graph);
+        constfold_exitswitch(&graph);
+        remove_trivial_links(&graph);
+
+        // Port-boundary invariant: every reachable link targets a live block, so
+        // flatten emits a Label for every referenced target (no unmarked label).
+        for link in graph.iterlinks() {
+            if let Some(target) = link.borrow().target.clone() {
+                assert!(
+                    !target.borrow().dead,
+                    "reachable link still targets a dead block"
+                );
+            }
+        }
+        // The dropped switch arm and the collapsed forwarder are unreachable.
+        let reachable = graph.iterblocks();
+        assert!(!reachable.contains(&dead_arm));
+        assert!(!reachable.contains(&fwd));
+        // The normalized graph is flatten-ready.
+        checkgraph(&graph);
     }
 }

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -69,9 +69,14 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
     let mut inner_sig = user_sig.clone();
     inner_sig.ident = inner_name.clone();
 
-    // Generate unwrap statements for each parameter.
+    // Generate unwrap statements for each parameter, and collect the
+    // parameter-name / required tables so the wrapper can resolve keyword
+    // arguments by name (PyPy gateway `Signature` + `_match_signature`).
     let mut unwrap_stmts = Vec::<proc_macro2::TokenStream>::new();
     let mut call_args = Vec::<proc_macro2::TokenStream>::new();
+    let mut param_names = Vec::<String>::new();
+    let mut param_required = Vec::<bool>::new();
+    let mut has_varargs = false;
     for (idx, arg) in user_sig.inputs.iter().enumerate() {
         let pat_type = match arg {
             FnArg::Typed(pt) => pt,
@@ -82,10 +87,48 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
                 ));
             }
         };
+        if is_varargs_param(&pat_type.ty) {
+            has_varargs = true;
+        }
+        param_names.push(param_name(idx, pat_type));
+        // Optional iff it has a `#[default(...)]` or is `Option<T>`.
+        param_required
+            .push(arg_default(pat_type)?.is_none() && option_inner(&pat_type.ty).is_none());
         let (unwrap, ident) = unwrap_arg(idx, pat_type)?;
         unwrap_stmts.push(unwrap);
         call_args.push(quote! { #ident });
     }
+
+    // Keyword-binding preamble: when the call carried a `__pyre_kw__`
+    // dict, rebind positional+keyword args into a resolved scope keyed by
+    // parameter name; otherwise the positional fast path runs unchanged.
+    // Skipped for varargs fns — `&[PyObjectRef]` consumes the whole slice
+    // (including any trailing kwargs dict), which the resolved-scope shape
+    // cannot express.
+    let kwargs_preamble = if has_varargs {
+        quote! {}
+    } else {
+        let name_lits = param_names.iter().map(|n| quote! { #n });
+        let req_lits = param_required.iter().map(|b| quote! { #b });
+        let fn_name_str = user_name.to_string();
+        quote! {
+            const __PYRE_PARAM_NAMES: &[&str] = &[ #(#name_lits),* ];
+            const __PYRE_PARAM_REQUIRED: &[bool] = &[ #(#req_lits),* ];
+            let __pyre_bound_args;
+            let args: &[::pyre_object::PyObjectRef] =
+                if crate::builtins::has_builtin_kwargs(args) {
+                    __pyre_bound_args = crate::builtins::bind_builtin_kwargs(
+                        args,
+                        __PYRE_PARAM_NAMES,
+                        __PYRE_PARAM_REQUIRED,
+                        #fn_name_str,
+                    )?;
+                    &__pyre_bound_args
+                } else {
+                    args
+                };
+        }
+    };
 
     let call_inner = quote! { #inner_name( #(#call_args),* ) };
     let body = wrap_return(&user_sig.output, call_inner)?;
@@ -110,6 +153,7 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
         #vis fn #user_name(
             args: &[::pyre_object::PyObjectRef],
         ) -> ::std::result::Result<::pyre_object::PyObjectRef, crate::PyError> {
+            #kwargs_preamble
             #(#unwrap_stmts)*
             #body
         }
@@ -137,7 +181,7 @@ fn unwrap_arg(idx: usize, pt: &PatType) -> syn::Result<(proc_macro2::TokenStream
     let unwrap = unwrap_expr(ty, idx)?;
     let expr = match arg_default(pt)? {
         Some(default) => quote! {
-            if args.len() > #idx { #unwrap } else { #default }
+            if #idx < args.len() && !args[#idx].is_null() { #unwrap } else { #default }
         },
         None => unwrap,
     };
@@ -328,12 +372,14 @@ fn unwrap_expr(ty: &Type, idx: usize) -> syn::Result<proc_macro2::TokenStream> {
         if type_is_py_object_ref(ty) {
             return Ok(quote! { args[#idx] });
         }
-        // `Option<T>` — `if args.len() > idx { Some(unwrap(args[idx])) } else { None }`.
-        // Mirrors PyPy `@unwrap_spec(s=W_Root)` with `def f(self, space, s=None)`.
+        // `Option<T>` — present when the slot is in range and not the
+        // `PY_NULL` "argument omitted" marker `bind_builtin_kwargs` writes
+        // for an absent optional after keyword resolution.  Mirrors PyPy
+        // `@unwrap_spec(s=W_Root)` with `def f(self, space, s=None)`.
         if let Some(inner) = option_inner(ty) {
             let inner_unwrap = unwrap_expr(inner, idx)?;
             return Ok(quote! {
-                if args.len() > #idx { Some(#inner_unwrap) } else { None }
+                if #idx < args.len() && !args[#idx].is_null() { Some(#inner_unwrap) } else { None }
             });
         }
         if let Some(seg) = p.path.segments.last() {
@@ -370,6 +416,28 @@ fn unwrap_expr(ty: &Type, idx: usize) -> syn::Result<proc_macro2::TokenStream> {
              add a mapping in pyre-macros/src/lib.rs::unwrap_expr"
         ),
     ))
+}
+
+/// The keyword name a parameter binds under — its identifier, or a
+/// synthetic positional-only placeholder for a non-ident pattern (which
+/// no real keyword can match).
+fn param_name(idx: usize, pt: &PatType) -> String {
+    match &*pt.pat {
+        Pat::Ident(pi) => pi.ident.to_string(),
+        _ => format!("__pyre_positional_{idx}"),
+    }
+}
+
+/// `true` for a `&[PyObjectRef]` varargs parameter (binds the whole arg
+/// slice).
+fn is_varargs_param(ty: &Type) -> bool {
+    let ty = unwrap_type_group(ty);
+    if let Type::Reference(r) = ty {
+        if let Type::Slice(s) = &*r.elem {
+            return type_is_py_object_ref(unwrap_type_group(&s.elem));
+        }
+    }
+    false
 }
 
 /// `Option<T>` → `Some(&T)`; anything else → None.


### PR DESCRIPTION
follow-up #112

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

This PR delivers two large areas: CPython-parity machinery in the interpreter (builtin-leaf subclass dispatch, dict-subclass/deque/operator support, class-creation and cellvar fixes that together enable the Enum/IntEnum/Flag/IntFlag and namedtuple stdlib paths) and canonical-graph JIT work (the #127 `simplify_graph` pass port, the #73 canonical `flatten_graph` lowering, and vectorizer Codex-parity). The Rust changes are in `pyre-interpreter`/`pyre-jit`/`majit`; the diff carries no enum/namedtuple test fixtures (the only test-ish file touched is `check.py`, for `fib_loop` headroom).

### Interpreter — builtin-leaf subclass dispatch (custom int·float·str·tuple, enabling enum / IntFlag)

- `int`/`long`/`float`/`bool`/`str` keep `ob_type` at the canonical storage type and carry the Python class in `w_class`; added `builtin_subclass_dunder` (`display.rs`) so `py_repr`/`py_str` consult a `__repr__`/`__str__` override resolved above `object` in the `w_class` MRO before the storage-keyed formatting (e.g. `repr(IntEnum.X)`).
- Replaced `tuple.__new__`'s `descr_new_wrapper!` with a hand-written `tuple_descr_new` that, for a subclass, copies into a fresh tuple and sets `w_class = cls` (mirroring `int_descr_new`/`float_descr_new`), so `collections.namedtuple` field access, repr, `_replace`/`_make`, and defaults work.
- `descroperation` now gates the binary operators, rich comparisons, and unary operators (`pos`/`neg`/`invert`) on a `w_class`-resolved override (`binop_dispatch_first`/`try_compare_override`/`try_unary_override`) before their `is_int_like`/`is_float_pair`/`is_str` storage fast paths; `operand_overrides` keys on the resolved method kind (mutable-code `FUNCTION_TYPE`, excluding fixed-code gateway builtins) so a `long` is not mistaken for an override and does not recurse — covers Python `__add__`/`__or__`, `__lt__`/`__eq__`, and `enum.IntFlag.__invert__`.
- `load_method` (`eval.rs`) no longer binds `self` for non-method descriptors (type/property/member/getset such as `__class__`) or MRO-absent attributes on a builtin-storage instance, fixing `self.__class__(value)` (compiled as `LOAD_METHOD`/`CALL_METHOD`) prepending an extra argument.
- `baseobjspace` resolves `__getitem__` on `type(cls)`'s MRO before the PEP 560 `__class_getitem__` fallback, consults the metaclass `__len__` for a type receiver, and resolves `__contains__` on the receiver's dynamic type before the getitem scan — routing `Color['RED']`, `len(Color)`, and `x in Color`/`x in flag` through `EnumMeta`/IntFlag instance methods.

### Interpreter — class creation, metaclass, cellvars

- `MAKE_CELL` now wraps a slot only when it does not already hold a cell, since `initialize_frame_scopes` pre-installs an empty cell for every pure cellvar; this stops never-reassigned cellvars like `__class__` from becoming a cell-of-cell, fixing `self.__class__` and zero-arg `super()` reads (previously infinite recursion in a dict-subclass `__repr__` calling `super().__repr__()`).
- `build_class` (`call.rs`) strips the compiler-internal class scaffolding (`__class__`, `__classdict__`, `__classcell__`, `__classdictcell__`) from the class namespace before building the type, captures the `__classcell__` cell, and binds it to the new class (`type_new_classcell`); a follow-up keeps `__classcell__`/`__classdictcell__` visible in the namespace a custom metaclass receives while still excluding them from the class `__dict__`, consuming them in `type.__new__` instead.
- `build_class` executes the class body directly against a custom `__prepare__` mapping (a dict subclass such as `enum._EnumDict`) via `setdictscope_object`, so its `__setitem__`/`__getitem__` fire mid-body, then mirrors the mapping's contents into `class_ns` and skips the metaclass-path replay; fixes Flag members like `WHITE = RED | GREEN | BLUE` reading unresolved `auto()` sentinels.
- `type.__new__` resolves the dict backing of the namespace before its copy and `__set_name__` loops, so a dict-subclass namespace (`PyDict_Check`, not `PyDict_CheckExact`) is walked instead of producing an empty `__dict__`.
- Adds the `type.mro()` method (`mro_external`), returning the MRO as a fresh list distinct from the `__mro__` tuple getset; its absence had blocked `import enum`.
- Adds regression tests pinning both single-cell `MAKE_CELL` shapes: a parameter captured by an inner function, and the implicit `__class__` cellvar resolving zero-arg `super()`.

### Interpreter — dict / dict-subclass / mapdict

- `dict.__getitem__` on a dict-subclass instance now looks up the key in the `__dict_data__` backing directly and, on a miss, dispatches `__missing__` against the subclass instance's type (upstream `dictmultiobject.py:166-170`) instead of the plain-dict backing — so e.g. `defaultdict.__missing__` fires; `dict_missing_or_key_error` is now `pub(crate)`.
- Added a `dict.__repr__` method (extracted into the shared `display::dict_repr` helper, upstream `dictmultiobject.py:130-150 descr_repr`) so dict-subclass instances and `super().__repr__()` format their backing rather than falling back to the object repr; unbound `dict.__repr__(x)` on a non-dict receiver now raises `TypeError` (the receiver-rejection lives in `typedef.rs`, not the `.py` ref).
- `dict.__delitem__` resolves the `__dict_data__` backing for subclass instances in `typedef.rs` (mirroring `__setitem__`), fixing infinite recursion where the instance branch re-looked-up and re-entered the inherited `dict.__delitem__`.
- Implemented `DevolvedDictTerminator` read/write in mapdict (`mapdict.py:383-395`): read via `getdict` + `finditem_str`, write via `getdict` + `setitem_str`, gated on `attrkind == DICT`; added `_mapdict_self_ref` to the `MapdictObject` trait to reach `_obj_getdict`. `switch_to_text_strategy` past `LIMIT_MAP_ATTRIBUTES` remains a documented deferral.

(Rust changes for the dict items above live in `typedef.rs`/`baseobjspace.rs`/`display.rs`/`mapdict.rs`; the `dictmultiobject.py` line citations are upstream PyPy parity attributions, not Rust paths.)

### Interpreter — deque, operator, builtin-kwargs ABI, misc / bench

- `_collections` deque: bounded the list-backed `W_Deque` to `maxlen`, trimming from the opposite end on `append`/`appendleft`/`extend`/`extendleft`, with the bound in the private `__maxlen__` slot and a read-only `maxlen` property; added `extendleft`, `rotate`, `count`, `remove`, `__contains__`, `reverse`, `index`, `copy`, `__setitem__`, `__delitem__`, `__repr__`, routing pop/popleft and the append family through shared snapshot/store helpers. `maxlen` is validated at construction via `gateway_nonnegint_w` (`TypeError`/`ValueError`), `__init__` propagates iterable errors, `__repr__` is `ReprGuard`-protected (`[...]`), and `__getitem__`/`__setitem__`/`__delitem__` go through a `deque_index` helper mirroring `space.decode_index4`. Added rich comparison (`__eq__`…`__ge__`, element-wise over both backings, `NotImplemented` for non-deque) and repetition (`__mul__`/`__rmul__`/`__imul__`, re-bounded by `maxlen`). The port covers these methods specifically; it is not a complete deque.
- `operator`: ported `itemgetter`/`attrgetter`/`methodcaller` as app-level callable classes plus the `_resolve_attr_chain` helper (verbatim `app_operator.py`), installed via the `appleveldefs` arm, replacing interp-level stubs that returned `args[0]` unchanged (which broke the stdlib namedtuple's `itemgetter(n)` accessors); also added app-level `countOf`. `length_hint` stays interp-level.
- `#[pyre_function]` keyword binding (`pyre-macros`): when a call carries the trailing `__pyre_kw__` dict, the wrapper rebinds positional+keyword args into a resolved scope via `bind_builtin_kwargs` (mirroring the gateway `Arguments._match_signature`) using parameter-name/required tables collected at expansion time; positionals fill left-to-right, keywords match by name, an absent optional becomes `PY_NULL`, and unknown/duplicate/missing-required raises `TypeError`. The positional fast path is unchanged when no kwargs dict is present; varargs fns keep the positional path. Fixes `deque(maxlen=3)` previously binding the dict as `iterable`.
- `pyframe`: `peekvalues(n)` now asserts only the lower `base` bound; the upper-bound assert is skipped for the empty peek (`n == 0`), which spuriously failed at peak stack depth and crashed `collections`/`reprlib` imports in debug builds. (Its commit also carries the `call.rs` `build_class` scaffolding-strip rustfmt rewrap and a stray formatting-only edit to a `simplify.rs` test — both non-behavioral.)
- Parity-comment corrections: document why the `Forwarded` enum has no `VectorInfo` variant (scratch is not clone-stable, lives in the pos-keyed `vecinfo_cache`), and fix the `defaultdict` doc-comment to state `__getitem__` invokes/stores `default_factory` (raising `KeyError` without one) rather than short-circuiting to `w_none()` — the same comment records that `W_DefaultDict` remains a stub subclassing `object` not `dict` (so `isinstance(d, dict)` is False) with `__missing__`/`__repr__`/`copy`/`__reduce__` still absent.
- `bench/list_reverse`: raised `REPS` from 15 to 401 (odd, keeping the reversed result) so the build loop and JIT trace warmup are amortised and the measurement reflects `reverse()`.
- `check.py`: gave cranelift `fib_loop` 3x-vs-cpython headroom (dynasm stays 2x) to absorb slower windows-runner variance on the bignum-add-bound benchmark.

### JIT — simplify_graph pass port (#127)

- Added a faithful operations-based `eliminate_empty_blocks` to `simplify.rs` (port of `simplify.py:52-69`, `not link.target.operations`), retargeting each predecessor link through an empty forwarding block, and wired it into `all_passes()`; the walker pipeline keeps the `block.dead`-predicate `codewriter::eliminate_empty_blocks`. Adds a graph-shape test for collapsing a non-dead arg-carrying forwarder.
- Fixed `remove_trivial_links`' merge bridge to strip the source block's trailing boundary `goto TLabel(target) + Unreachable` before absorbing the merged target's `per_block_ssarepr`, so the target's own terminator is the first terminator and the `emit_link_renamings_into_block` splice lands after the target opcodes.
- Reordered `rewrite_dead_forwarder_gotos` to run before `remove_trivial_links`/`rewrite_trivial_link_merges` so inline byte-stream gotos already name the surviving target when the merge bridge's `strip_trailing_boundary_goto` reads source terminators (fixes the `source -> dead_forwarder -> target` strip miss).
- Registered the `None`, `NotImplemented`, `Ellipsis`, `True`, and `False` prebuilt-singleton addresses in `jit_static_ref_addrs` under their `module::NAME` catalogue keys, so the front-end same-file `Expr::Path` fold emits `ConstRefAddr` instead of a rejected cross-block body-`Input` for `w_none`/`w_not_implemented`/`w_ellipsis`/`w_bool_from`.
- Documented the issue #112 scope #3 unmarked-label conclusion (per-pass coverage of the walker-safe subset, `assembler.rs::patch_labels` fail-loud note) and added a regression test asserting no reachable link targets a dead/dropped block after the subset runs on a graph with a dead switch arm and a trivial forwarder.

### JIT — canonical flatten_graph lowering (#73)

- Lower a returned graph `Constant` ref (`Operand::ConstRef`) in the canonical `flatten_graph` path via a new `JitCodeBuilder::ref_return_const`, mirroring `load_const_r` by encoding it as a constants-window register index (`num_regs_r + pool_idx`) patched in `finish()`; route `ref_return` `ConstRef` to it instead of `expect_reg`. Also names the dispatch opname in the `expect_reg` panic via a `CURRENT_DISPATCH_OP` thread-local.
- Add `setattr` to `is_pyre_canonical_elidable_hlop` alongside `getattr` and `type`: all three are paired with an inline `abort_permanent` by the walker (`StoreAttr` arm), so the canonical SSARepr elides the undispatchable HLOp (upstream `rclass.py rtype_setattr` rewrites to `setfield_gc`).
- Emit a trailing `-live-` after canonical `residual_call_*` / `inline_call_*` Insns under `lowering_ctx`, per `jtransform.py:467-482` `handle_residual_call` / `handle_regular_call`, supplying the post-call `guard_no_exception` / inline-boundary resume marker. Adds a unit test pinning the marker after a `residual_call_ir_r`. (A follow-up rustfmt-only commit rewraps the `trailing_live` binding/closure; non-behavioral.)
- Refined the residual-call gate from an unconditional superset to `calldescr_canraise` (`effect_info.check_can_raise(false)`), reading the `CallDescrStub` `EffectInfo` off the Insn, so the `EF_CANNOT_RAISE` `get_current_exception` call drops its marker while `inline_call_*` stays unconditional; adds a unit test covering both the can-raise and cannot-raise cases.

### JIT — vectorizer Codex-parity

- Threaded `jitcell_token: Option<&Arc<JitCellToken>>` through `optimize_vector`, `VectorizingOptimizer::run_optimization`, and `try_vectorize`, passing it to `finaloplist` in place of a hardcoded `None`; the standalone caller and the `Optimization`-trait `propagate_forward` path pass `None` while the compile path is disconnected, matching the upstream `jitcell_token=None` default (`vector.py:123,143,271`).
- Documented why the `forwarded_vecinfo` scheduling scratch (`schedule.py:20-28`) uses a `pos`-keyed `vecinfo_cache` instead of `op._forwarded`: `Op::clone` resets `forwarded` but preserves `pos` (`resoperation.rs:1344,1352`), the scheduler reads vecinfo off cloned ops (`dependency.rs:221`, unroll/schedule clones), and `INT_SIGNEXT` bytesize is the dynamic `arg1` value (`cast_to_bytesize_static` returns `None`) recoverable only via `int_signext_vecinfo`'s setup-time resolver that `vectorization_info_for_op(&Op)` cannot reach.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Complete `deque` implementation with extend, rotate, count, remove, copy, and rich comparisons
  * `operator` module now provides `countOf`, `attrgetter`, `itemgetter`, and `methodcaller`
  * Improved metaclass dispatch for type `__getitem__`, `__len__`, and `__contains__` operations
  * Better support for operation overrides in builtin-leaf subclasses
  * Enhanced `tuple` and `dict` subclass handling
  * Added `mro()` method for type objects
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
