### PR TITLE
JIT: const-ref handle table for GC-safe ref constants (#108)

### DIFF
--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -171,6 +171,21 @@ pub enum Forwarded {
     /// `optimizeopt/info.py:17 AbstractInfo (is_info_class = True)` family —
     /// `PtrInfo`, `IntBound`, `FloatConstInfo`, `EmptyInfo`, etc.
     Info(OpInfo),
+    // There is deliberately NO `VectorInfo` variant. Vectorizer scheduling
+    // scratch (`schedule.py:20-28 forwarded_vecinfo`) lives in the pos/OpRef-
+    // keyed `VecScheduleState.vecinfo_cache` (optimizeopt/schedule.rs), not in
+    // a `_forwarded` slot, on purpose: `Op::clone` resets `forwarded` to
+    // `None` (fresh identity) while preserving `pos`, and the scheduler reads
+    // vecinfo off cloned ops, so a `_forwarded`-borne scratch clone-drops and
+    // silently miscomputes INT_SIGNEXT (its dynamic arg1 bytesize resolves
+    // only at setup time through the const resolver that the bare
+    // `vectorization_info_for_op` reader does not hold). Loop `InputArg`
+    // operands also own no per-op vecinfo slot, so an OpRef-keyed cache is
+    // required regardless. `Op.vecinfo` (resoperation.rs) is the SEPARATE
+    // permanent `resoperation.py:511-518` VecOp datatype/bytesize/signed/count
+    // store and stays. Reviews recurringly flag the cache as a `_forwarded`
+    // parity regression — it is the clone-stable successor to the retired
+    // opref-keyed box_pool, not a regression; do not restore.
 }
 
 /// `Rc<Box>` newtype.

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -117,6 +117,18 @@ pub fn majit_log_enabled() -> bool {
     *ENABLED
 }
 
+/// Strict JIT mode: a non-`InvalidLoop` panic during compilation is a bug and
+/// must fail loudly rather than silently degrade to the interpreter and mask
+/// the bug behind correct output. Enabled in debug builds (`cargo test`) and
+/// whenever `MAJIT_STRICT` is set (release benches / CI); off in plain release
+/// so production keeps graceful degradation. Cached like `majit_log_enabled`.
+pub fn jit_strict_mode() -> bool {
+    static STRICT: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
+        cfg!(debug_assertions) || std::env::var_os("MAJIT_STRICT").is_some()
+    });
+    *STRICT
+}
+
 /// Result of tracing a single instruction.
 ///
 /// Returned by the interpreter's `trace_instruction()` function

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -10,31 +10,10 @@ use crate::optimizeopt::dependency::DependencyGraph;
 
 // ── vector.py:670-678: isomorphic ─────────────────────────────────────
 
-/// vector.py:670-678 helper — returns the bytesize from the op's vecinfo
-/// slot if present, otherwise the default for the op's result type.
-/// INT_WORD = 8, FLOAT_WORD = 8 on 64-bit; void → 0.
-fn get_op_bytesize(op: &Op) -> i32 {
-    if let Some(vi) = op.get_vecinfo() {
-        return vi.getbytesize() as i32;
-    }
-    match op.opcode.result_type() {
-        majit_ir::Type::Float => 8,
-        majit_ir::Type::Void => 0,
-        _ => 8, // INT_WORD on 64-bit
-    }
-}
-
-/// vector.py:670-678: isomorphic — two ops can be packed if they have
-/// the same opcode AND the same vecinfo bytesize.
-pub fn isomorphic(l_op: &Op, r_op: &Op) -> bool {
-    if l_op.opcode != r_op.opcode {
-        return false;
-    }
-    get_op_bytesize(l_op) == get_op_bytesize(r_op)
-}
-
-/// vector.py:670-678 production path. Uses `forwarded_vecinfo`, which stores
-/// `VectorizationInfo` in the same `_forwarded` slot that RPython uses.
+/// vector.py:670-678: isomorphic — two ops can be packed if they have the
+/// same opcode AND the same vecinfo bytesize. PyPy reads each side through
+/// `forwarded_vecinfo`, so the comparison runs against the same `_forwarded`
+/// (here `vecinfo_cache`) store that `VectorizationInfo(op)` populated.
 pub fn isomorphic_with_state(state: &mut VecScheduleState, l_op: &Op, r_op: &Op) -> bool {
     if l_op.opcode != r_op.opcode {
         return false;
@@ -793,13 +772,15 @@ pub struct VecScheduleState {
     pub accumulation: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, AccumEntry>,
     /// Next OpRef counter for newly created vector ops.
     next_pos: u32,
-    /// `schedule.py:20-28 forwarded_vecinfo(op)` cache. PyPy reads
-    /// `op._forwarded` as the `VectorizationInfo` carrier; pyre splits
-    /// the slot — `Op.vecinfo` is the per-op canonical (cleared by
-    /// `vector.py:58-60 teardown_vectorization`) and this cache holds
-    /// the schedule-local stamps for InputArg/transient OpRefs that
-    /// don't own an Op. Keyed by full `OpRef` so InputArg/op namespaces
-    /// don't collide.
+    /// `schedule.py:20-28 forwarded_vecinfo(op)` cache — pyre's stand-in
+    /// for PyPy's `op._forwarded` `VectorizationInfo` carrier. It is the
+    /// canonical store for the vector pass: `setup_vectorization` stamps
+    /// every loop op here through `VectorizationInfo(op)`, and
+    /// `forwarded_vecinfo` / `isomorphic_with_state` read it back. Living
+    /// on the state (not on the op) means it is dropped when the state
+    /// is, matching `vector.py:58-60 teardown_vectorization`'s
+    /// `set_forwarded(None)`. Keyed by full `OpRef` so InputArg/op
+    /// namespaces don't collide.
     vecinfo_cache: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::VectorizationInfo>,
 }
 
@@ -844,26 +825,26 @@ impl VecScheduleState {
 
     /// `resoperation.py:181-186 VectorizationInfo.__init__` INT_SIGNEXT
     /// branch.  PyPy reads `op.getarg(1).value` off the `ConstInt` object
-    /// directly; pyre's flat-OpRef encoding stores the const as a pool
-    /// index, so the caller-supplied resolver materialises the value at
-    /// stamp time.  Falls back to the generic branch when arg1 isn't a
-    /// resolvable constant (mirrors PyPy's `assert isinstance(arg1, ConstInt)`
-    /// degrading to the typecast-fallthrough path in non-translated runs).
+    /// directly, after `assert isinstance(arg1, history.ConstInt)`; pyre's
+    /// flat-OpRef encoding stores the const as a pool index, so the
+    /// caller-supplied resolver materialises `arg1.value`.  An unresolvable
+    /// `arg1` is a malformed INT_SIGNEXT, so this fails fast (mirroring the
+    /// `assert`) rather than silently degrading to a generic vecinfo.
     fn int_signext_vecinfo(
         &self,
         op: &Op,
         constant_of: &dyn Fn(OpRef) -> Option<i64>,
     ) -> majit_ir::VectorizationInfo {
-        if op.num_args() >= 2 {
-            if let Some(bytesize) = constant_of(op.arg(1).to_opref()) {
-                if (i8::MIN as i64..=i8::MAX as i64).contains(&bytesize) {
-                    let mut info = majit_ir::VectorizationInfo::new();
-                    info.setinfo('i', bytesize as i8, true);
-                    return info;
-                }
-            }
-        }
-        self.vectorization_info_for_op(op)
+        // resoperation.py:185 `assert isinstance(arg1, history.ConstInt)`.
+        let bytesize = constant_of(op.arg(1).to_opref())
+            .expect("INT_SIGNEXT arg1 must resolve to a ConstInt (resoperation.py:185)");
+        assert!(
+            (i8::MIN as i64..=i8::MAX as i64).contains(&bytesize),
+            "INT_SIGNEXT byte size {bytesize} out of VectorizationInfo range"
+        );
+        let mut info = majit_ir::VectorizationInfo::new();
+        info.setinfo('i', bytesize as i8, true);
+        info
     }
 
     fn get_forwarded_vecinfo(&self, opref: OpRef) -> Option<majit_ir::VectorizationInfo> {
@@ -893,7 +874,7 @@ impl VecScheduleState {
         info
     }
 
-    fn forwarded_vecinfo_for_ref(
+    pub fn forwarded_vecinfo_for_ref(
         &mut self,
         opref: OpRef,
         ops: &[Op],
@@ -925,13 +906,14 @@ impl VecScheduleState {
     /// Mirrors PyPy `resoperation.py:163-212 VectorizationInfo.__init__`.
     /// The `INT_SIGNEXT` branch (`:181-186`) is handled in
     /// `int_signext_vecinfo` at setup time because it needs the
-    /// caller-supplied const-pool resolver; once the inline vecinfo slot
-    /// is stamped, every later lookup hits the cache and never re-enters
-    /// this method for INT_SIGNEXT.  A bare miss-path call on
+    /// caller-supplied const-pool resolver; once the forwarded vecinfo
+    /// cache is stamped, every later lookup hits the cache and never
+    /// re-enters this method for INT_SIGNEXT.  A bare miss-path call on
     /// INT_SIGNEXT (e.g. a synthesised op that bypassed setup) falls
-    /// through to the typecast branch which returns `None` for it, and
-    /// then to the source-operand pass-through — same degradation as
-    /// PyPy's non-translated `assert` failure path.
+    /// through to the typecast branch, which returns `None` for it, and
+    /// then to the source-operand pass-through; `setup_vectorization`
+    /// stamps every loop INT_SIGNEXT up front, so this residual path is
+    /// not reached for real loop bodies.
     fn vectorization_info_for_op(&self, op: &Op) -> majit_ir::VectorizationInfo {
         // resoperation.py:170-180 primitive_array_access branch.
         if op.opcode.is_primitive_array_access_opcode() {
@@ -957,7 +939,7 @@ impl VecScheduleState {
         // resoperation.py:187-190 is_typecast branch (INT_SIGNEXT static
         // gating returns None per `cast_to_bytesize_static`; the dynamic
         // INT_SIGNEXT bytesize is stamped in `int_signext_vecinfo` at
-        // setup time and read back through the inline vecinfo slot).
+        // setup time and read back through the forwarded vecinfo cache).
         if op.opcode.is_typecast() {
             if let Some(bytesize) = op.opcode.cast_to_bytesize_static() {
                 let (_ft, tt) = op.opcode.cast_types();

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -12,9 +12,10 @@ use crate::optimizeopt::dependency::DependencyGraph;
 
 /// vector.py:670-678: isomorphic — two ops can be packed if they have the
 /// same opcode AND the same vecinfo bytesize. PyPy reads each side through
-/// `forwarded_vecinfo`, so the comparison runs against the same `_forwarded`
-/// (here `vecinfo_cache`) store that `VectorizationInfo(op)` populated.
-pub fn isomorphic_with_state(state: &mut VecScheduleState, l_op: &Op, r_op: &Op) -> bool {
+/// `forwarded_vecinfo(op)`, which lives on `op._forwarded`; pyre keeps that
+/// forwarded `VectorizationInfo` in the scheduler's pos-keyed store, so the
+/// store is the extra leading argument.
+pub fn isomorphic(state: &mut VecScheduleState, l_op: &Op, r_op: &Op) -> bool {
     if l_op.opcode != r_op.opcode {
         return false;
     }
@@ -245,7 +246,7 @@ impl PackSet {
         let l_op = &graph.nodes[lnode].op;
         let r_op = &graph.nodes[rnode].op;
 
-        if !isomorphic_with_state(state, l_op, r_op) {
+        if !isomorphic(state, l_op, r_op) {
             return Ok(None);
         }
 
@@ -774,13 +775,13 @@ pub struct VecScheduleState {
     next_pos: u32,
     /// `schedule.py:20-28 forwarded_vecinfo(op)` cache — pyre's stand-in
     /// for PyPy's `op._forwarded` `VectorizationInfo` carrier. It is the
-    /// canonical store for the vector pass: `setup_vectorization` stamps
-    /// every loop op here through `VectorizationInfo(op)`, and
-    /// `forwarded_vecinfo` / `isomorphic_with_state` read it back. Living
-    /// on the state (not on the op) means it is dropped when the state
-    /// is, matching `vector.py:58-60 teardown_vectorization`'s
-    /// `set_forwarded(None)`. Keyed by full `OpRef` so InputArg/op
-    /// namespaces don't collide.
+    /// canonical store for the vector pass: `VectorLoop::setup_vectorization`
+    /// stamps every loop op here through `VectorizationInfo(op)`, and
+    /// `forwarded_vecinfo` / `isomorphic` read it back. Living on the state
+    /// (not on the op) means it is dropped when the state is, and
+    /// `VectorLoop::teardown_vectorization` clears it per op
+    /// (`vector.py:58-60 set_forwarded(None)`). Keyed by full `OpRef` so
+    /// InputArg/op namespaces don't collide.
     vecinfo_cache: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::VectorizationInfo>,
 }
 
@@ -801,10 +802,10 @@ impl VecScheduleState {
         }
     }
 
-    /// vector.py:54-60 setup/teardown_vectorization. Seed only the local
-    /// scheduling vecinfo state; RPython clears this `_forwarded` state
-    /// after the vector pass, so it must not leak into the main
-    /// optimizer's forwarded state.
+    /// vector.py:54-56 `op.set_forwarded(VectorizationInfo(op))` for one op:
+    /// the per-op body that `VectorLoop::setup_vectorization` iterates.
+    /// PyPy stores the vecinfo on `op._forwarded`; pyre keeps it in this
+    /// scheduler's pos-keyed store.
     ///
     /// `constant_of` resolves the optimizer's const-pool so the
     /// `resoperation.py:181-186 INT_SIGNEXT` branch can read `arg1.value`
@@ -812,15 +813,23 @@ impl VecScheduleState {
     /// directly because `_args[1]` IS the const; pyre's flat-OpRef
     /// encoding stores constants as a pool index, so the resolver fills
     /// the same role at the moment we populate the inline vecinfo slot.
-    pub fn setup_vectorization(&mut self, ops: &[Op], constant_of: &dyn Fn(OpRef) -> Option<i64>) {
-        for op in ops {
-            let info = if op.opcode == OpCode::IntSignext {
-                self.int_signext_vecinfo(op, constant_of)
-            } else {
-                self.vectorization_info_for_op(op)
-            };
-            self.set_forwarded_vecinfo(op.pos.get(), info);
-        }
+    pub(crate) fn set_op_forwarded_vecinfo(
+        &mut self,
+        op: &Op,
+        constant_of: &dyn Fn(OpRef) -> Option<i64>,
+    ) {
+        let info = if op.opcode == OpCode::IntSignext {
+            self.int_signext_vecinfo(op, constant_of)
+        } else {
+            self.vectorization_info_for_op(op)
+        };
+        self.set_forwarded_vecinfo(op.pos.get(), info);
+    }
+
+    /// vector.py:58-60 `op.set_forwarded(None)` for one op: drops the
+    /// stored vecinfo, the per-op body of `VectorLoop::teardown_vectorization`.
+    pub(crate) fn clear_op_forwarded_vecinfo(&mut self, opref: OpRef) {
+        self.vecinfo_cache.remove(&opref);
     }
 
     /// `resoperation.py:181-186 VectorizationInfo.__init__` INT_SIGNEXT

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -443,8 +443,12 @@ impl VectorizingOptimizer {
             return Err(VectorizeError::NotVectorizeable);
         }
 
-        // vector.py:237-240: analyse_index_calculations → reorder
-        let constant_of = |_opref: OpRef| -> Option<i64> { None };
+        // vector.py:237-240: analyse_index_calculations → reorder.
+        // resoperation.py:181 reads `op.getarg(1).value` off the inline
+        // ConstInt; the standalone pass has no Optimizer context, so an
+        // inline `OpRef::ConstInt` is the only — and the faithful — const
+        // source for INT_SIGNEXT bytesize and adjacent-ref index detection.
+        let constant_of = |opref: OpRef| -> Option<i64> { opref.as_const_int() };
         if let Some(graph) = self.analyse_index_calculations(loop_, &constant_of) {
             let schedule = schedule_operations(&graph);
             if schedule.len() == loop_.operations.len() {
@@ -1832,6 +1836,35 @@ mod tests {
         assert!(vloop.prefix_label.is_none());
         assert_eq!(vloop.jump.getarglist_copy().len(), 2);
         assert_eq!(vloop.operations.len(), 1);
+    }
+
+    /// `run_optimization`'s standalone resolver has no Optimizer context, so
+    /// an `INT_SIGNEXT(x, ConstInt(n))` must take arg1's bytesize from the
+    /// inline `OpRef::ConstInt` (resoperation.py:181 reads `arg1.value`).
+    /// Regression: the resolver previously returned `None` for every opref,
+    /// so `int_signext_vecinfo`'s fail-fast `.expect()` panicked on a valid
+    /// INT_SIGNEXT.
+    #[test]
+    fn int_signext_setup_resolves_inline_const_in_standalone_pass() {
+        let signext = Op::new(
+            OpCode::IntSignext,
+            &[
+                BoxRef::from_opref(OpRef::input_arg_int(0)),
+                BoxRef::from_opref(OpRef::const_int(4)),
+            ],
+        );
+        let mut ops = vec![signext];
+        assign_positions(&mut ops, 10);
+
+        let mut st = VecScheduleState::new(100);
+        // The standalone run_optimization resolver: inline consts only.
+        let constant_of = |opref: OpRef| -> Option<i64> { opref.as_const_int() };
+        st.setup_vectorization(&ops, &constant_of);
+
+        let info = st.forwarded_vecinfo(&ops[0]);
+        assert_eq!(info.datatype, 'i');
+        assert_eq!(info.bytesize, 4);
+        assert!(info.signed);
     }
 
     /// Streaming refactor: a 4-op loop runs through the VectorizingOptimizer

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -143,13 +143,16 @@ impl VectorLoop {
     /// `label`: include `self.label` at the front. When false, follow
     ///   `vector.py:87-90` and clear the vectorize-time scratch
     ///   (`set_forwarded(None)` upstream) from every emitted prefix op plus
-    ///   the jump. In majit the vectorize-time scratch lives on
-    ///   `VectorizationInfo`, so the equivalent is `clear_vecinfo()`.
+    ///   the jump. That scratch lives in the scheduler's pos-keyed forwarded
+    ///   store (`state`), not on the permanent `Op.vecinfo`, so the
+    ///   equivalent is `state.clear_op_forwarded_vecinfo(pos)` — clearing
+    ///   `Op.vecinfo` here would instead wipe VecOperationNew metadata.
     pub fn finaloplist(
         &self,
         jitcell_token: Option<&std::sync::Arc<majit_backend::JitCellToken>>,
         reset_label_token: bool,
         label: bool,
+        state: &mut VecScheduleState,
     ) -> Vec<Op> {
         // vector.py:63-79: descr wiring against the owning JitCellToken.
         if let Some(jcell) = jitcell_token {
@@ -198,11 +201,13 @@ impl VectorLoop {
         // vector.py:87-90: when not emitting the label op (i.e. the prefix
         // is the *only* thing being compiled this round, e.g. a bridge),
         // strip vectorization scratch so nothing leaks into the next pass.
+        // The scratch is the pos-keyed forwarded store, not the permanent
+        // `Op.vecinfo`; mirror `teardown_vectorization`.
         if !label {
             for op in &oplist {
-                op.clear_vecinfo();
+                state.clear_op_forwarded_vecinfo(op.pos.get());
             }
-            self.jump.clear_vecinfo();
+            state.clear_op_forwarded_vecinfo(self.jump.pos.get());
         }
         // vector.py:91
         oplist.extend(self.operations.iter().cloned());
@@ -692,10 +697,11 @@ impl VectorizingOptimizer {
         // for op in loop.align_operations: op.set_forwarded(None).
         // We hand the align_operations back through `loop_.align_operations`
         // (already populated by `unroll_loop_iterations` on the align arm);
-        // clearing vecinfo matches the upstream `set_forwarded(None)` reset
-        // so post-vectorize passes don't see stale VectorizationInfo.
+        // clearing the pos-keyed forwarded scratch matches the upstream
+        // `set_forwarded(None)` reset so post-vectorize passes don't see
+        // stale VectorizationInfo; the permanent `Op.vecinfo` is preserved.
         for op in &loop_.align_operations {
-            op.clear_vecinfo();
+            sched_state.clear_op_forwarded_vecinfo(op.pos.get());
         }
 
         // vector.py:172 `finally: loop.teardown_vectorization()`. The
@@ -710,7 +716,7 @@ impl VectorizingOptimizer {
         // compiler; None here skips the descr/token wiring (faithful for the
         // currently-disconnected compile path). `label=false` matches RPython's
         // default (the vector.py:271 call omits the `label` argument).
-        Ok(loop_.finaloplist(None, false, false))
+        Ok(loop_.finaloplist(None, false, false, &mut sched_state))
     }
 
     // ── vector.py:273-344: unroll_loop_iterations ──────────────────────
@@ -1241,7 +1247,7 @@ impl VectorizingOptimizer {
         loop_.teardown_vectorization(&mut sched_state);
 
         let include_label = loop_.prefix_label.is_none();
-        Some(loop_.finaloplist(None, false, include_label))
+        Some(loop_.finaloplist(None, false, include_label, &mut sched_state))
     }
 
     // ── Static variants for extend/combine (used by try_vectorize) ─────
@@ -1722,11 +1728,12 @@ mod tests {
         let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]);
         let vloop = VectorLoop::new(label, ops, jump);
 
-        let with_label = vloop.finaloplist(None, true, true);
+        let mut state = VecScheduleState::new(0);
+        let with_label = vloop.finaloplist(None, true, true, &mut state);
         assert_eq!(with_label.len(), 3); // Label + IntAdd + Jump
         assert_eq!(with_label[0].opcode, OpCode::Label);
 
-        let without_label = vloop.finaloplist(None, true, false);
+        let without_label = vloop.finaloplist(None, true, false, &mut state);
         assert_eq!(without_label.len(), 2); // IntAdd + Jump
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1893,10 +1893,7 @@ mod tests {
                 BoxRef::from_opref(OpRef::const_int(4)),
             ],
         );
-        let jump = Op::new(
-            OpCode::Jump,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
+        let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]);
         let mut body = vec![signext];
         assign_positions(&mut body, 10);
         let vloop = VectorLoop::new(label, body, jump);

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -32,7 +32,7 @@ pub use crate::optimizeopt::dependency::{Node, schedule_operations};
 pub use crate::optimizeopt::schedule::{
     AccumEntry, AccumPack, CostModel, GenericCostModel, GuardAnalysis, NotAProfitableLoop,
     NotAVectorizeableLoop, Pack, PackSet, VecScheduleState, VectorizeError,
-    are_adjacent_memory_refs, isomorphic, turn_into_vector, unpack_from_vector,
+    are_adjacent_memory_refs, isomorphic_with_state, turn_into_vector, unpack_from_vector,
 };
 
 // ── vector.py:35-40: copy_resop ────────────────────────────────────────
@@ -103,33 +103,6 @@ impl VectorLoop {
             ops[label_pos + 1..jump_pos].to_vec(),
             ops[jump_pos].clone(),
         ))
-    }
-
-    /// vector.py:54-56: setup_vectorization — attach VectorizationInfo to
-    /// each operation in the loop body.
-    pub fn setup_vectorization(&mut self) {
-        for op in &mut self.operations {
-            if !op.has_vecinfo() {
-                let mut vi = majit_ir::VectorizationInfo::new();
-                let tp = op.opcode.result_type();
-                let dt = match tp {
-                    majit_ir::Type::Float => 'f',
-                    majit_ir::Type::Void => '\0',
-                    _ => 'i',
-                };
-                if dt != '\0' {
-                    vi.setinfo(dt, -1, true);
-                }
-                op.set_vecinfo(vi);
-            }
-        }
-    }
-
-    /// vector.py:58-60: teardown_vectorization — remove VectorizationInfo.
-    pub fn teardown_vectorization(&mut self) {
-        for op in &mut self.operations {
-            op.clear_vecinfo();
-        }
     }
 
     /// vector.py:62-92: finaloplist — assemble the complete operation list
@@ -282,17 +255,14 @@ pub fn optimize_vector(
     // error path; on success we hand back the vectorized ops directly.
     let version = loop_.clone_loop();
 
-    // vector.py:135: loop.setup_vectorization()
-    loop_.setup_vectorization();
-
     let result = (|| -> Result<Vec<Op>, VectorizeError> {
-        // vector.py:142-143
+        // vector.py:142-143. `run_optimization` performs vector.py:135
+        // `loop.setup_vectorization()` itself, stamping each op's
+        // VectorizationInfo into the scheduler's forwarded cache (the
+        // `_forwarded` equivalent that `forwarded_vecinfo` reads).
         let mut opt = VectorizingOptimizer::new_with_params(cost_threshold, vec_size);
         opt.run_optimization(loop_)
     })();
-
-    // vector.py:172: finally: loop.teardown_vectorization()
-    loop_.teardown_vectorization();
 
     if result.is_err() {
         // vector.py:155 / :160: `return loop_info, version.loop.finaloplist()`.
@@ -581,13 +551,12 @@ impl VectorizingOptimizer {
                 return Err(VectorizeError::NotVectorizeable);
             }
             let datatype = 'i';
-            let bytesize: i32 = loop_
-                .operations
-                .iter()
-                .find(|op| op.pos.get() == seed)
-                .and_then(|op| op.get_vecinfo())
-                .map(|vi| vi.getbytesize() as i32)
-                .unwrap_or(8);
+            // schedule.py:838-840: bytesize = pack.getbytesize() — read the
+            // seed's forwarded VectorizationInfo from the same cache that
+            // VectorizationInfo(op) populated, not a separate inline slot.
+            let bytesize: i32 = sched_state
+                .forwarded_vecinfo_for_ref(seed, &loop_.operations)
+                .getbytesize() as i32;
             let vec_reg_size: i32 = self.vec_size as i32;
             let count = (vec_reg_size / bytesize) as usize;
             let signed = true;
@@ -865,7 +834,7 @@ impl VectorizingOptimizer {
                 let l_op = &graph.nodes[l_dep].op;
                 let r_op = &graph.nodes[r_dep].op;
                 // vector.py:438-439: isomorphic and lnode.is_before(rnode)
-                if isomorphic(l_op, r_op) && l_dep < r_dep {
+                if isomorphic_with_state(state, l_op, r_op) && l_dep < r_dep {
                     match packset.can_be_packed(state, l_dep, r_dep, Some(pack), false, graph) {
                         Ok(Some(pair)) => packset.add_pack(pair),
                         Err(_) => return,
@@ -909,7 +878,7 @@ impl VectorizingOptimizer {
                 let l_op = &graph.nodes[l_user].op;
                 let r_op = &graph.nodes[r_user].op;
                 // vector.py:454-455: isomorphic and lnode.is_before(rnode)
-                if isomorphic(l_op, r_op) && l_user < r_user {
+                if isomorphic_with_state(state, l_op, r_op) && l_user < r_user {
                     match packset.can_be_packed(state, l_user, r_user, Some(pack), true, graph) {
                         Ok(Some(pair)) => packset.add_pack(pair),
                         Err(_) => return,
@@ -1117,13 +1086,12 @@ impl VectorizingOptimizer {
                 return None;
             }
             let datatype = 'i';
-            let bytesize: i32 = loop_
-                .operations
-                .iter()
-                .find(|op| op.pos.get() == seed)
-                .and_then(|op| op.get_vecinfo())
-                .map(|vi| vi.getbytesize() as i32)
-                .unwrap_or(8);
+            // schedule.py:838-840: bytesize = pack.getbytesize() — read the
+            // seed's forwarded VectorizationInfo from the same cache that
+            // VectorizationInfo(op) populated, not a separate inline slot.
+            let bytesize: i32 = sched_state
+                .forwarded_vecinfo_for_ref(seed, &loop_.operations)
+                .getbytesize() as i32;
             let vec_reg_size: i32 = self.vec_size as i32;
             let count = (vec_reg_size / bytesize) as usize;
             let signed = true;
@@ -2540,6 +2508,7 @@ mod tests {
 
     #[test]
     fn test_isomorphic_same_opcode() {
+        let mut state = VecScheduleState::new(0);
         let a = Op::new(
             OpCode::IntAdd,
             &[
@@ -2554,11 +2523,12 @@ mod tests {
                 BoxRef::from_opref(OpRef::input_arg_int(103)),
             ],
         );
-        assert!(isomorphic(&a, &b));
+        assert!(isomorphic_with_state(&mut state, &a, &b));
     }
 
     #[test]
     fn test_isomorphic_different_opcode() {
+        let mut state = VecScheduleState::new(0);
         let a = Op::new(
             OpCode::IntAdd,
             &[
@@ -2573,7 +2543,7 @@ mod tests {
                 BoxRef::from_opref(OpRef::input_arg_int(103)),
             ],
         );
-        assert!(!isomorphic(&a, &b));
+        assert!(!isomorphic_with_state(&mut state, &a, &b));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1175,6 +1175,13 @@ impl VectorizingOptimizer {
             }
         }
 
+        // vector.py:515-520 schedule(): post_schedule runs only when the cost
+        // model is profitable; an unprofitable loop returns before post_schedule
+        // mutates loop_ (matches the run_optimization path and PyPy).
+        if !sched_state.costmodel.profitable() {
+            return None;
+        }
+
         // schedule.py:762-779: VecScheduleState.post_schedule. Moves
         // invariant_oplist into loop_.prefix and routes invariant_vector_vars
         // through prefix_label/jump renaming. Reachable in the streaming path
@@ -1182,10 +1189,6 @@ impl VectorizingOptimizer {
         // the JUMP, builds this VectorLoop, and emits the finaloplist result —
         // so prefix ops land BEFORE the loop entry, not inside the body.
         sched_state.post_schedule(loop_, &mut seen);
-
-        if !sched_state.costmodel.profitable() {
-            return None;
-        }
 
         // Emit the original loop label only when post_schedule did NOT mint a
         // prefix_label (which replaces the label as the vectorized loop entry):

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -644,22 +644,19 @@ impl VectorizingOptimizer {
             }
         }
 
-        // schedule.py:762-779: VecScheduleState.post_schedule. Mirrors the call
-        // at the tail of schedule.py:103-106 schedule() (prepare → walk_and_emit →
-        // post_schedule), which runs unconditionally — moving invariant_oplist into
-        // loop.prefix and routing invariant_vector_vars through prefix_label/jump.
-        sched_state.post_schedule(loop_, &mut seen);
-
-        // vector.py:257-258: profitability check — runs AFTER post_schedule
-        // (schedule.py:103-106 runs post_schedule inside schedule(); the
-        // `if not state.profitable(): raise` check is the next statement at
-        // vector.py:257). A distinct error variant lets the caller react to
-        // cost-model rejection separately from a structural bail. On this Err
-        // the optimize_vector caller restores the pre-vectorize snapshot
-        // (vector.rs `*loop_ = version`), discarding the post_schedule mutation.
+        // vector.py:515-520 schedule(): `walk_and_emit` then, only when the
+        // cost model is profitable, `post_schedule()`. An unprofitable loop
+        // returns *before* post_schedule, so loop_ is never mutated by it.
+        // vector.py:256-258 then raises NotAProfitableLoop on the same check;
+        // run_optimization collapses both into this single early Err.
         if !sched_state.costmodel.profitable() {
             return Err(VectorizeError::NotProfitable);
         }
+
+        // schedule.py:762-779: VecScheduleState.post_schedule — moves
+        // invariant_oplist into loop.prefix and routes invariant_vector_vars
+        // through prefix_label/jump.
+        sched_state.post_schedule(loop_, &mut seen);
 
         // vector.py:267-269: extra_before_label = loop.align_operations;
         // for op in loop.align_operations: op.set_forwarded(None).

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -32,7 +32,7 @@ pub use crate::optimizeopt::dependency::{Node, schedule_operations};
 pub use crate::optimizeopt::schedule::{
     AccumEntry, AccumPack, CostModel, GenericCostModel, GuardAnalysis, NotAProfitableLoop,
     NotAVectorizeableLoop, Pack, PackSet, VecScheduleState, VectorizeError,
-    are_adjacent_memory_refs, isomorphic_with_state, turn_into_vector, unpack_from_vector,
+    are_adjacent_memory_refs, isomorphic, turn_into_vector, unpack_from_vector,
 };
 
 // ── vector.py:35-40: copy_resop ────────────────────────────────────────
@@ -103,6 +103,31 @@ impl VectorLoop {
             ops[label_pos + 1..jump_pos].to_vec(),
             ops[jump_pos].clone(),
         ))
+    }
+
+    /// vector.py:54-56: setup_vectorization — attach a `VectorizationInfo`
+    /// to every loop operation (`for op in self.operations:
+    /// op.set_forwarded(VectorizationInfo(op))`). PyPy stores it on
+    /// `op._forwarded`; pyre's flat-OpRef operands keep the per-op vecinfo
+    /// in the scheduler's pos-keyed store, so `state` carries it. INT_SIGNEXT
+    /// reads arg1's constant through `constant_of` (resoperation.py:181).
+    pub fn setup_vectorization(
+        &self,
+        state: &mut VecScheduleState,
+        constant_of: &dyn Fn(OpRef) -> Option<i64>,
+    ) {
+        for op in &self.operations {
+            state.set_op_forwarded_vecinfo(op, constant_of);
+        }
+    }
+
+    /// vector.py:58-60: teardown_vectorization — drop every loop op's
+    /// `VectorizationInfo` (`for op in self.operations:
+    /// op.set_forwarded(None)`), clearing the scheduler's forwarded store.
+    pub fn teardown_vectorization(&self, state: &mut VecScheduleState) {
+        for op in &self.operations {
+            state.clear_op_forwarded_vecinfo(op.pos.get());
+        }
     }
 
     /// vector.py:62-92: finaloplist — assemble the complete operation list
@@ -256,10 +281,11 @@ pub fn optimize_vector(
     let version = loop_.clone_loop();
 
     let result = (|| -> Result<Vec<Op>, VectorizeError> {
-        // vector.py:142-143. `run_optimization` performs vector.py:135
-        // `loop.setup_vectorization()` itself, stamping each op's
-        // VectorizationInfo into the scheduler's forwarded cache (the
-        // `_forwarded` equivalent that `forwarded_vecinfo` reads).
+        // vector.py:142-143. `run_optimization` owns the scheduler state, so
+        // it calls vector.py:135 `loop.setup_vectorization()` (and the
+        // vector.py:172 `teardown_vectorization()`) against that state
+        // internally, stamping each op's VectorizationInfo into the
+        // `_forwarded` equivalent that `forwarded_vecinfo` reads.
         let mut opt = VectorizingOptimizer::new_with_params(cost_threshold, vec_size);
         opt.run_optimization(loop_)
     })();
@@ -475,7 +501,7 @@ impl VectorizingOptimizer {
         let graph = DependencyGraph::build(&loop_.operations, &constant_of);
         // VecScheduleState is created before find_adjacent_memory_refs/
         // extend_packset because PackSet::can_be_packed now consults it via
-        // isomorphic_with_state (vector.py: packset.can_be_packed reaches
+        // isomorphic (vector.py: packset.can_be_packed reaches
         // state for accumulation/invariant lookups; pre-state form was a
         // pre-rebase fork).
         let start_pos = loop_
@@ -487,7 +513,7 @@ impl VectorizingOptimizer {
             + 1;
         let mut sched_state = VecScheduleState::new(start_pos);
         // vector.py:135 loop.setup_vectorization()
-        sched_state.setup_vectorization(&loop_.operations, &constant_of);
+        loop_.setup_vectorization(&mut sched_state, &constant_of);
         // vector.py:606-609 CostModel.__init__: savings = 0, threshold stored
         // separately. Initializing savings = self.cost_threshold inverted the
         // gate — a positive threshold made profitable() trivially true.
@@ -672,6 +698,11 @@ impl VectorizingOptimizer {
             op.clear_vecinfo();
         }
 
+        // vector.py:172 `finally: loop.teardown_vectorization()`. The
+        // earlier `?`/`return Err` exits drop `sched_state` instead, which
+        // discards the same pos-keyed forwarded store.
+        loop_.teardown_vectorization(&mut sched_state);
+
         // vector.py:271: return loop.finaloplist(jitcell_token, reset_label_token=False).
         // post_schedule already set loop_.operations / prefix / prefix_label / jump,
         // so finaloplist splices [prefix][prefix_label] operations [jump].
@@ -835,7 +866,7 @@ impl VectorizingOptimizer {
                 let l_op = &graph.nodes[l_dep].op;
                 let r_op = &graph.nodes[r_dep].op;
                 // vector.py:438-439: isomorphic and lnode.is_before(rnode)
-                if isomorphic_with_state(state, l_op, r_op) && l_dep < r_dep {
+                if isomorphic(state, l_op, r_op) && l_dep < r_dep {
                     match packset.can_be_packed(state, l_dep, r_dep, Some(pack), false, graph) {
                         Ok(Some(pair)) => packset.add_pack(pair),
                         Err(_) => return,
@@ -879,7 +910,7 @@ impl VectorizingOptimizer {
                 let l_op = &graph.nodes[l_user].op;
                 let r_op = &graph.nodes[r_user].op;
                 // vector.py:454-455: isomorphic and lnode.is_before(rnode)
-                if isomorphic_with_state(state, l_op, r_op) && l_user < r_user {
+                if isomorphic(state, l_op, r_op) && l_user < r_user {
                     match packset.can_be_packed(state, l_user, r_user, Some(pack), true, graph) {
                         Ok(Some(pair)) => packset.add_pack(pair),
                         Err(_) => return,
@@ -1015,7 +1046,7 @@ impl VectorizingOptimizer {
         // value for bytesize (resoperation.py:181); the constant_of
         // resolver feeds that through so the inline vecinfo slot matches
         // PyPy's VectorizationInfo(op) constructor.
-        sched_state.setup_vectorization(&loop_.operations, &constant_of);
+        loop_.setup_vectorization(&mut sched_state, &constant_of);
 
         // Phase 1: Schedule operations for ILP before packing.
         let dep_graph = DependencyGraph::build(&loop_.operations, &constant_of);
@@ -1026,7 +1057,7 @@ impl VectorizingOptimizer {
                 .map(|&i| loop_.operations[i].clone())
                 .collect();
             loop_.operations = scheduled;
-            sched_state.setup_vectorization(&loop_.operations, &constant_of);
+            loop_.setup_vectorization(&mut sched_state, &constant_of);
         }
 
         // Phase 2: Rebuild dependency graph and find packs.
@@ -1204,6 +1235,11 @@ impl VectorizingOptimizer {
         // correctly targets prefix_label. TODO: thread a JitCellToken when the
         // compile path is un-gated so finaloplist mints fresh prefix-label
         // tokens (vector.rs:156-185).
+        // vector.py:172 `finally: loop.teardown_vectorization()`. The earlier
+        // `return None` exits drop `sched_state` instead, discarding the same
+        // pos-keyed forwarded store.
+        loop_.teardown_vectorization(&mut sched_state);
+
         let include_label = loop_.prefix_label.is_none();
         Some(loop_.finaloplist(None, false, include_label))
     }
@@ -1846,6 +1882,10 @@ mod tests {
     /// INT_SIGNEXT.
     #[test]
     fn int_signext_setup_resolves_inline_const_in_standalone_pass() {
+        let label = Op::new(
+            OpCode::Label,
+            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
+        );
         let signext = Op::new(
             OpCode::IntSignext,
             &[
@@ -1853,15 +1893,20 @@ mod tests {
                 BoxRef::from_opref(OpRef::const_int(4)),
             ],
         );
-        let mut ops = vec![signext];
-        assign_positions(&mut ops, 10);
+        let jump = Op::new(
+            OpCode::Jump,
+            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
+        );
+        let mut body = vec![signext];
+        assign_positions(&mut body, 10);
+        let vloop = VectorLoop::new(label, body, jump);
 
         let mut st = VecScheduleState::new(100);
         // The standalone run_optimization resolver: inline consts only.
         let constant_of = |opref: OpRef| -> Option<i64> { opref.as_const_int() };
-        st.setup_vectorization(&ops, &constant_of);
+        vloop.setup_vectorization(&mut st, &constant_of);
 
-        let info = st.forwarded_vecinfo(&ops[0]);
+        let info = st.forwarded_vecinfo(&vloop.operations[0]);
         assert_eq!(info.datatype, 'i');
         assert_eq!(info.bytesize, 4);
         assert!(info.signed);
@@ -2556,7 +2601,7 @@ mod tests {
                 BoxRef::from_opref(OpRef::input_arg_int(103)),
             ],
         );
-        assert!(isomorphic_with_state(&mut state, &a, &b));
+        assert!(isomorphic(&mut state, &a, &b));
     }
 
     #[test]
@@ -2576,7 +2621,7 @@ mod tests {
                 BoxRef::from_opref(OpRef::input_arg_int(103)),
             ],
         );
-        assert!(!isomorphic_with_state(&mut state, &a, &b));
+        assert!(!isomorphic(&mut state, &a, &b));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -6826,7 +6826,10 @@ impl<M: Clone> MetaInterp<M> {
                 let is_invalid_loop =
                     self.note_jit_panic_or_reraise(payload, "compile_simple_loop", green_key);
                 if is_invalid_loop && crate::majit_log_enabled() {
-                    eprintln!("[jit] compile_simple_loop: InvalidLoop at key={}", green_key);
+                    eprintln!(
+                        "[jit] compile_simple_loop: InvalidLoop at key={}",
+                        green_key
+                    );
                 }
                 // compile.py:228-230: trace.cut_at(cut_at); return None
                 self.warm_state.abort_tracing(green_key, false);

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -9546,18 +9546,17 @@ impl<M: Clone> MetaInterp<M> {
             match bridge_result {
                 Ok(r) => r,
                 Err(payload) => {
-                    if crate::majit_log_enabled() {
-                        let msg = payload
-                            .downcast_ref::<String>()
-                            .map(|s| s.as_str())
-                            .or_else(|| payload.downcast_ref::<&str>().copied())
-                            .unwrap_or("unknown panic");
+                    let is_invalid_loop = self.note_jit_panic_or_reraise(
+                        payload,
+                        "compile_bridge backend",
+                        green_key,
+                    );
+                    if is_invalid_loop && crate::majit_log_enabled() {
                         eprintln!(
-                            "[jit] bridge compile_bridge panicked key={} guard={}: {msg}",
+                            "[jit] bridge compile_bridge InvalidLoop key={} guard={}",
                             green_key, fail_index
                         );
                     }
-                    self.note_jit_panic_or_reraise(payload, "compile_bridge backend", green_key);
                     Err(majit_backend::BackendError::CompilationFailed(
                         "panic during bridge compilation".to_string(),
                     ))

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -998,6 +998,12 @@ pub struct MetaInterp<M: Clone> {
     pub(crate) exported_state: Option<crate::optimizeopt::unroll::ExportedState>,
     /// pyjitpl.py:2373: number of cancelled compilation attempts.
     pub(crate) cancel_count: u32,
+    /// issue #108: count of non-`InvalidLoop` panics caught during JIT
+    /// compilation (a JIT bug, not a legitimate trace abort). In strict
+    /// builds these re-raise; in release they are swallowed for graceful
+    /// degradation, so this counter is the telemetry that the JIT was
+    /// silently disabled for some traces. `MAJIT_STATS=1` prints it on exit.
+    pub(crate) internal_compile_panics: u32,
     /// Actual green_key the last compile_loop stored under. May differ
     /// from the tracing green_key when cross-loop cut retargets to the
     /// inner loop's key (compile.py:269).
@@ -1275,6 +1281,10 @@ pub struct JitStats {
     pub loops_aborted: usize,
     pub bridges_compiled: usize,
     pub guard_failures: usize,
+    /// issue #108: non-`InvalidLoop` panics swallowed during compilation
+    /// (graceful degradation in release). Non-zero means the JIT was
+    /// silently disabled for some traces by an internal bug.
+    pub internal_compile_panics: u32,
 }
 
 /// Callback hooks for JIT events (compilation, guard failures, etc.).
@@ -2049,6 +2059,7 @@ impl<M: Clone> MetaInterp<M> {
             retracing_from: None,
             exported_state: None,
             cancel_count: 0,
+            internal_compile_panics: 0,
             last_compiled_key: None,
             num_scalar_inputargs: 0,
             potential_retrace_position: None,
@@ -3136,6 +3147,7 @@ impl<M: Clone> MetaInterp<M> {
             loops_aborted: self.stats.loops_aborted,
             bridges_compiled: self.stats.bridges_compiled,
             guard_failures: self.stats.guard_failures,
+            internal_compile_panics: self.internal_compile_panics,
         }
     }
 
@@ -4853,7 +4865,12 @@ impl<M: Clone> MetaInterp<M> {
                                 let ni = simple_opt.final_num_inputs();
                                 (retry_ops, ni)
                             }
-                            Err(_) => {
+                            Err(payload) => {
+                                self.note_jit_panic_or_reraise(
+                                    payload,
+                                    "retry optimize (no unroll)",
+                                    green_key,
+                                );
                                 self.warm_state.abort_tracing(green_key, false);
                                 self.exported_state = None;
                                 return CompileOutcome::Aborted;
@@ -5130,16 +5147,11 @@ impl<M: Clone> MetaInterp<M> {
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(e) => {
-                let is_invalid_loop = e.downcast_ref::<crate::optimize::InvalidLoop>().is_some();
-                if crate::debug::have_debug_prints() {
-                    let kind = if is_invalid_loop {
-                        "InvalidLoop"
-                    } else {
-                        "panic"
-                    };
+                let is_invalid_loop = self.note_jit_panic_or_reraise(e, "compile_loop", green_key);
+                if is_invalid_loop && crate::debug::have_debug_prints() {
                     crate::debug::log_one(
                         "jit-abort",
-                        &format!("compile_loop {kind}, aborting trace at key={green_key}"),
+                        &format!("compile_loop InvalidLoop, aborting trace at key={green_key}"),
                     );
                 }
                 // compile.py:288 parity: preserve preamble target_tokens
@@ -5338,6 +5350,39 @@ impl<M: Clone> MetaInterp<M> {
     fn cancelled_too_many_times(&self) -> bool {
         let limit = self.warm_state.max_unroll_loops();
         self.cancel_count > limit
+    }
+
+    /// Classify a panic payload caught from a JIT compile/optimize step and
+    /// return whether it is RPython's legitimate `InvalidLoop` abort signal.
+    ///
+    /// A non-`InvalidLoop` payload is always a JIT bug — `InvalidLoop` is the
+    /// only "give up on this trace" signal raised as a panic; every other
+    /// panic (e.g. `OpRef::raw()` on a handle) indicates broken codegen. In
+    /// strict builds (`jit_strict_mode`) the panic is re-raised so it fails
+    /// loudly instead of silently falling back to the interpreter and masking
+    /// the bug behind correct output; otherwise it is logged and counted in
+    /// `internal_compile_panics`, and the caller degrades the trace gracefully.
+    fn note_jit_panic_or_reraise(
+        &mut self,
+        payload: Box<dyn std::any::Any + Send>,
+        where_: &str,
+        green_key: u64,
+    ) -> bool {
+        if payload
+            .downcast_ref::<crate::optimize::InvalidLoop>()
+            .is_some()
+        {
+            return true;
+        }
+        if crate::jit_strict_mode() {
+            std::panic::resume_unwind(payload);
+        }
+        self.internal_compile_panics += 1;
+        eprintln!(
+            "[jit] internal compile panic in {where_} at key={green_key}: JIT \
+             disabled for this trace (set MAJIT_STRICT=1 to fail hard)"
+        );
+        false
     }
 
     /// pyjitpl.py:2389 attribute access — `self.partial_trace`.
@@ -5992,13 +6037,8 @@ impl<M: Clone> MetaInterp<M> {
         };
         let compile_result = match compile_result {
             Ok(r) => r,
-            Err(_) => {
-                if crate::debug::have_debug_prints() {
-                    crate::debug::log_one(
-                        "jit-abort",
-                        &format!("compile_retrace panicked at key={green_key}"),
-                    );
-                }
+            Err(payload) => {
+                self.note_jit_panic_or_reraise(payload, "compile_retrace", green_key);
                 self.warm_state.abort_tracing(green_key, false);
                 return false;
             }
@@ -6783,16 +6823,10 @@ impl<M: Clone> MetaInterp<M> {
         let optimized_ops = match optimize_result {
             Ok(ops) => ops,
             Err(payload) => {
-                if crate::majit_log_enabled() {
-                    if payload
-                        .downcast_ref::<crate::optimize::InvalidLoop>()
-                        .is_some()
-                    {
-                        eprintln!(
-                            "[jit] compile_simple_loop: InvalidLoop at key={}",
-                            green_key
-                        );
-                    }
+                let is_invalid_loop =
+                    self.note_jit_panic_or_reraise(payload, "compile_simple_loop", green_key);
+                if is_invalid_loop && crate::majit_log_enabled() {
+                    eprintln!("[jit] compile_simple_loop: InvalidLoop at key={}", green_key);
                 }
                 // compile.py:228-230: trace.cut_at(cut_at); return None
                 self.warm_state.abort_tracing(green_key, false);
@@ -8906,7 +8940,10 @@ impl<M: Clone> MetaInterp<M> {
         };
         let compile_result = match compile_result {
             Ok(r) => r,
-            Err(_) => return false,
+            Err(payload) => {
+                self.note_jit_panic_or_reraise(payload, "compile_entry_bridge backend", green_key);
+                return false;
+            }
         };
 
         match compile_result {
@@ -9505,20 +9542,21 @@ impl<M: Clone> MetaInterp<M> {
             };
             match bridge_result {
                 Ok(r) => r,
-                Err(e) => {
+                Err(payload) => {
                     if crate::majit_log_enabled() {
+                        let msg = payload
+                            .downcast_ref::<String>()
+                            .map(|s| s.as_str())
+                            .or_else(|| payload.downcast_ref::<&str>().copied())
+                            .unwrap_or("unknown panic");
                         eprintln!(
-                            "[jit] bridge compile_bridge panicked key={} guard={}: {:?}",
-                            green_key,
-                            fail_index,
-                            e.downcast_ref::<String>()
-                                .map(|s| s.as_str())
-                                .or_else(|| e.downcast_ref::<&str>().copied())
-                                .unwrap_or("unknown panic")
+                            "[jit] bridge compile_bridge panicked key={} guard={}: {msg}",
+                            green_key, fail_index
                         );
                     }
+                    self.note_jit_panic_or_reraise(payload, "compile_bridge backend", green_key);
                     Err(majit_backend::BackendError::CompilationFailed(
-                        "Cranelift panic during bridge compilation".to_string(),
+                        "panic during bridge compilation".to_string(),
                     ))
                 }
             }

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -55,22 +55,27 @@ def bold(s):   return f"\033[1m{s}\033[0m"
 
 # ── Child-process user CPU time ──────────────────────────────────────
 
-def _run_timed_unix(args, timeout_s):
+def _run_timed_unix(args, timeout_s, env=None):
     import resource
     before = resource.getrusage(resource.RUSAGE_CHILDREN)
     try:
         proc = subprocess.run(
-            args, stdout=subprocess.PIPE,
-            timeout=timeout_s,
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=timeout_s, env=env,
         )
     except subprocess.TimeoutExpired:
-        return "", 0.0, 124
+        return "", 0.0, 124, ""
     after = resource.getrusage(resource.RUSAGE_CHILDREN)
     utime = max(after.ru_utime - before.ru_utime, 0.0)
-    return proc.stdout.decode("utf-8", errors="replace"), utime, proc.returncode
+    return (
+        proc.stdout.decode("utf-8", errors="replace"),
+        utime,
+        proc.returncode,
+        proc.stderr.decode("utf-8", errors="replace"),
+    )
 
 
-def _run_timed_win32(args, timeout_s):
+def _run_timed_win32(args, timeout_s, env=None):
     import ctypes
     from ctypes import wintypes
 
@@ -107,19 +112,19 @@ def _run_timed_win32(args, timeout_s):
     job = kernel32.CreateJobObjectW(None, None)
 
     proc = subprocess.Popen(
-        args, stdout=subprocess.PIPE,
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
     )
     # Assigning right after Popen catches launchers like pypy3.exe before they
     # spawn their interpreter child; descendants inherit job membership.
     assigned = bool(kernel32.AssignProcessToJobObject(job, int(proc._handle)))
 
     try:
-        stdout_bytes, _ = proc.communicate(timeout=timeout_s)
+        stdout_bytes, stderr_bytes = proc.communicate(timeout=timeout_s)
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.communicate()
         kernel32.CloseHandle(job)
-        return "", 0.0, 124
+        return "", 0.0, 124, ""
 
     utime = 0.0
     JobObjectBasicAndIoAccountingInformation = 8
@@ -145,22 +150,72 @@ def _run_timed_win32(args, timeout_s):
             utime = ((ut.dwHighDateTime << 32) | ut.dwLowDateTime) / 1e7
     kernel32.CloseHandle(job)
     utime += WIN_TIMER_QUANTUM_S
-    return stdout_bytes.decode("utf-8", errors="replace"), utime, proc.returncode
+    return (
+        stdout_bytes.decode("utf-8", errors="replace"),
+        utime,
+        proc.returncode,
+        (stderr_bytes or b"").decode("utf-8", errors="replace"),
+    )
 
 
-def run_timed(args, timeout_s=None):
-    """Run *args*, return (stdout_str, user_cpu_seconds, returncode).
+def run_timed(args, timeout_s=None, env=None):
+    """Run *args*, return (stdout_str, user_cpu_seconds, returncode, stderr_str).
 
-    returncode 124 = timeout (matching coreutils convention).
+    returncode 124 = timeout (matching coreutils convention). *env* (when
+    given) replaces the child environment (pass a full os.environ copy plus
+    extras).
     """
     if sys.platform == "win32":
-        out, t, rc = _run_timed_win32(args, timeout_s)
+        out, t, rc, err = _run_timed_win32(args, timeout_s, env)
     else:
-        out, t, rc = _run_timed_unix(args, timeout_s)
+        out, t, rc, err = _run_timed_unix(args, timeout_s, env)
     # PyPy/CPython on Windows emit CRLF in stdout text mode; Rust's println!
     # emits LF on all platforms. Normalize so output comparisons aren't
     # platform-sensitive (and snapshots stay portable).
-    return out.replace("\r\n", "\n"), t, rc
+    return out.replace("\r\n", "\n"), t, rc, err
+
+
+def pyre_env():
+    """Child environment for pyre runs: strict JIT plus one-line stats.
+
+    MAJIT_STRICT=1 re-raises internal compile panics instead of silently
+    falling back to the interpreter, so a JIT bug surfaces as a crash here
+    rather than as correct-but-uncompiled output. MAJIT_STATS=1 prints the
+    `[jit-stats]` line that `_jit_panic_reason` inspects.
+    """
+    env = dict(os.environ)
+    env["MAJIT_STRICT"] = "1"
+    env["MAJIT_STATS"] = "1"
+    return env
+
+
+def _jit_panic_reason(stderr):
+    """Return a failure reason if *stderr* shows a JIT-level Rust panic or a
+    nonzero internal_compile_panics stat, else None.
+
+    A Rust panic prints 'panicked at' via the default hook (InvalidLoop is
+    suppressed by pyre's panic hook, so legitimate trace aborts never appear
+    here). A nonzero internal_compile_panics in the `[jit-stats]` line means an
+    internal compile bug fell back to the interpreter (only reachable in a
+    non-strict build; under MAJIT_STRICT the panic re-raises and shows up as
+    'panicked' plus a nonzero exit instead).
+    """
+    if not stderr:
+        return None
+    if "panicked" in stderr:
+        for line in stderr.splitlines():
+            if "panicked" in line:
+                return f"rust panic: {line.strip()[:80]}"
+        return "rust panic"
+    for line in stderr.splitlines():
+        if line.startswith("[jit-stats]") and "internal_compile_panics=" in line:
+            field = line.split("internal_compile_panics=", 1)[1].split()[0]
+            try:
+                if int(field) > 0:
+                    return f"internal_compile_panics={field}"
+            except ValueError:
+                pass
+    return None
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -405,9 +460,16 @@ class Check:
         sys.stdout.write(f"    {backend:<10s}")
         sys.stdout.flush()
 
-        output, elapsed, code = run_timed(
-            [pyre_bin, script], timeout_s=effective_timeout,
+        output, elapsed, code, stderr = run_timed(
+            [pyre_bin, script], timeout_s=effective_timeout, env=pyre_env(),
         )
+
+        panic_reason = _jit_panic_reason(stderr)
+        if panic_reason:
+            self._record(backend, False, name, panic_reason)
+            print(f"{red('JIT-PANIC')}  {panic_reason}")
+            self._append_comparison(backend, name, t_cpython, t_pypy, "FAIL")
+            return
 
         if code != 0:
             if code == 124:
@@ -504,7 +566,7 @@ class Check:
         if need_cpython:
             sys.stdout.write(f"    {'cpython':<10s}")
             sys.stdout.flush()
-            cpython_output, t_cpu, cpython_code = run_timed([PYTHON3, script])
+            cpython_output, t_cpu, cpython_code, _ = run_timed([PYTHON3, script])
             t_cpython = f"{t_cpu:.2f}"
             if cpython_code != 0:
                 print(f"{red('CRASH')} (exit {cpython_code})")
@@ -513,7 +575,7 @@ class Check:
 
         sys.stdout.write(f"    {'pypy':<10s}")
         sys.stdout.flush()
-        pypy_output, pypy_cpu, pypy_code = run_timed([PYPY3, script])
+        pypy_output, pypy_cpu, pypy_code, _ = run_timed([PYPY3, script])
         t_pypy = f"{pypy_cpu:.2f}" if pypy_code == 0 else "-"
         if pypy_code != 0:
             print(f"{red('CRASH')} (exit {pypy_code})")
@@ -558,7 +620,7 @@ class Check:
 
         sys.stdout.write(f"    {'cpython':<10s}")
         sys.stdout.flush()
-        cpython_output, cpython_time, cpython_code = run_timed(
+        cpython_output, cpython_time, cpython_code, _ = run_timed(
             [PYTHON3, path], timeout_s=effective_timeout,
         )
         if cpython_code != 0:
@@ -576,7 +638,7 @@ class Check:
 
         sys.stdout.write(f"    {'pypy':<10s}")
         sys.stdout.flush()
-        pypy_output, pypy_time, pypy_code = run_timed(
+        pypy_output, pypy_time, pypy_code, _ = run_timed(
             [PYPY3, path], timeout_s=effective_timeout,
         )
         if pypy_code != 0:

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5973,6 +5973,13 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 return Err(PyError::stop_iteration());
             }
             let result = crate::call::call_function_impl_result(callable, &[])?;
+            // `calliter_iternext` re-checks `it_callable` after the call: the
+            // callable may have re-entered `next()` on this same iterator and
+            // latched it to `PY_NULL`, exhausting it; discard the result and
+            // stay stopped rather than comparing a stale value to the sentinel.
+            if ci::w_callable_iterator_get_callable(obj).is_null() {
+                return Err(PyError::stop_iteration());
+            }
             let sentinel = ci::w_callable_iterator_get_sentinel(obj);
             if is_true(compare(result, sentinel, CompareOp::Eq)?) {
                 ci::w_callable_iterator_set_callable(obj, pyre_object::PY_NULL);

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -168,6 +168,27 @@ fn real_main(binary_name: &str) {
     }
 }
 
+/// Print a one-line JIT statistics summary to stderr when `MAJIT_STATS` is
+/// set. `internal_compile_panics > 0` means an internal JIT bug silently
+/// disabled compilation for some traces (graceful degradation in release);
+/// `check.py` asserts it stays 0. Must be called before any `process::exit`
+/// since exits skip destructors.
+fn maybe_print_jit_stats() {
+    if std::env::var_os("MAJIT_STATS").is_none() {
+        return;
+    }
+    let stats = pyre_jit::eval::driver_pair().0.get_stats();
+    eprintln!(
+        "[jit-stats] loops_compiled={} bridges_compiled={} loops_aborted={} \
+         guard_failures={} internal_compile_panics={}",
+        stats.loops_compiled,
+        stats.bridges_compiled,
+        stats.loops_aborted,
+        stats.guard_failures,
+        stats.internal_compile_panics,
+    );
+}
+
 fn run_source(source: &str, mode: Mode, filename: &str) {
     let code = match compile_source_with_filename(source, mode, filename) {
         Ok(code) => code,
@@ -225,10 +246,13 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
         Err(e) => {
             if e.kind == PyErrorKind::SystemExit {
                 let code: i32 = e.message.parse().unwrap_or(0);
+                maybe_print_jit_stats();
                 std::process::exit(code);
             }
+            maybe_print_jit_stats();
             pyre_interpreter::eprint_exception(&e, true);
             std::process::exit(1);
         }
     }
+    maybe_print_jit_stats();
 }


### PR DESCRIPTION
Fix #108

## Summary

Replaces inline moving-GC pointers in the **live op-graph** with a GC-traced
handle table, so ref constants survive a moving collection without each `Op`
holding a raw `GcRef` the GC would have to find and forward in place. This
mirrors RPython's single-`ConstPtr`-object model (`history.py:314`): one
GC-walked slot per ref constant rather than N inline copies. `ConstInt` /
`ConstFloat` stay inline (no GC interest).

`OpRef::ConstPtr(GcRef)` is **kept** for the byte-trace / transient
materialization form, matching `opencoder.py:328` (`ConstPtr(self.trace._refs[v])`),
whose backing list is already GC-tracked separately. Only the live op-graph
producers switch to handles.

### Const-ref handle table (#108)

- `ConstRefTable` owned by `MetaInterp` with a registered GC root walker;
  append-only, no dedup, slot 0 = `NULL_HANDLE` = `GcRef::NULL`, so
  `handle == 0 ⟺ NULL`. New `OpRef::ConstRefHandle(u32)` variant.
- Tracing/optimizer/history/frame/virtualizable producers mint handles via
  `TraceCtx::const_ref` / `const_from_value` when the table pointer is wired
  (null table → inline `ConstPtr`, for unit tests).
- All optimizer const-value readers and the backend const-read chokepoints are
  made handle-aware. Boundary resolution uses a disjoint-key trick: handle keys
  are small `u32` without `CONST_BIT`, const-namespace `raw()` keys carry it, so
  both share the backend `constants` pool. `build_const_ref_bits` scans
  args+fail_args and merges resolved bits via `set_const_ref_bits`.
- GC-rewrite (`is_null_constant`, `resolve_constant`) and cranelift operand
  resolvers handle the new variant (classification via `is_constant()`, value via
  a `const_ref_handle()` arm) — fixing a latent reader path that previously
  `raw()`-panicked on a handle.

### JIT silent-disablement hardening

While landing the above, a class of bug surfaced: a non-`InvalidLoop` panic
during compilation was caught and treated like a legitimate trace abort, so a
codegen bug fell back to the interpreter and produced correct output with the
JIT silently disabled — invisible to stdout-only benches.

- `jit_strict_mode()` (on under `debug_assertions` or `MAJIT_STRICT`) and
  `MetaInterp::note_jit_panic_or_reraise()` now route every swallowing
  `catch_unwind` arm in the loop / retrace / simple-loop / entry-bridge / bridge
  compile paths. `InvalidLoop` still aborts gracefully; any other panic re-raises
  in strict builds, otherwise it is logged and counted in
  `internal_compile_panics` before the trace degrades.
- `JitStats.internal_compile_panics` is exposed; `pyrex` prints a `[jit-stats]`
  line on exit when `MAJIT_STATS=1`.
- `pyre/check.py` runs pyre under `MAJIT_STRICT=1`/`MAJIT_STATS=1`, captures
  stderr, and fails a bench (`JIT-PANIC`) on a `panicked` line or
  `internal_compile_panics > 0`, so a swallowed compile bug can no longer pass.

### Testing

- `pyre/check.py`: 41/41 PASS on both dynasm and cranelift under strict mode,
  `internal_compile_panics = 0`.
- `cargo test` (debug = strict on) green across `majit-metainterp`, `majit-gc`,
  and `majit-backend-cranelift`. Workspace `cargo fmt --check` clean.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
"Structural adaptations."
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional strict JIT mode toggle.
  - Benchmark runner captures stderr, normalizes output, and flags JIT panics.
  - JIT statistics can be emitted on process exit when enabled.

- **Bug Fixes**
  - Callable iterator with a sentinel now correctly stops if exhausted during re-entrant next().

- **Chores**
  - Telemetry to count internal JIT compile panics and surface in reported stats.

- **Documentation**
  - Clarified scheduling/vectorizer implementation behavior in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->