### PR TITLE
optimizeopt: delete ensure_box for materialize_box_at

### DIFF
--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -333,7 +333,7 @@ impl BoxRef {
     /// `set_forwarded_*` / `clear_forwarded` calls write through to
     /// `op.forwarded` (the canonical host; there is no Box-side mirror).
     /// Stores a `Weak<Op>` to avoid an Rc cycle. Called when re-binding a
-    /// box to its producer (`ensure_box`'s synthetic-mint path, test
+    /// box to its producer (`materialize_box_at`'s synthetic-mint path, test
     /// fixtures). Panics if called on a non-ResOp Box.
     ///
     /// Late-binding carry-over: when the box is *already bound* (a rebind:
@@ -345,7 +345,7 @@ impl BoxRef {
     /// unbound box is always `Forwarded::None`. Carrying that `None` would
     /// *clobber* an already-populated canonical host's authoritative
     /// `_forwarded` (the bug that `box_pool` memoization used to mask by
-    /// returning the same bound box on a repeat `ensure_box`). So the
+    /// returning the same bound box on a repeat `materialize_box_at`). So the
     /// carry-over fires only when `self` is bound; binding a fresh box leaves
     /// the host's `_forwarded` intact.
     pub fn bind_op(&self, op: &crate::resoperation::OpRc) {

--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -251,11 +251,13 @@ pub fn deserialize_optimizer_knowledge(
                     majit_ir::GcRef(raw_ref as usize),
                 ));
                 let cls = cpu.cls_of_box(&const_box);
-                // optimizer.py:137-152 `make_constant_class` always
-                // updates `_forwarded` after `get_box_replacement` —
-                // `ensure_box` materializes a Box so the class info
-                // install is never silently skipped.
-                if let Some(b) = ctx.ensure_box(livebox) {
+                // optimizer.py:137-152 `make_constant_class` updates
+                // `_forwarded` after `get_box_replacement`. `livebox` is a
+                // bridge livebox (= inputarg materialized by
+                // `ensure_inputarg_bindings`, which runs before
+                // `deserialize_optimizer_knowledge`), so it always resolves
+                // and the class info install is never skipped.
+                if let Some(b) = ctx.get_box_replacement_box(livebox) {
                     super::optimizer::Optimizer::make_constant_class(ctx, &b, cls, true);
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -63,7 +63,7 @@ impl Default for OptEarlyForce {
 impl Optimization for OptEarlyForce {
     /// earlyforce.py:15-29: propagate_forward.
     /// Force all virtual args of non-exempt operations, then emit.
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         if Self::should_force_args(op) {
             // earlyforce.py:28: self.optimizer.force_box(arg, self)
             // In Rust, we can't call Optimizer.force_box (borrow conflict).

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -97,7 +97,7 @@ impl Optimization for OptEarlyForce {
                         .get_box_replacement_box(arg)
                         .expect("recorder-populated");
                     let mut info = ctx.take_ptr_info(&arg_box).unwrap();
-                    let _forced = info.force_box(arg, ctx);
+                    let _forced = info.force_box(arg_box, ctx);
                 }
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -71,11 +71,12 @@ impl Optimization for OptEarlyForce {
             // which uses ctx.current_pass_idx (== earlyforce_idx) for
             // emit_extra routing. This matches RPython's optforce=self.
             for i in 0..op.num_args() {
-                let arg = ctx.get_box_replacement(op.arg(i).to_opref());
-                let arg_is_virtual = ctx
-                    .get_box_replacement_box(op.arg(i).to_opref())
+                let arg_box = ctx.get_box_replacement_box(op.arg(i).to_opref());
+                let arg = arg_box
                     .as_ref()
-                    .map_or(false, |b| ctx.is_virtual(b));
+                    .map(|b| b.to_opref())
+                    .unwrap_or_else(|| op.arg(i).to_opref());
+                let arg_is_virtual = arg_box.as_ref().map_or(false, |b| ctx.is_virtual(b));
                 if arg_is_virtual {
                     // optimizer.py:345-364: force_box path.
                     // potential_extra_ops are handled by Optimizer.force_box,

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -63,7 +63,12 @@ impl Default for OptEarlyForce {
 impl Optimization for OptEarlyForce {
     /// earlyforce.py:15-29: propagate_forward.
     /// Force all virtual args of non-exempt operations, then emit.
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        _op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         if Self::should_force_args(op) {
             // earlyforce.py:28: self.optimizer.force_box(arg, self)
             // In Rust, we can't call Optimizer.force_box (borrow conflict).

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -1006,7 +1006,12 @@ impl Default for OptGuard {
 }
 
 impl Optimization for OptGuard {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        _op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         if !op.opcode.is_guard() {
             // Non-guard operations invalidate the last-guard descriptor
             // tracking (no longer consecutive).

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -1006,7 +1006,7 @@ impl Default for OptGuard {
 }
 
 impl Optimization for OptGuard {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         if !op.opcode.is_guard() {
             // Non-guard operations invalidate the last-guard descriptor
             // tracking (no longer consecutive).

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1409,7 +1409,7 @@ impl OptHeap {
     /// FLAG_LOOKUP (0): always cache and reuse.
     /// FLAG_STORE  (1): don't cache new; reuse only if cached value ≥ 0.
     /// FLAG_DELETE (2+): never cache, never reuse.
-    fn _optimize_call_dict_lookup(&mut self, op: &Op, ctx: &mut OptContext) -> bool {
+    fn _optimize_call_dict_lookup(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> bool {
         const FLAG_LOOKUP: i64 = 0;
         const FLAG_STORE: i64 = 1;
 
@@ -1484,9 +1484,7 @@ impl OptHeap {
                 }
             }
             // heap.py:525-527: make_equal_to + last_emitted_operation = REMOVED
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_res = ctx
                 .ensure_box(res_v)
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1885,7 +1883,7 @@ impl OptHeap {
 
     // ── Handlers for specific opcodes ──
 
-    fn optimize_getfield(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getfield(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let key = match Self::field_key(op) {
             Some(k) => k,
             None => return OptimizationResult::Emit(op.clone()),
@@ -1937,9 +1935,7 @@ impl OptHeap {
                 if ctx.same_box(*lazy_obj, obj) {
                     // MUST_ALIAS: lazy_set targets the same struct → return rhs
                     let cached = lazy_op.arg(1).to_opref();
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_cached = ctx
                         .ensure_box(cached)
                         .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1976,9 +1972,7 @@ impl OptHeap {
                             let cached = ctx.force_op_from_preamble_op(&pop);
                             ctx.structinfo_setfield(op, field_idx, cached);
                             self.field_cache(&descr).register_info(obj);
-                            let b_old = ctx
-                                .ensure_box(op.pos.get())
-                                .expect("body-namespace OpRef must have a BoxRef slot");
+                            let b_old = BoxRef::from_bound_op(op_rc);
                             let b_cached = ctx
                                 .get_box_replacement_box(cached)
                                 .or_else(|| ctx.ensure_box(cached))
@@ -1988,9 +1982,7 @@ impl OptHeap {
                         }
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
-                                let b_old = ctx
-                                    .ensure_box(op.pos.get())
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_old = BoxRef::from_bound_op(op_rc);
                                 let b_cached = ctx
                                     .get_box_replacement_box(cached)
                                     .or_else(|| ctx.ensure_box(cached))
@@ -2057,9 +2049,7 @@ impl OptHeap {
                         let cached = ctx.force_op_from_preamble_op(&pop);
                         ctx.structinfo_setfield(op, field_idx, cached);
                         self.field_cache(&descr).register_info(obj);
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = BoxRef::from_bound_op(op_rc);
                         let b_cached = ctx
                             .get_box_replacement_box(cached)
                             .or_else(|| ctx.ensure_box(cached))
@@ -2069,9 +2059,7 @@ impl OptHeap {
                     }
                     crate::optimizeopt::info::FieldEntry::Value(cached) => {
                         if !cached.is_none() {
-                            let b_old = ctx
-                                .ensure_box(op.pos.get())
-                                .expect("body-namespace OpRef must have a BoxRef slot");
+                            let b_old = BoxRef::from_bound_op(op_rc);
                             let b_cached = ctx
                                 .get_box_replacement_box(cached)
                                 .or_else(|| ctx.ensure_box(cached))
@@ -2089,9 +2077,7 @@ impl OptHeap {
         if let Some(qi_cached) = self.quasi_immut_cache.get(&key).copied() {
             if !qi_cached.is_none() {
                 // Subsequent read: reuse the cached value.
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_qi = ctx
                     .get_box_replacement_box(qi_cached)
                     .or_else(|| ctx.ensure_box(qi_cached))
@@ -2492,7 +2478,7 @@ impl OptHeap {
         }
     }
 
-    fn optimize_getarrayitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getarrayitem(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         // Install ArrayPtrInfo via ensure_ptr_info_arg0 (return value
         // unused — we re-borrow further down via a fresh call so the
         // intermediate cache mutations can take &mut ctx without
@@ -2520,9 +2506,7 @@ impl OptHeap {
                     if ctx.same_box(*lazy_obj, array) {
                         // MUST_ALIAS: lazy_set targets the same array → return rhs
                         let cached = lazy_op.arg(2).to_opref();
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = BoxRef::from_bound_op(op_rc);
                         let b_cached = ctx
                             .ensure_box(cached)
                             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -2557,9 +2541,7 @@ impl OptHeap {
                                 self.arrayitem_cache(&descr, const_index)
                                     .register_info(array);
                                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
-                                let b_old = ctx
-                                    .ensure_box(op.pos.get())
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_old = BoxRef::from_bound_op(op_rc);
                                 let b_cached = ctx
                                     .get_box_replacement_box(cached)
                                     .or_else(|| ctx.ensure_box(cached))
@@ -2569,9 +2551,7 @@ impl OptHeap {
                             }
                             crate::optimizeopt::info::FieldEntry::Value(cached) => {
                                 if !cached.is_none() {
-                                    let b_old = ctx
-                                        .ensure_box(op.pos.get())
-                                        .expect("body-namespace OpRef must have a BoxRef slot");
+                                    let b_old = BoxRef::from_bound_op(op_rc);
                                     let b_cached = ctx
                                         .get_box_replacement_box(cached)
                                         .or_else(|| ctx.ensure_box(cached))
@@ -2633,9 +2613,7 @@ impl OptHeap {
                 self.arrayitem_cache(&descr, const_index)
                     .register_info(array);
                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_cached = ctx
                     .get_box_replacement_box(cached)
                     .or_else(|| ctx.ensure_box(cached))
@@ -2655,9 +2633,7 @@ impl OptHeap {
                             self.arrayitem_cache(&descr, const_index)
                                 .register_info(array);
                             ctx.arrayinfo_setitem(op, const_index as usize, cached);
-                            let b_old = ctx
-                                .ensure_box(op.pos.get())
-                                .expect("body-namespace OpRef must have a BoxRef slot");
+                            let b_old = BoxRef::from_bound_op(op_rc);
                             let b_cached = ctx
                                 .get_box_replacement_box(cached)
                                 .or_else(|| ctx.ensure_box(cached))
@@ -2667,9 +2643,7 @@ impl OptHeap {
                         }
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
-                                let b_old = ctx
-                                    .ensure_box(op.pos.get())
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_old = BoxRef::from_bound_op(op_rc);
                                 let b_cached = ctx
                                     .get_box_replacement_box(cached)
                                     .or_else(|| ctx.ensure_box(cached))
@@ -2736,9 +2710,7 @@ impl OptHeap {
             let indexbox = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
             if let Some(submap) = self.get_cached_array_submap(descr_idx) {
                 if let Some(cached) = submap.lookup_cached(arrayinfo, indexbox, ctx) {
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_cached = ctx
                         .ensure_box(cached)
                         .expect("body-namespace OpRef must have a BoxRef slot");
@@ -2800,7 +2772,7 @@ impl OptHeap {
     /// Handle operations that may have side effects.
     /// Forces lazy sets and invalidates caches as needed.
     /// Tracks allocations for aliasing analysis.
-    fn handle_side_effects(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn handle_side_effects(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let opcode = op.opcode;
 
         // Track allocations for aliasing analysis.
@@ -2839,7 +2811,7 @@ impl OptHeap {
                 // self.emit(op) → emitting_operation → force_from_effectinfo,
                 // identical to a non-DICT_LOOKUP residual call.
                 OopSpecIndex::DictLookup => {
-                    if self._optimize_call_dict_lookup(op, ctx) {
+                    if self._optimize_call_dict_lookup(op, op_rc, ctx) {
                         return OptimizationResult::Remove;
                     }
                     return self.emit_residual_call(op, ctx);
@@ -2863,7 +2835,7 @@ impl OptHeap {
         OptimizationResult::Emit(op.clone())
     }
 
-    fn dispatch_propagate(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn dispatch_propagate(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         match op.opcode {
             // ── Field reads ──
             OpCode::GetfieldGcI
@@ -2871,7 +2843,7 @@ impl OptHeap {
             | OpCode::GetfieldGcF
             | OpCode::GetfieldGcPureI
             | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF => self.optimize_getfield(op, ctx),
+            | OpCode::GetfieldGcPureF => self.optimize_getfield(op, op_rc, ctx),
 
             // ── Raw field reads/writes ──
             // Keep these conservative. The standard heap.py cache/postprocess
@@ -2888,7 +2860,7 @@ impl OptHeap {
 
             // ── Array item reads ──
             OpCode::GetarrayitemGcI | OpCode::GetarrayitemGcR | OpCode::GetarrayitemGcF => {
-                self.optimize_getarrayitem(op, ctx)
+                self.optimize_getarrayitem(op, op_rc, ctx)
             }
 
             // ── Raw array item reads/writes ──
@@ -3138,7 +3110,7 @@ impl OptHeap {
             }
 
             // ── Everything else: check for side effects ──
-            _ => self.handle_side_effects(op, ctx),
+            _ => self.handle_side_effects(op, op_rc, ctx),
         }
     }
 }
@@ -3150,8 +3122,8 @@ impl Default for OptHeap {
 }
 
 impl Optimization for OptHeap {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
-        let result = self.dispatch_propagate(op, ctx);
+    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        let result = self.dispatch_propagate(op, op_rc, ctx);
         // heap.py:417-425 emit() override parity:
         // Before emitting any new op, flush the postponed op. Then
         // postpone comparison/ovf ops (call_may_force already handled
@@ -4071,7 +4043,9 @@ mod tests {
         let mut op = Op::with_descr(OpCode::GetfieldGcI, &[BoxRef::from_opref(p0)], d);
         op.pos.set(pos2);
 
-        let result = heap.optimize_getfield(&op, &mut ctx);
+        let op_rc = std::rc::Rc::new(op.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op_rc));
+        let result = heap.optimize_getfield(&op, &op_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(ctx.get_box_replacement(pos2).to_opref(), p1);
     }
@@ -4109,7 +4083,9 @@ mod tests {
             d_head.clone(),
         );
         op1.pos.set(pos2);
-        let result1 = heap.optimize_getfield(&op1, &mut ctx);
+        let op1_rc = std::rc::Rc::new(op1.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op1_rc));
+        let result1 = heap.optimize_getfield(&op1, &op1_rc, &mut ctx);
         assert!(matches!(result1, OptimizationResult::Remove));
         assert_eq!(ctx.get_box_replacement(pos2).to_opref(), p1);
 
@@ -4125,7 +4101,7 @@ mod tests {
             d_head.clone(),
         );
         op2.pos.set(pos3);
-        let result2 = heap.optimize_getfield(&op2, &mut ctx);
+        let result2 = heap.optimize_getfield(&op2, &std::rc::Rc::new(op2.clone()), &mut ctx);
         assert!(
             matches!(result2, OptimizationResult::Emit(_)),
             "getfield after invalidation must emit, not reuse stale import"
@@ -4154,7 +4130,7 @@ mod tests {
         let mut op = Op::with_descr(OpCode::GetfieldGcI, &[BoxRef::from_opref(p0)], d);
         op.pos.set(pos1);
 
-        let _ = heap.optimize_getfield(&op, &mut ctx);
+        let _ = heap.optimize_getfield(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
     }
 
     // ── Test 2: Two GETFIELDs on same object/field → second eliminated ──
@@ -6672,7 +6648,7 @@ mod tests {
         );
         op1.setdescr(descr.clone());
         op1.pos.set(pos1);
-        assert!(!heap._optimize_call_dict_lookup(&op1, &mut ctx));
+        assert!(!heap._optimize_call_dict_lookup(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx));
 
         // Second lookup with same dict+key — should be cached.
         let pos2 = ctx.reserve_pos_typed(Type::Int);
@@ -6688,7 +6664,9 @@ mod tests {
         );
         op2.setdescr(descr.clone());
         op2.pos.set(pos2);
-        assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
+        let op2_rc = std::rc::Rc::new(op2.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op2_rc));
+        assert!(heap._optimize_call_dict_lookup(&op2, &op2_rc, &mut ctx));
         assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
         assert!(heap.last_emitted_removed);
     }
@@ -6735,7 +6713,7 @@ mod tests {
             &pos1_box,
             &crate::optimizeopt::intutils::IntBound::from_constant(5),
         );
-        assert!(!heap._optimize_call_dict_lookup(&op1, &mut ctx));
+        assert!(!heap._optimize_call_dict_lookup(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx));
 
         // FLAG_STORE with known non-negative cached value → reuse.
         let pos2 = ctx.reserve_pos_typed(Type::Int);
@@ -6751,7 +6729,9 @@ mod tests {
         );
         op2.setdescr(descr.clone());
         op2.pos.set(pos2);
-        assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
+        let op2_rc = std::rc::Rc::new(op2.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op2_rc));
+        assert!(heap._optimize_call_dict_lookup(&op2, &op2_rc, &mut ctx));
         assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
     }
 
@@ -6785,7 +6765,7 @@ mod tests {
         );
         op1.setdescr(descr.clone());
         op1.pos.set(pos1);
-        heap._optimize_call_dict_lookup(&op1, &mut ctx);
+        heap._optimize_call_dict_lookup(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx);
         assert!(!heap.cached_dict_reads.is_empty());
 
         // clean_caches should clear it.
@@ -6806,7 +6786,7 @@ mod tests {
         );
         op2.setdescr(descr.clone());
         op2.pos.set(pos2);
-        assert!(!heap._optimize_call_dict_lookup(&op2, &mut ctx));
+        assert!(!heap._optimize_call_dict_lookup(&op2, &std::rc::Rc::new(op2.clone()), &mut ctx));
     }
 
     /// util.py:100/127 args_dict() / args_eq parity: same_box treats two
@@ -6855,7 +6835,7 @@ mod tests {
         );
         op1.setdescr(descr.clone());
         op1.pos.set(pos1);
-        assert!(!heap._optimize_call_dict_lookup(&op1, &mut ctx));
+        assert!(!heap._optimize_call_dict_lookup(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx));
 
         // Same value via a different const slot — must hit the cache.
         let pos2 = ctx.reserve_pos_typed(Type::Int);
@@ -6871,7 +6851,9 @@ mod tests {
         );
         op2.setdescr(descr.clone());
         op2.pos.set(pos2);
-        assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
+        let op2_rc = std::rc::Rc::new(op2.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op2_rc));
+        assert!(heap._optimize_call_dict_lookup(&op2, &op2_rc, &mut ctx));
         assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
     }
 
@@ -6941,7 +6923,7 @@ mod tests {
         );
         op1.setdescr(descr.clone());
         op1.pos.set(pos1);
-        assert!(!heap._optimize_call_dict_lookup(&op1, &mut ctx));
+        assert!(!heap._optimize_call_dict_lookup(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx));
         assert!(heap.cached_dict_reads.is_empty());
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1973,20 +1973,14 @@ impl OptHeap {
                             ctx.structinfo_setfield(op, field_idx, cached);
                             self.field_cache(&descr).register_info(obj);
                             let b_old = BoxRef::from_bound_op(op_rc);
-                            let b_cached = ctx
-                                .get_box_replacement_box(cached)
-                                .or_else(|| ctx.ensure_box(cached))
-                                .expect("body-namespace OpRef must have a BoxRef slot");
+                            let b_cached = ctx.get_box_replacement(cached);
                             ctx.make_equal_to(&b_old, &b_cached);
                             return OptimizationResult::Remove;
                         }
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
                                 let b_old = BoxRef::from_bound_op(op_rc);
-                                let b_cached = ctx
-                                    .get_box_replacement_box(cached)
-                                    .or_else(|| ctx.ensure_box(cached))
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_cached = ctx.get_box_replacement(cached);
                                 ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }
@@ -2050,20 +2044,14 @@ impl OptHeap {
                         ctx.structinfo_setfield(op, field_idx, cached);
                         self.field_cache(&descr).register_info(obj);
                         let b_old = BoxRef::from_bound_op(op_rc);
-                        let b_cached = ctx
-                            .get_box_replacement_box(cached)
-                            .or_else(|| ctx.ensure_box(cached))
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_cached = ctx.get_box_replacement(cached);
                         ctx.make_equal_to(&b_old, &b_cached);
                         return OptimizationResult::Remove;
                     }
                     crate::optimizeopt::info::FieldEntry::Value(cached) => {
                         if !cached.is_none() {
                             let b_old = BoxRef::from_bound_op(op_rc);
-                            let b_cached = ctx
-                                .get_box_replacement_box(cached)
-                                .or_else(|| ctx.ensure_box(cached))
-                                .expect("body-namespace OpRef must have a BoxRef slot");
+                            let b_cached = ctx.get_box_replacement(cached);
                             ctx.make_equal_to(&b_old, &b_cached);
                             return OptimizationResult::Remove;
                         }
@@ -2078,10 +2066,7 @@ impl OptHeap {
             if !qi_cached.is_none() {
                 // Subsequent read: reuse the cached value.
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_qi = ctx
-                    .get_box_replacement_box(qi_cached)
-                    .or_else(|| ctx.ensure_box(qi_cached))
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_qi = ctx.get_box_replacement(qi_cached);
                 ctx.make_equal_to(&b_old, &b_qi);
                 return OptimizationResult::Remove;
             }
@@ -2542,20 +2527,14 @@ impl OptHeap {
                                     .register_info(array);
                                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
                                 let b_old = BoxRef::from_bound_op(op_rc);
-                                let b_cached = ctx
-                                    .get_box_replacement_box(cached)
-                                    .or_else(|| ctx.ensure_box(cached))
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_cached = ctx.get_box_replacement(cached);
                                 ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }
                             crate::optimizeopt::info::FieldEntry::Value(cached) => {
                                 if !cached.is_none() {
                                     let b_old = BoxRef::from_bound_op(op_rc);
-                                    let b_cached = ctx
-                                        .get_box_replacement_box(cached)
-                                        .or_else(|| ctx.ensure_box(cached))
-                                        .expect("body-namespace OpRef must have a BoxRef slot");
+                                    let b_cached = ctx.get_box_replacement(cached);
                                     ctx.make_equal_to(&b_old, &b_cached);
                                     return OptimizationResult::Remove;
                                 }
@@ -2614,10 +2593,7 @@ impl OptHeap {
                     .register_info(array);
                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_cached = ctx
-                    .get_box_replacement_box(cached)
-                    .or_else(|| ctx.ensure_box(cached))
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_cached = ctx.get_box_replacement(cached);
                 ctx.make_equal_to(&b_old, &b_cached);
                 return OptimizationResult::Remove;
             }
@@ -2634,20 +2610,14 @@ impl OptHeap {
                                 .register_info(array);
                             ctx.arrayinfo_setitem(op, const_index as usize, cached);
                             let b_old = BoxRef::from_bound_op(op_rc);
-                            let b_cached = ctx
-                                .get_box_replacement_box(cached)
-                                .or_else(|| ctx.ensure_box(cached))
-                                .expect("body-namespace OpRef must have a BoxRef slot");
+                            let b_cached = ctx.get_box_replacement(cached);
                             ctx.make_equal_to(&b_old, &b_cached);
                             return OptimizationResult::Remove;
                         }
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
                                 let b_old = BoxRef::from_bound_op(op_rc);
-                                let b_cached = ctx
-                                    .get_box_replacement_box(cached)
-                                    .or_else(|| ctx.ensure_box(cached))
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_cached = ctx.get_box_replacement(cached);
                                 ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1409,7 +1409,12 @@ impl OptHeap {
     /// FLAG_LOOKUP (0): always cache and reuse.
     /// FLAG_STORE  (1): don't cache new; reuse only if cached value ≥ 0.
     /// FLAG_DELETE (2+): never cache, never reuse.
-    fn _optimize_call_dict_lookup(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> bool {
+    fn _optimize_call_dict_lookup(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> bool {
         const FLAG_LOOKUP: i64 = 0;
         const FLAG_STORE: i64 = 1;
 
@@ -1883,7 +1888,12 @@ impl OptHeap {
 
     // ── Handlers for specific opcodes ──
 
-    fn optimize_getfield(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getfield(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let key = match Self::field_key(op) {
             Some(k) => k,
             None => return OptimizationResult::Emit(op.clone()),
@@ -2463,7 +2473,12 @@ impl OptHeap {
         }
     }
 
-    fn optimize_getarrayitem(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getarrayitem(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         // Install ArrayPtrInfo via ensure_ptr_info_arg0 (return value
         // unused — we re-borrow further down via a fresh call so the
         // intermediate cache mutations can take &mut ctx without
@@ -2742,7 +2757,12 @@ impl OptHeap {
     /// Handle operations that may have side effects.
     /// Forces lazy sets and invalidates caches as needed.
     /// Tracks allocations for aliasing analysis.
-    fn handle_side_effects(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn handle_side_effects(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let opcode = op.opcode;
 
         // Track allocations for aliasing analysis.
@@ -2805,7 +2825,12 @@ impl OptHeap {
         OptimizationResult::Emit(op.clone())
     }
 
-    fn dispatch_propagate(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn dispatch_propagate(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         match op.opcode {
             // ── Field reads ──
             OpCode::GetfieldGcI
@@ -3092,7 +3117,12 @@ impl Default for OptHeap {
 }
 
 impl Optimization for OptHeap {
-    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let result = self.dispatch_propagate(op, op_rc, ctx);
         // heap.py:417-425 emit() override parity:
         // Before emitting any new op, flush the postponed op. Then
@@ -6857,7 +6887,8 @@ mod tests {
         // Now a GUARD_NO_EXCEPTION must be emitted, not removed.
         let mut guard = Op::new(OpCode::GuardNoException, &[]);
         guard.pos.set(ctx.reserve_pos_typed(Type::Void));
-        let guard_result = heap.propagate_forward(&guard, &std::rc::Rc::new(guard.clone()), &mut ctx);
+        let guard_result =
+            heap.propagate_forward(&guard, &std::rc::Rc::new(guard.clone()), &mut ctx);
         assert!(
             matches!(guard_result, OptimizationResult::Emit(_)),
             "GUARD_NO_EXCEPTION after a PassOn-emitted op must NOT be removed"

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -86,7 +86,7 @@ enum DictArgKey {
 
 impl DictArgKey {
     fn from_arg(arg: OpRef, ctx: &OptContext) -> Self {
-        let resolved = ctx.get_box_replacement(arg);
+        let resolved = ctx.get_box_replacement(arg).to_opref();
         let cval = ctx
             .get_box_replacement_box(resolved)
             .and_then(|cb| cb.const_value());
@@ -317,8 +317,8 @@ impl CachedField {
                 // Only compare concrete values; Preamble entries have no
                 // known constant value.
                 if let (Some(v1), Some(v2)) = (e1.as_opref(), e2.as_opref()) {
-                    let v1r = ctx.get_box_replacement(v1);
-                    let v2r = ctx.get_box_replacement(v2);
+                    let v1r = ctx.get_box_replacement(v1).to_opref();
+                    let v2r = ctx.get_box_replacement(v2).to_opref();
                     let c1 = ctx
                         .get_box_replacement_box(v1r)
                         .and_then(|cb| cb.const_value());
@@ -344,8 +344,8 @@ impl CachedField {
             .as_ref()
             .map(OptHeap::field_slot_index)
             .unwrap_or(0);
-        let arg = ctx.get_box_replacement(op.arg(1).to_opref());
-        let struct_opref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let arg = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
+        let struct_opref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         self.register_info(struct_opref);
         ctx.structinfo_setfield(op, descr_idx, arg);
     }
@@ -371,7 +371,7 @@ impl CachedField {
     ) {
         debug_assert!(self.lazy_set.is_none());
         for &cached in &self.cached_structs {
-            let structbox = ctx.get_box_replacement(cached);
+            let structbox = ctx.get_box_replacement(cached).to_opref();
             if structbox.is_none() {
                 continue;
             }
@@ -490,8 +490,12 @@ impl ArrayCachedItem {
         let len = items1.len().min(items2.len());
         for i in 0..len {
             // heap.py:289-290: value = get_box_replacement(content[index])
-            let v1 = items1[i].as_opref().map(|r| ctx.get_box_replacement(r));
-            let v2 = items2[i].as_opref().map(|r| ctx.get_box_replacement(r));
+            let v1 = items1[i]
+                .as_opref()
+                .map(|r| ctx.get_box_replacement(r).to_opref());
+            let v2 = items2[i]
+                .as_opref()
+                .map(|r| ctx.get_box_replacement(r).to_opref());
             // heap.py:291-292: if value is None: continue
             let (Some(v1), Some(v2)) = (v1, v2) else {
                 continue;
@@ -590,8 +594,8 @@ impl ArrayCachedItem {
 
     /// heap.py:252-255 ArrayCachedItem.put_field_back_to_info
     fn put_field_back_to_info(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg = ctx.get_box_replacement(op.arg(2).to_opref());
-        let struct_opref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let arg = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
+        let struct_opref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         self.register_info(struct_opref);
         ctx.arrayinfo_setitem(op, self.index as usize, arg);
     }
@@ -605,7 +609,7 @@ impl ArrayCachedItem {
     ) {
         debug_assert!(self.lazy_set.is_none());
         for &cached in &self.cached_structs {
-            let arraybox = ctx.get_box_replacement(cached);
+            let arraybox = ctx.get_box_replacement(cached).to_opref();
             if arraybox.is_none() {
                 continue;
             }
@@ -711,7 +715,7 @@ impl ArrayCacheSubMap {
                 // heap.py:322: cached_arrayinfo is arrayinfo
                 //   and get_box_replacement(cached_index) is indexbox
                 if cached_arrayinfo == arrayinfo && ctx.box_is(cached_index, indexbox) {
-                    return Some(ctx.get_box_replacement(cached_result));
+                    return Some(ctx.get_box_replacement(cached_result).to_opref());
                 }
             }
         }
@@ -948,7 +952,7 @@ impl OptHeap {
     /// Canonicalizes array and index through get_box_replacement.
     fn arrayitem_key(op: &Op, ctx: &mut OptContext) -> Option<ArrayItemKey> {
         let descr = op.getdescr()?;
-        let array = ctx.get_box_replacement(op.arg(0).to_opref());
+        let array = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let index_val = ctx
             .get_box_replacement_box(op.arg(1).to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))?;
@@ -1115,10 +1119,7 @@ impl OptHeap {
         // Non-virtual path: resolve forwarding and route after heap
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..op.num_args() {
-            op.setarg(
-                i,
-                BoxRef::from_opref(ctx.get_box_replacement(op.arg(i).to_opref())),
-            );
+            op.setarg(i, ctx.get_box_replacement(op.arg(i).to_opref()));
         }
         // heap.py:136: emit_extra(op, emit=False) → next_optimization
         ctx.emit_extra(ctx.current_pass_idx, op.clone());
@@ -1262,10 +1263,7 @@ impl OptHeap {
             // then put_field_back_to_info restores the cache.
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
-                op.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(op.arg(i).to_opref())),
-                );
+                op.setarg(i, ctx.get_box_replacement(op.arg(i).to_opref()));
             }
             let final_value = op.arg(1);
             // heap.py:129,189-191: invalidate(descr) — purity self-gate
@@ -1318,10 +1316,7 @@ impl OptHeap {
 
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
-                op.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(op.arg(i).to_opref())),
-                );
+                op.setarg(i, ctx.get_box_replacement(op.arg(i).to_opref()));
             }
             let final_value = op.arg(2);
             let array_ref = op.arg(0);
@@ -1603,7 +1598,7 @@ impl OptHeap {
         let mut stack: Vec<OpRef> = op
             .getarglist()
             .iter()
-            .map(|arg| ctx.get_box_replacement(arg.to_opref()))
+            .map(|arg| ctx.get_box_replacement(arg.to_opref()).to_opref())
             .collect();
         while let Some(owner) = stack.pop() {
             if owners.contains(&owner) {
@@ -1611,7 +1606,10 @@ impl OptHeap {
             }
             owners.push(owner);
             if let Some(deps) = self.heapc_deps.get(&owner) {
-                stack.extend(deps.iter().map(|dep| ctx.get_box_replacement(*dep)));
+                stack.extend(
+                    deps.iter()
+                        .map(|dep| ctx.get_box_replacement(*dep).to_opref()),
+                );
             }
         }
         owners
@@ -1661,7 +1659,7 @@ impl OptHeap {
             .into_iter()
             .filter_map(|(field_idx, descr, cf)| match cf.lazy_set.as_ref() {
                 Some((obj, _)) => {
-                    let owner = ctx.get_box_replacement(*obj);
+                    let owner = ctx.get_box_replacement(*obj).to_opref();
                     if escaped_owners.contains(&owner) {
                         cf.lazy_set
                             .take()
@@ -1682,10 +1680,7 @@ impl OptHeap {
             }
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..pending_op.num_args() {
-                pending_op.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(pending_op.arg(i).to_opref())),
-                );
+                pending_op.setarg(i, ctx.get_box_replacement(pending_op.arg(i).to_opref()));
             }
             self.emit_postponed_if_referenced(&pending_op, heap_pass_idx, ctx);
             let final_value = pending_op.arg(1);
@@ -1705,11 +1700,16 @@ impl OptHeap {
             sort_array_index_entries_untranslated(&mut index_entries);
             for (index, cai) in index_entries {
                 if cai.lazy_set.as_ref().map_or(false, |(obj, _)| {
-                    let owner = ctx.get_box_replacement(*obj);
+                    let owner = ctx.get_box_replacement(*obj).to_opref();
                     escaped_owners.contains(&owner)
                 }) {
                     if let Some((obj, op)) = cai.lazy_set.take() {
-                        pending_arrays.push((*descr_idx, index, ctx.get_box_replacement(obj), op));
+                        pending_arrays.push((
+                            *descr_idx,
+                            index,
+                            ctx.get_box_replacement(obj).to_opref(),
+                            op,
+                        ));
                     }
                 }
             }
@@ -1717,10 +1717,7 @@ impl OptHeap {
         for (descr_idx, index, _obj, mut pending_op) in pending_arrays {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..pending_op.num_args() {
-                pending_op.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(pending_op.arg(i).to_opref())),
-                );
+                pending_op.setarg(i, ctx.get_box_replacement(pending_op.arg(i).to_opref()));
             }
             self.invalidate_arrayitem_cache(descr_idx, index, ctx);
             self.emit_postponed_if_referenced(&pending_op, heap_pass_idx, ctx);
@@ -1930,7 +1927,7 @@ impl OptHeap {
         // Subsequent passes (intbounds, virtualstate) and the local
         // `setfield` mutation point all read/write that slot via the
         // canonical OpRef.
-        let obj = ctx.get_box_replacement(raw_obj);
+        let obj = ctx.get_box_replacement(raw_obj).to_opref();
         let _ = ctx.ensure_ptr_info_arg0(op);
         let mut force_lazy = false;
         if let Some(cf) = self.get_cached_field(&descr) {
@@ -2173,7 +2170,7 @@ impl OptHeap {
         let (raw_obj, _) = key;
         // heap.py:78 ensure_ptr_info_arg0 — install structinfo as a
         // side effect; canonical OpRef for the cache key.
-        let obj = ctx.get_box_replacement(raw_obj);
+        let obj = ctx.get_box_replacement(raw_obj).to_opref();
         let _ = ctx.ensure_ptr_info_arg0(op);
         // heapcache.py:224-230 _escape_from_write — pyre-specific
         // escape tracking outside the do_setfield contract.
@@ -2222,7 +2219,7 @@ impl OptHeap {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // heap.py:80 arg1 = get_box_replacement(self._get_rhs_from_set_op(op))
-        let arg1 = ctx.get_box_replacement(Self::field_get_rhs(op));
+        let arg1 = ctx.get_box_replacement(Self::field_get_rhs(op)).to_opref();
         let field_idx = Self::field_slot_index(descr);
         // heap.py:81-83 if self.possible_aliasing(structinfo):
         //                  self.force_lazy_set(optheap, op.getdescr())
@@ -2247,7 +2244,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.get_box_replacement(pop.op);
+                    let cached_seen = ctx.get_box_replacement(pop.op).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -2259,7 +2256,7 @@ impl OptHeap {
                     }
                 }
                 crate::optimizeopt::info::FieldEntry::Value(cached) => {
-                    let cached_resolved = ctx.get_box_replacement(cached);
+                    let cached_resolved = ctx.get_box_replacement(cached).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_resolved, arg1) {
                         // heap.py:100 self._lazy_set = None
@@ -2366,7 +2363,7 @@ impl OptHeap {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // heap.py:80 arg1 = get_box_replacement(self._get_rhs_from_set_op(op))
-        let arg1 = ctx.get_box_replacement(Self::array_get_rhs(op));
+        let arg1 = ctx.get_box_replacement(Self::array_get_rhs(op)).to_opref();
         // heap.py:81-83 if self.possible_aliasing(structinfo):
         //                  self.force_lazy_set(optheap, op.getdescr())
         let needs_force = self
@@ -2388,7 +2385,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.get_box_replacement(pop.op);
+                    let cached_seen = ctx.get_box_replacement(pop.op).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -2401,7 +2398,7 @@ impl OptHeap {
                     }
                 }
                 crate::optimizeopt::info::FieldEntry::Value(cached) => {
-                    let cached_resolved = ctx.get_box_replacement(cached);
+                    let cached_resolved = ctx.get_box_replacement(cached).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_resolved, arg1) {
                         // heap.py:100 self._lazy_set = None
@@ -2501,7 +2498,7 @@ impl OptHeap {
         // intermediate cache mutations can take &mut ctx without
         // tripping the borrow checker).
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let array_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let array_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
 
         // Try constant-index cache first.
         if let Some(key) = Self::arrayitem_key(op, ctx) {
@@ -2533,7 +2530,7 @@ impl OptHeap {
                         return OptimizationResult::Remove;
                     }
                     // heap.py:108 possible_aliasing_two_infos
-                    let lazy_obj_resolved = ctx.get_box_replacement(*lazy_obj);
+                    let lazy_obj_resolved = ctx.get_box_replacement(*lazy_obj).to_opref();
                     let cannot_alias = ArrayCachedItem::_cannot_alias_via_classes_or_lengths(
                         lazy_obj_resolved,
                         array,
@@ -2609,7 +2606,9 @@ impl OptHeap {
                     // can_cache=True: put_field_back_to_info
                     let final_value = lazy_op.arg(2);
                     let descr = lazy_op.getdescr();
-                    let lazy_obj = ctx.get_box_replacement(lazy_op.arg(0).to_opref());
+                    let lazy_obj = ctx
+                        .get_box_replacement(lazy_op.arg(0).to_opref())
+                        .to_opref();
                     self.cache_arrayitem(lazy_obj, descr_idx, const_index, descr.as_ref());
                     ctx.arrayinfo_setitem(&lazy_op, const_index as usize, final_value.to_opref());
                 }
@@ -2734,7 +2733,7 @@ impl OptHeap {
 
             let descr_idx = descr.index();
             let arrayinfo = array_ref;
-            let indexbox = ctx.get_box_replacement(op.arg(1).to_opref());
+            let indexbox = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
             if let Some(submap) = self.get_cached_array_submap(descr_idx) {
                 if let Some(cached) = submap.lookup_cached(arrayinfo, indexbox, ctx) {
                     let b_old = ctx
@@ -2758,7 +2757,7 @@ impl OptHeap {
 
     fn optimize_setarrayitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         // heapcache.py:224-230 _escape_from_write parity:
-        let array_obj = ctx.get_box_replacement(op.arg(0).to_opref());
+        let array_obj = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let stored_value = op.arg(2).to_opref();
         self.escape_from_write(array_obj, stored_value);
 
@@ -2775,9 +2774,9 @@ impl OptHeap {
                         .map(|b| ctx.getintbound_handle(&b).borrow().clone())
                         .expect("getintbound: operand must resolve to a BoxRef");
                     self.force_lazy_setarrayitem(&descr, Some(&indexb), false, ctx);
-                    let arrayinfo = ctx.get_box_replacement(op.arg(0).to_opref());
-                    let indexbox = ctx.get_box_replacement(op.arg(1).to_opref());
-                    let resbox = ctx.get_box_replacement(op.arg(2).to_opref());
+                    let arrayinfo = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
+                    let indexbox = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
+                    let resbox = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
                     self.arrayitem_submap(&descr)
                         .cache_varindex_write(arrayinfo, indexbox, resbox);
                 }
@@ -3021,7 +3020,9 @@ impl OptHeap {
                             .get_box_replacement_box(pending_op.arg(1).to_opref())
                             .and_then(|b| ctx.get_constant_int_box(&b))
                         {
-                            let array = ctx.get_box_replacement(pending_op.arg(0).to_opref());
+                            let array = ctx
+                                .get_box_replacement(pending_op.arg(0).to_opref())
+                                .to_opref();
                             let cai = self.arrayitem_cache(&descr, index);
                             cai.lazy_set = Some((array, pending_op));
                         } else {
@@ -3029,7 +3030,9 @@ impl OptHeap {
                         }
                     } else {
                         let descr = pending_op.getdescr().unwrap().clone();
-                        let obj = ctx.get_box_replacement(pending_op.arg(0).to_opref());
+                        let obj = ctx
+                            .get_box_replacement(pending_op.arg(0).to_opref())
+                            .to_opref();
                         let cf = self.field_cache(&descr);
                         cf.lazy_set = Some((obj, pending_op));
                     }
@@ -3386,7 +3389,7 @@ impl Optimization for OptHeap {
                     continue;
                 };
                 // heap.py:844: box2 = box2.get_box_replacement()
-                let val = ctx.get_box_replacement(val);
+                let val = ctx.get_box_replacement(val).to_opref();
                 // heap.py:845: if box2.is_constant() or box2 in available_boxes:
                 if val.is_none() {
                     continue;
@@ -3415,7 +3418,7 @@ impl Optimization for OptHeap {
                 continue;
             }
             let field_idx = Self::field_slot_index(descr);
-            let resolved = ctx.get_box_replacement(*box1);
+            let resolved = ctx.get_box_replacement(*box1).to_opref();
             // heap.py:872-873: parent_descr = descr.get_parent_descr()
             //                  assert parent_descr.is_object()
             let parent_descr = descr.as_field_descr().and_then(|fd| fd.get_parent_descr());
@@ -3517,7 +3520,7 @@ impl Optimization for OptHeap {
                         continue;
                     };
                     // heap.py:865: box2 = box2.get_box_replacement()
-                    let val = ctx.get_box_replacement(val);
+                    let val = ctx.get_box_replacement(val).to_opref();
                     // heap.py:866: if box2.is_constant() or box2 in available_boxes:
                     if val.is_none() {
                         continue;
@@ -3550,7 +3553,7 @@ impl Optimization for OptHeap {
             if box1.is_none() || box2.is_none() {
                 continue;
             }
-            let resolved = ctx.get_box_replacement(*box1);
+            let resolved = ctx.get_box_replacement(*box1).to_opref();
             // heap.py:886-892:
             //     if box1.is_constant(): arrayinfo = info.ConstPtrInfo(box1)
             //     else:
@@ -4070,7 +4073,7 @@ mod tests {
 
         let result = heap.optimize_getfield(&op, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(pos2), p1);
+        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), p1);
     }
 
     /// After consuming an imported short field, a cache invalidation followed
@@ -4108,7 +4111,7 @@ mod tests {
         op1.pos.set(pos2);
         let result1 = heap.optimize_getfield(&op1, &mut ctx);
         assert!(matches!(result1, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(pos2), p1);
+        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), p1);
 
         // A call invalidates all mutable field caches.
         heap.clean_caches(&mut ctx);
@@ -4351,10 +4354,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -4760,10 +4760,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -5484,10 +5481,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6074,10 +6068,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6160,10 +6151,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6385,10 +6373,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6456,10 +6441,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6524,10 +6506,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6710,7 +6689,7 @@ mod tests {
         op2.setdescr(descr.clone());
         op2.pos.set(pos2);
         assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
-        assert_eq!(ctx.get_box_replacement(pos2), pos1);
+        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
         assert!(heap.last_emitted_removed);
     }
 
@@ -6773,7 +6752,7 @@ mod tests {
         op2.setdescr(descr.clone());
         op2.pos.set(pos2);
         assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
-        assert_eq!(ctx.get_box_replacement(pos2), pos1);
+        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
     }
 
     /// heap.py:390 parity: clean_caches clears cached_dict_reads.
@@ -6893,7 +6872,7 @@ mod tests {
         op2.setdescr(descr.clone());
         op2.pos.set(pos2);
         assert!(heap._optimize_call_dict_lookup(&op2, &mut ctx));
-        assert_eq!(ctx.get_box_replacement(pos2), pos1);
+        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
     }
 
     /// optimizer.py:84-87 parity: every Optimization.emit overwrite path —

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -65,9 +65,7 @@ use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
 
 #[inline]
 fn make_nonnull_opref(ctx: &mut OptContext, opref: OpRef) {
-    if let Some(box_ref) = ctx
-        .get_box_replacement_box(opref)
-    {
+    if let Some(box_ref) = ctx.get_box_replacement_box(opref) {
         ctx.make_nonnull(&box_ref);
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -67,7 +67,6 @@ use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
 fn make_nonnull_opref(ctx: &mut OptContext, opref: OpRef) {
     if let Some(box_ref) = ctx
         .get_box_replacement_box(opref)
-        .or_else(|| ctx.ensure_box(opref))
     {
         ctx.make_nonnull(&box_ref);
     }
@@ -1490,9 +1489,7 @@ impl OptHeap {
             }
             // heap.py:525-527: make_equal_to + last_emitted_operation = REMOVED
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_res = ctx
-                .ensure_box(res_v)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_res = ctx.get_box_replacement(res_v);
             ctx.make_equal_to(&b_old, &b_res);
             self.last_emitted_removed = true;
             return true;
@@ -1946,9 +1943,7 @@ impl OptHeap {
                     // MUST_ALIAS: lazy_set targets the same struct → return rhs
                     let cached = lazy_op.arg(1).to_opref();
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_cached = ctx
-                        .ensure_box(cached)
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_cached = ctx.get_box_replacement(cached);
                     ctx.make_equal_to(&b_old, &b_cached);
                     return OptimizationResult::Remove;
                 }
@@ -2507,9 +2502,7 @@ impl OptHeap {
                         // MUST_ALIAS: lazy_set targets the same array → return rhs
                         let cached = lazy_op.arg(2).to_opref();
                         let b_old = BoxRef::from_bound_op(op_rc);
-                        let b_cached = ctx
-                            .ensure_box(cached)
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_cached = ctx.get_box_replacement(cached);
                         ctx.make_equal_to(&b_old, &b_cached);
                         return OptimizationResult::Remove;
                     }
@@ -2592,7 +2585,7 @@ impl OptHeap {
             // setarrayitem/call invalidates cached_arrayitems, the stale preamble
             // value cannot re-populate the cache on a subsequent getarrayitem.
             let pop = ctx
-                .ensure_box(array)
+                .get_box_replacement_box(array)
                 .and_then(|b| {
                     ctx.with_ptr_info_mut(&b, |info| info.take_preamble_item(const_index as usize))
                 })
@@ -2684,10 +2677,10 @@ impl OptHeap {
         //   cached_result = submap.lookup_cached(arrayinfo, indexop)
         if let Some(descr) = op.getdescr() {
             // heap.py:692-693: force lazy stores for this descr within the index bound
-            let indexb = ctx
-                .ensure_box(op.arg(1).to_opref())
-                .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-                .expect("getintbound: operand must resolve to a BoxRef");
+            let indexb = {
+                let b = ctx.get_box_replacement(op.arg(1).to_opref());
+                ctx.getintbound_handle(&b).borrow().clone()
+            };
             self.force_lazy_setarrayitem(&descr, Some(&indexb), true, ctx);
 
             let descr_idx = descr.index();
@@ -2696,9 +2689,7 @@ impl OptHeap {
             if let Some(submap) = self.get_cached_array_submap(descr_idx) {
                 if let Some(cached) = submap.lookup_cached(arrayinfo, indexbox, ctx) {
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_cached = ctx
-                        .ensure_box(cached)
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_cached = ctx.get_box_replacement(cached);
                     ctx.make_equal_to(&b_old, &b_cached);
                     return OptimizationResult::Remove;
                 }
@@ -2726,10 +2717,10 @@ impl OptHeap {
                 //   submap.cache_varindex_write(arrayinfo, ...)
                 //   return self.emit(op)
                 if let Some(descr) = op.getdescr() {
-                    let indexb = ctx
-                        .ensure_box(op.arg(1).to_opref())
-                        .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-                        .expect("getintbound: operand must resolve to a BoxRef");
+                    let indexb = {
+                        let b = ctx.get_box_replacement(op.arg(1).to_opref());
+                        ctx.getintbound_handle(&b).borrow().clone()
+                    };
                     self.force_lazy_setarrayitem(&descr, Some(&indexb), false, ctx);
                     let arrayinfo = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
                     let indexbox = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
@@ -4330,7 +4321,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -4736,7 +4735,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -5457,7 +5464,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6044,7 +6059,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6127,7 +6150,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6349,7 +6380,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6417,7 +6456,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -6482,7 +6529,15 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
+                let arg = resolved.arg(i);
+                let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(arg.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| arg.clone()),
+                };
+                resolved.setarg(i, rb);
             }
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3872,7 +3872,7 @@ mod tests {
                 same_as_source: None,
             }],
         );
-        let object_box = ctx.ensure_box(object).unwrap();
+        let object_box = ctx.materialize_box_at(object);
         ctx.set_ptr_info(&object_box, PtrInfo::instance(None, None));
         ctx.with_ptr_info_mut(&object_box, |info| {
             info.set_preamble_field(
@@ -4322,10 +4322,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -4367,9 +4371,7 @@ mod tests {
 
         let mut ctx = OptContext::new(256);
         ctx.make_constant(idx, majit_ir::Value::Int(3));
-        let pos100 = ctx
-            .ensure_box(OpRef::ref_op(100))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let pos100 = ctx.materialize_box_at(OpRef::ref_op(100));
         ctx.set_ptr_info(&pos100, PtrInfo::virtual_array(d, 8, false));
 
         let mut pass = OptHeap::new();
@@ -4409,9 +4411,7 @@ mod tests {
 
         let mut ctx = OptContext::new(256);
         ctx.make_constant(idx, majit_ir::Value::Int(3));
-        let pos100 = ctx
-            .ensure_box(OpRef::int_op(100))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let pos100 = ctx.materialize_box_at(OpRef::int_op(100));
         ctx.set_ptr_info(&pos100, PtrInfo::virtual_array(d.clone(), 8, false));
 
         let mut pass = OptHeap::new();
@@ -4736,10 +4736,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -5070,9 +5074,7 @@ mod tests {
         // Seed PtrInfo._fields[idx] with the cached value so the
         // produce_potential_short_preamble_ops read path can find it.
         use crate::optimizeopt::info::PtrInfo;
-        let pos100 = ctx
-            .ensure_box(OpRef::ref_op(100))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let pos100 = ctx.materialize_box_at(OpRef::ref_op(100));
         ctx.set_ptr_info(&pos100, PtrInfo::instance(None, None));
         ctx.with_ptr_info_mut(&pos100, |info| {
             info.setfield(descr.index(), OpRef::ref_op(101));
@@ -5465,10 +5467,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -6060,10 +6066,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -6151,10 +6161,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -6381,10 +6395,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -6457,10 +6475,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -6530,10 +6552,14 @@ mod tests {
                 let arg = resolved.arg(i);
                 let rb = match ctx.get_box_replacement_box(arg.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(arg.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| arg.clone()),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved.setarg(i, rb);
             }
@@ -6627,12 +6653,8 @@ mod tests {
         let const_20 = ctx.emit_constant_int(20);
         let const_30 = ctx.emit_constant_int(30);
 
-        let op1_box = ctx
-            .ensure_box(op1)
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let op2_box = ctx
-            .ensure_box(op2)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let op1_box = ctx.materialize_box_at(op1);
+        let op2_box = ctx.materialize_box_at(op2);
         ctx.set_ptr_info(
             &op1_box,
             PtrInfo::Array(ArrayPtrInfo {
@@ -6757,11 +6779,9 @@ mod tests {
         op1.pos.set(pos1);
         // Pretend the result is known >= 0.
         // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-        // `reserve_pos_typed` does not pre-mint a canonical host; `ensure_box`
+        // `reserve_pos_typed` does not pre-mint a canonical host; `materialize_box_at`
         // materializes the BoxRef for the reserved position here.
-        let pos1_box = ctx
-            .ensure_box(pos1)
-            .expect("body-namespace OpRef must resolve to a BoxRef");
+        let pos1_box = ctx.materialize_box_at(pos1);
         ctx.setintbound(
             &pos1_box,
             &crate::optimizeopt::intutils::IntBound::from_constant(5),

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3412,7 +3412,7 @@ impl Optimization for OptHeap {
                 && !resolved_is_virtual;
             if needs_install {
                 // info.py:175-188 InstancePtrInfo + init_fields
-                if let Some(b) = ctx.ensure_box(resolved) {
+                if let Some(b) = ctx.get_box_replacement_box(resolved) {
                     ctx.set_ptr_info(&b, PtrInfo::instance(parent_descr.clone(), None));
                 }
             }
@@ -3429,7 +3429,7 @@ impl Optimization for OptHeap {
                 }
             } else {
                 let box2 = *box2;
-                if let Some(b) = ctx.ensure_box(resolved) {
+                if let Some(b) = ctx.get_box_replacement_box(resolved) {
                     ctx.with_ptr_info_mut(&b, |info| info.setfield(field_idx, box2));
                 }
             }
@@ -3534,7 +3534,7 @@ impl Optimization for OptHeap {
                 .is_some()
                 && !resolved_is_virtual;
             if needs_install {
-                if let Some(b) = ctx.ensure_box(resolved) {
+                if let Some(b) = ctx.get_box_replacement_box(resolved) {
                     ctx.set_ptr_info(
                         &b,
                         PtrInfo::array(
@@ -3560,7 +3560,7 @@ impl Optimization for OptHeap {
             } else {
                 let idx = *index as usize;
                 let box2 = *box2;
-                if let Some(b) = ctx.ensure_box(resolved) {
+                if let Some(b) = ctx.get_box_replacement_box(resolved) {
                     ctx.with_ptr_info_mut(&b, |info| info.setitem(idx, box2));
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3150,7 +3150,7 @@ impl Default for OptHeap {
 }
 
 impl Optimization for OptHeap {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let result = self.dispatch_propagate(op, ctx);
         // heap.py:417-425 emit() override parity:
         // Before emitting any new op, flush the postponed op. Then
@@ -4356,7 +4356,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -4402,7 +4402,7 @@ mod tests {
         let mut pass = OptHeap::new();
         pass.setup();
 
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Emit(_)));
         let arr_box = ctx
             .get_box_replacement_box(OpRef::ref_op(100))
@@ -4444,7 +4444,7 @@ mod tests {
         let mut pass = OptHeap::new();
         pass.setup();
 
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         // _lazy_set holds the pending op; PtrInfo is NOT yet written.
         let cai = pass
@@ -4762,7 +4762,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -5483,7 +5483,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -6070,7 +6070,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -6153,7 +6153,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -6375,7 +6375,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -6443,7 +6443,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -6508,7 +6508,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -6895,7 +6895,7 @@ mod tests {
         let new_pos = ctx.reserve_pos_typed(Type::Ref);
         let mut new_op = Op::new(OpCode::New, &[]);
         new_op.pos.set(new_pos);
-        let result = heap.propagate_forward(&new_op, &mut ctx);
+        let result = heap.propagate_forward(&new_op, &std::rc::Rc::new(new_op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
         assert!(
             !heap.last_emitted_removed,
@@ -6905,7 +6905,7 @@ mod tests {
         // Now a GUARD_NO_EXCEPTION must be emitted, not removed.
         let mut guard = Op::new(OpCode::GuardNoException, &[]);
         guard.pos.set(ctx.reserve_pos_typed(Type::Void));
-        let guard_result = heap.propagate_forward(&guard, &mut ctx);
+        let guard_result = heap.propagate_forward(&guard, &std::rc::Rc::new(guard.clone()), &mut ctx);
         assert!(
             matches!(guard_result, OptimizationResult::Emit(_)),
             "GUARD_NO_EXCEPTION after a PassOn-emitted op must NOT be removed"

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -207,7 +207,7 @@ impl CachedField {
         }
         let descr_idx = OptHeap::field_slot_index(descr);
         for &obj in &self.cached_structs {
-            if let Some(b) = ctx.ensure_box(obj) {
+            if let Some(b) = ctx.get_box_replacement_box(obj) {
                 ctx.with_ptr_info_mut(&b, |info| info.clear_field(descr_idx));
             }
             // Clear existing const_infos slot if present; do NOT create.
@@ -531,7 +531,7 @@ impl ArrayCachedItem {
     fn invalidate(&mut self, ctx: &mut OptContext) {
         let index = self.index as usize;
         for &obj in &self.cached_structs {
-            if let Some(b) = ctx.ensure_box(obj) {
+            if let Some(b) = ctx.get_box_replacement_box(obj) {
                 ctx.with_ptr_info_mut(&b, |info| info.clear_item(index));
             }
             // info.py:728 ConstPtrInfo._get_array_info — only clear

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -822,7 +822,7 @@ fn force_box_impl(
     // `box_` is the bound BoxRef of the virtual being forced (callers resolve
     // op -> box before delegating). The OpRef view drives op identity (pos,
     // logging, alloc-vs-original comparisons); the box drives every
-    // make_equal_to / set_ptr_info receiver, so no `ensure_box` round-trip is
+    // make_equal_to / set_ptr_info receiver, so no `materialize_box_at` round-trip is
     // needed for the forwarding writes.
     let opref = box_.to_opref();
 
@@ -1576,9 +1576,7 @@ mod tests {
     fn test_str_ptr_info_plain_constant_string_spec_rejects_intbound_constant_chars() {
         let mut ctx = OptContext::new(16);
         let ch = OpRef::int_op(10);
-        let ch_box = ctx
-            .ensure_box(ch)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let ch_box = ctx.materialize_box_at(ch);
         ctx.setintbound(&ch_box, &IntBound::from_constant(97));
 
         assert_eq!(
@@ -1615,9 +1613,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(21), Value::Int(2));
 
         let source = OpRef::int_op(1);
-        let source_box = ctx
-            .ensure_box(source)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let source_box = ctx.materialize_box_at(source);
         ctx.set_ptr_info(
             &source_box,
             PtrInfo::Str(StrPtrInfo {
@@ -1667,9 +1663,7 @@ mod tests {
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
         });
-        let pos2 = ctx
-            .ensure_box(OpRef::int_op(2))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let pos2 = ctx.materialize_box_at(OpRef::int_op(2));
         ctx.set_ptr_info(
             &pos2,
             PtrInfo::Str(StrPtrInfo {

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -930,7 +930,7 @@ fn force_box_impl(
             // info.py:152 `newop.set_forwarded(self)` — unconditional.
             // Route through `ensure_box` so the just-emitted alloc op
             // materializes a BoxRef and the PtrInfo install lands.
-            if let Some(b) = ctx.ensure_box(alloc_ref) {
+            if let Some(b) = ctx.get_box_replacement_box(alloc_ref) {
                 ctx.set_ptr_info(&b, preserved);
             }
             if crate::optimizeopt::majit_log_enabled() {
@@ -987,7 +987,7 @@ fn force_box_impl(
             new_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, new_op);
             // info.py:152 `newop.set_forwarded(self)` — unconditional.
-            if let Some(b) = ctx.ensure_box(alloc_ref) {
+            if let Some(b) = ctx.get_box_replacement_box(alloc_ref) {
                 ctx.set_ptr_info(&b, preserved);
             }
             if crate::optimizeopt::majit_log_enabled() {
@@ -1175,7 +1175,7 @@ fn force_box_impl(
             let alloc_ref = emit_op(ctx, call_op);
 
             // info.py:152 unconditional set_forwarded.
-            if let Some(b) = ctx.ensure_box(alloc_ref) {
+            if let Some(b) = ctx.get_box_replacement_box(alloc_ref) {
                 ctx.set_ptr_info(&b, PtrInfo::nonnull());
             }
             if opref != alloc_ref {
@@ -1245,7 +1245,7 @@ fn force_box_impl(
             // `parent = OpRef::NONE` (RPython `self.parent = None`).
             // info.py:152 unconditional set_forwarded — route through
             // `ensure_box` so the emitted IntAdd op carries PtrInfo.
-            if let Some(b) = ctx.ensure_box(new_ref) {
+            if let Some(b) = ctx.get_box_replacement_box(new_ref) {
                 ctx.set_ptr_info(
                     &b,
                     PtrInfo::VirtualRawSlice(VirtualRawSliceInfo {
@@ -1325,7 +1325,7 @@ fn force_box_impl(
             let newop = emit_op(ctx, newstr_op);
 
             // vstring.py:98: newop.set_forwarded(self) — unconditional.
-            if let Some(b) = ctx.ensure_box(newop) {
+            if let Some(b) = ctx.get_box_replacement_box(newop) {
                 ctx.set_ptr_info(
                     &b,
                     PtrInfo::Str(StrPtrInfo {

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -339,7 +339,11 @@ pub trait PtrInfoExt {
 
     /// info.py:137-160 / 222-226: force_box() emits the allocation and
     /// field writes via emit_extra(), recursively forcing child virtuals.
-    fn force_box(&mut self, opref: OpRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef;
+    /// `box_` is the (bound) BoxRef of the virtual being forced — RPython
+    /// `force_box(self, op, optforce)` passes the box object directly
+    /// (info.py:148-152), so the make_equal_to / set_forwarded receiver
+    /// needs no lookup.
+    fn force_box(&mut self, box_: BoxRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef;
 
     /// info.py:273-303: `_is_immutable_and_filled_with_constants`
     /// — used by `force_box` to decide whether a virtual can be
@@ -750,8 +754,8 @@ impl PtrInfoExt for PtrInfo {
     ///
     /// Generated ops are routed via emit_extra() (RPython
     /// emit_extra parity) so downstream passes can observe them.
-    fn force_box(&mut self, opref: OpRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef {
-        force_box_impl(self, opref, ctx)
+    fn force_box(&mut self, box_: BoxRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef {
+        force_box_impl(self, box_, ctx)
     }
 
     /// info.py:273-303: _is_immutable_and_filled_with_constants
@@ -810,10 +814,17 @@ impl PtrInfoExt for PtrInfo {
 
 fn force_box_impl(
     self_: &mut PtrInfo,
-    opref: OpRef,
+    box_: BoxRef,
     ctx: &mut crate::optimizeopt::OptContext,
 ) -> OpRef {
     use majit_ir::{Op, OpCode};
+
+    // `box_` is the bound BoxRef of the virtual being forced (callers resolve
+    // op -> box before delegating). The OpRef view drives op identity (pos,
+    // logging, alloc-vs-original comparisons); the box drives every
+    // make_equal_to / set_ptr_info receiver, so no `ensure_box` round-trip is
+    // needed for the forwarding writes.
+    let opref = box_.to_opref();
 
     fn force_child(orig_ref: OpRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef {
         let value_box = ctx.get_box_replacement_box(orig_ref);
@@ -821,7 +832,7 @@ fn force_box_impl(
         if value_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let value_box = value_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&value_box).unwrap();
-            let forced = force_box_impl(&mut info, value_ref, ctx);
+            let forced = force_box_impl(&mut info, value_box, ctx);
             return ctx
                 .get_box_replacement_box(forced)
                 .map(|b| b.to_opref())
@@ -891,15 +902,12 @@ fn force_box_impl(
                         }
                     }
                     // info.py:142: op.set_forwarded(constptr) — write
-                    // unconditional. Route through `ensure_box` so the
-                    // chain walks to the just-installed Const target
-                    // (where `set_ptr_info` is a no-op per Const-box
-                    // invariant) and never silently drops the write.
+                    // unconditional. `set_ptr_info` on `box_` walks the
+                    // chain to the just-installed Const target (where it
+                    // is a no-op per Const-box invariant).
                     let const_ref = GcRef(ptr.0);
                     ctx.make_constant(opref, Value::Ref(const_ref));
-                    if let Some(b) = ctx.ensure_box(opref) {
-                        ctx.set_ptr_info(&b, PtrInfo::Constant(const_ref));
-                    }
+                    ctx.set_ptr_info(&box_, PtrInfo::Constant(const_ref));
                     return opref;
                 }
             }
@@ -928,8 +936,8 @@ fn force_box_impl(
             new_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, new_op);
             // info.py:152 `newop.set_forwarded(self)` — unconditional.
-            // Route through `ensure_box` so the just-emitted alloc op
-            // materializes a BoxRef and the PtrInfo install lands.
+            // The just-emitted alloc op is bound, so its resolved box
+            // carries the PtrInfo install.
             if let Some(b) = ctx.get_box_replacement_box(alloc_ref) {
                 ctx.set_ptr_info(&b, preserved);
             }
@@ -940,11 +948,8 @@ fn force_box_impl(
                 );
             }
             if opref != alloc_ref {
-                let b_opref = ctx
-                    .ensure_box(opref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(&b_opref, &b_alloc);
+                ctx.make_equal_to(&box_, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
                 let value_ref = force_child(value_ref, ctx);
@@ -997,11 +1002,8 @@ fn force_box_impl(
                 );
             }
             if opref != alloc_ref {
-                let b_opref = ctx
-                    .ensure_box(opref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(&b_opref, &b_alloc);
+                ctx.make_equal_to(&box_, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
                 let value_ref = force_child(value_ref, ctx);
@@ -1021,13 +1023,9 @@ fn force_box_impl(
         PtrInfo::VirtualArray(vinfo) => {
             // info.py:540-558 ArrayPtrInfo._force_elements
             // RPython `op.set_forwarded(self)` (post-force) is
-            // unconditional. `ensure_box` lazy-allocates the backing
-            // BoxRef, matching upstream's implicit "every Box exists"
-            // invariant.
+            // unconditional; the bound `box_` carries the PtrInfo write.
             let len = vinfo.items.len();
-            if let Some(b) = ctx.ensure_box(opref) {
-                ctx.set_ptr_info(&b, PtrInfo::nonnull());
-            }
+            ctx.set_ptr_info(&box_, PtrInfo::nonnull());
 
             let len_ref = ctx.emit_constant_int(len as i64);
             let alloc_opcode = if vinfo.clear {
@@ -1040,11 +1038,8 @@ fn force_box_impl(
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
             if opref != alloc_ref {
-                let b_opref = ctx
-                    .ensure_box(opref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(&b_opref, &b_alloc);
+                ctx.make_equal_to(&box_, &b_alloc);
             }
 
             // info.py:542: const = optforce.optimizer.new_const_item(self.descr)
@@ -1093,11 +1088,9 @@ fn force_box_impl(
             // created with clear=True, so the original op is always
             // NEW_ARRAY_CLEAR.
             // RPython `op.set_forwarded(self)` (post-force) is
-            // unconditional; ensure_box lazy-allocates the BoxRef.
+            // unconditional; the bound `box_` carries the PtrInfo write.
             let num_elements = vinfo.element_fields.len();
-            if let Some(b) = ctx.ensure_box(opref) {
-                ctx.set_ptr_info(&b, PtrInfo::nonnull());
-            }
+            ctx.set_ptr_info(&box_, PtrInfo::nonnull());
 
             let len_ref = ctx.emit_constant_int(num_elements as i64);
             let mut alloc_op = Op::new(OpCode::NewArrayClear, &[BoxRef::from_opref(len_ref)]);
@@ -1105,11 +1098,8 @@ fn force_box_impl(
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
             if opref != alloc_ref {
-                let b_opref = ctx
-                    .ensure_box(opref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(&b_opref, &b_alloc);
+                ctx.make_equal_to(&box_, &b_alloc);
             }
 
             // info.py:672: fielddescrs = op.getdescr().get_all_fielddescrs()
@@ -1179,11 +1169,8 @@ fn force_box_impl(
                 ctx.set_ptr_info(&b, PtrInfo::nonnull());
             }
             if opref != alloc_ref {
-                let b_opref = ctx
-                    .ensure_box(opref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(&b_opref, &b_alloc);
+                ctx.make_equal_to(&box_, &b_alloc);
             }
 
             // info.py:425: CHECK_MEMORY_ERROR
@@ -1243,8 +1230,8 @@ fn force_box_impl(
             let new_ref = emit_op(ctx, add_op);
             // Preserve raw-slice identity; mark non-virtual via
             // `parent = OpRef::NONE` (RPython `self.parent = None`).
-            // info.py:152 unconditional set_forwarded — route through
-            // `ensure_box` so the emitted IntAdd op carries PtrInfo.
+            // info.py:152 unconditional set_forwarded — the emitted
+            // IntAdd op is bound, so its resolved box carries PtrInfo.
             if let Some(b) = ctx.get_box_replacement_box(new_ref) {
                 ctx.set_ptr_info(
                     &b,
@@ -1257,11 +1244,8 @@ fn force_box_impl(
                 );
             }
             if opref != new_ref {
-                let b_opref = ctx
-                    .ensure_box(opref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
                 let b_new = ctx.get_box_replacement(new_ref);
-                ctx.make_equal_to(&b_opref, &b_new);
+                ctx.make_equal_to(&box_, &b_new);
             }
             new_ref
         }
@@ -1342,11 +1326,8 @@ fn force_box_impl(
 
             // vstring.py:99-100: op.set_forwarded(newop)
             if opref != newop {
-                let b_opref = ctx
-                    .ensure_box(opref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
                 let b_newop = ctx.get_box_replacement(newop);
-                ctx.make_equal_to(&b_opref, &b_newop);
+                ctx.make_equal_to(&box_, &b_newop);
             }
 
             // vstring.py:101-102: initialize_forced_string(op, optstring, op, CONST_0, mode)

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -817,10 +817,7 @@ fn force_box_impl(
 
     fn force_child(orig_ref: OpRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef {
         let value_box = ctx.get_box_replacement_box(orig_ref);
-        let value_ref = value_box
-            .as_ref()
-            .map(|b| b.to_opref())
-            .unwrap_or(orig_ref);
+        let value_ref = value_box.as_ref().map(|b| b.to_opref()).unwrap_or(orig_ref);
         if value_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let value_box = value_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&value_box).unwrap();

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -943,9 +943,7 @@ fn force_box_impl(
                 let b_opref = ctx
                     .ensure_box(opref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_alloc = ctx
-                    .ensure_box(alloc_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(&b_opref, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
@@ -1002,9 +1000,7 @@ fn force_box_impl(
                 let b_opref = ctx
                     .ensure_box(opref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_alloc = ctx
-                    .ensure_box(alloc_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(&b_opref, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
@@ -1047,9 +1043,7 @@ fn force_box_impl(
                 let b_opref = ctx
                     .ensure_box(opref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_alloc = ctx
-                    .ensure_box(alloc_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(&b_opref, &b_alloc);
             }
 
@@ -1114,9 +1108,7 @@ fn force_box_impl(
                 let b_opref = ctx
                     .ensure_box(opref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_alloc = ctx
-                    .ensure_box(alloc_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(&b_opref, &b_alloc);
             }
 
@@ -1190,9 +1182,7 @@ fn force_box_impl(
                 let b_opref = ctx
                     .ensure_box(opref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_alloc = ctx
-                    .ensure_box(alloc_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(&b_opref, &b_alloc);
             }
 
@@ -1270,9 +1260,7 @@ fn force_box_impl(
                 let b_opref = ctx
                     .ensure_box(opref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_new = ctx
-                    .ensure_box(new_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_new = ctx.get_box_replacement(new_ref);
                 ctx.make_equal_to(&b_opref, &b_new);
             }
             new_ref
@@ -1357,9 +1345,7 @@ fn force_box_impl(
                 let b_opref = ctx
                     .ensure_box(opref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_newop = ctx
-                    .ensure_box(newop)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_newop = ctx.get_box_replacement(newop);
                 ctx.make_equal_to(&b_opref, &b_newop);
             }
 

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -816,13 +816,19 @@ fn force_box_impl(
     use majit_ir::{Op, OpCode};
 
     fn force_child(orig_ref: OpRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef {
-        let value_ref = ctx.get_box_replacement(orig_ref);
         let value_box = ctx.get_box_replacement_box(orig_ref);
+        let value_ref = value_box
+            .as_ref()
+            .map(|b| b.to_opref())
+            .unwrap_or(orig_ref);
         if value_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let value_box = value_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&value_box).unwrap();
             let forced = force_box_impl(&mut info, value_ref, ctx);
-            return ctx.get_box_replacement(forced);
+            return ctx
+                .get_box_replacement_box(forced)
+                .map(|b| b.to_opref())
+                .unwrap_or(forced);
         }
         value_ref
     }
@@ -1311,7 +1317,10 @@ fn force_box_impl(
             // vstring.py:92: lengthbox = self.getstrlen(op, optstring, mode)
             let lengthbox = match &variant {
                 VStringVariant::Plain(info) => ctx.emit_constant_int(info._chars.len() as i64),
-                VStringVariant::Slice(info) => ctx.get_box_replacement(info.lgtop),
+                VStringVariant::Slice(info) => ctx
+                    .get_box_replacement_box(info.lgtop)
+                    .map(|b| b.to_opref())
+                    .unwrap_or(info.lgtop),
                 VStringVariant::Concat(info) => {
                     let left_len = ctx.getstrlen_opref(info.vleft, mode);
                     let right_len = ctx.getstrlen_opref(info.vright, mode);
@@ -1372,7 +1381,10 @@ fn force_box_impl(
                     let one = ctx.emit_constant_int(1);
                     for ch in &info._chars {
                         if let Some(ch_ref) = ch {
-                            let ch_resolved = ctx.get_box_replacement(*ch_ref);
+                            let ch_resolved = ctx
+                                .get_box_replacement_box(*ch_ref)
+                                .map(|b| b.to_opref())
+                                .unwrap_or(*ch_ref);
                             let setitem_op = Op::new(
                                 set_opcode,
                                 &[

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -107,13 +107,13 @@ impl OptIntBounds {
     }
 
     fn getintbound_box(&self, opref: OpRef, ctx: &mut OptContext) -> IntBound {
-        match ctx.get_box_replacement_box(opref) {
-            Some(b) => ctx.getintbound_handle(&b).borrow().clone(),
-            None => ctx
-                .ensure_box(opref)
-                .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-                .expect("getintbound: operand must resolve to a BoxRef"),
-        }
+        // optimizer.py:99-113 `getintbound`: `op = get_box_replacement(op)`
+        // then read/lazy-install the bound. The dispatch-entry rebind
+        // (propagate_from_pass_range) mints + registers a canonical host for
+        // every operand, so `get_box_replacement` resolves to a BOUND terminal
+        // on which `getintbound_handle`'s lazy install is safe.
+        let b = ctx.get_box_replacement(opref);
+        ctx.getintbound_handle(&b).borrow().clone()
     }
 
     /// `BoxRef`-terminal variant of [`getintbound_box`]: reads the bound off
@@ -125,30 +125,27 @@ impl OptIntBounds {
 
     /// Resolve an operand to its forwarded terminal `BoxRef`, the `op =
     /// get_box_replacement(op)` step shared by every `optimize_INT_*` body
-    /// (intbounds.py / optimizer.py:343). Walks the `_forwarded` chain via
-    /// `get_box_replacement_box`, falling back to `ensure_box` for the
-    /// retrace/test baseline that carries no upstream binding (the same
-    /// fallback `getintbound_box` uses). The returned box is the operand the
-    /// bound and the `arg0 is arg1` identity check both read, so a single
-    /// resolve replaces the prior resolve-for-`==` plus resolve-inside-
-    /// `getintbound_box` pair.
+    /// (intbounds.py / optimizer.py:343). The dispatch-entry rebind
+    /// registers a canonical host for every operand, so `get_box_replacement`
+    /// is total and resolves to a bound terminal. The returned box is the
+    /// operand the bound and the `arg0 is arg1` identity check both read, so
+    /// a single resolve replaces the prior resolve-for-`==` plus
+    /// resolve-inside-`getintbound_box` pair.
     fn resolve_box(&self, opref: OpRef, ctx: &mut OptContext) -> crate::r#box::BoxRef {
-        ctx.get_box_replacement_box(opref)
-            .or_else(|| ctx.ensure_box(opref))
-            .expect("intbounds operand must resolve to a BoxRef")
+        ctx.get_box_replacement(opref)
     }
 
     /// Intersect a bound into the stored bound for opref. RPython:
     /// `self.getintbound(op).intersect(bound)` (mutates the IntBound stored
     /// on `op._forwarded` in place).
     fn intersect_bound(&mut self, opref: OpRef, bound: &IntBound, ctx: &mut OptContext) {
-        // optimizer.py:99-113 `getintbound` lazy-installs unbounded on
-        // first access; `ensure_box` mirrors the materialize-always
-        // invariant. `get_box_replacement_box` would silently skip an
-        // opref it can't resolve, losing the bound write.
-        if let Some(op_box) = ctx.ensure_box(opref) {
-            ctx.setintbound(&op_box, bound);
-        }
+        // optimizer.py:99-113 `getintbound` lazy-installs unbounded on first
+        // access; `setintbound` re-walks via `get_box_replacement` internally
+        // before writing. The dispatch-entry rebind registers a canonical host
+        // for every operand, so `get_box_replacement` resolves to a bound
+        // terminal the bound can install onto.
+        let op_box = ctx.get_box_replacement(opref);
+        ctx.setintbound(&op_box, bound);
     }
 
     /// optimizer.py:434: make_constant_int(box, intvalue) — RPython just
@@ -3444,17 +3441,21 @@ mod tests {
         for op in ops.iter() {
             let mut resolved_op = op.clone();
             // Keep the op.pos as set by the test (not overriding with index)
-            // optimizer.py:651-652 setarg loop parity.
+            // optimizer.py:651-652 setarg loop parity. Mirror
+            // `propagate_from_pass_range`'s dispatch-entry rebind: mint +
+            // register a canonical host for producer-less operands (via
+            // `ensure_box`) so the pass's `get_box_replacement` resolves to a
+            // bound terminal instead of an unbound `from_opref` box.
             for i in 0..resolved_op.num_args() {
-                let a = resolved_op.arg(i).to_opref();
-                resolved_op.setarg(
-                    i,
-                    crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement_box(a)
-                            .map(|b| b.to_opref())
-                            .unwrap_or(a),
-                    ),
-                );
+                let a = resolved_op.arg(i);
+                let resolved = match ctx.get_box_replacement_box(a.to_opref()) {
+                    Some(b) => b,
+                    None => ctx
+                        .ensure_box(a.to_opref())
+                        .map(|b| b.get_box_replacement(false))
+                        .unwrap_or_else(|| a.clone()),
+                };
+                resolved_op.setarg(i, resolved);
             }
             let emitted_op = match pass.propagate_forward(
                 &resolved_op,

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1986,12 +1986,12 @@ impl OptIntBounds {
         // the BoxRef's authoritative `_forwarded` slot.
         let bound = ctx.with_ensured_ptr_info_arg0(op, |mut array| array.getlenbound(None));
         if let Some(bound) = bound {
-            // `ensure_box` resolves `op.pos` to its bound `Op`/`InputArg`,
-            // mirroring RPython's "Box always exists" invariant
-            // (`resoperation.py:233-248`).
-            if let Some(pos_box) = ctx.ensure_box(op.pos.get()) {
-                ctx.setintbound(&pos_box, &bound);
-            }
+            // optimizer.py:115 setintbound(op, ...): `op` is the result box.
+            // `get_box_replacement` resolves `op.pos` to its bound host
+            // (always registered post-emit), matching RPython's
+            // unconditional setintbound call.
+            let pos_box = ctx.get_box_replacement(op.pos.get());
+            ctx.setintbound(&pos_box, &bound);
         }
     }
 
@@ -2007,17 +2007,15 @@ impl OptIntBounds {
         // by calling ensure_ptr_info_arg0 (which constructs StrPtrInfo for
         // STRLEN per optimizer.py:490-491) and then invoking getlenbound on
         // the returned handle.
-        if let Some(arg0_box) = ctx.ensure_box(op.arg(0).to_opref()) {
-            ctx.make_nonnull_str(&arg0_box, 0);
-        }
+        let arg0_box = ctx.get_box_replacement(op.arg(0).to_opref());
+        ctx.make_nonnull_str(&arg0_box, 0);
         // `getlenbound` is a lazy-fill mutator on `StrPtrInfo.lenbound`
         // (`vstring.py:62`). Route through `with_ensured_ptr_info_arg0`
         // so the BoxRef-held StrPtrInfo is updated in place.
         let bound = ctx.with_ensured_ptr_info_arg0(op, |mut info| info.getlenbound(Some(0)));
         if let Some(bound) = bound {
-            if let Some(pos_box) = ctx.ensure_box(op.pos.get()) {
-                ctx.setintbound(&pos_box, &bound);
-            }
+            let pos_box = ctx.get_box_replacement(op.pos.get());
+            ctx.setintbound(&pos_box, &bound);
         }
     }
 
@@ -2026,16 +2024,14 @@ impl OptIntBounds {
         //     self.make_nonnull_str(op.getarg(0), vstring.mode_unicode)
         //     array = getptrinfo(op.getarg(0))
         //     self.optimizer.setintbound(op, array.getlenbound(vstring.mode_unicode))
-        if let Some(arg0_box) = ctx.ensure_box(op.arg(0).to_opref()) {
-            ctx.make_nonnull_str(&arg0_box, 1);
-        }
+        let arg0_box = ctx.get_box_replacement(op.arg(0).to_opref());
+        ctx.make_nonnull_str(&arg0_box, 1);
         // Same wrapper rationale as `postprocess_strlen` — lazy-fill
         // mutation on StrPtrInfo.lenbound needs BoxRef mirror.
         let bound = ctx.with_ensured_ptr_info_arg0(op, |mut info| info.getlenbound(Some(1)));
         if let Some(bound) = bound {
-            if let Some(pos_box) = ctx.ensure_box(op.pos.get()) {
-                ctx.setintbound(&pos_box, &bound);
-            }
+            let pos_box = ctx.get_box_replacement(op.pos.get());
+            ctx.setintbound(&pos_box, &bound);
         }
     }
 
@@ -2057,9 +2053,7 @@ impl OptIntBounds {
             if b.is_within_range(start, stop - 1) {
                 // The value already fits; replace with the input.
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx
-                    .ensure_box(op.arg(0).to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_arg = ctx.get_box_replacement(op.arg(0).to_opref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -2074,9 +2068,7 @@ impl OptIntBounds {
             let numbits = byte_size * 8;
             let start = -(1i64 << (numbits - 1));
             let stop = 1i64 << (numbits - 1);
-            let op_pos_box = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let op_pos_box = ctx.get_box_replacement(op.pos.get());
             let _ = ctx.with_intbound_mut(&op_pos_box, |bm| bm.intersect_const(start, stop - 1));
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1727,7 +1727,7 @@ impl OptIntBounds {
     /// matches, else None.
     fn as_operation(&self, opref: OpRef, opcode: OpCode, ctx: &mut OptContext) -> Option<Op> {
         let op = ctx
-            .ensure_box(opref)
+            .get_box_replacement_box(opref)
             .and_then(|pb| ctx.get_producing_op(&pb))?;
         if op.opcode == opcode { Some(op) } else { None }
     }

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1,3 +1,4 @@
+use crate::r#box::BoxRef;
 /// Integer bounds optimization pass.
 ///
 /// Translated from rpython/jit/metainterp/optimizeopt/intbounds.py.
@@ -6,7 +7,6 @@
 /// a condition that is already known true from integer bounds, the guard can be
 /// removed. It also narrows bounds after guards and arithmetic operations.
 use majit_ir::{Op, OpCode, OpRef, Value};
-use crate::r#box::BoxRef;
 
 use crate::optimizeopt::intutils::IntBound;
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
@@ -257,7 +257,12 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1220-1320 optimize_INT_EQ — rules:
     /// eq_different_knownbits / eq_same / eq_one / eq_zero / eq_sub_eq.
-    fn optimize_int_eq(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_eq(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -460,7 +465,12 @@ impl OptIntBounds {
 
     /// autogenintrules.py:23-143 optimize_INT_ADD — rules:
     /// add_zero / add_reassoc_consts / add_sub_x_c_c / add_sub_c_x_c.
-    fn optimize_int_add(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_add(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -566,7 +576,12 @@ impl OptIntBounds {
     /// sub_zero / sub_from_zero / sub_x_x / sub_add_consts / sub_add /
     /// sub_add_neg / sub_sub_left_x_c_c / sub_sub_left_c_x_c /
     /// sub_xor_x_y_y / sub_or_x_y_y / sub_invert_one.
-    fn optimize_int_sub(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_sub(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -701,7 +716,12 @@ impl OptIntBounds {
 
     /// autogenintrules.py:315-410 optimize_INT_MUL — rules:
     /// mul_zero / mul_one / mul_minus_one / mul_pow2_const / mul_lshift.
-    fn optimize_int_mul(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_mul(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -797,7 +817,12 @@ impl OptIntBounds {
     /// autogenintrules.py:414-581 optimize_INT_AND — rules:
     /// and_known_result / and_x_c_in_range / and_x_x / and_idempotent /
     /// and_reassoc_consts / and_absorb / and_or.
-    fn optimize_int_and(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_and(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -965,7 +990,12 @@ impl OptIntBounds {
     /// second of each pair is dead because the first always returns
     /// when its predicate holds. Preserved here to mirror upstream's
     /// auto-generated output line for line.
-    fn optimize_int_or(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_or(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1179,7 +1209,12 @@ impl OptIntBounds {
     /// autogenintrules.py:791-942 optimize_INT_XOR — rules:
     /// xor_x_x / xor_reassoc_consts / xor_absorb / xor_zero /
     /// xor_minus_1 / xor_known_result / xor_is_not.
-    fn optimize_int_xor(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_xor(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1313,7 +1348,12 @@ impl OptIntBounds {
     }
 
     /// autogenintrules.py:1432-1443 optimize_INT_INVERT — rules: invert_invert.
-    fn optimize_int_invert(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_invert(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         // invert_invert: int_invert(int_invert(x)) => x
         if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntInvert, ctx) {
@@ -1326,7 +1366,12 @@ impl OptIntBounds {
     }
 
     /// autogenintrules.py:1447-1458 optimize_INT_NEG — rules: neg_neg.
-    fn optimize_int_neg(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_neg(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         // neg_neg: int_neg(int_neg(x)) => x
         if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntNeg, ctx) {
@@ -1342,7 +1387,12 @@ impl OptIntBounds {
     /// lshift_zero_x / lshift_x_zero / lshift_rshift_c_c / lshift_and_rshift /
     /// lshift_urshift_c_c / lshift_and_urshift / lshift_lshift_c_c.
     /// LONG_BIT inlined as 64 (pyre is 64-bit only).
-    fn optimize_int_lshift(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_lshift(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1481,7 +1531,12 @@ impl OptIntBounds {
     /// autogenintrules.py:1113-1169 optimize_INT_RSHIFT — rules:
     /// rshift_zero_x / rshift_x_zero / rshift_known_result / rshift_lshift /
     /// rshift_rshift_c_c. LONG_BIT inlined as 64.
-    fn optimize_int_rshift(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_rshift(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1543,7 +1598,12 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1364-1399 optimize_INT_IS_TRUE — rules:
     /// is_true_bool / is_true_true / is_true_and_minint.
-    fn optimize_int_is_true(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_is_true(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         // is_true_true: int_is_true(x) => 1
@@ -1592,7 +1652,12 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1415-1428 optimize_INT_FORCE_GE_ZERO — rules:
     /// force_ge_zero_pos / force_ge_zero_neg.
-    fn optimize_int_force_ge_zero(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_force_ge_zero(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         // force_ge_zero_neg: int_force_ge_zero(x) => 0  (when x < 0)
@@ -1612,7 +1677,12 @@ impl OptIntBounds {
     /// autogenintrules.py:1173-1216 optimize_UINT_RSHIFT — rules:
     /// urshift_zero_x / urshift_x_zero / urshift_known_result /
     /// urshift_lshift_x_c_c.
-    fn optimize_uint_rshift(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_uint_rshift(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1974,7 +2044,12 @@ impl OptIntBounds {
 
     // ── INT_SIGNEXT optimization ──
 
-    fn optimize_int_signext(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_signext(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let b = self.getintbound_box(op.arg(0).to_opref(), ctx);
         let b1 = self.getintbound_box(op.arg(1).to_opref(), ctx);
         if b1.is_constant() {
@@ -2929,7 +3004,12 @@ impl Default for OptIntBounds {
 }
 
 impl Optimization for OptIntBounds {
-    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let result = match op.opcode {
             // ── Comparisons ──
             OpCode::IntLt => self.optimize_int_lt(op, ctx),
@@ -3376,7 +3456,11 @@ mod tests {
                     ),
                 );
             }
-            let emitted_op = match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
+            let emitted_op = match pass.propagate_forward(
+                &resolved_op,
+                &std::rc::Rc::new(resolved_op.clone()),
+                &mut ctx,
+            ) {
                 OptimizationResult::Emit(emit_op) => {
                     ctx.emit(emit_op.clone());
                     Some(emit_op)

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -6,6 +6,7 @@
 /// a condition that is already known true from integer bounds, the guard can be
 /// removed. It also narrows bounds after guards and arithmetic operations.
 use majit_ir::{Op, OpCode, OpRef, Value};
+use crate::r#box::BoxRef;
 
 use crate::optimizeopt::intutils::IntBound;
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
@@ -256,7 +257,7 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1220-1320 optimize_INT_EQ — rules:
     /// eq_different_knownbits / eq_same / eq_one / eq_zero / eq_sub_eq.
-    fn optimize_int_eq(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_eq(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -329,17 +330,13 @@ impl OptIntBounds {
         }
         // eq_one: int_eq(1, x) => x  (when x is bool)
         if b0.is_constant() && b0.get_constant_int() == 1 && b1.is_bool() {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         // eq_one: int_eq(x, 1) => x  (when x is bool)
         if b1.is_constant() && b1.get_constant_int() == 1 && b0.is_bool() {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -463,24 +460,20 @@ impl OptIntBounds {
 
     /// autogenintrules.py:23-143 optimize_INT_ADD — rules:
     /// add_zero / add_reassoc_consts / add_sub_x_c_c / add_sub_c_x_c.
-    fn optimize_int_add(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_add(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // add_zero: int_add(0, x) => x
         if b0.is_constant() && b0.get_constant_int() == 0 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         // add_zero: int_add(x, 0) => x
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -573,7 +566,7 @@ impl OptIntBounds {
     /// sub_zero / sub_from_zero / sub_x_x / sub_add_consts / sub_add /
     /// sub_add_neg / sub_sub_left_x_c_c / sub_sub_left_c_x_c /
     /// sub_xor_x_y_y / sub_or_x_y_y / sub_invert_one.
-    fn optimize_int_sub(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_sub(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -590,16 +583,12 @@ impl OptIntBounds {
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0_0);
                 return OptimizationResult::Remove;
             }
             if autogen_eq_b(&arg1, &b1, &arg0_0, &b0_0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0_1);
                 return OptimizationResult::Remove;
             }
@@ -610,16 +599,12 @@ impl OptIntBounds {
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0_0);
                 return OptimizationResult::Remove;
             }
             if autogen_eq_b(&arg1, &b1, &arg0_0, &b0_0) && b0_1.and_bound(&b0_0).known_eq_const(0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0_1);
                 return OptimizationResult::Remove;
             }
@@ -630,25 +615,19 @@ impl OptIntBounds {
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0_0);
                 return OptimizationResult::Remove;
             }
             if autogen_eq_b(&arg1, &b1, &arg0_0, &b0_0) && b0_1.and_bound(&b0_0).known_eq_const(0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0_1);
                 return OptimizationResult::Remove;
             }
         }
         // sub_zero: int_sub(x, 0) => x
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -722,7 +701,7 @@ impl OptIntBounds {
 
     /// autogenintrules.py:315-410 optimize_INT_MUL — rules:
     /// mul_zero / mul_one / mul_minus_one / mul_pow2_const / mul_lshift.
-    fn optimize_int_mul(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_mul(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -739,17 +718,13 @@ impl OptIntBounds {
         }
         // mul_one: int_mul(1, x) => x
         if b0.is_constant() && b0.get_constant_int() == 1 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         // mul_one: int_mul(x, 1) => x
         if b1.is_constant() && b1.get_constant_int() == 1 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -822,7 +797,7 @@ impl OptIntBounds {
     /// autogenintrules.py:414-581 optimize_INT_AND — rules:
     /// and_known_result / and_x_c_in_range / and_x_x / and_idempotent /
     /// and_reassoc_consts / and_absorb / and_or.
-    fn optimize_int_and(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_and(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -844,9 +819,7 @@ impl OptIntBounds {
             let c = b0.get_constant_int();
             let mask = !((c as u64).wrapping_add(1)) as i64;
             if b1.lower >= 0 && b1.upper <= c & mask {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg1);
                 return OptimizationResult::Remove;
             }
@@ -856,35 +829,27 @@ impl OptIntBounds {
             let c = b1.get_constant_int();
             let mask = !((c as u64).wrapping_add(1)) as i64;
             if b0.lower >= 0 && b0.upper <= c & mask {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0);
                 return OptimizationResult::Remove;
             }
         }
         // and_x_x: int_and(a, a) => a
         if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // and_idempotent: int_and(x, y) => x
         // when b1.tvalue | ~(b0.tvalue | b0.tmask) == all-ones
         if b1.tvalue | !(b0.tvalue | b0.tmask) == u64::MAX {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // and_idempotent: int_and(y, x) => x
         if b0.tvalue | !(b1.tvalue | b1.tmask) == u64::MAX {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
@@ -1000,7 +965,7 @@ impl OptIntBounds {
     /// second of each pair is dead because the first always returns
     /// when its predicate holds. Preserved here to mirror upstream's
     /// auto-generated output line for line.
-    fn optimize_int_or(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_or(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1018,26 +983,20 @@ impl OptIntBounds {
         }
         // or_x_x: int_or(a, a) => a
         if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // or_idempotent: int_or(x, y) => x
         // when b0.tvalue | ~(b1.tvalue | b1.tmask) == all-ones
         if b0.tvalue | !(b1.tvalue | b1.tmask) == u64::MAX {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // or_idempotent: int_or(y, x) => x
         if b1.tvalue | !(b0.tvalue | b0.tmask) == u64::MAX {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
@@ -1220,7 +1179,7 @@ impl OptIntBounds {
     /// autogenintrules.py:791-942 optimize_INT_XOR — rules:
     /// xor_x_x / xor_reassoc_consts / xor_absorb / xor_zero /
     /// xor_minus_1 / xor_known_result / xor_is_not.
-    fn optimize_int_xor(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_xor(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1244,9 +1203,7 @@ impl OptIntBounds {
         // xor_zero: int_xor(0, a) => a   (else: producer-xor absorbs)
         if b0.is_constant() {
             if b0.get_constant_int() == 0 {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg1);
                 return OptimizationResult::Remove;
             }
@@ -1257,17 +1214,13 @@ impl OptIntBounds {
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // xor_absorb: int_xor(int_xor(a, b), b) => a
             if autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &inner_0);
                 return OptimizationResult::Remove;
             }
             // xor_absorb: int_xor(int_xor(b, a), b) => a
             if autogen_eq_b(&arg1, &b1, &inner_0, &b_inner_0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &inner_1);
                 return OptimizationResult::Remove;
             }
@@ -1275,9 +1228,7 @@ impl OptIntBounds {
         // xor_zero: int_xor(a, 0) => a   (else: producer-xor absorbs)
         if b1.is_constant() {
             if b1.get_constant_int() == 0 {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &arg0);
                 return OptimizationResult::Remove;
             }
@@ -1288,17 +1239,13 @@ impl OptIntBounds {
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // xor_absorb: int_xor(b, int_xor(a, b)) => a
             if autogen_eq_b(&inner_1, &b_inner_1, &arg0, &b0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &inner_0);
                 return OptimizationResult::Remove;
             }
             // xor_absorb: int_xor(b, int_xor(b, a)) => a
             if autogen_eq_b(&inner_0, &b_inner_0, &arg0, &b0) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &inner_1);
                 return OptimizationResult::Remove;
             }
@@ -1366,14 +1313,12 @@ impl OptIntBounds {
     }
 
     /// autogenintrules.py:1432-1443 optimize_INT_INVERT — rules: invert_invert.
-    fn optimize_int_invert(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_invert(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         // invert_invert: int_invert(int_invert(x)) => x
         if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntInvert, ctx) {
             let inner_0 = self.resolve_box(inner.arg(0).to_opref(), ctx);
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &inner_0);
             return OptimizationResult::Remove;
         }
@@ -1381,14 +1326,12 @@ impl OptIntBounds {
     }
 
     /// autogenintrules.py:1447-1458 optimize_INT_NEG — rules: neg_neg.
-    fn optimize_int_neg(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_neg(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         // neg_neg: int_neg(int_neg(x)) => x
         if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntNeg, ctx) {
             let inner_0 = self.resolve_box(inner.arg(0).to_opref(), ctx);
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &inner_0);
             return OptimizationResult::Remove;
         }
@@ -1399,7 +1342,7 @@ impl OptIntBounds {
     /// lshift_zero_x / lshift_x_zero / lshift_rshift_c_c / lshift_and_rshift /
     /// lshift_urshift_c_c / lshift_and_urshift / lshift_lshift_c_c.
     /// LONG_BIT inlined as 64 (pyre is 64-bit only).
-    fn optimize_int_lshift(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_lshift(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1411,9 +1354,7 @@ impl OptIntBounds {
         }
         // lshift_x_zero: int_lshift(x, 0) => x
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -1540,7 +1481,7 @@ impl OptIntBounds {
     /// autogenintrules.py:1113-1169 optimize_INT_RSHIFT — rules:
     /// rshift_zero_x / rshift_x_zero / rshift_known_result / rshift_lshift /
     /// rshift_rshift_c_c. LONG_BIT inlined as 64.
-    fn optimize_int_rshift(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_rshift(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1565,18 +1506,14 @@ impl OptIntBounds {
             if autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1)
                 && b_inner_0.lshift_bound_cannot_overflow(&b_inner_1)
             {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 ctx.make_equal_to(&b_old, &inner_0);
                 return OptimizationResult::Remove;
             }
         }
         // rshift_x_zero: int_rshift(x, 0) => x
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -1606,7 +1543,7 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1364-1399 optimize_INT_IS_TRUE — rules:
     /// is_true_bool / is_true_true / is_true_and_minint.
-    fn optimize_int_is_true(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_is_true(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         // is_true_true: int_is_true(x) => 1
@@ -1617,9 +1554,7 @@ impl OptIntBounds {
         }
         // is_true_bool: int_is_true(x) => x  (when x is bool)
         if b0.is_bool() {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -1657,7 +1592,7 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1415-1428 optimize_INT_FORCE_GE_ZERO — rules:
     /// force_ge_zero_pos / force_ge_zero_neg.
-    fn optimize_int_force_ge_zero(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_force_ge_zero(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         // force_ge_zero_neg: int_force_ge_zero(x) => 0  (when x < 0)
@@ -1667,9 +1602,7 @@ impl OptIntBounds {
         }
         // force_ge_zero_pos: int_force_ge_zero(x) => x  (when x >= 0)
         if b0.known_nonnegative() {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -1679,7 +1612,7 @@ impl OptIntBounds {
     /// autogenintrules.py:1173-1216 optimize_UINT_RSHIFT — rules:
     /// urshift_zero_x / urshift_x_zero / urshift_known_result /
     /// urshift_lshift_x_c_c.
-    fn optimize_uint_rshift(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_uint_rshift(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
@@ -1697,9 +1630,7 @@ impl OptIntBounds {
         }
         // urshift_x_zero: uint_rshift(x, 0) => x
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
@@ -2043,7 +1974,7 @@ impl OptIntBounds {
 
     // ── INT_SIGNEXT optimization ──
 
-    fn optimize_int_signext(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_signext(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let b = self.getintbound_box(op.arg(0).to_opref(), ctx);
         let b1 = self.getintbound_box(op.arg(1).to_opref(), ctx);
         if b1.is_constant() {
@@ -2053,9 +1984,7 @@ impl OptIntBounds {
             let stop = 1i64 << (numbits - 1);
             if b.is_within_range(start, stop - 1) {
                 // The value already fits; replace with the input.
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_arg = ctx
                     .ensure_box(op.arg(0).to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -3000,14 +2929,14 @@ impl Default for OptIntBounds {
 }
 
 impl Optimization for OptIntBounds {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let result = match op.opcode {
             // ── Comparisons ──
             OpCode::IntLt => self.optimize_int_lt(op, ctx),
             OpCode::IntLe => self.optimize_int_le(op, ctx),
             OpCode::IntGt => self.optimize_int_gt(op, ctx),
             OpCode::IntGe => self.optimize_int_ge(op, ctx),
-            OpCode::IntEq => self.optimize_int_eq(op, ctx),
+            OpCode::IntEq => self.optimize_int_eq(op, op_rc, ctx),
             OpCode::IntNe => self.optimize_int_ne(op, ctx),
             OpCode::UintLt => self.optimize_uint_lt(op, ctx),
             OpCode::UintLe => self.optimize_uint_le(op, ctx),
@@ -3015,23 +2944,23 @@ impl Optimization for OptIntBounds {
             OpCode::UintGe => self.optimize_uint_ge(op, ctx),
 
             // ── Arithmetic folds (autogenintrules.py) ──
-            OpCode::IntAdd => self.optimize_int_add(op, ctx),
-            OpCode::IntSub => self.optimize_int_sub(op, ctx),
-            OpCode::IntMul => self.optimize_int_mul(op, ctx),
-            OpCode::IntAnd => self.optimize_int_and(op, ctx),
-            OpCode::IntOr => self.optimize_int_or(op, ctx),
-            OpCode::IntXor => self.optimize_int_xor(op, ctx),
-            OpCode::IntNeg => self.optimize_int_neg(op, ctx),
-            OpCode::IntInvert => self.optimize_int_invert(op, ctx),
-            OpCode::IntLshift => self.optimize_int_lshift(op, ctx),
-            OpCode::IntRshift => self.optimize_int_rshift(op, ctx),
-            OpCode::UintRshift => self.optimize_uint_rshift(op, ctx),
-            OpCode::IntIsTrue => self.optimize_int_is_true(op, ctx),
+            OpCode::IntAdd => self.optimize_int_add(op, op_rc, ctx),
+            OpCode::IntSub => self.optimize_int_sub(op, op_rc, ctx),
+            OpCode::IntMul => self.optimize_int_mul(op, op_rc, ctx),
+            OpCode::IntAnd => self.optimize_int_and(op, op_rc, ctx),
+            OpCode::IntOr => self.optimize_int_or(op, op_rc, ctx),
+            OpCode::IntXor => self.optimize_int_xor(op, op_rc, ctx),
+            OpCode::IntNeg => self.optimize_int_neg(op, op_rc, ctx),
+            OpCode::IntInvert => self.optimize_int_invert(op, op_rc, ctx),
+            OpCode::IntLshift => self.optimize_int_lshift(op, op_rc, ctx),
+            OpCode::IntRshift => self.optimize_int_rshift(op, op_rc, ctx),
+            OpCode::UintRshift => self.optimize_uint_rshift(op, op_rc, ctx),
+            OpCode::IntIsTrue => self.optimize_int_is_true(op, op_rc, ctx),
             OpCode::IntIsZero => self.optimize_int_is_zero(op, ctx),
-            OpCode::IntForceGeZero => self.optimize_int_force_ge_zero(op, ctx),
+            OpCode::IntForceGeZero => self.optimize_int_force_ge_zero(op, op_rc, ctx),
 
             // ── Signext ──
-            OpCode::IntSignext => self.optimize_int_signext(op, ctx),
+            OpCode::IntSignext => self.optimize_int_signext(op, op_rc, ctx),
 
             // ── Overflow arithmetic ──
             OpCode::IntAddOvf => self.optimize_int_add_ovf(op, ctx),

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -27,6 +27,36 @@ fn autogen_eq(box1: OpRef, bound1: &IntBound, box2: OpRef, bound2: &IntBound) ->
     false
 }
 
+/// `BoxRef`-terminal variant of [`autogen_eq`]: identity via `same_box`
+/// (resoperation.py:38 `self is other`, with `Const.same_box` value
+/// comparison) instead of the OpRef-flat `==`, plus the same
+/// constant-bound equality fallback. Used by the `optimize_INT_*` bodies
+/// that resolve operands to their `_forwarded` terminal via `resolve_box`.
+///
+/// The `to_opref()` equality mirrors `OptContext::same_box`'s fallback for
+/// operands whose canonical box store is absent (test fixtures with dangling
+/// position refs): two fresh `ensure_box` materializations of the same
+/// position are not `Rc::ptr_eq` but denote the same operand. In production
+/// both operands resolve to one shared canonical box, so `same_box` already
+/// short-circuits.
+fn autogen_eq_b(
+    box1: &crate::r#box::BoxRef,
+    bound1: &IntBound,
+    box2: &crate::r#box::BoxRef,
+    bound2: &IntBound,
+) -> bool {
+    if box1.same_box(box2) || box1.to_opref() == box2.to_opref() {
+        return true;
+    }
+    if bound1.is_constant()
+        && bound2.is_constant()
+        && bound1.get_constant_int() == bound2.get_constant_int()
+    {
+        return true;
+    }
+    false
+}
+
 /// autogenintrules.py:54-55 rewrite helper:
 /// `newop = self.replace_op_with(op, opcode, args=[...]);
 ///  self.optimizer.send_extra_operation(newop); return`.
@@ -83,6 +113,13 @@ impl OptIntBounds {
                 .map(|b| ctx.getintbound_handle(&b).borrow().clone())
                 .expect("getintbound: operand must resolve to a BoxRef"),
         }
+    }
+
+    /// `BoxRef`-terminal variant of [`getintbound_box`]: reads the bound off
+    /// an operand already resolved to its `_forwarded` terminal (the box
+    /// `resolve_box` returns), so no second `get_box_replacement` walk.
+    fn getintbound_b(&self, b: &crate::r#box::BoxRef, ctx: &mut OptContext) -> IntBound {
+        ctx.getintbound_handle(b).borrow().clone()
     }
 
     /// Resolve an operand to its forwarded terminal `BoxRef`, the `op =
@@ -220,55 +257,55 @@ impl OptIntBounds {
     /// autogenintrules.py:1220-1320 optimize_INT_EQ — rules:
     /// eq_different_knownbits / eq_same / eq_one / eq_zero / eq_sub_eq.
     fn optimize_int_eq(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // eq_sub_eq: int_eq(int_sub(x, int_eq(x, a)), a) => 0 (4 forms)
-        if let Some(arg0_sub) = self.as_operation(arg0, OpCode::IntSub, ctx) {
-            let arg0_0 = ctx.get_box_replacement(arg0_sub.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_sub.arg(1).to_opref());
-            let b_arg0_0 = self.getintbound_box(arg0_0, ctx);
-            if let Some(inner_eq) = self.as_operation(arg0_1, OpCode::IntEq, ctx) {
-                let inner_0 = ctx.get_box_replacement(inner_eq.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(inner_eq.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg0_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
+            let arg0_0 = self.resolve_box(arg0_sub.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_sub.arg(1).to_opref(), ctx);
+            let b_arg0_0 = self.getintbound_b(&arg0_0, ctx);
+            if let Some(inner_eq) = self.as_operation_b(&arg0_1, OpCode::IntEq, ctx) {
+                let inner_0 = self.resolve_box(inner_eq.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(inner_eq.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // eq_sub_eq: int_eq(int_sub(x, int_eq(x, a)), a) => 0
-                if autogen_eq(inner_0, &b_inner_0, arg0_0, &b_arg0_0)
-                    && autogen_eq(arg1, &b1, inner_1, &b_inner_1)
+                if autogen_eq_b(&inner_0, &b_inner_0, &arg0_0, &b_arg0_0)
+                    && autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1)
                 {
                     self.make_constant_int(op, 0, ctx);
                     return OptimizationResult::Remove;
                 }
                 // eq_sub_eq: int_eq(int_sub(x, int_eq(a, x)), a) => 0
-                if autogen_eq(inner_1, &b_inner_1, arg0_0, &b_arg0_0)
-                    && autogen_eq(arg1, &b1, inner_0, &b_inner_0)
+                if autogen_eq_b(&inner_1, &b_inner_1, &arg0_0, &b_arg0_0)
+                    && autogen_eq_b(&arg1, &b1, &inner_0, &b_inner_0)
                 {
                     self.make_constant_int(op, 0, ctx);
                     return OptimizationResult::Remove;
                 }
             }
         }
-        if let Some(arg1_sub) = self.as_operation(arg1, OpCode::IntSub, ctx) {
-            let arg1_0 = ctx.get_box_replacement(arg1_sub.arg(0).to_opref());
-            let arg1_1 = ctx.get_box_replacement(arg1_sub.arg(1).to_opref());
-            let b_arg1_0 = self.getintbound_box(arg1_0, ctx);
-            if let Some(inner_eq) = self.as_operation(arg1_1, OpCode::IntEq, ctx) {
-                let inner_0 = ctx.get_box_replacement(inner_eq.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(inner_eq.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg1_sub) = self.as_operation_b(&arg1, OpCode::IntSub, ctx) {
+            let arg1_0 = self.resolve_box(arg1_sub.arg(0).to_opref(), ctx);
+            let arg1_1 = self.resolve_box(arg1_sub.arg(1).to_opref(), ctx);
+            let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
+            if let Some(inner_eq) = self.as_operation_b(&arg1_1, OpCode::IntEq, ctx) {
+                let inner_0 = self.resolve_box(inner_eq.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(inner_eq.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // eq_sub_eq: int_eq(a, int_sub(x, int_eq(x, a))) => 0
-                if autogen_eq(inner_0, &b_inner_0, arg1_0, &b_arg1_0)
-                    && autogen_eq(inner_1, &b_inner_1, arg0, &b0)
+                if autogen_eq_b(&inner_0, &b_inner_0, &arg1_0, &b_arg1_0)
+                    && autogen_eq_b(&inner_1, &b_inner_1, &arg0, &b0)
                 {
                     self.make_constant_int(op, 0, ctx);
                     return OptimizationResult::Remove;
                 }
                 // eq_sub_eq: int_eq(a, int_sub(x, int_eq(a, x))) => 0
-                if autogen_eq(inner_0, &b_inner_0, arg0, &b0)
-                    && autogen_eq(inner_1, &b_inner_1, arg1_0, &b_arg1_0)
+                if autogen_eq_b(&inner_0, &b_inner_0, &arg0, &b0)
+                    && autogen_eq_b(&inner_1, &b_inner_1, &arg1_0, &b_arg1_0)
                 {
                     self.make_constant_int(op, 0, ctx);
                     return OptimizationResult::Remove;
@@ -276,7 +313,7 @@ impl OptIntBounds {
             }
         }
         // eq_same: int_eq(x, x) => 1
-        if autogen_eq(arg1, &b1, arg0, &b0) {
+        if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
             self.make_constant_int(op, 1, ctx);
             return OptimizationResult::Remove;
         }
@@ -295,10 +332,7 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg1)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         // eq_one: int_eq(x, 1) => x  (when x is bool)
@@ -306,19 +340,16 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // eq_zero: int_eq(0, x) => int_is_zero(x)
         if b0.is_constant() && b0.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsZero, &[arg1]);
+            return replace_with(op, OpCode::IntIsZero, &[arg1.to_opref()]);
         }
         // eq_zero: int_eq(x, 0) => int_is_zero(x)
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsZero, &[arg0]);
+            return replace_with(op, OpCode::IntIsZero, &[arg0.to_opref()]);
         }
         OptimizationResult::PassOn
     }
@@ -326,12 +357,12 @@ impl OptIntBounds {
     /// autogenintrules.py:1324-1360 optimize_INT_NE — rules:
     /// ne_different_knownbits / ne_same / ne_zero.
     fn optimize_int_ne(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // ne_same: int_ne(x, x) => 0
-        if autogen_eq(arg1, &b1, arg0, &b0) {
+        if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
             self.make_constant_int(op, 0, ctx);
             return OptimizationResult::Remove;
         }
@@ -347,11 +378,11 @@ impl OptIntBounds {
         }
         // ne_zero: int_ne(0, x) => int_is_true(x)
         if b0.is_constant() && b0.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsTrue, &[arg1]);
+            return replace_with(op, OpCode::IntIsTrue, &[arg1.to_opref()]);
         }
         // ne_zero: int_ne(x, 0) => int_is_true(x)
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsTrue, &[arg0]);
+            return replace_with(op, OpCode::IntIsTrue, &[arg0.to_opref()]);
         }
         OptimizationResult::PassOn
     }
@@ -1737,6 +1768,18 @@ impl OptIntBounds {
         let op = ctx
             .ensure_box(opref)
             .and_then(|pb| ctx.get_producing_op(&pb))?;
+        if op.opcode == opcode { Some(op) } else { None }
+    }
+
+    /// `BoxRef`-terminal variant of [`as_operation`]: the producing op of an
+    /// operand already resolved to its terminal box (`resolve_box`).
+    fn as_operation_b(
+        &self,
+        b: &crate::r#box::BoxRef,
+        opcode: OpCode,
+        ctx: &mut OptContext,
+    ) -> Option<Op> {
+        let op = ctx.get_producing_op(b)?;
         if op.opcode == opcode { Some(op) } else { None }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -778,7 +778,11 @@ impl OptIntBounds {
                 && b_inner_1.known_ge_const(0)
                 && b_inner_1.known_le_const(64)
             {
-                return replace_with(op, OpCode::IntLshift, &[arg1.to_opref(), inner_1.to_opref()]);
+                return replace_with(
+                    op,
+                    OpCode::IntLshift,
+                    &[arg1.to_opref(), inner_1.to_opref()],
+                );
             }
         }
         // Outer const on arg1: mul_minus_one / mul_pow2_const
@@ -805,7 +809,11 @@ impl OptIntBounds {
                 && b_inner_1.known_ge_const(0)
                 && b_inner_1.known_le_const(64)
             {
-                return replace_with(op, OpCode::IntLshift, &[arg0.to_opref(), inner_1.to_opref()]);
+                return replace_with(
+                    op,
+                    OpCode::IntLshift,
+                    &[arg0.to_opref(), inner_1.to_opref()],
+                );
             }
         }
         OptimizationResult::PassOn
@@ -923,11 +931,19 @@ impl OptIntBounds {
             }
             // and_absorb: int_and(int_and(a, b), a) => int_and(a, b)
             if autogen_eq_b(&arg1, &b1, &inner_0, &b_inner_0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), inner_1.to_opref()]);
+                return replace_with(
+                    op,
+                    OpCode::IntAnd,
+                    &[inner_0.to_opref(), inner_1.to_opref()],
+                );
             }
             // and_absorb: int_and(int_and(b, a), a) => int_and(a, b)
             if autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1) {
-                return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), inner_0.to_opref()]);
+                return replace_with(
+                    op,
+                    OpCode::IntAnd,
+                    &[inner_1.to_opref(), inner_0.to_opref()],
+                );
             }
         } else if let Some(arg0_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
             let inner_0 = self.resolve_box(arg0_or.arg(0).to_opref(), ctx);
@@ -1063,13 +1079,21 @@ impl OptIntBounds {
                         if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_1, &b_arg0_1) {
                             let folded = c_arg0_0 | b_arg1_0.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_1.to_opref(), const_ref],
+                            );
                         }
                         // dead twin per autogenintrules.py:668-673
                         if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_1, &b_arg0_1) {
                             let folded = b_arg1_0.get_constant_int() | c_arg0_0;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_1.to_opref(), const_ref],
+                            );
                         }
                     }
                     if b_arg1_1.is_constant() {
@@ -1077,13 +1101,21 @@ impl OptIntBounds {
                         if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_1, &b_arg0_1) {
                             let folded = b_arg1_1.get_constant_int() | c_arg0_0;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_1.to_opref(), const_ref],
+                            );
                         }
                         // dead twin per autogenintrules.py:684-689
                         if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_1, &b_arg0_1) {
                             let folded = c_arg0_0 | b_arg1_1.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_1.to_opref(), const_ref],
+                            );
                         }
                     }
                 }
@@ -1100,13 +1132,21 @@ impl OptIntBounds {
                         if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_0, &b_arg0_0) {
                             let folded = c_arg0_1 | b_arg1_0.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_0.to_opref(), const_ref],
+                            );
                         }
                         // dead twin per autogenintrules.py:708-713
                         if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_0, &b_arg0_0) {
                             let folded = b_arg1_0.get_constant_int() | c_arg0_1;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_0.to_opref(), const_ref],
+                            );
                         }
                     }
                     if b_arg1_1.is_constant() {
@@ -1114,13 +1154,21 @@ impl OptIntBounds {
                         if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_0, &b_arg0_0) {
                             let folded = c_arg0_1 | b_arg1_1.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_0.to_opref(), const_ref],
+                            );
                         }
                         // dead twin per autogenintrules.py:724-729
                         if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_0, &b_arg0_0) {
                             let folded = b_arg1_1.get_constant_int() | c_arg0_1;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[arg0_0.to_opref(), const_ref],
+                            );
                         }
                     }
                 }
@@ -1390,7 +1438,8 @@ impl OptIntBounds {
                             return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
                         }
                     }
-                } else if let Some(urshift) = self.as_operation_b(&inner_1, OpCode::UintRshift, ctx) {
+                } else if let Some(urshift) = self.as_operation_b(&inner_1, OpCode::UintRshift, ctx)
+                {
                     let r0 = self.resolve_box(urshift.arg(0).to_opref(), ctx);
                     let r1 = self.resolve_box(urshift.arg(1).to_opref(), ctx);
                     let b_r1 = self.getintbound_b(&r1, ctx);
@@ -1448,7 +1497,11 @@ impl OptIntBounds {
                     let folded = c1.wrapping_add(c2);
                     if folded < 64 {
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntLshift, &[inner_0.to_opref(), const_ref]);
+                        return replace_with(
+                            op,
+                            OpCode::IntLshift,
+                            &[inner_0.to_opref(), const_ref],
+                        );
                     }
                 }
             }
@@ -1539,7 +1592,11 @@ impl OptIntBounds {
                     let folded = c1.wrapping_add(c2).min(63);
                     if (0..64).contains(&folded) {
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntRshift, &[inner_0.to_opref(), const_ref]);
+                        return replace_with(
+                            op,
+                            OpCode::IntRshift,
+                            &[inner_0.to_opref(), const_ref],
+                        );
                     }
                 }
             }
@@ -1705,8 +1762,18 @@ impl OptIntBounds {
         // intbounds.py:125-127:
         //   self.optimizer.pure_from_args2(rop.INT_SUB, op, arg1, arg0)
         //   self.optimizer.pure_from_args2(rop.INT_SUB, op, arg0, arg1)
-        ctx.register_pure_from_args2(OpCode::IntSub, arg0.to_opref(), op.pos.get(), arg1.to_opref());
-        ctx.register_pure_from_args2(OpCode::IntSub, arg1.to_opref(), op.pos.get(), arg0.to_opref());
+        ctx.register_pure_from_args2(
+            OpCode::IntSub,
+            arg0.to_opref(),
+            op.pos.get(),
+            arg1.to_opref(),
+        );
+        ctx.register_pure_from_args2(
+            OpCode::IntSub,
+            arg1.to_opref(),
+            op.pos.get(),
+            arg0.to_opref(),
+        );
         // intbounds.py:128-142: pick the constant arg, fall back to commutative
         // swap so `arg1` ends up holding the non-const operand.
         // intbounds.py:128/134 `isinstance(argN, ConstInt)` — raw Const
@@ -1747,8 +1814,18 @@ impl OptIntBounds {
         let b = b0.sub_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
         // Synthesis: INT_SUB(a,b)=res → INT_ADD(res,b)=a, INT_SUB(a,res)=b
-        ctx.register_pure_from_args2(OpCode::IntAdd, arg0.to_opref(), op.pos.get(), arg1.to_opref());
-        ctx.register_pure_from_args2(OpCode::IntSub, arg1.to_opref(), arg0.to_opref(), op.pos.get());
+        ctx.register_pure_from_args2(
+            OpCode::IntAdd,
+            arg0.to_opref(),
+            op.pos.get(),
+            arg1.to_opref(),
+        );
+        ctx.register_pure_from_args2(
+            OpCode::IntSub,
+            arg1.to_opref(),
+            arg0.to_opref(),
+            op.pos.get(),
+        );
         // intbounds.py: constant inversion for INT_SUB — `isinstance(arg1,
         // ConstInt)` raw Const check (no IntBound synthesis).
         if let Some(Value::Int(c1)) = arg1.const_value() {
@@ -1788,8 +1865,18 @@ impl OptIntBounds {
             // intbounds.py:66-69:
             //   pure_from_args2(rop.INT_ADD, arg0, arg1, op)
             //   pure_from_args2(rop.INT_XOR, arg0, arg1, op)
-            ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), arg0.to_opref(), arg1.to_opref());
-            ctx.register_pure_from_args2(OpCode::IntXor, op.pos.get(), arg0.to_opref(), arg1.to_opref());
+            ctx.register_pure_from_args2(
+                OpCode::IntAdd,
+                op.pos.get(),
+                arg0.to_opref(),
+                arg1.to_opref(),
+            );
+            ctx.register_pure_from_args2(
+                OpCode::IntXor,
+                op.pos.get(),
+                arg0.to_opref(),
+                arg1.to_opref(),
+            );
         }
         let b = b0.or_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
@@ -1806,8 +1893,18 @@ impl OptIntBounds {
             // intbounds.py:79-82:
             //   pure_from_args2(rop.INT_ADD, arg0, arg1, op)
             //   pure_from_args2(rop.INT_OR, arg0, arg1, op)
-            ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), arg0.to_opref(), arg1.to_opref());
-            ctx.register_pure_from_args2(OpCode::IntOr, op.pos.get(), arg0.to_opref(), arg1.to_opref());
+            ctx.register_pure_from_args2(
+                OpCode::IntAdd,
+                op.pos.get(),
+                arg0.to_opref(),
+                arg1.to_opref(),
+            );
+            ctx.register_pure_from_args2(
+                OpCode::IntOr,
+                op.pos.get(),
+                arg0.to_opref(),
+                arg1.to_opref(),
+            );
         }
         let b = b0.xor_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
@@ -1824,7 +1921,12 @@ impl OptIntBounds {
         self.intersect_bound(op.pos.get(), &b, ctx);
         // intbounds.py:185: only synthesize reverse if lshift cannot overflow
         if b0.lshift_bound_cannot_overflow(&b1) {
-            ctx.register_pure_from_args2(OpCode::IntRshift, arg0.to_opref(), op.pos.get(), arg1.to_opref());
+            ctx.register_pure_from_args2(
+                OpCode::IntRshift,
+                arg0.to_opref(),
+                op.pos.get(),
+                arg1.to_opref(),
+            );
         }
     }
 
@@ -3339,7 +3441,9 @@ mod tests {
                 resolved_op.setarg(
                     i,
                     crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement_box(a).map(|b| b.to_opref()).unwrap_or(a),
+                        ctx.get_box_replacement_box(a)
+                            .map(|b| b.to_opref())
+                            .unwrap_or(a),
                     ),
                 );
             }
@@ -3368,12 +3472,18 @@ mod tests {
                 match emitted.opcode {
                     OpCode::GuardTrue => {
                         let a = emitted.arg(0).to_opref();
-                        let cond = ctx.get_box_replacement_box(a).map(|b| b.to_opref()).unwrap_or(a);
+                        let cond = ctx
+                            .get_box_replacement_box(a)
+                            .map(|b| b.to_opref())
+                            .unwrap_or(a);
                         ctx.make_constant(cond, majit_ir::Value::Int(1));
                     }
                     OpCode::GuardFalse => {
                         let a = emitted.arg(0).to_opref();
-                        let cond = ctx.get_box_replacement_box(a).map(|b| b.to_opref()).unwrap_or(a);
+                        let cond = ctx
+                            .get_box_replacement_box(a)
+                            .map(|b| b.to_opref())
+                            .unwrap_or(a);
                         ctx.make_constant(cond, majit_ir::Value::Int(0));
                     }
                     _ => {}

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -36,7 +36,7 @@ fn autogen_eq(box1: OpRef, bound1: &IntBound, box2: OpRef, bound2: &IntBound) ->
 ///
 /// The `to_opref()` equality mirrors `OptContext::same_box`'s fallback for
 /// operands whose canonical box store is absent (test fixtures with dangling
-/// position refs): two fresh `ensure_box` materializations of the same
+/// position refs): two fresh `materialize_box_at` materializations of the same
 /// position are not `Rc::ptr_eq` but denote the same operand. In production
 /// both operands resolve to one shared canonical box, so `same_box` already
 /// short-circuits.
@@ -3239,7 +3239,7 @@ impl Optimization for OptIntBounds {
     ) -> crate::optimizeopt::vec_assoc::VecAssoc<OpRef, IntBound> {
         let mut exported = crate::optimizeopt::vec_assoc::VecAssoc::new();
         for &arg in args {
-            // `&OptContext` here forbids the `ensure_box` fallback in
+            // `&OptContext` here forbids the `materialize_box_at` fallback in
             // `resolve_box`, so use the immutable forwarded-chain walk
             // (`get_box_replacement(arg) ≡ get_box_replacement_box(arg)
             // .to_opref()` with the unresolvable-arg fallthrough).
@@ -3357,9 +3357,7 @@ mod tests {
         pass.setup();
         for (opref, bound) in initial_bounds {
             // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-            let op_box = ctx
-                .ensure_box(*opref)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let op_box = ctx.materialize_box_at(*opref);
             ctx.setintbound(&op_box, bound);
         }
 
@@ -3369,16 +3367,21 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity. Mirror
             // `propagate_from_pass_range`'s dispatch-entry rebind: mint +
             // register a canonical host for producer-less operands (via
-            // `ensure_box`) so the pass's `get_box_replacement` resolves to a
-            // bound terminal instead of an unbound `from_opref` box.
+            // `materialize_box_at`) so the pass's `get_box_replacement`
+            // resolves to a bound terminal instead of an unbound `from_opref`
+            // box.
             for i in 0..resolved_op.num_args() {
                 let a = resolved_op.arg(i);
                 let resolved = match ctx.get_box_replacement_box(a.to_opref()) {
                     Some(b) => b,
-                    None => ctx
-                        .ensure_box(a.to_opref())
-                        .map(|b| b.get_box_replacement(false))
-                        .unwrap_or_else(|| a.clone()),
+                    None => {
+                        let ar = a.to_opref();
+                        if ar.is_none() {
+                            a.clone()
+                        } else {
+                            ctx.materialize_box_at(ar).get_box_replacement(false)
+                        }
+                    }
                 };
                 resolved_op.setarg(i, resolved);
             }
@@ -3481,10 +3484,10 @@ mod tests {
         assert_eq!(result[0].opcode, OpCode::IntAdd);
 
         // The result should have bounds [5, 30]
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert_eq!(b.lower, 5);
         assert_eq!(b.upper, 30);
     }
@@ -3567,10 +3570,10 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
 
         // After the guard, i0 should be < 10, meaning upper <= 9
-        let b0 = ctx
-            .ensure_box(OpRef::int_op(0))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b0 = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(
             b0.upper <= 9,
             "After GUARD_TRUE(INT_LT(i0, 10)), i0.upper should be <= 9, got {}",
@@ -3593,10 +3596,10 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
 
-        let b0 = ctx
-            .ensure_box(OpRef::int_op(0))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b0 = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(
             b0.lower >= 5,
             "After GUARD_TRUE(INT_GE(i0, 5)), i0.lower should be >= 5, got {}",
@@ -3760,10 +3763,10 @@ mod tests {
             "INT_LT should be removed when known true"
         );
         // The constant should be set
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.is_constant() && b.get_constant_int() == 1);
     }
 
@@ -3784,10 +3787,10 @@ mod tests {
             result.is_empty(),
             "INT_LT should be removed when known false"
         );
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.is_constant() && b.get_constant_int() == 0);
     }
 
@@ -3804,10 +3807,10 @@ mod tests {
             result.is_empty(),
             "INT_EQ(x, x) should be removed (always 1)"
         );
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.is_constant() && b.get_constant_int() == 1);
     }
 
@@ -3824,10 +3827,10 @@ mod tests {
             result.is_empty(),
             "INT_NE(x, x) should be removed (always 0)"
         );
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.is_constant() && b.get_constant_int() == 0);
     }
 
@@ -3885,10 +3888,10 @@ mod tests {
 
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert_eq!(result.len(), 1);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         // [10, 20] - [0, 5] = [5, 20]
         assert_eq!(b.lower, 5);
         assert_eq!(b.upper, 20);
@@ -3908,10 +3911,10 @@ mod tests {
 
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert_eq!(result.len(), 1);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         // [2, 5] * [3, 7] = [6, 35]
         assert_eq!(b.lower, 6);
         assert_eq!(b.upper, 35);
@@ -3931,10 +3934,10 @@ mod tests {
 
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert_eq!(result.len(), 1);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         // AND of [0, 255] and [0, 15] -> [0, 15]
         assert!(b.lower >= 0);
         assert!(b.upper <= 15);
@@ -3959,10 +3962,10 @@ mod tests {
             "INT_AND of constants should be folded out, got {:?}",
             result.iter().map(|o| o.opcode).collect::<Vec<_>>()
         );
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.is_constant(), "result should be constant");
         assert_eq!(b.get_constant_int(), 0x0f);
     }
@@ -4025,10 +4028,10 @@ mod tests {
             "INT_OR of constants should be folded out, got {:?}",
             result.iter().map(|o| o.opcode).collect::<Vec<_>>()
         );
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.is_constant(), "result should be constant");
         assert_eq!(b.get_constant_int(), 0xff);
     }
@@ -4082,10 +4085,10 @@ mod tests {
         let ops = vec![make_op(OpCode::IntForceGeZero, &[OpRef::int_op(0)], 1)];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(
             b.lower >= 0,
             "INT_FORCE_GE_ZERO result should be >= 0, got {}",
@@ -4105,10 +4108,10 @@ mod tests {
         let ops = vec![op];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.lower >= 0, "ARRAYLEN_GC result should be non-negative");
     }
 
@@ -4117,10 +4120,10 @@ mod tests {
         let ops = vec![make_op(OpCode::Strlen, &[OpRef::int_op(0)], 1)];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.lower >= 0, "STRLEN result should be non-negative");
     }
 
@@ -4130,10 +4133,10 @@ mod tests {
         let ops = vec![make_op(OpCode::IntNeg, &[OpRef::int_op(0)], 1)];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         // neg([3, 10]) = [-10, -3]
         assert_eq!(b.lower, -10);
         assert_eq!(b.upper, -3);
@@ -4145,10 +4148,10 @@ mod tests {
         let ops = vec![make_op(OpCode::IntInvert, &[OpRef::int_op(0)], 1)];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         // invert([3, 10]) = [!10, !3] = [-11, -4]
         assert_eq!(b.lower, -11);
         assert_eq!(b.upper, -4);
@@ -4166,10 +4169,10 @@ mod tests {
 
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert!(result.is_empty(), "INT_SUB_OVF(x, x) should be removed");
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.is_constant() && b.get_constant_int() == 0);
     }
 
@@ -4209,10 +4212,10 @@ mod tests {
         )];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         // [1, 4] << 2 = [4, 16]
         assert_eq!(b.lower, 4);
         assert_eq!(b.upper, 16);
@@ -4233,10 +4236,10 @@ mod tests {
         )];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         // [8, 20] >> 2 = [2, 5]
         assert_eq!(b.lower, 2);
         assert_eq!(b.upper, 5);
@@ -4324,10 +4327,10 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::IntSignext);
         // Result should have bounds [-128, 127]
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.lower >= -128);
         assert!(b.upper <= 127);
     }
@@ -4375,10 +4378,10 @@ mod tests {
         ];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b0 = ctx
-            .ensure_box(OpRef::int_op(0))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b0 = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(
             b0.lower >= 1,
             "After GUARD_TRUE(INT_IS_TRUE(i0)), i0.lower should be >= 1, got {}",
@@ -4399,10 +4402,10 @@ mod tests {
         ];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b0 = ctx
-            .ensure_box(OpRef::int_op(0))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b0 = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(
             b0.is_constant() && b0.get_constant_int() == 0,
             "After GUARD_FALSE(INT_IS_TRUE(i0)), i0 should be 0, got [{}, {}]",
@@ -4424,10 +4427,10 @@ mod tests {
         )];
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(1))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.lower >= 6, "lower should be >= 6, got {}", b.lower);
         assert!(b.upper <= 10, "upper should be <= 10, got {}", b.upper);
     }
@@ -4449,15 +4452,13 @@ mod tests {
         // fresh one to drive the backward propagation step.
         let mut pass = OptIntBounds::new();
         // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-        let i1_box = ctx
-            .ensure_box(OpRef::int_op(1))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let i1_box = ctx.materialize_box_at(OpRef::int_op(1));
         ctx.setintbound(&i1_box, &IntBound::bounded(-5, -1));
         pass.propagate_bounds_backward(OpRef::int_op(1), &mut ctx);
-        let b0 = ctx
-            .ensure_box(OpRef::int_op(0))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b0 = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(
             b0.lower >= 1,
             "backward neg: lower should be >= 1, got {}",
@@ -4479,10 +4480,10 @@ mod tests {
             2,
         )];
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert!(b.lower >= 0, "STRGETITEM lower should be >= 0");
         assert!(b.upper <= 255, "STRGETITEM upper should be <= 255");
     }
@@ -4504,10 +4505,10 @@ mod tests {
         ];
 
         let (_result, mut ctx) = run_pass_with_bounds(&[call], &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert_eq!(b.lower, -50);
         assert_eq!(b.upper, -3);
     }
@@ -4528,10 +4529,10 @@ mod tests {
         ];
 
         let (_result, mut ctx) = run_pass_with_bounds(&[call], &initial_bounds);
-        let b = ctx
-            .ensure_box(OpRef::int_op(2))
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
         assert_eq!(b.lower, -3);
         assert_eq!(b.upper, 0);
     }

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -3000,7 +3000,7 @@ impl Default for OptIntBounds {
 }
 
 impl Optimization for OptIntBounds {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let result = match op.opcode {
             // ── Comparisons ──
             OpCode::IntLt => self.optimize_int_lt(op, ctx),
@@ -3447,7 +3447,7 @@ mod tests {
                     ),
                 );
             }
-            let emitted_op = match pass.propagate_forward(&resolved_op, &mut ctx) {
+            let emitted_op = match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
                 OptimizationResult::Emit(emit_op) => {
                     ctx.emit(emit_op.clone());
                     Some(emit_op)

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -464,19 +464,16 @@ impl OptIntBounds {
     /// autogenintrules.py:23-143 optimize_INT_ADD — rules:
     /// add_zero / add_reassoc_consts / add_sub_x_c_c / add_sub_c_x_c.
     fn optimize_int_add(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // add_zero: int_add(0, x) => x
         if b0.is_constant() && b0.get_constant_int() == 0 {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg1)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         // add_zero: int_add(x, 0) => x
@@ -484,90 +481,87 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // autogenintrules.py:42-88 — outer const on arg0, inner producer on arg1.
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
-            if let Some(arg1_add) = self.as_operation(arg1, OpCode::IntAdd, ctx) {
-                let inner_0 = ctx.get_box_replacement(arg1_add.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(arg1_add.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            if let Some(arg1_add) = self.as_operation_b(&arg1, OpCode::IntAdd, ctx) {
+                let inner_0 = self.resolve_box(arg1_add.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(arg1_add.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // add_reassoc_consts: int_add(C2, int_add(C1, x)) => int_add(x, C1+C2)
                 if b_inner_0.is_constant() {
                     let folded = c_outer.wrapping_add(b_inner_0.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAdd, &[inner_1, const_ref]);
+                    return replace_with(op, OpCode::IntAdd, &[inner_1.to_opref(), const_ref]);
                 }
                 // add_reassoc_consts: int_add(C2, int_add(x, C1)) => int_add(x, C1+C2)
                 if b_inner_1.is_constant() {
                     let folded = c_outer.wrapping_add(b_inner_1.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAdd, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
                 }
-            } else if let Some(arg1_sub) = self.as_operation(arg1, OpCode::IntSub, ctx) {
-                let inner_0 = ctx.get_box_replacement(arg1_sub.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(arg1_sub.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            } else if let Some(arg1_sub) = self.as_operation_b(&arg1, OpCode::IntSub, ctx) {
+                let inner_0 = self.resolve_box(arg1_sub.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(arg1_sub.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // add_sub_c_x_c: int_add(C2, int_sub(C1, x)) => int_sub(C1+C2, x)
                 if b_inner_0.is_constant() {
                     let folded = c_outer.wrapping_add(b_inner_0.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[const_ref, inner_1]);
+                    return replace_with(op, OpCode::IntSub, &[const_ref, inner_1.to_opref()]);
                 }
                 // add_sub_x_c_c: int_add(C2, int_sub(x, C1)) => int_add(x, C2-C1)
                 if b_inner_1.is_constant() {
                     let folded = c_outer.wrapping_sub(b_inner_1.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAdd, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
                 }
             }
         } else {
             // autogenintrules.py:89-142 — inner producer on arg0, outer const on arg1.
-            if let Some(arg0_add) = self.as_operation(arg0, OpCode::IntAdd, ctx) {
-                let inner_0 = ctx.get_box_replacement(arg0_add.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(arg0_add.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            if let Some(arg0_add) = self.as_operation_b(&arg0, OpCode::IntAdd, ctx) {
+                let inner_0 = self.resolve_box(arg0_add.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(arg0_add.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 if b1.is_constant() {
                     let c_outer = b1.get_constant_int();
                     // add_reassoc_consts: int_add(int_add(C1, x), C2) => int_add(x, C1+C2)
                     if b_inner_0.is_constant() {
                         let folded = b_inner_0.get_constant_int().wrapping_add(c_outer);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAdd, &[inner_1, const_ref]);
+                        return replace_with(op, OpCode::IntAdd, &[inner_1.to_opref(), const_ref]);
                     }
                     // add_reassoc_consts: int_add(int_add(x, C1), C2) => int_add(x, C1+C2)
                     if b_inner_1.is_constant() {
                         let folded = b_inner_1.get_constant_int().wrapping_add(c_outer);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAdd, &[inner_0, const_ref]);
+                        return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
                     }
                 }
-            } else if let Some(arg0_sub) = self.as_operation(arg0, OpCode::IntSub, ctx) {
-                let inner_0 = ctx.get_box_replacement(arg0_sub.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(arg0_sub.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            } else if let Some(arg0_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
+                let inner_0 = self.resolve_box(arg0_sub.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(arg0_sub.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 if b1.is_constant() {
                     let c_outer = b1.get_constant_int();
                     // add_sub_c_x_c: int_add(int_sub(C1, x), C2) => int_sub(C1+C2, x)
                     if b_inner_0.is_constant() {
                         let folded = b_inner_0.get_constant_int().wrapping_add(c_outer);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntSub, &[const_ref, inner_1]);
+                        return replace_with(op, OpCode::IntSub, &[const_ref, inner_1.to_opref()]);
                     }
                     // add_sub_x_c_c: int_add(int_sub(x, C1), C2) => int_add(x, C2-C1)
                     if b_inner_1.is_constant() {
                         let folded = c_outer.wrapping_sub(b_inner_1.get_constant_int());
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAdd, &[inner_0, const_ref]);
+                        return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
                     }
                 }
             }
@@ -580,91 +574,73 @@ impl OptIntBounds {
     /// sub_add_neg / sub_sub_left_x_c_c / sub_sub_left_c_x_c /
     /// sub_xor_x_y_y / sub_or_x_y_y / sub_invert_one.
     fn optimize_int_sub(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // sub_x_x: int_sub(x, x) => 0
-        if autogen_eq(arg1, &b1, arg0, &b0) {
+        if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
             self.make_constant_int(op, 0, ctx);
             return OptimizationResult::Remove;
         }
         // sub_add: int_sub(int_add(x, y), y) => x / int_sub(int_add(y, x), y) => x
-        if let Some(arg0_int_add) = self.as_operation(arg0, OpCode::IntAdd, ctx) {
-            let arg0_0 = ctx.get_box_replacement(arg0_int_add.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_int_add.arg(1).to_opref());
-            let b0_0 = self.getintbound_box(arg0_0, ctx);
-            let b0_1 = self.getintbound_box(arg0_1, ctx);
-            if autogen_eq(arg1, &b1, arg0_1, &b0_1) {
+        if let Some(arg0_int_add) = self.as_operation_b(&arg0, OpCode::IntAdd, ctx) {
+            let arg0_0 = self.resolve_box(arg0_int_add.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_add.arg(1).to_opref(), ctx);
+            let b0_0 = self.getintbound_b(&arg0_0, ctx);
+            let b0_1 = self.getintbound_b(&arg0_1, ctx);
+            if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0_0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0_0);
                 return OptimizationResult::Remove;
             }
-            if autogen_eq(arg1, &b1, arg0_0, &b0_0) {
+            if autogen_eq_b(&arg1, &b1, &arg0_0, &b0_0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0_1)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0_1);
                 return OptimizationResult::Remove;
             }
-        } else if let Some(arg0_int_or) = self.as_operation(arg0, OpCode::IntOr, ctx) {
+        } else if let Some(arg0_int_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
             // sub_or_x_y_y: int_sub(int_or(x, y), y) => x  (when x & y == 0)
-            let arg0_0 = ctx.get_box_replacement(arg0_int_or.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_int_or.arg(1).to_opref());
-            let b0_0 = self.getintbound_box(arg0_0, ctx);
-            let b0_1 = self.getintbound_box(arg0_1, ctx);
-            if autogen_eq(arg1, &b1, arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
+            let arg0_0 = self.resolve_box(arg0_int_or.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_or.arg(1).to_opref(), ctx);
+            let b0_0 = self.getintbound_b(&arg0_0, ctx);
+            let b0_1 = self.getintbound_b(&arg0_1, ctx);
+            if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0_0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0_0);
                 return OptimizationResult::Remove;
             }
-            if autogen_eq(arg1, &b1, arg0_0, &b0_0) && b0_1.and_bound(&b0_0).known_eq_const(0) {
+            if autogen_eq_b(&arg1, &b1, &arg0_0, &b0_0) && b0_1.and_bound(&b0_0).known_eq_const(0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0_1)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0_1);
                 return OptimizationResult::Remove;
             }
-        } else if let Some(arg0_int_xor) = self.as_operation(arg0, OpCode::IntXor, ctx) {
+        } else if let Some(arg0_int_xor) = self.as_operation_b(&arg0, OpCode::IntXor, ctx) {
             // sub_xor_x_y_y: int_sub(int_xor(x, y), y) => x  (when x & y == 0)
-            let arg0_0 = ctx.get_box_replacement(arg0_int_xor.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_int_xor.arg(1).to_opref());
-            let b0_0 = self.getintbound_box(arg0_0, ctx);
-            let b0_1 = self.getintbound_box(arg0_1, ctx);
-            if autogen_eq(arg1, &b1, arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
+            let arg0_0 = self.resolve_box(arg0_int_xor.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_xor.arg(1).to_opref(), ctx);
+            let b0_0 = self.getintbound_b(&arg0_0, ctx);
+            let b0_1 = self.getintbound_b(&arg0_1, ctx);
+            if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0_0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0_0);
                 return OptimizationResult::Remove;
             }
-            if autogen_eq(arg1, &b1, arg0_0, &b0_0) && b0_1.and_bound(&b0_0).known_eq_const(0) {
+            if autogen_eq_b(&arg1, &b1, &arg0_0, &b0_0) && b0_1.and_bound(&b0_0).known_eq_const(0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0_1)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0_1);
                 return OptimizationResult::Remove;
             }
         }
@@ -673,75 +649,72 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // sub_from_zero: int_sub(0, x) => int_neg(x)
         if b0.is_constant() && b0.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntNeg, &[arg1]);
+            return replace_with(op, OpCode::IntNeg, &[arg1.to_opref()]);
         }
-        if let Some(arg0_int_invert) = self.as_operation(arg0, OpCode::IntInvert, ctx) {
-            let arg0_0 = ctx.get_box_replacement(arg0_int_invert.arg(0).to_opref());
+        if let Some(arg0_int_invert) = self.as_operation_b(&arg0, OpCode::IntInvert, ctx) {
+            let arg0_0 = self.resolve_box(arg0_int_invert.arg(0).to_opref(), ctx);
             // sub_invert_one: int_sub(int_invert(x), -1) => int_neg(x)
             if b1.is_constant() && b1.get_constant_int() == -1 {
-                return replace_with(op, OpCode::IntNeg, &[arg0_0]);
+                return replace_with(op, OpCode::IntNeg, &[arg0_0.to_opref()]);
             }
-        } else if let Some(arg0_int_add) = self.as_operation(arg0, OpCode::IntAdd, ctx) {
-            let arg0_0 = ctx.get_box_replacement(arg0_int_add.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_int_add.arg(1).to_opref());
-            let b0_0 = self.getintbound_box(arg0_0, ctx);
-            let b0_1 = self.getintbound_box(arg0_1, ctx);
+        } else if let Some(arg0_int_add) = self.as_operation_b(&arg0, OpCode::IntAdd, ctx) {
+            let arg0_0 = self.resolve_box(arg0_int_add.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_add.arg(1).to_opref(), ctx);
+            let b0_0 = self.getintbound_b(&arg0_0, ctx);
+            let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if b1.is_constant() {
                 let c_outer = b1.get_constant_int();
                 // sub_add_consts: int_sub(int_add(C1, x), C2) => int_sub(x, C-C1)
                 if b0_0.is_constant() {
                     let folded = c_outer.wrapping_sub(b0_0.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[arg0_1, const_ref]);
+                    return replace_with(op, OpCode::IntSub, &[arg0_1.to_opref(), const_ref]);
                 }
                 // sub_add_consts: int_sub(int_add(x, C1), C2) => int_sub(x, C-C1)
                 if b0_1.is_constant() {
                     let folded = c_outer.wrapping_sub(b0_1.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[arg0_0, const_ref]);
+                    return replace_with(op, OpCode::IntSub, &[arg0_0.to_opref(), const_ref]);
                 }
             }
-        } else if let Some(arg0_int_sub) = self.as_operation(arg0, OpCode::IntSub, ctx) {
-            let arg0_0 = ctx.get_box_replacement(arg0_int_sub.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_int_sub.arg(1).to_opref());
-            let b0_0 = self.getintbound_box(arg0_0, ctx);
-            let b0_1 = self.getintbound_box(arg0_1, ctx);
+        } else if let Some(arg0_int_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
+            let arg0_0 = self.resolve_box(arg0_int_sub.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_sub.arg(1).to_opref(), ctx);
+            let b0_0 = self.getintbound_b(&arg0_0, ctx);
+            let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if b1.is_constant() {
                 let c_outer = b1.get_constant_int();
                 // sub_sub_left_c_x_c: int_sub(int_sub(C1, x), C2) => int_sub(C1-C2, x)
                 if b0_0.is_constant() {
                     let folded = b0_0.get_constant_int().wrapping_sub(c_outer);
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[const_ref, arg0_1]);
+                    return replace_with(op, OpCode::IntSub, &[const_ref, arg0_1.to_opref()]);
                 }
                 // sub_sub_left_x_c_c: int_sub(int_sub(x, C1), C2) => int_sub(x, C1+C2)
                 if b0_1.is_constant() {
                     let folded = b0_1.get_constant_int().wrapping_add(c_outer);
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[arg0_0, const_ref]);
+                    return replace_with(op, OpCode::IntSub, &[arg0_0.to_opref(), const_ref]);
                 }
             }
         }
-        if let Some(arg1_int_add) = self.as_operation(arg1, OpCode::IntAdd, ctx) {
-            let arg1_0 = ctx.get_box_replacement(arg1_int_add.arg(0).to_opref());
-            let arg1_1 = ctx.get_box_replacement(arg1_int_add.arg(1).to_opref());
-            let b1_0 = self.getintbound_box(arg1_0, ctx);
-            let b1_1 = self.getintbound_box(arg1_1, ctx);
+        if let Some(arg1_int_add) = self.as_operation_b(&arg1, OpCode::IntAdd, ctx) {
+            let arg1_0 = self.resolve_box(arg1_int_add.arg(0).to_opref(), ctx);
+            let arg1_1 = self.resolve_box(arg1_int_add.arg(1).to_opref(), ctx);
+            let b1_0 = self.getintbound_b(&arg1_0, ctx);
+            let b1_1 = self.getintbound_b(&arg1_1, ctx);
             // sub_add_neg: int_sub(y, int_add(x, y)) => int_neg(x)
-            if autogen_eq(arg1_1, &b1_1, arg0, &b0) {
-                return replace_with(op, OpCode::IntNeg, &[arg1_0]);
+            if autogen_eq_b(&arg1_1, &b1_1, &arg0, &b0) {
+                return replace_with(op, OpCode::IntNeg, &[arg1_0.to_opref()]);
             }
             // sub_add_neg: int_sub(y, int_add(y, x)) => int_neg(x)
-            if autogen_eq(arg1_0, &b1_0, arg0, &b0) {
-                return replace_with(op, OpCode::IntNeg, &[arg1_1]);
+            if autogen_eq_b(&arg1_0, &b1_0, &arg0, &b0) {
+                return replace_with(op, OpCode::IntNeg, &[arg1_1.to_opref()]);
             }
         }
         OptimizationResult::PassOn
@@ -750,10 +723,10 @@ impl OptIntBounds {
     /// autogenintrules.py:315-410 optimize_INT_MUL — rules:
     /// mul_zero / mul_one / mul_minus_one / mul_pow2_const / mul_lshift.
     fn optimize_int_mul(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // mul_zero: int_mul(0, x) => 0
         if b0.is_constant() && b0.get_constant_int() == 0 {
             self.make_constant_int(op, 0, ctx);
@@ -769,10 +742,7 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg1)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         // mul_one: int_mul(x, 1) => x
@@ -780,10 +750,7 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // Outer const on arg0: mul_minus_one / mul_pow2_const
@@ -791,27 +758,27 @@ impl OptIntBounds {
             let c = b0.get_constant_int();
             // mul_minus_one: int_mul(-1, x) => int_neg(x)
             if c == -1 {
-                return replace_with(op, OpCode::IntNeg, &[arg1]);
+                return replace_with(op, OpCode::IntNeg, &[arg1.to_opref()]);
             }
             // mul_pow2_const: int_mul(C, x) where C > 0 && (C & (C-1)) == 0
             // => int_lshift(x, highest_bit(C))
             if c > 0 && (c & c.wrapping_sub(1)) == 0 {
                 let shift = c.trailing_zeros() as i64;
                 let shift_ref = ctx.make_constant_int(shift);
-                return replace_with(op, OpCode::IntLshift, &[arg1, shift_ref]);
+                return replace_with(op, OpCode::IntLshift, &[arg1.to_opref(), shift_ref]);
             }
-        } else if let Some(arg0_lshift) = self.as_operation(arg0, OpCode::IntLshift, ctx) {
+        } else if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
             // mul_lshift: int_mul(int_lshift(1, y), x) => int_lshift(x, y)
-            let inner_0 = ctx.get_box_replacement(arg0_lshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_lshift.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant()
                 && b_inner_0.get_constant_int() == 1
                 && b_inner_1.known_ge_const(0)
                 && b_inner_1.known_le_const(64)
             {
-                return replace_with(op, OpCode::IntLshift, &[arg1, inner_1]);
+                return replace_with(op, OpCode::IntLshift, &[arg1.to_opref(), inner_1.to_opref()]);
             }
         }
         // Outer const on arg1: mul_minus_one / mul_pow2_const
@@ -819,26 +786,26 @@ impl OptIntBounds {
             let c = b1.get_constant_int();
             // mul_minus_one: int_mul(x, -1) => int_neg(x)
             if c == -1 {
-                return replace_with(op, OpCode::IntNeg, &[arg0]);
+                return replace_with(op, OpCode::IntNeg, &[arg0.to_opref()]);
             }
             // mul_pow2_const: int_mul(x, C) where C > 0 && pow2
             if c > 0 && (c & c.wrapping_sub(1)) == 0 {
                 let shift = c.trailing_zeros() as i64;
                 let shift_ref = ctx.make_constant_int(shift);
-                return replace_with(op, OpCode::IntLshift, &[arg0, shift_ref]);
+                return replace_with(op, OpCode::IntLshift, &[arg0.to_opref(), shift_ref]);
             }
-        } else if let Some(arg1_lshift) = self.as_operation(arg1, OpCode::IntLshift, ctx) {
+        } else if let Some(arg1_lshift) = self.as_operation_b(&arg1, OpCode::IntLshift, ctx) {
             // mul_lshift: int_mul(x, int_lshift(1, y)) => int_lshift(x, y)
-            let inner_0 = ctx.get_box_replacement(arg1_lshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg1_lshift.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            let inner_0 = self.resolve_box(arg1_lshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg1_lshift.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant()
                 && b_inner_0.get_constant_int() == 1
                 && b_inner_1.known_ge_const(0)
                 && b_inner_1.known_le_const(64)
             {
-                return replace_with(op, OpCode::IntLshift, &[arg0, inner_1]);
+                return replace_with(op, OpCode::IntLshift, &[arg0.to_opref(), inner_1.to_opref()]);
             }
         }
         OptimizationResult::PassOn
@@ -848,10 +815,10 @@ impl OptIntBounds {
     /// and_known_result / and_x_c_in_range / and_x_x / and_idempotent /
     /// and_reassoc_consts / and_absorb / and_or.
     fn optimize_int_and(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // and_known_result: int_and(a, b) bound is constant => ConstInt(C)
         let bound = b0.and_bound(&b1);
         if bound.is_constant() {
@@ -872,10 +839,7 @@ impl OptIntBounds {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg1)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg1);
                 return OptimizationResult::Remove;
             }
         }
@@ -887,22 +851,16 @@ impl OptIntBounds {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0);
                 return OptimizationResult::Remove;
             }
         }
         // and_x_x: int_and(a, a) => a
-        if autogen_eq(arg1, &b1, arg0, &b0) {
+        if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // and_idempotent: int_and(x, y) => x
@@ -911,10 +869,7 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // and_idempotent: int_and(y, x) => x
@@ -922,43 +877,40 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg1)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
-            if let Some(arg1_and) = self.as_operation(arg1, OpCode::IntAnd, ctx) {
-                let inner_0 = ctx.get_box_replacement(arg1_and.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(arg1_and.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
+                let inner_0 = self.resolve_box(arg1_and.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(arg1_and.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // and_reassoc_consts: int_and(C2, int_and(C1, x)) => int_and(x, C1&C2)
                 if b_inner_0.is_constant() {
                     let folded = b_inner_0.get_constant_int() & c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_1, const_ref]);
+                    return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), const_ref]);
                 }
                 // and_reassoc_consts: int_and(C2, int_and(x, C1)) => int_and(x, C1&C2)
                 if b_inner_1.is_constant() {
                     let folded = b_inner_1.get_constant_int() & c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
                 }
             }
-        } else if let Some(arg0_and) = self.as_operation(arg0, OpCode::IntAnd, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_and.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_and.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
+            let inner_0 = self.resolve_box(arg0_and.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_and.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant() {
                 if b1.is_constant() {
                     // and_reassoc_consts: int_and(int_and(C1, x), C2) => int_and(x, C1&C2)
                     let folded = b_inner_0.get_constant_int() & b1.get_constant_int();
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_1, const_ref]);
+                    return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), const_ref]);
                 }
             }
             if b_inner_1.is_constant() {
@@ -966,57 +918,57 @@ impl OptIntBounds {
                     // and_reassoc_consts: int_and(int_and(x, C1), C2) => int_and(x, C1&C2)
                     let folded = b_inner_1.get_constant_int() & b1.get_constant_int();
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
                 }
             }
             // and_absorb: int_and(int_and(a, b), a) => int_and(a, b)
-            if autogen_eq(arg1, &b1, inner_0, &b_inner_0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_0, inner_1]);
+            if autogen_eq_b(&arg1, &b1, &inner_0, &b_inner_0) {
+                return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), inner_1.to_opref()]);
             }
             // and_absorb: int_and(int_and(b, a), a) => int_and(a, b)
-            if autogen_eq(arg1, &b1, inner_1, &b_inner_1) {
-                return replace_with(op, OpCode::IntAnd, &[inner_1, inner_0]);
+            if autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1) {
+                return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), inner_0.to_opref()]);
             }
-        } else if let Some(arg0_or) = self.as_operation(arg0, OpCode::IntOr, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_or.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_or.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg0_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
+            let inner_0 = self.resolve_box(arg0_or.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_or.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_or: int_and(int_or(x, y), z) => int_and(x, z)
             if b_inner_1.and_bound(&b1).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_0, arg1]);
+                return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), arg1.to_opref()]);
             }
             // and_or: int_and(int_or(y, x), z) => int_and(x, z)
             if b_inner_0.and_bound(&b1).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_1, arg1]);
+                return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), arg1.to_opref()]);
             }
         }
         // Symmetric arm: producer on arg1.
-        if let Some(arg1_and) = self.as_operation(arg1, OpCode::IntAnd, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg1_and.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg1_and.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
+            let inner_0 = self.resolve_box(arg1_and.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg1_and.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_absorb: int_and(a, int_and(a, b)) => int_and(a, b)
-            if autogen_eq(inner_0, &b_inner_0, arg0, &b0) {
-                return replace_with(op, OpCode::IntAnd, &[arg0, inner_1]);
+            if autogen_eq_b(&inner_0, &b_inner_0, &arg0, &b0) {
+                return replace_with(op, OpCode::IntAnd, &[arg0.to_opref(), inner_1.to_opref()]);
             }
             // and_absorb: int_and(a, int_and(b, a)) => int_and(a, b)
-            if autogen_eq(inner_1, &b_inner_1, arg0, &b0) {
-                return replace_with(op, OpCode::IntAnd, &[arg0, inner_0]);
+            if autogen_eq_b(&inner_1, &b_inner_1, &arg0, &b0) {
+                return replace_with(op, OpCode::IntAnd, &[arg0.to_opref(), inner_0.to_opref()]);
             }
-        } else if let Some(arg1_or) = self.as_operation(arg1, OpCode::IntOr, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg1_or.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg1_or.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg1_or) = self.as_operation_b(&arg1, OpCode::IntOr, ctx) {
+            let inner_0 = self.resolve_box(arg1_or.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg1_or.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_or: int_and(z, int_or(x, y)) => int_and(x, z)
             if b_inner_1.and_bound(&b0).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_0, arg0]);
+                return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), arg0.to_opref()]);
             }
             // and_or: int_and(z, int_or(y, x)) => int_and(x, z)
             if b_inner_0.and_bound(&b0).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_1, arg0]);
+                return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), arg0.to_opref()]);
             }
         }
         OptimizationResult::PassOn
@@ -1033,10 +985,10 @@ impl OptIntBounds {
     /// when its predicate holds. Preserved here to mirror upstream's
     /// auto-generated output line for line.
     fn optimize_int_or(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // or_known_result: int_or(a, b) bound is constant => ConstInt(C)
         let bound = b0.or_bound(&b1);
         if bound.is_constant() {
@@ -1049,14 +1001,11 @@ impl OptIntBounds {
             return OptimizationResult::Remove;
         }
         // or_x_x: int_or(a, a) => a
-        if autogen_eq(arg1, &b1, arg0, &b0) {
+        if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // or_idempotent: int_or(x, y) => x
@@ -1065,10 +1014,7 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
         // or_idempotent: int_or(y, x) => x
@@ -1076,151 +1022,148 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg1)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg1);
             return OptimizationResult::Remove;
         }
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
-            if let Some(arg1_or) = self.as_operation(arg1, OpCode::IntOr, ctx) {
-                let inner_0 = ctx.get_box_replacement(arg1_or.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(arg1_or.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            if let Some(arg1_or) = self.as_operation_b(&arg1, OpCode::IntOr, ctx) {
+                let inner_0 = self.resolve_box(arg1_or.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(arg1_or.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // or_reassoc_consts: int_or(C2, int_or(C1, x)) => int_or(x, C1|C2)
                 if b_inner_0.is_constant() {
                     let folded = b_inner_0.get_constant_int() | c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntOr, &[inner_1, const_ref]);
+                    return replace_with(op, OpCode::IntOr, &[inner_1.to_opref(), const_ref]);
                 }
                 // or_reassoc_consts: int_or(C2, int_or(x, C1)) => int_or(x, C1|C2)
                 if b_inner_1.is_constant() {
                     let folded = b_inner_1.get_constant_int() | c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntOr, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntOr, &[inner_0.to_opref(), const_ref]);
                 }
             }
-        } else if let Some(arg0_and) = self.as_operation(arg0, OpCode::IntAnd, ctx) {
-            let arg0_0 = ctx.get_box_replacement(arg0_and.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_and.arg(1).to_opref());
-            let b_arg0_0 = self.getintbound_box(arg0_0, ctx);
-            let b_arg0_1 = self.getintbound_box(arg0_1, ctx);
+        } else if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
+            let arg0_0 = self.resolve_box(arg0_and.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_and.arg(1).to_opref(), ctx);
+            let b_arg0_0 = self.getintbound_b(&arg0_0, ctx);
+            let b_arg0_1 = self.getintbound_b(&arg0_1, ctx);
             // or_and_two_parts shapes when outer = int_and(C, x):
             if b_arg0_0.is_constant() {
                 let c_arg0_0 = b_arg0_0.get_constant_int();
-                if let Some(arg1_and) = self.as_operation(arg1, OpCode::IntAnd, ctx) {
-                    let arg1_0 = ctx.get_box_replacement(arg1_and.arg(0).to_opref());
-                    let arg1_1 = ctx.get_box_replacement(arg1_and.arg(1).to_opref());
-                    let b_arg1_0 = self.getintbound_box(arg1_0, ctx);
-                    let b_arg1_1 = self.getintbound_box(arg1_1, ctx);
+                if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
+                    let arg1_0 = self.resolve_box(arg1_and.arg(0).to_opref(), ctx);
+                    let arg1_1 = self.resolve_box(arg1_and.arg(1).to_opref(), ctx);
+                    let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
+                    let b_arg1_1 = self.getintbound_b(&arg1_1, ctx);
                     if b_arg1_0.is_constant() {
                         // int_or(int_and(C1, x), int_and(C2, x)) => int_and(x, C1|C2)
-                        if autogen_eq(arg1_1, &b_arg1_1, arg0_1, &b_arg0_1) {
+                        if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_1, &b_arg0_1) {
                             let folded = c_arg0_0 | b_arg1_0.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
                         }
                         // dead twin per autogenintrules.py:668-673
-                        if autogen_eq(arg1_1, &b_arg1_1, arg0_1, &b_arg0_1) {
+                        if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_1, &b_arg0_1) {
                             let folded = b_arg1_0.get_constant_int() | c_arg0_0;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
                         }
                     }
                     if b_arg1_1.is_constant() {
                         // int_or(int_and(C, x), int_and(x, C1)) => int_and(x, C|C1)
-                        if autogen_eq(arg1_0, &b_arg1_0, arg0_1, &b_arg0_1) {
+                        if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_1, &b_arg0_1) {
                             let folded = b_arg1_1.get_constant_int() | c_arg0_0;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
                         }
                         // dead twin per autogenintrules.py:684-689
-                        if autogen_eq(arg1_0, &b_arg1_0, arg0_1, &b_arg0_1) {
+                        if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_1, &b_arg0_1) {
                             let folded = c_arg0_0 | b_arg1_1.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_1, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_1.to_opref(), const_ref]);
                         }
                     }
                 }
             }
             if b_arg0_1.is_constant() {
                 let c_arg0_1 = b_arg0_1.get_constant_int();
-                if let Some(arg1_and) = self.as_operation(arg1, OpCode::IntAnd, ctx) {
-                    let arg1_0 = ctx.get_box_replacement(arg1_and.arg(0).to_opref());
-                    let arg1_1 = ctx.get_box_replacement(arg1_and.arg(1).to_opref());
-                    let b_arg1_0 = self.getintbound_box(arg1_0, ctx);
-                    let b_arg1_1 = self.getintbound_box(arg1_1, ctx);
+                if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
+                    let arg1_0 = self.resolve_box(arg1_and.arg(0).to_opref(), ctx);
+                    let arg1_1 = self.resolve_box(arg1_and.arg(1).to_opref(), ctx);
+                    let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
+                    let b_arg1_1 = self.getintbound_b(&arg1_1, ctx);
                     if b_arg1_0.is_constant() {
                         // int_or(int_and(x, C1), int_and(C2, x)) => int_and(x, C)
-                        if autogen_eq(arg1_1, &b_arg1_1, arg0_0, &b_arg0_0) {
+                        if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_0, &b_arg0_0) {
                             let folded = c_arg0_1 | b_arg1_0.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
                         }
                         // dead twin per autogenintrules.py:708-713
-                        if autogen_eq(arg1_1, &b_arg1_1, arg0_0, &b_arg0_0) {
+                        if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0_0, &b_arg0_0) {
                             let folded = b_arg1_0.get_constant_int() | c_arg0_1;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
                         }
                     }
                     if b_arg1_1.is_constant() {
                         // int_or(int_and(x, C1), int_and(x, C2)) => int_and(x, C)
-                        if autogen_eq(arg1_0, &b_arg1_0, arg0_0, &b_arg0_0) {
+                        if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_0, &b_arg0_0) {
                             let folded = c_arg0_1 | b_arg1_1.get_constant_int();
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
                         }
                         // dead twin per autogenintrules.py:724-729
-                        if autogen_eq(arg1_0, &b_arg1_0, arg0_0, &b_arg0_0) {
+                        if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0_0, &b_arg0_0) {
                             let folded = b_arg1_1.get_constant_int() | c_arg0_1;
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[arg0_0, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[arg0_0.to_opref(), const_ref]);
                         }
                     }
                 }
             }
-        } else if let Some(arg0_or) = self.as_operation(arg0, OpCode::IntOr, ctx) {
-            let arg0_0 = ctx.get_box_replacement(arg0_or.arg(0).to_opref());
-            let arg0_1 = ctx.get_box_replacement(arg0_or.arg(1).to_opref());
-            let b_arg0_0 = self.getintbound_box(arg0_0, ctx);
-            let b_arg0_1 = self.getintbound_box(arg0_1, ctx);
+        } else if let Some(arg0_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
+            let arg0_0 = self.resolve_box(arg0_or.arg(0).to_opref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_or.arg(1).to_opref(), ctx);
+            let b_arg0_0 = self.getintbound_b(&arg0_0, ctx);
+            let b_arg0_1 = self.getintbound_b(&arg0_1, ctx);
             if b_arg0_0.is_constant() && b1.is_constant() {
                 // or_reassoc_consts: int_or(int_or(C1, x), C2) => int_or(x, C1|C2)
                 let folded = b_arg0_0.get_constant_int() | b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntOr, &[arg0_1, const_ref]);
+                return replace_with(op, OpCode::IntOr, &[arg0_1.to_opref(), const_ref]);
             }
             if b_arg0_1.is_constant() && b1.is_constant() {
                 // or_reassoc_consts: int_or(int_or(x, C1), C2) => int_or(x, C1|C2)
                 let folded = b_arg0_1.get_constant_int() | b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntOr, &[arg0_0, const_ref]);
+                return replace_with(op, OpCode::IntOr, &[arg0_0.to_opref(), const_ref]);
             }
             // or_absorb: int_or(int_or(a, b), a) => int_or(a, b)
-            if autogen_eq(arg1, &b1, arg0_0, &b_arg0_0) {
-                return replace_with(op, OpCode::IntOr, &[arg0_0, arg0_1]);
+            if autogen_eq_b(&arg1, &b1, &arg0_0, &b_arg0_0) {
+                return replace_with(op, OpCode::IntOr, &[arg0_0.to_opref(), arg0_1.to_opref()]);
             }
             // or_absorb: int_or(int_or(b, a), a) => int_or(a, b)
-            if autogen_eq(arg1, &b1, arg0_1, &b_arg0_1) {
-                return replace_with(op, OpCode::IntOr, &[arg0_1, arg0_0]);
+            if autogen_eq_b(&arg1, &b1, &arg0_1, &b_arg0_1) {
+                return replace_with(op, OpCode::IntOr, &[arg0_1.to_opref(), arg0_0.to_opref()]);
             }
         }
         // Symmetric arm: producer on arg1.
-        if let Some(arg1_or) = self.as_operation(arg1, OpCode::IntOr, ctx) {
-            let arg1_0 = ctx.get_box_replacement(arg1_or.arg(0).to_opref());
-            let arg1_1 = ctx.get_box_replacement(arg1_or.arg(1).to_opref());
-            let b_arg1_0 = self.getintbound_box(arg1_0, ctx);
-            let b_arg1_1 = self.getintbound_box(arg1_1, ctx);
+        if let Some(arg1_or) = self.as_operation_b(&arg1, OpCode::IntOr, ctx) {
+            let arg1_0 = self.resolve_box(arg1_or.arg(0).to_opref(), ctx);
+            let arg1_1 = self.resolve_box(arg1_or.arg(1).to_opref(), ctx);
+            let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
+            let b_arg1_1 = self.getintbound_b(&arg1_1, ctx);
             // or_absorb: int_or(a, int_or(a, b)) => int_or(a, b)
-            if autogen_eq(arg1_0, &b_arg1_0, arg0, &b0) {
-                return replace_with(op, OpCode::IntOr, &[arg0, arg1_1]);
+            if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0, &b0) {
+                return replace_with(op, OpCode::IntOr, &[arg0.to_opref(), arg1_1.to_opref()]);
             }
             // or_absorb: int_or(a, int_or(b, a)) => int_or(a, b)
-            if autogen_eq(arg1_1, &b_arg1_1, arg0, &b0) {
-                return replace_with(op, OpCode::IntOr, &[arg0, arg1_0]);
+            if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0, &b0) {
+                return replace_with(op, OpCode::IntOr, &[arg0.to_opref(), arg1_0.to_opref()]);
             }
         }
         OptimizationResult::PassOn
@@ -1230,10 +1173,10 @@ impl OptIntBounds {
     /// xor_x_x / xor_reassoc_consts / xor_absorb / xor_zero /
     /// xor_minus_1 / xor_known_result / xor_is_not.
     fn optimize_int_xor(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // xor_known_result: int_xor(a, b) bound is constant => ConstInt(C)
         let bound = b0.xor_bound(&b1);
         if bound.is_constant() {
@@ -1246,7 +1189,7 @@ impl OptIntBounds {
             return OptimizationResult::Remove;
         }
         // xor_x_x: int_xor(a, a) => 0
-        if autogen_eq(arg1, &b1, arg0, &b0) {
+        if autogen_eq_b(&arg1, &b1, &arg0, &b0) {
             self.make_constant_int(op, 0, ctx);
             return OptimizationResult::Remove;
         }
@@ -1256,37 +1199,28 @@ impl OptIntBounds {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg1)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg1);
                 return OptimizationResult::Remove;
             }
-        } else if let Some(arg0_xor) = self.as_operation(arg0, OpCode::IntXor, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_xor.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_xor.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg0_xor) = self.as_operation_b(&arg0, OpCode::IntXor, ctx) {
+            let inner_0 = self.resolve_box(arg0_xor.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_xor.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // xor_absorb: int_xor(int_xor(a, b), b) => a
-            if autogen_eq(arg1, &b1, inner_1, &b_inner_1) {
+            if autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_inner = ctx
-                    .ensure_box(inner_0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_inner);
+                ctx.make_equal_to(&b_old, &inner_0);
                 return OptimizationResult::Remove;
             }
             // xor_absorb: int_xor(int_xor(b, a), b) => a
-            if autogen_eq(arg1, &b1, inner_0, &b_inner_0) {
+            if autogen_eq_b(&arg1, &b1, &inner_0, &b_inner_0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_inner = ctx
-                    .ensure_box(inner_1)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_inner);
+                ctx.make_equal_to(&b_old, &inner_1);
                 return OptimizationResult::Remove;
             }
         }
@@ -1296,85 +1230,76 @@ impl OptIntBounds {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_arg = ctx
-                    .ensure_box(arg0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_arg);
+                ctx.make_equal_to(&b_old, &arg0);
                 return OptimizationResult::Remove;
             }
-        } else if let Some(arg1_xor) = self.as_operation(arg1, OpCode::IntXor, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg1_xor.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg1_xor.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg1_xor) = self.as_operation_b(&arg1, OpCode::IntXor, ctx) {
+            let inner_0 = self.resolve_box(arg1_xor.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg1_xor.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // xor_absorb: int_xor(b, int_xor(a, b)) => a
-            if autogen_eq(inner_1, &b_inner_1, arg0, &b0) {
+            if autogen_eq_b(&inner_1, &b_inner_1, &arg0, &b0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_inner = ctx
-                    .ensure_box(inner_0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_inner);
+                ctx.make_equal_to(&b_old, &inner_0);
                 return OptimizationResult::Remove;
             }
             // xor_absorb: int_xor(b, int_xor(b, a)) => a
-            if autogen_eq(inner_0, &b_inner_0, arg0, &b0) {
+            if autogen_eq_b(&inner_0, &b_inner_0, &arg0, &b0) {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_inner = ctx
-                    .ensure_box(inner_1)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_inner);
+                ctx.make_equal_to(&b_old, &inner_1);
                 return OptimizationResult::Remove;
             }
         }
         // Constant-on-left arm (b_arg_0 constant): reassoc_consts/minus_1/is_not
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
-            if let Some(arg1_xor) = self.as_operation(arg1, OpCode::IntXor, ctx) {
-                let inner_0 = ctx.get_box_replacement(arg1_xor.arg(0).to_opref());
-                let inner_1 = ctx.get_box_replacement(arg1_xor.arg(1).to_opref());
-                let b_inner_0 = self.getintbound_box(inner_0, ctx);
-                let b_inner_1 = self.getintbound_box(inner_1, ctx);
+            if let Some(arg1_xor) = self.as_operation_b(&arg1, OpCode::IntXor, ctx) {
+                let inner_0 = self.resolve_box(arg1_xor.arg(0).to_opref(), ctx);
+                let inner_1 = self.resolve_box(arg1_xor.arg(1).to_opref(), ctx);
+                let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+                let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // xor_reassoc_consts: int_xor(C2, int_xor(C1, x)) => int_xor(x, C1^C2)
                 if b_inner_0.is_constant() {
                     let folded = b_inner_0.get_constant_int() ^ c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntXor, &[inner_1, const_ref]);
+                    return replace_with(op, OpCode::IntXor, &[inner_1.to_opref(), const_ref]);
                 }
                 // xor_reassoc_consts: int_xor(C2, int_xor(x, C1)) => int_xor(x, C1^C2)
                 if b_inner_1.is_constant() {
                     let folded = b_inner_1.get_constant_int() ^ c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntXor, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntXor, &[inner_0.to_opref(), const_ref]);
                 }
             }
             // xor_minus_1: int_xor(-1, x) => int_invert(x)
             if c_outer == -1 {
-                return replace_with(op, OpCode::IntInvert, &[arg1]);
+                return replace_with(op, OpCode::IntInvert, &[arg1.to_opref()]);
             }
             // xor_is_not: int_xor(1, x) => int_is_zero(x)  (when x is bool)
             if c_outer == 1 && b1.is_bool() {
-                return replace_with(op, OpCode::IntIsZero, &[arg1]);
+                return replace_with(op, OpCode::IntIsZero, &[arg1.to_opref()]);
             }
-        } else if let Some(arg0_xor) = self.as_operation(arg0, OpCode::IntXor, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_xor.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_xor.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg0_xor) = self.as_operation_b(&arg0, OpCode::IntXor, ctx) {
+            let inner_0 = self.resolve_box(arg0_xor.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_xor.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant() && b1.is_constant() {
                 // xor_reassoc_consts: int_xor(int_xor(C1, x), C2) => int_xor(x, C1^C2)
                 let folded = b_inner_0.get_constant_int() ^ b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntXor, &[inner_1, const_ref]);
+                return replace_with(op, OpCode::IntXor, &[inner_1.to_opref(), const_ref]);
             }
             if b_inner_1.is_constant() && b1.is_constant() {
                 // xor_reassoc_consts: int_xor(int_xor(x, C1), C2) => int_xor(x, C1^C2)
                 let folded = b_inner_1.get_constant_int() ^ b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntXor, &[inner_0, const_ref]);
+                return replace_with(op, OpCode::IntXor, &[inner_0.to_opref(), const_ref]);
             }
         }
         // Constant-on-right arm (b_arg_1 constant): minus_1/is_not
@@ -1382,11 +1307,11 @@ impl OptIntBounds {
             let c = b1.get_constant_int();
             // xor_minus_1: int_xor(x, -1) => int_invert(x)
             if c == -1 {
-                return replace_with(op, OpCode::IntInvert, &[arg0]);
+                return replace_with(op, OpCode::IntInvert, &[arg0.to_opref()]);
             }
             // xor_is_not: int_xor(x, 1) => int_is_zero(x)  (when x is bool)
             if c == 1 && b0.is_bool() {
-                return replace_with(op, OpCode::IntIsZero, &[arg0]);
+                return replace_with(op, OpCode::IntIsZero, &[arg0.to_opref()]);
             }
         }
         OptimizationResult::PassOn
@@ -1394,17 +1319,14 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1432-1443 optimize_INT_INVERT — rules: invert_invert.
     fn optimize_int_invert(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         // invert_invert: int_invert(int_invert(x)) => x
-        if let Some(inner) = self.as_operation(arg0, OpCode::IntInvert, ctx) {
-            let inner_0 = ctx.get_box_replacement(inner.arg(0).to_opref());
+        if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntInvert, ctx) {
+            let inner_0 = self.resolve_box(inner.arg(0).to_opref(), ctx);
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_inner = ctx
-                .ensure_box(inner_0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_inner);
+            ctx.make_equal_to(&b_old, &inner_0);
             return OptimizationResult::Remove;
         }
         OptimizationResult::PassOn
@@ -1412,17 +1334,14 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1447-1458 optimize_INT_NEG — rules: neg_neg.
     fn optimize_int_neg(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
         // neg_neg: int_neg(int_neg(x)) => x
-        if let Some(inner) = self.as_operation(arg0, OpCode::IntNeg, ctx) {
-            let inner_0 = ctx.get_box_replacement(inner.arg(0).to_opref());
+        if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntNeg, ctx) {
+            let inner_0 = self.resolve_box(inner.arg(0).to_opref(), ctx);
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_inner = ctx
-                .ensure_box(inner_0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_inner);
+            ctx.make_equal_to(&b_old, &inner_0);
             return OptimizationResult::Remove;
         }
         OptimizationResult::PassOn
@@ -1433,10 +1352,10 @@ impl OptIntBounds {
     /// lshift_urshift_c_c / lshift_and_urshift / lshift_lshift_c_c.
     /// LONG_BIT inlined as 64 (pyre is 64-bit only).
     fn optimize_int_lshift(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // lshift_zero_x: int_lshift(0, x) => 0
         if b0.is_constant() && b0.get_constant_int() == 0 {
             self.make_constant_int(op, 0, ctx);
@@ -1447,23 +1366,20 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
-        if let Some(arg0_and) = self.as_operation(arg0, OpCode::IntAnd, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_and.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_and.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
+            let inner_0 = self.resolve_box(arg0_and.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_and.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant() {
                 let c_arg0_0 = b_inner_0.get_constant_int();
-                if let Some(rshift) = self.as_operation(inner_1, OpCode::IntRshift, ctx) {
-                    let r0 = ctx.get_box_replacement(rshift.arg(0).to_opref());
-                    let r1 = ctx.get_box_replacement(rshift.arg(1).to_opref());
-                    let b_r1 = self.getintbound_box(r1, ctx);
+                if let Some(rshift) = self.as_operation_b(&inner_1, OpCode::IntRshift, ctx) {
+                    let r0 = self.resolve_box(rshift.arg(0).to_opref(), ctx);
+                    let r1 = self.resolve_box(rshift.arg(1).to_opref(), ctx);
+                    let b_r1 = self.getintbound_b(&r1, ctx);
                     if b_r1.is_constant() && b1.is_constant() {
                         let c_r1 = b_r1.get_constant_int();
                         let c_arg1 = b1.get_constant_int();
@@ -1471,13 +1387,13 @@ impl OptIntBounds {
                         if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                             let folded = c_arg0_0.wrapping_shl(c_r1 as u32);
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[r0, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
                         }
                     }
-                } else if let Some(urshift) = self.as_operation(inner_1, OpCode::UintRshift, ctx) {
-                    let r0 = ctx.get_box_replacement(urshift.arg(0).to_opref());
-                    let r1 = ctx.get_box_replacement(urshift.arg(1).to_opref());
-                    let b_r1 = self.getintbound_box(r1, ctx);
+                } else if let Some(urshift) = self.as_operation_b(&inner_1, OpCode::UintRshift, ctx) {
+                    let r0 = self.resolve_box(urshift.arg(0).to_opref(), ctx);
+                    let r1 = self.resolve_box(urshift.arg(1).to_opref(), ctx);
+                    let b_r1 = self.getintbound_b(&r1, ctx);
                     if b_r1.is_constant() && b1.is_constant() {
                         let c_r1 = b_r1.get_constant_int();
                         let c_arg1 = b1.get_constant_int();
@@ -1485,14 +1401,14 @@ impl OptIntBounds {
                         if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                             let folded = c_arg0_0.wrapping_shl(c_r1 as u32);
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[r0, const_ref]);
+                            return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
                         }
                     }
                 }
-            } else if let Some(rshift) = self.as_operation(inner_0, OpCode::IntRshift, ctx) {
-                let r0 = ctx.get_box_replacement(rshift.arg(0).to_opref());
-                let r1 = ctx.get_box_replacement(rshift.arg(1).to_opref());
-                let b_r1 = self.getintbound_box(r1, ctx);
+            } else if let Some(rshift) = self.as_operation_b(&inner_0, OpCode::IntRshift, ctx) {
+                let r0 = self.resolve_box(rshift.arg(0).to_opref(), ctx);
+                let r1 = self.resolve_box(rshift.arg(1).to_opref(), ctx);
+                let b_r1 = self.getintbound_b(&r1, ctx);
                 if b_r1.is_constant() && b_inner_1.is_constant() && b1.is_constant() {
                     let c_r1 = b_r1.get_constant_int();
                     let c_arg0_1 = b_inner_1.get_constant_int();
@@ -1501,13 +1417,13 @@ impl OptIntBounds {
                     if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                         let folded = c_arg0_1.wrapping_shl(c_r1 as u32);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAnd, &[r0, const_ref]);
+                        return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
                     }
                 }
-            } else if let Some(urshift) = self.as_operation(inner_0, OpCode::UintRshift, ctx) {
-                let r0 = ctx.get_box_replacement(urshift.arg(0).to_opref());
-                let r1 = ctx.get_box_replacement(urshift.arg(1).to_opref());
-                let b_r1 = self.getintbound_box(r1, ctx);
+            } else if let Some(urshift) = self.as_operation_b(&inner_0, OpCode::UintRshift, ctx) {
+                let r0 = self.resolve_box(urshift.arg(0).to_opref(), ctx);
+                let r1 = self.resolve_box(urshift.arg(1).to_opref(), ctx);
+                let b_r1 = self.getintbound_b(&r1, ctx);
                 if b_r1.is_constant() && b_inner_1.is_constant() && b1.is_constant() {
                     let c_r1 = b_r1.get_constant_int();
                     let c_arg0_1 = b_inner_1.get_constant_int();
@@ -1516,14 +1432,14 @@ impl OptIntBounds {
                     if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                         let folded = c_arg0_1.wrapping_shl(c_r1 as u32);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAnd, &[r0, const_ref]);
+                        return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
                     }
                 }
             }
-        } else if let Some(arg0_lshift) = self.as_operation(arg0, OpCode::IntLshift, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_lshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_lshift.arg(1).to_opref());
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_opref(), ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
                 let c2 = b1.get_constant_int();
@@ -1532,14 +1448,14 @@ impl OptIntBounds {
                     let folded = c1.wrapping_add(c2);
                     if folded < 64 {
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntLshift, &[inner_0, const_ref]);
+                        return replace_with(op, OpCode::IntLshift, &[inner_0.to_opref(), const_ref]);
                     }
                 }
             }
-        } else if let Some(arg0_rshift) = self.as_operation(arg0, OpCode::IntRshift, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_rshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_rshift.arg(1).to_opref());
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg0_rshift) = self.as_operation_b(&arg0, OpCode::IntRshift, ctx) {
+            let inner_0 = self.resolve_box(arg0_rshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_rshift.arg(1).to_opref(), ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
                 let c2 = b1.get_constant_int();
@@ -1547,13 +1463,13 @@ impl OptIntBounds {
                 if c2 == c1 && (0..64).contains(&c1) {
                     let mask = (-1i64).wrapping_shl(c1 as u32);
                     let const_ref = ctx.make_constant_int(mask);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
                 }
             }
-        } else if let Some(arg0_urshift) = self.as_operation(arg0, OpCode::UintRshift, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_urshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_urshift.arg(1).to_opref());
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        } else if let Some(arg0_urshift) = self.as_operation_b(&arg0, OpCode::UintRshift, ctx) {
+            let inner_0 = self.resolve_box(arg0_urshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_urshift.arg(1).to_opref(), ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
                 let c2 = b1.get_constant_int();
@@ -1561,7 +1477,7 @@ impl OptIntBounds {
                 if c2 == c1 && (0..64).contains(&c1) {
                     let mask = (-1i64).wrapping_shl(c1 as u32);
                     let const_ref = ctx.make_constant_int(mask);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
                 }
             }
         }
@@ -1572,10 +1488,10 @@ impl OptIntBounds {
     /// rshift_zero_x / rshift_x_zero / rshift_known_result / rshift_lshift /
     /// rshift_rshift_c_c. LONG_BIT inlined as 64.
     fn optimize_int_rshift(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // rshift_zero_x: int_rshift(0, x) => 0
         if b0.is_constant() && b0.get_constant_int() == 0 {
             self.make_constant_int(op, 0, ctx);
@@ -1587,22 +1503,19 @@ impl OptIntBounds {
             self.make_constant_int(op, bound.get_constant_int(), ctx);
             return OptimizationResult::Remove;
         }
-        if let Some(arg0_lshift) = self.as_operation(arg0, OpCode::IntLshift, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_lshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_lshift.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // rshift_lshift: int_rshift(int_lshift(x, y), y) => x
-            if autogen_eq(arg1, &b1, inner_1, &b_inner_1)
+            if autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1)
                 && b_inner_0.lshift_bound_cannot_overflow(&b_inner_1)
             {
                 let b_old = ctx
                     .ensure_box(op.pos.get())
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_inner = ctx
-                    .ensure_box(inner_0)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
-                ctx.make_equal_to(&b_old, &b_inner);
+                ctx.make_equal_to(&b_old, &inner_0);
                 return OptimizationResult::Remove;
             }
         }
@@ -1611,16 +1524,13 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
-        if let Some(arg0_rshift) = self.as_operation(arg0, OpCode::IntRshift, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_rshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_rshift.arg(1).to_opref());
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg0_rshift) = self.as_operation_b(&arg0, OpCode::IntRshift, ctx) {
+            let inner_0 = self.resolve_box(arg0_rshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_rshift.arg(1).to_opref(), ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
                 let c2 = b1.get_constant_int();
@@ -1629,7 +1539,7 @@ impl OptIntBounds {
                     let folded = c1.wrapping_add(c2).min(63);
                     if (0..64).contains(&folded) {
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntRshift, &[inner_0, const_ref]);
+                        return replace_with(op, OpCode::IntRshift, &[inner_0.to_opref(), const_ref]);
                     }
                 }
             }
@@ -1640,8 +1550,8 @@ impl OptIntBounds {
     /// autogenintrules.py:1364-1399 optimize_INT_IS_TRUE — rules:
     /// is_true_bool / is_true_true / is_true_and_minint.
     fn optimize_int_is_true(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
         // is_true_true: int_is_true(x) => 1
         // when bound excludes 0: lower > 0, or upper < 0, or any tvalue bit set.
         if b0.lower > 0 || b0.upper < 0 || b0.tvalue != 0 {
@@ -1653,26 +1563,23 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
-        if let Some(arg0_and) = self.as_operation(arg0, OpCode::IntAnd, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_and.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_and.arg(1).to_opref());
-            let b_inner_0 = self.getintbound_box(inner_0, ctx);
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
+            let inner_0 = self.resolve_box(arg0_and.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_and.arg(1).to_opref(), ctx);
+            let b_inner_0 = self.getintbound_b(&inner_0, ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // is_true_and_minint: int_is_true(int_and(MININT, x)) => int_lt(x, 0)
             if b_inner_0.is_constant() && b_inner_0.get_constant_int() == i64::MIN {
                 let zero_ref = ctx.make_constant_int(0);
-                return replace_with(op, OpCode::IntLt, &[inner_1, zero_ref]);
+                return replace_with(op, OpCode::IntLt, &[inner_1.to_opref(), zero_ref]);
             }
             // is_true_and_minint: int_is_true(int_and(x, MININT)) => int_lt(x, 0)
             if b_inner_1.is_constant() && b_inner_1.get_constant_int() == i64::MIN {
                 let zero_ref = ctx.make_constant_int(0);
-                return replace_with(op, OpCode::IntLt, &[inner_0, zero_ref]);
+                return replace_with(op, OpCode::IntLt, &[inner_0.to_opref(), zero_ref]);
             }
         }
         OptimizationResult::PassOn
@@ -1716,10 +1623,10 @@ impl OptIntBounds {
     /// urshift_zero_x / urshift_x_zero / urshift_known_result /
     /// urshift_lshift_x_c_c.
     fn optimize_uint_rshift(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // urshift_zero_x: uint_rshift(0, x) => 0
         if b0.is_constant() && b0.get_constant_int() == 0 {
             self.make_constant_int(op, 0, ctx);
@@ -1736,16 +1643,13 @@ impl OptIntBounds {
             let b_old = ctx
                 .ensure_box(op.pos.get())
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_arg = ctx
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.make_equal_to(&b_old, &b_arg);
+            ctx.make_equal_to(&b_old, &arg0);
             return OptimizationResult::Remove;
         }
-        if let Some(arg0_lshift) = self.as_operation(arg0, OpCode::IntLshift, ctx) {
-            let inner_0 = ctx.get_box_replacement(arg0_lshift.arg(0).to_opref());
-            let inner_1 = ctx.get_box_replacement(arg0_lshift.arg(1).to_opref());
-            let b_inner_1 = self.getintbound_box(inner_1, ctx);
+        if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_opref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_opref(), ctx);
+            let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
                 let c2 = b1.get_constant_int();
@@ -1754,7 +1658,7 @@ impl OptIntBounds {
                 if c2 == c1 && (0..64).contains(&c1) {
                     let mask = ((((-1i64) as u64) << c1) >> c1) as i64;
                     let const_ref = ctx.make_constant_int(mask);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0, const_ref]);
+                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
                 }
             }
         }
@@ -2112,12 +2016,12 @@ impl OptIntBounds {
 
     /// intbounds.py:275-287 optimize_INT_SUB_OVF
     fn optimize_int_sub_ovf(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
         // intbounds.py:278-279: b0/b1 are computed before the same_box check.
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
-        if ctx.same_box(arg0, arg1) {
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
+        if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
             // intbounds.py:280: arg0.same_box(arg1) → x - x = 0
             self.make_constant_int(op, 0, ctx);
             return OptimizationResult::Remove;

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -2317,18 +2317,14 @@ impl OptIntBounds {
     /// RPython `if`.
     fn make_int_lt(&mut self, box1: OpRef, box2: OpRef, ctx: &mut OptContext) {
         let b2 = self.getintbound_box(box2, ctx);
-        let changed1 = ctx
-            .ensure_box(box1)
-            .map(|b| ctx.with_intbound_mut(&b, |b1| matches!(b1.make_lt(&b2), Ok(true))))
-            .unwrap_or(false);
+        let box1_h = ctx.get_box_replacement(box1);
+        let changed1 = ctx.with_intbound_mut(&box1_h, |b1| matches!(b1.make_lt(&b2), Ok(true)));
         if changed1 {
             self.propagate_bounds_backward(box1, ctx);
         }
         let b1 = self.getintbound_box(box1, ctx);
-        let changed2 = ctx
-            .ensure_box(box2)
-            .map(|b| ctx.with_intbound_mut(&b, |b2| matches!(b2.make_gt(&b1), Ok(true))))
-            .unwrap_or(false);
+        let box2_h = ctx.get_box_replacement(box2);
+        let changed2 = ctx.with_intbound_mut(&box2_h, |b2| matches!(b2.make_gt(&b1), Ok(true)));
         if changed2 {
             self.propagate_bounds_backward(box2, ctx);
         }
@@ -2337,18 +2333,14 @@ impl OptIntBounds {
     /// intbounds.py:572-578 make_int_le
     fn make_int_le(&mut self, box1: OpRef, box2: OpRef, ctx: &mut OptContext) {
         let b2 = self.getintbound_box(box2, ctx);
-        let changed1 = ctx
-            .ensure_box(box1)
-            .map(|b| ctx.with_intbound_mut(&b, |b1| matches!(b1.make_le(&b2), Ok(true))))
-            .unwrap_or(false);
+        let box1_h = ctx.get_box_replacement(box1);
+        let changed1 = ctx.with_intbound_mut(&box1_h, |b1| matches!(b1.make_le(&b2), Ok(true)));
         if changed1 {
             self.propagate_bounds_backward(box1, ctx);
         }
         let b1 = self.getintbound_box(box1, ctx);
-        let changed2 = ctx
-            .ensure_box(box2)
-            .map(|b| ctx.with_intbound_mut(&b, |b2| matches!(b2.make_ge(&b1), Ok(true))))
-            .unwrap_or(false);
+        let box2_h = ctx.get_box_replacement(box2);
+        let changed2 = ctx.with_intbound_mut(&box2_h, |b2| matches!(b2.make_ge(&b1), Ok(true)));
         if changed2 {
             self.propagate_bounds_backward(box2, ctx);
         }
@@ -2367,18 +2359,16 @@ impl OptIntBounds {
     /// intbounds.py:586-592 make_unsigned_lt
     fn make_unsigned_lt(&mut self, box1: OpRef, box2: OpRef, ctx: &mut OptContext) {
         let b2 = self.getintbound_box(box2, ctx);
-        let changed1 = ctx
-            .ensure_box(box1)
-            .map(|b| ctx.with_intbound_mut(&b, |b1| matches!(b1.make_unsigned_lt(&b2), Ok(true))))
-            .unwrap_or(false);
+        let box1_h = ctx.get_box_replacement(box1);
+        let changed1 =
+            ctx.with_intbound_mut(&box1_h, |b1| matches!(b1.make_unsigned_lt(&b2), Ok(true)));
         if changed1 {
             self.propagate_bounds_backward(box1, ctx);
         }
         let b1 = self.getintbound_box(box1, ctx);
-        let changed2 = ctx
-            .ensure_box(box2)
-            .map(|b| ctx.with_intbound_mut(&b, |b2| matches!(b2.make_unsigned_gt(&b1), Ok(true))))
-            .unwrap_or(false);
+        let box2_h = ctx.get_box_replacement(box2);
+        let changed2 =
+            ctx.with_intbound_mut(&box2_h, |b2| matches!(b2.make_unsigned_gt(&b1), Ok(true)));
         if changed2 {
             self.propagate_bounds_backward(box2, ctx);
         }
@@ -2387,18 +2377,16 @@ impl OptIntBounds {
     /// intbounds.py:594-600 make_unsigned_le
     fn make_unsigned_le(&mut self, box1: OpRef, box2: OpRef, ctx: &mut OptContext) {
         let b2 = self.getintbound_box(box2, ctx);
-        let changed1 = ctx
-            .ensure_box(box1)
-            .map(|b| ctx.with_intbound_mut(&b, |b1| matches!(b1.make_unsigned_le(&b2), Ok(true))))
-            .unwrap_or(false);
+        let box1_h = ctx.get_box_replacement(box1);
+        let changed1 =
+            ctx.with_intbound_mut(&box1_h, |b1| matches!(b1.make_unsigned_le(&b2), Ok(true)));
         if changed1 {
             self.propagate_bounds_backward(box1, ctx);
         }
         let b1 = self.getintbound_box(box1, ctx);
-        let changed2 = ctx
-            .ensure_box(box2)
-            .map(|b| ctx.with_intbound_mut(&b, |b2| matches!(b2.make_unsigned_ge(&b1), Ok(true))))
-            .unwrap_or(false);
+        let box2_h = ctx.get_box_replacement(box2);
+        let changed2 =
+            ctx.with_intbound_mut(&box2_h, |b2| matches!(b2.make_unsigned_ge(&b1), Ok(true)));
         if changed2 {
             self.propagate_bounds_backward(box2, ctx);
         }
@@ -2427,18 +2415,14 @@ impl OptIntBounds {
     /// ```
     fn make_eq(&mut self, arg0: OpRef, arg1: OpRef, ctx: &mut OptContext) {
         let b1 = self.getintbound_box(arg1, ctx);
-        let changed0 = ctx
-            .ensure_box(arg0)
-            .map(|b| ctx.with_intbound_mut(&b, |b0| matches!(b0.intersect(&b1), Ok(true))))
-            .unwrap_or(false);
+        let arg0_h = ctx.get_box_replacement(arg0);
+        let changed0 = ctx.with_intbound_mut(&arg0_h, |b0| matches!(b0.intersect(&b1), Ok(true)));
         if changed0 {
             self.propagate_bounds_backward(arg0, ctx);
         }
         let b0 = self.getintbound_box(arg0, ctx);
-        let changed1 = ctx
-            .ensure_box(arg1)
-            .map(|b| ctx.with_intbound_mut(&b, |b1| matches!(b1.intersect(&b0), Ok(true))))
-            .unwrap_or(false);
+        let arg1_h = ctx.get_box_replacement(arg1);
+        let changed1 = ctx.with_intbound_mut(&arg1_h, |b1| matches!(b1.intersect(&b0), Ok(true)));
         if changed1 {
             self.propagate_bounds_backward(arg1, ctx);
         }
@@ -2463,10 +2447,8 @@ impl OptIntBounds {
         let b1 = self.getintbound_box(arg1, ctx);
         if b1.is_constant() {
             let v1 = b1.get_constant_int();
-            let did = ctx
-                .ensure_box(arg0)
-                .map(|b| ctx.with_intbound_mut(&b, |b0| b0.make_ne_const(v1)))
-                .unwrap_or(false);
+            let arg0_h = ctx.get_box_replacement(arg0);
+            let did = ctx.with_intbound_mut(&arg0_h, |b0| b0.make_ne_const(v1));
             if did {
                 self.propagate_bounds_backward(arg0, ctx);
             }
@@ -2474,10 +2456,8 @@ impl OptIntBounds {
             let b0 = self.getintbound_box(arg0, ctx);
             if b0.is_constant() {
                 let v0 = b0.get_constant_int();
-                let did = ctx
-                    .ensure_box(arg1)
-                    .map(|b| ctx.with_intbound_mut(&b, |b1| b1.make_ne_const(v0)))
-                    .unwrap_or(false);
+                let arg1_h = ctx.get_box_replacement(arg1);
+                let did = ctx.with_intbound_mut(&arg1_h, |b1| b1.make_ne_const(v0));
                 if did {
                     self.propagate_bounds_backward(arg1, ctx);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -2505,11 +2505,11 @@ impl OptIntBounds {
     ) {
         let arg0 = op.arg(0).to_opref();
         // optimizer.py:99-113 `getintbound` lazy-installs unbounded; the
-        // is_raw_ptr read + downstream bound write both materialize via
-        // `ensure_box` so the write path doesn't silently skip an opref
-        // it can't resolve.
-        let arg0_box = ctx.ensure_box(arg0);
-        if arg0_box.as_ref().map_or(false, |b| ctx.is_raw_ptr(b)) {
+        // dispatch-entry rebind registers the operand, so
+        // `get_box_replacement` resolves to the bound host the is_raw_ptr
+        // read and the downstream bound write both use.
+        let arg0_box = ctx.get_box_replacement(arg0);
+        if ctx.is_raw_ptr(&arg0_box) {
             return;
         }
         let r = self.getintbound_box(op.pos.get(), ctx);
@@ -2520,14 +2520,10 @@ impl OptIntBounds {
         if r_const == valnonzero {
             let b1 = self.getintbound_box(arg0, ctx);
             if b1.known_nonnegative() {
-                if let Some(bx) = &arg0_box {
-                    let _ = ctx.with_intbound_mut(bx, |bm| bm.make_gt_const(0));
-                }
+                let _ = ctx.with_intbound_mut(&arg0_box, |bm| bm.make_gt_const(0));
                 self.propagate_bounds_backward(arg0, ctx);
             } else if b1.known_le_const(0) {
-                if let Some(bx) = &arg0_box {
-                    let _ = ctx.with_intbound_mut(bx, |bm| bm.make_lt_const(0));
-                }
+                let _ = ctx.with_intbound_mut(&arg0_box, |bm| bm.make_lt_const(0));
                 self.propagate_bounds_backward(arg0, ctx);
             }
         } else if r_const == valzero {
@@ -2557,31 +2553,23 @@ impl OptIntBounds {
             OpCode::IntAdd | OpCode::IntAddOvf => {
                 let arg0 = op.arg(0).to_opref();
                 let arg1 = op.arg(1).to_opref();
-                // OpRef → BoxRef shim until the propagate_bounds_backward
-                // path migrates to take `&BoxRef` (Phase D-2).
-                let arg0_box = ctx.ensure_box(arg0);
-                let arg1_box = ctx.ensure_box(arg1);
-                let arg0_is_raw = arg0_box.as_ref().map_or(false, |b| ctx.is_raw_ptr(b));
-                let arg1_is_raw = arg1_box.as_ref().map_or(false, |b| ctx.is_raw_ptr(b));
-                if arg0_is_raw || arg1_is_raw {
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let arg1_box = ctx.get_box_replacement(arg1);
+                if ctx.is_raw_ptr(&arg0_box) || ctx.is_raw_ptr(&arg1_box) {
                     return;
                 }
                 let b1 = self.getintbound_box(arg0, ctx);
                 let b2 = self.getintbound_box(arg1, ctx);
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.sub_bound(&b2);
-                let changed0 = arg0_box
-                    .as_ref()
-                    .map(|bx| ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let changed0 =
+                    ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
                     self.propagate_bounds_backward(arg0, ctx);
                 }
                 let b = r.sub_bound(&b1);
-                let changed1 = arg1_box
-                    .as_ref()
-                    .map(|bx| ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let changed1 =
+                    ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
                     self.propagate_bounds_backward(arg1, ctx);
                 }
@@ -2594,18 +2582,16 @@ impl OptIntBounds {
                 let b2 = self.getintbound_box(arg1, ctx);
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.add_bound(&b2);
-                let changed0 = ctx
-                    .ensure_box(arg0)
-                    .map(|bx| ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let changed0 =
+                    ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
                     self.propagate_bounds_backward(arg0, ctx);
                 }
                 let b = r.sub_bound(&b1).neg_bound();
-                let changed1 = ctx
-                    .ensure_box(arg1)
-                    .map(|bx| ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let arg1_box = ctx.get_box_replacement(arg1);
+                let changed1 =
+                    ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
                     self.propagate_bounds_backward(arg1, ctx);
                 }
@@ -2621,18 +2607,16 @@ impl OptIntBounds {
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.py_div_bound(&b2);
-                let changed0 = ctx
-                    .ensure_box(arg0)
-                    .map(|bx| ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let changed0 =
+                    ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
                     self.propagate_bounds_backward(arg0, ctx);
                 }
                 let b = r.py_div_bound(&b1);
-                let changed1 = ctx
-                    .ensure_box(arg1)
-                    .map(|bx| ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let arg1_box = ctx.get_box_replacement(arg1);
+                let changed1 =
+                    ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
                     self.propagate_bounds_backward(arg1, ctx);
                 }
@@ -2648,12 +2632,9 @@ impl OptIntBounds {
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if let Ok(b) = r.lshift_bound_backwards(&b2) {
-                    let changed = ctx
-                        .ensure_box(arg0)
-                        .map(|bx| {
-                            ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&b), Ok(true)))
-                        })
-                        .unwrap_or(false);
+                    let arg0_box = ctx.get_box_replacement(arg0);
+                    let changed =
+                        ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
                         self.propagate_bounds_backward(arg0, ctx);
                     }
@@ -2668,10 +2649,9 @@ impl OptIntBounds {
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.rshift_bound_backwards(&b2);
-                let changed = ctx
-                    .ensure_box(arg0)
-                    .map(|bx| ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let changed =
+                    ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed {
                     self.propagate_bounds_backward(arg0, ctx);
                 }
@@ -2685,10 +2665,9 @@ impl OptIntBounds {
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.urshift_bound_backwards(&b2);
-                let changed = ctx
-                    .ensure_box(arg0)
-                    .map(|bx| ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let changed =
+                    ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed {
                     self.propagate_bounds_backward(arg0, ctx);
                 }
@@ -2700,26 +2679,18 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b0 = self.getintbound_box(arg0, ctx);
                 let b1 = self.getintbound_box(arg1, ctx);
-                let arg0_box = ctx.ensure_box(arg0);
-                let arg1_box = ctx.ensure_box(arg1);
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let arg1_box = ctx.get_box_replacement(arg1);
                 if let Ok(b) = b0.and_bound_backwards(&r) {
-                    let changed = arg1_box
-                        .as_ref()
-                        .map(|bx| {
-                            ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true)))
-                        })
-                        .unwrap_or(false);
+                    let changed =
+                        ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
                         self.propagate_bounds_backward(arg1, ctx);
                     }
                 }
                 if let Ok(b) = b1.and_bound_backwards(&r) {
-                    let changed = arg0_box
-                        .as_ref()
-                        .map(|bx| {
-                            ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true)))
-                        })
-                        .unwrap_or(false);
+                    let changed =
+                        ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
                         self.propagate_bounds_backward(arg0, ctx);
                     }
@@ -2732,26 +2703,18 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b0 = self.getintbound_box(arg0, ctx);
                 let b1 = self.getintbound_box(arg1, ctx);
-                let arg0_box = ctx.ensure_box(arg0);
-                let arg1_box = ctx.ensure_box(arg1);
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let arg1_box = ctx.get_box_replacement(arg1);
                 if let Ok(b) = b0.or_bound_backwards(&r) {
-                    let changed = arg1_box
-                        .as_ref()
-                        .map(|bx| {
-                            ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true)))
-                        })
-                        .unwrap_or(false);
+                    let changed =
+                        ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
                         self.propagate_bounds_backward(arg1, ctx);
                     }
                 }
                 if let Ok(b) = b1.or_bound_backwards(&r) {
-                    let changed = arg0_box
-                        .as_ref()
-                        .map(|bx| {
-                            ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true)))
-                        })
-                        .unwrap_or(false);
+                    let changed =
+                        ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
                         self.propagate_bounds_backward(arg0, ctx);
                     }
@@ -2764,22 +2727,18 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b0 = self.getintbound_box(arg0, ctx);
                 let b1 = self.getintbound_box(arg1, ctx);
-                let arg0_box = ctx.ensure_box(arg0);
-                let arg1_box = ctx.ensure_box(arg1);
+                let arg0_box = ctx.get_box_replacement(arg0);
+                let arg1_box = ctx.get_box_replacement(arg1);
                 // xor is its own inverse
                 let b = b0.xor_bound(&r);
-                let changed1 = arg1_box
-                    .as_ref()
-                    .map(|bx| ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let changed1 =
+                    ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
                     self.propagate_bounds_backward(arg1, ctx);
                 }
                 let b = b1.xor_bound(&r);
-                let changed0 = arg0_box
-                    .as_ref()
-                    .map(|bx| ctx.with_intbound_mut(bx, |bm| matches!(bm.intersect(&b), Ok(true))))
-                    .unwrap_or(false);
+                let changed0 =
+                    ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
                     self.propagate_bounds_backward(arg0, ctx);
                 }
@@ -2789,12 +2748,9 @@ impl OptIntBounds {
                 let arg0 = op.arg(0).to_opref();
                 let bres = self.getintbound_box(op.pos.get(), ctx);
                 let bounds = bres.invert_bound();
+                let arg0_box = ctx.get_box_replacement(arg0);
                 let changed = ctx
-                    .ensure_box(arg0)
-                    .map(|bx| {
-                        ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&bounds), Ok(true)))
-                    })
-                    .unwrap_or(false);
+                    .with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&bounds), Ok(true)));
                 if changed {
                     self.propagate_bounds_backward(arg0, ctx);
                 }
@@ -2804,12 +2760,9 @@ impl OptIntBounds {
                 let arg0 = op.arg(0).to_opref();
                 let bres = self.getintbound_box(op.pos.get(), ctx);
                 let bounds = bres.neg_bound();
+                let arg0_box = ctx.get_box_replacement(arg0);
                 let changed = ctx
-                    .ensure_box(arg0)
-                    .map(|bx| {
-                        ctx.with_intbound_mut(&bx, |bm| matches!(bm.intersect(&bounds), Ok(true)))
-                    })
-                    .unwrap_or(false);
+                    .with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&bounds), Ok(true)));
                 if changed {
                     self.propagate_bounds_backward(arg0, ctx);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1691,39 +1691,33 @@ impl OptIntBounds {
 
     /// intbounds.py:114-146 postprocess_INT_ADD
     fn postprocess_int_add(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
         // intbounds.py:119-123: if arg0 is arg1: b = b0.lshift_bound(1) (x+x is even)
-        let b = if arg0 == arg1 {
+        let b = if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
             b0.lshift_bound(&IntBound::from_constant(1))
         } else {
-            let b1 = self.getintbound_box(arg1, ctx);
+            let b1 = self.getintbound_b(&arg1, ctx);
             b0.add_bound(&b1)
         };
         self.intersect_bound(op.pos.get(), &b, ctx);
         // intbounds.py:125-127:
         //   self.optimizer.pure_from_args2(rop.INT_SUB, op, arg1, arg0)
         //   self.optimizer.pure_from_args2(rop.INT_SUB, op, arg0, arg1)
-        ctx.register_pure_from_args2(OpCode::IntSub, arg0, op.pos.get(), arg1);
-        ctx.register_pure_from_args2(OpCode::IntSub, arg1, op.pos.get(), arg0);
+        ctx.register_pure_from_args2(OpCode::IntSub, arg0.to_opref(), op.pos.get(), arg1.to_opref());
+        ctx.register_pure_from_args2(OpCode::IntSub, arg1.to_opref(), op.pos.get(), arg0.to_opref());
         // intbounds.py:128-142: pick the constant arg, fall back to commutative
         // swap so `arg1` ends up holding the non-const operand.
         // intbounds.py:128/134 `isinstance(argN, ConstInt)` — raw Const
         // check, no IntBound synthesis, so read const_value() not the
         // synthesizing get_constant_int_box.
-        let (inv_const, other) = if let Some(Value::Int(c)) = ctx
-            .get_box_replacement_box(arg0)
-            .and_then(|b| b.const_value())
-        {
+        let (inv_const, other) = if let Some(Value::Int(c)) = arg0.const_value() {
             if c == i64::MIN {
                 return;
             }
             (c, arg1)
-        } else if let Some(Value::Int(c)) = ctx
-            .get_box_replacement_box(arg1)
-            .and_then(|b| b.const_value())
-        {
+        } else if let Some(Value::Int(c)) = arg1.const_value() {
             if c == i64::MIN {
                 return;
             }
@@ -1731,6 +1725,7 @@ impl OptIntBounds {
         } else {
             return;
         };
+        let other = other.to_opref();
         let neg_ref = self.get_or_make_const(-inv_const, ctx);
         // intbounds.py:143-146:
         //   self.optimizer.pure_from_args2(rop.INT_SUB, arg1, inv_arg0, op)
@@ -1745,22 +1740,20 @@ impl OptIntBounds {
 
     /// intbounds.py: INT_SUB postprocess with constant inversion synthesis.
     fn postprocess_int_sub(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         let b = b0.sub_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
         // Synthesis: INT_SUB(a,b)=res → INT_ADD(res,b)=a, INT_SUB(a,res)=b
-        ctx.register_pure_from_args2(OpCode::IntAdd, arg0, op.pos.get(), arg1);
-        ctx.register_pure_from_args2(OpCode::IntSub, arg1, arg0, op.pos.get());
+        ctx.register_pure_from_args2(OpCode::IntAdd, arg0.to_opref(), op.pos.get(), arg1.to_opref());
+        ctx.register_pure_from_args2(OpCode::IntSub, arg1.to_opref(), arg0.to_opref(), op.pos.get());
         // intbounds.py: constant inversion for INT_SUB — `isinstance(arg1,
         // ConstInt)` raw Const check (no IntBound synthesis).
-        if let Some(Value::Int(c1)) = ctx
-            .get_box_replacement_box(arg1)
-            .and_then(|b| b.const_value())
-        {
+        if let Some(Value::Int(c1)) = arg1.const_value() {
             if c1 != i64::MIN {
+                let arg0 = arg0.to_opref();
                 let neg_ref = self.get_or_make_const(-c1, ctx);
                 ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), arg0, neg_ref);
                 ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), neg_ref, arg0);
@@ -1786,17 +1779,17 @@ impl OptIntBounds {
 
     /// intbounds.py:60-71 postprocess_INT_OR
     fn postprocess_int_or(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // intbounds.py:65: if b0.and_bound(b1).known_eq_const(0):
         if b0.and_bound(&b1).known_eq_const(0) {
             // intbounds.py:66-69:
             //   pure_from_args2(rop.INT_ADD, arg0, arg1, op)
             //   pure_from_args2(rop.INT_XOR, arg0, arg1, op)
-            ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), arg0, arg1);
-            ctx.register_pure_from_args2(OpCode::IntXor, op.pos.get(), arg0, arg1);
+            ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), arg0.to_opref(), arg1.to_opref());
+            ctx.register_pure_from_args2(OpCode::IntXor, op.pos.get(), arg0.to_opref(), arg1.to_opref());
         }
         let b = b0.or_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
@@ -1804,17 +1797,17 @@ impl OptIntBounds {
 
     /// intbounds.py:73-84 postprocess_INT_XOR
     fn postprocess_int_xor(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         // intbounds.py:78: if b0.and_bound(b1).known_eq_const(0):
         if b0.and_bound(&b1).known_eq_const(0) {
             // intbounds.py:79-82:
             //   pure_from_args2(rop.INT_ADD, arg0, arg1, op)
             //   pure_from_args2(rop.INT_OR, arg0, arg1, op)
-            ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), arg0, arg1);
-            ctx.register_pure_from_args2(OpCode::IntOr, op.pos.get(), arg0, arg1);
+            ctx.register_pure_from_args2(OpCode::IntAdd, op.pos.get(), arg0.to_opref(), arg1.to_opref());
+            ctx.register_pure_from_args2(OpCode::IntOr, op.pos.get(), arg0.to_opref(), arg1.to_opref());
         }
         let b = b0.xor_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
@@ -1823,15 +1816,15 @@ impl OptIntBounds {
     /// intbounds.py: INT_LSHIFT pure_from_args synthesis.
     /// If res = INT_LSHIFT(a, b), then a = INT_RSHIFT(res, b).
     fn postprocess_int_lshift(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b1 = self.getintbound_box(arg1, ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b1 = self.getintbound_b(&arg1, ctx);
         let b = b0.lshift_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
         // intbounds.py:185: only synthesize reverse if lshift cannot overflow
         if b0.lshift_bound_cannot_overflow(&b1) {
-            ctx.register_pure_from_args2(OpCode::IntRshift, arg0, op.pos.get(), arg1);
+            ctx.register_pure_from_args2(OpCode::IntRshift, arg0.to_opref(), op.pos.get(), arg1.to_opref());
         }
     }
 
@@ -2002,13 +1995,13 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_add_ovf(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b = if arg0 == arg1 {
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b = if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
             b0.mul2_bound_no_overflow()
         } else {
-            let b1 = self.getintbound_box(arg1, ctx);
+            let b1 = self.getintbound_b(&arg1, ctx);
             b0.add_bound_no_overflow(&b1)
         };
         self.intersect_bound(op.pos.get(), &b, ctx);
@@ -2058,13 +2051,13 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_mul_ovf(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let b0 = self.getintbound_box(arg0, ctx);
-        let b = if arg0 == arg1 {
+        let arg0 = self.resolve_box(op.arg(0).to_opref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_opref(), ctx);
+        let b0 = self.getintbound_b(&arg0, ctx);
+        let b = if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
             b0.square_bound_no_overflow()
         } else {
-            let b1 = self.getintbound_box(arg1, ctx);
+            let b1 = self.getintbound_b(&arg1, ctx);
             b0.mul_bound_no_overflow(&b1)
         };
         self.intersect_bound(op.pos.get(), &b, ctx);
@@ -2141,24 +2134,21 @@ impl OptIntBounds {
     /// the default dispatch in RPython. In majit, we do them here
     /// because we don't have per-opcode default dispatch.
     fn optimize_guard_true(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let cond_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let cond = self.resolve_box(op.arg(0).to_opref(), ctx);
 
         // Constant check: if condition is known constant nonzero, remove guard.
-        if let Some(val) = ctx
-            .get_box_replacement_box(cond_ref)
-            .and_then(|b| ctx.get_constant_int_box(&b))
-        {
+        if let Some(val) = ctx.get_constant_int_box(&cond) {
             if val != 0 {
                 return OptimizationResult::Remove;
             }
         }
 
-        if !matches!(ctx.opref_type(cond_ref), Some(majit_ir::Type::Int)) {
+        if !matches!(ctx.opref_type(cond.to_opref()), Some(majit_ir::Type::Int)) {
             return OptimizationResult::PassOn;
         }
 
         // Bound check: if bound proves always nonzero, remove guard.
-        let b = self.getintbound_box(cond_ref, ctx);
+        let b = self.getintbound_b(&cond, ctx);
         if b.known_gt_const(0) {
             return OptimizationResult::Remove;
         }
@@ -2167,22 +2157,19 @@ impl OptIntBounds {
     }
 
     fn optimize_guard_false(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let cond_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let cond = self.resolve_box(op.arg(0).to_opref(), ctx);
 
-        if let Some(val) = ctx
-            .get_box_replacement_box(cond_ref)
-            .and_then(|b| ctx.get_constant_int_box(&b))
-        {
+        if let Some(val) = ctx.get_constant_int_box(&cond) {
             if val == 0 {
                 return OptimizationResult::Remove;
             }
         }
 
-        if !matches!(ctx.opref_type(cond_ref), Some(majit_ir::Type::Int)) {
+        if !matches!(ctx.opref_type(cond.to_opref()), Some(majit_ir::Type::Int)) {
             return OptimizationResult::PassOn;
         }
 
-        let b = self.getintbound_box(cond_ref, ctx);
+        let b = self.getintbound_b(&cond, ctx);
         if b.known_eq_const(0) {
             return OptimizationResult::Remove;
         }
@@ -3219,7 +3206,14 @@ impl Optimization for OptIntBounds {
     ) -> crate::optimizeopt::vec_assoc::VecAssoc<OpRef, IntBound> {
         let mut exported = crate::optimizeopt::vec_assoc::VecAssoc::new();
         for &arg in args {
-            let resolved = ctx.get_box_replacement(arg);
+            // `&OptContext` here forbids the `ensure_box` fallback in
+            // `resolve_box`, so use the immutable forwarded-chain walk
+            // (`get_box_replacement(arg) ≡ get_box_replacement_box(arg)
+            // .to_opref()` with the unresolvable-arg fallthrough).
+            let resolved = ctx
+                .get_box_replacement_box(arg)
+                .map(|b| b.to_opref())
+                .unwrap_or(arg);
             if !matches!(ctx.opref_type(resolved), Some(majit_ir::Type::Int)) {
                 continue;
             }
@@ -3341,10 +3335,11 @@ mod tests {
             // Keep the op.pos as set by the test (not overriding with index)
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved_op.num_args() {
+                let a = resolved_op.arg(i).to_opref();
                 resolved_op.setarg(
                     i,
                     crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement(resolved_op.arg(i).to_opref()),
+                        ctx.get_box_replacement_box(a).map(|b| b.to_opref()).unwrap_or(a),
                     ),
                 );
             }
@@ -3372,11 +3367,13 @@ mod tests {
                 // condition = CONST_1 before intbounds postprocess runs.
                 match emitted.opcode {
                     OpCode::GuardTrue => {
-                        let cond = ctx.get_box_replacement(emitted.arg(0).to_opref());
+                        let a = emitted.arg(0).to_opref();
+                        let cond = ctx.get_box_replacement_box(a).map(|b| b.to_opref()).unwrap_or(a);
                         ctx.make_constant(cond, majit_ir::Value::Int(1));
                     }
                     OpCode::GuardFalse => {
-                        let cond = ctx.get_box_replacement(emitted.arg(0).to_opref());
+                        let a = emitted.arg(0).to_opref();
+                        let cond = ctx.get_box_replacement_box(a).map(|b| b.to_opref()).unwrap_or(a);
                         ctx.make_constant(cond, majit_ir::Value::Int(0));
                     }
                     _ => {}

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -222,7 +222,7 @@ mod tests {
 
     fn drain_extra_ops(ctx: &mut OptContext) {
         while let Some((_, op)) = ctx.extra_operations_after.pop_front() {
-            ctx.new_operations.push(std::rc::Rc::new(op));
+            ctx.new_operations.push(op);
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7600,9 +7600,7 @@ impl OptContext {
         let b_old = self
             .ensure_box(old)
             .expect("body-namespace OpRef must have a BoxRef slot");
-        let b_new = self
-            .ensure_box(new_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_new = self.get_box_replacement(new_ref);
         self.make_equal_to(&b_old, &b_new);
         new_ref
     }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7400,12 +7400,10 @@ impl OptContext {
                     | PtrInfo::Str(_)
             )
         ) {
-            // optimizer.py:469: return opinfo. `ensure_box` guarantees a
-            // BoxRef even for positions whose pool slot was skipped by the
-            // recorder.
-            let bx = self
-                .ensure_box(arg0)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            // optimizer.py:469: return opinfo. The matches! above required
+            // arg0_box to carry a virtual/known PtrInfo, so the terminal
+            // BoxRef is already resolved — reuse it instead of re-minting.
+            let bx = arg0_box.expect("matched PtrInfo implies a resolved arg0 BoxRef");
             return EnsuredPtrInfo::ForwardedBox(bx);
         }
         let last_guard_pos = if let Some(opinfo) =

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5389,7 +5389,10 @@ impl OptContext {
         let resolved_box = self.get_box_replacement_box(opref);
         if let Some(mut info) = resolved_box.as_ref().and_then(|b| self.peek_ptr_info(b)) {
             if info.is_virtual() {
-                let forced = info.force_box(resolved, self);
+                let box_ = resolved_box
+                    .clone()
+                    .expect("is_virtual implies resolved_box is Some");
+                let forced = info.force_box(box_, self);
                 return self.get_box_replacement(forced).to_opref();
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -871,7 +871,7 @@ pub struct OptBoxEnv<'a> {
 
 impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
     fn get_box_replacement(&self, opref: OpRef) -> OpRef {
-        self.ctx.get_box_replacement(opref)
+        self.ctx.get_box_replacement(opref).to_opref()
     }
 
     fn get_box_replacement_not_const(&self, opref: OpRef) -> OpRef {
@@ -999,7 +999,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fields
                             .iter()
                             .find(|(field_idx, _)| *field_idx == fi as u32)
-                            .map(|(_, vref)| self.ctx.get_box_replacement(*vref))
+                            .map(|(_, vref)| self.ctx.get_box_replacement(*vref).to_opref())
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect(),
@@ -1014,7 +1014,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fields
                             .iter()
                             .find(|(field_idx, _)| *field_idx == fi as u32)
-                            .map(|(_, vref)| self.ctx.get_box_replacement(*vref))
+                            .map(|(_, vref)| self.ctx.get_box_replacement(*vref).to_opref())
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect(),
@@ -1025,7 +1025,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 field_oprefs: vi
                     .items
                     .iter()
-                    .map(|vref| self.ctx.get_box_replacement(*vref))
+                    .map(|vref| self.ctx.get_box_replacement(*vref).to_opref())
                     .collect(),
             }),
             PtrInfo::VirtualArrayStruct(vi) => Some(majit_ir::VirtualFieldsInfo {
@@ -1038,7 +1038,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fielddescrs.iter().enumerate().map(|(fi, _)| {
                             ef.iter()
                                 .find(|(field_idx, _)| *field_idx == fi as u32)
-                                .map(|(_, vref)| self.ctx.get_box_replacement(*vref))
+                                .map(|(_, vref)| self.ctx.get_box_replacement(*vref).to_opref())
                                 .unwrap_or(OpRef::NONE)
                         })
                     })
@@ -1051,7 +1051,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                     .buffer
                     .values()
                     .iter()
-                    .map(|vref| self.ctx.get_box_replacement(*vref))
+                    .map(|vref| self.ctx.get_box_replacement(*vref).to_opref())
                     .collect(),
             }),
             // `info.py:478-482` `RawSlicePtrInfo._visitor_walk_recursive`:
@@ -1077,7 +1077,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 Some(majit_ir::VirtualFieldsInfo {
                     descr: None,
                     known_class: None,
-                    field_oprefs: vec![self.ctx.get_box_replacement(vi.parent)],
+                    field_oprefs: vec![self.ctx.get_box_replacement(vi.parent).to_opref()],
                 })
             }
             // vstring.py:207-208 VStringPlainInfo._visitor_walk_recursive:
@@ -1104,20 +1104,20 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         ._chars
                         .iter()
                         .map(|slot| {
-                            slot.map(|r| self.ctx.get_box_replacement(r))
+                            slot.map(|r| self.ctx.get_box_replacement(r).to_opref())
                                 .unwrap_or(OpRef::NONE)
                         })
                         .collect(),
                     // vstring.py:255-257: [self.s, self.start, self.lgtop].
                     VStringVariant::Slice(s) => vec![
-                        self.ctx.get_box_replacement(s.s),
-                        self.ctx.get_box_replacement(s.start),
-                        self.ctx.get_box_replacement(s.lgtop),
+                        self.ctx.get_box_replacement(s.s).to_opref(),
+                        self.ctx.get_box_replacement(s.start).to_opref(),
+                        self.ctx.get_box_replacement(s.lgtop).to_opref(),
                     ],
                     // vstring.py:319-324: [self.vleft, self.vright].
                     VStringVariant::Concat(c) => vec![
-                        self.ctx.get_box_replacement(c.vleft),
-                        self.ctx.get_box_replacement(c.vright),
+                        self.ctx.get_box_replacement(c.vleft).to_opref(),
+                        self.ctx.get_box_replacement(c.vright).to_opref(),
                     ],
                     // Non-virtual `VStringVariant::Ptr` would not reach
                     // here because of the `is_virtual()` guard above.
@@ -2110,7 +2110,7 @@ impl OptContext {
     ///
     /// When both are the same, use `getstrlen_opref(opref, mode)` instead.
     pub fn getstrlen_for(&mut self, info_opref: OpRef, op_opref: OpRef, mode: u8) -> OpRef {
-        let resolved = self.get_box_replacement(info_opref);
+        let resolved = self.get_box_replacement(info_opref).to_opref();
         let resolved_box = self.get_box_replacement_box(info_opref);
         // vstring.py:112/283: if self.lgtop is not None: return self.lgtop
         if let Some(info) = resolved_box.as_ref().and_then(|b| self.getptrinfo(b)) {
@@ -2161,7 +2161,7 @@ impl OptContext {
         // vstring.py:115-118: base StrPtrInfo — emit STRLEN/UNICODELEN
         // RPython: lengthop = ResOperation(mode.STRLEN, [op])
         // `op` comes from op_opref (the first arg to getstrlen in RPython).
-        let op_resolved = self.get_box_replacement(op_opref);
+        let op_resolved = self.get_box_replacement(op_opref).to_opref();
         let strlen_opcode = if mode != 0 {
             majit_ir::OpCode::Unicodelen
         } else {
@@ -2924,7 +2924,7 @@ impl OptContext {
         // body-visible OpRef. Non-invented Pure has no forwarding installed,
         // so `get_box_replacement(source) == source` and the body references
         // source directly (RPython parity for non-invented `op = self.res`).
-        let result = self.get_box_replacement(preamble_op.op);
+        let result = self.get_box_replacement(preamble_op.op).to_opref();
         let result_type = preamble_op.preamble_op.result_type();
         let is_constant = self
             .get_box_replacement_box(preamble_source)
@@ -2987,7 +2987,7 @@ impl OptContext {
             if !is_constant {
                 // unroll.py:35-36: invented_name → get_box_replacement(op)
                 let key = if preamble_op.invented_name {
-                    self.get_box_replacement(preamble_source)
+                    self.get_box_replacement(preamble_source).to_opref()
                 } else {
                     preamble_source
                 };
@@ -3318,7 +3318,7 @@ impl OptContext {
             &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::info::OpInfo>,
         >,
     ) {
-        let op = self.get_box_replacement(op);
+        let op = self.get_box_replacement(op).to_opref();
         // unroll.py:55: if op.get_forwarded() is not None: return
         // (covers Op redirect + Info + IntBound + Const states uniformly,
         // matching the sibling setinfo_from_preamble_item pattern below.)
@@ -3520,7 +3520,7 @@ impl OptContext {
     ) {
         use crate::optimizeopt::info::OpInfo;
         // unroll.py:53-54 `op = get_box_replacement(op)`
-        let target = self.get_box_replacement(op);
+        let target = self.get_box_replacement(op).to_opref();
         // unroll.py:55-56 `if op.get_forwarded() is not None: return`
         if let Some(b) = self.get_box_replacement_box(op) {
             if self.has_forwarding(&b) {
@@ -3588,7 +3588,7 @@ impl OptContext {
         >,
     ) {
         use crate::optimizeopt::info::OpInfo;
-        let target = self.get_box_replacement(op);
+        let target = self.get_box_replacement(op).to_opref();
         if self
             .get_box_replacement_box(target)
             .and_then(|cb| cb.const_value())
@@ -3994,8 +3994,19 @@ impl OptContext {
         source
     }
 
-    pub fn get_box_replacement(&self, opref: OpRef) -> OpRef {
-        self.get_box_replacement_impl(opref, false)
+    /// resoperation.py:57-68 `get_box_replacement` — walk `op._forwarded`
+    /// to the terminal box and return it. PyPy returns the box object
+    /// directly; pyre returns the `BoxRef` view. `OpRef`-keyed callers that
+    /// still need an integer handle bridge back with `.to_opref()` (the
+    /// remaining `Op.args` / fail-args boundary, retired at S-12).
+    ///
+    /// Total over `opref`: an unresolvable root (sentinel / test baseline,
+    /// where `get_box_replacement_box` is `None`) falls back to a
+    /// position-only `BoxRef::from_opref`, so `get_box_replacement(o)
+    /// .to_opref() == o` there — preserving the prior `OpRef`-walker contract.
+    pub fn get_box_replacement(&self, opref: OpRef) -> crate::r#box::BoxRef {
+        self.get_box_replacement_box(opref)
+            .unwrap_or_else(|| crate::r#box::BoxRef::from_opref(opref))
     }
 
     /// resoperation.py:58 get_box_replacement(not_const=True). This is used
@@ -4006,23 +4017,20 @@ impl OptContext {
         self.get_box_replacement_impl(opref, true)
     }
 
-    /// PyPy parity reader — returns the terminal `BoxRef` in the
-    /// `_forwarded` chain rooted at the Box for `opref`.
+    /// `Option`-exposing sibling of [`OptContext::get_box_replacement`]:
+    /// walks the `_forwarded` chain rooted at the Box for `opref` and returns
+    /// the terminal `BoxRef`, or `None` when the root does not resolve.
     ///
     /// `resoperation.py:57-68 get_box_replacement(self, op)` walks
     /// `op._forwarded` until `None | AbstractInfo`, returning the terminal
-    /// Box object. PyPy callers consume the Box directly. The OpRef-returning
-    /// `get_box_replacement` above is the pyre-side adaptation that exists
-    /// only because the rest of the optimizer still indexes by integer
-    /// `OpRef`; this BoxRef-returning variant is the parity-faithful API.
+    /// Box object. `get_box_replacement` above is total (an unresolvable root
+    /// falls back to `BoxRef::from_opref`); this variant instead surfaces the
+    /// `None` so callers that must distinguish "no bound box" — a sentinel,
+    /// or a test / retrace baseline with no upstream binding — can branch on
+    /// it rather than act on a position-only placeholder.
     ///
     /// `BoxRef._forwarded` (`box.rs`) is the authoritative storage; both
     /// readers walk the same chain and agree by construction.
-    ///
-    /// Returns `None` when `opref` is sentinel/None or has no resolvable
-    /// producer / inputarg / const entry (the test / retrace baseline that
-    /// runs without an upstream binding). Callers in that case fall back to
-    /// the `OpRef`-returning walker.
     pub fn get_box_replacement_box(&self, opref: OpRef) -> Option<crate::r#box::BoxRef> {
         // S-8.A.4: resolve the chain root through `resolve_to_boxref`, the
         // variant-aware canonical-host resolver (producer `Op` for ResOp
@@ -4483,7 +4491,7 @@ impl OptContext {
             "peek_intbound: expected 'i'-typed OpRef, got {:?}",
             self.opref_type(opref)
         );
-        let replaced = self.get_box_replacement(opref);
+        let replaced = self.get_box_replacement(opref).to_opref();
         if let Some(Value::Int(v)) = self
             .get_box_replacement_box(replaced)
             .and_then(|cb| cb.const_value())
@@ -4708,7 +4716,9 @@ impl OptContext {
     pub fn make_constant(&mut self, opref: OpRef, value: Value) {
         let b = self
             .get_box_replacement_box(opref)
-            .or_else(|| self.ensure_box(self.get_box_replacement(opref)));
+            // `get_box_replacement_box` already returned `None` here, so the
+            // `_forwarded` walk is the identity on `opref`; materialize it.
+            .or_else(|| self.ensure_box(opref));
         if let Some(b) = b {
             self.make_constant_box(&b, value);
         }
@@ -5044,7 +5054,7 @@ impl OptContext {
     /// a shared `BoxRef` per box, this collapses to
     /// `Rc::ptr_eq(&get_box_replacement(a), &get_box_replacement(b))`.
     pub fn box_is(&self, a: OpRef, b: OpRef) -> bool {
-        self.get_box_replacement(a) == self.get_box_replacement(b)
+        self.get_box_replacement(a).to_opref() == self.get_box_replacement(b).to_opref()
     }
 
     /// resoperation.py:38 `same_box` (non-Const: `self is other`) +
@@ -5061,8 +5071,8 @@ impl OptContext {
         ) {
             (Some(ref a), Some(ref b)) => a.same_box(b),
             _ => {
-                let query = self.get_box_replacement(query);
-                let stored = self.get_box_replacement(stored);
+                let query = self.get_box_replacement(query).to_opref();
+                let stored = self.get_box_replacement(stored).to_opref();
                 if query == stored {
                     return true;
                 }
@@ -5233,7 +5243,7 @@ impl OptContext {
                         // regalloc.py:1206: Const objects skip forcing.
                         // Constant OpRefs may collide with virtual positions;
                         // forcing would corrupt the virtual's PtrInfo.
-                        let resolved = self.get_box_replacement(farg);
+                        let resolved = self.get_box_replacement(farg).to_opref();
                         if !self
                             .get_box_replacement_box(resolved)
                             .and_then(|cb| cb.const_value())
@@ -5261,7 +5271,7 @@ impl OptContext {
     fn maybe_replace_guard_value(&self, op: &mut Op) {
         let arg0 = op.arg(0);
         // optimizer.py:755: if op.getarg(0).type == 'i'
-        let arg0_resolved = self.get_box_replacement(arg0.to_opref());
+        let arg0_resolved = self.get_box_replacement(arg0.to_opref()).to_opref();
         if self.opref_type(arg0_resolved) != Some(majit_ir::Type::Int) {
             return;
         }
@@ -5302,12 +5312,12 @@ impl OptContext {
     /// through Phase 1 source directly, so the prior reverse-lookup 3rd
     /// key is no longer needed.
     fn force_box_inline(&mut self, opref: OpRef) -> OpRef {
-        let resolved = self.get_box_replacement(opref);
+        let resolved = self.get_box_replacement(opref).to_opref();
         let tracked = self
             .take_potential_extra_op(resolved)
             .or_else(|| self.take_potential_extra_op(opref));
         if let Some(preamble_op) = tracked {
-            let resolved_for_pop = self.get_box_replacement(preamble_op.op);
+            let resolved_for_pop = self.get_box_replacement(preamble_op.op).to_opref();
             if let Some(builder) = self.active_short_preamble_producer_mut() {
                 builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
             } else if let Some(builder) = self.imported_short_preamble_builder.as_mut() {
@@ -5318,7 +5328,7 @@ impl OptContext {
         if let Some(mut info) = resolved_box.as_ref().and_then(|b| self.peek_ptr_info(b)) {
             if info.is_virtual() {
                 let forced = info.force_box(resolved, self);
-                return self.get_box_replacement(forced);
+                return self.get_box_replacement(forced).to_opref();
             }
         }
         resolved
@@ -5500,7 +5510,7 @@ impl OptContext {
                 .copied()
                 .map(|boxref| {
                     let boxref = boxref.opref;
-                    let resolved = self.get_box_replacement(boxref);
+                    let resolved = self.get_box_replacement(boxref).to_opref();
                     let is_virtual = self
                         .get_box_replacement_box(boxref)
                         .as_ref()
@@ -5515,7 +5525,7 @@ impl OptContext {
                 .copied()
                 .map(|boxref| {
                     let boxref = boxref.opref;
-                    let resolved = self.get_box_replacement(boxref);
+                    let resolved = self.get_box_replacement(boxref).to_opref();
                     let is_virtual = self
                         .get_box_replacement_box(boxref)
                         .as_ref()
@@ -6103,7 +6113,7 @@ impl OptContext {
     /// RPython's "unknown type" path and avoid making structural
     /// assumptions about it.
     pub fn opref_type(&self, opref: OpRef) -> Option<majit_ir::Type> {
-        let resolved = self.get_box_replacement(opref);
+        let resolved = self.get_box_replacement(opref).to_opref();
         // 0. Inputarg slot (recorder-side `InputArg{Int,Ref,Float}.tp`,
         //    history.py:220 parity per resoperation.py:719/727/739).
         //    `inputarg_types[idx]` is the canonical Box.type source
@@ -6864,7 +6874,7 @@ impl OptContext {
     /// In majit, we follow the Op chain to the terminal OpRef and set Info there.
     fn ensure_ptr_info_preserve_forwarding(&mut self, opref: OpRef, info: PtrInfo) {
         use crate::optimizeopt::info::OpInfo;
-        let terminal = self.get_box_replacement(opref);
+        let terminal = self.get_box_replacement(opref).to_opref();
         if terminal.is_constant() {
             return;
         }
@@ -7065,7 +7075,7 @@ impl OptContext {
     /// constant case lands on `const_infos[gcref]`; the regular case
     /// runs `ensure_ptr_info_arg0(op).as_mut().setfield(...)`.
     pub fn structinfo_setfield(&mut self, op: &Op, field_idx: u32, value: OpRef) {
-        let arg0 = self.get_box_replacement(op.arg(0).to_opref());
+        let arg0 = self.get_box_replacement(op.arg(0).to_opref()).to_opref();
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -7094,7 +7104,7 @@ impl OptContext {
     /// constant arg0 path so the const_infos slot is created as
     /// `PtrInfo::Array` rather than `PtrInfo::Instance`.
     pub fn arrayinfo_setitem(&mut self, op: &Op, index: usize, value: OpRef) {
-        let arg0 = self.get_box_replacement(op.arg(0).to_opref());
+        let arg0 = self.get_box_replacement(op.arg(0).to_opref()).to_opref();
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -7210,7 +7220,7 @@ impl OptContext {
     /// `arrayinfo.getlenbound(...)` patterns.
     pub fn ensure_ptr_info_arg0(&mut self, op: &Op) -> EnsuredPtrInfo {
         // optimizer.py:464: arg0 = self.get_box_replacement(op.getarg(0))
-        let arg0 = self.get_box_replacement(op.arg(0).to_opref());
+        let arg0 = self.get_box_replacement(op.arg(0).to_opref()).to_opref();
         // optimizer.py:465-466: if arg0.is_constant(): return info.ConstPtrInfo(arg0)
         //
         // PyPy's `info.ConstPtrInfo(arg0)` wraps the constant box itself,
@@ -7990,7 +8000,8 @@ mod boxref_forwarding_tests {
         ctx.make_equal_to(&b0, &b_const);
 
         assert_eq!(
-            ctx.get_box_replacement(OpRef::input_arg_typed(0, Type::Int)),
+            ctx.get_box_replacement(OpRef::input_arg_typed(0, Type::Int))
+                .to_opref(),
             const_opref
         );
         assert_eq!(
@@ -8000,7 +8011,8 @@ mod boxref_forwarding_tests {
 
         ctx.make_equal_to(&b1, &b0);
         assert_eq!(
-            ctx.get_box_replacement(OpRef::input_arg_typed(1, Type::Int)),
+            ctx.get_box_replacement(OpRef::input_arg_typed(1, Type::Int))
+                .to_opref(),
             const_opref
         );
         assert_eq!(
@@ -8075,7 +8087,7 @@ mod boxref_forwarding_tests {
         assert!(matches!(via_box, PtrInfo::NonNull { .. }));
 
         // Chain walk lands on target_p1.
-        let resolved = ctx.get_box_replacement(source_p2);
+        let resolved = ctx.get_box_replacement(source_p2).to_opref();
         assert_eq!(resolved, target_p1);
 
         // Placeholder Box absorbed the mirror write, so its _forwarded now
@@ -8133,7 +8145,7 @@ mod boxref_forwarding_tests {
 
         // Legacy Vec reader: chain walks source → target_p1 → None
         // (Phase 2's fresh Vec has no entry for target_p1).
-        let resolved = ctx.get_box_replacement(source_p2);
+        let resolved = ctx.get_box_replacement(source_p2).to_opref();
         assert_eq!(resolved, target_p1);
 
         // Placeholder Box was not mutated (no info import fired) — still None.

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2081,13 +2081,26 @@ impl OptContext {
     /// `alloc_op_position_typed` instead when no forwarded write follows
     /// (e.g. an `Unknown` leaf), to avoid an eager synthetic for a
     /// position that is never written.
+    /// Explicit "create" half of the former find-or-create `ensure_box`:
+    /// mint a `SameAs*` synthetic at `opref` and return a BoxRef bound to it,
+    /// so a subsequent `set_forwarded_*` lands on the canonical `Op._forwarded`
+    /// host. `opref` must be a non-const, non-sentinel resop position whose
+    /// producer is not yet emitted (a virgin alias). Callers reach this only on
+    /// the `None` arm of `get_box_replacement_box`; an already-minted or
+    /// producer-backed opref resolves there. Mirrors `ensure_box`'s resop
+    /// lazy-alloc arm (`mint_synthetic_resop` + bind).
+    pub(crate) fn mint_box_at(&mut self, opref: OpRef) -> crate::r#box::BoxRef {
+        let tp = opref.ty().unwrap_or(majit_ir::Type::Void);
+        let synthetic = self.mint_synthetic_resop(opref, tp);
+        crate::r#box::BoxRef::from_bound_op(&synthetic)
+    }
+
     pub(crate) fn reserve_virtual_box(
         &mut self,
         tp: majit_ir::Type,
     ) -> (OpRef, crate::r#box::BoxRef) {
         let opref = self.reserve_pos_typed(tp);
-        let synthetic = self.mint_synthetic_resop(opref, tp);
-        let b = crate::r#box::BoxRef::from_bound_op(&synthetic);
+        let b = self.mint_box_at(opref);
         (opref, b)
     }
 
@@ -2250,7 +2263,8 @@ impl OptContext {
         // lenbound on the StrPtrInfo is a PtrInfo-internal mutation that
         // RPython performs on the StrPtrInfo instance directly. Route
         // through `ensure_box` so the BoxRef exists for the chain walk.
-        let lenbound = self.get_box_replacement_box(resolved)
+        let lenbound = self
+            .get_box_replacement_box(resolved)
             .as_ref()
             .and_then(|b| self.get_str_lenbound(b));
         if let Some(bound) = lenbound {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7571,7 +7571,7 @@ impl OptContext {
 /// optimizer.py: Optimization base class.
 pub trait Optimization {
     /// Process an operation. Called for each operation in the trace.
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult;
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult;
 
     /// optimizer.py:71 propagate_postprocess — called AFTER the op has been
     /// emitted through all passes and added to new_operations. Runs in

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -751,7 +751,12 @@ pub struct OptContext {
     /// for the OptContext's lifetime so any lingering `Weak<Op>`
     /// upgrades (e.g. in already-installed `Forwarded::Op` chains)
     /// stay valid.
-    pub(crate) resop_refs: Vec<Option<majit_ir::resoperation::OpRc>>,
+    ///
+    /// Keyed by the full type-tagged `OpRef`, so a typed and an untyped
+    /// (or differently-typed) position sharing a raw `u32` are distinct
+    /// entries instead of evicting each other in a raw-indexed slot.
+    pub(crate) resop_refs:
+        crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::resoperation::OpRc>,
     /// Live synthetic stand-ins (mint_synthetic_resop / bind_input_resops
     /// products) that have NOT been superseded by an `emit` at their
     /// position. The end-of-Phase-1 orphan-binding pass drains this into
@@ -760,8 +765,8 @@ pub struct OptContext {
     /// synthetic here (it stays strongly held by `resop_refs` for lookup,
     /// but is no longer an orphan needing carry). Tracking liveness
     /// incrementally by `OpRc` identity sidesteps the flat-OpRef raw/type
-    /// collision that makes the final `resop_refs` / `new_operations` state
-    /// ambiguous about which type-tagged value won a shared raw slot.
+    /// collision that makes the final `new_operations` state ambiguous
+    /// about which type-tagged value won a shared raw slot.
     pub(crate) live_synthetics: Vec<majit_ir::resoperation::OpRc>,
     /// Phase 1 emit ops carried into Phase 2's lookup surface.
     ///
@@ -1540,7 +1545,7 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
-            resop_refs: Vec::new(),
+            resop_refs: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             live_synthetics: Vec::new(),
             phase1_emit_ops: Vec::new(),
             input_ops: Vec::new(),
@@ -1701,13 +1706,7 @@ impl OptContext {
         {
             return Some(op.clone());
         }
-        if let Some(op) = self
-            .resop_refs
-            .get(opref.raw() as usize)
-            .and_then(|slot| slot.as_ref())
-            .filter(|op| op.pos.get() == opref)
-            .cloned()
-        {
+        if let Some(op) = self.resop_refs.get(&opref).cloned() {
             return Some(op);
         }
         // Lowest-priority store: the recorder's input ops (seeded at setup
@@ -1722,7 +1721,7 @@ impl OptContext {
 
     /// S-8.A.1: mint a `SameAsI/F/R` (or `Jump` for `Void`) synthetic
     /// stand-in `OpRc` for `opref` with the correct result type and
-    /// stash it in `resop_refs[idx]` so `emit()`'s
+    /// stash it in `resop_refs[opref]` so `emit()`'s
     /// `bound_is_synthetic` rebind path later upgrades the binding to
     /// the real producer via `bind_op`'s carry-over. The synthetic
     /// stays referenced from `resop_refs` for the OptContext's
@@ -1742,11 +1741,7 @@ impl OptContext {
         };
         let synthetic = std::rc::Rc::new(Op::new(opcode, &[]));
         synthetic.pos.set(opref);
-        let idx = opref.raw() as usize;
-        if idx >= self.resop_refs.len() {
-            self.resop_refs.resize_with(idx + 1, || None);
-        }
-        self.resop_refs[idx] = Some(synthetic.clone());
+        self.resop_refs.insert(opref, synthetic.clone());
         self.live_synthetics.push(synthetic.clone());
         synthetic
     }
@@ -1829,7 +1824,7 @@ impl OptContext {
         }
         // A ResOp position with no producer in any canonical store resolves
         // to `None`: the caller's `ensure_box` mints a `SameAs*` synthetic
-        // into `resop_refs[idx]` and binds it, so the next `find_producer_op`
+        // into `resop_refs[opref]` and binds it, so the next `find_producer_op`
         // (and hence the next `resolve_to_boxref` / `make_constant` chain)
         // reaches that same `_forwarded` host. Routing a ResOp OpRef to
         // `inputarg_refs[idx]` here would re-introduce the raw-position
@@ -1866,7 +1861,7 @@ impl OptContext {
     /// `inputarg_refs`) from a list of already-bound `BoxRef`s, mirroring
     /// what the production recorder→optimizer handoff populates. Each box
     /// is distributed by its bound identity: InputArg boxes land in
-    /// `inputarg_refs[index]`, ResOp boxes in `resop_refs[pos.raw()]`. This
+    /// `inputarg_refs[index]`, ResOp boxes in `resop_refs[pos]`. This
     /// replaces the retired `ctx.box_pool = vec![..]` fixture pattern so
     /// `resolve_to_boxref` / `ensure_box` / `find_producer_op` resolve each
     /// OpRef through the same canonical hosts production uses, returning a
@@ -1882,11 +1877,7 @@ impl OptContext {
                 }
                 self.inputarg_refs[idx] = ia;
             } else if let Some(op) = b.bound_op() {
-                let idx = op.pos.get().raw() as usize;
-                if idx >= self.resop_refs.len() {
-                    self.resop_refs.resize_with(idx + 1, || None);
-                }
-                self.resop_refs[idx] = Some(op);
+                self.resop_refs.insert(op.pos.get(), op);
             }
         }
     }
@@ -1908,7 +1899,7 @@ impl OptContext {
     /// only resop positions land here. Each phase's input `ops` carry that
     /// phase's own positions (Phase 2 body ops sit above the Phase 1 emit
     /// namespace, so they never collide with an inherited bound slot), and
-    /// the `resop_refs[idx]` dedup covers intra-`ops` repeats.
+    /// the `resop_refs[opref]` dedup covers intra-`ops` repeats.
     pub(crate) fn bind_input_resops(&mut self, ops: &[majit_ir::OpRc]) {
         // The loop over the caller-threaded `ops` self-guards (no-op on an
         // empty slice) and records each resop producer into `resop_refs` /
@@ -1927,24 +1918,15 @@ impl OptContext {
             ) {
                 continue;
             }
-            let idx = pos.raw() as usize;
             // Dedup: a producer for this exact pos is already recorded.
-            if self
-                .resop_refs
-                .get(idx)
-                .and_then(|s| s.as_ref())
-                .is_some_and(|o| o.pos.get() == pos)
-            {
+            if self.resop_refs.contains_key(&pos) {
                 continue;
             }
             // Record the caller-threaded `OpRc` so the iterated input op,
             // `resop_refs`, and `live_synthetics` share one `Op` identity
             // (no second private copy).
             let op_rc = op.clone();
-            if idx >= self.resop_refs.len() {
-                self.resop_refs.resize_with(idx + 1, || None);
-            }
-            self.resop_refs[idx] = Some(op_rc.clone());
+            self.resop_refs.insert(pos, op_rc.clone());
             self.live_synthetics.push(op_rc);
         }
     }
@@ -2014,7 +1996,7 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
-            resop_refs: Vec::new(),
+            resop_refs: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             live_synthetics: Vec::new(),
             phase1_emit_ops: Vec::new(),
             input_ops: Vec::new(),
@@ -2325,18 +2307,19 @@ impl OptContext {
     }
 
     /// Whether the canonical `_forwarded` host for raw position `raw`
-    /// (`resop_refs[raw]` for a ResOp slot, `inputarg_refs[raw]` for an
-    /// InputArg slot) carries `Forwarded::Const`. The position-keyed
-    /// replacement for the retired `box_pool.get_at_position(raw)` const
-    /// probe in `allocate_next_pos_raw`.
+    /// (any `resop_refs` entry whose `OpRef` shares this raw, or
+    /// `inputarg_refs[raw]` for an InputArg slot) carries `Forwarded::Const`.
+    /// The position-keyed replacement for the retired
+    /// `box_pool.get_at_position(raw)` const probe in `allocate_next_pos_raw`.
     fn position_is_const_forwarded(&self, raw: u32) -> bool {
         use crate::r#box::Forwarded;
         let idx = raw as usize;
-        let resop_const = self
-            .resop_refs
-            .get(idx)
-            .and_then(|s| s.as_ref())
-            .is_some_and(|op| matches!(*op.forwarded.borrow(), Forwarded::Const(_)));
+        // `resop_refs` is keyed by the full type-tagged `OpRef`; a raw `u32`
+        // can host more than one entry (typed vs untyped). Any host at this
+        // raw carrying `Forwarded::Const` claims the position.
+        let resop_const = self.resop_refs.values().any(|op| {
+            op.pos.get().raw() == raw && matches!(*op.forwarded.borrow(), Forwarded::Const(_))
+        });
         let inputarg_const = self
             .inputarg_refs
             .get(idx)
@@ -4159,9 +4142,9 @@ impl OptContext {
         // A resop reaching here has no producer in any `find_producer_op`
         // store (else it returned above), so it falls through to the
         // lazy-alloc arm below, which mints a `SameAs*` synthetic into
-        // `resop_refs[idx]` and binds a BoxRef to it. A subsequent
+        // `resop_refs[opref]` and binds a BoxRef to it. A subsequent
         // `ensure_box` / `find_producer_op` for the same OpRef re-resolves to
-        // that synthetic (`resop_refs[idx].pos == opref`), so the synthetic is
+        // that synthetic (`resop_refs[opref].pos == opref`), so the synthetic is
         // the stable `_forwarded` host across calls; no memoization side-table
         // is needed.
         let idx = opref.raw() as usize;

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2530,8 +2530,27 @@ impl OptContext {
         // through `propagate_one` into `new_operations`, `op_at` resolves
         // its type without the side-table detour.
         Self::debug_assert_box_type_invariant(&op);
+        let op_rc = std::rc::Rc::new(op);
+        // Register the queued op as the producer for its position, mirroring
+        // `bind_input_resops`: `find_producer_op(pos)` then resolves box lookups
+        // for this position — `ensure_box(pos)` and operand resolution alike —
+        // to this `OpRc`'s `_forwarded` host (resoperation.py:233) instead of a
+        // freshly-minted stand-in, keeping a single box identity per position.
+        // `emit`'s `live_synthetics` catch-up upgrades the binding to the real
+        // producer once the op is emitted; a folded op stays as the chain host.
+        if !pos_ref.is_none()
+            && !pos_ref.is_constant()
+            && !matches!(
+                pos_ref,
+                OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+            )
+            && !self.resop_refs.contains_key(&pos_ref)
+        {
+            self.resop_refs.insert(pos_ref, op_rc.clone());
+            self.live_synthetics.push(op_rc.clone());
+        }
         self.extra_operations_after
-            .push_back((after_pass_idx + 1, std::rc::Rc::new(op)));
+            .push_back((after_pass_idx + 1, op_rc));
         pos_ref
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -565,7 +565,9 @@ pub struct OptContext {
     /// processed starting from a specific pass index (skipping earlier passes).
     /// Used by heap's force_lazy_set to route ops through remaining passes
     /// without re-entering the heap pass itself.
-    pub(crate) extra_operations_after: VecDeque<(usize, Op)>,
+    /// Held as `OpRc` (resoperation.py: emit_extra appends a ResOperation
+    /// object) so the queued op carries object identity into the drain.
+    pub(crate) extra_operations_after: VecDeque<(usize, majit_ir::OpRc)>,
     /// optimizer.py:47-54: deferred postprocess for GUARD_CLASS.
     /// Set by rewrite pass, executed by emit_operation after the guard
     /// is added to new_operations (matching RPython's callback pattern).
@@ -2529,7 +2531,7 @@ impl OptContext {
         // its type without the side-table detour.
         Self::debug_assert_box_type_invariant(&op);
         self.extra_operations_after
-            .push_back((after_pass_idx + 1, op));
+            .push_back((after_pass_idx + 1, std::rc::Rc::new(op)));
         pos_ref
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1748,6 +1748,48 @@ impl OptContext {
         synthetic
     }
 
+    /// `replace_op_with` (optimizer.py:replace_op_with) parity for the
+    /// dispatcher's `Restart` arm: the rewritten op supersedes the original
+    /// as the producer at its (preserved) position. RPython performs
+    /// `original.set_forwarded(newop)`, after which every read of that
+    /// position resolves to `newop` and `setintbound`/`setptrinfo` writes
+    /// decorate `newop` directly. In pyre's producer-registry model the
+    /// equivalent is to make `restart_op` the SOLE registered producer at
+    /// its position: `find_producer_op(pos)` then returns `restart_op`, so
+    /// `ensure_box(pos)` / `from_bound_op(restart_op)` agree on one canonical
+    /// `_forwarded` host, and the bound the re-dispatch accumulates survives
+    /// `emit`'s `live_synthetics` catch-up onto the emitted op.
+    ///
+    /// Without this the re-dispatch runs against a fresh, unregistered
+    /// `Rc<Op>` (`Rc::new(restart_op)`): writes such as `setintbound` land on
+    /// a host absent from `live_synthetics`, the superseded original keeps its
+    /// stale stand-in slot, and the carry-over at emit migrates the wrong
+    /// (empty) `_forwarded` — dropping the rewrite's bound.
+    pub(crate) fn supersede_restart_producer(&mut self, restart_op: &majit_ir::OpRc) {
+        let pos = restart_op.pos.get();
+        if pos.is_none() || pos.is_constant() {
+            return;
+        }
+        // InputArg positions have no producing op (handled by
+        // `ensure_inputarg_bindings`); a rewrite never targets one.
+        if matches!(
+            pos,
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+        ) {
+            return;
+        }
+        // Drop the superseded stand-in at this position so the single
+        // `live_synthetics` entry the emit catch-up migrates is `restart_op`'s
+        // accumulated `_forwarded`, not the original's stale slot. At most one
+        // live stand-in exists per position (mod.rs::emit invariant), so a
+        // single removal is sufficient.
+        if let Some(i) = self.live_synthetics.iter().position(|s| s.pos.get() == pos) {
+            self.live_synthetics.swap_remove(i);
+        }
+        self.resop_refs.insert(pos, restart_op.clone());
+        self.live_synthetics.push(restart_op.clone());
+    }
+
     /// S-8.A: read `_forwarded` for `opref` directly off the canonical
     /// host (`op.forwarded` / `inputarg.forwarded`). Mirrors
     /// `BoxRef::get_forwarded` semantics

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -742,7 +742,7 @@ pub struct OptContext {
     pub(crate) inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// Synthetic `OpRc` stand-ins for ResOp BoxRef placeholders whose
     /// real producer has not been (and may never be) emitted, indexed
-    /// sparsely by `OpRef::raw()`. `ensure_box` falls back to
+    /// sparsely by `OpRef::raw()`. `materialize_box_at` falls back to
     /// synthesising a `SameAsI/F/R` (or `Jump`) Op with the requested
     /// type and binding the BoxRef to it so `make_equal_to` routes a
     /// chain step that targets such a placeholder through
@@ -1638,8 +1638,8 @@ impl OptContext {
         // `self.inputargs` because Phase 2 walks the body half with the same
         // per-arg types). Pre-populating `inputarg_refs` for both subsets makes
         // every InputArg OpRef resolve through `inputarg_refs` (read path:
-        // `resolve_to_boxref` / `read_forwarded`; write path: `ensure_box`'s
-        // InputArg branch). `ensure_box` type-repairs any position this derive
+        // `resolve_to_boxref` / `read_forwarded`; write path: `materialize_box_at`'s
+        // InputArg branch). `materialize_box_at` type-repairs any position this derive
         // misses. Both loops no-op when `self.inputargs` is empty
         // (`seed_boxes_canonical` fixtures populate `inputarg_refs` directly).
         // Void slots are skipped: `InputArg{Int,Ref,Float}` has no Void
@@ -1667,11 +1667,11 @@ impl OptContext {
 
     /// Ensure `inputarg_refs[pos]` holds a canonical `InputArgRc` of type
     /// `tp` (the `_forwarded` host that `resolve_to_boxref` / `read_forwarded`
-    /// / `clear_forwarded` / `ensure_box` route the matching InputArg OpRef
+    /// / `clear_forwarded` / `materialize_box_at` route the matching InputArg OpRef
     /// through). Idempotent: keeps an existing same-shape host (preserving any
     /// `_forwarded` chain / live `Weak<InputArg>` chain targets on it) and only
     /// (re)allocates when the slot is absent or its type/index mismatch (mirrors
-    /// the `ensure_box` InputArg arm).
+    /// the `materialize_box_at` InputArg arm).
     fn bind_canonical_inputarg(&mut self, pos: usize, tp: majit_ir::Type) {
         if pos >= self.inputarg_refs.len() {
             self.inputarg_refs
@@ -1756,7 +1756,7 @@ impl OptContext {
     /// decorate `newop` directly. In pyre's producer-registry model the
     /// equivalent is to make `restart_op` the SOLE registered producer at
     /// its position: `find_producer_op(pos)` then returns `restart_op`, so
-    /// `ensure_box(pos)` / `from_bound_op(restart_op)` agree on one canonical
+    /// `materialize_box_at(pos)` / `from_bound_op(restart_op)` agree on one canonical
     /// `_forwarded` host, and the bound the re-dispatch accumulates survives
     /// `emit`'s `live_synthetics` catch-up onto the emitted op.
     ///
@@ -1867,7 +1867,7 @@ impl OptContext {
             _ => {}
         }
         // A ResOp position with no producer in any canonical store resolves
-        // to `None`: the caller's `ensure_box` mints a `SameAs*` synthetic
+        // to `None`: the caller's `materialize_box_at` mints a `SameAs*` synthetic
         // into `resop_refs[opref]` and binds it, so the next `find_producer_op`
         // (and hence the next `resolve_to_boxref` / `make_constant` chain)
         // reaches that same `_forwarded` host. Routing a ResOp OpRef to
@@ -1907,7 +1907,7 @@ impl OptContext {
     /// is distributed by its bound identity: InputArg boxes land in
     /// `inputarg_refs[index]`, ResOp boxes in `resop_refs[pos]`. This
     /// replaces the retired `ctx.box_pool = vec![..]` fixture pattern so
-    /// `resolve_to_boxref` / `ensure_box` / `find_producer_op` resolve each
+    /// `resolve_to_boxref` / `materialize_box_at` / `find_producer_op` resolve each
     /// OpRef through the same canonical hosts production uses, returning a
     /// fresh `BoxRef` bound to the seeded `Op` / `InputArg`.
     #[cfg(test)]
@@ -2073,21 +2073,21 @@ impl OptContext {
     /// synthetics: importers that allocate a position purely to carry a
     /// forwarded write (PtrInfo / IntBound / Const for an imported virtual
     /// state leaf) get a bound write target in one step, instead of
-    /// `alloc_op_position_typed` followed by a lazy `ensure_box(opref)`
+    /// `alloc_op_position_typed` followed by a lazy `materialize_box_at(opref)`
     /// re-materialization. The minted synthetic is identical to the one
-    /// `ensure_box`'s producer-less arm mints (`mint_synthetic_resop`), so
+    /// `materialize_box_at`'s producer-less arm mints (`mint_synthetic_resop`), so
     /// a later `emit()` for the same position supersedes it through the
     /// same `live_synthetics` catch-up. Reserve a bare position via
     /// `alloc_op_position_typed` instead when no forwarded write follows
     /// (e.g. an `Unknown` leaf), to avoid an eager synthetic for a
     /// position that is never written.
-    /// Explicit "create" half of the former find-or-create `ensure_box`:
+    /// Explicit "create" half of the find-or-create `materialize_box_at`:
     /// mint a `SameAs*` synthetic at `opref` and return a BoxRef bound to it,
     /// so a subsequent `set_forwarded_*` lands on the canonical `Op._forwarded`
     /// host. `opref` must be a non-const, non-sentinel resop position whose
     /// producer is not yet emitted (a virgin alias). Callers reach this only on
     /// the `None` arm of `get_box_replacement_box`; an already-minted or
-    /// producer-backed opref resolves there. Mirrors `ensure_box`'s resop
+    /// producer-backed opref resolves there. Mirrors `materialize_box_at`'s resop
     /// lazy-alloc arm (`mint_synthetic_resop` + bind).
     pub(crate) fn mint_box_at(&mut self, opref: OpRef) -> crate::r#box::BoxRef {
         let tp = opref.ty().unwrap_or(majit_ir::Type::Void);
@@ -2208,7 +2208,7 @@ impl OptContext {
             .and_then(|info| info.get_known_str_length(self, mode));
         if let Some(len) = known_len {
             let len_opref = self.make_constant_int(len);
-            // BoxRef shim — write path through `ensure_box` per the
+            // BoxRef shim — write path through `materialize_box_at` per the
             // "Box always exists" invariant for set_forwarded mirrors.
             if let Some(b) = self.get_box_replacement_box(resolved) {
                 self.set_str_lgtop(&b, len_opref);
@@ -2257,12 +2257,12 @@ impl OptContext {
         let result = self.emit_extra(self.current_pass_idx, strlen_op);
         // vstring.py:116: lengthop.set_forwarded(self.getlenbound(mode))
         // `set_forwarded` writes the bound unconditionally; route through
-        // `ensure_box` so the new STRLEN/UNICODELEN box materializes for
+        // `materialize_box_at` so the new STRLEN/UNICODELEN box materializes for
         // the IntBound install ("Box always exists" per resoperation.py:233-248).
         // BoxRef shim for `get_str_lenbound(&BoxRef)`; lazy-install of
         // lenbound on the StrPtrInfo is a PtrInfo-internal mutation that
         // RPython performs on the StrPtrInfo instance directly. Route
-        // through `ensure_box` so the BoxRef exists for the chain walk.
+        // through `materialize_box_at` so the BoxRef exists for the chain walk.
         let lenbound = self
             .get_box_replacement_box(resolved)
             .as_ref()
@@ -2349,7 +2349,7 @@ impl OptContext {
     pub(crate) fn reserve_pos_typed(&mut self, tp: majit_ir::Type) -> OpRef {
         let raw = self.allocate_next_pos_raw();
         // The position's canonical host is materialized lazily on first
-        // access (`ensure_box` / `resolve_to_boxref` mint a `SameAs*`
+        // access (`materialize_box_at` / `resolve_to_boxref` mint a `SameAs*`
         // synthetic into `resop_refs[raw]` keyed by the full OpRef). No eager
         // pre-mint here: an eager synthetic for a position that is reserved
         // but never emitted (label / jump positions on an empty trace) would
@@ -2567,13 +2567,13 @@ impl OptContext {
         Self::debug_assert_box_type_invariant(&op);
         let op_pos = op.pos.get();
         let op_rc = std::rc::Rc::new(op);
-        // Catch up any BoxRef placeholder that `ensure_box` created for
+        // Catch up any BoxRef placeholder that `materialize_box_at` created for
         // `op_pos` ahead of this emit (forward-reference path).
         // `resoperation.py:233 _forwarded` lives on the operation
         // object; late binding establishes that connection so
         // subsequent `box.set_forwarded` reaches `op.forwarded`.
         //
-        // The synthetic stand-in registered for `op_pos` by `ensure_box` /
+        // The synthetic stand-in registered for `op_pos` by `materialize_box_at` /
         // `bind_input_resops` is the `live_synthetics` entry at this position.
         // Migrate its `_forwarded` onto the real producer (resoperation.py:233
         // `_forwarded` lives on the op) and drop it from `live_synthetics` so
@@ -2614,7 +2614,7 @@ impl OptContext {
         let op_rc = std::rc::Rc::new(op);
         // Register the queued op as the producer for its position, mirroring
         // `bind_input_resops`: `find_producer_op(pos)` then resolves box lookups
-        // for this position — `ensure_box(pos)` and operand resolution alike —
+        // for this position — `materialize_box_at(pos)` and operand resolution alike —
         // to this `OpRc`'s `_forwarded` host (resoperation.py:233) instead of a
         // freshly-minted stand-in, keeping a single box identity per position.
         // `emit`'s `live_synthetics` catch-up upgrades the binding to the real
@@ -3313,10 +3313,14 @@ impl OptContext {
                 return;
             }
         }
-        // BoxRef-direct write — authoritative.
-        let b = self
-            .ensure_box(source)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        // shortpreamble.py:425 `preamble_op.set_forwarded(info)`. The replay
+        // OpRef is a short-preamble op whose producer may not be registered
+        // yet (the Pure / Heap / LoopInvariant replay slot is seeded here,
+        // before the short-preamble body that builds the producing op).
+        // `materialize_box_at` returns the canonical host, minting a `SameAs*`
+        // synthetic into `resop_refs` when absent; `emit()` later re-binds it
+        // to the real producer, carrying the forwarded state across.
+        let b = self.materialize_box_at(source);
         match info {
             OpInfo::Unknown => b.clear_forwarded(),
             other => b.set_forwarded_info(other.clone()),
@@ -3439,12 +3443,11 @@ impl OptContext {
         }
         // BoxRef shim for `set_ptr_info` / `make_nonnull` calls below.
         // RPython `unroll.py:54` `op = get_box_replacement(op)` followed
-        // by `op.set_forwarded(...)` writes unconditionally; route through
-        // `ensure_box` so the "Box always exists" invariant holds even
-        // when the BoxRef has not yet been materialized.
-        let Some(op_box) = self.ensure_box(op) else {
-            return;
-        };
+        // by `op.set_forwarded(...)` writes unconditionally; `op` was
+        // chain-resolved and checked non-forwarded / non-constant above, so
+        // `materialize_box_at` returns its canonical `_forwarded` host
+        // (minting one only for an unbound preamble/test slot).
+        let op_box = self.materialize_box_at(op);
 
         // unroll.py:60-64: virtual — set_forwarded + recurse, then return.
         // Identity-preserving install: clone the `Rc` (not the inner
@@ -3590,13 +3593,14 @@ impl OptContext {
                     // unroll.py:49: item.set_forwarded(None)
                     // "let's not inherit stuff we don't know anything about"
                     // Clears `item`'s OWN slot, not the chain terminal —
-                    // `ensure_box` returns the BoxRef at item's pool slot
-                    // directly without `get_box_replacement` walking. For
-                    // a const-namespace OpRef, `ensure_box` returns a
-                    // fresh `BoxRef::new_const` whose `clear_forwarded` is
-                    // a no-op (Const has no `_forwarded`), matching
-                    // RPython where `Const.set_forwarded` raises.
-                    if let Some(b) = self.ensure_box(item) {
+                    // `resolve_to_boxref` returns the BoxRef bound to item's
+                    // canonical `_forwarded` host directly, without
+                    // `get_box_replacement` walking. For a const-namespace
+                    // OpRef it returns a fresh `BoxRef::new_const` whose
+                    // `clear_forwarded` is a no-op (Const has no
+                    // `_forwarded`), matching RPython where
+                    // `Const.set_forwarded` raises.
+                    if let Some(b) = self.resolve_to_boxref(item) {
                         b.clear_forwarded();
                     }
                 }
@@ -3659,9 +3663,7 @@ impl OptContext {
             // unroll.py:93-96 IntBound with widen(): intersect unconditionally.
             OpInfo::IntBound(bound) => {
                 let widened = bound.borrow().widen();
-                let target_box = self
-                    .ensure_box(target)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let target_box = self.materialize_box_at(target);
                 self.with_intbound_mut(&target_box, |bm| {
                     let _ = bm.intersect(&widened);
                 });
@@ -3710,9 +3712,7 @@ impl OptContext {
             }
             OpInfo::IntBound(bound) => {
                 let widened = bound.borrow().widen();
-                let target_box = self
-                    .ensure_box(target)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let target_box = self.materialize_box_at(target);
                 self.with_intbound_mut(&target_box, |bm| {
                     let _ = bm.intersect(&widened);
                 });
@@ -4080,7 +4080,7 @@ impl OptContext {
         if let Some(pos) = terminal.position() {
             let tp = terminal.type_();
             // `Type::Void` targets are lazy-allocated phantom placeholders
-            // (`ensure_box` fallback for OpRef variants with no `ty()`); the
+            // (`materialize_box_at` fallback for OpRef variants with no `ty()`); the
             // placeholder carries no type information, so preserve the source variant via `with_raw`
             // instead of promoting to `void_op` / `input_arg_typed(_, Void)`.
             if matches!(tp, majit_ir::Type::Void) {
@@ -4138,9 +4138,9 @@ impl OptContext {
         // variant-aware canonical-host resolver (producer `Op` for ResOp
         // variants, `inputarg_refs` for InputArg, inline-Const for Const),
         // rather than `box_pool.get` whose position-collapse merges a ResOp
-        // and an InputArg sharing a raw slot index. Production `ensure_box`
+        // and an InputArg sharing a raw slot index. Production `materialize_box_at`
         // binds every resop slot to the same producer `Op`, so reads here
-        // and writes through `ensure_box` agree by hitting the identical
+        // and writes through `materialize_box_at` agree by hitting the identical
         // `Op.forwarded` / `InputArg.forwarded` host. A `None` resolve
         // (sentinel, or a position with no producer / inputarg / const)
         // leaves callers on the OpRef-returning walker fallback.
@@ -4148,44 +4148,32 @@ impl OptContext {
         Some(start.get_box_replacement(false))
     }
 
-    /// RPython "Box always exists" invariant materializer
-    /// (`resoperation.py:233-248 AbstractResOpOrInputArg._forwarded`).
-    ///
-    /// Returns a `BoxRef` for `opref`, materializing the canonical
-    /// `Op`/`InputArg` host for non-const OpRefs if absent. Mirrors PyPy's model
-    /// where every operand in a trace has a backing `AbstractValue`; write
-    /// paths (`setintbound`, `set_ptr_info`, `with_intbound_mut`,
-    /// `with_ptr_info_mut`, `make_constant_class`, …) MUST use this helper
-    /// — `get_box_replacement_box` returns `None` for absent slots which
-    /// would silently lose the forwarded write (parity regression).
-    ///
-    /// For const-namespace OpRefs, constructs a fresh `BoxRef::new_const
-    /// (value)` from `const_pool` per `history.py:220 ConstInt` no-dedup
-    /// parity — Const boxes have no `_forwarded` slot so any write the
-    /// caller attempts is a `BoxRef::set_forwarded_info` no-op (asserts on
-    /// Const internally).
-    ///
-    /// Returns `None` only for:
-    /// - `opref.is_none()` (sentinel — RPython has no equivalent)
-    /// - const OpRef with no `const_pool` entry (test fixture skipped seed)
-    pub fn ensure_box(&mut self, opref: OpRef) -> Option<crate::r#box::BoxRef> {
-        if opref.is_none() {
-            return None;
-        }
+    /// "Box always exists" materializer (`resoperation.py:233-248
+    /// AbstractResOpOrInputArg._forwarded`). Returns the canonical
+    /// `Op` / `InputArg` `_forwarded` host for `opref`, minting a `SameAs*`
+    /// synthetic into `resop_refs` when no producer is registered yet (the
+    /// lazy-alloc arm). For a const-namespace OpRef returns a fresh
+    /// `BoxRef::new_const` (`history.py:220` no-dedup; Const boxes have no
+    /// `_forwarded`, so any write the caller attempts is a no-op). Unlike
+    /// `resolve_to_boxref` it never returns `None` for a value-bearing OpRef
+    /// — the explicit-mint endpoint (#47) at find-or-create write sites whose
+    /// receiver may be unbound (test fixtures, short-preamble replay slots).
+    /// The sentinel `OpRef::none()` has no box (debug-asserted); resolve it
+    /// with `resolve_to_boxref` / `get_box_replacement_box` instead.
+    pub(crate) fn materialize_box_at(&mut self, opref: OpRef) -> crate::r#box::BoxRef {
+        debug_assert!(
+            !opref.is_none(),
+            "materialize_box_at: sentinel OpRef::none() has no box"
+        );
         if opref.is_constant() {
             // history.py:220/261/307: a Const carries its Value on the OpRef.
-            // The strict materializer has no notion of a "Const without a
-            // Value", so a const OpRef that carries none is a caller bug —
-            // fail loud rather than silently drop the forwarded write (the
-            // tolerant `get_box_replacement_box` returns None for the same
-            // input).
             let value = self.get_constant(opref).unwrap_or_else(|| {
                 panic!(
-                    "ensure_box: const OpRef {opref:?} carries no Value — \
+                    "materialize_box_at: const OpRef {opref:?} carries no Value — \
                      a Const carries its Value (history.py:220/261/307)"
                 )
             });
-            return Some(crate::r#box::BoxRef::new_const(value));
+            return crate::r#box::BoxRef::new_const(value);
         }
         // S-8.A.4: align the write-path host with `resolve_to_boxref`
         // (the read path behind `get_box_replacement_box`). For ResOp
@@ -4199,7 +4187,7 @@ impl OptContext {
         // (no producing op), falling through to the InputArg / lazy-alloc
         // paths below unchanged.
         if let Some(op_rc) = self.find_producer_op(opref) {
-            return Some(crate::r#box::BoxRef::from_bound_op(&op_rc));
+            return crate::r#box::BoxRef::from_bound_op(&op_rc);
         }
         // InputArg write path: route through the canonical `inputarg_refs`
         // host (symmetric with `resolve_to_boxref`'s InputArg branch and the
@@ -4234,9 +4222,7 @@ impl OptContext {
                 self.inputarg_refs[idx] =
                     std::rc::Rc::new(majit_ir::InputArg::from_type(tp, idx as u32));
             }
-            return Some(crate::r#box::BoxRef::from_bound_inputarg(
-                &self.inputarg_refs[idx],
-            ));
+            return crate::r#box::BoxRef::from_bound_inputarg(&self.inputarg_refs[idx]);
         }
         // Existing entries keep their construction-time shape (the recorder
         // / `with_inputarg_types` plant authoritative BoxRefs upstream);
@@ -4253,7 +4239,7 @@ impl OptContext {
         // store (else it returned above), so it falls through to the
         // lazy-alloc arm below, which mints a `SameAs*` synthetic into
         // `resop_refs[opref]` and binds a BoxRef to it. A subsequent
-        // `ensure_box` / `find_producer_op` for the same OpRef re-resolves to
+        // `materialize_box_at` / `find_producer_op` for the same OpRef re-resolves to
         // that synthetic (`resop_refs[opref].pos == opref`), so the synthetic is
         // the stable `_forwarded` host across calls; no memoization side-table
         // is needed.
@@ -4326,7 +4312,7 @@ impl OptContext {
         // InputArg arm, only reachable in `#[cfg(test)]` since production
         // InputArgs resolve through the `inputarg_refs` branch above), so it
         // carries the canonical `_forwarded` host.
-        Some(placeholder)
+        placeholder
     }
 
     /// `optimizer.py:1009 getptrinfo + info.is_virtual()` BoxRef-routing
@@ -4569,9 +4555,7 @@ impl OptContext {
             // circuits on `box.is_constant()` before reaching `set_forwarded`;
             // seed_constant is the recorder/bulk-seed entry where the
             // forwarding slot is authoritative when present).
-            let box_at = self
-                .ensure_box(opref)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let box_at = self.materialize_box_at(opref);
             if matches!(box_at.get_forwarded(), crate::r#box::Forwarded::None) {
                 box_at.set_forwarded_const(majit_ir::Const::from_value(value));
             }
@@ -4613,7 +4597,7 @@ impl OptContext {
             return None;
         }
         // BoxRef-authoritative reader. IntBound writers populate the
-        // BoxRef via `ensure_box`.
+        // BoxRef via `materialize_box_at`.
         let b = self.get_box_replacement_box(replaced)?;
         b.int_bound().map(|ib| ib.clone())
     }
@@ -4702,7 +4686,7 @@ impl OptContext {
         use crate::optimizeopt::info::OpInfo;
         // optimizer.py:116: assert op.type == 'i' — structural assert,
         // matches RPython's release-build invariant. Type::Void boxes are
-        // pyre-only phantom placeholders surfaced by `ensure_box` when the
+        // pyre-only phantom placeholders surfaced by `materialize_box_at` when the
         // recorder has not yet typed the position; accept them as the pyre
         // equivalent of RPython's "the trace typing hasn't reached this
         // OpRef yet" tolerance (PRE-EXISTING-ADAPTATION on the placeholder
@@ -4762,7 +4746,7 @@ impl OptContext {
         use crate::r#box::Forwarded;
         use crate::optimizeopt::info::OpInfo;
         // optimizer.py:99-100: assert op.type == 'i'. Active in release
-        // builds per upstream. Void-typed phantoms (`ensure_box` lazy-alloc)
+        // builds per upstream. Void-typed phantoms (`materialize_box_at` lazy-alloc)
         // are accepted because they are placeholder boxes pending recorder
         // typing — their chain walk may still terminate at an int-typed
         // Const/InputArg.
@@ -4816,11 +4800,14 @@ impl OptContext {
     /// Mirrors PyPy optimizer.py:432: `box.set_forwarded(constbox)`.
     /// The constant Box carries the fresh Const identity.
     pub fn make_constant(&mut self, opref: OpRef, value: Value) {
-        let b = self
-            .get_box_replacement_box(opref)
-            // `get_box_replacement_box` already returned `None` here, so the
-            // `_forwarded` walk is the identity on `opref`; materialize it.
-            .or_else(|| self.ensure_box(opref));
+        // optimizer.py:415/432 `box = get_box_replacement(box); box.set_forwarded(constbox)`.
+        // Resolve the chain terminal; for a body-namespace operand with no
+        // registered producer yet (preamble / test slot) materialize its
+        // `_forwarded` host so the constant forwarding lands. A sentinel
+        // `opref` has no host to forward.
+        let b = self.get_box_replacement_box(opref).or_else(|| {
+            (!opref.is_none() && !opref.is_constant()).then(|| self.materialize_box_at(opref))
+        });
         if let Some(b) = b {
             self.make_constant_box(&b, value);
         }
@@ -6863,7 +6850,7 @@ impl OptContext {
         // optimizer.py:128: if op.type == 'r' or self.is_raw_ptr(op):
         //
         // `Box.type` is intrinsic in upstream — never Void. In pyre,
-        // `ensure_box` lazy-creates `Type::Void` phantom placeholders
+        // `materialize_box_at` lazy-creates `Type::Void` phantom placeholders
         // for OpRefs the recorder has not yet typed; the chain walker
         // hop into the terminal Box (which carries the proper type via
         // `BoxRef::new_const` for Const targets) recovers the
@@ -6983,9 +6970,7 @@ impl OptContext {
         if terminal.is_constant() {
             return;
         }
-        let b = self
-            .ensure_box(terminal)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = self.materialize_box_at(terminal);
         let already_set = !matches!(b.get_forwarded(), crate::r#box::Forwarded::None);
         if !already_set {
             b.set_forwarded_info(OpInfo::ptr(info));
@@ -7044,7 +7029,7 @@ impl OptContext {
         opref: OpRef,
     ) -> Option<&mut crate::optimizeopt::info::PtrInfo> {
         use crate::optimizeopt::info::PtrInfo;
-        // Use ensure_box (non-walking, &mut self) so the original
+        // Use materialize_box_at (non-walking, &mut self) so the original
         // BoxRef is materialized — getptrinfo's internal chain
         // walk then advances from the original BoxRef whose position
         // is preserved, allowing the opref_type fallback to read the
@@ -7075,7 +7060,7 @@ impl OptContext {
     ) -> Option<&mut crate::optimizeopt::info::PtrInfo> {
         use crate::optimizeopt::info::PtrInfo;
         // info.py:719: ref = self._const.getref_base()
-        // Use ensure_box (non-walking, &mut self) so the original
+        // Use materialize_box_at (non-walking, &mut self) so the original
         // BoxRef is materialized — getptrinfo's internal chain
         // walk then advances from the original BoxRef whose position
         // is preserved, allowing the opref_type fallback to read the
@@ -7133,7 +7118,7 @@ impl OptContext {
         use crate::optimizeopt::info::PtrInfo;
         // info.py:729: ref = self._const.getref_base() — same dispatch as
         // _get_info; route through getptrinfo for the op.type contract.
-        // Use ensure_box (non-walking, &mut self) so the original
+        // Use materialize_box_at (non-walking, &mut self) so the original
         // BoxRef is materialized — getptrinfo's internal chain
         // walk then advances from the original BoxRef whose position
         // is preserved, allowing the opref_type fallback to read the
@@ -7534,9 +7519,7 @@ impl OptContext {
         // optimizer.py:497: opinfo.last_guard_pos = last_guard_pos
         new_info.set_last_guard_pos(last_guard_pos);
         // optimizer.py:498: arg0.set_forwarded(opinfo)
-        let bx = self
-            .ensure_box(arg0)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let bx = self.materialize_box_at(arg0);
         use crate::optimizeopt::info::OpInfo;
         bx.set_forwarded_info(OpInfo::ptr(new_info));
         // optimizer.py:499: return opinfo — hand back the BoxRef so subsequent
@@ -7942,9 +7925,7 @@ mod boxref_forwarding_tests {
         // Forward to an inline-Const target — history.py:227 ConstInt.value
         // carries the value on the Box itself, no const_pool seed needed.
         let const_opref = OpRef::const_int(42);
-        let b_const = ctx
-            .ensure_box(const_opref)
-            .expect("inline-Const carries the value on the Box");
+        let b_const = ctx.materialize_box_at(const_opref);
         ctx.make_equal_to(&b0, &b_const);
         // The IntBound on old is gone (overwritten by Forwarded::Op(const)).
         // Const targets do not carry transferred info — PyPy skips this case.
@@ -8021,14 +8002,12 @@ mod boxref_forwarding_tests {
         ctx.seed_boxes_canonical(&[b0.clone(), b1.clone()]);
         // (a) Const-namespace OpRef terminates at a Const box.
         let const_opref = OpRef::const_int(7);
-        let const_box = ctx.ensure_box(const_opref).expect("const box");
+        let const_box = ctx.materialize_box_at(const_opref);
         assert!(const_box.get_box_replacement(false).is_constant());
         // (b) `Forwarded::Box(constbox)` chain on a non-Const-namespace OpRef.
-        let b0_iarg = ctx
-            .ensure_box(OpRef::input_arg_int(0))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b0_iarg = ctx.materialize_box_at(OpRef::input_arg_int(0));
         ctx.make_equal_to(&b0_iarg, &const_box);
-        let b0_after = ctx.ensure_box(OpRef::input_arg_int(0)).expect("b0");
+        let b0_after = ctx.materialize_box_at(OpRef::input_arg_int(0));
         assert!(b0_after.get_box_replacement(false).is_constant());
         // `Forwarded::Box(constbox)` planted directly via set_forwarded_box.
         b1.set_forwarded_box(BoxRef::new_const(Value::Int(42)));
@@ -8078,9 +8057,7 @@ mod boxref_forwarding_tests {
     fn h3_4_replace_op_const_target_mirrors_value_box() {
         let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         let const_opref = OpRef::const_int(42);
-        let b_const = ctx
-            .ensure_box(const_opref)
-            .expect("inline-Const carries the value on the Box");
+        let b_const = ctx.materialize_box_at(const_opref);
         ctx.make_equal_to(&b0, &b_const);
         match &b0.get_forwarded() {
             BoxForwarded::Const(majit_ir::Const::Int(v)) => {
@@ -8098,9 +8075,7 @@ mod boxref_forwarding_tests {
     fn get_box_replacement_not_const_stops_before_const_target() {
         let (mut ctx, b0, b1, _ia_holder) = ctx_with_two_int_boxes();
         let const_opref = OpRef::const_int(42);
-        let b_const = ctx
-            .ensure_box(const_opref)
-            .expect("inline-Const carries the value on the Box");
+        let b_const = ctx.materialize_box_at(const_opref);
         ctx.make_equal_to(&b0, &b_const);
 
         assert_eq!(
@@ -8176,9 +8151,7 @@ mod boxref_forwarding_tests {
         // then calls `set_ptr_info(target_p1, info)`. Replicate the
         // post-walk write directly.
         let info = PtrInfo::NonNull { last_guard_pos: -1 };
-        let target_p1_box = ctx
-            .ensure_box(target_p1)
-            .expect("body-namespace OpRef must resolve to a BoxRef");
+        let target_p1_box = ctx.materialize_box_at(target_p1);
         ctx.set_ptr_info(&target_p1_box, info.clone());
 
         // Read via BoxRef-routing path: walk source's chain to placeholder.
@@ -8949,7 +8922,7 @@ mod constant_ptr_info_tests {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::ref_op(10_000);
         ctx.seed_constant(opref, Value::Ref(GcRef(0xdead_beef)));
-        let b = ctx.ensure_box(opref).expect("box");
+        let b = ctx.materialize_box_at(opref);
         match ctx.getptrinfo(&b) {
             Some(PtrInfo::Constant(g)) => assert_eq!(g.0, 0xdead_beef),
             other => panic!("expected ConstPtrInfo(0xdeadbeef), got {other:?}"),
@@ -8966,7 +8939,7 @@ mod constant_ptr_info_tests {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::int_op(10_002);
         ctx.seed_constant(opref, Value::Int(42));
-        let b = ctx.ensure_box(opref).expect("box");
+        let b = ctx.materialize_box_at(opref);
         match ctx.getptrinfo(&b) {
             Some(PtrInfo::Constant(g)) => assert_eq!(g.0, 42),
             other => panic!("expected ConstPtrInfo(42), got {other:?}"),
@@ -9058,12 +9031,8 @@ mod constant_ptr_info_tests {
         let parent = OpRef::ref_op(10_010);
         let slice = OpRef::ref_op(10_011);
 
-        let parent_box = ctx
-            .ensure_box(parent)
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let slice_box = ctx
-            .ensure_box(slice)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let parent_box = ctx.materialize_box_at(parent);
+        let slice_box = ctx.materialize_box_at(slice);
         ctx.set_ptr_info(
             &parent_box,
             PtrInfo::VirtualRawBuffer(VirtualRawBufferInfo::new(0, 32, None)),
@@ -9098,9 +9067,7 @@ mod constant_ptr_info_tests {
         // Synthetic-OpRef test fixture: lazy-allocate the BoxRef so the
         // BoxRef-direct `make_nonnull_str` can write through it. Production
         // callers obtain the box via `get_box_replacement_box`.
-        let op_box = ctx
-            .ensure_box(opref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let op_box = ctx.materialize_box_at(opref);
 
         ctx.make_nonnull_str(&op_box, 0);
 
@@ -9450,9 +9417,7 @@ mod ensure_ptr_info_arg0_tests {
     fn ensure_ptr_info_arg0_upgrades_nonnull_to_struct() {
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
         // Pre-install a NonNullPtrInfo with a specific last_guard_pos.
-        let pos0_box = ctx
-            .ensure_box(OpRef::input_arg_ref(0))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let pos0_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
         ctx.set_ptr_info(&pos0_box, PtrInfo::NonNull { last_guard_pos: 7 });
         let _parent = struct_parent_descr();
         let op = field_op_with_parent(_parent.clone());
@@ -9474,9 +9439,7 @@ mod ensure_ptr_info_arg0_tests {
     #[test]
     fn ensure_ptr_info_arg0_does_not_overwrite_existing_instance() {
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
-        let pos0_box = ctx
-            .ensure_box(OpRef::input_arg_ref(0))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let pos0_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
         ctx.set_ptr_info(
             &pos0_box,
             PtrInfo::instance(Some(instance_parent_descr()), Some(0xc0de)),
@@ -9611,10 +9574,10 @@ mod intbound_invariant_tests {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::ref_op(20_000);
         ctx.seed_constant(opref, Value::Ref(GcRef(0xdead_beef)));
-        let _ = ctx
-            .ensure_box(opref)
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let _ = {
+            let __mb = ctx.materialize_box_at(opref);
+            ctx.getintbound_handle(&__mb).borrow().clone()
+        };
     }
 
     #[test]
@@ -9729,12 +9692,8 @@ mod opt_box_env_tests {
         let mut ctx = OptContext::with_num_inputs(16, 0);
         let source = OpRef::ref_op(12);
         let target = OpRef::ref_op(21);
-        let source_box = ctx
-            .ensure_box(source)
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let target_box = ctx
-            .ensure_box(target)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let source_box = ctx.materialize_box_at(source);
+        let target_box = ctx.materialize_box_at(target);
         ctx.make_equal_to(&source_box, &target_box);
         ctx.set_ptr_info(
             &target_box,
@@ -9756,16 +9715,15 @@ mod opt_box_env_tests {
     }
 
     #[test]
-    fn ensure_box_lazy_materialises_inputarg_for_empty_inputarg_slot() {
+    fn materialize_box_at_lazy_materialises_inputarg_for_empty_inputarg_slot() {
         // `resoperation.py:699 AbstractInputArg` and
         // `resoperation.py:250 AbstractResOp` are distinct classes
         // upstream — a Box materialised against `OpRef::InputArg*`
         // must be `is_inputarg()` so the chain walker reconstructs
         // the same variant on the round-trip through
         // `Forwarded::Box`.  Prior to the per-variant empty-slot
-        // path, `ensure_box` routed through `ensure_box_at_typed`
-        // which always emits `new_resop`, silently demoting the
-        // inputarg.
+        // path, materialisation always emitted `new_resop`,
+        // silently demoting the inputarg.
         // `with_inputarg_types` would seed the inputarg slots
         // eagerly, defeating the lazy-materialisation check.  Use
         // `with_num_inputs(_, 0)` to get an empty pool then hand an
@@ -9774,9 +9732,7 @@ mod opt_box_env_tests {
         // mint a `new_inputarg`.
         let mut ctx = OptContext::with_num_inputs(8, 0);
         let arg = OpRef::input_arg_typed(0, majit_ir::Type::Int);
-        let materialised = ctx
-            .ensure_box(arg)
-            .expect("InputArg OpRef must materialise a BoxRef");
+        let materialised = ctx.materialize_box_at(arg);
         assert!(
             materialised.is_inputarg(),
             "empty InputArg* slot lazy-materialised the wrong BoxKind",
@@ -9787,12 +9743,10 @@ mod opt_box_env_tests {
         // Re-entering must resolve to the same canonical `_forwarded`
         // host (`resoperation.py:700 AbstractInputArg._forwarded`). The
         // `BoxRef` wrapper carries no state post-S-0.C, so two
-        // `ensure_box` calls return distinct wrappers bound to the same
-        // `InputArgRc`; identity lives on that bound host, not the
+        // `materialize_box_at` calls return distinct wrappers bound to the
+        // same `InputArgRc`; identity lives on that bound host, not the
         // wrapper `Rc`.
-        let second = ctx
-            .ensure_box(arg)
-            .expect("InputArg OpRef must continue to resolve");
+        let second = ctx.materialize_box_at(arg);
         assert!(
             std::rc::Rc::ptr_eq(
                 &materialised
@@ -9800,19 +9754,17 @@ mod opt_box_env_tests {
                     .expect("materialised bound to InputArg"),
                 &second.bound_inputarg().expect("second bound to InputArg"),
             ),
-            "second ensure_box must resolve to the same InputArg host",
+            "second materialize_box_at must resolve to the same InputArg host",
         );
     }
 
     #[test]
-    fn ensure_box_lazy_materialises_resop_for_empty_resop_slot() {
+    fn materialize_box_at_lazy_materialises_resop_for_empty_resop_slot() {
         // Companion to the InputArg case — `OpRef::int_op(_)` must
         // continue to produce a `new_resop` Box so `is_resop()` holds.
         let mut ctx = OptContext::with_num_inputs(8, 0);
         let result = OpRef::int_op(3);
-        let materialised = ctx
-            .ensure_box(result)
-            .expect("ResOp OpRef must materialise a BoxRef");
+        let materialised = ctx.materialize_box_at(result);
         assert!(
             materialised.is_resop(),
             "empty ResOp slot lazy-materialised the wrong BoxKind",

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2065,6 +2065,32 @@ impl OptContext {
         self.reserve_pos_typed(tp)
     }
 
+    /// Allocate a fresh OpRef position and eagerly mint its canonical
+    /// `_forwarded` host — a `SameAs*`/`Jump` synthetic in `resop_refs` —
+    /// returning both the position and a `BoxRef` bound to that host.
+    ///
+    /// This is the explicit creation primitive for producer-less
+    /// synthetics: importers that allocate a position purely to carry a
+    /// forwarded write (PtrInfo / IntBound / Const for an imported virtual
+    /// state leaf) get a bound write target in one step, instead of
+    /// `alloc_op_position_typed` followed by a lazy `ensure_box(opref)`
+    /// re-materialization. The minted synthetic is identical to the one
+    /// `ensure_box`'s producer-less arm mints (`mint_synthetic_resop`), so
+    /// a later `emit()` for the same position supersedes it through the
+    /// same `live_synthetics` catch-up. Reserve a bare position via
+    /// `alloc_op_position_typed` instead when no forwarded write follows
+    /// (e.g. an `Unknown` leaf), to avoid an eager synthetic for a
+    /// position that is never written.
+    pub(crate) fn reserve_virtual_box(
+        &mut self,
+        tp: majit_ir::Type,
+    ) -> (OpRef, crate::r#box::BoxRef) {
+        let opref = self.reserve_pos_typed(tp);
+        let synthetic = self.mint_synthetic_resop(opref, tp);
+        let b = crate::r#box::BoxRef::from_bound_op(&synthetic);
+        (opref, b)
+    }
+
     /// Dispatch on a `Value`'s type tag and produce a typed `*Op` OpRef
     /// at the given position (resoperation.py:564-638
     /// IntOp/FloatOp/RefOp/VoidOp mixins).

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7613,7 +7613,12 @@ impl OptContext {
 /// optimizer.py: Optimization base class.
 pub trait Optimization {
     /// Process an operation. Called for each operation in the trace.
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult;
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        _op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult;
 
     /// optimizer.py:71 propagate_postprocess — called AFTER the op has been
     /// emitted through all passes and added to new_operations. Runs in

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2171,7 +2171,7 @@ impl OptContext {
             let len_opref = self.make_constant_int(len);
             // BoxRef shim — write path through `ensure_box` per the
             // "Box always exists" invariant for set_forwarded mirrors.
-            if let Some(b) = self.ensure_box(resolved) {
+            if let Some(b) = self.get_box_replacement_box(resolved) {
                 self.set_str_lgtop(&b, len_opref);
             }
             return len_opref;
@@ -2197,7 +2197,7 @@ impl OptContext {
             let right_len = self.getstrlen_for(vright, vright, mode);
             let result = crate::optimizeopt::vstring::_int_add(left_len, right_len, self);
             // vstring.py:293: self.lgtop = _int_add(optstring, len1box, len2box)
-            if let Some(b) = self.ensure_box(resolved) {
+            if let Some(b) = self.get_box_replacement_box(resolved) {
                 self.set_str_lgtop(&b, result);
             }
             return result;
@@ -2224,17 +2224,16 @@ impl OptContext {
         // lenbound on the StrPtrInfo is a PtrInfo-internal mutation that
         // RPython performs on the StrPtrInfo instance directly. Route
         // through `ensure_box` so the BoxRef exists for the chain walk.
-        let lenbound = self
-            .ensure_box(resolved)
+        let lenbound = self.get_box_replacement_box(resolved)
             .as_ref()
             .and_then(|b| self.get_str_lenbound(b));
         if let Some(bound) = lenbound {
-            if let Some(result_box) = self.ensure_box(result) {
+            if let Some(result_box) = self.get_box_replacement_box(result) {
                 self.setintbound(&result_box, &bound);
             }
         }
         // vstring.py:117: self.lgtop = lengthop
-        if let Some(b) = self.ensure_box(resolved) {
+        if let Some(b) = self.get_box_replacement_box(resolved) {
             self.set_str_lgtop(&b, result);
         }
         result
@@ -7007,7 +7006,7 @@ impl OptContext {
         // walk then advances from the original BoxRef whose position
         // is preserved, allowing the opref_type fallback to read the
         // seed_constant Ref override (Phase D-5 transitional).
-        let opref_box = self.ensure_box(opref);
+        let opref_box = self.get_box_replacement_box(opref);
         let gcref = match opref_box.as_ref().and_then(|b| self.getptrinfo(b)) {
             Some(PtrInfo::Constant(g)) => g,
             _ => return None,
@@ -7038,7 +7037,7 @@ impl OptContext {
         // walk then advances from the original BoxRef whose position
         // is preserved, allowing the opref_type fallback to read the
         // seed_constant Ref override (Phase D-5 transitional).
-        let opref_box = self.ensure_box(opref);
+        let opref_box = self.get_box_replacement_box(opref);
         let gcref = match opref_box.as_ref().and_then(|b| self.getptrinfo(b)) {
             Some(PtrInfo::Constant(g)) => g,
             _ => return None,
@@ -7096,7 +7095,7 @@ impl OptContext {
         // walk then advances from the original BoxRef whose position
         // is preserved, allowing the opref_type fallback to read the
         // seed_constant Ref override (Phase D-5 transitional).
-        let opref_box = self.ensure_box(opref);
+        let opref_box = self.get_box_replacement_box(opref);
         let gcref = match opref_box.as_ref().and_then(|b| self.getptrinfo(b)) {
             Some(PtrInfo::Constant(g)) => g,
             _ => return None,
@@ -7597,9 +7596,7 @@ impl OptContext {
     /// Replace old opref AND emit the new op.
     pub fn replace_op_with(&mut self, old: OpRef, new_op: Op) -> OpRef {
         let new_ref = self.emit(new_op);
-        let b_old = self
-            .ensure_box(old)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_old = self.get_box_replacement(old);
         let b_new = self.get_box_replacement(new_ref);
         self.make_equal_to(&b_old, &b_new);
         new_ref

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3937,6 +3937,8 @@ impl Optimizer {
         // optimizer.py:598-602:
         //     if rop.returns_bool_result(op.opnum):
         //         self.getintbound(op).make_bool()
+        // The `make_bool` IntBound write runs post-emit (below), once the
+        // op's box is bound; only the type assertion is checked here.
         if op.opcode.returns_bool() {
             assert_eq!(
                 op.result_type(),
@@ -3946,13 +3948,6 @@ impl Optimizer {
                 op.pos.get(),
                 op.getarglist()
             );
-            // 5: returns_bool ops are constructed Int-typed
-            // (asserted above) and `Op.type_ == Int` already provides the
-            // type to `opref_type` via the priority-2 op_at fast path.
-            let op_pos_box = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            ctx.with_intbound_mut(&op_pos_box, |bound| bound.make_bool());
         }
         let emitted = ctx.emit(op.clone());
         // optimizer.py:674 `self._emittedoperations[op] = None` — record
@@ -3966,6 +3961,15 @@ impl Optimizer {
         // flag transition from true (prior Remove) → false (this
         // emit).
         ctx.last_op_removed = false;
+        // optimizer.py:598-602: returns_bool_result → getintbound(op).make_bool().
+        // Run here (post-emit) so the now-bound op box carries the IntBound
+        // write; returns_bool ops are Int-typed (asserted above).
+        if op.opcode.returns_bool() {
+            let bound_box = ctx
+                .get_box_replacement_box(emitted)
+                .expect("just-emitted op resolves to a bound BoxRef");
+            ctx.with_intbound_mut(&bound_box, |bound| bound.make_bool());
+        }
         // optimizer.py:603-611: after emit, promote IntBound→Const.
         //   op = self.get_box_replacement(op)
         //   if op.type == 'i':

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3701,7 +3701,7 @@ impl Optimizer {
             ctx.current_pass_idx = pass_idx;
             let result = {
                 let pass = &mut self.passes[pass_idx];
-                pass.propagate_forward(&current_op, ctx)
+                pass.propagate_forward(&current_op, op_rc, ctx)
             };
             self.drain_extra_operations_from(pass_idx + 1, ctx);
             match result {
@@ -4543,7 +4543,7 @@ mod tests {
     struct AddZeroElimination;
 
     impl Optimization for AddZeroElimination {
-        fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if op.opcode == OpCode::IntAdd {
                 // Check if second arg is constant 0
                 if let Some(0) = ctx
@@ -4581,7 +4581,7 @@ mod tests {
     }
 
     impl Optimization for AddVirtualInputsOnce {
-        fn propagate_forward(&mut self, _op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, _op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if !self.added {
                 ctx.num_inputs += 2;
                 self.added = true;
@@ -4595,7 +4595,7 @@ mod tests {
     }
 
     impl Optimization for RemoveAsConstant {
-        fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if op.pos.get() == self.target {
                 ctx.make_constant(op.pos.get(), majit_ir::Value::Int(self.value));
                 return OptimizationResult::Remove;
@@ -4613,7 +4613,7 @@ mod tests {
     }
 
     impl Optimization for FlushCounter {
-        fn propagate_forward(&mut self, _op: &Op, _ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, _op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
             OptimizationResult::PassOn
         }
 
@@ -4632,7 +4632,7 @@ mod tests {
     }
 
     impl Optimization for RemoveAsTypedConstant {
-        fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if op.pos.get() == self.target {
                 ctx.make_constant(op.pos.get(), self.value.clone());
                 return OptimizationResult::Remove;
@@ -4651,7 +4651,7 @@ mod tests {
     }
 
     impl Optimization for MarkAsTypedConstantButKeep {
-        fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if op.pos.get() == self.target {
                 ctx.make_constant(op.pos.get(), self.value.clone());
             }
@@ -4773,7 +4773,7 @@ mod tests {
     }
 
     impl Optimization for QueueForceLikeExtraOps {
-        fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if !self.queued && op.opcode == OpCode::IntAdd {
                 self.queued = true;
 
@@ -4801,7 +4801,7 @@ mod tests {
     }
 
     impl Optimization for QueueRestartCandidate {
-        fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if !self.queued && op.opcode == OpCode::IntMul {
                 self.queued = true;
                 ctx.emit_extra(
@@ -4822,7 +4822,7 @@ mod tests {
     }
 
     impl Optimization for CountRestartedIntSub {
-        fn propagate_forward(&mut self, op: &Op, _ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
             if op.opcode == OpCode::IntSub {
                 self.hits.set(self.hits.get() + 1);
             }
@@ -4837,7 +4837,7 @@ mod tests {
     struct RestartIntAddAsSub;
 
     impl Optimization for RestartIntAddAsSub {
-        fn propagate_forward(&mut self, op: &Op, _ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
             if op.opcode == OpCode::IntAdd {
                 let mut restarted = Op::new(OpCode::IntSub, &[op.arg(0), op.arg(1)]);
                 restarted.pos.set(op.pos.get());
@@ -5493,7 +5493,7 @@ mod tests {
     }
 
     impl Optimization for QueueTwoForceLikePairs {
-        fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
             if !self.queued && op.opcode == OpCode::IntAdd {
                 self.queued = true;
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -322,10 +322,8 @@ pub(crate) fn merge_backend_constants_from_ctx(
     for op in &ctx.phase1_emit_ops {
         consider(op);
     }
-    for slot in &ctx.resop_refs {
-        if let Some(op) = slot {
-            consider(op);
-        }
+    for op in ctx.resop_refs.values() {
+        consider(op);
     }
 }
 
@@ -3033,10 +3031,8 @@ impl Optimizer {
             for op in &ctx.phase1_emit_ops {
                 consider_const(op);
             }
-            for slot in &ctx.resop_refs {
-                if let Some(op) = slot {
-                    consider_const(op);
-                }
+            for op in ctx.resop_refs.values() {
+                consider_const(op);
             }
             drop(consider_const);
             // Align each const-folded producer's canonical `Op.pos` to its

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2275,13 +2275,14 @@ impl Optimizer {
                                 source,
                             )
                         });
-                        let fresh = ctx.alloc_op_position_typed(tp);
+                        // `fresh` is a producer-less resop: mint its bound
+                        // box up front. `source` is a Phase 2 inputarg whose
+                        // slot `ensure_inputarg_bindings` materialized above,
+                        // so it resolves without minting.
+                        let (fresh, b_fresh) = ctx.reserve_virtual_box(tp);
                         let b_source = ctx
-                            .ensure_box(source)
-                            .expect("body-namespace OpRef must have a BoxRef slot");
-                        let b_fresh = ctx
-                            .ensure_box(fresh)
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                            .get_box_replacement_box(source)
+                            .expect("Phase 2 source inputarg must have a materialized BoxRef slot");
                         ctx.make_equal_to(&b_source, &b_fresh);
                         fresh
                     } else {
@@ -2673,10 +2674,10 @@ impl Optimizer {
                                             orig_field,
                                         )
                                     });
-                                    let ff = ctx.alloc_op_position_typed(tp);
-                                    let b_ff = ctx
-                                        .ensure_box(ff)
-                                        .expect("body-namespace OpRef must have a BoxRef slot");
+                                    // Producer-less alias resop: mint its
+                                    // bound box up front and forward it to the
+                                    // original field box.
+                                    let (ff, b_ff) = ctx.reserve_virtual_box(tp);
                                     let b_orig = ctx.get_box_replacement(orig_field);
                                     ctx.make_equal_to(&b_ff, &b_orig);
                                     field.1 = ff;

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -398,33 +398,51 @@ impl Optimizer {
             ),
             VirtualStateInfo::Unknown(tp) => *tp,
         };
-        let opref = ctx.alloc_op_position_typed(tp);
+        // `Unknown` leaves carry no forwarded write (the
+        // `apply_imported_virtual_state` arm is a no-op), so reserve a bare
+        // position with no eager synthetic — matching the prior lazy path
+        // where nothing was minted until a later `ensure_box` access.
+        if let VirtualStateInfo::Unknown(_) = info {
+            let opref = ctx.alloc_op_position_typed(tp);
+            if crate::debug::have_debug_prints() {
+                crate::debug::log_one(
+                    "jit-optimizer",
+                    &format!("import_virtual_state_value {opref:?} <= {info:?}"),
+                );
+            }
+            return opref;
+        }
+        // Producer-less leaf with a forwarded write: mint the box up front
+        // and route the write through it (retires the per-arm
+        // `ensure_box(opref)` materialization inside
+        // `apply_imported_virtual_state`).
+        let (opref, box_) = ctx.reserve_virtual_box(tp);
         if crate::debug::have_debug_prints() {
             crate::debug::log_one(
                 "jit-optimizer",
                 &format!("import_virtual_state_value {opref:?} <= {info:?}"),
             );
         }
-        Self::apply_imported_virtual_state(info, opref, ctx);
+        Self::apply_imported_virtual_state(info, &box_, ctx);
         opref
     }
 
     fn apply_imported_virtual_state(
         info: &crate::optimizeopt::virtualstate::VirtualStateInfo,
-        opref: OpRef,
+        box_: &crate::r#box::BoxRef,
         ctx: &mut OptContext,
     ) {
         use crate::optimizeopt::virtualstate::VirtualStateInfo;
 
-        // `op.set_forwarded(info)` per optimizer.py — each arm materializes
-        // the box via `ensure_box(opref)` then writes through
-        // `set_ptr_info(&b, _)`. Constants take the value-only path via
-        // `make_constant`; ensure_box returns `None` for OpRef::NONE /
-        // OpRef::Const* so non-PtrInfo opref values silently no-op,
-        // matching upstream `Const.set_forwarded` assert.
+        // `op.set_forwarded(info)` per optimizer.py — each arm writes the
+        // imported state through the caller-provided bound box: fresh
+        // virtual-state leaves arrive minted via `reserve_virtual_box`,
+        // imported label-arg leaves arrive resolved via
+        // `get_box_replacement_box`. Constants take the value-only path via
+        // `make_constant_box`.
         match info {
             VirtualStateInfo::Constant(value) => {
-                ctx.make_constant(opref, value.clone());
+                ctx.make_constant_box(box_, value.clone());
             }
             VirtualStateInfo::Virtual {
                 descr,
@@ -450,41 +468,37 @@ impl Optimizer {
                     imported_fields.push((*field_idx, field_ref));
                 }
                 let _ = field_descrs; // descr.all_fielddescrs() is authoritative
-                if let Some(b) = ctx.ensure_box(opref) {
-                    ctx.set_ptr_info(
-                        &b,
-                        crate::optimizeopt::info::PtrInfo::Virtual(
-                            crate::optimizeopt::info::VirtualInfo {
-                                descr: descr.clone(),
-                                known_class: *known_class,
-                                ob_type_descr: ob_type_descr.clone(),
-                                fields: imported_fields,
-                                last_guard_pos: -1,
-                                avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
-                            },
-                        ),
-                    );
-                }
+                ctx.set_ptr_info(
+                    box_,
+                    crate::optimizeopt::info::PtrInfo::Virtual(
+                        crate::optimizeopt::info::VirtualInfo {
+                            descr: descr.clone(),
+                            known_class: *known_class,
+                            ob_type_descr: ob_type_descr.clone(),
+                            fields: imported_fields,
+                            last_guard_pos: -1,
+                            avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
+                        },
+                    ),
+                );
             }
             VirtualStateInfo::VArray { descr, items, .. } => {
                 let imported_items = items
                     .iter()
                     .map(|item_info| Self::import_virtual_state_value(item_info, ctx))
                     .collect();
-                if let Some(b) = ctx.ensure_box(opref) {
-                    ctx.set_ptr_info(
-                        &b,
-                        crate::optimizeopt::info::PtrInfo::VirtualArray(
-                            crate::optimizeopt::info::VirtualArrayInfo {
-                                descr: descr.clone(),
-                                clear: false,
-                                items: imported_items,
-                                last_guard_pos: -1,
-                                avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
-                            },
-                        ),
-                    );
-                }
+                ctx.set_ptr_info(
+                    box_,
+                    crate::optimizeopt::info::PtrInfo::VirtualArray(
+                        crate::optimizeopt::info::VirtualArrayInfo {
+                            descr: descr.clone(),
+                            clear: false,
+                            items: imported_items,
+                            last_guard_pos: -1,
+                            avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
+                        },
+                    ),
+                );
             }
             VirtualStateInfo::VStruct {
                 descr,
@@ -497,19 +511,17 @@ impl Optimizer {
                     imported_fields.push((*field_idx, field_ref));
                 }
                 let _ = field_descrs; // descr.all_fielddescrs() is authoritative
-                if let Some(b) = ctx.ensure_box(opref) {
-                    ctx.set_ptr_info(
-                        &b,
-                        crate::optimizeopt::info::PtrInfo::VirtualStruct(
-                            crate::optimizeopt::info::VirtualStructInfo {
-                                descr: descr.clone(),
-                                fields: imported_fields,
-                                last_guard_pos: -1,
-                                avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
-                            },
-                        ),
-                    );
-                }
+                ctx.set_ptr_info(
+                    box_,
+                    crate::optimizeopt::info::PtrInfo::VirtualStruct(
+                        crate::optimizeopt::info::VirtualStructInfo {
+                            descr: descr.clone(),
+                            fields: imported_fields,
+                            last_guard_pos: -1,
+                            avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
+                        },
+                    ),
+                );
             }
             VirtualStateInfo::VArrayStruct {
                 descr,
@@ -530,43 +542,34 @@ impl Optimizer {
                             .collect()
                     })
                     .collect();
-                if let Some(b) = ctx.ensure_box(opref) {
-                    ctx.set_ptr_info(
-                        &b,
-                        crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(
-                            crate::optimizeopt::info::VirtualArrayStructInfo {
-                                descr: descr.clone(),
-                                fielddescrs: fielddescrs.clone(),
-                                element_fields: imported_elements,
-                                last_guard_pos: -1,
-                                avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
-                            },
-                        ),
-                    );
-                }
+                ctx.set_ptr_info(
+                    box_,
+                    crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(
+                        crate::optimizeopt::info::VirtualArrayStructInfo {
+                            descr: descr.clone(),
+                            fielddescrs: fielddescrs.clone(),
+                            element_fields: imported_elements,
+                            last_guard_pos: -1,
+                            avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
+                        },
+                    ),
+                );
             }
             VirtualStateInfo::KnownClass { class_ptr } => {
-                if let Some(b) = ctx.ensure_box(opref) {
-                    ctx.set_ptr_info(
-                        &b,
-                        crate::optimizeopt::info::PtrInfo::known_class(*class_ptr, true),
-                    );
-                }
+                ctx.set_ptr_info(
+                    box_,
+                    crate::optimizeopt::info::PtrInfo::known_class(*class_ptr, true),
+                );
             }
             VirtualStateInfo::NonNull => {
-                if let Some(b) = ctx.ensure_box(opref) {
-                    ctx.set_ptr_info(&b, crate::optimizeopt::info::PtrInfo::nonnull());
-                }
+                ctx.set_ptr_info(box_, crate::optimizeopt::info::PtrInfo::nonnull());
             }
             VirtualStateInfo::IntBounded(bound) => {
                 // RPython parity: imported preamble bounds become the box's
                 // forwarded IntBound directly (optimizer.py:115-125
                 // setintbound). No separate "imported" or "lower-only" maps.
                 let widened = bound.widen();
-                // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-                if let Some(op_box) = ctx.get_box_replacement_box(opref) {
-                    ctx.setintbound(&op_box, &widened);
-                }
+                ctx.setintbound(box_, &widened);
             }
             VirtualStateInfo::Unknown(_tp) => {
                 // virtualstate.py:655-683 make_inputargs parity: each
@@ -1083,7 +1086,15 @@ impl Optimizer {
                         OpRef::NONE
                     });
                 *label_slot += 1;
-                Self::apply_imported_virtual_state(info, opref, ctx);
+                // Imported label-arg leaf (KnownClass / NonNull / IntBounded
+                // / Unknown): resolve the already-materialized box for this
+                // label slot and write the imported state through it. An
+                // unresolvable slot (`OpRef::NONE`, e.g. the MISS fallback
+                // above) yields `None` and the write no-ops — matching the
+                // prior `ensure_box(OpRef::NONE) -> None` behavior.
+                if let Some(box_) = ctx.get_box_replacement_box(opref) {
+                    Self::apply_imported_virtual_state(info, &box_, ctx);
+                }
                 ctx.get_box_replacement(opref).to_opref()
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -401,7 +401,7 @@ impl Optimizer {
         // `Unknown` leaves carry no forwarded write (the
         // `apply_imported_virtual_state` arm is a no-op), so reserve a bare
         // position with no eager synthetic — matching the prior lazy path
-        // where nothing was minted until a later `ensure_box` access.
+        // where nothing was minted until a later `materialize_box_at` access.
         if let VirtualStateInfo::Unknown(_) = info {
             let opref = ctx.alloc_op_position_typed(tp);
             if crate::debug::have_debug_prints() {
@@ -414,7 +414,7 @@ impl Optimizer {
         }
         // Producer-less leaf with a forwarded write: mint the box up front
         // and route the write through it (retires the per-arm
-        // `ensure_box(opref)` materialization inside
+        // `materialize_box_at(opref)` materialization inside
         // `apply_imported_virtual_state`).
         let (opref, box_) = ctx.reserve_virtual_box(tp);
         if crate::debug::have_debug_prints() {
@@ -791,7 +791,7 @@ impl Optimizer {
         // unroll.py:55: if op.get_forwarded() is not None: return
         // Skip heads that already have PtrInfo (duplicate entries from
         // aliased JUMP args sharing the same VirtualState position).
-        // Keyed by the virtual head's Box identity. `ensure_box` is
+        // Keyed by the virtual head's Box identity. `materialize_box_at` is
         // position-stable (a head position resolves to one canonical Box),
         // so two entries sharing a head dedupe by `Rc::ptr_eq`. The head is
         // always a NEW (virtual-alloc) ResOp with a producer, so
@@ -1091,7 +1091,7 @@ impl Optimizer {
                 // label slot and write the imported state through it. An
                 // unresolvable slot (`OpRef::NONE`, e.g. the MISS fallback
                 // above) yields `None` and the write no-ops — matching the
-                // prior `ensure_box(OpRef::NONE) -> None` behavior.
+                // prior `materialize_box_at(OpRef::NONE) -> None` behavior.
                 if let Some(box_) = ctx.get_box_replacement_box(opref) {
                     Self::apply_imported_virtual_state(info, &box_, ctx);
                 }
@@ -1746,7 +1746,7 @@ impl Optimizer {
     pub fn getnullness(ctx: &mut OptContext, opref: OpRef) -> i8 {
         // optimizer.py:127-135 `getnullness` has no missing-Box branch —
         // every `op` has a backing `AbstractValue` per `resoperation.py:
-        // 233-248 _forwarded`. `ensure_box` lazy-allocates the Box (or
+        // 233-248 _forwarded`. `materialize_box_at` lazy-allocates the Box (or
         // returns the const-namespace fresh) so the inlined
         // `getintbound` side effect (`optimizer.py:110-113` unbounded
         // install) materializes on first access, matching upstream's
@@ -2521,8 +2521,8 @@ impl Optimizer {
         //   - Unbound orphan: the pipeline folded/dropped the op so
         //     `ctx.emit` never ran. Synthesize a `SameAs` stand-in
         //     and bind the slot.
-        //   - Synthetic-bound: a forward reference reached `ensure_box`
-        //     first; `ensure_box` minted a `SameAs` stand-in into
+        //   - Synthetic-bound: a forward reference reached `materialize_box_at`
+        //     first; `materialize_box_at` minted a `SameAs` stand-in into
         //     `ctx.resop_refs[idx]` and `bind_op`'ed it. When `emit`
         //     never arrived to upgrade the binding to a real producer,
         //     the stand-in itself is the chain target carrier.
@@ -3648,7 +3648,7 @@ impl Optimizer {
         ctx: &mut OptContext,
     ) {
         // The canonical `OpRc` is threaded in so a later slice can collapse
-        // `ensure_box(op.pos.get())` to `BoxRef::from_bound_op(op_rc)`. For now
+        // `materialize_box_at(op.pos.get())` to `BoxRef::from_bound_op(op_rc)`. For now
         // the body reads through this `&Op` view (Deref), behaviour-identical.
         let op: &Op = op_rc;
         // 5: Box.type lives intrinsically on `OpRef.ty()` (variant
@@ -3681,19 +3681,22 @@ impl Optimizer {
             // producer is registered yet — a short-preamble / bridge operand
             // dispatched mid-pass through `send_extra_operation`, whose
             // producer is neither emitted nor in `resop_refs` —
-            // `get_box_replacement_box` returns None. `ensure_box` then mints
-            // and registers the canonical `_forwarded` host (the "Box always
-            // exists" invariant, resoperation.py:233) and we walk it to its
-            // terminal, so the stored arg is BOUND on every dispatch path.
-            // This lets operand readers resolve through `get_box_replacement`
-            // (the minted host is now in `resop_refs`) instead of needing
-            // their own `ensure_box` mint fallback.
+            // `get_box_replacement_box` returns None. `materialize_box_at`
+            // then mints and registers the canonical `_forwarded` host (the
+            // "Box always exists" invariant, resoperation.py:233) and we walk
+            // it to its terminal, so the stored arg is BOUND on every dispatch
+            // path. A sentinel operand keeps its unbound arg box (const
+            // operands resolve through the `Some` arm above).
             let resolved = match ctx.get_box_replacement_box(arg.to_opref()) {
                 Some(b) => b,
-                None => ctx
-                    .ensure_box(arg.to_opref())
-                    .map(|b| b.get_box_replacement(false))
-                    .unwrap_or_else(|| arg.clone()),
+                None => {
+                    let argref = arg.to_opref();
+                    if argref.is_none() {
+                        arg.clone()
+                    } else {
+                        ctx.materialize_box_at(argref).get_box_replacement(false)
+                    }
+                }
             };
             resolved_op.setarg(i, resolved);
         }
@@ -4041,7 +4044,7 @@ impl Optimizer {
             // `optimizer.py:137-151` where `isinstance(opinfo,
             // InstancePtrInfo)` mutates in place.
             // optimizer.py:137-152 `make_constant_class` always updates
-            // `_forwarded` — `ensure_box` materializes the Box so the
+            // `_forwarded` — `materialize_box_at` materializes the Box so the
             // write is never silently skipped. Same materializer feeds
             // the `last_guard_pos` read; `info.py:91-103
             // get_last_guard_pos` reads the PtrInfo field (None if no
@@ -4588,12 +4591,8 @@ mod tests {
                     // Replace with first arg
                     let old = op.pos.get();
                     let new = op.arg(0).to_opref();
-                    let b_old = ctx
-                        .ensure_box(old)
-                        .expect("body-namespace OpRef must have a BoxRef slot");
-                    let b_new = ctx
-                        .ensure_box(new)
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = ctx.materialize_box_at(old);
+                    let b_new = ctx.materialize_box_at(new);
                     ctx.make_equal_to(&b_old, &b_new);
                     return OptimizationResult::Remove;
                 }
@@ -6004,9 +6003,7 @@ mod tests {
         // for the test, every slot uses Ref to match the producer-side shape
         // (`inputarg_from_tp` per opencoder.py:259 with all Ref args).
         let mut ctx = OptContext::with_inputarg_types(32, &vec![Type::Ref; 1024]);
-        let b10 = ctx
-            .ensure_box(OpRef::int_op(10))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b10 = ctx.materialize_box_at(OpRef::int_op(10));
         ctx.set_ptr_info(
             &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {
@@ -6016,16 +6013,10 @@ mod tests {
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
         );
-        let b11 = ctx
-            .ensure_box(OpRef::int_op(11))
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let b20 = ctx
-            .ensure_box(OpRef::int_op(20))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b11 = ctx.materialize_box_at(OpRef::int_op(11));
+        let b20 = ctx.materialize_box_at(OpRef::int_op(20));
         ctx.make_equal_to(&b11, &b20);
-        let b20 = ctx
-            .ensure_box(OpRef::int_op(20))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b20 = ctx.materialize_box_at(OpRef::int_op(20));
         ctx.set_ptr_info(
             &b20,
             PtrInfo::VirtualStruct(VirtualStructInfo {
@@ -6075,9 +6066,7 @@ mod tests {
                 .with_all_fielddescrs(vec![field_descr_typed]),
         );
         let mut ctx = OptContext::with_inputarg_types(16, &[Type::Ref]);
-        let b10 = ctx
-            .ensure_box(OpRef::ref_op(10))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b10 = ctx.materialize_box_at(OpRef::ref_op(10));
         ctx.set_ptr_info(
             &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4548,7 +4548,12 @@ mod tests {
     struct AddZeroElimination;
 
     impl Optimization for AddZeroElimination {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if op.opcode == OpCode::IntAdd {
                 // Check if second arg is constant 0
                 if let Some(0) = ctx
@@ -4586,7 +4591,12 @@ mod tests {
     }
 
     impl Optimization for AddVirtualInputsOnce {
-        fn propagate_forward(&mut self, _op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            _op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if !self.added {
                 ctx.num_inputs += 2;
                 self.added = true;
@@ -4600,7 +4610,12 @@ mod tests {
     }
 
     impl Optimization for RemoveAsConstant {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if op.pos.get() == self.target {
                 ctx.make_constant(op.pos.get(), majit_ir::Value::Int(self.value));
                 return OptimizationResult::Remove;
@@ -4618,7 +4633,12 @@ mod tests {
     }
 
     impl Optimization for FlushCounter {
-        fn propagate_forward(&mut self, _op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            _op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            _ctx: &mut OptContext,
+        ) -> OptimizationResult {
             OptimizationResult::PassOn
         }
 
@@ -4637,7 +4657,12 @@ mod tests {
     }
 
     impl Optimization for RemoveAsTypedConstant {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if op.pos.get() == self.target {
                 ctx.make_constant(op.pos.get(), self.value.clone());
                 return OptimizationResult::Remove;
@@ -4656,7 +4681,12 @@ mod tests {
     }
 
     impl Optimization for MarkAsTypedConstantButKeep {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if op.pos.get() == self.target {
                 ctx.make_constant(op.pos.get(), self.value.clone());
             }
@@ -4778,7 +4808,12 @@ mod tests {
     }
 
     impl Optimization for QueueForceLikeExtraOps {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if !self.queued && op.opcode == OpCode::IntAdd {
                 self.queued = true;
 
@@ -4806,7 +4841,12 @@ mod tests {
     }
 
     impl Optimization for QueueRestartCandidate {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if !self.queued && op.opcode == OpCode::IntMul {
                 self.queued = true;
                 ctx.emit_extra(
@@ -4827,7 +4867,12 @@ mod tests {
     }
 
     impl Optimization for CountRestartedIntSub {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            _ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if op.opcode == OpCode::IntSub {
                 self.hits.set(self.hits.get() + 1);
             }
@@ -4842,7 +4887,12 @@ mod tests {
     struct RestartIntAddAsSub;
 
     impl Optimization for RestartIntAddAsSub {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            _ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if op.opcode == OpCode::IntAdd {
                 let mut restarted = Op::new(OpCode::IntSub, &[op.arg(0), op.arg(1)]);
                 restarted.pos.set(op.pos.get());
@@ -5498,7 +5548,12 @@ mod tests {
     }
 
     impl Optimization for QueueTwoForceLikePairs {
-        fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        fn propagate_forward(
+            &mut self,
+            op: &Op,
+            _op_rc: &majit_ir::OpRc,
+            ctx: &mut OptContext,
+        ) -> OptimizationResult {
             if !self.queued && op.opcode == OpCode::IntAdd {
                 self.queued = true;
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1740,7 +1740,7 @@ impl Optimizer {
         // `getintbound` side effect (`optimizer.py:110-113` unbounded
         // install) materializes on first access, matching upstream's
         // Box-always-exists invariant.
-        let Some(b) = ctx.ensure_box(opref) else {
+        let Some(b) = ctx.get_box_replacement_box(opref) else {
             return crate::optimizeopt::INFO_UNKNOWN;
         };
         ctx.getnullness(&b)
@@ -3694,11 +3694,8 @@ impl Optimizer {
             current_op.opcode,
             OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF
         ) {
-            let old = current_op.pos.get();
             let new = current_op.arg(0).to_opref();
-            let b_old = ctx
-                .ensure_box(old)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_new = ctx.get_box_replacement(new);
             ctx.make_equal_to(&b_old, &b_new);
             return;
@@ -4033,7 +4030,7 @@ impl Optimizer {
             // the `last_guard_pos` read; `info.py:91-103
             // get_last_guard_pos` reads the PtrInfo field (None if no
             // PtrInfo, mapped to -1 = "no guard recorded").
-            let pp_obj_box = ctx.ensure_box(pp.obj);
+            let pp_obj_box = ctx.get_box_replacement_box(pp.obj);
             let old_guard_pos = pp_obj_box
                 .as_ref()
                 .and_then(|b| ctx.last_guard_pos(b))
@@ -4458,10 +4455,10 @@ impl Optimizer {
             return op;
         }
         // optimizer.py:756-757: b = self.getintbound(op.getarg(0)); if b.is_bool()
-        let b = ctx
-            .ensure_box(arg0.to_opref())
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b = {
+            let b = ctx.get_box_replacement(arg0.to_opref());
+            ctx.getintbound_handle(&b).borrow().clone()
+        };
         if !b.is_bool() {
             return op;
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3612,7 +3612,12 @@ impl Optimizer {
         }
     }
 
-    fn propagate_from_pass(&mut self, start_pass: usize, op: &majit_ir::OpRc, ctx: &mut OptContext) {
+    fn propagate_from_pass(
+        &mut self,
+        start_pass: usize,
+        op: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) {
         self.propagate_from_pass_range(start_pass, self.passes.len(), op, ctx);
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -691,7 +691,7 @@ impl Optimizer {
                 let pos = ctx.inputarg_base + iv.inputarg_index as u32;
                 let raw =
                     OpRef::input_arg_typed(pos, ctx.inputarg_type_at_strict(iv.inputarg_index));
-                let virtual_head = ctx.get_box_replacement(raw);
+                let virtual_head = ctx.get_box_replacement(raw).to_opref();
                 walk_visited.insert(top_key, virtual_head);
                 let mut fields = Vec::new();
                 for (descr, field_info) in &iv.fields {
@@ -1083,7 +1083,7 @@ impl Optimizer {
                     });
                 *label_slot += 1;
                 Self::apply_imported_virtual_state(info, opref, ctx);
-                ctx.get_box_replacement(opref)
+                ctx.get_box_replacement(opref).to_opref()
             }
         }
     }
@@ -1471,14 +1471,14 @@ impl Optimizer {
     /// longer needed. Mirrors force_box_inline (mod.rs) contract.
     pub fn force_box(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
         // optimizer.py:346: op = get_box_replacement(op)
-        let resolved = ctx.get_box_replacement(opref);
+        let resolved = ctx.get_box_replacement(opref).to_opref();
         // optimizer.py:351-359: potential_extra_ops.pop(op)
         // → sb.add_preamble_op(preamble_op)
         let tracked = ctx
             .take_potential_extra_op(resolved)
             .or_else(|| ctx.take_potential_extra_op(opref));
         if let Some(preamble_op) = tracked {
-            let resolved_for_pop = ctx.get_box_replacement(preamble_op.op);
+            let resolved_for_pop = ctx.get_box_replacement(preamble_op.op).to_opref();
             if let Some(builder) = ctx.active_short_preamble_producer_mut() {
                 builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
             } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {
@@ -1505,7 +1505,7 @@ impl Optimizer {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
             let forced = info.force_box(resolved, ctx);
-            return ctx.get_box_replacement(forced);
+            return ctx.get_box_replacement(forced).to_opref();
         }
         resolved
     }
@@ -1536,7 +1536,7 @@ impl Optimizer {
     /// `force_at_the_end_of_preamble` directly should route through
     /// this wrapper for RPython structural parity (unroll.py:126-127).
     pub fn force_box_for_end_of_preamble(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
-        let resolved = ctx.get_box_replacement(opref);
+        let resolved = ctx.get_box_replacement(opref).to_opref();
         match ctx.opref_type(resolved) {
             // optimizer.py:307-313 — `box.type == 'r'` path.
             Some(majit_ir::Type::Ref) => {
@@ -1586,7 +1586,7 @@ impl Optimizer {
         ctx: &mut OptContext,
         rec: &mut majit_ir::vec_set::VecSet<OpRef>,
     ) -> OpRef {
-        let resolved = ctx.get_box_replacement(opref);
+        let resolved = ctx.get_box_replacement(opref).to_opref();
         let resolved_box = ctx.get_box_replacement_box(opref);
         let Some(mut info) = resolved_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) else {
             return resolved;
@@ -2304,7 +2304,7 @@ impl Optimizer {
                         let raw = OpRef::input_arg_typed(raw_pos, tp);
                         eprintln!(
                             "[jit] import_state_resolved: raw={raw:?} resolved={:?}",
-                            ctx.get_box_replacement(raw)
+                            ctx.get_box_replacement(raw).to_opref()
                         );
                     }
                 }
@@ -2400,7 +2400,7 @@ impl Optimizer {
             let resolved_args: Vec<OpRef> = terminal_op
                 .getarglist()
                 .iter()
-                .map(|arg| ctx.get_box_replacement(arg.to_opref()))
+                .map(|arg| ctx.get_box_replacement(arg.to_opref()).to_opref())
                 .collect();
             for &resolved in &resolved_args {
                 self.force_box_for_end_of_preamble(resolved, &mut ctx);
@@ -2412,7 +2412,7 @@ impl Optimizer {
             //   for i in range(op.numargs()): op.setarg(i, force_box(...))
             for i in 0..terminal_op.num_args() {
                 let arg = terminal_op.arg(i);
-                let resolved = ctx.get_box_replacement(arg.to_opref());
+                let resolved = ctx.get_box_replacement(arg.to_opref()).to_opref();
                 let expected_ref =
                     i < inputargs.len() && inputargs[i].ty() == Some(majit_ir::Type::Ref);
                 // setup_optimizations seeds `trace_inputargs` into
@@ -2458,7 +2458,7 @@ impl Optimizer {
             for i in force_needed {
                 let original = terminal_op.arg(i);
                 let forced = self.force_box(original.to_opref(), &mut ctx);
-                terminal_op.setarg(i, BoxRef::from_opref(ctx.get_box_replacement(forced)));
+                terminal_op.setarg(i, ctx.get_box_replacement(forced));
             }
             if self.skip_flush {
                 // flush=False: store for caller to consume.
@@ -2564,7 +2564,7 @@ impl Optimizer {
                 .map(|v| v.iter().map(|b| b.to_opref()).collect())
                 .unwrap_or_else(|| {
                     jump.getarglist().iter()
-                        .map(|a| ctx.get_box_replacement(a.to_opref()))
+                        .map(|a| ctx.get_box_replacement(a.to_opref()).to_opref())
                         .collect()
                 });
             let mut resolved_args = original_jump_args.clone();
@@ -2709,7 +2709,7 @@ impl Optimizer {
             // do in RPython.
             let post_force_args: Vec<OpRef> = resolved_args
                 .iter()
-                .map(|&a| ctx.get_box_replacement(a))
+                .map(|&a| ctx.get_box_replacement(a).to_opref())
                 .collect();
             let preview_virtual_state =
                 crate::optimizeopt::virtualstate::export_state(&post_force_args, &ctx);
@@ -2769,7 +2769,7 @@ impl Optimizer {
             ctx.exported_short_boxes = produced
                 .into_iter()
                 .map(|(result, produced)| {
-                    let canonical_result = ctx.get_box_replacement(result);
+                    let canonical_result = ctx.get_box_replacement(result).to_opref();
                     let mut preamble_op = produced.preamble_op;
                     // RPython parity: key and preamble_op.pos must be the
                     // same resolved value. Independent get_box_replacement
@@ -2780,14 +2780,12 @@ impl Optimizer {
                     for i in 0..preamble_op.num_args() {
                         preamble_op.setarg(
                             i,
-                            BoxRef::from_opref(
-                                ctx.get_box_replacement(preamble_op.arg(i).to_opref()),
-                            ),
+                            ctx.get_box_replacement(preamble_op.arg(i).to_opref()),
                         );
                     }
                     if let Some(fail_args) = preamble_op.fail_args_mut() {
                         for arg in fail_args {
-                            *arg = BoxRef::from_opref(ctx.get_box_replacement(arg.to_opref()));
+                            *arg = ctx.get_box_replacement(arg.to_opref());
                         }
                     }
                     crate::optimizeopt::shortpreamble::PreambleOp {
@@ -3660,14 +3658,6 @@ impl Optimizer {
             let resolved = ctx
                 .get_box_replacement_box(arg.to_opref())
                 .unwrap_or_else(|| arg.clone());
-            // The canonical box's OpRef identity must equal the OpRef-path
-            // bridge result so OpRef-keyed consumers (box_pool, VecAssoc) see
-            // the same key; only the carried _forwarded info is added.
-            debug_assert_eq!(
-                resolved.to_opref(),
-                ctx.get_box_replacement(arg.to_opref()),
-                "resolver canonical box to_opref diverged from OpRef bridge",
-            );
             resolved_op.setarg(i, resolved);
         }
 
@@ -3957,7 +3947,7 @@ impl Optimizer {
         //       if opinfo is not None and opinfo.is_constant():
         //           op.set_forwarded(ConstInt(opinfo.get_constant_int()))
         if op.result_type() == majit_ir::Type::Int {
-            let replaced = ctx.get_box_replacement(emitted);
+            let replaced = ctx.get_box_replacement(emitted).to_opref();
             // BoxRef shim — peek_intbound_box takes &BoxRef per optimizer.py:99-113.
             let bound = ctx
                 .get_box_replacement_box(emitted)
@@ -4119,7 +4109,8 @@ impl Optimizer {
                             // (caught at pyjitpl/mod.rs:3454) on
                             // either invariant violation rather
                             // than silently coercing to 0.
-                            let boxindex = ctx.get_box_replacement(pf_op.arg(1).to_opref());
+                            let boxindex =
+                                ctx.get_box_replacement(pf_op.arg(1).to_opref()).to_opref();
                             let idx = match ctx
                                 .get_box_replacement_box(boxindex)
                                 .and_then(|cb| cb.const_int())
@@ -4137,8 +4128,8 @@ impl Optimizer {
                         majit_ir::GuardPendingFieldEntry {
                             descr: pf_op.getdescr(),
                             item_index,
-                            target: ctx.get_box_replacement(target),
-                            value: ctx.get_box_replacement(value),
+                            target: ctx.get_box_replacement(target).to_opref(),
+                            value: ctx.get_box_replacement(value).to_opref(),
                             target_tagged: majit_ir::resumedata::UNASSIGNED,
                             value_tagged: majit_ir::resumedata::UNASSIGNED,
                         }
@@ -4375,7 +4366,7 @@ impl Optimizer {
         let mut loopinvariant_results = Vec::new();
         for pass in &self.passes {
             for (func_ptr, result) in pass.serialize_optrewrite() {
-                let replaced = ctx.get_box_replacement(result);
+                let replaced = ctx.get_box_replacement(result).to_opref();
                 loopinvariant_results.push((func_ptr, replaced));
             }
         }
@@ -5954,7 +5945,10 @@ mod tests {
         // The virtual is forced to a concrete allocation; the returned ref
         // is the allocation's position, which ctx.get_box_replacement(OpRef::int_op(10))
         // should resolve to.
-        assert_eq!(result, ctx.get_box_replacement(OpRef::int_op(10)));
+        assert_eq!(
+            result,
+            ctx.get_box_replacement(OpRef::int_op(10)).to_opref()
+        );
         // After forcing, the struct's ptr_info reflects that field 1
         // (originally OpRef::int_op(11), forwarded to OpRef::int_op(20)) has been recursively forced.
         let result_box = ctx.get_box_replacement_box(result);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1448,7 +1448,8 @@ impl Optimizer {
     /// a new operation from the trace. Used by passes that need to
     /// inject additional operations.
     pub fn send_extra_operation(&mut self, op: &Op, ctx: &mut OptContext) {
-        self.propagate_from_pass(0, op, ctx);
+        let op_rc = std::rc::Rc::new(op.clone());
+        self.propagate_from_pass(0, &op_rc, ctx);
     }
 
     /// RPython optimizer.py: emit_extra(op, emit=False) parity.
@@ -1460,7 +1461,8 @@ impl Optimizer {
         op: &Op,
         ctx: &mut OptContext,
     ) {
-        self.propagate_from_pass(after_pass_idx + 1, op, ctx);
+        let op_rc = std::rc::Rc::new(op.clone());
+        self.propagate_from_pass(after_pass_idx + 1, &op_rc, ctx);
     }
 
     /// optimizer.py:345-364: force_box — force a virtual to be materialized.
@@ -3592,7 +3594,7 @@ impl Optimizer {
     /// The Emit variant's position tracking is handled by each pass
     /// and OptContext. Adding automatic replacement mapping here
     /// causes spurious forwarding that breaks heap/guard tests.
-    fn propagate_one(&mut self, op: &Op, ctx: &mut OptContext) {
+    fn propagate_one(&mut self, op: &majit_ir::OpRc, ctx: &mut OptContext) {
         self.propagate_from_pass(0, op, ctx);
     }
 
@@ -3610,7 +3612,7 @@ impl Optimizer {
         }
     }
 
-    fn propagate_from_pass(&mut self, start_pass: usize, op: &Op, ctx: &mut OptContext) {
+    fn propagate_from_pass(&mut self, start_pass: usize, op: &majit_ir::OpRc, ctx: &mut OptContext) {
         self.propagate_from_pass_range(start_pass, self.passes.len(), op, ctx);
     }
 
@@ -3626,9 +3628,13 @@ impl Optimizer {
         &mut self,
         start_pass: usize,
         end_pass: usize,
-        op: &Op,
+        op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) {
+        // The canonical `OpRc` is threaded in so a later slice can collapse
+        // `ensure_box(op.pos.get())` to `BoxRef::from_bound_op(op_rc)`. For now
+        // the body reads through this `&Op` view (Deref), behaviour-identical.
+        let op: &Op = op_rc;
         // 5: Box.type lives intrinsically on `OpRef.ty()` (variant
         // tag, history.py:220 + resoperation.py:1693 parity) and on
         // `Op.type_` once the op lands in `new_operations`, so the
@@ -3748,7 +3754,8 @@ impl Optimizer {
                     );
                     // 5: Restart's new op carries `Op.type_` from
                     // construction; no side-table refresh needed.
-                    self.propagate_from_pass_range(0, end_pass, &op, ctx);
+                    let restart_op_rc = std::rc::Rc::new(op);
+                    self.propagate_from_pass_range(0, end_pass, &restart_op_rc, ctx);
                     // Run any postprocess callbacks accumulated in the outer
                     // chain (passes that already returned PassOn for the
                     // original op before the Restart-returning pass fired).

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3665,9 +3665,24 @@ impl Optimizer {
         // Box object itself. A from_opref box is unbound and drops the chain.
         for i in 0..resolved_op.num_args() {
             let arg = resolved_op.arg(i);
-            let resolved = ctx
-                .get_box_replacement_box(arg.to_opref())
-                .unwrap_or_else(|| arg.clone());
+            // Resolve each operand to its canonical bound terminal. When no
+            // producer is registered yet — a short-preamble / bridge operand
+            // dispatched mid-pass through `send_extra_operation`, whose
+            // producer is neither emitted nor in `resop_refs` —
+            // `get_box_replacement_box` returns None. `ensure_box` then mints
+            // and registers the canonical `_forwarded` host (the "Box always
+            // exists" invariant, resoperation.py:233) and we walk it to its
+            // terminal, so the stored arg is BOUND on every dispatch path.
+            // This lets operand readers resolve through `get_box_replacement`
+            // (the minted host is now in `resop_refs`) instead of needing
+            // their own `ensure_box` mint fallback.
+            let resolved = match ctx.get_box_replacement_box(arg.to_opref()) {
+                Some(b) => b,
+                None => ctx
+                    .ensure_box(arg.to_opref())
+                    .map(|b| b.get_box_replacement(false))
+                    .unwrap_or_else(|| arg.clone()),
+            };
             resolved_op.setarg(i, resolved);
         }
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1507,7 +1507,7 @@ impl Optimizer {
             // installs a non-virtual (Instance/Struct) at the alloc_ref.
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
-            let forced = info.force_box(resolved, ctx);
+            let forced = info.force_box(resolved_box, ctx);
             return ctx.get_box_replacement(forced).to_opref();
         }
         resolved

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -791,18 +791,19 @@ impl Optimizer {
         // Keyed by the virtual head's Box identity. `ensure_box` is
         // position-stable (a head position resolves to one canonical Box),
         // so two entries sharing a head dedupe by `Rc::ptr_eq`. The head is
-        // always a NEW (virtual-alloc) ResOp, so `ensure_box` returns
-        // `Some`; a `None` head is left un-deduped, which only costs a
-        // redundant idempotent `set_ptr_info`.
+        // always a NEW (virtual-alloc) ResOp with a producer, so
+        // `get_box_replacement` returns the memoized bound Box that dedupes;
+        // a producer-less head resolves to a fresh unbound box that never
+        // matches, leaving it un-deduped (only costs a redundant idempotent
+        // `set_ptr_info`).
         let mut installed_heads: majit_ir::vec_set::VecSet<crate::r#box::BoxRef> =
             majit_ir::vec_set::VecSet::new();
         for entry in entries {
-            if let Some(head_key) = ctx.ensure_box(entry.head) {
-                if installed_heads.contains(&head_key) {
-                    continue;
-                }
-                installed_heads.insert(head_key);
+            let head_key = ctx.get_box_replacement(entry.head);
+            if installed_heads.contains(&head_key) {
+                continue;
             }
+            installed_heads.insert(head_key);
             if std::env::var_os("MAJIT_LOG").is_some() {
                 eprintln!(
                     "[jit] install_imported_virtual head={:?} fields={:?}",
@@ -2665,9 +2666,7 @@ impl Optimizer {
                                     let b_ff = ctx
                                         .ensure_box(ff)
                                         .expect("body-namespace OpRef must have a BoxRef slot");
-                                    let b_orig = ctx
-                                        .ensure_box(orig_field)
-                                        .expect("body-namespace OpRef must have a BoxRef slot");
+                                    let b_orig = ctx.get_box_replacement(orig_field);
                                     ctx.make_equal_to(&b_ff, &b_orig);
                                     field.1 = ff;
                                 }
@@ -3685,9 +3684,7 @@ impl Optimizer {
             let b_old = ctx
                 .ensure_box(old)
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_new = ctx
-                .ensure_box(new)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_new = ctx.get_box_replacement(new);
             ctx.make_equal_to(&b_old, &b_new);
             return;
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3760,6 +3760,11 @@ impl Optimizer {
                     // 5: Restart's new op carries `Op.type_` from
                     // construction; no side-table refresh needed.
                     let restart_op_rc = std::rc::Rc::new(op);
+                    // replace_op_with parity: the rewrite supersedes the
+                    // original as the producer at its position so the
+                    // re-dispatch reads/writes one canonical `_forwarded` host
+                    // and the bound it accumulates survives emit's catch-up.
+                    ctx.supersede_restart_producer(&restart_op_rc);
                     self.propagate_from_pass_range(0, end_pass, &restart_op_rc, ctx);
                     // Run any postprocess callbacks accumulated in the outer
                     // chain (passes that already returned PassOn for the

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -835,7 +835,7 @@ impl Optimization for OptPure {
         self.cache = RecentPureOpTable::new(limit);
     }
 
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         // optimizer.py: pure_from_args1 parity — consume pending registrations
         // from rewrite pass (CAST_*, CONVERT_* reverse-pure relationships)
         // and virtualize pass (ARRAYLEN_GC with array descr keying per
@@ -1753,7 +1753,7 @@ mod tests {
         );
         let mut op0 = op0;
         op0.pos.set(OpRef::int_op(2));
-        let result0 = pass.propagate_forward(&op0, &mut ctx);
+        let result0 = pass.propagate_forward(&op0, &std::rc::Rc::new(op0.clone()), &mut ctx);
         assert!(matches!(result0, OptimizationResult::PassOn));
 
         // Simulate: op1 = int_add(a, b) with same args
@@ -1766,7 +1766,7 @@ mod tests {
         );
         let mut op1 = op1;
         op1.pos.set(OpRef::int_op(3));
-        let result1 = pass.propagate_forward(&op1, &mut ctx);
+        let result1 = pass.propagate_forward(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx);
         assert!(matches!(result1, OptimizationResult::Remove));
     }
 
@@ -2274,7 +2274,7 @@ mod tests {
         pass.setup();
 
         assert_eq!(ctx.constant_fold(&op), Some(Value::Int(123)));
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(0))
@@ -2306,7 +2306,7 @@ mod tests {
         pass.setup();
 
         assert_eq!(ctx.constant_fold(&op), Some(Value::Float(3.5)));
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::float_op(0))
@@ -2343,7 +2343,7 @@ mod tests {
             ctx.constant_fold(&op),
             Some(Value::Ref(GcRef(0x1234_5678usize)))
         );
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::ref_op(0))
@@ -2714,7 +2714,7 @@ mod tests {
         );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(call_descr);
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -2737,7 +2737,7 @@ mod tests {
             ],
         );
         op.pos.set(OpRef::int_op(2));
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
 
         let mut sb = crate::optimizeopt::shortpreamble::ShortBoxes::with_label_args(&[
@@ -2782,7 +2782,7 @@ mod tests {
                 majit_ir::OopSpecIndex::None,
             ),
         ));
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         match result {
             OptimizationResult::Emit(emitted) => assert_eq!(emitted.opcode, OpCode::CallI),
             other => panic!("expected emitted demoted call, got {other:?}"),
@@ -2831,14 +2831,14 @@ mod tests {
             ),
         ));
         // OptRewrite demotes CallLoopinvariantI → CallI
-        let rewrite_result = rewrite.propagate_forward(&op, &mut ctx);
+        let rewrite_result = rewrite.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         let demoted = match rewrite_result {
             OptimizationResult::Emit(emitted) => emitted,
             other => panic!("expected OptRewrite to emit demoted call, got {other:?}"),
         };
         assert_eq!(demoted.opcode, OpCode::CallI);
         // OptPure sees the demoted CallI
-        let result = pass.propagate_forward(&demoted, &mut ctx);
+        let result = pass.propagate_forward(&demoted, &std::rc::Rc::new(demoted.clone()), &mut ctx);
         match result {
             OptimizationResult::Emit(emitted) => assert_eq!(emitted.opcode, OpCode::CallI),
             OptimizationResult::PassOn => {} // PassOn is also acceptable

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -799,7 +799,7 @@ impl OptPure {
         if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
-            let forced = info.force_box(resolved, ctx);
+            let forced = info.force_box(resolved_box, ctx);
             return ctx
                 .get_box_replacement_box(forced)
                 .map(|b| b.to_opref())

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -310,6 +310,12 @@ pub struct OptPure {
     /// Postponed OVF operation: INT_ADD_OVF, INT_SUB_OVF, INT_MUL_OVF.
     /// pure.py: postponed_op — deferred until GUARD_NO_OVERFLOW is seen.
     postponed_op: Option<Op>,
+    /// Bound `BoxRef` of `postponed_op`, captured from the live `OpRc` at
+    /// postponement. The OVF op is `Remove`d before emit, so its head box
+    /// is never bound by the emit path; capturing it here (where the op
+    /// object is live) gives `make_equal_to` a bound receiver without an
+    /// `ensure_box` round-trip through the opref.
+    postponed_box: Option<crate::r#box::BoxRef>,
     /// Indices into new_operations of emitted CALL_PURE ops.
     /// pure.py: call_pure_positions — tracked for short preamble generation.
     call_pure_positions: Vec<usize>,
@@ -358,6 +364,7 @@ impl OptPure {
         OptPure {
             cache: RecentPureOpTable::new(crate::jit::PARAMETERS.pureop_historylength as usize),
             postponed_op: None,
+            postponed_box: None,
             call_pure_positions: Vec::new(),
             short_preamble_pure_ops: Vec::new(),
             last_emitted_was_removed: false,
@@ -867,11 +874,16 @@ impl Optimization for OptPure {
         // GUARD_NO_OVERFLOW, so we can try CSE on the OVF op + guard pair.
         if op.opcode.is_ovf() {
             self.postponed_op = Some(op.clone());
+            self.postponed_box = Some(BoxRef::from_bound_op(op_rc));
             return OptimizationResult::Remove;
         }
 
         // Handle the postponed OVF op when we see GUARD_NO_OVERFLOW.
         if let Some(mut postponed) = self.postponed_op.take() {
+            let postponed_box = self
+                .postponed_box
+                .take()
+                .expect("postponed_box is set whenever postponed_op is set");
             if op.opcode == OpCode::GuardNoOverflow {
                 // pure.py:126-136 — only call `constant_fold` when every
                 // arg has resolved to a `Const*` via `get_constant_box`
@@ -897,9 +909,7 @@ impl Optimization for OptPure {
                 // pure.py:50-55: force_preamble_op replaces the OVF op
                 // with the preamble's cached result.
                 if let Some(cached_ref) = self.force_preamble_op(&postponed, ctx) {
-                    let b_old = ctx
-                        .ensure_box(postponed.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = postponed_box.clone();
                     let b_cached = ctx.get_box_replacement(cached_ref);
                     ctx.make_equal_to(&b_old, &b_cached);
                     self.last_emitted_was_removed = true;
@@ -913,9 +923,7 @@ impl Optimization for OptPure {
                 let key = PureOpKey::from_op(&postponed);
                 if let Some(cached_ref) = self.lookup_pure(&key, ctx) {
                     if Self::_can_reuse_oldop(postponed.opcode, postponed.opcode, true) {
-                        let b_old = ctx
-                            .ensure_box(postponed.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = postponed_box.clone();
                         let b_cached = ctx.get_box_replacement(cached_ref);
                         ctx.make_equal_to(&b_old, &b_cached);
                         self.last_emitted_was_removed = true;
@@ -1208,6 +1216,7 @@ impl Optimization for OptPure {
         let limit = self.cache.history_length();
         self.cache = RecentPureOpTable::new(limit);
         self.postponed_op = None;
+        self.postponed_box = None;
         self.call_pure_positions.clear();
         self.short_preamble_pure_ops.clear();
         self.last_emitted_was_removed = false;
@@ -1697,6 +1706,7 @@ mod tests {
         opt.add_pass(Box::new(OptPure {
             cache: RecentPureOpTable::new(16),
             postponed_op: None,
+            postponed_box: None,
             call_pure_positions: Vec::new(),
             short_preamble_pure_ops: Vec::new(),
             last_emitted_was_removed: false,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -913,10 +913,7 @@ impl Optimization for OptPure {
                         let b_old = ctx
                             .ensure_box(postponed.pos.get())
                             .expect("body-namespace OpRef must have a BoxRef slot");
-                        let b_cached = ctx
-                            .get_box_replacement_box(cached_ref)
-                            .or_else(|| ctx.ensure_box(cached_ref))
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_cached = ctx.get_box_replacement(cached_ref);
                         ctx.make_equal_to(&b_old, &b_cached);
                         self.last_emitted_was_removed = true;
                         return OptimizationResult::Remove; // guard also removed
@@ -1070,10 +1067,7 @@ impl Optimization for OptPure {
             // CSE: exact same operation already computed?
             if let Some(cached_ref) = self.lookup_pure(&key, ctx) {
                 let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
-                let b_cached = ctx
-                    .get_box_replacement_box(cached_ref)
-                    .or_else(|| ctx.ensure_box(cached_ref))
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_cached = ctx.get_box_replacement(cached_ref);
                 ctx.make_equal_to(&b_old, &b_cached);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;
@@ -1119,10 +1113,7 @@ impl Optimization for OptPure {
                     ) {
                         let cached_src = old_op.pos.get();
                         let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
-                        let b_cached = ctx
-                            .get_box_replacement_box(cached_src)
-                            .or_else(|| ctx.ensure_box(cached_src))
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_cached = ctx.get_box_replacement(cached_src);
                         ctx.make_equal_to(&b_old, &b_cached);
                         self.last_emitted_was_removed = true;
                         return OptimizationResult::Remove;
@@ -1179,10 +1170,7 @@ impl Optimization for OptPure {
                     }
                 };
                 let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
-                let b_cached = ctx
-                    .get_box_replacement_box(entry_result)
-                    .or_else(|| ctx.ensure_box(entry_result))
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_cached = ctx.get_box_replacement(entry_result);
                 ctx.make_equal_to(&b_old, &b_cached);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;
@@ -1190,10 +1178,7 @@ impl Optimization for OptPure {
             // pure.py:211-220: known_result_call_pure.
             if let Some(result_ref) = self.lookup_known_result(op, start_index, ctx) {
                 let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
-                let b_result = ctx
-                    .get_box_replacement_box(result_ref)
-                    .or_else(|| ctx.ensure_box(result_ref))
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_result = ctx.get_box_replacement(result_ref);
                 ctx.make_equal_to(&b_old, &b_result);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -314,7 +314,7 @@ pub struct OptPure {
     /// postponement. The OVF op is `Remove`d before emit, so its head box
     /// is never bound by the emit path; capturing it here (where the op
     /// object is live) gives `make_equal_to` a bound receiver without an
-    /// `ensure_box` round-trip through the opref.
+    /// `materialize_box_at` round-trip through the opref.
     postponed_box: Option<crate::r#box::BoxRef>,
     /// Indices into new_operations of emitted CALL_PURE ops.
     /// pure.py: call_pure_positions — tracked for short preamble generation.
@@ -2464,9 +2464,7 @@ mod tests {
         let canonical_arg = OpRef::int_op(8);
         let other_arg = OpRef::int_op(9);
         let result = OpRef::int_op(42);
-        let b_query = ctx
-            .ensure_box(query_arg)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_query = ctx.materialize_box_at(query_arg);
         let b_canonical = ctx.get_box_replacement(canonical_arg);
         ctx.make_equal_to(&b_query, &b_canonical);
 

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -900,9 +900,7 @@ impl Optimization for OptPure {
                     let b_old = ctx
                         .ensure_box(postponed.pos.get())
                         .expect("body-namespace OpRef must have a BoxRef slot");
-                    let b_cached = ctx
-                        .ensure_box(cached_ref)
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_cached = ctx.get_box_replacement(cached_ref);
                     ctx.make_equal_to(&b_old, &b_cached);
                     self.last_emitted_was_removed = true;
                     return OptimizationResult::Remove; // guard also removed
@@ -1059,9 +1057,7 @@ impl Optimization for OptPure {
 
             if let Some(cached_ref) = self.force_preamble_op(op, ctx) {
                 let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
-                let b_cached = ctx
-                    .ensure_box(cached_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_cached = ctx.get_box_replacement(cached_ref);
                 ctx.make_equal_to(&b_old, &b_cached);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -783,8 +783,15 @@ impl Default for OptPure {
 
 impl OptPure {
     fn force_box(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
-        let resolved = ctx.get_box_replacement(opref);
+        // Single resolve through the BoxRef terminal; the OpRef view is the
+        // terminal's `to_opref()` (keystone equivalence, #113), so the prior
+        // paired `get_box_replacement` + `get_box_replacement_box` of the
+        // same `opref` was a redundant double walk.
         let resolved_box = ctx.get_box_replacement_box(opref);
+        let resolved = resolved_box
+            .as_ref()
+            .map(|b| b.to_opref())
+            .unwrap_or(opref);
         if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2461,9 +2461,7 @@ mod tests {
         let b_query = ctx
             .ensure_box(query_arg)
             .expect("body-namespace OpRef must have a BoxRef slot");
-        let b_canonical = ctx
-            .ensure_box(canonical_arg)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_canonical = ctx.get_box_replacement(canonical_arg);
         ctx.make_equal_to(&b_query, &b_canonical);
 
         pass.pure_from_args2(OpCode::IntAdd, canonical_arg, other_arg, result);

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -793,7 +793,10 @@ impl OptPure {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
             let forced = info.force_box(resolved, ctx);
-            return ctx.get_box_replacement(forced);
+            return ctx
+                .get_box_replacement_box(forced)
+                .map(|b| b.to_opref())
+                .unwrap_or(forced);
         }
         resolved
     }
@@ -2713,7 +2716,11 @@ mod tests {
         op.setdescr(call_descr);
         let result = pass.propagate_forward(&op, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(OpRef::int_op(2)), OpRef::int_op(1));
+        assert_eq!(
+            ctx.get_box_replacement_box(OpRef::int_op(2))
+                .map(|b| b.to_opref()),
+            Some(OpRef::int_op(1))
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -788,10 +788,7 @@ impl OptPure {
         // paired `get_box_replacement` + `get_box_replacement_box` of the
         // same `opref` was a redundant double walk.
         let resolved_box = ctx.get_box_replacement_box(opref);
-        let resolved = resolved_box
-            .as_ref()
-            .map(|b| b.to_opref())
-            .unwrap_or(opref);
+        let resolved = resolved_box.as_ref().map(|b| b.to_opref()).unwrap_or(opref);
         if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -835,7 +835,12 @@ impl Optimization for OptPure {
         self.cache = RecentPureOpTable::new(limit);
     }
 
-    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         // optimizer.py: pure_from_args1 parity — consume pending registrations
         // from rewrite pass (CAST_*, CONVERT_* reverse-pure relationships)
         // and virtualize pass (ARRAYLEN_GC with array descr keying per
@@ -2812,7 +2817,8 @@ mod tests {
             ),
         ));
         // OptRewrite demotes CallLoopinvariantI → CallI
-        let rewrite_result = rewrite.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
+        let rewrite_result =
+            rewrite.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         let demoted = match rewrite_result {
             OptimizationResult::Emit(emitted) => emitted,
             other => panic!("expected OptRewrite to emit demoted call, got {other:?}"),

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -835,7 +835,7 @@ impl Optimization for OptPure {
         self.cache = RecentPureOpTable::new(limit);
     }
 
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         // optimizer.py: pure_from_args1 parity — consume pending registrations
         // from rewrite pass (CAST_*, CONVERT_* reverse-pure relationships)
         // and virtualize pass (ARRAYLEN_GC with array descr keying per
@@ -1056,9 +1056,7 @@ impl Optimization for OptPure {
             }
 
             if let Some(cached_ref) = self.force_preamble_op(op, ctx) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
                 let b_cached = ctx
                     .ensure_box(cached_ref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1071,9 +1069,7 @@ impl Optimization for OptPure {
 
             // CSE: exact same operation already computed?
             if let Some(cached_ref) = self.lookup_pure(&key, ctx) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
                 let b_cached = ctx
                     .get_box_replacement_box(cached_ref)
                     .or_else(|| ctx.ensure_box(cached_ref))
@@ -1122,9 +1118,7 @@ impl Optimization for OptPure {
                         ctx,
                     ) {
                         let cached_src = old_op.pos.get();
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
                         let b_cached = ctx
                             .get_box_replacement_box(cached_src)
                             .or_else(|| ctx.ensure_box(cached_src))
@@ -1184,9 +1178,7 @@ impl Optimization for OptPure {
                         _ => unreachable!("non-preamble matched index must be Direct"),
                     }
                 };
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
                 let b_cached = ctx
                     .get_box_replacement_box(entry_result)
                     .or_else(|| ctx.ensure_box(entry_result))
@@ -1197,9 +1189,7 @@ impl Optimization for OptPure {
             }
             // pure.py:211-220: known_result_call_pure.
             if let Some(result_ref) = self.lookup_known_result(op, start_index, ctx) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = crate::r#box::BoxRef::from_bound_op(op_rc);
                 let b_result = ctx
                     .get_box_replacement_box(result_ref)
                     .or_else(|| ctx.ensure_box(result_ref))
@@ -2714,7 +2704,13 @@ mod tests {
         );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(call_descr);
-        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
+        // Register the dispatched op as the producer at its position so the
+        // collapsed `from_bound_op(op_rc)` resolves to the same box the test
+        // reads back via `get_box_replacement_box(pos)` (mirrors production
+        // input-op binding).
+        let op_rc = std::rc::Rc::new(op.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op_rc));
+        let result = pass.propagate_forward(&op, &op_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3015,10 +3015,7 @@ impl OptRewrite {
             {
                 if v == 1.0 {
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_v2 = ctx
-                        .get_box_replacement_box(rhs.to_opref())
-                        .or_else(|| ctx.ensure_box(rhs.to_opref()))
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_v2 = ctx.get_box_replacement(rhs.to_opref());
                     ctx.make_equal_to(&b_old, &b_v2);
                     return OptimizationResult::Remove;
                 }
@@ -3556,10 +3553,7 @@ impl Optimization for OptRewrite {
                             LoopInvariantEntry::Direct(r) => r,
                         };
                         let b_old = BoxRef::from_bound_op(op_rc);
-                        let b_cached = ctx
-                            .get_box_replacement_box(cached_result)
-                            .or_else(|| ctx.ensure_box(cached_result))
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_cached = ctx.get_box_replacement(cached_result);
                         ctx.make_equal_to(&b_old, &b_cached);
                         ctx.last_op_removed = true;
                         return OptimizationResult::Remove;

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -172,7 +172,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_ADD.
     /// `x + 0 -> x`, `0 + x -> x`, `x + x -> x << 1`
-    fn optimize_int_add(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_add(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -298,7 +303,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_SUB.
     /// `x - 0 -> x`, `x - x -> 0`
-    fn optimize_int_sub(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_sub(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -492,7 +502,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_MUL.
     /// `x * 0 -> 0`, `x * 1 -> x`, `0 * x -> 0`, `1 * x -> x`
-    fn optimize_int_mul(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_mul(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -624,7 +639,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_FLOORDIV.
     /// `x // 1 -> x`, constant fold when both operands are known.
-    fn optimize_int_floor_div(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_floor_div(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -725,7 +745,12 @@ impl OptRewrite {
     /// Try algebraic simplification for INT_MOD.
     ///
     /// Strength reduction from rpython/jit/metainterp/optimizeopt/intdiv.py.
-    fn optimize_int_mod(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_mod(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -802,7 +827,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_AND.
     /// `x & 0 -> 0`, `x & -1 -> x`
-    fn optimize_int_and(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_and(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -975,7 +1005,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_OR.
     /// `x | 0 -> x`, `x | -1 -> -1`
-    fn optimize_int_or(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_or(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1133,7 +1168,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_XOR.
     /// `x ^ 0 -> x`, `x ^ x -> 0`
-    fn optimize_int_xor(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_xor(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1257,7 +1297,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_LSHIFT.
     /// `x << 0 -> x`
-    fn optimize_int_lshift(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_lshift(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1416,7 +1461,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_RSHIFT.
     /// `x >> 0 -> x`
-    fn optimize_int_rshift(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_rshift(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1524,7 +1574,12 @@ impl OptRewrite {
 
     /// Try algebraic simplification for UINT_RSHIFT.
     /// `x >>> 0 -> x`
-    fn optimize_uint_rshift(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_uint_rshift(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1611,7 +1666,12 @@ impl OptRewrite {
     // ── Unary operations ──
 
     /// Constant fold or simplify INT_NEG.
-    fn optimize_int_neg(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_neg(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         if let Some(a) = ctx
@@ -1643,7 +1703,12 @@ impl OptRewrite {
     }
 
     /// Constant fold or simplify INT_INVERT.
-    fn optimize_int_invert(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_invert(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         if let Some(a) = ctx
@@ -1687,7 +1752,12 @@ impl OptRewrite {
     ///         self.make_equal_to(op, op.getarg(0))
     ///         return
     ///     return self._optimize_nullness(op, op.getarg(0), True)
-    fn optimize_int_is_true(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_is_true(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         // rewrite.py:505-510 optimize_INT_IS_TRUE:
@@ -1869,7 +1939,12 @@ impl OptRewrite {
     }
 
     /// Constant fold INT_FORCE_GE_ZERO.
-    fn optimize_int_force_ge_zero(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_force_ge_zero(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         if let Some(a) = ctx
@@ -1928,7 +2003,12 @@ impl OptRewrite {
     // ── Comparisons ──
 
     /// Constant fold binary comparisons.
-    fn optimize_comparison(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_comparison(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -2446,7 +2526,12 @@ impl OptRewrite {
 
     /// rewrite.py:95-101: _optimize_CALL_INT_UDIV
     /// x / 1 → x
-    fn optimize_call_int_udiv(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> bool {
+    fn optimize_call_int_udiv(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> bool {
         if op.num_args() < 3 {
             return false;
         }
@@ -2881,7 +2966,12 @@ impl OptRewrite {
         true
     }
 
-    fn optimize_same_as(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_same_as(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         if op.num_args() == 0 {
             return OptimizationResult::PassOn;
         }
@@ -2954,7 +3044,12 @@ impl OptRewrite {
     /// 1. boolinverse(same args)
     /// 2. boolreflex(swapped args)
     /// 3. boolreflex.boolinverse(swapped args)
-    fn find_rewritable_bool(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> Option<OptimizationResult> {
+    fn find_rewritable_bool(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> Option<OptimizationResult> {
         if op.num_args() < 2 {
             return None;
         }
@@ -3000,7 +3095,12 @@ impl OptRewrite {
     // Constant folding for all float ops is handled by execute_nonspec_const.
 
     /// rewrite.py:103-120 optimize_FLOAT_MUL
-    fn optimize_float_mul(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_float_mul(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
         // rewrite.py:109: for lhs, rhs in [(arg1, arg2), (arg2, arg1)]:
@@ -3067,7 +3167,12 @@ impl OptRewrite {
     }
 
     /// rewrite.py:147-153 optimize_FLOAT_NEG
-    fn optimize_float_neg(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_float_neg(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let v = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
@@ -3085,7 +3190,12 @@ impl OptRewrite {
     }
 
     /// rewrite.py:155-161 optimize_FLOAT_ABS
-    fn optimize_float_abs(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_float_abs(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let v = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
@@ -3120,7 +3230,12 @@ impl OptRewrite {
 }
 
 impl Optimization for OptRewrite {
-    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         // Track last_op_removed for GuardNoException optimization.
         // Reset for non-guard ops (guards don't count as "the last op").
         if !op.opcode.is_guard() {
@@ -3289,7 +3404,9 @@ impl Optimization for OptRewrite {
             OpCode::FloatAbs => self.optimize_float_abs(op, op_rc, ctx),
 
             // ── Identity ops ──
-            OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF => self.optimize_same_as(op, op_rc, ctx),
+            OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF => {
+                self.optimize_same_as(op, op_rc, ctx)
+            }
 
             // ── Conditional calls ──
             OpCode::CondCallN => {
@@ -3476,13 +3593,15 @@ impl Optimization for OptRewrite {
                             }
                             // rewrite.py:689: OS_INT_PY_DIV
                             majit_ir::OopSpecIndex::IntPyDiv => {
-                                if let Some(result) = self.optimize_call_int_py_div(op, op_rc, ctx) {
+                                if let Some(result) = self.optimize_call_int_py_div(op, op_rc, ctx)
+                                {
                                     return result;
                                 }
                             }
                             // rewrite.py:692: OS_INT_PY_MOD
                             majit_ir::OopSpecIndex::IntPyMod => {
-                                if let Some(result) = self.optimize_call_int_py_mod(op, op_rc, ctx) {
+                                if let Some(result) = self.optimize_call_int_py_mod(op, op_rc, ctx)
+                                {
                                     return result;
                                 }
                             }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -223,7 +223,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntAdd {
@@ -247,7 +247,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntSub {
@@ -271,7 +271,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntSub {
@@ -354,7 +354,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntAdd {
@@ -374,7 +374,7 @@ impl OptRewrite {
 
         // sub_add: int_sub(int_add(x, y), y) => x
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntAdd && inner.arg(1).to_opref() == arg1.to_opref() {
@@ -391,7 +391,7 @@ impl OptRewrite {
 
         // sub_add_neg: int_sub(y, int_add(x, y)) => int_neg(x)
         if let Some(inner) = ctx
-            .ensure_box(arg1.to_opref())
+            .get_box_replacement_box(arg1.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntAdd && inner.arg(1).to_opref() == arg0.to_opref() {
@@ -407,7 +407,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntSub {
@@ -442,7 +442,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntInvert {
@@ -455,7 +455,7 @@ impl OptRewrite {
 
         // sub_xor_x_y_y: int_sub(int_xor(x, y), y) => x (if x & y == 0)
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntXor && inner.arg(1).to_opref() == arg1.to_opref() {
@@ -620,7 +620,7 @@ impl OptRewrite {
 
         // mul_lshift: int_mul(x, int_lshift(1, y)) => int_lshift(x, y)
         if let Some(inner) = ctx
-            .ensure_box(arg1.to_opref())
+            .get_box_replacement_box(arg1.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntLshift {
@@ -903,7 +903,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntAnd {
@@ -923,7 +923,7 @@ impl OptRewrite {
 
         // and_absorb: int_and(a, int_and(a, b)) => int_and(a, b)
         if let Some(inner) = ctx
-            .ensure_box(arg1.to_opref())
+            .get_box_replacement_box(arg1.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntAnd && inner.arg(0).to_opref() == arg0.to_opref() {
@@ -987,7 +987,7 @@ impl OptRewrite {
 
         // and_or: int_and(int_or(x, y), z) => int_and(x, z) (if y & z known 0)
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntOr {
@@ -1088,7 +1088,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntOr {
@@ -1108,7 +1108,7 @@ impl OptRewrite {
 
         // or_absorb: int_or(a, int_or(a, b)) => int_or(a, b)
         if let Some(inner) = ctx
-            .ensure_box(arg1.to_opref())
+            .get_box_replacement_box(arg1.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntOr && inner.arg(0).to_opref() == arg0.to_opref() {
@@ -1125,9 +1125,9 @@ impl OptRewrite {
 
         // or_and_two_parts: int_or(int_and(x, C1), int_and(x, C2)) => int_and(x, C1|C2)
         if let (Some(inner0), Some(inner1)) = (
-            ctx.ensure_box(arg0.to_opref())
+            ctx.get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb)),
-            ctx.ensure_box(arg1.to_opref())
+            ctx.get_box_replacement_box(arg1.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb)),
         ) {
             if inner0.opcode == OpCode::IntAnd
@@ -1252,7 +1252,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntXor {
@@ -1272,7 +1272,7 @@ impl OptRewrite {
 
         // xor_absorb: int_xor(int_xor(a, b), b) => a
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntXor && inner.arg(1).to_opref() == arg1.to_opref() {
@@ -1356,7 +1356,7 @@ impl OptRewrite {
         {
             if (0..64).contains(&c1) {
                 if let Some(inner) = ctx
-                    .ensure_box(arg0.to_opref())
+                    .get_box_replacement_box(arg0.to_opref())
                     .and_then(|pb| ctx.get_producing_op(&pb))
                 {
                     if inner.opcode == OpCode::IntRshift {
@@ -1393,7 +1393,7 @@ impl OptRewrite {
                             .and_then(|b| ctx.get_constant_int_box(&b))
                         {
                             if let Some(inner2) = ctx
-                                .ensure_box(inner.arg(0).to_opref())
+                                .get_box_replacement_box(inner.arg(0).to_opref())
                                 .and_then(|pb| ctx.get_producing_op(&pb))
                             {
                                 if inner2.opcode == OpCode::IntRshift
@@ -1440,7 +1440,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntLshift {
@@ -1526,7 +1526,7 @@ impl OptRewrite {
 
         // rshift_lshift: int_rshift(int_lshift(x, y), y) => x (if no overflow)
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntLshift && inner.arg(1).to_opref() == arg1.to_opref() {
@@ -1556,7 +1556,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(inner) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner.opcode == OpCode::IntRshift {
@@ -1643,7 +1643,7 @@ impl OptRewrite {
         {
             if (0..64).contains(&c) {
                 if let Some(inner) = ctx
-                    .ensure_box(arg0.to_opref())
+                    .get_box_replacement_box(arg0.to_opref())
                     .and_then(|pb| ctx.get_producing_op(&pb))
                 {
                     if inner.opcode == OpCode::IntLshift
@@ -1686,7 +1686,7 @@ impl OptRewrite {
 
         // neg_neg: int_neg(int_neg(x)) => x
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntNeg {
@@ -1720,7 +1720,7 @@ impl OptRewrite {
 
         // invert_invert: int_invert(int_invert(x)) => x
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntInvert {
@@ -1791,7 +1791,7 @@ impl OptRewrite {
 
         // is_true_and_minint: int_is_true(int_and(x, MININT)) => int_lt(x, 0)
         if let Some(inner) = ctx
-            .ensure_box(arg0.to_opref())
+            .get_box_replacement_box(arg0.to_opref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntAnd {
@@ -2103,13 +2103,13 @@ impl OptRewrite {
         // eq_sub_eq: int_eq(int_sub(x, int_eq(x, a)), a) => 0
         if op.opcode == OpCode::IntEq {
             if let Some(inner_sub) = ctx
-                .ensure_box(arg0.to_opref())
+                .get_box_replacement_box(arg0.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if inner_sub.opcode == OpCode::IntSub && inner_sub.arg(0).to_opref() != OpRef::NONE
                 {
                     if let Some(inner_eq) = ctx
-                        .ensure_box(inner_sub.arg(1).to_opref())
+                        .get_box_replacement_box(inner_sub.arg(1).to_opref())
                         .and_then(|pb| ctx.get_producing_op(&pb))
                     {
                         if inner_eq.opcode == OpCode::IntEq
@@ -2641,7 +2641,7 @@ impl OptRewrite {
             // rewrite.py:731-740: x // (1 << y) → x >> y
             // when 0 <= y < LONG_BIT - 1
             if let Some(shift_op) = ctx
-                .ensure_box(arg2.to_opref())
+                .get_box_replacement_box(arg2.to_opref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if shift_op.opcode == OpCode::IntLshift

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3111,8 +3111,7 @@ impl OptRewrite {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let v = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let v = ctx.get_box_replacement_box(op.arg(0).to_opref());
         if let Some(v) = v {
             if let Some(arg_op) = ctx.get_producing_op(&v) {
                 if arg_op.opcode == OpCode::FloatAbs {
@@ -3606,8 +3605,7 @@ impl Optimization for OptRewrite {
             // ── rewrite.py:373-374: optimize_ASSERT_NOT_NONE ──
             OpCode::AssertNotNone => {
                 // RPython: self.make_nonnull(op.getarg(0))
-                let obj_box = ctx
-                    .get_box_replacement_box(op.arg(0).to_opref());
+                let obj_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
                 let has_info = obj_box.as_ref().map_or(false, |b| ctx.has_ptr_info(b));
                 if !has_info {
                     if let Some(b) = obj_box.as_ref() {
@@ -3635,8 +3633,7 @@ impl Optimization for OptRewrite {
                     if let Some(expected_class) = expected_class {
                         // getptrinfo synthesizes ConstPtrInfo for constant
                         // Refs so `get_known_class` reads cls_of_box for them.
-                        let obj_box = ctx
-                            .get_box_replacement_box(op.arg(0).to_opref());
+                        let obj_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
                         if let Some(known) = obj_box
                             .as_ref()
                             .and_then(|b| ctx.getptrinfo(b))

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -1862,8 +1862,8 @@ impl OptRewrite {
         }
 
         // rewrite.py:528-531: null checks — fall back to OpRef for downstream
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
+        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
+        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
         if info1.as_ref().is_some_and(|i| i.is_null()) {
             return self.optimize_nullness(op, arg0, expect_isnot, ctx);
         }
@@ -2329,7 +2329,7 @@ impl OptRewrite {
         // rewrite.py postprocess_GUARD_VALUE:
         //   box = get_box_replacement(op.getarg(0))
         //   self.make_constant(box, op.getarg(1))
-        let box_ref = ctx.get_box_replacement(arg0.to_opref());
+        let box_ref = ctx.get_box_replacement(arg0.to_opref()).to_opref();
         let v = ctx
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| b.const_value())
@@ -2350,7 +2350,7 @@ impl OptRewrite {
         // EnsuredPtrInfo borrow; downstream lookups re-acquire via
         // `getptrinfo` / `get_ptr_info` against the resolved OpRef.
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let obj = ctx.get_box_replacement(op.arg(0).to_opref());
+        let obj = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         // rewrite.py:397-407: ensure_ptr_info_arg0 → info.py:880 getptrinfo.
         // `getptrinfo(ConstPtr)` returns a synthesized ConstPtrInfo, so a
         // constant Ref arg0 is handled uniformly with virtual / instance
@@ -2651,7 +2651,9 @@ impl OptRewrite {
                         .and_then(|cb| cb.const_int())
                         == Some(1)
                 {
-                    let shiftvar = ctx.get_box_replacement(shift_op.arg(1).to_opref());
+                    let shiftvar = ctx
+                        .get_box_replacement(shift_op.arg(1).to_opref())
+                        .to_opref();
                     let shiftbound = ctx
                         .ensure_box(shiftvar)
                         .map(|b| ctx.getintbound_handle(&b).borrow().clone())
@@ -2753,8 +2755,8 @@ impl OptRewrite {
             return true;
         }
 
-        let source_box = ctx.get_box_replacement(source_box);
-        let dest_box = ctx.get_box_replacement(dest_box);
+        let source_box = ctx.get_box_replacement(source_box).to_opref();
+        let dest_box = ctx.get_box_replacement(dest_box).to_opref();
         let source_is_virtual = ctx
             .get_box_replacement_box(source_box)
             .as_ref()
@@ -3269,7 +3271,7 @@ impl Optimization for OptRewrite {
                 //         if opinfo.is_nonnull(): return
                 //         elif opinfo.is_null(): raise InvalidLoop(...)
                 //     return self.emit(op)
-                let obj = ctx.get_box_replacement(op.arg(0).to_opref());
+                let obj = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
                 let obj_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
                 if let Some(info) = obj_box.as_ref().and_then(|b| ctx.getptrinfo(b)) {
                     if info.is_nonnull() {
@@ -3299,7 +3301,7 @@ impl Optimization for OptRewrite {
                 //         if info.is_null(): return
                 //         elif info.is_nonnull(): raise InvalidLoop(...)
                 //     return self.emit(op)
-                let obj = ctx.get_box_replacement(op.arg(0).to_opref());
+                let obj = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
                 let obj_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
                 if let Some(info) = obj_box.as_ref().and_then(|b| ctx.getptrinfo(b)) {
                     if info.is_null() {
@@ -3446,8 +3448,8 @@ impl Optimization for OptRewrite {
                     //     arg0 = get_box_replacement(op.getarg(0))
                     //     arg1 = get_box_replacement(op.getarg(1))
                     //     self.pure_from_args2(rop.INSTANCE_PTR_EQ, arg1, arg0, op)
-                    let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-                    let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
+                    let arg0 = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
+                    let arg1 = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
                     ctx.register_pure_from_args2(OpCode::InstancePtrEq, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, false, instance, ctx);
@@ -3456,8 +3458,8 @@ impl Optimization for OptRewrite {
                 let instance = matches!(op.opcode, OpCode::InstancePtrNe);
                 if instance {
                     // rewrite.py:568-571 optimize_INSTANCE_PTR_NE: same swap.
-                    let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
-                    let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
+                    let arg0 = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
+                    let arg1 = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
                     ctx.register_pure_from_args2(OpCode::InstancePtrNe, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, true, instance, ctx);
@@ -3616,7 +3618,7 @@ impl Optimization for OptRewrite {
                             // so `take_preamble_forwarded_opinfo` reads the
                             // info seeded at result_opref's slot per the
                             // dual-slot rule (mod.rs:1817 replay_pos).
-                            let replay_pos = ctx.get_box_replacement(source);
+                            let replay_pos = ctx.get_box_replacement(source).to_opref();
                             let mut replay =
                                 Op::new(OpCode::SameAsI, &[BoxRef::from_opref(source)]);
                             replay.pos.set(replay_pos);
@@ -3923,10 +3925,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
 
             match pass.propagate_forward(&resolved, &mut ctx) {
@@ -3988,7 +3987,7 @@ mod tests {
             "{opcode:?} with const {const_val} at pos {const_pos} should Remove"
         );
         assert_eq!(
-            ctx.get_box_replacement(OpRef::int_op(2)),
+            ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
             OpRef::int_op(expected_forward_to),
             "{opcode:?} should forward to {expected_forward_to}"
         );
@@ -4472,7 +4471,10 @@ mod tests {
         let mut pass = OptRewrite::new();
         let result = pass.propagate_forward(&ops[1], &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(OpRef::int_op(1)), OpRef::int_op(0));
+        assert_eq!(
+            ctx.get_box_replacement(OpRef::int_op(1)).to_opref(),
+            OpRef::int_op(0)
+        );
     }
 
     // ── Integration test: full optimizer with OptRewrite ──
@@ -4509,10 +4511,7 @@ mod tests {
             let mut resolved = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                );
+                resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
@@ -4543,7 +4542,10 @@ mod tests {
         // the IntAdd was removed and the result is forwarded.
         // op0 is emitted, op1 is emitted (just a constant), op2 is removed.
         // After forwarding, any reference to op2 should resolve to op0.
-        assert_eq!(ctx.get_box_replacement(OpRef::int_op(2)), OpRef::int_op(0));
+        assert_eq!(
+            ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
+            OpRef::int_op(0)
+        );
     }
 
     #[test]
@@ -4570,10 +4572,7 @@ mod tests {
                 let mut resolved = op.clone();
                 // optimizer.py:651-652 setarg loop parity.
                 for i in 0..resolved.num_args() {
-                    resolved.setarg(
-                        i,
-                        BoxRef::from_opref(ctx.get_box_replacement(resolved.arg(i).to_opref())),
-                    );
+                    resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
                 }
                 match pass.propagate_forward(&resolved, &mut ctx) {
                     OptimizationResult::Emit(emitted) => {
@@ -4821,7 +4820,10 @@ mod tests {
         let mut pass = OptRewrite::new();
         let result = pass.propagate_forward(&ops[2], &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(OpRef::int_op(2)), OpRef::int_op(0));
+        assert_eq!(
+            ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
+            OpRef::int_op(0)
+        );
     }
 
     #[test]
@@ -4880,7 +4882,7 @@ mod tests {
         let result = pass.propagate_forward(&ops[2], &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
-            ctx.get_box_replacement(OpRef::float_op(2)),
+            ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
             OpRef::float_op(0)
         );
     }
@@ -4908,7 +4910,7 @@ mod tests {
         let result = pass.propagate_forward(&ops[2], &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
-            ctx.get_box_replacement(OpRef::float_op(2)),
+            ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
             OpRef::float_op(1)
         );
     }
@@ -4935,7 +4937,7 @@ mod tests {
         let result2 = pass.propagate_forward(&ops[2], &mut ctx);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
-            ctx.get_box_replacement(OpRef::float_op(2)),
+            ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
             OpRef::float_op(0)
         );
     }
@@ -5084,7 +5086,7 @@ mod tests {
         let mut pass = OptRewrite::new();
         let result = pass.propagate_forward(&ops[3], &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
-        let resolved = ctx.get_box_replacement(OpRef::int_op(3));
+        let resolved = ctx.get_box_replacement(OpRef::int_op(3)).to_opref();
         assert!(resolved.is_constant());
         assert_eq!(
             ctx.get_box_replacement_box(resolved)
@@ -5340,7 +5342,10 @@ mod tests {
         let mut pass = OptRewrite::new();
         let result = pass.propagate_forward(&ops[1], &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(OpRef::ref_op(1)), OpRef::ref_op(0));
+        assert_eq!(
+            ctx.get_box_replacement(OpRef::ref_op(1)).to_opref(),
+            OpRef::ref_op(0)
+        );
     }
 
     // ── CONVERT_FLOAT_BYTES tests ──

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3175,7 +3175,7 @@ impl OptRewrite {
     ) -> OptimizationResult {
         let v = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .or_else(|| Some(ctx.get_box_replacement(op.arg(0).to_opref())));
         if let Some(arg_op) = v.and_then(|pb| ctx.get_producing_op(&pb)) {
             if arg_op.opcode == OpCode::FloatNeg {
                 let b_old = BoxRef::from_bound_op(op_rc);

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -200,9 +200,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -211,9 +209,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg1.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg1.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -331,9 +327,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -383,9 +377,7 @@ impl OptRewrite {
         {
             if inner.opcode == OpCode::IntAdd && inner.arg(1).to_opref() == arg1.to_opref() {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_inner = ctx
-                    .ensure_box(inner.arg(0).to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_inner = ctx.get_box_replacement(inner.arg(0).to_opref());
                 ctx.make_equal_to(&b_old, &b_inner);
                 return OptimizationResult::Remove;
             }
@@ -469,9 +461,7 @@ impl OptRewrite {
                 ) {
                     if bx.and_bound(&by).known_eq_const(0) {
                         let b_old = BoxRef::from_bound_op(op_rc);
-                        let b_inner = ctx
-                            .ensure_box(inner.arg(0).to_opref())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_inner = ctx.get_box_replacement(inner.arg(0).to_opref());
                         ctx.make_equal_to(&b_old, &b_inner);
                         return OptimizationResult::Remove;
                     }
@@ -487,9 +477,7 @@ impl OptRewrite {
                 ) {
                     if bx.and_bound(&by).known_eq_const(0) {
                         let b_old = BoxRef::from_bound_op(op_rc);
-                        let b_inner = ctx
-                            .ensure_box(inner.arg(0).to_opref())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_inner = ctx.get_box_replacement(inner.arg(0).to_opref());
                         ctx.make_equal_to(&b_old, &b_inner);
                         return OptimizationResult::Remove;
                     }
@@ -546,9 +534,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -558,9 +544,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg1.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg1.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -667,9 +651,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -714,9 +696,7 @@ impl OptRewrite {
                     &[arg0, BoxRef::from_opref(shift_ref)],
                 ));
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_res = ctx
-                    .ensure_box(result_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_res = ctx.get_box_replacement(result_ref);
                 ctx.make_equal_to(&b_old, &b_res);
                 return OptimizationResult::Remove;
             }
@@ -731,9 +711,7 @@ impl OptRewrite {
                     ctx,
                 );
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_res = ctx
-                    .ensure_box(result)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_res = ctx.get_box_replacement(result);
                 ctx.make_equal_to(&b_old, &b_res);
                 return OptimizationResult::Remove;
             }
@@ -814,9 +792,7 @@ impl OptRewrite {
                     ctx,
                 );
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_res = ctx
-                    .ensure_box(result)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_res = ctx.get_box_replacement(result);
                 ctx.make_equal_to(&b_old, &b_res);
                 return OptimizationResult::Remove;
             }
@@ -870,9 +846,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -881,18 +855,14 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg1.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg1.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
         // and_x_x: int_and(a, a) => a
         if self.boxes_equal_via_intbound(arg0.to_opref(), arg1.to_opref(), ctx) {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -928,9 +898,7 @@ impl OptRewrite {
         {
             if inner.opcode == OpCode::IntAnd && inner.arg(0).to_opref() == arg0.to_opref() {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx
-                    .ensure_box(arg1.to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_arg = ctx.get_box_replacement(arg1.to_opref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -947,9 +915,7 @@ impl OptRewrite {
             {
                 if bound.lower >= 0 && bound.upper <= (c & !(c.wrapping_add(1))) {
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_arg = ctx
-                        .ensure_box(arg0.to_opref())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_arg = ctx.get_box_replacement(arg0.to_opref());
                     ctx.make_equal_to(&b_old, &b_arg);
                     return OptimizationResult::Remove;
                 }
@@ -971,9 +937,7 @@ impl OptRewrite {
             // and_idempotent: int_and(x, y) => x (if y.ones | x.zeros == -1)
             if (bb.tvalue | (!ba.tvalue & !ba.tmask)) == u64::MAX {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx
-                    .ensure_box(arg0.to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_arg = ctx.get_box_replacement(arg0.to_opref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -1033,9 +997,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1044,9 +1006,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg1.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg1.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1068,9 +1028,7 @@ impl OptRewrite {
         // or_x_x: int_or(a, a) => a
         if self.boxes_equal_via_intbound(arg0.to_opref(), arg1.to_opref(), ctx) {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1106,9 +1064,7 @@ impl OptRewrite {
         {
             if inner.opcode == OpCode::IntOr && inner.arg(0).to_opref() == arg0.to_opref() {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx
-                    .ensure_box(arg1.to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_arg = ctx.get_box_replacement(arg1.to_opref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -1155,9 +1111,7 @@ impl OptRewrite {
             // or_idempotent: int_or(x, y) => x (if x.ones | y.zeros == -1)
             if (ba.tvalue | (!bb.tvalue & !bb.tmask)) == u64::MAX {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx
-                    .ensure_box(arg0.to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_arg = ctx.get_box_replacement(arg0.to_opref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -1196,9 +1150,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1207,9 +1159,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg1.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg1.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1267,9 +1217,7 @@ impl OptRewrite {
         {
             if inner.opcode == OpCode::IntXor && inner.arg(1).to_opref() == arg1.to_opref() {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_inner = ctx
-                    .ensure_box(inner.arg(0).to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_inner = ctx.get_box_replacement(inner.arg(0).to_opref());
                 ctx.make_equal_to(&b_old, &b_inner);
                 return OptimizationResult::Remove;
             }
@@ -1325,9 +1273,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1489,9 +1435,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1532,9 +1476,7 @@ impl OptRewrite {
                 ) {
                     if bx.lshift_bound_cannot_overflow(&by) {
                         let b_old = BoxRef::from_bound_op(op_rc);
-                        let b_inner = ctx
-                            .ensure_box(inner.arg(0).to_opref())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_inner = ctx.get_box_replacement(inner.arg(0).to_opref());
                         ctx.make_equal_to(&b_old, &b_inner);
                         return OptimizationResult::Remove;
                     }
@@ -1602,9 +1544,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg0.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg0.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
@@ -1691,9 +1631,7 @@ impl OptRewrite {
         {
             if inner.opcode == OpCode::IntNeg {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_inner = ctx
-                    .ensure_box(inner.arg(0).to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_inner = ctx.get_box_replacement(inner.arg(0).to_opref());
                 ctx.make_equal_to(&b_old, &b_inner);
                 return OptimizationResult::Remove;
             }
@@ -1728,9 +1666,7 @@ impl OptRewrite {
         {
             if inner.opcode == OpCode::IntInvert {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_inner = ctx
-                    .ensure_box(inner.arg(0).to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_inner = ctx.get_box_replacement(inner.arg(0).to_opref());
                 ctx.make_equal_to(&b_old, &b_inner);
                 return OptimizationResult::Remove;
             }
@@ -1784,9 +1720,7 @@ impl OptRewrite {
                 if bound.is_bool() {
                     // make_equal_to: replace INT_IS_TRUE result with arg0.
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_arg = ctx
-                        .ensure_box(arg0.to_opref())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_arg = ctx.get_box_replacement(arg0.to_opref());
                     ctx.make_equal_to(&b_old, &b_arg);
                     return OptimizationResult::Remove;
                 }
@@ -1962,9 +1896,7 @@ impl OptRewrite {
         {
             if bound.known_nonnegative() {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx
-                    .ensure_box(arg0.to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_arg = ctx.get_box_replacement(arg0.to_opref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -2100,9 +2032,7 @@ impl OptRewrite {
                 {
                     if bound.is_bool() {
                         let b_old = BoxRef::from_bound_op(op_rc);
-                        let b_arg = ctx
-                            .ensure_box(arg0.to_opref())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_arg = ctx.get_box_replacement(arg0.to_opref());
                         ctx.make_equal_to(&b_old, &b_arg);
                         return OptimizationResult::Remove;
                     }
@@ -2445,7 +2375,7 @@ impl OptRewrite {
                     // parity) rather than snapping it to the tail of
                     // new_operations.
                     if let Some(class_val) = ctx.get_constant_int(op.arg(1).to_opref()) {
-                        if let Some(b) = ctx.ensure_box(obj) {
+                        if let Some(b) = ctx.get_box_replacement_box(obj) {
                             crate::optimizeopt::optimizer::Optimizer::make_constant_class(
                                 ctx, &b, class_val, /* update_last_guard = */ false,
                             );
@@ -2483,12 +2413,11 @@ impl OptRewrite {
     fn getnullness(&self, opref: OpRef, ctx: &mut OptContext) -> Nullness {
         // optimizer.py:127-135 `getnullness` has no missing-Box branch —
         // every `op` has a backing `AbstractValue` per
-        // `resoperation.py:233-248`. `ensure_box` lazy-allocates the
-        // Box (or constructs the const-namespace fresh) so the inlined
-        // `getintbound` side effect (`optimizer.py:110-113` unbounded
-        // install) materializes on first access. `INFO_UNKNOWN` only
-        // for OpRef::NONE sentinels (no upstream equivalent).
-        let info = match ctx.ensure_box(opref) {
+        // `resoperation.py:233-248`. `get_box_replacement_box` resolves
+        // the opref to its bound host; the read-only `getnullness` below
+        // never writes, so an unresolvable opref (OpRef::NONE sentinel,
+        // no upstream equivalent) maps to `INFO_UNKNOWN`.
+        let info = match ctx.get_box_replacement_box(opref) {
             Some(b) => ctx.getnullness(&b),
             None => crate::optimizeopt::INFO_UNKNOWN,
         };
@@ -2541,9 +2470,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(op.arg(1).to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(op.arg(1).to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             ctx.last_op_removed = true;
             return true;
@@ -2563,14 +2490,14 @@ impl OptRewrite {
         }
         let arg1 = op.arg(1);
         let arg2 = op.arg(2);
-        let b1 = ctx
-            .ensure_box(arg1.to_opref())
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
-        let b2 = ctx
-            .ensure_box(arg2.to_opref())
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b1 = {
+            let b = ctx.get_box_replacement(arg1.to_opref());
+            ctx.getintbound_handle(&b).borrow().clone()
+        };
+        let b2 = {
+            let b = ctx.get_box_replacement(arg2.to_opref());
+            ctx.getintbound_handle(&b).borrow().clone()
+        };
 
         // rewrite.py:774-777: b1.known_eq_const(0) → 0
         if b1.known_eq_const(0) {
@@ -2614,9 +2541,7 @@ impl OptRewrite {
             ctx,
         );
         let b_old = BoxRef::from_bound_op(op_rc);
-        let b_res = ctx
-            .ensure_box(result_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_res = ctx.get_box_replacement(result_ref);
         ctx.make_equal_to(&b_old, &b_res);
         ctx.last_op_removed = true;
         Some(OptimizationResult::Remove)
@@ -2634,14 +2559,14 @@ impl OptRewrite {
         }
         let arg1 = op.arg(1);
         let arg2 = op.arg(2);
-        let b1 = ctx
-            .ensure_box(arg1.to_opref())
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
-        let b2 = ctx
-            .ensure_box(arg2.to_opref())
-            .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let b1 = {
+            let b = ctx.get_box_replacement(arg1.to_opref());
+            ctx.getintbound_handle(&b).borrow().clone()
+        };
+        let b2 = {
+            let b = ctx.get_box_replacement(arg2.to_opref());
+            ctx.getintbound_handle(&b).borrow().clone()
+        };
 
         // rewrite.py:726-729: b1.known_eq_const(0) → 0
         if b1.known_eq_const(0) {
@@ -2667,10 +2592,10 @@ impl OptRewrite {
                     let shiftvar = ctx
                         .get_box_replacement(shift_op.arg(1).to_opref())
                         .to_opref();
-                    let shiftbound = ctx
-                        .ensure_box(shiftvar)
-                        .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-                        .expect("getintbound: operand must resolve to a BoxRef");
+                    let shiftbound = {
+                        let b = ctx.get_box_replacement(shiftvar);
+                        ctx.getintbound_handle(&b).borrow().clone()
+                    };
                     if shiftbound.known_nonnegative() && shiftbound.known_lt_const(63) {
                         let mut rshift_op =
                             Op::new(OpCode::IntRshift, &[arg1, BoxRef::from_opref(shiftvar)]);
@@ -2701,9 +2626,7 @@ impl OptRewrite {
         // rewrite.py:752-755: x // 1 → x
         if val == 1 {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx
-                .ensure_box(arg1.to_opref())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_arg = ctx.get_box_replacement(arg1.to_opref());
             ctx.make_equal_to(&b_old, &b_arg);
             ctx.last_op_removed = true;
             return Some(OptimizationResult::Remove);
@@ -2729,9 +2652,7 @@ impl OptRewrite {
             ctx,
         );
         let b_old = BoxRef::from_bound_op(op_rc);
-        let b_res = ctx
-            .ensure_box(result_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_res = ctx.get_box_replacement(result_ref);
         ctx.make_equal_to(&b_old, &b_res);
         ctx.last_op_removed = true;
         Some(OptimizationResult::Remove)
@@ -2875,7 +2796,7 @@ impl OptRewrite {
                         });
                     if let Some(val) = val {
                         let idx = (index + dest_start) as usize;
-                        if let Some(b) = ctx.ensure_box(dest_box) {
+                        if let Some(b) = ctx.get_box_replacement_box(dest_box) {
                             ctx.with_ptr_info_mut(&b, |info| {
                                 info.setinteriorfield_virtual(idx, fdescr_idx, val);
                             });
@@ -2945,7 +2866,7 @@ impl OptRewrite {
             if dest_is_virtual {
                 // rewrite.py:662-665: dest_info.setitem(...)
                 let idx = (index + dest_start) as usize;
-                if let Some(b) = ctx.ensure_box(dest_box) {
+                if let Some(b) = ctx.get_box_replacement_box(dest_box) {
                     ctx.with_ptr_info_mut(&b, |info| info.setitem(idx, val));
                 }
             } else {
@@ -2977,9 +2898,7 @@ impl OptRewrite {
         }
         let arg0 = op.arg(0);
         let b_old = BoxRef::from_bound_op(op_rc);
-        let b_arg = ctx
-            .ensure_box(arg0.to_opref())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_arg = ctx.get_box_replacement(arg0.to_opref());
         ctx.make_equal_to(&b_old, &b_arg);
         OptimizationResult::Remove
     }
@@ -3070,9 +2989,7 @@ impl OptRewrite {
             let key = (reflex_opcode, arg1.to_opref(), arg0.to_opref());
             if let Some(&cached_ref) = self.bool_result_cache.get(&key) {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_cached = ctx
-                    .ensure_box(cached_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_cached = ctx.get_box_replacement(cached_ref);
                 ctx.make_equal_to(&b_old, &b_cached);
                 return Some(OptimizationResult::Remove);
             }
@@ -3179,9 +3096,7 @@ impl OptRewrite {
         if let Some(arg_op) = v.and_then(|pb| ctx.get_producing_op(&pb)) {
             if arg_op.opcode == OpCode::FloatNeg {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_inner = ctx
-                    .ensure_box(arg_op.arg(0).to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_inner = ctx.get_box_replacement(arg_op.arg(0).to_opref());
                 ctx.make_equal_to(&b_old, &b_inner);
                 return OptimizationResult::Remove;
             }
@@ -3197,8 +3112,7 @@ impl OptRewrite {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let v = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
         if let Some(v) = v {
             if let Some(arg_op) = ctx.get_producing_op(&v) {
                 if arg_op.opcode == OpCode::FloatAbs {
@@ -3312,7 +3226,7 @@ impl Optimization for OptRewrite {
                 // until emit adds the guard to new_operations.
                 let has_info = obj_box.as_ref().map_or(false, |b| ctx.has_ptr_info(b));
                 if !has_info {
-                    if let Some(b) = ctx.ensure_box(obj) {
+                    if let Some(b) = ctx.get_box_replacement_box(obj) {
                         ctx.set_ptr_info(&b, crate::optimizeopt::info::PtrInfo::nonnull());
                     }
                 }
@@ -3440,9 +3354,7 @@ impl Optimization for OptRewrite {
                 // rewrite.py:486-489: INFO_NONNULL → result is arg(0)
                 if nullness == Nullness::Nonnull {
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_arg = ctx
-                        .ensure_box(op.arg(0).to_opref())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_arg = ctx.get_box_replacement(op.arg(0).to_opref());
                     ctx.make_equal_to(&b_old, &b_arg);
                     ctx.last_op_removed = true;
                     return OptimizationResult::Remove;
@@ -3512,9 +3424,7 @@ impl Optimization for OptRewrite {
             // jtransform.py:1264-1266: CAST_OPAQUE_PTR is identity (no-op).
             OpCode::CastOpaquePtr => {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx
-                    .ensure_box(op.arg(0).to_opref())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_arg = ctx.get_box_replacement(op.arg(0).to_opref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 OptimizationResult::Remove
             }
@@ -3697,8 +3607,7 @@ impl Optimization for OptRewrite {
             OpCode::AssertNotNone => {
                 // RPython: self.make_nonnull(op.getarg(0))
                 let obj_box = ctx
-                    .get_box_replacement_box(op.arg(0).to_opref())
-                    .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+                    .get_box_replacement_box(op.arg(0).to_opref());
                 let has_info = obj_box.as_ref().map_or(false, |b| ctx.has_ptr_info(b));
                 if !has_info {
                     if let Some(b) = obj_box.as_ref() {
@@ -3727,8 +3636,7 @@ impl Optimization for OptRewrite {
                         // getptrinfo synthesizes ConstPtrInfo for constant
                         // Refs so `get_known_class` reads cls_of_box for them.
                         let obj_box = ctx
-                            .get_box_replacement_box(op.arg(0).to_opref())
-                            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+                            .get_box_replacement_box(op.arg(0).to_opref());
                         if let Some(known) = obj_box
                             .as_ref()
                             .and_then(|b| ctx.getptrinfo(b))

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3209,7 +3209,7 @@ impl OptRewrite {
 }
 
 impl Optimization for OptRewrite {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         // Track last_op_removed for GuardNoException optimization.
         // Reset for non-guard ops (guards don't count as "the last op").
         if !op.opcode.is_guard() {
@@ -3928,7 +3928,7 @@ mod tests {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
 
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -3981,7 +3981,7 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(const_pos as u32), Value::Int(const_val));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(
             matches!(result, OptimizationResult::Remove),
             "{opcode:?} with const {const_val} at pos {const_pos} should Remove"
@@ -4013,7 +4013,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(a));
         ctx.make_constant(OpRef::int_op(1), Value::Int(b));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(
             matches!(result, OptimizationResult::Remove),
             "{opcode:?}({a}, {b}) should constant-fold"
@@ -4042,7 +4042,7 @@ mod tests {
         let mut ctx = OptContext::new(2);
         ctx.emit(ops[0].clone());
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(
             matches!(result, OptimizationResult::Remove),
             "{opcode:?}(x, x) should Remove"
@@ -4084,7 +4084,7 @@ mod tests {
         let mut ctx = OptContext::new(2);
         ctx.emit(ops[0].clone());
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         // x + x may be rewritten to lshift(x, 1) or kept
         assert!(
             !matches!(result, OptimizationResult::PassOn)
@@ -4123,7 +4123,7 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(1), Value::Int(0));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4157,7 +4157,7 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(1), Value::Int(8));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         match result {
             OptimizationResult::Replace(ref new_op) | OptimizationResult::Emit(ref new_op) => {
                 assert_eq!(new_op.opcode, OpCode::IntLshift);
@@ -4188,7 +4188,7 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4222,7 +4222,7 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(1), Value::Int(1));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4271,7 +4271,7 @@ mod tests {
         ctx.emit(ops[0].clone());
         ctx.make_constant(OpRef::int_op(0), Value::Int(42));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -4288,7 +4288,7 @@ mod tests {
         let mut ctx2 = OptContext::new(2);
         ctx2.emit(ops2[0].clone());
         ctx2.make_constant(OpRef::int_op(0), Value::Int(0xFF));
-        let result2 = pass.propagate_forward(&ops2[1], &mut ctx2);
+        let result2 = pass.propagate_forward(&ops2[1], &std::rc::Rc::new(ops2[1].clone()), &mut ctx2);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
             ctx2.get_box_replacement_box(OpRef::int_op(1))
@@ -4309,7 +4309,7 @@ mod tests {
         let mut ctx = OptContext::new(2);
         ctx.emit(ops[0].clone());
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -4326,7 +4326,7 @@ mod tests {
         let mut ctx2 = OptContext::new(2);
         ctx2.emit(ops2[0].clone());
         ctx2.make_constant(OpRef::int_op(0), Value::Int(5));
-        let result2 = pass.propagate_forward(&ops2[1], &mut ctx2);
+        let result2 = pass.propagate_forward(&ops2[1], &std::rc::Rc::new(ops2[1].clone()), &mut ctx2);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
             ctx2.get_box_replacement_box(OpRef::int_op(1))
@@ -4358,7 +4358,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -4375,7 +4375,7 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            pass.propagate_forward(&ops[1], &mut ctx)
+            pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx)
         }))
         .expect_err("guard_true(0) should abort as InvalidLoop");
         assert!(err.downcast_ref::<crate::optimize::InvalidLoop>().is_some());
@@ -4392,7 +4392,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -4408,7 +4408,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -4425,7 +4425,7 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            pass.propagate_forward(&ops[1], &mut ctx)
+            pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx)
         }))
         .expect_err("guard_false(1) should abort as InvalidLoop");
         assert!(err.downcast_ref::<crate::optimize::InvalidLoop>().is_some());
@@ -4452,7 +4452,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(42));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -4469,7 +4469,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::int_op(1)).to_opref(),
@@ -4513,7 +4513,7 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -4574,7 +4574,7 @@ mod tests {
                 for i in 0..resolved.num_args() {
                     resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
                 }
-                match pass.propagate_forward(&resolved, &mut ctx) {
+                match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                     OptimizationResult::Emit(emitted) => {
                         ctx.emit(emitted);
                     }
@@ -4621,7 +4621,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4652,7 +4652,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4681,7 +4681,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4711,7 +4711,7 @@ mod tests {
         ctx.emit(ops[1].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -4728,7 +4728,7 @@ mod tests {
         let mut ctx = OptContext::new(1);
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[0], &mut ctx);
+        let result = pass.propagate_forward(&ops[0], &std::rc::Rc::new(ops[0].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -4755,7 +4755,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(0x0F));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4787,7 +4787,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(0x0F));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4818,7 +4818,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
@@ -4847,7 +4847,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         // u64::MAX >> 1 = i64::MAX
         assert_eq!(
@@ -4879,7 +4879,7 @@ mod tests {
         ctx.make_constant(OpRef::float_op(1), Value::Float(1.0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
@@ -4907,7 +4907,7 @@ mod tests {
         ctx.make_constant(OpRef::float_op(0), Value::Float(1.0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
@@ -4929,12 +4929,12 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         // Process op1 first (pass it through)
-        let result1 = pass.propagate_forward(&ops[1], &mut ctx);
+        let result1 = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result1, OptimizationResult::PassOn));
         ctx.emit(ops[1].clone());
 
         // Process op2: should detect double negation
-        let result2 = pass.propagate_forward(&ops[2], &mut ctx);
+        let result2 = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
@@ -4963,7 +4963,7 @@ mod tests {
         ctx.make_constant(OpRef::float_op(1), Value::Float(2.0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Emit(_)));
     }
 
@@ -4987,7 +4987,7 @@ mod tests {
         ctx.emit(ops[1].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5017,7 +5017,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &mut ctx);
+        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -5045,7 +5045,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &mut ctx);
+        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
         match result {
             OptimizationResult::Replace(op) => {
                 assert_eq!(op.opcode, OpCode::CallN);
@@ -5084,7 +5084,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(42));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &mut ctx);
+        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         let resolved = ctx.get_box_replacement(OpRef::int_op(3)).to_opref();
         assert!(resolved.is_constant());
@@ -5119,7 +5119,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &mut ctx);
+        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
         match result {
             OptimizationResult::Replace(op) => {
                 assert_eq!(op.opcode, OpCode::CallPureI);
@@ -5153,7 +5153,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5180,7 +5180,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5207,7 +5207,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5234,7 +5234,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5273,7 +5273,7 @@ mod tests {
         ctx.make_constant(OpRef::ref_op(1), Value::Ref(GcRef(200)));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &mut ctx);
+        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         // rewrite.py:564 `return self.emit(op)` — rewrite passes the op on
         // unchanged; it does not fold distinct constants.
         assert!(matches!(result, OptimizationResult::PassOn));
@@ -5302,7 +5302,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5321,7 +5321,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5340,7 +5340,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::ref_op(1)).to_opref(),
@@ -5367,7 +5367,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5385,7 +5385,7 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &mut ctx);
+        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         // PassOn: op is emitted, no replacement registered.
         assert!(matches!(result, OptimizationResult::PassOn));
     }
@@ -5415,11 +5415,11 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         // Process CondCallN -> removed
-        let result2 = pass.propagate_forward(&ops[2], &mut ctx);
+        let result2 = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result2, OptimizationResult::Remove));
 
         // Process GuardNoException -> should also be removed
-        let result3 = pass.propagate_forward(&ops[3], &mut ctx);
+        let result3 = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
         assert!(matches!(result3, OptimizationResult::Remove));
     }
 
@@ -5437,12 +5437,12 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         // Process CallN -> PassOn (not handled by OptRewrite)
-        let result1 = pass.propagate_forward(&ops[1], &mut ctx);
+        let result1 = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
         assert!(matches!(result1, OptimizationResult::PassOn));
         ctx.emit(ops[1].clone());
 
         // Process GuardNoException -> should NOT be removed
-        let result2 = pass.propagate_forward(&ops[2], &mut ctx);
+        let result2 = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
         assert!(matches!(result2, OptimizationResult::PassOn));
     }
 
@@ -5453,7 +5453,7 @@ mod tests {
         op.pos.set(OpRef::void_op(0));
         let mut ctx = OptContext::new(1);
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&op, &mut ctx);
+        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert!(ctx.patchguardop.is_some());
         assert_eq!(

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3840,6 +3840,94 @@ mod tests {
         }
     }
 
+    fn i(pos: u32) -> BoxRef {
+        BoxRef::from_opref(OpRef::int_op(pos))
+    }
+
+    fn f(pos: u32) -> BoxRef {
+        BoxRef::from_opref(OpRef::float_op(pos))
+    }
+
+    fn r(pos: u32) -> BoxRef {
+        BoxRef::from_opref(OpRef::ref_op(pos))
+    }
+
+    fn same_i() -> Op {
+        Op::new(OpCode::SameAsI, &[])
+    }
+
+    fn same_f() -> Op {
+        Op::new(OpCode::SameAsF, &[])
+    }
+
+    fn same_r() -> Op {
+        Op::new(OpCode::SameAsR, &[])
+    }
+
+    fn bin_i(opcode: OpCode, left: u32, right: u32) -> Op {
+        Op::new(opcode, &[i(left), i(right)])
+    }
+
+    fn bin_f(opcode: OpCode, left: u32, right: u32) -> Op {
+        Op::new(opcode, &[f(left), f(right)])
+    }
+
+    fn bin_r(opcode: OpCode, left: u32, right: u32) -> Op {
+        Op::new(opcode, &[r(left), r(right)])
+    }
+
+    fn unary_i(opcode: OpCode, arg: u32) -> Op {
+        Op::new(opcode, &[i(arg)])
+    }
+
+    fn unary_f(opcode: OpCode, arg: u32) -> Op {
+        Op::new(opcode, &[f(arg)])
+    }
+
+    fn unary_r(opcode: OpCode, arg: u32) -> Op {
+        Op::new(opcode, &[r(arg)])
+    }
+
+    fn run_one(
+        mut ops: Vec<Op>,
+        target: usize,
+        constants: &[(OpRef, Value)],
+    ) -> (OptimizationResult, OptContext) {
+        with_positions(&mut ops);
+        let mut ctx = OptContext::new(ops.len());
+        for op in &ops[..target] {
+            ctx.emit(op.clone());
+        }
+        for &(opref, value) in constants {
+            ctx.make_constant(opref, value);
+        }
+        let mut pass = OptRewrite::new();
+        let op_rc = std::rc::Rc::new(ops[target].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op_rc));
+        let result = pass.propagate_forward(&ops[target], &op_rc, &mut ctx);
+        (result, ctx)
+    }
+
+    fn assert_remove(result: &OptimizationResult) {
+        assert!(matches!(result, OptimizationResult::Remove));
+    }
+
+    fn assert_pass_on(result: &OptimizationResult) {
+        assert!(matches!(result, OptimizationResult::PassOn));
+    }
+
+    fn assert_int_const(ctx: &OptContext, opref: OpRef, expected: i64) {
+        assert_eq!(
+            ctx.get_box_replacement_box(opref)
+                .and_then(|cb| cb.const_int()),
+            Some(expected)
+        );
+    }
+
+    fn assert_forward(ctx: &OptContext, from: OpRef, to: OpRef) {
+        assert_eq!(ctx.get_box_replacement(from).to_opref(), to);
+    }
+
     /// Run the rewrite pass on a sequence of ops and return the optimized ops.
     fn run_rewrite(ops: &mut [Op]) -> (Vec<Op>, OptContext) {
         with_positions(ops);
@@ -3892,102 +3980,35 @@ mod tests {
         const_val: i64,
         expected_forward_to: u32,
     ) {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                opcode,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(const_pos as u32), Value::Int(const_val));
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(
-            matches!(result, OptimizationResult::Remove),
-            "{opcode:?} with const {const_val} at pos {const_pos} should Remove"
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(opcode, 0, 1)],
+            2,
+            &[(OpRef::int_op(const_pos as u32), Value::Int(const_val))],
         );
-        assert_eq!(
-            ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
-            OpRef::int_op(expected_forward_to),
-            "{opcode:?} should forward to {expected_forward_to}"
-        );
+        assert_remove(&result);
+        assert_forward(&ctx, OpRef::int_op(2), OpRef::int_op(expected_forward_to));
     }
 
     /// Helper: test constant fold → expect Remove + constant result.
     fn assert_binop_const_fold(opcode: OpCode, a: i64, b: i64, expected: i64) {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                opcode,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(a));
-        ctx.make_constant(OpRef::int_op(1), Value::Int(b));
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(
-            matches!(result, OptimizationResult::Remove),
-            "{opcode:?}({a}, {b}) should constant-fold"
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(opcode, 0, 1)],
+            2,
+            &[
+                (OpRef::int_op(0), Value::Int(a)),
+                (OpRef::int_op(1), Value::Int(b)),
+            ],
         );
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(expected),
-            "{opcode:?}({a}, {b}) = {expected}"
-        );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), expected);
     }
 
     /// Helper: test same-arg binop → expect Remove.
     fn assert_binop_self(opcode: OpCode, expected_const: Option<i64>) {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                opcode,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(
-            matches!(result, OptimizationResult::Remove),
-            "{opcode:?}(x, x) should Remove"
-        );
+        let (result, ctx) = run_one(vec![same_i(), bin_i(opcode, 0, 0)], 1, &[]);
+        assert_remove(&result);
         if let Some(val) = expected_const {
-            assert_eq!(
-                ctx.get_box_replacement_box(OpRef::int_op(1))
-                    .and_then(|cb| cb.const_int()),
-                Some(val),
-                "{opcode:?}(x, x) = {val}"
-            );
+            assert_int_const(&ctx, OpRef::int_op(1), val);
         }
     }
 
@@ -4004,23 +4025,7 @@ mod tests {
     #[test]
     fn test_int_add_x_plus_x() {
         // x + x → lshift(x, 1) — keep as separate test (rewrite, not identity)
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
+        let (result, _) = run_one(vec![same_i(), bin_i(OpCode::IntAdd, 0, 0)], 1, &[]);
         // x + x may be rewritten to lshift(x, 1) or kept
         assert!(
             !matches!(result, OptimizationResult::PassOn)
@@ -4042,32 +4047,13 @@ mod tests {
     #[test]
     fn test_int_mul_identities() {
         // x * 0 = 0
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(1), Value::Int(0));
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntMul, 0, 1)],
+            2,
+            &[(OpRef::int_op(1), Value::Int(0))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), 0);
 
         // x * 1 = x
         assert_binop_identity(OpCode::IntMul, 1, 1, 0);
@@ -4078,26 +4064,11 @@ mod tests {
     #[test]
     fn test_int_mul_power_of_two() {
         // x * 8 → lshift(x, 3)
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(1), Value::Int(8));
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
+        let (result, _) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntMul, 0, 1)],
+            2,
+            &[(OpRef::int_op(1), Value::Int(8))],
+        );
         match result {
             OptimizationResult::Replace(ref new_op) | OptimizationResult::Emit(ref new_op) => {
                 assert_eq!(new_op.opcode, OpCode::IntLshift);
@@ -4111,32 +4082,13 @@ mod tests {
         // x / 1 = x
         assert_binop_identity(OpCode::IntFloorDiv, 1, 1, 0);
         // 0 / x = 0
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntFloorDiv,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntFloorDiv, 0, 1)],
+            2,
+            &[(OpRef::int_op(0), Value::Int(0))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), 0);
         // x / x = 1
         assert_binop_self(OpCode::IntFloorDiv, Some(1));
         // x / -1 = neg(x)
@@ -4147,32 +4099,13 @@ mod tests {
     #[test]
     fn test_int_mod_identities() {
         // x % 1 = 0
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntMod,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(1), Value::Int(1));
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntMod, 0, 1)],
+            2,
+            &[(OpRef::int_op(1), Value::Int(1))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), 0);
         // x % x = 0
         assert_binop_self(OpCode::IntMod, Some(0));
     }
@@ -4206,85 +4139,43 @@ mod tests {
     #[test]
     fn test_unary_constant_fold() {
         // neg constant
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::IntNeg, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(42));
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(-42)
+        let (result, ctx) = run_one(
+            vec![same_i(), unary_i(OpCode::IntNeg, 0)],
+            1,
+            &[(OpRef::int_op(0), Value::Int(42))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), -42);
 
         // invert constant
-        let mut ops2 = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::IntInvert, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops2);
-        let mut ctx2 = OptContext::new(2);
-        ctx2.emit(ops2[0].clone());
-        ctx2.make_constant(OpRef::int_op(0), Value::Int(0xFF));
-        let __pf_rc = std::rc::Rc::new(ops2[1].clone());
-        ctx2.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result2 = pass.propagate_forward(&ops2[1], &__pf_rc, &mut ctx2);
-        assert!(matches!(result2, OptimizationResult::Remove));
-        assert_eq!(
-            ctx2.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(!0xFF)
+        let (result, ctx) = run_one(
+            vec![same_i(), unary_i(OpCode::IntInvert, 0)],
+            1,
+            &[(OpRef::int_op(0), Value::Int(0xFF))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), !0xFF);
     }
 
     #[test]
     fn test_int_is_zero_and_is_true() {
-        let mut pass = OptRewrite::new();
         // is_zero(0) = 1
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::IntIsZero, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(1)
+        let (result, ctx) = run_one(
+            vec![same_i(), unary_i(OpCode::IntIsZero, 0)],
+            1,
+            &[(OpRef::int_op(0), Value::Int(0))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), 1);
 
         // is_zero(5) = 0
-        let mut ops2 = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::IntIsZero, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops2);
-        let mut ctx2 = OptContext::new(2);
-        ctx2.emit(ops2[0].clone());
-        ctx2.make_constant(OpRef::int_op(0), Value::Int(5));
-        let __pf_rc = std::rc::Rc::new(ops2[1].clone());
-        ctx2.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result2 = pass.propagate_forward(&ops2[1], &__pf_rc, &mut ctx2);
-        assert!(matches!(result2, OptimizationResult::Remove));
-        assert_eq!(
-            ctx2.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
+        let (result, ctx) = run_one(
+            vec![same_i(), unary_i(OpCode::IntIsZero, 0)],
+            1,
+            &[(OpRef::int_op(0), Value::Int(5))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), 0);
     }
 
     #[test]
@@ -4300,143 +4191,80 @@ mod tests {
 
     #[test]
     fn test_guard_true_known_true() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(1));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
+        let (result, _) = run_one(
+            vec![same_i(), Op::new(OpCode::GuardTrue, &[i(0)])],
+            1,
+            &[(OpRef::int_op(0), Value::Int(1))],
+        );
+        assert_remove(&result);
     }
 
     #[test]
     fn test_guard_true_known_false() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-
-        let mut pass = OptRewrite::new();
-        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx)
-        }))
-        .expect_err("guard_true(0) should abort as InvalidLoop");
+        let err = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            run_one(
+                vec![same_i(), Op::new(OpCode::GuardTrue, &[i(0)])],
+                1,
+                &[(OpRef::int_op(0), Value::Int(0))],
+            )
+        })) {
+            Ok(_) => panic!("guard_true(0) should abort as InvalidLoop"),
+            Err(err) => err,
+        };
         assert!(err.downcast_ref::<crate::optimize::InvalidLoop>().is_some());
     }
 
     #[test]
     fn test_guard_true_unknown() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::PassOn));
+        let (result, _) = run_one(vec![same_i(), Op::new(OpCode::GuardTrue, &[i(0)])], 1, &[]);
+        assert_pass_on(&result);
     }
 
     #[test]
     fn test_guard_false_known_false() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::GuardFalse, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
+        let (result, _) = run_one(
+            vec![same_i(), Op::new(OpCode::GuardFalse, &[i(0)])],
+            1,
+            &[(OpRef::int_op(0), Value::Int(0))],
+        );
+        assert_remove(&result);
     }
 
     #[test]
     fn test_guard_false_known_true() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::GuardFalse, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(1));
-
-        let mut pass = OptRewrite::new();
-        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx)
-        }))
-        .expect_err("guard_false(1) should abort as InvalidLoop");
+        let err = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            run_one(
+                vec![same_i(), Op::new(OpCode::GuardFalse, &[i(0)])],
+                1,
+                &[(OpRef::int_op(0), Value::Int(1))],
+            )
+        })) {
+            Ok(_) => panic!("guard_false(1) should abort as InvalidLoop"),
+            Err(err) => err,
+        };
         assert!(err.downcast_ref::<crate::optimize::InvalidLoop>().is_some());
     }
 
     #[test]
     fn test_guard_value_match() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::GuardValue,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(42));
-        ctx.make_constant(OpRef::int_op(1), Value::Int(42));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
+        let (result, _) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::GuardValue, 0, 1)],
+            2,
+            &[
+                (OpRef::int_op(0), Value::Int(42)),
+                (OpRef::int_op(1), Value::Int(42)),
+            ],
+        );
+        assert_remove(&result);
     }
 
     // ── SAME_AS tests ──
 
     #[test]
     fn test_same_as_i() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement(OpRef::int_op(1)).to_opref(),
-            OpRef::int_op(0)
-        );
+        let (result, ctx) = run_one(vec![same_i(), Op::new(OpCode::SameAsI, &[i(0)])], 1, &[]);
+        assert_remove(&result);
+        assert_forward(&ctx, OpRef::int_op(1), OpRef::int_op(0));
     }
 
     // ── Integration test: full optimizer with OptRewrite ──
@@ -4568,339 +4396,150 @@ mod tests {
 
     #[test]
     fn test_int_add_wrapping() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(i64::MAX));
-        ctx.make_constant(OpRef::int_op(1), Value::Int(1));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(i64::MIN)
-        ); // wrapping
+        // wrapping
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntAdd, 0, 1)],
+            2,
+            &[
+                (OpRef::int_op(0), Value::Int(i64::MAX)),
+                (OpRef::int_op(1), Value::Int(1)),
+            ],
+        );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), i64::MIN);
     }
 
     // ── Shift of zero constant tests ──
 
     #[test]
     fn test_zero_lshift_anything() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntLshift,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntLshift, 0, 1)],
+            2,
+            &[(OpRef::int_op(0), Value::Int(0))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), 0);
     }
 
     #[test]
     fn test_zero_rshift_anything() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntRshift,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntRshift, 0, 1)],
+            2,
+            &[(OpRef::int_op(0), Value::Int(0))],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), 0);
     }
 
     // ── Non-optimizable cases (should PassOn) ──
 
     #[test]
     fn test_int_add_no_constants() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::PassOn));
+        let (result, _) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntAdd, 0, 1)],
+            2,
+            &[],
+        );
+        assert_pass_on(&result);
     }
 
     #[test]
     fn test_unknown_opcode_passthrough() {
-        let mut ops = vec![Op::new(
-            OpCode::SetfieldGc,
-            &[
-                BoxRef::from_opref(OpRef::void_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        )];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(1);
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[0].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[0], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::PassOn));
+        let (result, _) = run_one(
+            vec![Op::new(
+                OpCode::SetfieldGc,
+                &[BoxRef::from_opref(OpRef::void_op(0)), i(1)],
+            )],
+            0,
+            &[],
+        );
+        assert_pass_on(&result);
     }
 
     // ── INT_AND constant fold ──
 
     #[test]
     fn test_int_and_constant_fold() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntAnd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0xFF));
-        ctx.make_constant(OpRef::int_op(1), Value::Int(0x0F));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(0x0F)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntAnd, 0, 1)],
+            2,
+            &[
+                (OpRef::int_op(0), Value::Int(0xFF)),
+                (OpRef::int_op(1), Value::Int(0x0F)),
+            ],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), 0x0F);
     }
 
     // ── INT_OR constant fold ──
 
     #[test]
     fn test_int_or_constant_fold() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::IntOr,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0xF0));
-        ctx.make_constant(OpRef::int_op(1), Value::Int(0x0F));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(0xFF)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::IntOr, 0, 1)],
+            2,
+            &[
+                (OpRef::int_op(0), Value::Int(0xF0)),
+                (OpRef::int_op(1), Value::Int(0x0F)),
+            ],
         );
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(2), 0xFF);
     }
 
     // ── UINT_RSHIFT tests ──
 
     #[test]
     fn test_uint_rshift_zero() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::UintRshift,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(1), Value::Int(0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
-            OpRef::int_op(0)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::UintRshift, 0, 1)],
+            2,
+            &[(OpRef::int_op(1), Value::Int(0))],
         );
+        assert_remove(&result);
+        assert_forward(&ctx, OpRef::int_op(2), OpRef::int_op(0));
     }
 
     #[test]
     fn test_uint_rshift_constant_fold() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(OpCode::SameAsI, &[]),
-            Op::new(
-                OpCode::UintRshift,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(-1)); // all ones
-        ctx.make_constant(OpRef::int_op(1), Value::Int(1));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        // u64::MAX >> 1 = i64::MAX
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .and_then(|cb| cb.const_int()),
-            Some(i64::MAX)
+        let (result, ctx) = run_one(
+            vec![same_i(), same_i(), bin_i(OpCode::UintRshift, 0, 1)],
+            2,
+            &[
+                (OpRef::int_op(0), Value::Int(-1)), // all ones
+                (OpRef::int_op(1), Value::Int(1)),
+            ],
         );
+        assert_remove(&result);
+        // u64::MAX >> 1 = i64::MAX
+        assert_int_const(&ctx, OpRef::int_op(2), i64::MAX);
     }
 
     // ── Float optimization tests ──
 
     #[test]
     fn test_float_mul_one_right() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(
-                OpCode::FloatMul,
-                &[
-                    BoxRef::from_opref(OpRef::float_op(0)),
-                    BoxRef::from_opref(OpRef::float_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::float_op(1), Value::Float(1.0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
-            OpRef::float_op(0)
+        let (result, ctx) = run_one(
+            vec![same_f(), same_f(), bin_f(OpCode::FloatMul, 0, 1)],
+            2,
+            &[(OpRef::float_op(1), Value::Float(1.0))],
         );
+        assert_remove(&result);
+        assert_forward(&ctx, OpRef::float_op(2), OpRef::float_op(0));
     }
 
     #[test]
     fn test_float_mul_one_left() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(
-                OpCode::FloatMul,
-                &[
-                    BoxRef::from_opref(OpRef::float_op(0)),
-                    BoxRef::from_opref(OpRef::float_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::float_op(0), Value::Float(1.0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
-            OpRef::float_op(1)
+        let (result, ctx) = run_one(
+            vec![same_f(), same_f(), bin_f(OpCode::FloatMul, 0, 1)],
+            2,
+            &[(OpRef::float_op(0), Value::Float(1.0))],
         );
+        assert_remove(&result);
+        assert_forward(&ctx, OpRef::float_op(2), OpRef::float_op(1));
     }
 
     #[test]
@@ -4937,54 +4576,23 @@ mod tests {
     #[test]
     fn test_float_truediv_power_of_two() {
         // x / 2.0 → x * 0.5
-        let mut ops = vec![
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(
-                OpCode::FloatTrueDiv,
-                &[
-                    BoxRef::from_opref(OpRef::float_op(0)),
-                    BoxRef::from_opref(OpRef::float_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.make_constant(OpRef::float_op(1), Value::Float(2.0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
+        let (result, _) = run_one(
+            vec![same_f(), same_f(), bin_f(OpCode::FloatTrueDiv, 0, 1)],
+            2,
+            &[(OpRef::float_op(1), Value::Float(2.0))],
+        );
         assert!(matches!(result, OptimizationResult::Emit(_)));
     }
 
     #[test]
     fn test_float_no_opt_passthrough() {
         // FloatAdd with no constants: no RPython rewrite → PassOn
-        let mut ops = vec![
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(OpCode::SameAsF, &[]),
-            Op::new(
-                OpCode::FloatAdd,
-                &[
-                    BoxRef::from_opref(OpRef::float_op(0)),
-                    BoxRef::from_opref(OpRef::float_op(1)),
-                ],
-            ),
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::PassOn));
+        let (result, _) = run_one(
+            vec![same_f(), same_f(), bin_f(OpCode::FloatAdd, 0, 1)],
+            2,
+            &[],
+        );
+        assert_pass_on(&result);
     }
 
     // ── COND_CALL tests ──
@@ -4992,60 +4600,32 @@ mod tests {
     #[test]
     fn test_cond_call_constant_false_removed() {
         // CondCallN(condition=0, func, arg1) -> removed (dead call)
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: condition (const 0)
-            Op::new(OpCode::SameAsI, &[]), // op1: func
-            Op::new(OpCode::SameAsI, &[]), // op2: arg1
-            Op::new(
-                OpCode::CondCallN,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-            ), // op3
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(4);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.emit(ops[2].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[3].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
+        let (result, _) = run_one(
+            vec![
+                same_i(),
+                same_i(),
+                same_i(),
+                Op::new(OpCode::CondCallN, &[i(0), i(1), i(2)]),
+            ],
+            3,
+            &[(OpRef::int_op(0), Value::Int(0))],
+        );
+        assert_remove(&result);
     }
 
     #[test]
     fn test_cond_call_constant_true_to_direct_call() {
         // CondCallN(condition=1, func, arg1) -> CallN(func, arg1)
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: condition (const 1)
-            Op::new(OpCode::SameAsI, &[]), // op1: func
-            Op::new(OpCode::SameAsI, &[]), // op2: arg1
-            Op::new(
-                OpCode::CondCallN,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-            ), // op3
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(4);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.emit(ops[2].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(1));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[3].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
+        let (result, _) = run_one(
+            vec![
+                same_i(),
+                same_i(),
+                same_i(),
+                Op::new(OpCode::CondCallN, &[i(0), i(1), i(2)]),
+            ],
+            3,
+            &[(OpRef::int_op(0), Value::Int(1))],
+        );
         match result {
             OptimizationResult::Replace(op) => {
                 assert_eq!(op.opcode, OpCode::CallN);
@@ -5063,31 +4643,17 @@ mod tests {
     #[test]
     fn test_cond_call_value_nonnull_returns_value() {
         // CondCallValueI(value=42, func, arg1) -> value itself (no call needed)
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: value (const 42)
-            Op::new(OpCode::SameAsI, &[]), // op1: func
-            Op::new(OpCode::SameAsI, &[]), // op2: arg1
-            Op::new(
-                OpCode::CondCallValueI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-            ), // op3
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(4);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.emit(ops[2].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(42));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[3].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
+        let (result, ctx) = run_one(
+            vec![
+                same_i(),
+                same_i(),
+                same_i(),
+                Op::new(OpCode::CondCallValueI, &[i(0), i(1), i(2)]),
+            ],
+            3,
+            &[(OpRef::int_op(0), Value::Int(42))],
+        );
+        assert_remove(&result);
         let resolved = ctx.get_box_replacement(OpRef::int_op(3)).to_opref();
         assert!(resolved.is_constant());
         assert_eq!(
@@ -5100,30 +4666,16 @@ mod tests {
     #[test]
     fn test_cond_call_value_null_to_direct_call() {
         // CondCallValueI(value=0, func, arg1) -> CallPureI(func, arg1)
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: value (const 0)
-            Op::new(OpCode::SameAsI, &[]), // op1: func
-            Op::new(OpCode::SameAsI, &[]), // op2: arg1
-            Op::new(
-                OpCode::CondCallValueI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-            ), // op3
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(4);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
-        ctx.emit(ops[2].clone());
-        ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[3].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
+        let (result, _) = run_one(
+            vec![
+                same_i(),
+                same_i(),
+                same_i(),
+                Op::new(OpCode::CondCallValueI, &[i(0), i(1), i(2)]),
+            ],
+            3,
+            &[(OpRef::int_op(0), Value::Int(0))],
+        );
         match result {
             OptimizationResult::Replace(op) => {
                 assert_eq!(op.opcode, OpCode::CallPureI);
@@ -5142,117 +4694,33 @@ mod tests {
         // PtrEq(x, x) -> 1
         // resoperation.py:739 InputArgRef / 615 RefOp `type = 'r'`: ptr
         // boxes carry the Ref variant tag, not Int.
-        let mut ops = vec![
-            Op::new(OpCode::SameAsR, &[]), // op0: x
-            Op::new(
-                OpCode::PtrEq,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                ],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(1)
-        );
+        let (result, ctx) = run_one(vec![same_r(), bin_r(OpCode::PtrEq, 0, 0)], 1, &[]);
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), 1);
     }
 
     #[test]
     fn test_ptr_ne_same_opref() {
         // PtrNe(x, x) -> 0
-        let mut ops = vec![
-            Op::new(OpCode::SameAsR, &[]), // op0: x
-            Op::new(
-                OpCode::PtrNe,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                ],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
-        );
+        let (result, ctx) = run_one(vec![same_r(), bin_r(OpCode::PtrNe, 0, 0)], 1, &[]);
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), 0);
     }
 
     #[test]
     fn test_instance_ptr_eq_same_opref() {
         // InstancePtrEq(x, x) -> 1
-        let mut ops = vec![
-            Op::new(OpCode::SameAsR, &[]), // op0: x
-            Op::new(
-                OpCode::InstancePtrEq,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                ],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(1)
-        );
+        let (result, ctx) = run_one(vec![same_r(), bin_r(OpCode::InstancePtrEq, 0, 0)], 1, &[]);
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), 1);
     }
 
     #[test]
     fn test_instance_ptr_ne_same_opref() {
         // InstancePtrNe(x, x) -> 0
-        let mut ops = vec![
-            Op::new(OpCode::SameAsR, &[]), // op0: x
-            Op::new(
-                OpCode::InstancePtrNe,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                ],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(1))
-                .and_then(|cb| cb.const_int()),
-            Some(0)
-        );
+        let (result, ctx) = run_one(vec![same_r(), bin_r(OpCode::InstancePtrNe, 0, 0)], 1, &[]);
+        assert_remove(&result);
+        assert_int_const(&ctx, OpRef::int_op(1), 0);
     }
 
     #[test]
@@ -5263,34 +4731,20 @@ mod tests {
         // False for distinct ConstPtr, so it falls through to `emit(op)`
         // (line 564). The actual constant fold lives in the pure pass
         // (pure.py:126-136 → execute_ptr_compare_const), not rewrite.
-        let mut ops = vec![
-            Op::new(OpCode::SameAsR, &[]), // op0: const 100
-            Op::new(OpCode::SameAsR, &[]), // op1: const 200
-            Op::new(
-                OpCode::PtrEq,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(1)),
-                ],
-            ), // op2
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
         // history.py:307 ConstPtr — Value::Ref must land on a Ref-tagged
         // OpRef so the box class identity matches the resoperation.py:615
         // RefOp mixin of the producer SameAsR.
-        ctx.make_constant(OpRef::ref_op(0), Value::Ref(GcRef(100)));
-        ctx.make_constant(OpRef::ref_op(1), Value::Ref(GcRef(200)));
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
+        let (result, ctx) = run_one(
+            vec![same_r(), same_r(), bin_r(OpCode::PtrEq, 0, 1)],
+            2,
+            &[
+                (OpRef::ref_op(0), Value::Ref(GcRef(100))),
+                (OpRef::ref_op(1), Value::Ref(GcRef(200))),
+            ],
+        );
         // rewrite.py:564 `return self.emit(op)` — rewrite passes the op on
         // unchanged; it does not fold distinct constants.
-        assert!(matches!(result, OptimizationResult::PassOn));
+        assert_pass_on(&result);
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
                 .and_then(|cb| cb.const_int()),
@@ -5304,68 +4758,23 @@ mod tests {
     fn test_cast_ptr_to_int_passes_through() {
         // rewrite.py:807-809: CastPtrToInt registers pure inverse, emits.
         // arg0 is a Ref box (resoperation.py:615 RefOp `type = 'r'`).
-        let mut ops = vec![
-            Op::new(OpCode::SameAsR, &[]), // op0: x
-            Op::new(
-                OpCode::CastPtrToInt,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::PassOn));
+        let (result, _) = run_one(vec![same_r(), unary_r(OpCode::CastPtrToInt, 0)], 1, &[]);
+        assert_pass_on(&result);
     }
 
     #[test]
     fn test_cast_int_to_ptr_passes_through() {
         // rewrite.py:811-813: CastIntToPtr registers pure inverse, emits.
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: x
-            Op::new(
-                OpCode::CastIntToPtr,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::PassOn));
+        let (result, _) = run_one(vec![same_i(), unary_i(OpCode::CastIntToPtr, 0)], 1, &[]);
+        assert_pass_on(&result);
     }
 
     #[test]
     fn test_cast_opaque_ptr_eliminated() {
         // CastOpaquePtr(x) -> x
-        let mut ops = vec![
-            Op::new(OpCode::SameAsR, &[]), // op0: x
-            Op::new(
-                OpCode::CastOpaquePtr,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(
-            ctx.get_box_replacement(OpRef::ref_op(1)).to_opref(),
-            OpRef::ref_op(0)
-        );
+        let (result, ctx) = run_one(vec![same_r(), unary_r(OpCode::CastOpaquePtr, 0)], 1, &[]);
+        assert_remove(&result);
+        assert_forward(&ctx, OpRef::ref_op(1), OpRef::ref_op(0));
     }
 
     // ── CONVERT_FLOAT_BYTES tests ──
@@ -5375,43 +4784,23 @@ mod tests {
 
     #[test]
     fn test_convert_float_bytes_to_longlong_passes_through() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsF, &[]), // op0: x
-            Op::new(
-                OpCode::ConvertFloatBytesToLonglong,
-                &[BoxRef::from_opref(OpRef::float_op(0))],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::PassOn));
+        let (result, _) = run_one(
+            vec![same_f(), unary_f(OpCode::ConvertFloatBytesToLonglong, 0)],
+            1,
+            &[],
+        );
+        assert_pass_on(&result);
     }
 
     #[test]
     fn test_convert_longlong_bytes_to_float_passes_through() {
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: x
-            Op::new(
-                OpCode::ConvertLonglongBytesToFloat,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
-            ), // op1
-        ];
-        with_positions(&mut ops);
-        let mut ctx = OptContext::new(2);
-        ctx.emit(ops[0].clone());
-
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
+        let (result, _) = run_one(
+            vec![same_i(), unary_i(OpCode::ConvertLonglongBytesToFloat, 0)],
+            1,
+            &[],
+        );
         // PassOn: op is emitted, no replacement registered.
-        assert!(matches!(result, OptimizationResult::PassOn));
+        assert_pass_on(&result);
     }
 
     // ── GUARD_NO_EXCEPTION tests ──
@@ -5481,14 +4870,8 @@ mod tests {
     #[test]
     fn test_guard_future_condition_records_and_removes() {
         // rewrite.py: GUARD_FUTURE_CONDITION → record in patchguardop + remove
-        let mut op = Op::new(OpCode::GuardFutureCondition, &[]);
-        op.pos.set(OpRef::void_op(0));
-        let mut ctx = OptContext::new(1);
-        let mut pass = OptRewrite::new();
-        let __pf_rc = std::rc::Rc::new(op.clone());
-        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
-        let result = pass.propagate_forward(&op, &__pf_rc, &mut ctx);
-        assert!(matches!(result, OptimizationResult::Remove));
+        let (result, ctx) = run_one(vec![Op::new(OpCode::GuardFutureCondition, &[])], 0, &[]);
+        assert_remove(&result);
         assert!(ctx.patchguardop.is_some());
         assert_eq!(
             ctx.patchguardop.unwrap().opcode,

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -172,7 +172,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_ADD.
     /// `x + 0 -> x`, `0 + x -> x`, `x + x -> x << 1`
-    fn optimize_int_add(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_add(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -194,9 +194,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -207,9 +205,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg0.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg1.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -302,7 +298,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_SUB.
     /// `x - 0 -> x`, `x - x -> 0`
-    fn optimize_int_sub(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_sub(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -324,9 +320,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -378,9 +372,7 @@ impl OptRewrite {
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntAdd && inner.arg(1).to_opref() == arg1.to_opref() {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_inner = ctx
                     .ensure_box(inner.arg(0).to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -466,9 +458,7 @@ impl OptRewrite {
                         .and_then(|b| ctx.peek_intbound_box(&b)),
                 ) {
                     if bx.and_bound(&by).known_eq_const(0) {
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = BoxRef::from_bound_op(op_rc);
                         let b_inner = ctx
                             .ensure_box(inner.arg(0).to_opref())
                             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -486,9 +476,7 @@ impl OptRewrite {
                         .and_then(|b| ctx.peek_intbound_box(&b)),
                 ) {
                     if bx.and_bound(&by).known_eq_const(0) {
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = BoxRef::from_bound_op(op_rc);
                         let b_inner = ctx
                             .ensure_box(inner.arg(0).to_opref())
                             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -504,7 +492,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_MUL.
     /// `x * 0 -> 0`, `x * 1 -> x`, `0 * x -> 0`, `1 * x -> x`
-    fn optimize_int_mul(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_mul(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -542,9 +530,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -556,9 +542,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg0.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg1.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -640,7 +624,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_FLOORDIV.
     /// `x // 1 -> x`, constant fold when both operands are known.
-    fn optimize_int_floor_div(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_floor_div(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -662,9 +646,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -711,9 +693,7 @@ impl OptRewrite {
                     OpCode::IntRshift,
                     &[arg0, BoxRef::from_opref(shift_ref)],
                 ));
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_res = ctx
                     .ensure_box(result_ref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -730,9 +710,7 @@ impl OptRewrite {
                     ctx.current_pass_idx,
                     ctx,
                 );
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_res = ctx
                     .ensure_box(result)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -747,7 +725,7 @@ impl OptRewrite {
     /// Try algebraic simplification for INT_MOD.
     ///
     /// Strength reduction from rpython/jit/metainterp/optimizeopt/intdiv.py.
-    fn optimize_int_mod(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_mod(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -810,9 +788,7 @@ impl OptRewrite {
                     ctx.current_pass_idx,
                     ctx,
                 );
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_res = ctx
                     .ensure_box(result)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -826,7 +802,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_AND.
     /// `x & 0 -> 0`, `x & -1 -> x`
-    fn optimize_int_and(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_and(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -863,9 +839,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -876,9 +850,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg0.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg1.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -887,9 +859,7 @@ impl OptRewrite {
         }
         // and_x_x: int_and(a, a) => a
         if self.boxes_equal_via_intbound(arg0.to_opref(), arg1.to_opref(), ctx) {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -927,9 +897,7 @@ impl OptRewrite {
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntAnd && inner.arg(0).to_opref() == arg0.to_opref() {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_arg = ctx
                     .ensure_box(arg1.to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -948,9 +916,7 @@ impl OptRewrite {
                 .and_then(|b| ctx.peek_intbound_box(&b))
             {
                 if bound.lower >= 0 && bound.upper <= (c & !(c.wrapping_add(1))) {
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_arg = ctx
                         .ensure_box(arg0.to_opref())
                         .expect("body-namespace OpRef must have a BoxRef slot");
@@ -974,9 +940,7 @@ impl OptRewrite {
             }
             // and_idempotent: int_and(x, y) => x (if y.ones | x.zeros == -1)
             if (bb.tvalue | (!ba.tvalue & !ba.tmask)) == u64::MAX {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_arg = ctx
                     .ensure_box(arg0.to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1011,7 +975,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_OR.
     /// `x | 0 -> x`, `x | -1 -> -1`
-    fn optimize_int_or(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_or(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1033,9 +997,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1046,9 +1008,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg0.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg1.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1072,9 +1032,7 @@ impl OptRewrite {
         }
         // or_x_x: int_or(a, a) => a
         if self.boxes_equal_via_intbound(arg0.to_opref(), arg1.to_opref(), ctx) {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1112,9 +1070,7 @@ impl OptRewrite {
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntOr && inner.arg(0).to_opref() == arg0.to_opref() {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_arg = ctx
                     .ensure_box(arg1.to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1163,9 +1119,7 @@ impl OptRewrite {
             }
             // or_idempotent: int_or(x, y) => x (if x.ones | y.zeros == -1)
             if (ba.tvalue | (!bb.tvalue & !bb.tmask)) == u64::MAX {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_arg = ctx
                     .ensure_box(arg0.to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1179,7 +1133,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_XOR.
     /// `x ^ 0 -> x`, `x ^ x -> 0`
-    fn optimize_int_xor(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_xor(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1201,9 +1155,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1214,9 +1166,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg0.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg1.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1276,9 +1226,7 @@ impl OptRewrite {
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntXor && inner.arg(1).to_opref() == arg1.to_opref() {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_inner = ctx
                     .ensure_box(inner.arg(0).to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1309,7 +1257,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_LSHIFT.
     /// `x << 0 -> x`
-    fn optimize_int_lshift(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_lshift(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1331,9 +1279,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1470,7 +1416,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for INT_RSHIFT.
     /// `x >> 0 -> x`
-    fn optimize_int_rshift(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_rshift(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1492,9 +1438,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1537,9 +1481,7 @@ impl OptRewrite {
                         .and_then(|b| ctx.peek_intbound_box(&b)),
                 ) {
                     if bx.lshift_bound_cannot_overflow(&by) {
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = BoxRef::from_bound_op(op_rc);
                         let b_inner = ctx
                             .ensure_box(inner.arg(0).to_opref())
                             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1582,7 +1524,7 @@ impl OptRewrite {
 
     /// Try algebraic simplification for UINT_RSHIFT.
     /// `x >>> 0 -> x`
-    fn optimize_uint_rshift(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_uint_rshift(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -1604,9 +1546,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg1.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg0.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1671,7 +1611,7 @@ impl OptRewrite {
     // ── Unary operations ──
 
     /// Constant fold or simplify INT_NEG.
-    fn optimize_int_neg(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_neg(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         if let Some(a) = ctx
@@ -1690,9 +1630,7 @@ impl OptRewrite {
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntNeg {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_inner = ctx
                     .ensure_box(inner.arg(0).to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1705,7 +1643,7 @@ impl OptRewrite {
     }
 
     /// Constant fold or simplify INT_INVERT.
-    fn optimize_int_invert(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_invert(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         if let Some(a) = ctx
@@ -1724,9 +1662,7 @@ impl OptRewrite {
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntInvert {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_inner = ctx
                     .ensure_box(inner.arg(0).to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1751,7 +1687,7 @@ impl OptRewrite {
     ///         self.make_equal_to(op, op.getarg(0))
     ///         return
     ///     return self._optimize_nullness(op, op.getarg(0), True)
-    fn optimize_int_is_true(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_is_true(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         // rewrite.py:505-510 optimize_INT_IS_TRUE:
@@ -1777,9 +1713,7 @@ impl OptRewrite {
             {
                 if bound.is_bool() {
                     // make_equal_to: replace INT_IS_TRUE result with arg0.
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_arg = ctx
                         .ensure_box(arg0.to_opref())
                         .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1935,7 +1869,7 @@ impl OptRewrite {
     }
 
     /// Constant fold INT_FORCE_GE_ZERO.
-    fn optimize_int_force_ge_zero(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_force_ge_zero(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
 
         if let Some(a) = ctx
@@ -1952,9 +1886,7 @@ impl OptRewrite {
             .and_then(|b| ctx.peek_intbound_box(&b))
         {
             if bound.known_nonnegative() {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_arg = ctx
                     .ensure_box(arg0.to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1996,7 +1928,7 @@ impl OptRewrite {
     // ── Comparisons ──
 
     /// Constant fold binary comparisons.
-    fn optimize_comparison(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_comparison(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
 
@@ -2087,9 +2019,7 @@ impl OptRewrite {
                     .and_then(|b| ctx.peek_intbound_box(&b))
                 {
                     if bound.is_bool() {
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = BoxRef::from_bound_op(op_rc);
                         let b_arg = ctx
                             .ensure_box(arg0.to_opref())
                             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -2516,7 +2446,7 @@ impl OptRewrite {
 
     /// rewrite.py:95-101: _optimize_CALL_INT_UDIV
     /// x / 1 → x
-    fn optimize_call_int_udiv(&mut self, op: &Op, ctx: &mut OptContext) -> bool {
+    fn optimize_call_int_udiv(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> bool {
         if op.num_args() < 3 {
             return false;
         }
@@ -2525,9 +2455,7 @@ impl OptRewrite {
             .get_box_replacement_box(arg2.to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(op.arg(1).to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -2542,6 +2470,7 @@ impl OptRewrite {
     fn optimize_call_int_py_mod(
         &mut self,
         op: &Op,
+        op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> Option<OptimizationResult> {
         if op.num_args() < 3 {
@@ -2599,9 +2528,7 @@ impl OptRewrite {
             ctx.current_pass_idx,
             ctx,
         );
-        let b_old = ctx
-            .ensure_box(op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_old = BoxRef::from_bound_op(op_rc);
         let b_res = ctx
             .ensure_box(result_ref)
             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -2614,6 +2541,7 @@ impl OptRewrite {
     fn optimize_call_int_py_div(
         &mut self,
         op: &Op,
+        op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> Option<OptimizationResult> {
         if op.num_args() < 3 {
@@ -2687,9 +2615,7 @@ impl OptRewrite {
         }
         // rewrite.py:752-755: x // 1 → x
         if val == 1 {
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_arg = ctx
                 .ensure_box(arg1.to_opref())
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -2717,9 +2643,7 @@ impl OptRewrite {
             ctx.current_pass_idx,
             ctx,
         );
-        let b_old = ctx
-            .ensure_box(op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_old = BoxRef::from_bound_op(op_rc);
         let b_res = ctx
             .ensure_box(result_ref)
             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -2957,14 +2881,12 @@ impl OptRewrite {
         true
     }
 
-    fn optimize_same_as(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_same_as(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         if op.num_args() == 0 {
             return OptimizationResult::PassOn;
         }
         let arg0 = op.arg(0);
-        let b_old = ctx
-            .ensure_box(op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_old = BoxRef::from_bound_op(op_rc);
         let b_arg = ctx
             .ensure_box(arg0.to_opref())
             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -3032,7 +2954,7 @@ impl OptRewrite {
     /// 1. boolinverse(same args)
     /// 2. boolreflex(swapped args)
     /// 3. boolreflex.boolinverse(swapped args)
-    fn find_rewritable_bool(&self, op: &Op, ctx: &mut OptContext) -> Option<OptimizationResult> {
+    fn find_rewritable_bool(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> Option<OptimizationResult> {
         if op.num_args() < 2 {
             return None;
         }
@@ -3052,9 +2974,7 @@ impl OptRewrite {
         if let Some(reflex_opcode) = op.opcode.bool_reflex() {
             let key = (reflex_opcode, arg1.to_opref(), arg0.to_opref());
             if let Some(&cached_ref) = self.bool_result_cache.get(&key) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_cached = ctx
                     .ensure_box(cached_ref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -3080,7 +3000,7 @@ impl OptRewrite {
     // Constant folding for all float ops is handled by execute_nonspec_const.
 
     /// rewrite.py:103-120 optimize_FLOAT_MUL
-    fn optimize_float_mul(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_float_mul(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
         // rewrite.py:109: for lhs, rhs in [(arg1, arg2), (arg2, arg1)]:
@@ -3094,9 +3014,7 @@ impl OptRewrite {
                 })
             {
                 if v == 1.0 {
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_v2 = ctx
                         .get_box_replacement_box(rhs.to_opref())
                         .or_else(|| ctx.ensure_box(rhs.to_opref()))
@@ -3152,15 +3070,13 @@ impl OptRewrite {
     }
 
     /// rewrite.py:147-153 optimize_FLOAT_NEG
-    fn optimize_float_neg(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_float_neg(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let v = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
         if let Some(arg_op) = v.and_then(|pb| ctx.get_producing_op(&pb)) {
             if arg_op.opcode == OpCode::FloatNeg {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_inner = ctx
                     .ensure_box(arg_op.arg(0).to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -3172,16 +3088,14 @@ impl OptRewrite {
     }
 
     /// rewrite.py:155-161 optimize_FLOAT_ABS
-    fn optimize_float_abs(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_float_abs(&self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let v = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
         if let Some(v) = v {
             if let Some(arg_op) = ctx.get_producing_op(&v) {
                 if arg_op.opcode == OpCode::FloatAbs {
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     ctx.make_equal_to(&b_old, &v);
                     return OptimizationResult::Remove;
                 }
@@ -3209,7 +3123,7 @@ impl OptRewrite {
 }
 
 impl Optimization for OptRewrite {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         // Track last_op_removed for GuardNoException optimization.
         // Reset for non-guard ops (guards don't count as "the last op").
         if !op.opcode.is_guard() {
@@ -3218,31 +3132,31 @@ impl Optimization for OptRewrite {
 
         // Try boolean inverse/reflex rewrites for comparisons
         if op.opcode.bool_inverse().is_some() || op.opcode.bool_reflex().is_some() {
-            if let Some(result) = self.find_rewritable_bool(op, ctx) {
+            if let Some(result) = self.find_rewritable_bool(op, op_rc, ctx) {
                 return result;
             }
         }
 
         match op.opcode {
             // ── Binary integer arithmetic ──
-            OpCode::IntAdd => self.optimize_int_add(op, ctx),
-            OpCode::IntSub => self.optimize_int_sub(op, ctx),
-            OpCode::IntMul => self.optimize_int_mul(op, ctx),
-            OpCode::IntFloorDiv => self.optimize_int_floor_div(op, ctx),
-            OpCode::IntMod => self.optimize_int_mod(op, ctx),
-            OpCode::IntAnd => self.optimize_int_and(op, ctx),
-            OpCode::IntOr => self.optimize_int_or(op, ctx),
-            OpCode::IntXor => self.optimize_int_xor(op, ctx),
-            OpCode::IntLshift => self.optimize_int_lshift(op, ctx),
-            OpCode::IntRshift => self.optimize_int_rshift(op, ctx),
-            OpCode::UintRshift => self.optimize_uint_rshift(op, ctx),
+            OpCode::IntAdd => self.optimize_int_add(op, op_rc, ctx),
+            OpCode::IntSub => self.optimize_int_sub(op, op_rc, ctx),
+            OpCode::IntMul => self.optimize_int_mul(op, op_rc, ctx),
+            OpCode::IntFloorDiv => self.optimize_int_floor_div(op, op_rc, ctx),
+            OpCode::IntMod => self.optimize_int_mod(op, op_rc, ctx),
+            OpCode::IntAnd => self.optimize_int_and(op, op_rc, ctx),
+            OpCode::IntOr => self.optimize_int_or(op, op_rc, ctx),
+            OpCode::IntXor => self.optimize_int_xor(op, op_rc, ctx),
+            OpCode::IntLshift => self.optimize_int_lshift(op, op_rc, ctx),
+            OpCode::IntRshift => self.optimize_int_rshift(op, op_rc, ctx),
+            OpCode::UintRshift => self.optimize_uint_rshift(op, op_rc, ctx),
 
             // ── Unary integer operations ──
-            OpCode::IntNeg => self.optimize_int_neg(op, ctx),
-            OpCode::IntInvert => self.optimize_int_invert(op, ctx),
+            OpCode::IntNeg => self.optimize_int_neg(op, op_rc, ctx),
+            OpCode::IntInvert => self.optimize_int_invert(op, op_rc, ctx),
             OpCode::IntIsZero => self.optimize_int_is_zero(op, ctx),
-            OpCode::IntIsTrue => self.optimize_int_is_true(op, ctx),
-            OpCode::IntForceGeZero => self.optimize_int_force_ge_zero(op, ctx),
+            OpCode::IntIsTrue => self.optimize_int_is_true(op, op_rc, ctx),
+            OpCode::IntForceGeZero => self.optimize_int_force_ge_zero(op, op_rc, ctx),
             OpCode::IntBetween => self.optimize_int_between(op, ctx),
 
             // ── Comparisons ──
@@ -3255,7 +3169,7 @@ impl Optimization for OptRewrite {
             | OpCode::UintLt
             | OpCode::UintLe
             | OpCode::UintGt
-            | OpCode::UintGe => self.optimize_comparison(op, ctx),
+            | OpCode::UintGe => self.optimize_comparison(op, op_rc, ctx),
 
             // ── Guards ──
             OpCode::GuardTrue => self.optimize_guard_true(op, ctx),
@@ -3372,13 +3286,13 @@ impl Optimization for OptRewrite {
             }
 
             // ── Float arithmetic ──
-            OpCode::FloatMul => self.optimize_float_mul(op, ctx),
+            OpCode::FloatMul => self.optimize_float_mul(op, op_rc, ctx),
             OpCode::FloatTrueDiv => self.optimize_float_truediv(op, ctx),
-            OpCode::FloatNeg => self.optimize_float_neg(op, ctx),
-            OpCode::FloatAbs => self.optimize_float_abs(op, ctx),
+            OpCode::FloatNeg => self.optimize_float_neg(op, op_rc, ctx),
+            OpCode::FloatAbs => self.optimize_float_abs(op, op_rc, ctx),
 
             // ── Identity ops ──
-            OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF => self.optimize_same_as(op, ctx),
+            OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF => self.optimize_same_as(op, op_rc, ctx),
 
             // ── Conditional calls ──
             OpCode::CondCallN => {
@@ -3411,9 +3325,7 @@ impl Optimization for OptRewrite {
                 let nullness = self.getnullness(op.arg(0).to_opref(), ctx);
                 // rewrite.py:486-489: INFO_NONNULL → result is arg(0)
                 if nullness == Nullness::Nonnull {
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_arg = ctx
                         .ensure_box(op.arg(0).to_opref())
                         .expect("body-namespace OpRef must have a BoxRef slot");
@@ -3485,9 +3397,7 @@ impl Optimization for OptRewrite {
             }
             // jtransform.py:1264-1266: CAST_OPAQUE_PTR is identity (no-op).
             OpCode::CastOpaquePtr => {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_arg = ctx
                     .ensure_box(op.arg(0).to_opref())
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -3563,19 +3473,19 @@ impl Optimization for OptRewrite {
                         match ei.oopspecindex {
                             // rewrite.py:688: OS_INT_UDIV
                             majit_ir::OopSpecIndex::IntUdiv => {
-                                if self.optimize_call_int_udiv(op, ctx) {
+                                if self.optimize_call_int_udiv(op, op_rc, ctx) {
                                     return OptimizationResult::Remove;
                                 }
                             }
                             // rewrite.py:689: OS_INT_PY_DIV
                             majit_ir::OopSpecIndex::IntPyDiv => {
-                                if let Some(result) = self.optimize_call_int_py_div(op, ctx) {
+                                if let Some(result) = self.optimize_call_int_py_div(op, op_rc, ctx) {
                                     return result;
                                 }
                             }
                             // rewrite.py:692: OS_INT_PY_MOD
                             majit_ir::OopSpecIndex::IntPyMod => {
-                                if let Some(result) = self.optimize_call_int_py_mod(op, ctx) {
+                                if let Some(result) = self.optimize_call_int_py_mod(op, op_rc, ctx) {
                                     return result;
                                 }
                             }
@@ -3645,9 +3555,7 @@ impl Optimization for OptRewrite {
                             }
                             LoopInvariantEntry::Direct(r) => r,
                         };
-                        let b_old = ctx
-                            .ensure_box(op.pos.get())
-                            .expect("body-namespace OpRef must have a BoxRef slot");
+                        let b_old = BoxRef::from_bound_op(op_rc);
                         let b_cached = ctx
                             .get_box_replacement_box(cached_result)
                             .or_else(|| ctx.ensure_box(cached_result))
@@ -3928,7 +3836,9 @@ mod tests {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
 
-            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
+            let __pf_rc = std::rc::Rc::new(resolved.clone());
+            ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+            match pass.propagate_forward(&resolved, &__pf_rc, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -3981,7 +3891,9 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(const_pos as u32), Value::Int(const_val));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(
             matches!(result, OptimizationResult::Remove),
             "{opcode:?} with const {const_val} at pos {const_pos} should Remove"
@@ -4013,7 +3925,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(a));
         ctx.make_constant(OpRef::int_op(1), Value::Int(b));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(
             matches!(result, OptimizationResult::Remove),
             "{opcode:?}({a}, {b}) should constant-fold"
@@ -4042,7 +3956,9 @@ mod tests {
         let mut ctx = OptContext::new(2);
         ctx.emit(ops[0].clone());
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(
             matches!(result, OptimizationResult::Remove),
             "{opcode:?}(x, x) should Remove"
@@ -4084,7 +4000,9 @@ mod tests {
         let mut ctx = OptContext::new(2);
         ctx.emit(ops[0].clone());
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         // x + x may be rewritten to lshift(x, 1) or kept
         assert!(
             !matches!(result, OptimizationResult::PassOn)
@@ -4123,7 +4041,9 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(1), Value::Int(0));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4157,7 +4077,9 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(1), Value::Int(8));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         match result {
             OptimizationResult::Replace(ref new_op) | OptimizationResult::Emit(ref new_op) => {
                 assert_eq!(new_op.opcode, OpCode::IntLshift);
@@ -4188,7 +4110,9 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4222,7 +4146,9 @@ mod tests {
         ctx.emit(ops[1].clone());
         ctx.make_constant(OpRef::int_op(1), Value::Int(1));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4271,7 +4197,9 @@ mod tests {
         ctx.emit(ops[0].clone());
         ctx.make_constant(OpRef::int_op(0), Value::Int(42));
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -4288,7 +4216,9 @@ mod tests {
         let mut ctx2 = OptContext::new(2);
         ctx2.emit(ops2[0].clone());
         ctx2.make_constant(OpRef::int_op(0), Value::Int(0xFF));
-        let result2 = pass.propagate_forward(&ops2[1], &std::rc::Rc::new(ops2[1].clone()), &mut ctx2);
+        let __pf_rc = std::rc::Rc::new(ops2[1].clone());
+        ctx2.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result2 = pass.propagate_forward(&ops2[1], &__pf_rc, &mut ctx2);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
             ctx2.get_box_replacement_box(OpRef::int_op(1))
@@ -4309,7 +4239,9 @@ mod tests {
         let mut ctx = OptContext::new(2);
         ctx.emit(ops[0].clone());
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -4326,7 +4258,9 @@ mod tests {
         let mut ctx2 = OptContext::new(2);
         ctx2.emit(ops2[0].clone());
         ctx2.make_constant(OpRef::int_op(0), Value::Int(5));
-        let result2 = pass.propagate_forward(&ops2[1], &std::rc::Rc::new(ops2[1].clone()), &mut ctx2);
+        let __pf_rc = std::rc::Rc::new(ops2[1].clone());
+        ctx2.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result2 = pass.propagate_forward(&ops2[1], &__pf_rc, &mut ctx2);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
             ctx2.get_box_replacement_box(OpRef::int_op(1))
@@ -4358,7 +4292,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -4392,7 +4328,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -4408,7 +4346,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -4452,7 +4392,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(42));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -4469,7 +4411,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::int_op(1)).to_opref(),
@@ -4513,7 +4457,9 @@ mod tests {
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
+            let __pf_rc = std::rc::Rc::new(resolved.clone());
+            ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+            match pass.propagate_forward(&resolved, &__pf_rc, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -4574,7 +4520,9 @@ mod tests {
                 for i in 0..resolved.num_args() {
                     resolved.setarg(i, ctx.get_box_replacement(resolved.arg(i).to_opref()));
                 }
-                match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
+                let __pf_rc = std::rc::Rc::new(resolved.clone());
+                ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+                match pass.propagate_forward(&resolved, &__pf_rc, &mut ctx) {
                     OptimizationResult::Emit(emitted) => {
                         ctx.emit(emitted);
                     }
@@ -4621,7 +4569,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4652,7 +4602,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4681,7 +4633,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4711,7 +4665,9 @@ mod tests {
         ctx.emit(ops[1].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -4728,7 +4684,9 @@ mod tests {
         let mut ctx = OptContext::new(1);
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[0], &std::rc::Rc::new(ops[0].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[0].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[0], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -4755,7 +4713,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(0x0F));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4787,7 +4747,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(0x0F));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(2))
@@ -4818,7 +4780,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
@@ -4847,7 +4811,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(1), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         // u64::MAX >> 1 = i64::MAX
         assert_eq!(
@@ -4879,7 +4845,9 @@ mod tests {
         ctx.make_constant(OpRef::float_op(1), Value::Float(1.0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
@@ -4907,7 +4875,9 @@ mod tests {
         ctx.make_constant(OpRef::float_op(0), Value::Float(1.0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
@@ -4929,12 +4899,16 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         // Process op1 first (pass it through)
-        let result1 = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result1 = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result1, OptimizationResult::PassOn));
         ctx.emit(ops[1].clone());
 
         // Process op2: should detect double negation
-        let result2 = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result2 = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
@@ -4963,7 +4937,9 @@ mod tests {
         ctx.make_constant(OpRef::float_op(1), Value::Float(2.0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Emit(_)));
     }
 
@@ -4987,7 +4963,9 @@ mod tests {
         ctx.emit(ops[1].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5017,7 +4995,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[3].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
     }
 
@@ -5045,7 +5025,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(1));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[3].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
         match result {
             OptimizationResult::Replace(op) => {
                 assert_eq!(op.opcode, OpCode::CallN);
@@ -5084,7 +5066,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(42));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[3].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         let resolved = ctx.get_box_replacement(OpRef::int_op(3)).to_opref();
         assert!(resolved.is_constant());
@@ -5119,7 +5103,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(0), Value::Int(0));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[3].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
         match result {
             OptimizationResult::Replace(op) => {
                 assert_eq!(op.opcode, OpCode::CallPureI);
@@ -5153,7 +5139,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5180,7 +5168,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5207,7 +5197,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5234,7 +5226,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement_box(OpRef::int_op(1))
@@ -5273,7 +5267,9 @@ mod tests {
         ctx.make_constant(OpRef::ref_op(1), Value::Ref(GcRef(200)));
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         // rewrite.py:564 `return self.emit(op)` — rewrite passes the op on
         // unchanged; it does not fold distinct constants.
         assert!(matches!(result, OptimizationResult::PassOn));
@@ -5302,7 +5298,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5321,7 +5319,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5340,7 +5340,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
             ctx.get_box_replacement(OpRef::ref_op(1)).to_opref(),
@@ -5367,7 +5369,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -5385,7 +5389,9 @@ mod tests {
         ctx.emit(ops[0].clone());
 
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         // PassOn: op is emitted, no replacement registered.
         assert!(matches!(result, OptimizationResult::PassOn));
     }
@@ -5415,11 +5421,15 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         // Process CondCallN -> removed
-        let result2 = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result2 = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result2, OptimizationResult::Remove));
 
         // Process GuardNoException -> should also be removed
-        let result3 = pass.propagate_forward(&ops[3], &std::rc::Rc::new(ops[3].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[3].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result3 = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
         assert!(matches!(result3, OptimizationResult::Remove));
     }
 
@@ -5437,12 +5447,16 @@ mod tests {
 
         let mut pass = OptRewrite::new();
         // Process CallN -> PassOn (not handled by OptRewrite)
-        let result1 = pass.propagate_forward(&ops[1], &std::rc::Rc::new(ops[1].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result1 = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result1, OptimizationResult::PassOn));
         ctx.emit(ops[1].clone());
 
         // Process GuardNoException -> should NOT be removed
-        let result2 = pass.propagate_forward(&ops[2], &std::rc::Rc::new(ops[2].clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result2 = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result2, OptimizationResult::PassOn));
     }
 
@@ -5453,7 +5467,9 @@ mod tests {
         op.pos.set(OpRef::void_op(0));
         let mut ctx = OptContext::new(1);
         let mut pass = OptRewrite::new();
-        let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
+        let __pf_rc = std::rc::Rc::new(op.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
+        let result = pass.propagate_forward(&op, &__pf_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert!(ctx.patchguardop.is_some());
         assert_eq!(

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1478,7 +1478,7 @@ impl ProducedShortOp {
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
         let descr_idx = descr.index();
-        let obj_resolved = ctx.get_box_replacement(obj);
+        let obj_resolved = ctx.get_box_replacement(obj).to_opref();
         // shortpreamble.py:66-68: if g.getarg(0) in exported_infos:
         //     setinfo_from_preamble(g.getarg(0), exported_infos[...])
         // Pass the Rc handle (unroll.py:61 identity preservation).
@@ -1595,7 +1595,7 @@ impl ProducedShortOp {
         // without relying on the use-before-def assembly adaptation.
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
-        let obj_resolved = ctx.get_box_replacement(obj);
+        let obj_resolved = ctx.get_box_replacement(obj).to_opref();
         // shortpreamble.py:68-71 applies to both getfield and
         // getarrayitem: if the base object has exported info, import it
         // before ensuring heap/array PtrInfo.

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1367,12 +1367,14 @@ impl ProducedShortOp {
         // and corrupts the SAME_AS in `extra_same_as`.
         // Non-invented re-uses self.res directly without forwarding.
         if self.invented_name {
-            let b_source = ctx
-                .ensure_box(source)
-                .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_result = ctx
-                .ensure_box(result_opref)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_source = match ctx.get_box_replacement_box(source) {
+                Some(b) => b,
+                None => ctx.mint_box_at(source),
+            };
+            let b_result = match ctx.get_box_replacement_box(result_opref) {
+                Some(b) => b,
+                None => ctx.mint_box_at(result_opref),
+            };
             ctx.make_equal_to(&b_source, &b_result);
         }
         // `result_opref` is a typed synthetic alias minted by
@@ -1526,12 +1528,14 @@ impl ProducedShortOp {
         // Cat-2.2 alignment: forward `source -> result_opref` after the
         // PtrInfo / const-info side tables have been seeded (so the seeds
         // see the unforwarded source key consistent with `pop.op = source`).
-        let b_source = ctx
-            .ensure_box(source)
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let b_result = ctx
-            .ensure_box(result_opref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_source = match ctx.get_box_replacement_box(source) {
+            Some(b) => b,
+            None => ctx.mint_box_at(source),
+        };
+        let b_result = match ctx.get_box_replacement_box(result_opref) {
+            Some(b) => b,
+            None => ctx.mint_box_at(result_opref),
+        };
         ctx.make_equal_to(&b_source, &b_result);
         // see produce_pure: extra_same_as collected lazily by
         // imported_short_preamble_builder; eager push would be a dual-write.
@@ -1653,12 +1657,14 @@ impl ProducedShortOp {
         }
         // Cat-2.2 alignment: forward `source -> result_opref` after the
         // const-info / ArrayPtrInfo side tables have been seeded.
-        let b_source = ctx
-            .ensure_box(source)
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let b_result = ctx
-            .ensure_box(result_opref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_source = match ctx.get_box_replacement_box(source) {
+            Some(b) => b,
+            None => ctx.mint_box_at(source),
+        };
+        let b_result = match ctx.get_box_replacement_box(result_opref) {
+            Some(b) => b,
+            None => ctx.mint_box_at(result_opref),
+        };
         ctx.make_equal_to(&b_source, &b_result);
         // see produce_pure: extra_same_as collected lazily by
         // imported_short_preamble_builder; eager push would be a dual-write.
@@ -1707,12 +1713,14 @@ impl ProducedShortOp {
         // get_box_replacement uniformly.
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
-        let b_source = ctx
-            .ensure_box(source)
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let b_result = ctx
-            .ensure_box(result_opref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_source = match ctx.get_box_replacement_box(source) {
+            Some(b) => b,
+            None => ctx.mint_box_at(source),
+        };
+        let b_result = match ctx.get_box_replacement_box(result_opref) {
+            Some(b) => b,
+            None => ctx.mint_box_at(result_opref),
+        };
         ctx.make_equal_to(&b_source, &b_result);
         // `rewrite.py:31` `self.opt.loop_invariant_results[key] = old_op` —
         // dict-as-map semantics; pyre's Vec-backed parity overwrites the

--- a/majit/majit-metainterp/src/optimizeopt/simplify.rs
+++ b/majit/majit-metainterp/src/optimizeopt/simplify.rs
@@ -39,7 +39,7 @@ impl Default for OptSimplify {
 }
 
 impl Optimization for OptSimplify {
-    fn propagate_forward(&mut self, op: &Op, _ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
         match op.opcode {
             // CALL_PURE_* -> CALL_*
             OpCode::CallPureI | OpCode::CallPureR | OpCode::CallPureF | OpCode::CallPureN => {

--- a/majit/majit-metainterp/src/optimizeopt/simplify.rs
+++ b/majit/majit-metainterp/src/optimizeopt/simplify.rs
@@ -39,7 +39,12 @@ impl Default for OptSimplify {
 }
 
 impl Optimization for OptSimplify {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, _ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        _op_rc: &majit_ir::OpRc,
+        _ctx: &mut OptContext,
+    ) -> OptimizationResult {
         match op.opcode {
             // CALL_PURE_* -> CALL_*
             OpCode::CallPureI | OpCode::CallPureR | OpCode::CallPureF | OpCode::CallPureN => {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5223,7 +5223,12 @@ impl Default for OptUnroll {
 }
 
 impl Optimization for OptUnroll {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        _op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         // Only peel once per trace, and only for Jump (back-edge).
         if op.opcode == OpCode::Jump && !self.seen_jump {
             self.seen_jump = true;

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5223,7 +5223,7 @@ impl Default for OptUnroll {
 }
 
 impl Optimization for OptUnroll {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         // Only peel once per trace, and only for Jump (back-edge).
         if op.opcode == OpCode::Jump && !self.seen_jump {
             self.seen_jump = true;

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3780,9 +3780,13 @@ impl OptUnroll {
             // makes this hold by construction in production callers.
             debug_assert!(source != *target, "import_state: source is target");
             // source.set_forwarded(target)
+            // `source` is `targetargs[i]`, produced by the caller's
+            // cross-slot resolution as either a materialized inputarg or a
+            // `reserve_virtual_box`-minted alias — both resolve without
+            // minting here.
             let b_source = ctx
-                .ensure_box(source)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+                .get_box_replacement_box(source)
+                .expect("import_state source must have a materialized BoxRef slot");
             let b_target = ctx.get_box_replacement(*target);
             ctx.make_equal_to(&b_source, &b_target);
             if crate::debug::have_debug_prints() {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3783,9 +3783,7 @@ impl OptUnroll {
             let b_source = ctx
                 .ensure_box(source)
                 .expect("body-namespace OpRef must have a BoxRef slot");
-            let b_target = ctx
-                .ensure_box(*target)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_target = ctx.get_box_replacement(*target);
             ctx.make_equal_to(&b_source, &b_target);
             if crate::debug::have_debug_prints() {
                 crate::debug::log_one(
@@ -4655,9 +4653,7 @@ fn assemble_peeled_trace_with_jump_args(
                 let b_js = ctx
                     .ensure_box(jump_source)
                     .expect("body-namespace OpRef must have a BoxRef slot");
-                let b_ela = ctx
-                    .ensure_box(extended_label_arg)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_ela = ctx.get_box_replacement(extended_label_arg);
                 ctx.make_equal_to(&b_js, &b_ela);
                 assembly_alias_remap.insert(jump_source, extended_label_arg);
             }
@@ -6628,9 +6624,7 @@ mod tests {
         let b_src = ctx
             .ensure_box(OpRef::ref_op(19))
             .expect("body-namespace OpRef must have a BoxRef slot");
-        let b_tgt = ctx
-            .ensure_box(OpRef::ref_op(14))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_tgt = ctx.get_box_replacement(OpRef::ref_op(14));
         ctx.make_equal_to(&b_src, &b_tgt);
         let pop = crate::optimizeopt::info::PreambleOp {
             op: OpRef::ref_op(19),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1930,7 +1930,7 @@ pub struct ExportedState {
     pub patchguardop: Option<majit_ir::Op>,
     /// `OptContext::next_pos` at end of Phase 1 — strict upper bound of
     /// every OpRef Phase 1 allocated, including intermediates folded /
-    /// forwarded away. `reserve_pos_typed` skips `ensure_box` on the
+    /// forwarded away. `reserve_pos_typed` skips `materialize_box_at` on the
     /// zero-inputarg / retrace baselines (`optimizeopt/mod.rs:2026`),
     /// so capturing `ctx.next_pos` at export is the only reliable
     /// floor. Phase 2 / retrace seed their TraceIterator namespace
@@ -2923,7 +2923,7 @@ impl OptUnroll {
         // `OptContext::next_pos` is the strict upper bound on raw OpRefs
         // Phase 1 allocated, including intermediates folded / forwarded
         // away before any structure-stored field could observe them.
-        // `reserve_pos_typed` skips `ensure_box` on the zero-inputarg /
+        // `reserve_pos_typed` skips `materialize_box_at` on the zero-inputarg /
         // retrace baselines (`optimizeopt/mod.rs:2026`), so capturing
         // `ctx.next_pos` at export is the only reliable floor for
         // `opref_high_water()` to feed retrace's `start_fresh`.
@@ -2960,7 +2960,7 @@ impl OptUnroll {
                 }
                 // S-0.C: `box_pool[*ia_opref].bound_inputarg()` resolves
                 // to the same `InputArgRc` as `inputarg_refs[idx]` after
-                // `ensure_inputarg_bindings` / `ensure_box`'s InputArg
+                // `ensure_inputarg_bindings` / `materialize_box_at`'s InputArg
                 // placeholder arm have run (both write the canonical
                 // `InputArgRc` matching the OpRef's type). Drop the
                 // box_pool fallback — fall through to a fresh `InputArg`
@@ -4654,9 +4654,7 @@ fn assemble_peeled_trace_with_jump_args(
         );
         if let Some(&jump_source) = filtered_extra_jump_args.get(i) {
             if !jump_source.is_none() && jump_source != source_slot {
-                let b_js = ctx
-                    .ensure_box(jump_source)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_js = ctx.materialize_box_at(jump_source);
                 let b_ela = ctx.get_box_replacement(extended_label_arg);
                 ctx.make_equal_to(&b_js, &b_ela);
                 assembly_alias_remap.insert(jump_source, extended_label_arg);
@@ -6249,10 +6247,10 @@ mod tests {
         // directly on the box's _forwarded slot via setintbound.
         // widen() relaxes bounds: lower < MININT/2 → MININT, upper > MAXINT/2 → MAXINT.
         // For [10, 20], both are within MININT/2..MAXINT/2 so widen() preserves them.
-        let imported_bound = ctx2
-            .ensure_box(OpRef::int_op(21))
-            .map(|b| ctx2.getintbound_handle(&b).borrow().clone())
-            .expect("getintbound: operand must resolve to a BoxRef");
+        let imported_bound = {
+            let __mb = ctx2.materialize_box_at(OpRef::int_op(21));
+            ctx2.getintbound_handle(&__mb).borrow().clone()
+        };
         assert_eq!((imported_bound.lower, imported_bound.upper), (10, 20));
     }
 
@@ -6625,9 +6623,7 @@ mod tests {
         // make_equal_to, but the test still walks the get_box_replacement
         // chain inside force_box's add_preamble_op, so install a manual
         // forwarding to the body-visible OpRef to exercise that path.
-        let b_src = ctx
-            .ensure_box(OpRef::ref_op(19))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_src = ctx.materialize_box_at(OpRef::ref_op(19));
         let b_tgt = ctx.get_box_replacement(OpRef::ref_op(14));
         ctx.make_equal_to(&b_src, &b_tgt);
         let pop = crate::optimizeopt::info::PreambleOp {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1171,14 +1171,14 @@ impl UnrollOptimizer {
                     // dispatcher, matching optimizer.py:306-319.
                     let resolved_jump_args: Vec<OpRef> = body_jump_args
                         .iter()
-                        .map(|&arg| final_ctx.get_box_replacement(arg))
+                        .map(|&arg| final_ctx.get_box_replacement(arg).to_opref())
                         .collect();
                     for &arg in &resolved_jump_args {
                         let _ = opt_p2.force_box_for_end_of_preamble(arg, &mut final_ctx);
                     }
                     let forced_jump_args: Vec<OpRef> = body_jump_args
                         .iter()
-                        .map(|&arg| final_ctx.get_box_replacement(arg))
+                        .map(|&arg| final_ctx.get_box_replacement(arg).to_opref())
                         .collect();
                     let current_vs = crate::optimizeopt::virtualstate::export_state(
                         &forced_jump_args,
@@ -1257,7 +1257,7 @@ impl UnrollOptimizer {
                                 continue;
                             }
                             visited_force.insert(arg);
-                            let resolved = final_ctx.get_box_replacement(arg);
+                            let resolved = final_ctx.get_box_replacement(arg).to_opref();
                             let needs_force = final_ctx
                                 .potential_extra_ops
                                 .iter()
@@ -1809,7 +1809,9 @@ impl UnrollOptimizer {
     /// unroll.py: _check_no_forwarding(lsts)
     /// Debug assertion: verify no OpRef in the lists has been forwarded.
     pub fn check_no_forwarding(ctx: &crate::optimizeopt::OptContext, oprefs: &[OpRef]) -> bool {
-        oprefs.iter().all(|&r| ctx.get_box_replacement(r) == r)
+        oprefs
+            .iter()
+            .all(|&r| ctx.get_box_replacement(r).to_opref() == r)
     }
 
     /// unroll.py: disable_retracing_if_max_retrace_guards(ops, target_token)
@@ -2822,7 +2824,7 @@ impl OptUnroll {
         let end_args: Vec<OpRef> = ctx.preamble_end_args.clone().unwrap_or_else(|| {
             original_label_args
                 .iter()
-                .map(|&a| ctx.get_box_replacement(a))
+                .map(|&a| ctx.get_box_replacement(a).to_opref())
                 .collect()
         });
         // unroll.py:457 `virtual_state = self.get_virtual_state(end_args)`
@@ -2901,7 +2903,7 @@ impl OptUnroll {
         // unroll.py:458 `end_args = [get_box_replacement(arg) for arg in end_args]`.
         let resolved_next_iteration_args: Vec<OpRef> = end_args
             .iter()
-            .map(|&a| ctx.get_box_replacement(a))
+            .map(|&a| ctx.get_box_replacement(a).to_opref())
             .collect();
         // Phase B B1: `produced_short_boxes` is derived from
         // `exported_short_boxes` lazily at the consumer site
@@ -3025,7 +3027,7 @@ impl OptUnroll {
             crate::optimizeopt::info::OpInfo,
         >,
     ) {
-        let resolved = ctx.get_box_replacement(arg);
+        let resolved = ctx.get_box_replacement(arg).to_opref();
         if infos.contains_key(&resolved) {
             // Also store under the original key so import_state can
             // find the info using the unresolved next_iteration_args key.
@@ -3212,7 +3214,7 @@ impl OptUnroll {
             .unwrap_or_else(|| crate::optimizeopt::virtualstate::export_state(jump_args, ctx));
         let mut args: Vec<OpRef> = jump_args
             .iter()
-            .map(|&a| ctx.get_box_replacement(a))
+            .map(|&a| ctx.get_box_replacement(a).to_opref())
             .collect();
 
         for (tt_idx, target_token) in target_tokens.iter_mut().enumerate() {
@@ -3343,7 +3345,7 @@ impl OptUnroll {
                     if force_boxes {
                         args = jump_args
                             .iter()
-                            .map(|&a| ctx.get_box_replacement(a))
+                            .map(|&a| ctx.get_box_replacement(a).to_opref())
                             .collect();
                         virtual_state = crate::optimizeopt::virtualstate::export_state(&args, ctx);
                     }
@@ -3691,7 +3693,7 @@ impl OptUnroll {
                         } else {
                             *mapping.get(jump_arg).expect("mapping missing jump_arg")
                         };
-                        ctx.get_box_replacement(mapped)
+                        ctx.get_box_replacement(mapped).to_opref()
                     })
                     .collect();
                 // unroll.py:419-421
@@ -3715,7 +3717,7 @@ impl OptUnroll {
             .iter()
             .map(|&jump_arg| {
                 let mapped = mapping.get(&jump_arg).copied().unwrap_or(jump_arg);
-                ctx.get_box_replacement(mapped)
+                ctx.get_box_replacement(mapped).to_opref()
             })
             .collect()
     }
@@ -3979,7 +3981,7 @@ impl OptUnroll {
         >,
     ) -> Option<crate::optimizeopt::info::OpInfo> {
         use crate::optimizeopt::info::{OpInfo, PtrInfo};
-        let resolved = ctx.get_box_replacement(opref);
+        let resolved = ctx.get_box_replacement(opref).to_opref();
         // unroll.py:432-443 `_expand_info` calls `self.optimizer.getinfo(arg)`
         // which itself runs `get_box_replacement` first, so a non-constant
         // OpRef forwarded to a Const surfaces the corresponding constant
@@ -4527,11 +4529,9 @@ fn assemble_peeled_trace_with_jump_args(
                 // Label carries the forwarded Box, but first fall-through
                 // only has the preamble source; pyre's flat OpRef model
                 // needs an explicit SameAs bridge before the Label.
-                if let Some(source) = preamble_defs
-                    .iter()
-                    .copied()
-                    .find(|&source| source != arg && ctx.get_box_replacement(source) == arg)
-                {
+                if let Some(source) = preamble_defs.iter().copied().find(|&source| {
+                    source != arg && ctx.get_box_replacement(source).to_opref() == arg
+                }) {
                     let tp = ctx
                         .opref_type(arg)
                         .or_else(|| ctx.opref_type(source))

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1661,7 +1661,12 @@ impl Default for VectorizingOptimizer {
 }
 
 impl Optimization for VectorizingOptimizer {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        _op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         match op.opcode {
             OpCode::Label => {
                 self.in_loop = true;

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1661,7 +1661,7 @@ impl Default for VectorizingOptimizer {
 }
 
 impl Optimization for VectorizingOptimizer {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         match op.opcode {
             OpCode::Label => {
                 self.in_loop = true;

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -248,7 +248,7 @@ impl VirtualizableTracker {
         &self,
         array_box: &crate::r#box::BoxRef,
         ctx: &mut OptContext,
-    ) -> Option<(OpRef, u32)> {
+    ) -> Option<(crate::r#box::BoxRef, u32)> {
         let producer = ctx.get_producing_op(array_box)?;
         if !matches!(
             producer.opcode,
@@ -256,9 +256,8 @@ impl VirtualizableTracker {
         ) {
             return None;
         }
-        let frame_ref = ctx
-            .get_box_replacement(producer.arg(0).to_opref())
-            .to_opref();
+        // Terminal box of the GetfieldRaw receiver — the virtualizable frame.
+        let frame_box = ctx.get_box_replacement(producer.arg(0).to_opref());
         let is_standard = ctx
             .get_box_replacement_box(producer.arg(0).to_opref())
             .map_or(false, |b| self.is_standard_ref(&b, ctx));
@@ -271,7 +270,7 @@ impl VirtualizableTracker {
             .getdescr()
             .and_then(|d| d.as_field_descr().map(|fd| fd.offset()))?;
         let array_idx = self.array_idx_for_offset(offset)?;
-        Some((frame_ref, array_idx))
+        Some((frame_box, array_idx))
     }
 
     /// Mirror a setarrayitem write to the virtualizable array state.
@@ -282,15 +281,13 @@ impl VirtualizableTracker {
         value_ref: OpRef,
         ctx: &mut OptContext,
     ) {
-        if let Some((frame_ref, array_idx)) = self.resolve_array_source(array_box, ctx) {
+        if let Some((frame_box, array_idx)) = self.resolve_array_source(array_box, ctx) {
             let elem_idx = index as usize;
-            if let Some(b) = ctx.ensure_box(frame_ref) {
-                ctx.with_ptr_info_mut(&b, |info| {
-                    if let PtrInfo::Virtualizable(vstate) = info {
-                        set_array_element(&mut vstate.arrays, array_idx, elem_idx, value_ref);
-                    }
-                });
-            }
+            ctx.with_ptr_info_mut(&frame_box, |info| {
+                if let PtrInfo::Virtualizable(vstate) = info {
+                    set_array_element(&mut vstate.arrays, array_idx, elem_idx, value_ref);
+                }
+            });
         }
     }
 }
@@ -1153,7 +1150,7 @@ impl OptVirtualize {
             // virtualize.py:374-381: try setitem_raw → return (remove);
             // except InvalidRawOperation → pass → emit(op)
             let item_size = ad.item_size();
-            let outcome = ctx.ensure_box(parent).and_then(|b| {
+            let outcome = ctx.get_box_replacement_box(parent).and_then(|b| {
                 ctx.with_ptr_info_mut(&b, |info| {
                     if let PtrInfo::VirtualRawBuffer(vinfo) = info {
                         Some(
@@ -1410,7 +1407,7 @@ impl OptVirtualize {
                             }
                             return OptimizationResult::PassOn;
                         };
-                        let outcome = ctx.ensure_box(parent).and_then(|b| {
+                        let outcome = ctx.get_box_replacement_box(parent).and_then(|b| {
                             ctx.with_ptr_info_mut(&b, |info| {
                                 if let PtrInfo::VirtualRawBuffer(vinfo) = info {
                                     Some(
@@ -1699,10 +1696,12 @@ impl OptVirtualize {
             return false;
         }
         // self.make_equal_to(op, forcedop)
+        // `forced_resolved` is the chain terminal of a forced virtual, which
+        // is always an emitted producer, so it resolves without minting.
         let b_old = BoxRef::from_bound_op(op_rc);
         let b_forced = ctx
-            .ensure_box(forced_resolved)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+            .get_box_replacement_box(forced_resolved)
+            .expect("forced virtual terminal must resolve to a BoxRef");
         ctx.make_equal_to(&b_old, &b_forced);
         // self.last_emitted_operation = REMOVED
         self.last_emitted_was_removed = true;

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -747,9 +747,7 @@ impl OptVirtualize {
             };
             if let Some(val_ref) = field_val {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_val = ctx
-                    .ensure_box(val_ref)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_val = ctx.get_box_replacement(val_ref);
                 ctx.make_equal_to(&b_old, &b_val);
                 return OptimizationResult::Remove;
             }
@@ -864,9 +862,7 @@ impl OptVirtualize {
                         return OptimizationResult::InvalidLoop;
                     }
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_item = ctx
-                        .ensure_box(item_ref)
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_item = ctx.get_box_replacement(item_ref);
                     ctx.make_equal_to(&b_old, &b_item);
                     return OptimizationResult::Remove;
                 }
@@ -943,9 +939,7 @@ impl OptVirtualize {
                 }
                 let fld = fld.unwrap();
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_fld = ctx
-                    .ensure_box(fld)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_fld = ctx.get_box_replacement(fld);
                 ctx.make_equal_to(&b_old, &b_fld);
                 return OptimizationResult::Remove;
             }
@@ -1112,9 +1106,7 @@ impl OptVirtualize {
                 // rawbuffer.py:120: read_value(offset, length, descr)
                 if let Ok(val_ref) = vinfo.read_value(lookup_offset, ad.item_size(), &descr) {
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_val = ctx
-                        .ensure_box(val_ref)
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_val = ctx.get_box_replacement(val_ref);
                     ctx.make_equal_to(&b_old, &b_val);
                     return OptimizationResult::Remove;
                 }
@@ -1307,9 +1299,7 @@ impl OptVirtualize {
                             if let Ok(val_ref) = vinfo.read_value(lookup_offset, itemsize_u, &descr)
                             {
                                 let b_old = BoxRef::from_bound_op(op_rc);
-                                let b_val = ctx
-                                    .ensure_box(val_ref)
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_val = ctx.get_box_replacement(val_ref);
                                 ctx.make_equal_to(&b_old, &b_val);
                                 return OptimizationResult::Remove;
                             }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -579,8 +579,7 @@ impl OptVirtualize {
 
     fn optimize_setfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let struct_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
         let value_ref = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
         let setfield_descr_arc = op
             .getdescr()
@@ -707,8 +706,7 @@ impl OptVirtualize {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let struct_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
         let field_descr_arc = op
             .getdescr()
             .expect("optimize_getfield_gc: field op without FieldDescr");
@@ -799,8 +797,7 @@ impl OptVirtualize {
 
     fn optimize_setarrayitem_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
         let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
 
@@ -847,8 +844,7 @@ impl OptVirtualize {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
 
         if let Some(info) = array_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
@@ -888,8 +884,7 @@ impl OptVirtualize {
     /// virtualize.py:268-274 optimize_ARRAYLEN_GC
     fn optimize_arraylen_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
 
         if let Some(PtrInfo::VirtualArray(vinfo)) =
             array_box.as_ref().and_then(|b| ctx.peek_ptr_info(b))
@@ -915,8 +910,7 @@ impl OptVirtualize {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
         // `info.py:573-581 getinteriorfield_virtual` indexes the per-element
         // field list by `fielddescr.get_index()`.  Strip the surrounding
@@ -972,8 +966,7 @@ impl OptVirtualize {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref())
-            .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
+            .get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
         let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
         // `info.py:583-594 setinteriorfield_virtual` indexes the per-element
@@ -1240,7 +1233,7 @@ impl OptVirtualize {
                     // pointer descr would panic at resume time.
                     // Reject pointer descrs at entry instead.
                     if ad.is_array_of_pointers() {
-                        if let Some(array_box) = ctx.ensure_box(array_ref) {
+                        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                             ctx.make_nonnull(&array_box);
                         }
                         return OptimizationResult::PassOn;
@@ -1262,7 +1255,7 @@ impl OptVirtualize {
                     let (Ok(basesize), Ok(itemsize)) =
                         (i64::try_from(basesize_u), i64::try_from(itemsize_u))
                     else {
-                        if let Some(array_box) = ctx.ensure_box(array_ref) {
+                        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                             ctx.make_nonnull(&array_box);
                         }
                         return OptimizationResult::PassOn;
@@ -1271,7 +1264,7 @@ impl OptVirtualize {
                         .checked_mul(index)
                         .and_then(|m| basesize.checked_add(m))
                     else {
-                        if let Some(array_box) = ctx.ensure_box(array_ref) {
+                        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                             ctx.make_nonnull(&array_box);
                         }
                         return OptimizationResult::PassOn;
@@ -1301,7 +1294,7 @@ impl OptVirtualize {
                             // and matches an entry written at the
                             // same negative offset.
                             let Some(lookup_offset) = base_offset.checked_add(item_offset) else {
-                                if let Some(array_box) = ctx.ensure_box(array_ref) {
+                                if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                                     ctx.make_nonnull(&array_box);
                                 }
                                 return OptimizationResult::PassOn;
@@ -1329,7 +1322,7 @@ impl OptVirtualize {
         // arrays this is a no-op because the helper skips `op.type == 'i'`
         // (raw pointer); kept literal so the upstream callsite stays
         // 1:1 with the source.
-        if let Some(array_box) = ctx.ensure_box(array_ref) {
+        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
             ctx.make_nonnull(&array_box);
         }
         OptimizationResult::PassOn
@@ -1372,7 +1365,7 @@ impl OptVirtualize {
                     // surface guarantees this never reaches the
                     // optimiser.
                     if ad.is_array_of_pointers() {
-                        if let Some(array_box) = ctx.ensure_box(array_ref) {
+                        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                             ctx.make_nonnull(&array_box);
                         }
                         return OptimizationResult::PassOn;
@@ -1390,7 +1383,7 @@ impl OptVirtualize {
                     let (Ok(basesize), Ok(itemsize)) =
                         (i64::try_from(basesize_u), i64::try_from(itemsize_u))
                     else {
-                        if let Some(array_box) = ctx.ensure_box(array_ref) {
+                        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                             ctx.make_nonnull(&array_box);
                         }
                         return OptimizationResult::PassOn;
@@ -1399,7 +1392,7 @@ impl OptVirtualize {
                         .checked_mul(index)
                         .and_then(|m| basesize.checked_add(m))
                     else {
-                        if let Some(array_box) = ctx.ensure_box(array_ref) {
+                        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                             ctx.make_nonnull(&array_box);
                         }
                         return OptimizationResult::PassOn;
@@ -1422,7 +1415,7 @@ impl OptVirtualize {
                         // signed compare; a negative store_offset is
                         // a legitimate write key.
                         let Some(store_offset) = base_offset.checked_add(item_offset) else {
-                            if let Some(array_box) = ctx.ensure_box(array_ref) {
+                            if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
                                 ctx.make_nonnull(&array_box);
                             }
                             return OptimizationResult::PassOn;
@@ -1459,7 +1452,7 @@ impl OptVirtualize {
         // virtualize.py:348: self.make_nonnull(op.getarg(0)) — no-op for
         // raw pointers via the helper's `op.type == 'i'` skip; kept
         // literal for callsite parity.
-        if let Some(array_box) = ctx.ensure_box(array_ref) {
+        if let Some(array_box) = ctx.get_box_replacement_box(array_ref) {
             ctx.make_nonnull(&array_box);
         }
         OptimizationResult::PassOn
@@ -1489,7 +1482,7 @@ impl OptVirtualize {
         // virtualize.py:127: token = ResOperation(rop.FORCE_TOKEN, [])
         let token_op = Op::new(OpCode::ForceToken, &[]);
         let token_ref = ctx.emit_extra(ctx.current_pass_idx, token_op);
-        if let Some(b) = ctx.ensure_box(token_ref) {
+        if let Some(b) = ctx.get_box_replacement_box(token_ref) {
             ctx.set_ptr_info(&b, PtrInfo::nonnull());
         }
 
@@ -1568,7 +1561,7 @@ impl OptVirtualize {
         // (majit in-place absorption, see doc comment above).
         // virtualize.py:150-153: set 'forced' to point to the real object
         // (skipped when objbox is CONST_NULL).
-        let vref_box = ctx.ensure_box(vref_ref);
+        let vref_box = ctx.get_box_replacement_box(vref_ref);
         let did_forced_write = vref_box
             .as_ref()
             .and_then(|b| {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 
 use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Type, Value};
+use crate::r#box::BoxRef;
 
 use crate::optimizeopt::info::{
     PtrInfo, VirtualArrayInfo, VirtualArrayStructInfo, VirtualInfo, VirtualStructInfo,
@@ -383,6 +384,7 @@ impl OptVirtualize {
         offset: i64,
         parent: OpRef,
         source_op: &Op,
+        source_op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) {
         let opinfo = crate::optimizeopt::info::VirtualRawSliceInfo {
@@ -391,9 +393,7 @@ impl OptVirtualize {
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
         };
-        let b = ctx
-            .ensure_box(source_op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = BoxRef::from_bound_op(source_op_rc);
         ctx.set_ptr_info(&b, PtrInfo::VirtualRawSlice(opinfo));
     }
 
@@ -407,13 +407,12 @@ impl OptVirtualize {
         size: usize,
         func: i64,
         source_op: &Op,
+        source_op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) {
         let opinfo =
             crate::optimizeopt::info::VirtualRawBufferInfo::new(func, size, source_op.getdescr());
-        let b = ctx
-            .ensure_box(source_op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = BoxRef::from_bound_op(source_op_rc);
         ctx.set_ptr_info(&b, PtrInfo::VirtualRawBuffer(opinfo));
     }
 
@@ -443,7 +442,7 @@ impl OptVirtualize {
 
     // ── Per-opcode handlers ──
 
-    fn optimize_new_with_vtable(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_new_with_vtable(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let descr = op.getdescr().expect("NEW_WITH_VTABLE needs descr");
         // virtualize.py:208 `known_class = ConstInt(op.getdescr().get_vtable())`
         // — no null filter; ConstInt(0) flows downstream as the
@@ -460,14 +459,12 @@ impl OptVirtualize {
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
         };
-        let b = ctx
-            .ensure_box(op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = BoxRef::from_bound_op(op_rc);
         ctx.set_ptr_info(&b, PtrInfo::Virtual(vinfo));
         OptimizationResult::Remove
     }
 
-    fn optimize_new(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_new(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let descr = op.getdescr().expect("NEW needs descr");
         let vinfo = VirtualStructInfo {
             descr,
@@ -475,14 +472,12 @@ impl OptVirtualize {
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
         };
-        let b = ctx
-            .ensure_box(op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = BoxRef::from_bound_op(op_rc);
         ctx.set_ptr_info(&b, PtrInfo::VirtualStruct(vinfo));
         OptimizationResult::Remove
     }
 
-    fn optimize_new_array(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_new_array(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let size_ref = op.arg(0).to_opref();
         if let Some(size) = ctx
             .get_box_replacement_box(size_ref)
@@ -517,9 +512,7 @@ impl OptVirtualize {
                         last_guard_pos: -1,
                         avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
                     };
-                    let b = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b = BoxRef::from_bound_op(op_rc);
                     ctx.set_ptr_info(&b, PtrInfo::VirtualArrayStruct(vinfo));
                 } else {
                     let items = vec![OpRef::NONE; size as usize];
@@ -530,9 +523,7 @@ impl OptVirtualize {
                         last_guard_pos: -1,
                         avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
                     };
-                    let b = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b = BoxRef::from_bound_op(op_rc);
                     ctx.set_ptr_info(&b, PtrInfo::VirtualArray(vinfo));
                 }
                 return OptimizationResult::Remove;
@@ -562,8 +553,8 @@ impl OptVirtualize {
     /// so this wrapper has no behavioral effect. Kept as a structural
     /// mirror of the upstream dispatch table.
     #[allow(dead_code)]
-    fn optimize_new_array_clear(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        self.optimize_new_array(op, ctx)
+    fn optimize_new_array_clear(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+        self.optimize_new_array(op, op_rc, ctx)
     }
 
     fn optimize_setfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
@@ -689,7 +680,7 @@ impl OptVirtualize {
         OptimizationResult::PassOn
     }
 
-    fn optimize_getfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getfield_gc(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let struct_box = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
@@ -732,9 +723,7 @@ impl OptVirtualize {
                 _ => None,
             };
             if let Some(val_ref) = field_val {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_val = ctx
                     .ensure_box(val_ref)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -826,7 +815,7 @@ impl OptVirtualize {
     }
 
     /// virtualize.py:276-296 optimize_GETARRAYITEM_GC_I (aliased to R/F and PURE variants)
-    fn optimize_getarrayitem_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getarrayitem_gc(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let array_box = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
@@ -848,9 +837,7 @@ impl OptVirtualize {
                     if item_ref.is_none() {
                         return OptimizationResult::InvalidLoop;
                     }
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_item = ctx
                         .ensure_box(item_ref)
                         .expect("body-namespace OpRef must have a BoxRef slot");
@@ -894,6 +881,7 @@ impl OptVirtualize {
     fn optimize_getinteriorfield_gc(
         &mut self,
         op: &Op,
+        op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let array_box = ctx
@@ -930,9 +918,7 @@ impl OptVirtualize {
                     return OptimizationResult::InvalidLoop;
                 }
                 let fld = fld.unwrap();
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_fld = ctx
                     .ensure_box(fld)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1028,7 +1014,7 @@ impl OptVirtualize {
     /// raw_load/store walk the chain via `resolve_raw_slice` and
     /// accumulate offsets. This matches `info.RawSlicePtrInfo.getitem_raw`,
     /// which delegates to `self.parent.getitem_raw(self.offset + offset, ...)`.
-    fn optimize_int_add(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_add(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         if op.num_args() < 2 {
             return OptimizationResult::PassOn;
         }
@@ -1043,14 +1029,14 @@ impl OptVirtualize {
         let info = arg0_box.as_ref().and_then(|b| ctx.peek_ptr_info(b));
         match info {
             Some(PtrInfo::VirtualRawBuffer(_)) | Some(PtrInfo::VirtualRawSlice(_)) => {
-                self.make_virtual_raw_slice(offset, arg0, op, ctx);
+                self.make_virtual_raw_slice(offset, arg0, op, op_rc, ctx);
                 OptimizationResult::Remove
             }
             _ => OptimizationResult::PassOn,
         }
     }
 
-    fn optimize_raw_load(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_raw_load(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let buf_ref = op.arg(0).to_opref();
         let offset_ref = op.arg(1).to_opref();
 
@@ -1092,9 +1078,7 @@ impl OptVirtualize {
                 };
                 // rawbuffer.py:120: read_value(offset, length, descr)
                 if let Ok(val_ref) = vinfo.read_value(lookup_offset, ad.item_size(), &descr) {
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_val = ctx
                         .ensure_box(val_ref)
                         .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1192,7 +1176,7 @@ impl OptVirtualize {
     /// Slice walk via `resolve_raw_slice` is the pyre equivalent of
     /// `RawSlicePtrInfo.getitem_raw` (`info.py`) recursing through
     /// `self.parent.getitem_raw(self.offset + offset, ...)`.
-    fn optimize_getarrayitem_raw(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getarrayitem_raw(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let array_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let index_ref = op.arg(1).to_opref();
 
@@ -1284,9 +1268,7 @@ impl OptVirtualize {
                             // make_nonnull + emit.
                             if let Ok(val_ref) = vinfo.read_value(lookup_offset, itemsize_u, &descr)
                             {
-                                let b_old = ctx
-                                    .ensure_box(op.pos.get())
-                                    .expect("body-namespace OpRef must have a BoxRef slot");
+                                let b_old = BoxRef::from_bound_op(op_rc);
                                 let b_val = ctx
                                     .ensure_box(val_ref)
                                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1449,7 +1431,7 @@ impl OptVirtualize {
     /// - forced: set to CONST_NULL
     /// The typeptr/vtable at offset 0 is handled by NEW_WITH_VTABLE when
     /// the vref is forced — not stored as a tracked virtual field.
-    fn optimize_virtual_ref(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_virtual_ref(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         // `virtualize.py:140` `vrefinfo = ... metainterp_sd.virtualref_info`
         // / `virtualize.py:123` `vrefinfo.descr` parity.
         let vref_descr: DescrRef = self.vrefinfo.descr.clone();
@@ -1481,9 +1463,7 @@ impl OptVirtualize {
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
         };
-        let b = ctx
-            .ensure_box(op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = BoxRef::from_bound_op(op_rc);
         ctx.set_ptr_info(&b, PtrInfo::Virtual(vinfo));
 
         OptimizationResult::Remove
@@ -1636,7 +1616,7 @@ impl OptVirtualize {
     /// field must hold a constant null (set by VirtualRefFinish on the normal
     /// frame-leave path), and its `forced` field must point at a non-null
     /// object (set by VirtualRefFinish in the forced-during-tracing path).
-    fn optimize_jit_force_virtual(&mut self, op: &Op, ctx: &mut OptContext) -> bool {
+    fn optimize_jit_force_virtual(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> bool {
         if op.num_args() < 2 {
             return false;
         }
@@ -1685,9 +1665,7 @@ impl OptVirtualize {
             return false;
         }
         // self.make_equal_to(op, forcedop)
-        let b_old = ctx
-            .ensure_box(op.pos.get())
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b_old = BoxRef::from_bound_op(op_rc);
         let b_forced = ctx
             .ensure_box(forced_resolved)
             .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1705,7 +1683,7 @@ impl Default for OptVirtualize {
 }
 
 impl Optimization for OptVirtualize {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         if let Some(ref mut vt) = self.vable {
             vt.ensure_setup(ctx);
         }
@@ -1722,9 +1700,9 @@ impl Optimization for OptVirtualize {
         match op.opcode {
             // virtualize.py:207-209: optimize_NEW_WITH_VTABLE → make_virtual.
             // InstancePtrInfo(descr, known_class, is_virtual=True)
-            OpCode::NewWithVtable => self.optimize_new_with_vtable(op, ctx),
-            OpCode::New => self.optimize_new(op, ctx),
-            OpCode::NewArray | OpCode::NewArrayClear => self.optimize_new_array(op, ctx),
+            OpCode::NewWithVtable => self.optimize_new_with_vtable(op, op_rc, ctx),
+            OpCode::New => self.optimize_new(op, op_rc, ctx),
+            OpCode::NewArray | OpCode::NewArrayClear => self.optimize_new_array(op, op_rc, ctx),
 
             // Field access on potentially-virtual objects
             OpCode::SetfieldGc | OpCode::SetfieldRaw => self.optimize_setfield_gc(op, ctx),
@@ -1736,7 +1714,7 @@ impl Optimization for OptVirtualize {
             | OpCode::GetfieldGcPureF
             | OpCode::GetfieldRawI
             | OpCode::GetfieldRawR
-            | OpCode::GetfieldRawF => self.optimize_getfield_gc(op, ctx),
+            | OpCode::GetfieldRawF => self.optimize_getfield_gc(op, op_rc, ctx),
 
             // virtualize.py:298 optimize_SETARRAYITEM_GC vs
             // virtualize.py:336 optimize_SETARRAYITEM_RAW — upstream
@@ -1756,7 +1734,7 @@ impl Optimization for OptVirtualize {
             | OpCode::GetarrayitemGcF
             | OpCode::GetarrayitemGcPureI
             | OpCode::GetarrayitemGcPureR
-            | OpCode::GetarrayitemGcPureF => self.optimize_getarrayitem_gc(op, ctx),
+            | OpCode::GetarrayitemGcPureF => self.optimize_getarrayitem_gc(op, op_rc, ctx),
             // virtualize.py:318-334 optimize_GETARRAYITEM_RAW_I (aliased
             // to _F at virtualize.py:334). Upstream's
             // `GETARRAYITEM_RAW` family is `_I/_F` only — RPython
@@ -1773,7 +1751,7 @@ impl Optimization for OptVirtualize {
             // catchall arm to plain emit, mirroring upstream's
             // "no fold for `_R`" surface.
             OpCode::GetarrayitemRawI | OpCode::GetarrayitemRawF => {
-                self.optimize_getarrayitem_raw(op, ctx)
+                self.optimize_getarrayitem_raw(op, op_rc, ctx)
             }
 
             // Array length
@@ -1782,14 +1760,14 @@ impl Optimization for OptVirtualize {
             // Interior field access on potentially-virtual array-of-structs
             OpCode::GetinteriorfieldGcI
             | OpCode::GetinteriorfieldGcR
-            | OpCode::GetinteriorfieldGcF => self.optimize_getinteriorfield_gc(op, ctx),
+            | OpCode::GetinteriorfieldGcF => self.optimize_getinteriorfield_gc(op, op_rc, ctx),
             OpCode::SetinteriorfieldGc => self.optimize_setinteriorfield_gc(op, ctx),
 
             // virtualize.py:255-266 optimize_INT_ADD: rawbuf + const → slice
-            OpCode::IntAdd => self.optimize_int_add(op, ctx),
+            OpCode::IntAdd => self.optimize_int_add(op, op_rc, ctx),
 
             // Raw memory access on potentially-virtual raw buffers (and slices)
-            OpCode::RawLoadI | OpCode::RawLoadF => self.optimize_raw_load(op, ctx),
+            OpCode::RawLoadI | OpCode::RawLoadF => self.optimize_raw_load(op, op_rc, ctx),
             OpCode::RawStore => self.optimize_raw_store(op, ctx),
 
             // RPython virtualize.py does NOT define optimize_GUARD_CLASS,
@@ -1801,7 +1779,7 @@ impl Optimization for OptVirtualize {
             // need to pre-process guard fail_args here.
 
             // VirtualRef: replace with a virtual struct tracking token + forced fields
-            OpCode::VirtualRefR | OpCode::VirtualRefI => self.optimize_virtual_ref(op, ctx),
+            OpCode::VirtualRefR | OpCode::VirtualRefI => self.optimize_virtual_ref(op, op_rc, ctx),
             // VirtualRefFinish: finalize the virtual ref
             OpCode::VirtualRefFinish => self.optimize_virtual_ref_finish(op, ctx),
 
@@ -1850,7 +1828,7 @@ impl Optimization for OptVirtualize {
                     if let Some(cd) = descr.as_call_descr() {
                         let ei = cd.get_extra_info();
                         if ei.oopspecindex == OopSpecIndex::JitForceVirtual {
-                            if self.optimize_jit_force_virtual(op, ctx) {
+                            if self.optimize_jit_force_virtual(op, op_rc, ctx) {
                                 return OptimizationResult::Remove;
                             }
                         }
@@ -1965,7 +1943,7 @@ impl Optimization for OptVirtualize {
                                         .expect(
                                             "virtualize.py:53 source_op.getarg(0) must be ConstInt",
                                         );
-                                    self.make_virtual_raw_memory(size as usize, func, op, ctx);
+                                    self.make_virtual_raw_memory(size as usize, func, op, op_rc, ctx);
                                     self.last_emitted_was_removed = true;
                                     return OptimizationResult::Remove;
                                 }
@@ -2690,7 +2668,9 @@ mod tests {
                 );
             }
 
-            match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
+            let resolved_rc = std::rc::Rc::new(resolved_op.clone());
+            ctx.bind_input_resops(std::slice::from_ref(&resolved_rc));
+            match pass.propagate_forward(&resolved_op, &resolved_rc, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -3224,16 +3204,18 @@ mod tests {
         pass.setup();
 
         let mut new_op = Op::with_descr(OpCode::NewWithVtable, &[], sd);
-        new_op.pos.set(OpRef::input_arg_ref(0));
+        new_op.pos.set(OpRef::ref_op(0));
+        let new_op_rc = std::rc::Rc::new(new_op.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&new_op_rc));
         assert!(matches!(
-            pass.propagate_forward(&new_op, &std::rc::Rc::new(new_op.clone()), &mut ctx),
+            pass.propagate_forward(&new_op, &new_op_rc, &mut ctx),
             OptimizationResult::Remove
         ));
 
         let mut set_op = Op::with_descr(
             OpCode::SetfieldGc,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
+                crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
                 crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
             ],
             fd,
@@ -3245,7 +3227,7 @@ mod tests {
         ));
 
         let inputarg_box = ctx
-            .get_box_replacement_box(OpRef::input_arg_ref(0))
+            .get_box_replacement_box(OpRef::ref_op(0))
             .expect("inputarg BoxRef populated");
         let info = ctx
             .peek_ptr_info(&inputarg_box)
@@ -4509,7 +4491,9 @@ mod tests {
                 );
             }
 
-            match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
+            let resolved_rc = std::rc::Rc::new(resolved_op.clone());
+            ctx.bind_input_resops(std::slice::from_ref(&resolved_rc));
+            match pass.propagate_forward(&resolved_op, &resolved_rc, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -1557,16 +1557,12 @@ impl OptVirtualize {
 
         // virtualize.py:151: `CONST_NULL.same_constant(objbox)` — only a
         // Ref-typed null constant matches; a plain ConstInt(0) does not.
-        // Route through `ensure_box` so const-namespace OpRefs (whose
-        // backing const `BoxRef::new_const` is constructed on demand)
-        // materialize from `const_pool` and the null check still fires;
-        // the `unwrap_or(false)` fallback only applies to the
-        // OpRef::NONE sentinel.
-        let obj_box = ctx.ensure_box(obj_ref);
-        let obj_is_null = obj_box
-            .as_ref()
-            .map(|b| ctx.is_const_null(b))
-            .unwrap_or(false);
+        // `get_box_replacement` resolves const-namespace OpRefs to their
+        // on-demand `BoxRef::new_const` and walks the chain terminal;
+        // `is_const_null` reads `const_value()` and tolerates an unbound
+        // terminal (non-const -> false), so the null check is read-only.
+        let obj_box = ctx.get_box_replacement(obj_ref);
+        let obj_is_null = ctx.is_const_null(&obj_box);
 
         // If vref is still virtual, update the virtual struct fields directly
         // (majit in-place absorption, see doc comment above).

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -121,7 +121,8 @@ impl VirtualizableTracker {
                     .as_ref()
                     .map_or(false, |b| ctx.has_ptr_info(b));
                 if !second_check {
-                    if let Some(b) = ctx.ensure_box(OpRef::input_arg_ref(0)) {
+                    {
+                        let b = ctx.materialize_box_at(OpRef::input_arg_ref(0));
                         ctx.set_ptr_info(
                             &b,
                             PtrInfo::Virtualizable(VirtualizableFieldState {
@@ -222,9 +223,8 @@ impl VirtualizableTracker {
             }
         }
 
-        if let Some(b) = ctx.ensure_box(OpRef::input_arg_ref(0)) {
-            ctx.set_ptr_info(&b, PtrInfo::Virtualizable(state));
-        }
+        let b = ctx.materialize_box_at(OpRef::input_arg_ref(0));
+        ctx.set_ptr_info(&b, PtrInfo::Virtualizable(state));
     }
 
     fn is_standard_ref(&self, b: &crate::r#box::BoxRef, ctx: &OptContext) -> bool {
@@ -2737,9 +2737,7 @@ mod tests {
         // without destroying the tracked field state.
         // opencoder.py:259 inputarg_from_tp — vable is the sole Ref inputarg.
         let mut ctx = OptContext::with_inputarg_types(8, &[Type::Ref]);
-        let vable_box = ctx
-            .ensure_box(OpRef::input_arg_ref(0))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let vable_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
         ctx.set_ptr_info(
             &vable_box,
             PtrInfo::Virtualizable(VirtualizableFieldState {
@@ -4508,9 +4506,7 @@ mod tests {
 
         // Pre-populate VirtualRawBuffer info for specified OpRefs
         for &(opref, size) in raw_bufs {
-            let b = ctx
-                .ensure_box(opref)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b = ctx.materialize_box_at(opref);
             ctx.set_ptr_info(
                 &b,
                 PtrInfo::VirtualRawBuffer(VirtualRawBufferInfo::new(0, size, None)),

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -255,7 +255,9 @@ impl VirtualizableTracker {
         ) {
             return None;
         }
-        let frame_ref = ctx.get_box_replacement(producer.arg(0).to_opref());
+        let frame_ref = ctx
+            .get_box_replacement(producer.arg(0).to_opref())
+            .to_opref();
         let is_standard = ctx
             .get_box_replacement_box(producer.arg(0).to_opref())
             .map_or(false, |b| self.is_standard_ref(&b, ctx));
@@ -568,7 +570,7 @@ impl OptVirtualize {
         let struct_box = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
-        let value_ref = ctx.get_box_replacement(op.arg(1).to_opref());
+        let value_ref = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
         let setfield_descr_arc = op
             .getdescr()
             .expect("optimize_setfield_gc: field op without FieldDescr");
@@ -786,7 +788,7 @@ impl OptVirtualize {
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
         let index_ref = op.arg(1).to_opref();
-        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref());
+        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
 
         if let Some(index) = ctx
             .get_box_replacement_box(index_ref)
@@ -957,7 +959,7 @@ impl OptVirtualize {
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
         let index_ref = op.arg(1).to_opref();
-        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref());
+        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
         // `info.py:583-594 setinteriorfield_virtual` indexes the per-element
         // field list by `fielddescr.get_index()`.  Same shape as the GET
         // counterpart — strip the outer `InteriorFieldDescr` first.
@@ -1030,7 +1032,7 @@ impl OptVirtualize {
         if op.num_args() < 2 {
             return OptimizationResult::PassOn;
         }
-        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref());
+        let arg0 = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let Some(offset) = ctx
             .get_box_replacement_box(op.arg(1).to_opref())
             .and_then(|b| ctx.get_constant_int_box(&b))
@@ -1105,9 +1107,9 @@ impl OptVirtualize {
     }
 
     fn optimize_raw_store(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let buf_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let buf_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let offset_ref = op.arg(1).to_opref();
-        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref());
+        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
 
         if let Some(offset) = ctx
             .get_box_replacement_box(offset_ref)
@@ -1191,7 +1193,7 @@ impl OptVirtualize {
     /// `RawSlicePtrInfo.getitem_raw` (`info.py`) recursing through
     /// `self.parent.getitem_raw(self.offset + offset, ...)`.
     fn optimize_getarrayitem_raw(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let array_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let index_ref = op.arg(1).to_opref();
 
         if let Some(index) = ctx
@@ -1325,9 +1327,9 @@ impl OptVirtualize {
     ///     return self.emit(op)
     /// ```
     fn optimize_setarrayitem_raw(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let array_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let index_ref = op.arg(1).to_opref();
-        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref());
+        let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
 
         if let Some(index) = ctx
             .get_box_replacement_box(index_ref)
@@ -1520,8 +1522,8 @@ impl OptVirtualize {
     /// here on the VirtualStruct half and the setfield_gc emit path is
     /// taken only when the vref has already escaped.
     fn optimize_virtual_ref_finish(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let vref_ref = ctx.get_box_replacement(op.arg(0).to_opref());
-        let obj_ref = ctx.get_box_replacement(op.arg(1).to_opref());
+        let vref_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
+        let obj_ref = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
 
         // virtualize.py:151: `CONST_NULL.same_constant(objbox)` — only a
         // Ref-typed null constant matches; a plain ConstInt(0) does not.
@@ -1673,7 +1675,7 @@ impl OptVirtualize {
             Some(r) if r != OpRef::NONE => r,
             _ => return false,
         };
-        let forced_resolved = ctx.get_box_replacement(forced_ref);
+        let forced_resolved = ctx.get_box_replacement(forced_ref).to_opref();
         let forced_box = ctx.get_box_replacement_box(forced_ref);
         let forced_ok = match forced_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
             Some(info) => !info.is_null(),
@@ -2682,7 +2684,8 @@ mod tests {
                 resolved_op.setarg(
                     i,
                     crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement(resolved_op.arg(i).to_opref()),
+                        ctx.get_box_replacement(resolved_op.arg(i).to_opref())
+                            .to_opref(),
                     ),
                 );
             }
@@ -2820,7 +2823,8 @@ mod tests {
                 resolved.setarg(
                     i,
                     crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement(resolved.arg(i).to_opref()),
+                        ctx.get_box_replacement(resolved.arg(i).to_opref())
+                            .to_opref(),
                     ),
                 );
             }
@@ -4499,7 +4503,8 @@ mod tests {
                 resolved_op.setarg(
                     i,
                     crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement(resolved_op.arg(i).to_opref()),
+                        ctx.get_box_replacement(resolved_op.arg(i).to_opref())
+                            .to_opref(),
                     ),
                 );
             }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -1705,7 +1705,7 @@ impl Default for OptVirtualize {
 }
 
 impl Optimization for OptVirtualize {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         if let Some(ref mut vt) = self.vable {
             vt.ensure_setup(ctx);
         }
@@ -2690,7 +2690,7 @@ mod tests {
                 );
             }
 
-            match pass.propagate_forward(&resolved_op, &mut ctx) {
+            match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -2828,7 +2828,7 @@ mod tests {
                     ),
                 );
             }
-            match pass.propagate_forward(&resolved, &mut ctx) {
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -2890,7 +2890,7 @@ mod tests {
         // RPython parity: virtualize.py's default for calls is emit(op)
         // which forwards to the next pass without forcing. Forcing happens
         // in _emit_operation (Optimizer level). OptVirtualize returns PassOn.
-        let result = pass.propagate_forward(&call, &mut ctx);
+        let result = pass.propagate_forward(&call, &std::rc::Rc::new(call.clone()), &mut ctx);
         assert!(
             matches!(result, OptimizationResult::PassOn),
             "call should PassOn (forcing happens at Optimizer::emit_operation level)"
@@ -2928,7 +2928,7 @@ mod tests {
         get.setdescr(test_vable_field_descr(8, Type::Int, 1));
         get.pos.set(OpRef::int_op(10));
 
-        let result = pass.propagate_forward(&get, &mut ctx);
+        let result = pass.propagate_forward(&get, &std::rc::Rc::new(get.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -2957,7 +2957,7 @@ mod tests {
         );
         set.setdescr(test_vable_field_descr(8, Type::Int, 1));
 
-        let result = pass.propagate_forward(&set, &mut ctx);
+        let result = pass.propagate_forward(&set, &std::rc::Rc::new(set.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -3032,7 +3032,7 @@ mod tests {
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
         assert!(matches!(
-            pass.propagate_forward(&get_field, &mut ctx),
+            pass.propagate_forward(&get_field, &std::rc::Rc::new(get_field.clone()), &mut ctx),
             OptimizationResult::PassOn
         ));
         ctx.emit(get_field);
@@ -3045,7 +3045,7 @@ mod tests {
             ],
         );
         get_item.setdescr(array_descr(24));
-        let result = pass.propagate_forward(&get_item, &mut ctx);
+        let result = pass.propagate_forward(&get_item, &std::rc::Rc::new(get_item.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -3072,7 +3072,7 @@ mod tests {
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
         assert!(matches!(
-            pass.propagate_forward(&get_field, &mut ctx),
+            pass.propagate_forward(&get_field, &std::rc::Rc::new(get_field.clone()), &mut ctx),
             OptimizationResult::PassOn
         ));
         ctx.emit(get_field);
@@ -3086,7 +3086,7 @@ mod tests {
             ],
         );
         set_item.setdescr(array_descr(24));
-        let result = pass.propagate_forward(&set_item, &mut ctx);
+        let result = pass.propagate_forward(&set_item, &std::rc::Rc::new(set_item.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -3226,7 +3226,7 @@ mod tests {
         let mut new_op = Op::with_descr(OpCode::NewWithVtable, &[], sd);
         new_op.pos.set(OpRef::input_arg_ref(0));
         assert!(matches!(
-            pass.propagate_forward(&new_op, &mut ctx),
+            pass.propagate_forward(&new_op, &std::rc::Rc::new(new_op.clone()), &mut ctx),
             OptimizationResult::Remove
         ));
 
@@ -3240,7 +3240,7 @@ mod tests {
         );
         set_op.pos.set(OpRef::int_op(1));
         assert!(matches!(
-            pass.propagate_forward(&set_op, &mut ctx),
+            pass.propagate_forward(&set_op, &std::rc::Rc::new(set_op.clone()), &mut ctx),
             OptimizationResult::Remove
         ));
 
@@ -4509,7 +4509,7 @@ mod tests {
                 );
             }
 
-            match pass.propagate_forward(&resolved_op, &mut ctx) {
+            match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -575,8 +575,7 @@ impl OptVirtualize {
     }
 
     fn optimize_setfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let struct_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let struct_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
         let value_ref = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
         let setfield_descr_arc = op
             .getdescr()
@@ -702,8 +701,7 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let struct_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let struct_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
         let field_descr_arc = op
             .getdescr()
             .expect("optimize_getfield_gc: field op without FieldDescr");
@@ -791,8 +789,7 @@ impl OptVirtualize {
     }
 
     fn optimize_setarrayitem_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let array_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
         let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
 
@@ -838,8 +835,7 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let array_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
 
         if let Some(info) = array_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
@@ -876,8 +872,7 @@ impl OptVirtualize {
 
     /// virtualize.py:268-274 optimize_ARRAYLEN_GC
     fn optimize_arraylen_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let array_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
 
         if let Some(PtrInfo::VirtualArray(vinfo)) =
             array_box.as_ref().and_then(|b| ctx.peek_ptr_info(b))
@@ -902,8 +897,7 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let array_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
         // `info.py:573-581 getinteriorfield_virtual` indexes the per-element
         // field list by `fielddescr.get_index()`.  Strip the surrounding
@@ -956,8 +950,7 @@ impl OptVirtualize {
         op: &Op,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_box = ctx
-            .get_box_replacement_box(op.arg(0).to_opref());
+        let array_box = ctx.get_box_replacement_box(op.arg(0).to_opref());
         let index_ref = op.arg(1).to_opref();
         let value_ref = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
         // `info.py:583-594 setinteriorfield_virtual` indexes the per-element

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -8,8 +8,8 @@
 /// it gets "forced" (materialized by emitting the allocation + setfield ops).
 use std::sync::Arc;
 
-use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Type, Value};
 use crate::r#box::BoxRef;
+use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Type, Value};
 
 use crate::optimizeopt::info::{
     PtrInfo, VirtualArrayInfo, VirtualArrayStructInfo, VirtualInfo, VirtualStructInfo,
@@ -442,7 +442,12 @@ impl OptVirtualize {
 
     // ── Per-opcode handlers ──
 
-    fn optimize_new_with_vtable(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_new_with_vtable(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let descr = op.getdescr().expect("NEW_WITH_VTABLE needs descr");
         // virtualize.py:208 `known_class = ConstInt(op.getdescr().get_vtable())`
         // — no null filter; ConstInt(0) flows downstream as the
@@ -464,7 +469,12 @@ impl OptVirtualize {
         OptimizationResult::Remove
     }
 
-    fn optimize_new(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_new(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let descr = op.getdescr().expect("NEW needs descr");
         let vinfo = VirtualStructInfo {
             descr,
@@ -477,7 +487,12 @@ impl OptVirtualize {
         OptimizationResult::Remove
     }
 
-    fn optimize_new_array(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_new_array(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let size_ref = op.arg(0).to_opref();
         if let Some(size) = ctx
             .get_box_replacement_box(size_ref)
@@ -553,7 +568,12 @@ impl OptVirtualize {
     /// so this wrapper has no behavioral effect. Kept as a structural
     /// mirror of the upstream dispatch table.
     #[allow(dead_code)]
-    fn optimize_new_array_clear(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_new_array_clear(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         self.optimize_new_array(op, op_rc, ctx)
     }
 
@@ -680,7 +700,12 @@ impl OptVirtualize {
         OptimizationResult::PassOn
     }
 
-    fn optimize_getfield_gc(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getfield_gc(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let struct_box = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
@@ -815,7 +840,12 @@ impl OptVirtualize {
     }
 
     /// virtualize.py:276-296 optimize_GETARRAYITEM_GC_I (aliased to R/F and PURE variants)
-    fn optimize_getarrayitem_gc(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getarrayitem_gc(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let array_box = ctx
             .get_box_replacement_box(op.arg(0).to_opref())
             .or_else(|| ctx.ensure_box(op.arg(0).to_opref()));
@@ -1014,7 +1044,12 @@ impl OptVirtualize {
     /// raw_load/store walk the chain via `resolve_raw_slice` and
     /// accumulate offsets. This matches `info.RawSlicePtrInfo.getitem_raw`,
     /// which delegates to `self.parent.getitem_raw(self.offset + offset, ...)`.
-    fn optimize_int_add(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_int_add(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         if op.num_args() < 2 {
             return OptimizationResult::PassOn;
         }
@@ -1036,7 +1071,12 @@ impl OptVirtualize {
         }
     }
 
-    fn optimize_raw_load(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_raw_load(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let buf_ref = op.arg(0).to_opref();
         let offset_ref = op.arg(1).to_opref();
 
@@ -1176,7 +1216,12 @@ impl OptVirtualize {
     /// Slice walk via `resolve_raw_slice` is the pyre equivalent of
     /// `RawSlicePtrInfo.getitem_raw` (`info.py`) recursing through
     /// `self.parent.getitem_raw(self.offset + offset, ...)`.
-    fn optimize_getarrayitem_raw(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_getarrayitem_raw(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let array_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let index_ref = op.arg(1).to_opref();
 
@@ -1431,7 +1476,12 @@ impl OptVirtualize {
     /// - forced: set to CONST_NULL
     /// The typeptr/vtable at offset 0 is handled by NEW_WITH_VTABLE when
     /// the vref is forced — not stored as a tracked virtual field.
-    fn optimize_virtual_ref(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_virtual_ref(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         // `virtualize.py:140` `vrefinfo = ... metainterp_sd.virtualref_info`
         // / `virtualize.py:123` `vrefinfo.descr` parity.
         let vref_descr: DescrRef = self.vrefinfo.descr.clone();
@@ -1616,7 +1666,12 @@ impl OptVirtualize {
     /// field must hold a constant null (set by VirtualRefFinish on the normal
     /// frame-leave path), and its `forced` field must point at a non-null
     /// object (set by VirtualRefFinish in the forced-during-tracing path).
-    fn optimize_jit_force_virtual(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> bool {
+    fn optimize_jit_force_virtual(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> bool {
         if op.num_args() < 2 {
             return false;
         }
@@ -1683,7 +1738,12 @@ impl Default for OptVirtualize {
 }
 
 impl Optimization for OptVirtualize {
-    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         if let Some(ref mut vt) = self.vable {
             vt.ensure_setup(ctx);
         }
@@ -1943,7 +2003,13 @@ impl Optimization for OptVirtualize {
                                         .expect(
                                             "virtualize.py:53 source_op.getarg(0) must be ConstInt",
                                         );
-                                    self.make_virtual_raw_memory(size as usize, func, op, op_rc, ctx);
+                                    self.make_virtual_raw_memory(
+                                        size as usize,
+                                        func,
+                                        op,
+                                        op_rc,
+                                        ctx,
+                                    );
                                     self.last_emitted_was_removed = true;
                                     return OptimizationResult::Remove;
                                 }
@@ -3025,7 +3091,8 @@ mod tests {
             ],
         );
         get_item.setdescr(array_descr(24));
-        let result = pass.propagate_forward(&get_item, &std::rc::Rc::new(get_item.clone()), &mut ctx);
+        let result =
+            pass.propagate_forward(&get_item, &std::rc::Rc::new(get_item.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 
@@ -3066,7 +3133,8 @@ mod tests {
             ],
         );
         set_item.setdescr(array_descr(24));
-        let result = pass.propagate_forward(&set_item, &std::rc::Rc::new(set_item.clone()), &mut ctx);
+        let result =
+            pass.propagate_forward(&set_item, &std::rc::Rc::new(set_item.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -1048,7 +1048,7 @@ impl VirtualState {
                             .as_ref()
                             .and_then(|info| info.getfield(*field_idx))
                             .and_then(|e| e.as_opref())
-                            .map(|f| ctx.get_box_replacement(f))
+                            .map(|f| ctx.get_box_replacement(f).to_opref())
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect();
@@ -1199,7 +1199,7 @@ impl VirtualState {
                 //             else:
                 //                 raise VirtualStatesCantMatch
                 //     boxes[self.position_in_notvirtuals] = box
-                let resolved = ctx.get_box_replacement(opref);
+                let resolved = ctx.get_box_replacement(opref).to_opref();
                 let forced = match ctx
                     .get_box_replacement_box(opref)
                     .as_ref()
@@ -1227,7 +1227,7 @@ impl VirtualState {
                      assigned by enum_top_level"
                 );
                 let slot = slot_i32 as usize;
-                let resolved_for_store = ctx.get_box_replacement(forced);
+                let resolved_for_store = ctx.get_box_replacement(forced).to_opref();
                 // virtualstate.py:417 NotVirtualStateInfo{Int,Ptr}: Box.type
                 // immutability. RPython dispatches `isinstance(self,
                 // NotVirtualStateInfoInt)` vs `NotVirtualStateInfoPtr` on a
@@ -2662,7 +2662,7 @@ fn export_single_value(
     // distinct field-side OpRefs that resolve to the same forwarded box
     // would each receive their own Rc, breaking the dedup invariant
     // `enum_forced_boxes` and RPython matching rely on.
-    let opref = ctx.get_box_replacement(opref);
+    let opref = ctx.get_box_replacement(opref).to_opref();
     // virtualstate.py:714-716: cache hit returns the cached state directly.
     if let Some(cached) = cache.finished.get(&opref) {
         return Rc::clone(cached);
@@ -3413,7 +3413,10 @@ mod tests {
         // forced allocation ref (which is what ctx.get_replacement
         // resolves the original virtual_ref to).
         assert_eq!(inputargs.len(), 1);
-        assert_eq!(inputargs[0], ctx.get_box_replacement(virtual_ref));
+        assert_eq!(
+            inputargs[0],
+            ctx.get_box_replacement(virtual_ref).to_opref()
+        );
         assert!(virtuals.is_empty());
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -3055,9 +3055,7 @@ mod tests {
         let rb0 = ctx.make_constant_ref(GcRef(0x200));
         let rb1 = ctx.make_constant_ref(GcRef(0x300));
         let boxes = vec![OpRef::ref_op(100), OpRef::ref_op(101)];
-        let b0 = ctx
-            .ensure_box(boxes[0])
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b0 = ctx.materialize_box_at(boxes[0]);
         ctx.set_ptr_info(
             &b0,
             crate::optimizeopt::info::PtrInfo::known_class(0x100, false),
@@ -3151,9 +3149,7 @@ mod tests {
         // virtualstate.py:185 requires `info.is_virtual()` for the
         // VStruct walker to descend; mirror by attaching a virtual
         // PtrInfo to the corresponding OpRef.
-        let b11 = ctx
-            .ensure_box(OpRef::ref_op(11))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b11 = ctx.materialize_box_at(OpRef::ref_op(11));
         ctx.set_ptr_info(
             &b11,
             PtrInfo::VirtualStruct(VirtualStructInfo {
@@ -3189,9 +3185,7 @@ mod tests {
         ]);
 
         let mut ctx = OptContext::new(16);
-        let b21 = ctx
-            .ensure_box(OpRef::ref_op(21))
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b21 = ctx.materialize_box_at(OpRef::ref_op(21));
         ctx.set_ptr_info(
             &b21,
             PtrInfo::VirtualStruct(VirtualStructInfo {
@@ -3248,12 +3242,8 @@ mod tests {
         let mut ctx = OptContext::new(64);
         // Both outer boxes resolve to a virtual struct whose field 0 is
         // the shared inner OpRef.
-        let outer_a_box = ctx
-            .ensure_box(outer_a_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
-        let outer_b_box = ctx
-            .ensure_box(outer_b_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let outer_a_box = ctx.materialize_box_at(outer_a_ref);
+        let outer_b_box = ctx.materialize_box_at(outer_b_ref);
         ctx.set_ptr_info(
             &outer_a_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
@@ -3324,9 +3314,7 @@ mod tests {
             field_descrs: Vec::new(),
         }]);
         let mut ctx = OptContext::new(32);
-        let virtual_box = ctx
-            .ensure_box(virtual_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let virtual_box = ctx.materialize_box_at(virtual_ref);
         ctx.set_ptr_info(
             &virtual_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
@@ -3385,9 +3373,7 @@ mod tests {
         let state = VirtualState::new(vec![VirtualStateInfo::NonNull]);
         // Generous Ref-typed inputarg pool for the test fixture.
         let mut ctx = OptContext::with_inputarg_types(32, &vec![Type::Ref; 1024]);
-        let virtual_box = ctx
-            .ensure_box(virtual_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let virtual_box = ctx.materialize_box_at(virtual_ref);
         ctx.set_ptr_info(
             &virtual_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -329,7 +329,7 @@ fn force_child_for_string(opref: OpRef, ctx: &mut OptContext) -> OpRef {
     if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
         let resolved_box = resolved_box.expect("recorder-populated");
         let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
-        let forced = info.force_box(resolved, ctx);
+        let forced = info.force_box(resolved_box, ctx);
         return ctx.get_box_replacement(forced).to_opref();
     }
     resolved
@@ -434,7 +434,7 @@ impl OptString {
         if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
-            let forced = info.force_box(resolved, ctx);
+            let forced = info.force_box(resolved_box, ctx);
             return ctx.get_box_replacement(forced).to_opref();
         }
         resolved

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -829,7 +829,7 @@ impl OptString {
             1u8
         };
         // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-        if let Some(arg0_box) = ctx.ensure_box(op.arg(0).to_opref()) {
+        if let Some(arg0_box) = ctx.get_box_replacement_box(op.arg(0).to_opref()) {
             ctx.make_nonnull_str(&arg0_box, mode);
         }
         let str_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
@@ -898,10 +898,10 @@ impl OptString {
             let vleft = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
             let vright = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
             // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-            if let Some(vleft_box) = ctx.ensure_box(vleft) {
+            if let Some(vleft_box) = ctx.get_box_replacement_box(vleft) {
                 ctx.make_nonnull_str(&vleft_box, mode);
             }
-            if let Some(vright_box) = ctx.ensure_box(vright) {
+            if let Some(vright_box) = ctx.get_box_replacement_box(vright) {
                 ctx.make_nonnull_str(&vright_box, mode);
             }
             let b = BoxRef::from_bound_op(op_rc);
@@ -938,7 +938,7 @@ impl OptString {
         if op.num_args() >= 4 {
             let mut s = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
             // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-            if let Some(s_box) = ctx.ensure_box(s) {
+            if let Some(s_box) = ctx.get_box_replacement_box(s) {
                 ctx.make_nonnull_str(&s_box, mode);
             }
             let mut start = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
@@ -1080,7 +1080,7 @@ impl OptString {
                 if self.is_known_nonnull(arg1, ctx) {
                     // vstring.py:745: self.make_nonnull_str(arg1, mode)
                     // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-                    if let Some(arg1_box) = ctx.ensure_box(arg1) {
+                    if let Some(arg1_box) = ctx.get_box_replacement_box(arg1) {
                         ctx.make_nonnull_str(&arg1_box, mode);
                     }
                     // vstring.py:747: lengthbox = i1.getstrlen(arg1, self, mode)
@@ -1182,10 +1182,10 @@ impl OptString {
         };
         // vstring.py:795-805: l2info = self.getintbound(l2box)
         if let Some(l2ref) = l2box {
-            let l2info = ctx
-                .ensure_box(l2ref)
-                .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-                .expect("getintbound: operand must resolve to a BoxRef");
+            let l2info = {
+                let b = ctx.get_box_replacement(l2ref);
+                ctx.getintbound_handle(&b).borrow().clone()
+            };
             if l2info.is_constant() && l2info.get_constant_int() == 1 {
                 // vstring.py:799: vchar = self.strgetitem(None, arg2, CONST_0, mode)
                 if let Some(vchar) = self.strgetitem(arg2, 0, ctx) {
@@ -1308,9 +1308,7 @@ impl OptString {
             ) {
                 let result = self.int_sub(char1, char2, ctx);
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_result = ctx
-                    .ensure_box(result)
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_result = ctx.get_box_replacement(result);
                 ctx.make_equal_to(&b_old, &b_result);
                 return OptimizationResult::Remove;
             }
@@ -1360,8 +1358,7 @@ impl OptString {
     ) -> OptimizationResult {
         if op.num_args() >= 3 {
             let arg1_box = ctx
-                .get_box_replacement_box(op.arg(1).to_opref())
-                .or_else(|| ctx.ensure_box(op.arg(1).to_opref()));
+                .get_box_replacement_box(op.arg(1).to_opref());
             let length = ctx
                 .get_box_replacement_box(op.arg(2).to_opref())
                 .and_then(|b| ctx.get_constant_int_box(&b));

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1547,7 +1547,7 @@ mod tests {
         // Drain extra_operations_after (from emit_extra during force_box)
         // into new_operations so the test can see all emitted ops.
         while let Some((_pass_idx, extra_op)) = ctx.extra_operations_after.pop_front() {
-            ctx.new_operations.push(std::rc::Rc::new(extra_op));
+            ctx.new_operations.push(extra_op);
         }
         ctx.new_operations
             .into_iter()
@@ -2446,7 +2446,7 @@ mod tests {
 
         // emit_for_force routes to extra_operations_after; drain it.
         while let Some((_pass_idx, extra_op)) = ctx.extra_operations_after.pop_front() {
-            ctx.new_operations.push(std::rc::Rc::new(extra_op));
+            ctx.new_operations.push(extra_op);
         }
 
         // Check that STRGETITEM ops were emitted (inline path) instead of

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -98,14 +98,17 @@ pub fn copy_str_content(
     };
 
     // vstring.py:341-347: determine inline threshold M using intbound
+    // A producer-less operand has no forwarded bound; getintbound returns
+    // unbounded for it, so resolve-or-unbounded matches the prior
+    // ensure_box (mint synthetic → unbounded) behavior without minting.
     let srcoffset_bound = ctx
-        .ensure_box(srcoffsetbox)
+        .get_box_replacement_box(srcoffsetbox)
         .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-        .expect("getintbound: operand must resolve to a BoxRef");
+        .unwrap_or_else(crate::optimizeopt::intutils::IntBound::unbounded);
     let lgt_bound = ctx
-        .ensure_box(lengthbox)
+        .get_box_replacement_box(lengthbox)
         .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-        .expect("getintbound: operand must resolve to a BoxRef");
+        .unwrap_or_else(crate::optimizeopt::intutils::IntBound::unbounded);
     // vstring.py:343: isinstance(srcbox, ConstPtr)
     let src_is_const = ctx
         .get_box_replacement_box(srcbox)
@@ -135,9 +138,9 @@ pub fn copy_str_content(
                     //     None, srcbox, srcoffsetbox, mode)
                     // vstring.py:495: vindex = self.getintbound(index)
                     let vindex = ctx
-                        .ensure_box(src_offset)
+                        .get_box_replacement_box(src_offset)
                         .map(|b| ctx.getintbound_handle(&b).borrow().clone())
-                        .expect("getintbound: operand must resolve to a BoxRef");
+                        .unwrap_or_else(crate::optimizeopt::intutils::IntBound::unbounded);
                     let resolved_idx = if vindex.is_constant() {
                         Some(vindex.get_constant_int())
                     } else {
@@ -483,11 +486,12 @@ impl OptString {
             });
         if let Some(len) = known_len {
             let len_opref = ctx.make_constant_int(len);
-            // Cache in lgtop for identity reuse.
-            // BoxRef shim — set_str_lgtop takes &BoxRef per
+            // Cache in lgtop for identity reuse. `resolved_box` is Some here
+            // (known_len required its ptr_info), so reuse it instead of
+            // re-resolving. set_str_lgtop takes &BoxRef per
             // vstring.py:117/174/293.
-            if let Some(b) = ctx.ensure_box(opref) {
-                ctx.set_str_lgtop(&b, len_opref);
+            if let Some(b) = &resolved_box {
+                ctx.set_str_lgtop(b, len_opref);
             }
             return Some(len_opref);
         }

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -537,7 +537,7 @@ impl OptString {
     /// length is a small constant; otherwise install a non-virtual StrPtrInfo
     /// and emit the op. `postprocess_NEWSTR` (vstring.py:455-459) registers
     /// `pure(STRLEN, op) = length_arg` for CSE via the pure cache.
-    fn _optimize_newstr(&mut self, op: &Op, mode: u8, ctx: &mut OptContext) -> OptimizationResult {
+    fn _optimize_newstr(&mut self, op: &Op, op_rc: &majit_ir::OpRc, mode: u8, ctx: &mut OptContext) -> OptimizationResult {
         let len_ref = op.arg(0).to_opref();
         if let Some(len) = ctx
             .get_box_replacement_box(len_ref)
@@ -545,9 +545,7 @@ impl OptString {
         {
             if len >= 0 && (len as usize) <= MAX_CONST_LEN {
                 // vstring.py:450: self.make_vstring_plain(op, mode, length)
-                let b = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b = BoxRef::from_bound_op(op_rc);
                 {
                     ctx.set_ptr_info(
                         &b,
@@ -569,9 +567,8 @@ impl OptString {
         }
         // vstring.py:452: self.make_nonnull_str(op, mode); return self.emit(op)
         // OpRef → BoxRef shim until this caller migrates (Phase D-2).
-        if let Some(op_box) = ctx.ensure_box(op.pos.get()) {
-            ctx.make_nonnull_str(&op_box, mode);
-        }
+        let op_box = BoxRef::from_bound_op(op_rc);
+        ctx.make_nonnull_str(&op_box, mode);
         // vstring.py:455-459 postprocess_NEWSTR / postprocess_NEWUNICODE:
         //   self.pure_from_args1(mode.STRLEN, op, op.getarg(0))
         let strlen_opcode = if mode == 1 {
@@ -614,7 +611,7 @@ impl OptString {
     }
 
     /// Handle STRGETITEM: if source is virtual, resolve the character.
-    fn optimize_strgetitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_strgetitem(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let str_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let idx_ref = op.arg(1).to_opref();
 
@@ -623,9 +620,7 @@ impl OptString {
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             if let Some(ch_ref) = self.strgetitem(str_ref, idx, ctx) {
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_new = ctx
                     .get_box_replacement_box(ch_ref)
                     .or_else(|| ctx.ensure_box(ch_ref))
@@ -640,7 +635,7 @@ impl OptString {
     }
 
     /// vstring.py:525-533 _optimize_STRLEN
-    fn optimize_strlen(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_strlen(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         let mode = if op.opcode == OpCode::Unicodelen {
             1u8
         } else {
@@ -656,9 +651,7 @@ impl OptString {
             // vstring.py:529: lgtop = opinfo.getstrlen(arg1, self, mode)
             let lgtop = ctx.getstrlen_opref(op.arg(0).to_opref(), mode);
             // vstring.py:531: self.make_equal_to(op, lgtop)
-            let b_old = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_old = BoxRef::from_bound_op(op_rc);
             let b_lgtop = ctx
                 .ensure_box(lgtop)
                 .expect("body-namespace OpRef must have a BoxRef slot");
@@ -855,19 +848,20 @@ impl OptString {
     fn optimize_oopspec_call(
         &mut self,
         op: &Op,
+        op_rc: &majit_ir::OpRc,
         ei: &EffectInfo,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         match ei.oopspecindex {
-            OopSpecIndex::StrConcat => self.opt_call_stroruni_str_concat(op, mode_string, ctx),
-            OopSpecIndex::StrSlice => self.opt_call_stroruni_str_slice(op, mode_string, ctx),
+            OopSpecIndex::StrConcat => self.opt_call_stroruni_str_concat(op, op_rc, mode_string, ctx),
+            OopSpecIndex::StrSlice => self.opt_call_stroruni_str_slice(op, op_rc, mode_string, ctx),
             OopSpecIndex::StrEqual => self.opt_call_stroruni_str_equal(op, mode_string, ctx),
-            OopSpecIndex::StrCmp => self.opt_call_stroruni_str_cmp(op, mode_string, ctx),
-            OopSpecIndex::UniConcat => self.opt_call_stroruni_str_concat(op, mode_unicode, ctx),
-            OopSpecIndex::UniSlice => self.opt_call_stroruni_str_slice(op, mode_unicode, ctx),
+            OopSpecIndex::StrCmp => self.opt_call_stroruni_str_cmp(op, op_rc, mode_string, ctx),
+            OopSpecIndex::UniConcat => self.opt_call_stroruni_str_concat(op, op_rc, mode_unicode, ctx),
+            OopSpecIndex::UniSlice => self.opt_call_stroruni_str_slice(op, op_rc, mode_unicode, ctx),
             OopSpecIndex::UniEqual => self.opt_call_stroruni_str_equal(op, mode_unicode, ctx),
-            OopSpecIndex::UniCmp => self.opt_call_stroruni_str_cmp(op, mode_unicode, ctx),
-            OopSpecIndex::ShrinkArray => self.opt_call_shrink_array(op, ctx),
+            OopSpecIndex::UniCmp => self.opt_call_stroruni_str_cmp(op, op_rc, mode_unicode, ctx),
+            OopSpecIndex::ShrinkArray => self.opt_call_shrink_array(op, op_rc, ctx),
             _ => {
                 self.force_args_if_virtual(op, ctx);
                 OptimizationResult::PassOn
@@ -879,6 +873,7 @@ impl OptString {
     fn opt_call_stroruni_str_concat(
         &mut self,
         op: &Op,
+        op_rc: &majit_ir::OpRc,
         mode: u8,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
@@ -892,9 +887,7 @@ impl OptString {
             if let Some(vright_box) = ctx.ensure_box(vright) {
                 ctx.make_nonnull_str(&vright_box, mode);
             }
-            let b = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b = BoxRef::from_bound_op(op_rc);
             ctx.set_ptr_info(
                 &b,
                 PtrInfo::Str(StrPtrInfo {
@@ -921,6 +914,7 @@ impl OptString {
     fn opt_call_stroruni_str_slice(
         &mut self,
         op: &Op,
+        op_rc: &majit_ir::OpRc,
         mode: u8,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
@@ -941,9 +935,7 @@ impl OptString {
             }
             // vstring.py:220-225: VStringSliceInfo.__init__ sets
             // self.lgtop = length on the inherited StrPtrInfo field.
-            let b = ctx
-                .ensure_box(op.pos.get())
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b = BoxRef::from_bound_op(op_rc);
             ctx.set_ptr_info(
                 &b,
                 PtrInfo::Str(StrPtrInfo {
@@ -1262,6 +1254,7 @@ impl OptString {
     fn opt_call_stroruni_str_cmp(
         &mut self,
         op: &Op,
+        op_rc: &majit_ir::OpRc,
         mode: u8,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
@@ -1297,9 +1290,7 @@ impl OptString {
                 self.strgetitem(op.arg(2).to_opref(), 0, ctx),
             ) {
                 let result = self.int_sub(char1, char2, ctx);
-                let b_old = ctx
-                    .ensure_box(op.pos.get())
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_old = BoxRef::from_bound_op(op_rc);
                 let b_result = ctx
                     .ensure_box(result)
                     .expect("body-namespace OpRef must have a BoxRef slot");
@@ -1344,7 +1335,7 @@ impl OptString {
     ///         return True
     ///     return False
     /// ```
-    fn opt_call_shrink_array(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn opt_call_shrink_array(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         if op.num_args() >= 3 {
             let arg1_box = ctx
                 .get_box_replacement_box(op.arg(1).to_opref())
@@ -1372,9 +1363,7 @@ impl OptString {
                     .unwrap_or(false);
                 if did_shrink {
                     // vstring.py:849: self.make_equal_to(op, op.getarg(1))
-                    let b_old = ctx
-                        .ensure_box(op.pos.get())
-                        .expect("body-namespace OpRef must have a BoxRef slot");
+                    let b_old = BoxRef::from_bound_op(op_rc);
                     let b_arg1 = arg1_box.expect("body-namespace OpRef must have a BoxRef slot");
                     ctx.make_equal_to(&b_old, &b_arg1);
                     return OptimizationResult::Remove;
@@ -1393,22 +1382,22 @@ impl Default for OptString {
 }
 
 impl Optimization for OptString {
-    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         match op.opcode {
             // vstring.py:440-444 optimize_NEWSTR / optimize_NEWUNICODE:
             // both dispatch to _optimize_NEWSTR(op, mode).
-            OpCode::Newstr => self._optimize_newstr(op, mode_string, ctx),
-            OpCode::Newunicode => self._optimize_newstr(op, mode_unicode, ctx),
+            OpCode::Newstr => self._optimize_newstr(op, op_rc, mode_string, ctx),
+            OpCode::Newunicode => self._optimize_newstr(op, op_rc, mode_unicode, ctx),
             OpCode::Strsetitem => self.optimize_strsetitem(op, ctx),
-            OpCode::Strgetitem => self.optimize_strgetitem(op, ctx),
-            OpCode::Strlen => self.optimize_strlen(op, ctx),
+            OpCode::Strgetitem => self.optimize_strgetitem(op, op_rc, ctx),
+            OpCode::Strlen => self.optimize_strlen(op, op_rc, ctx),
             OpCode::Copystrcontent => self.optimize_copystrcontent(op, mode_string, ctx),
 
             // vstring.py: Unicode operations — same logic as string ops
             // but with unicode-specific opcodes.
             OpCode::Unicodesetitem => self.optimize_strsetitem(op, ctx),
-            OpCode::Unicodegetitem => self.optimize_strgetitem(op, ctx),
-            OpCode::Unicodelen => self.optimize_strlen(op, ctx),
+            OpCode::Unicodegetitem => self.optimize_strgetitem(op, op_rc, ctx),
+            OpCode::Unicodelen => self.optimize_strlen(op, op_rc, ctx),
             OpCode::Copyunicodecontent => self.optimize_copystrcontent(op, mode_unicode, ctx),
 
             // vstring.py: STRHASH/UNICODEHASH — force virtual string and emit.
@@ -1445,7 +1434,7 @@ impl Optimization for OptString {
                     if let Some(cd) = descr.as_call_descr() {
                         let ei = cd.get_extra_info();
                         if ei.has_oopspec() {
-                            return self.optimize_oopspec_call(op, &ei, ctx);
+                            return self.optimize_oopspec_call(op, op_rc, &ei, ctx);
                         }
                     }
                 }
@@ -1524,7 +1513,9 @@ mod tests {
             for i in 0..resolved_op.num_args() {
                 resolved_op.setarg(i, ctx.get_box_replacement(resolved_op.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
+            let resolved_rc = std::rc::Rc::new(resolved_op.clone());
+            ctx.bind_input_resops(std::slice::from_ref(&resolved_rc));
+            match pass.propagate_forward(&resolved_op, &resolved_rc, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -2272,7 +2263,9 @@ mod tests {
         ctx.make_constant(OpRef::int_op(200), Value::Int(2));
 
         // Process NEWSTR → creates virtual Plain
-        let _ = pass.propagate_forward(&left_op, &std::rc::Rc::new(left_op.clone()), &mut ctx);
+        let left_op_rc = std::rc::Rc::new(left_op.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&left_op_rc));
+        let _ = pass.propagate_forward(&left_op, &left_op_rc, &mut ctx);
         assert!(pass.is_virtual(left, &ctx));
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -367,9 +367,10 @@ impl OptString {
         ctx: &mut OptContext,
         f: impl FnOnce(&mut VStringPlainInfo) -> R,
     ) -> Option<R> {
-        let b = ctx
-            .get_box_replacement_box(opref)
-            .or_else(|| ctx.ensure_box(opref))?;
+        // When `opref` does not resolve, `ensure_box` would mint a fresh
+        // box carrying no PtrInfo, so `with_ptr_info_mut` returns `None`
+        // either way — the `?` early-out is equivalent without the mint.
+        let b = ctx.get_box_replacement_box(opref)?;
         ctx.with_ptr_info_mut(&b, |info| {
             if let PtrInfo::Str(sinfo) = info {
                 if let VStringVariant::Plain(plain) = &mut sinfo.variant {

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -665,9 +665,7 @@ impl OptString {
             let lgtop = ctx.getstrlen_opref(op.arg(0).to_opref(), mode);
             // vstring.py:531: self.make_equal_to(op, lgtop)
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_lgtop = ctx
-                .ensure_box(lgtop)
-                .expect("body-namespace OpRef must have a BoxRef slot");
+            let b_lgtop = ctx.get_box_replacement(lgtop);
             ctx.make_equal_to(&b_old, &b_lgtop);
             return OptimizationResult::Remove;
         }

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1362,8 +1362,7 @@ impl OptString {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         if op.num_args() >= 3 {
-            let arg1_box = ctx
-                .get_box_replacement_box(op.arg(1).to_opref());
+            let arg1_box = ctx.get_box_replacement_box(op.arg(1).to_opref());
             let length = ctx
                 .get_box_replacement_box(op.arg(2).to_opref())
                 .and_then(|b| ctx.get_constant_int_box(&b));

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1393,7 +1393,7 @@ impl Default for OptString {
 }
 
 impl Optimization for OptString {
-    fn propagate_forward(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(&mut self, op: &Op, _op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
         match op.opcode {
             // vstring.py:440-444 optimize_NEWSTR / optimize_NEWUNICODE:
             // both dispatch to _optimize_NEWSTR(op, mode).
@@ -1524,7 +1524,7 @@ mod tests {
             for i in 0..resolved_op.num_args() {
                 resolved_op.setarg(i, ctx.get_box_replacement(resolved_op.arg(i).to_opref()));
             }
-            match pass.propagate_forward(&resolved_op, &mut ctx) {
+            match pass.propagate_forward(&resolved_op, &std::rc::Rc::new(resolved_op.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
                 }
@@ -2272,7 +2272,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(200), Value::Int(2));
 
         // Process NEWSTR → creates virtual Plain
-        let _ = pass.propagate_forward(&left_op, &mut ctx);
+        let _ = pass.propagate_forward(&left_op, &std::rc::Rc::new(left_op.clone()), &mut ctx);
         assert!(pass.is_virtual(left, &ctx));
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -621,10 +621,7 @@ impl OptString {
         {
             if let Some(ch_ref) = self.strgetitem(str_ref, idx, ctx) {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_new = ctx
-                    .get_box_replacement_box(ch_ref)
-                    .or_else(|| ctx.ensure_box(ch_ref))
-                    .expect("body-namespace OpRef must have a BoxRef slot");
+                let b_new = ctx.get_box_replacement(ch_ref);
                 ctx.make_equal_to(&b_old, &b_new);
                 return OptimizationResult::Remove;
             }

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -100,7 +100,7 @@ pub fn copy_str_content(
     // vstring.py:341-347: determine inline threshold M using intbound
     // A producer-less operand has no forwarded bound; getintbound returns
     // unbounded for it, so resolve-or-unbounded matches the prior
-    // ensure_box (mint synthetic → unbounded) behavior without minting.
+    // materialize_box_at (mint synthetic → unbounded) behavior without minting.
     let srcoffset_bound = ctx
         .get_box_replacement_box(srcoffsetbox)
         .map(|b| ctx.getintbound_handle(&b).borrow().clone())
@@ -370,7 +370,7 @@ impl OptString {
         ctx: &mut OptContext,
         f: impl FnOnce(&mut VStringPlainInfo) -> R,
     ) -> Option<R> {
-        // When `opref` does not resolve, `ensure_box` would mint a fresh
+        // When `opref` does not resolve, `materialize_box_at` would mint a fresh
         // box carrying no PtrInfo, so `with_ptr_info_mut` returns `None`
         // either way — the `?` early-out is equivalent without the mint.
         let b = ctx.get_box_replacement_box(opref)?;
@@ -1576,9 +1576,7 @@ mod tests {
 
     fn set_vstring_plain(ctx: &mut OptContext, opref: OpRef, chars: Vec<Option<OpRef>>) {
         let length = chars.len() as i32;
-        let b = ctx
-            .ensure_box(opref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = ctx.materialize_box_at(opref);
         ctx.set_ptr_info(
             &b,
             PtrInfo::Str(StrPtrInfo {
@@ -1594,9 +1592,7 @@ mod tests {
     }
 
     fn set_vstring_concat(ctx: &mut OptContext, opref: OpRef, vleft: OpRef, vright: OpRef) {
-        let b = ctx
-            .ensure_box(opref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = ctx.materialize_box_at(opref);
         ctx.set_ptr_info(
             &b,
             PtrInfo::Str(StrPtrInfo {
@@ -1616,9 +1612,7 @@ mod tests {
     }
 
     fn set_vstring_slice(ctx: &mut OptContext, opref: OpRef, s: OpRef, start: OpRef, lgtop: OpRef) {
-        let b = ctx
-            .ensure_box(opref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let b = ctx.materialize_box_at(opref);
         ctx.set_ptr_info(
             &b,
             PtrInfo::Str(StrPtrInfo {
@@ -1866,9 +1860,7 @@ mod tests {
 
         // start is not a literal ConstInt box; it is only known via IntBound.
         let start_ref = OpRef::int_op(300);
-        let start_box = ctx
-            .ensure_box(start_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let start_box = ctx.materialize_box_at(start_ref);
         ctx.with_intbound_mut(&start_box, |b| {
             *b = IntBound::from_constant(1);
         });
@@ -1922,9 +1914,7 @@ mod tests {
         // non-virtual StrPtrInfo with `mode = 1` so that later getstrlen
         // selects UNICODELEN instead of STRLEN.
         // Synthetic-OpRef test fixture: lazy-allocate BoxRef for the unicode_ref slot.
-        let unicode_box = ctx
-            .ensure_box(unicode_ref)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let unicode_box = ctx.materialize_box_at(unicode_ref);
         ctx.make_nonnull_str(&unicode_box, 1);
 
         let len_ref = pass.getstrlen(unicode_ref, &mut ctx);
@@ -2339,9 +2329,7 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(4, 0, 0, 50);
         let p0 = OpRef::ref_op(0);
         // Non-virtual Str with unknown length
-        let p0_box = ctx
-            .ensure_box(p0)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let p0_box = ctx.materialize_box_at(p0);
         ctx.set_ptr_info(
             &p0_box,
             PtrInfo::Str(StrPtrInfo {
@@ -2430,9 +2418,7 @@ mod tests {
 
         // srcbox (p0): non-null string, not virtual
         let p0 = OpRef::ref_op(0);
-        let p0_box = ctx
-            .ensure_box(p0)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let p0_box = ctx.materialize_box_at(p0);
         ctx.set_ptr_info(
             &p0_box,
             PtrInfo::Str(StrPtrInfo {
@@ -2451,9 +2437,7 @@ mod tests {
         // lengthbox (i2): int with constant intbound = 2
         // Use an OpRef with IntBound set (not a literal constant)
         let i2 = OpRef::int_op(2);
-        let i2_box = ctx
-            .ensure_box(i2)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let i2_box = ctx.materialize_box_at(i2);
         ctx.with_intbound_mut(&i2_box, |b| {
             *b = IntBound::from_constant(2);
         });
@@ -2498,9 +2482,7 @@ mod tests {
     fn test_getstrlen_opref_on_nonvirtual() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(10, 0, 0, 50);
         let arg2 = OpRef::ref_op(1);
-        let arg2_box = ctx
-            .ensure_box(arg2)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let arg2_box = ctx.materialize_box_at(arg2);
 
         ctx.set_ptr_info(
             &arg2_box,
@@ -2548,9 +2530,7 @@ mod tests {
         let arg2 = OpRef::ref_op(1);
 
         // Attach non-virtual StrPtrInfo to arg2 with lgtop=None.
-        let arg2_box = ctx
-            .ensure_box(arg2)
-            .expect("body-namespace OpRef must have a BoxRef slot");
+        let arg2_box = ctx.materialize_box_at(arg2);
         ctx.set_ptr_info(
             &arg2_box,
             PtrInfo::Str(StrPtrInfo {

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -537,7 +537,13 @@ impl OptString {
     /// length is a small constant; otherwise install a non-virtual StrPtrInfo
     /// and emit the op. `postprocess_NEWSTR` (vstring.py:455-459) registers
     /// `pure(STRLEN, op) = length_arg` for CSE via the pure cache.
-    fn _optimize_newstr(&mut self, op: &Op, op_rc: &majit_ir::OpRc, mode: u8, ctx: &mut OptContext) -> OptimizationResult {
+    fn _optimize_newstr(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        mode: u8,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let len_ref = op.arg(0).to_opref();
         if let Some(len) = ctx
             .get_box_replacement_box(len_ref)
@@ -611,7 +617,12 @@ impl OptString {
     }
 
     /// Handle STRGETITEM: if source is virtual, resolve the character.
-    fn optimize_strgetitem(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_strgetitem(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let str_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let idx_ref = op.arg(1).to_opref();
 
@@ -632,7 +643,12 @@ impl OptString {
     }
 
     /// vstring.py:525-533 _optimize_STRLEN
-    fn optimize_strlen(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn optimize_strlen(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         let mode = if op.opcode == OpCode::Unicodelen {
             1u8
         } else {
@@ -850,12 +866,18 @@ impl OptString {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         match ei.oopspecindex {
-            OopSpecIndex::StrConcat => self.opt_call_stroruni_str_concat(op, op_rc, mode_string, ctx),
+            OopSpecIndex::StrConcat => {
+                self.opt_call_stroruni_str_concat(op, op_rc, mode_string, ctx)
+            }
             OopSpecIndex::StrSlice => self.opt_call_stroruni_str_slice(op, op_rc, mode_string, ctx),
             OopSpecIndex::StrEqual => self.opt_call_stroruni_str_equal(op, mode_string, ctx),
             OopSpecIndex::StrCmp => self.opt_call_stroruni_str_cmp(op, op_rc, mode_string, ctx),
-            OopSpecIndex::UniConcat => self.opt_call_stroruni_str_concat(op, op_rc, mode_unicode, ctx),
-            OopSpecIndex::UniSlice => self.opt_call_stroruni_str_slice(op, op_rc, mode_unicode, ctx),
+            OopSpecIndex::UniConcat => {
+                self.opt_call_stroruni_str_concat(op, op_rc, mode_unicode, ctx)
+            }
+            OopSpecIndex::UniSlice => {
+                self.opt_call_stroruni_str_slice(op, op_rc, mode_unicode, ctx)
+            }
             OopSpecIndex::UniEqual => self.opt_call_stroruni_str_equal(op, mode_unicode, ctx),
             OopSpecIndex::UniCmp => self.opt_call_stroruni_str_cmp(op, op_rc, mode_unicode, ctx),
             OopSpecIndex::ShrinkArray => self.opt_call_shrink_array(op, op_rc, ctx),
@@ -1332,7 +1354,12 @@ impl OptString {
     ///         return True
     ///     return False
     /// ```
-    fn opt_call_shrink_array(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn opt_call_shrink_array(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         if op.num_args() >= 3 {
             let arg1_box = ctx
                 .get_box_replacement_box(op.arg(1).to_opref())
@@ -1379,7 +1406,12 @@ impl Default for OptString {
 }
 
 impl Optimization for OptString {
-    fn propagate_forward(&mut self, op: &Op, op_rc: &majit_ir::OpRc, ctx: &mut OptContext) -> OptimizationResult {
+    fn propagate_forward(
+        &mut self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> OptimizationResult {
         match op.opcode {
             // vstring.py:440-444 optimize_NEWSTR / optimize_NEWUNICODE:
             // both dispatch to _optimize_NEWSTR(op, mode).

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -82,7 +82,7 @@ pub fn copy_str_content(
     mode: u8,
     need_next_offset: bool,
 ) -> OpRef {
-    let srcbox = ctx.get_box_replacement(srcbox);
+    let srcbox = ctx.get_box_replacement(srcbox).to_opref();
     let (set_opcode, copy_opcode, get_opcode) = if mode != 0 {
         (
             OpCode::Unicodesetitem,
@@ -283,7 +283,7 @@ pub fn string_copy_parts(
             let one = ctx.emit_constant_int(1);
             for ch in &chars {
                 if let Some(ch_ref) = ch {
-                    let ch_resolved = ctx.get_box_replacement(*ch_ref);
+                    let ch_resolved = ctx.get_box_replacement(*ch_ref).to_opref();
                     let setitem_op = Op::new(
                         set_opcode,
                         &[
@@ -324,13 +324,13 @@ pub fn string_copy_parts(
 /// Force a string-typed OpRef if it's virtual. Used by string_copy_parts
 /// base class path (vstring.py:138: srcbox = self.force_box(op, optstring)).
 fn force_child_for_string(opref: OpRef, ctx: &mut OptContext) -> OpRef {
-    let resolved = ctx.get_box_replacement(opref);
+    let resolved = ctx.get_box_replacement(opref).to_opref();
     let resolved_box = ctx.get_box_replacement_box(opref);
     if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
         let resolved_box = resolved_box.expect("recorder-populated");
         let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
         let forced = info.force_box(resolved, ctx);
-        return ctx.get_box_replacement(forced);
+        return ctx.get_box_replacement(forced).to_opref();
     }
     resolved
 }
@@ -429,13 +429,13 @@ impl OptString {
 
     /// vstring.py:76-103 StrPtrInfo.force_box — delegate to PtrInfo::force_box.
     fn force_box(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
-        let resolved = ctx.get_box_replacement(opref);
+        let resolved = ctx.get_box_replacement(opref).to_opref();
         let resolved_box = ctx.get_box_replacement_box(opref);
         if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
             let forced = info.force_box(resolved, ctx);
-            return ctx.get_box_replacement(forced);
+            return ctx.get_box_replacement(forced).to_opref();
         }
         resolved
     }
@@ -585,10 +585,10 @@ impl OptString {
 
     /// Handle STRSETITEM: if target is virtual Plain and index is constant, track.
     fn optimize_strsetitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let str_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let str_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let idx_ref = op.arg(1).to_opref();
         let char_ref = op.arg(2).to_opref();
-        let char_resolved = ctx.get_box_replacement(char_ref);
+        let char_resolved = ctx.get_box_replacement(char_ref).to_opref();
 
         if let Some(idx) = ctx
             .get_box_replacement_box(idx_ref)
@@ -615,7 +615,7 @@ impl OptString {
 
     /// Handle STRGETITEM: if source is virtual, resolve the character.
     fn optimize_strgetitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let str_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let str_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         let idx_ref = op.arg(1).to_opref();
 
         if let Some(idx) = ctx
@@ -686,8 +686,8 @@ impl OptString {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // copystrcontent(src, dst, src_start, dst_start, length)
-        let src_ref = ctx.get_box_replacement(op.arg(0).to_opref());
-        let dst_ref = ctx.get_box_replacement(op.arg(1).to_opref());
+        let src_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
+        let dst_ref = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
         let src_start_ref = op.arg(2).to_opref();
         let dst_start_ref = op.arg(3).to_opref();
         let length_ref = op.arg(4).to_opref();
@@ -723,7 +723,7 @@ impl OptString {
                 for index in 0..length {
                     let char_ref =
                         if let Some(ch_ref) = self.strgetitem(src_ref, src_start + index, ctx) {
-                            ctx.get_box_replacement(ch_ref)
+                            ctx.get_box_replacement(ch_ref).to_opref()
                         } else {
                             // vstring.py:580-581 → _strgetitem → emit_extra
                             let index_ref = ctx.make_constant_int(src_start + index);
@@ -828,7 +828,7 @@ impl OptString {
         if let Some(arg0_box) = ctx.ensure_box(op.arg(0).to_opref()) {
             ctx.make_nonnull_str(&arg0_box, mode);
         }
-        let str_ref = ctx.get_box_replacement(op.arg(0).to_opref());
+        let str_ref = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
         if let Some(len) = self.get_known_length(str_ref, ctx) {
             let _ = len;
         }
@@ -839,7 +839,7 @@ impl OptString {
         let args: Vec<OpRef> = op
             .getarglist()
             .iter()
-            .map(|a| ctx.get_box_replacement(a.to_opref()))
+            .map(|a| ctx.get_box_replacement(a.to_opref()).to_opref())
             .collect();
         for arg in args {
             if self.is_virtual(arg, ctx) {
@@ -883,8 +883,8 @@ impl OptString {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         if op.num_args() >= 3 {
-            let vleft = ctx.get_box_replacement(op.arg(1).to_opref());
-            let vright = ctx.get_box_replacement(op.arg(2).to_opref());
+            let vleft = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
+            let vright = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
             // OpRef → BoxRef shim until this caller migrates (Phase D-2).
             if let Some(vleft_box) = ctx.ensure_box(vleft) {
                 ctx.make_nonnull_str(&vleft_box, mode);
@@ -925,13 +925,13 @@ impl OptString {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         if op.num_args() >= 4 {
-            let mut s = ctx.get_box_replacement(op.arg(1).to_opref());
+            let mut s = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
             // OpRef → BoxRef shim until this caller migrates (Phase D-2).
             if let Some(s_box) = ctx.ensure_box(s) {
                 ctx.make_nonnull_str(&s_box, mode);
             }
-            let mut start = ctx.get_box_replacement(op.arg(2).to_opref());
-            let stop = ctx.get_box_replacement(op.arg(3).to_opref());
+            let mut start = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
+            let stop = ctx.get_box_replacement(op.arg(3).to_opref()).to_opref();
             let lgtop = self.int_sub(stop, start, ctx);
             if let Some(info) = self.get_slice_info(s, ctx) {
                 let source = info.s;
@@ -974,8 +974,8 @@ impl OptString {
             return OptimizationResult::PassOn;
         }
         // vstring.py:693-696
-        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref());
-        let arg2 = ctx.get_box_replacement(op.arg(2).to_opref());
+        let arg1 = ctx.get_box_replacement(op.arg(1).to_opref()).to_opref();
+        let arg2 = ctx.get_box_replacement(op.arg(2).to_opref()).to_opref();
         let i1 = ctx
             .get_box_replacement_box(op.arg(1).to_opref())
             .as_ref()
@@ -1112,7 +1112,7 @@ impl OptString {
                     }
                 }
                 // vstring.py:769-774: arg1 is a virtual slice, arg2 is length 1
-                let resolved1 = ctx.get_box_replacement(arg1);
+                let resolved1 = ctx.get_box_replacement(arg1).to_opref();
                 if let Some(info) = self.get_slice_info(resolved1, ctx) {
                     let source = info.s;
                     let start = info.start;
@@ -1191,7 +1191,7 @@ impl OptString {
             }
         }
         // vstring.py:807-813: if arg1 is a virtual slice
-        let resolved1 = ctx.get_box_replacement(arg1);
+        let resolved1 = ctx.get_box_replacement(arg1).to_opref();
         if let Some(info) = self.get_slice_info(resolved1, ctx) {
             let source = info.s;
             let start = info.start;
@@ -1413,7 +1413,7 @@ impl Optimization for OptString {
 
             // vstring.py: STRHASH/UNICODEHASH — force virtual string and emit.
             OpCode::Strhash | OpCode::Unicodehash => {
-                let src = ctx.get_box_replacement(op.arg(0).to_opref());
+                let src = ctx.get_box_replacement(op.arg(0).to_opref()).to_opref();
                 self.force_if_virtual(src, ctx);
                 OptimizationResult::PassOn
             }
@@ -1522,10 +1522,7 @@ mod tests {
             let mut resolved_op = op.clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved_op.num_args() {
-                resolved_op.setarg(
-                    i,
-                    BoxRef::from_opref(ctx.get_box_replacement(resolved_op.arg(i).to_opref())),
-                );
+                resolved_op.setarg(i, ctx.get_box_replacement(resolved_op.arg(i).to_opref()));
             }
             match pass.propagate_forward(&resolved_op, &mut ctx) {
                 OptimizationResult::Emit(emitted) => {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1679,7 +1679,7 @@ where
                     vable_opref,
                     fielddescr,
                     value,
-                    Value::Int(concrete),
+                    Some(Value::Int(concrete)),
                 );
             }
             jitcode::insns::BC_SETFIELD_VABLE_R => {
@@ -1700,7 +1700,7 @@ where
                     vable_opref,
                     fielddescr,
                     value,
-                    Value::Ref(majit_ir::GcRef(concrete as usize)),
+                    Some(Value::Ref(majit_ir::GcRef(concrete as usize))),
                 );
             }
             jitcode::insns::BC_SETFIELD_VABLE_F => {
@@ -1721,7 +1721,7 @@ where
                     vable_opref,
                     fielddescr,
                     value,
-                    Value::Float(f64::from_bits(concrete as u64)),
+                    Some(Value::Float(f64::from_bits(concrete as u64))),
                 );
             }
             // ── BC_GETARRAYITEM_GC_I (Slice C.2) ──

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1322,6 +1322,15 @@ fn walk_op_const_ptr_refs(op: &Op, visitor: &mut dyn FnMut(&mut GcRef)) {
             arg.walk_const_ptr_refs(visitor);
         }
     }
+    // The recorder stamps the concrete runtime result onto `Op.value`
+    // (recorder `set_concrete_at`). A `Value::Ref` there is a live nursery
+    // pointer distinct from the inline `ConstPtr` args above, so it must be
+    // forwarded too. `Op.value` is a `Cell` reached only through a shared
+    // `Rc<Op>`: read the Copy value out, forward a temporary, write it back.
+    if let Some(Value::Ref(mut r)) = op.get_value() {
+        visitor(&mut r);
+        op.set_value(Value::Ref(r));
+    }
 }
 
 impl<M: Clone> MetaInterp<M> {
@@ -1442,6 +1451,16 @@ impl<M: Clone> MetaInterp<M> {
         };
         for op in trace_ctx.recorder.ops() {
             walk_op_const_ptr_refs(op, &mut visitor);
+        }
+        // `set_concrete_at` also stamps a runtime `Value::Ref` onto recorder
+        // InputArgs (loop / bridge entry args). No other walker visits them,
+        // and an InputArg carries no args / fail_args, so `.value` is the only
+        // forwardable slot. Same `Cell` get / forward / set dance as ops above.
+        for ia in trace_ctx.recorder.inputargs() {
+            if let Some(Value::Ref(mut r)) = ia.get_value() {
+                visitor(&mut r);
+                ia.set_value(Value::Ref(r));
+            }
         }
         // pyjitpl.py:3290-3306 — `initialize_virtualizable` /
         // `force_start_tracing` / `setup_tracing` snapshot inputarg
@@ -17617,6 +17636,59 @@ mod tests {
 
         let ops = meta.tracing.as_ref().unwrap().recorder.ops();
         assert_eq!(ops[0].arg(0).to_opref().as_const_ptr(), Some(GcRef(0xB000)));
+    }
+
+    #[test]
+    fn walk_active_trace_refs_forwards_op_value_ref() {
+        // task #107: the recorder stamps the concrete runtime result onto
+        // `Op.value` (`set_concrete_at`). A minor collection during tracing
+        // must forward a `Value::Ref` there; a non-Ref `Value` is untouched.
+        let mut meta = MetaInterp::<()>::new(0);
+        let mut trace_ctx = crate::trace_ctx::TraceCtx::for_test(1);
+        let op = mk_op(
+            OpCode::PtrEq,
+            &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
+            5,
+        );
+        op.set_value(Value::Ref(GcRef(0xA000)));
+        trace_ctx.recorder.push_op_for_test(op);
+        let int_op = mk_op(OpCode::IntAdd, &[OpRef::input_arg_int(0)], 6);
+        int_op.set_value(Value::Int(7));
+        trace_ctx.recorder.push_op_for_test(int_op);
+        meta.tracing = Some(trace_ctx);
+
+        meta.walk_active_trace_refs(|slot| {
+            if slot.0 == 0xA000 {
+                slot.0 = 0xB000;
+            }
+        });
+
+        let ops = meta.tracing.as_ref().unwrap().recorder.ops();
+        assert!(matches!(ops[0].get_value(), Some(Value::Ref(GcRef(0xB000)))));
+        assert!(matches!(ops[1].get_value(), Some(Value::Int(7))));
+    }
+
+    #[test]
+    fn walk_active_trace_refs_forwards_inputarg_value_ref() {
+        // task #107: `set_concrete_at` also stamps `Value::Ref` onto recorder
+        // InputArgs (loop / bridge entry args), reached only through this
+        // walker since an InputArg has no args / fail_args to forward.
+        let mut meta = MetaInterp::<()>::new(0);
+        let trace_ctx = crate::trace_ctx::TraceCtx::for_test_types(&[Type::Ref]);
+        trace_ctx.recorder.inputargs()[0].set_value(Value::Ref(GcRef(0x7000)));
+        meta.tracing = Some(trace_ctx);
+
+        meta.walk_active_trace_refs(|slot| {
+            if slot.0 == 0x7000 {
+                slot.0 = 0x8000;
+            }
+        });
+
+        let inputargs = meta.tracing.as_ref().unwrap().recorder.inputargs();
+        assert!(matches!(
+            inputargs[0].get_value(),
+            Some(Value::Ref(GcRef(0x8000)))
+        ));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -3835,7 +3835,7 @@ impl<M: Clone> MetaInterp<M> {
         self.tracing
             .as_mut()
             .expect("opimpl_setfield_vable_int requires active tracing")
-            .vable_setfield(pc, vable_opref, fielddescr, value, concrete);
+            .vable_setfield(pc, vable_opref, fielddescr, value, Some(concrete));
     }
 
     /// pyjitpl.py:1188-1199 `_opimpl_setfield_vable` — ref variant.
@@ -3850,7 +3850,7 @@ impl<M: Clone> MetaInterp<M> {
         self.tracing
             .as_mut()
             .expect("opimpl_setfield_vable_ref requires active tracing")
-            .vable_setfield(pc, vable_opref, fielddescr, value, concrete);
+            .vable_setfield(pc, vable_opref, fielddescr, value, Some(concrete));
     }
 
     /// pyjitpl.py:1188-1199 `_opimpl_setfield_vable` — float variant.
@@ -3865,7 +3865,7 @@ impl<M: Clone> MetaInterp<M> {
         self.tracing
             .as_mut()
             .expect("opimpl_setfield_vable_float requires active tracing")
-            .vable_setfield(pc, vable_opref, fielddescr, value, concrete);
+            .vable_setfield(pc, vable_opref, fielddescr, value, Some(concrete));
     }
 
     /// pyjitpl.py:1218-1234 `_opimpl_getarrayitem_vable` — int variant.

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -17664,7 +17664,10 @@ mod tests {
         });
 
         let ops = meta.tracing.as_ref().unwrap().recorder.ops();
-        assert!(matches!(ops[0].get_value(), Some(Value::Ref(GcRef(0xB000)))));
+        assert!(matches!(
+            ops[0].get_value(),
+            Some(Value::Ref(GcRef(0xB000)))
+        ));
         assert!(matches!(ops[1].get_value(), Some(Value::Int(7))));
     }
 

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -109,16 +109,17 @@ pub(crate) fn value_to_raw_bits(value: Value) -> i64 {
 }
 
 /// pyjitpl.py:1135-1138 `rop.PTR_EQ` runtime outcome.  Compare the
-/// concrete ptrs carried by two Refs (virtualizable identity).  Non-Ref
-/// values are never compared as virtualizable boxes, so falling into the
-/// catch-all `false` branch preserves the Step 4 "not standard" path in
-/// `is_nonstandard_virtualizable` — this is how an `opref` backed by a
-/// non-Ref constant (e.g. `ConstInt(0xCAFE)` in a test) still resolves to
+/// concrete ptrs carried by two Refs (virtualizable identity).  `None`
+/// (no concrete known) and non-Ref values are never the standard box, so
+/// falling into the catch-all `false` branch preserves the Step 4 "not
+/// standard" path in `is_nonstandard_virtualizable` — this is how an
+/// `opref` with no resolvable concrete, or one backed by a non-Ref
+/// constant (e.g. `ConstInt(0xCAFE)` in a test), still resolves to
 /// `isstandard = 0` and proceeds to Step 5 / `emit_force_virtualizable`,
 /// matching upstream's runtime behavior for the same bogus input.
-fn concrete_ptrs_eq(a: &Value, b: &Value) -> bool {
+fn concrete_ptrs_eq(a: Option<&Value>, b: Option<&Value>) -> bool {
     match (a, b) {
-        (Value::Ref(ra), Value::Ref(rb)) => ra == rb,
+        (Some(Value::Ref(ra)), Some(Value::Ref(rb))) => ra == rb,
         _ => false,
     }
 }
@@ -1813,28 +1814,26 @@ impl TraceCtx {
     ///      site that has the runtime result in scope (HEAP loads,
     ///      register reads, resume-data materialization).  Covers
     ///      non-Const result OpRefs whose runtime concrete is known.
-    ///   4. Fallback — a sentinel `Value::Ref(GcRef(usize::MAX))` that
-    ///      never matches a real heap pointer, so PTR_EQ comparisons with
-    ///      the standard vable resolve to "different" at trace time.
-    pub fn concrete_of_opref(&self, opref: OpRef) -> Value {
+    ///   4. Fallback — `None`: no concrete is known.  Consumers treat
+    ///      `None` as "never matches a real heap pointer", so PTR_EQ
+    ///      comparisons with the standard vable resolve to "different" at
+    ///      trace time.
+    pub fn concrete_of_opref(&self, opref: OpRef) -> Option<Value> {
         if opref.is_constant() {
             // history.py:220/261/307 box.type parity: the OpRef variant
             // carries the typed `Value` inline — the variant tag carries
             // the `Box.type` intrinsically, so no separate type lookup
             // is required.
             if let Some(value) = opref.inline_const_to_value() {
-                return value;
+                return Some(value);
             }
         }
         if Some(opref) == self.standard_virtualizable_box() {
             if let Some(v) = self.standard_virtualizable_concrete() {
-                return v;
+                return Some(v);
             }
         }
-        if let Some(v) = self.lookup_opref_concrete(opref) {
-            return v;
-        }
-        Value::Ref(majit_ir::GcRef(usize::MAX))
+        self.lookup_opref_concrete(opref)
     }
 
     /// Whether standard virtualizable boxes are active.
@@ -2304,7 +2303,7 @@ impl TraceCtx {
         pc: usize,
         vable_opref: OpRef,
         fielddescr: &DescrRef,
-        concrete: Value,
+        concrete: Option<Value>,
     ) -> bool {
         // Step 1: heapcache short-circuit.
         //     if self.metainterp.heapcache.is_known_nonstandard_virtualizable(box):
@@ -2376,9 +2375,7 @@ impl TraceCtx {
             None => true,
         };
         if descriptor_has_matching_vinfo {
-            let standard_concrete = self
-                .standard_virtualizable_concrete()
-                .unwrap_or(Value::Ref(majit_ir::GcRef(usize::MAX)));
+            let standard_concrete = self.standard_virtualizable_concrete();
             // pyjitpl.py:1135-1138 `eqbox = self.metainterp.execute_and_record(
             //     rop.PTR_EQ, None, box, standard_box);
             //     eqbox = self.implement_guard_value(eqbox, pc);
@@ -2394,7 +2391,8 @@ impl TraceCtx {
             // parameter is documented here but not consumed at this layer.
             let _ = pc;
             let eqbox = self.record_op(OpCode::PtrEq, &[vable_opref, standard_box]);
-            let isstandard: i64 = if concrete_ptrs_eq(&concrete, &standard_concrete) {
+            let isstandard: i64 = if concrete_ptrs_eq(concrete.as_ref(), standard_concrete.as_ref())
+            {
                 1
             } else {
                 0
@@ -2665,7 +2663,7 @@ impl TraceCtx {
         vable_opref: OpRef,
         fielddescr: DescrRef,
         value: OpRef,
-        concrete: Value,
+        concrete: Option<Value>,
     ) {
         let vable_concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fielddescr, vable_concrete) {
@@ -2702,7 +2700,13 @@ impl TraceCtx {
             .expect("vable_setfield: virtualizable_info missing")
             .static_field_by_descr(&fielddescr)
             .expect("vable_setfield: standard virtualizable field descr missing");
-        self.set_virtualizable_entry_at(index, value, concrete);
+        // `virtualizable_values` is a dense `Vec<Value>`, so an unknown
+        // concrete still needs a placeholder slot.  This is the lone
+        // remaining materialization of the "no concrete" marker; the
+        // role-2 shadow store keeps a `Value::Ref(GcRef(usize::MAX))`
+        // until that store is itself moved to `Vec<Option<Value>>`.
+        let stored = concrete.unwrap_or(Value::Ref(majit_ir::GcRef(usize::MAX)));
+        self.set_virtualizable_entry_at(index, value, stored);
         // pyjitpl.py:3446 write_boxes parity: mirror the updated
         // shadow slot back into the live virtualizable.
         self.synchronize_virtualizable();
@@ -4017,7 +4021,7 @@ mod tests {
             fn sync_virtualizable_before_residual_call(&self, ctx: &mut TraceCtx) {
                 // Write field 0 to heap
                 let fd = majit_ir::make_field_descr(0, 8, Type::Int, majit_ir::ArrayFlag::Signed);
-                ctx.vable_setfield(0, self.vable_ref, fd, self.field_val, Value::Int(0));
+                ctx.vable_setfield(0, self.vable_ref, fd, self.field_val, Some(Value::Int(0)));
             }
 
             fn sync_virtualizable_after_residual_call(
@@ -4167,7 +4171,7 @@ mod tests {
                     self.vable_ref,
                     fd,
                     self.field_val,
-                    Value::Ref(majit_ir::GcRef::NULL),
+                    Some(Value::Ref(majit_ir::GcRef::NULL)),
                 );
             }
 
@@ -4248,7 +4252,13 @@ mod tests {
 
             fn sync_virtualizable_before_residual_call(&self, ctx: &mut TraceCtx) {
                 let fd = majit_ir::make_field_descr(0, 8, Type::Float, majit_ir::ArrayFlag::Float);
-                ctx.vable_setfield(0, self.vable_ref, fd, self.field_val, Value::Float(0.0));
+                ctx.vable_setfield(
+                    0,
+                    self.vable_ref,
+                    fd,
+                    self.field_val,
+                    Some(Value::Float(0.0)),
+                );
             }
 
             fn sync_virtualizable_after_residual_call(
@@ -4463,7 +4473,7 @@ mod tests {
         );
 
         // setfield offset=8 → updates box0
-        ctx.vable_setfield(0, vable, fd8.clone(), new_val, ph(Type::Int));
+        ctx.vable_setfield(0, vable, fd8.clone(), new_val, Some(ph(Type::Int)));
 
         // Box 0 should now be new_val
         let (result, _) = ctx.vable_getfield_int(0, vable, 0, fd8);
@@ -4511,7 +4521,7 @@ mod tests {
         );
 
         let fd8 = majit_ir::make_field_descr(8, 8, Type::Int, majit_ir::ArrayFlag::Signed);
-        ctx.vable_setfield(0, vable, fd8, val, ph(Type::Int));
+        ctx.vable_setfield(0, vable, fd8, val, Some(ph(Type::Int)));
 
         let ops = take_all_ops(ctx);
         assert_eq!(ops.len(), 1);
@@ -4755,7 +4765,7 @@ mod tests {
         assert_eq!(boxes, vec![box0, box1, vable]);
 
         // After mutation
-        ctx.vable_setfield(0, vable, fd8, new_val, ph(Type::Int));
+        ctx.vable_setfield(0, vable, fd8, new_val, Some(ph(Type::Int)));
         let boxes = ctx.collect_virtualizable_boxes().unwrap();
         assert_eq!(boxes, vec![new_val, box1, vable]);
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1001,7 +1001,7 @@ fn concrete_int_for_switch(
     ctx: &WalkContext<'_, '_>,
 ) -> Result<i64, DispatchError> {
     match ctx.trace_ctx.concrete_of_opref(value) {
-        Value::Int(v) => Ok(v),
+        Some(Value::Int(v)) => Ok(v),
         _ => Err(DispatchError::SwitchValueNotConcrete { pc: op.pc, value }),
     }
 }
@@ -1220,18 +1220,18 @@ fn write_int_reg(
 /// `binop_int_record` / `unop_int_record`, and standard virtualizable
 /// box hits all surface here.
 ///
-/// Returns `ConcreteValue::Null` when the table has no entry — the
-/// caller's downstream `goto_if_not/iL` / GUARD_CLASS dispatch treats
-/// Null as "skip the fold / skip the guard".  The sentinel
-/// `Value::Ref(GcRef(usize::MAX))` (`trace_ctx.rs:1461`) is mapped to
-/// Null since it signals "no concrete known" rather than an actual
-/// pointer.
+/// Returns `ConcreteValue::Null` when `concrete_of_opref` yields `None`
+/// (no concrete known) — the caller's downstream `goto_if_not/iL` /
+/// GUARD_CLASS dispatch treats Null as "skip the fold / skip the guard".
+/// A residual `Value::Ref(GcRef(usize::MAX))` storage placeholder
+/// (`vable_setfield`) is likewise mapped to Null since it signals "no
+/// concrete known" rather than an actual pointer.
 #[inline]
 fn concrete_from_recorded_opref(ctx: &WalkContext<'_, '_>, opref: OpRef) -> ConcreteValue {
     match ctx.trace_ctx.concrete_of_opref(opref) {
-        Value::Int(v) => ConcreteValue::Int(v),
-        Value::Float(v) => ConcreteValue::Float(v),
-        Value::Ref(r) if r != majit_ir::GcRef(usize::MAX) => {
+        Some(Value::Int(v)) => ConcreteValue::Int(v),
+        Some(Value::Float(v)) => ConcreteValue::Float(v),
+        Some(Value::Ref(r)) if r != majit_ir::GcRef(usize::MAX) => {
             ConcreteValue::Ref(r.as_usize() as pyre_object::PyObjectRef)
         }
         _ => ConcreteValue::Null,
@@ -3194,7 +3194,7 @@ fn funcptr_concrete_int(ctx: &WalkContext<'_, '_>, funcptr: OpRef) -> Option<i64
         return None;
     }
     match ctx.trace_ctx.concrete_of_opref(funcptr) {
-        majit_ir::Value::Int(v) => Some(v),
+        Some(majit_ir::Value::Int(v)) => Some(v),
         _ => None,
     }
 }
@@ -5209,7 +5209,7 @@ fn handle(
             let valuebox = read_int_reg(code, op, 0, ctx)?;
             let target = read_label(code, op, 1);
             let switchcase = match ctx.trace_ctx.concrete_of_opref(valuebox) {
-                Value::Int(v) => v,
+                Some(Value::Int(v)) => v,
                 _ => {
                     return Err(DispatchError::GotoIfNotValueNotConcrete {
                         pc: op.pc,


### PR DESCRIPTION
#47
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Routes optimizer forwarding through `Op`/`InputArg` box identity instead of the OpRef-keyed `ensure_box` find-or-create path, and deletes `ensure_box` entirely (the #47 box-identity goal).

- `get_box_replacement` returns `BoxRef`; reader/writer sites call it directly.
- Canonical `OpRc` is threaded through pass dispatch so every operand has a registered producer and `get_box_replacement[_box]` always resolves.
- `ensure_box` is removed. Resolve-only callers route through `get_box_replacement[_box]` / `resolve_to_boxref` / `from_bound_op`; the genuine find-or-create write sites call `materialize_box_at`, the explicit-mint endpoint that returns the canonical `Op`/`InputArg` `_forwarded` host and mints a `SameAs*` synthetic only when no producer is registered.
- Explicit mint primitives (`materialize_box_at`, `mint_box_at`, `reserve_virtual_box`) cover the genuinely producer-less positions (import aliases, reserved virtuals, short-preamble replay slots).
- No `ensure_box` references remain in `majit/`.
- Includes two rebase-base salvage fixes: `resop_refs` collision re-key (#97) and GC-walk of `Op.value`/`InputArg.value` (#107).

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the JIT optimizer's internal pipeline to improve virtual object tracking and memory reference resolution. Enhanced how the optimizer materializes and threads operation references through optimization passes for more consistent handling of virtual state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->