### PR TITLE
match cascade lowering + isinstance + llmemory address family

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -336,7 +336,8 @@ pub struct OptPure {
     /// shortpreamble.py:124-126: PureOp.produce_op stores PreambleOp in
     /// optpure's cache. In majit, PreambleOp entries stored here are
     /// searched with forwarding-aware matching (force_preamble_op pattern).
-    /// Body CSE uses the HashMap (unchanged).
+    /// Body CSE uses `RecentPureOpTable` (the `cache` field above) — a
+    /// per-opcode bucket array, not a hashmap.
     preamble_pure_ops: Vec<PreamblePureEntry>,
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -622,8 +622,6 @@ impl VirtualState {
     /// a stop-the-world GC walk we mutate the node payloads in place so all
     /// shared references observe the forwarded address.
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        use std::collections::HashSet;
-
         fn visit_value(value: &mut Value, visitor: &mut dyn FnMut(&mut GcRef)) {
             if let Value::Ref(gcref) = value {
                 visitor(gcref);
@@ -633,12 +631,13 @@ impl VirtualState {
         fn visit_node(
             node: &Rc<VirtualStateInfoNode>,
             visitor: &mut dyn FnMut(&mut GcRef),
-            seen: &mut HashSet<*const VirtualStateInfoNode>,
+            seen: &mut Vec<*const VirtualStateInfoNode>,
         ) {
             let ptr = Rc::as_ptr(node);
-            if !seen.insert(ptr) {
+            if seen.contains(&ptr) {
                 return;
             }
+            seen.push(ptr);
             // SAFETY: GC root walking is stop-the-world in pyre. RPython mutates
             // the same object-graph fields in place; this mirrors that by
             // updating the shared Rc node payload so every alias sees the
@@ -650,7 +649,7 @@ impl VirtualState {
         fn visit_info(
             info: &mut VirtualStateInfo,
             visitor: &mut dyn FnMut(&mut GcRef),
-            seen: &mut HashSet<*const VirtualStateInfoNode>,
+            seen: &mut Vec<*const VirtualStateInfoNode>,
         ) {
             match info {
                 VirtualStateInfo::Constant(value) => visit_value(value, visitor),
@@ -685,7 +684,7 @@ impl VirtualState {
             }
         }
 
-        let mut seen = HashSet::new();
+        let mut seen: Vec<*const VirtualStateInfoNode> = Vec::new();
         for node in &self.state {
             visit_node(node, visitor, &mut seen);
         }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5203,6 +5203,7 @@ pub fn eval_unary_i(opcode: OpCode, value: i64) -> i64 {
         OpCode::IntNeg => value.wrapping_neg(),
         OpCode::IntInvert => !value,
         OpCode::IntIsTrue => i64::from(value != 0),
+        OpCode::IntIsZero => i64::from(value == 0),
         other => panic!("unsupported jitcode integer unary op {other:?}"),
     }
 }

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -1820,7 +1820,22 @@ impl RPythonAnnotator {
         inputcells: &[Option<SomeValue>],
     ) {
         let blk = block.borrow();
-        let oldcells: Vec<SomeValue> = blk.inputargs.iter().map(|a| self.binding(a)).collect();
+        let oldcells: Vec<SomeValue> = blk
+            .inputargs
+            .iter()
+            .enumerate()
+            .map(|(i, a)| {
+                self.annotation(a).unwrap_or_else(|| {
+                    panic!(
+                        "KeyError: no binding for arg [mergeinputargs slot={i}/{n} \
+                         block={block_id:?} graph_inputargs_len={ga_len}] {a:?}",
+                        n = blk.inputargs.len(),
+                        block_id = std::ptr::addr_of!(*blk),
+                        ga_len = graph.borrow().getargs().len(),
+                    )
+                })
+            })
+            .collect();
         drop(blk);
 
         // `annrpython.py:432` calls `unionof(c1, c2)` directly —

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2072,29 +2072,28 @@ impl<'a> Lowering<'a> {
     ) -> Result<(), LowerError> {
         let bb_id = self.block_id[mir_bb];
         let discr_var = self.resolve_operand(mir_bb, discr)?;
-        let mut links: Vec<Link> = Vec::new();
         match targets {
             SwitchTargets::If(then_bb, else_bb) => {
-                links.push(
-                    Link::new_mixed(
-                        vec![],
-                        self.block_id[else_bb as usize],
-                        Some(ExitCase::Bool(false)),
-                    )
-                    .with_prevblock(bb_id)
-                    .with_llexitcase_from_exitcase(),
+                // Route through `set_branch` so the cond gets the
+                // upstream `bool` UnaryOp wrap before becoming the
+                // exitswitch (flowcontext.py:756
+                // `Variable.bool().eval(self)`).  Necessary because the
+                // MIR discriminant for an `If` target can be a Ref
+                // (e.g. a SyntheticTransparentCtor result) whereas
+                // jit_codewriter/assembler.rs::FlatOp::GotoIfNot expects
+                // `cond.kind == RegKind::Int`.
+                self.graph.set_branch(
+                    bb_id,
+                    discr_var,
+                    self.block_id[then_bb as usize],
+                    vec![],
+                    self.block_id[else_bb as usize],
+                    vec![],
                 );
-                links.push(
-                    Link::new_mixed(
-                        vec![],
-                        self.block_id[then_bb as usize],
-                        Some(ExitCase::Bool(true)),
-                    )
-                    .with_prevblock(bb_id)
-                    .with_llexitcase_from_exitcase(),
-                );
+                Ok(())
             }
             SwitchTargets::SwitchInt(_int_ty, arms, default) => {
+                let mut links: Vec<Link> = Vec::new();
                 for (scalar, bb) in arms {
                     let case = scalar_to_const_value(&scalar).ok_or_else(|| {
                         LowerError::Unsupported(format!(
@@ -2119,11 +2118,11 @@ impl<'a> Lowering<'a> {
                     )
                     .with_prevblock(bb_id),
                 );
+                self.graph.block_mut(bb_id).exitswitch = Some(ExitSwitch::Value(discr_var));
+                self.graph.closeblock(bb_id, links);
+                Ok(())
             }
         }
-        self.graph.block_mut(bb_id).exitswitch = Some(ExitSwitch::Value(discr_var));
-        self.graph.closeblock(bb_id, links);
-        Ok(())
     }
 }
 

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -658,6 +658,11 @@ fn remap_op_kind(
             value: remap_var(value),
             kind_char: *kind_char,
         },
+        OpKind::IsInstance { obj, class_carrier, result_ty } => OpKind::IsInstance {
+            obj: remap_var(obj),
+            class_carrier: remap_var(class_carrier),
+            result_ty: result_ty.clone(),
+        },
         OpKind::Live => OpKind::Live,
         OpKind::JitMergePoint {
             jitdriver_index,
@@ -874,6 +879,9 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         OpKind::AssertGreen { value, .. }
         | OpKind::IsConstant { value, .. }
         | OpKind::IsVirtual { value, .. } => vec![clone_var(value)],
+        OpKind::IsInstance { obj, class_carrier, .. } => {
+            vec![clone_var(obj), clone_var(class_carrier)]
+        }
         OpKind::VtableMethodPtr { receiver, .. } => vec![clone_var(receiver)],
         OpKind::IndirectCall { funcptr, args, .. } => {
             let mut v = vec![clone_var(funcptr)];
@@ -1124,6 +1132,7 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::AssertGreen { .. }
         | OpKind::IsConstant { .. }
         | OpKind::IsVirtual { .. }
+        | OpKind::IsInstance { .. }
         | OpKind::CurrentTraceLength
         | OpKind::JitDebug { .. }
         | OpKind::JitMergePoint { .. }

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -658,7 +658,11 @@ fn remap_op_kind(
             value: remap_var(value),
             kind_char: *kind_char,
         },
-        OpKind::IsInstance { obj, class_carrier, result_ty } => OpKind::IsInstance {
+        OpKind::IsInstance {
+            obj,
+            class_carrier,
+            result_ty,
+        } => OpKind::IsInstance {
             obj: remap_var(obj),
             class_carrier: remap_var(class_carrier),
             result_ty: result_ty.clone(),
@@ -879,7 +883,9 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         OpKind::AssertGreen { value, .. }
         | OpKind::IsConstant { value, .. }
         | OpKind::IsVirtual { value, .. } => vec![clone_var(value)],
-        OpKind::IsInstance { obj, class_carrier, .. } => {
+        OpKind::IsInstance {
+            obj, class_carrier, ..
+        } => {
             vec![clone_var(obj), clone_var(class_carrier)]
         }
         OpKind::VtableMethodPtr { receiver, .. } => vec![clone_var(receiver)],

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -1078,6 +1078,13 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::VtableMethodPtr { .. }
         // `newtuple` is `PureOperation` (`operation.py:542-548`).
         | OpKind::NewTuple { .. }
+        // `isinstance` lowers to `int_between` over `obj.typeptr`'s
+        // subclass-range fields plus an optional null branch — all
+        // pure reads, classified `canfold=True` upstream
+        // (`lloperation.py instance_isinstance`).  Keeping dead
+        // `IsInstance` results alive would block prune_dead_phis Step
+        // 5 even though the predicate is side-effect-free.
+        | OpKind::IsInstance { .. }
         // `LoadStatic` reads a `static` declaration's compile-time
         // address — equivalent to `LOAD_GLOBAL` → Constant lookup,
         // pure.
@@ -1132,7 +1139,6 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::AssertGreen { .. }
         | OpKind::IsConstant { .. }
         | OpKind::IsVirtual { .. }
-        | OpKind::IsInstance { .. }
         | OpKind::CurrentTraceLength
         | OpKind::JitDebug { .. }
         | OpKind::JitMergePoint { .. }

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -523,20 +523,16 @@ impl Assembler {
             // RPython flatten.py:247-267: goto_if_not(cond, TLabel(false_path))
             // Only goto_if_not exists — no goto_if_true in RPython.
             FlatOp::GotoIfNot { cond, target } => {
-                // `flatten.py:248` asserts `block.exitswitch.concretetype
-                // == lltype.Bool`, so the cond is always an Int-bank
-                // bool.  `set_branch` enforces this upstream by wrapping
-                // every exitswitch in a `bool` HighLevelOp (parity with
-                // `flowcontext.py:744-779`), which the rtyper specialises
-                // per repr down to an Int-bank result.
-                assert_eq!(
-                    cond.kind,
-                    crate::jit_codewriter::flatten::RegKind::Int,
-                    "goto_if_not cond must be an Int-bank bool (graph={}, cond={:?}, target={:?})",
-                    self.current_graph_name.as_deref().unwrap_or("?"),
-                    cond,
-                    target,
-                );
+                // RPython parity expectation: `cond.kind == RegKind::Int`
+                // because `block.exitswitch.concretetype == lltype.Bool`
+                // is the build-time gate at `flatten.py:248`.  Pyre's
+                // annotator/rtyper coverage gap (TODO #71/#74)
+                // occasionally lets a Ref cond reach this site (e.g.
+                // `eval_loop_jit`'s portal bool branches).  The
+                // `cond.index` byte still encodes the regalloc color
+                // correctly so emission proceeds; the parity gap is
+                // tracked above lookup_coloring_var rather than asserted
+                // here.
                 let opnum = self.get_opnum("goto_if_not/iL");
                 state.startpoints.insert(state.code.len());
                 state.code.push(opnum);

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -526,13 +526,19 @@ impl Assembler {
                 // RPython parity expectation: `cond.kind == RegKind::Int`
                 // because `block.exitswitch.concretetype == lltype.Bool`
                 // is the build-time gate at `flatten.py:248`.  Pyre's
-                // annotator/rtyper coverage gap (TODO #71/#74)
-                // occasionally lets a Ref cond reach this site (e.g.
-                // `eval_loop_jit`'s portal bool branches).  The
+                // `FunctionGraph::set_branch` (model.rs) bool-wraps the
+                // exitswitch at build time (mirroring upstream
+                // `flowcontext.py:756 Variable.bool().eval(self)`), but
+                // some annotator/rtyper paths still let an unwrapped
+                // Ref cond reach this site (empirically verified
+                // 2026-06-06: adding `assert_eq!(cond.kind,
+                // RegKind::Int)` panics during build-script
+                // ullbc-to-jitcode lowering with `got Ref`).  The
                 // `cond.index` byte still encodes the regalloc color
                 // correctly so emission proceeds; the parity gap is
-                // tracked above lookup_coloring_var rather than asserted
-                // here.
+                // tracked above lookup_coloring_var rather than
+                // asserted here pending closure of the set_branch
+                // unwrap residual.
                 let opnum = self.get_opnum("goto_if_not/iL");
                 state.startpoints.insert(state.code.len());
                 state.code.push(opnum);

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -3274,12 +3274,21 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::IsVirtual { kind_char, .. } => {
             format!("{}_isvirtual", kind_char_to_name(*kind_char))
         }
-        // Mirrors flowspace/operation.rs OpKind::IsInstance opname:
-        // the rtyper dispatches the `"isinstance"` string at
-        // rtyper.rs:2035 to InstanceRepr::rtype_isinstance, which
-        // resolves it to the per-class `ll_isinstance_const_*` or the
-        // unspecialised `ll_isinstance` helper.
-        OpKind::IsInstance { .. } => "isinstance".into(),
+        // The rtyper at rtyper.rs:2035 dispatches the flowspace
+        // `"isinstance"` opname through `InstanceRepr::rtype_isinstance`,
+        // which lowers it into a direct_call to the per-class
+        // `ll_isinstance_const_*` or unspecialised `ll_isinstance`
+        // helper.  By the time the codewriter assembler runs every
+        // `OpKind::IsInstance` should already have been replaced with
+        // that direct_call, so reaching this arm signals an rtyper
+        // gap.  Fail loudly rather than emit an `"isinstance"` opname
+        // with no corresponding entry in `insns.rs::wellknown_bh_insns`.
+        OpKind::IsInstance { .. } => panic!(
+            "OpKind::IsInstance reached the JitCode assembler; the rtyper \
+             must lower isinstance to ll_isinstance* direct_call before \
+             codewriter emission (rtyper.rs:2035 / \
+             InstanceRepr::rtype_isinstance)"
+        ),
         OpKind::RecordKnownResult { result_kind, .. } => {
             format!("record_known_result_{result_kind}")
         }

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -523,22 +523,24 @@ impl Assembler {
             // RPython flatten.py:247-267: goto_if_not(cond, TLabel(false_path))
             // Only goto_if_not exists — no goto_if_true in RPython.
             FlatOp::GotoIfNot { cond, target } => {
-                // RPython parity expectation: `cond.kind == RegKind::Int`
-                // because `block.exitswitch.concretetype == lltype.Bool`
-                // is the build-time gate at `flatten.py:248`.  Pyre's
-                // `FunctionGraph::set_branch` (model.rs) bool-wraps the
-                // exitswitch at build time (mirroring upstream
-                // `flowcontext.py:756 Variable.bool().eval(self)`), but
-                // some annotator/rtyper paths still let an unwrapped
-                // Ref cond reach this site (empirically verified
-                // 2026-06-06: adding `assert_eq!(cond.kind,
-                // RegKind::Int)` panics during build-script
-                // ullbc-to-jitcode lowering with `got Ref`).  The
-                // `cond.index` byte still encodes the regalloc color
-                // correctly so emission proceeds; the parity gap is
-                // tracked above lookup_coloring_var rather than
-                // asserted here pending closure of the set_branch
-                // unwrap residual.
+                // RPython parity: `cond.kind == RegKind::Int` because
+                // `block.exitswitch.concretetype == lltype.Bool` is the
+                // build-time gate at `flatten.py:248`.  Pyre routes
+                // every Variable-cond exitswitch installation through
+                // `FunctionGraph::set_branch` (model.rs), which appends
+                // a `bool` UnaryOp (flowcontext.py:756
+                // `Variable.bool().eval(self)`) so the rtyper lowers
+                // the cond to a Bool register before flatten emits.
+                // Fail loud if a non-Int slips through — mirrors
+                // `FlatOp::Switch`'s assert below.
+                assert_eq!(
+                    cond.kind,
+                    RegKind::Int,
+                    "FlatOp::GotoIfNot.cond must be RegKind::Int \
+                     (flatten.py:248 `block.exitswitch.concretetype == lltype.Bool`); \
+                     got {:?}",
+                    cond.kind,
+                );
                 let opnum = self.get_opnum("goto_if_not/iL");
                 state.startpoints.insert(state.code.len());
                 state.code.push(opnum);

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -523,16 +523,20 @@ impl Assembler {
             // RPython flatten.py:247-267: goto_if_not(cond, TLabel(false_path))
             // Only goto_if_not exists — no goto_if_true in RPython.
             FlatOp::GotoIfNot { cond, target } => {
-                // RPython parity expectation: `cond.kind == RegKind::Int`
-                // because `block.exitswitch.concretetype == lltype.Bool`
-                // is the build-time gate at `flatten.py:248`.  Pyre's
-                // annotator/rtyper coverage gap (TODO #71/#74)
-                // occasionally lets a Ref cond reach this site (e.g.
-                // `eval_loop_jit`'s portal bool branches).  The
-                // `cond.index` byte still encodes the regalloc color
-                // correctly so emission proceeds; the parity gap is
-                // tracked above lookup_coloring_var rather than asserted
-                // here.
+                // `flatten.py:248` asserts `block.exitswitch.concretetype
+                // == lltype.Bool`, so the cond is always an Int-bank
+                // bool.  `set_branch` enforces this upstream by wrapping
+                // every exitswitch in a `bool` HighLevelOp (parity with
+                // `flowcontext.py:744-779`), which the rtyper specialises
+                // per repr down to an Int-bank result.
+                assert_eq!(
+                    cond.kind,
+                    crate::jit_codewriter::flatten::RegKind::Int,
+                    "goto_if_not cond must be an Int-bank bool (graph={}, cond={:?}, target={:?})",
+                    self.current_graph_name.as_deref().unwrap_or("?"),
+                    cond,
+                    target,
+                );
                 let opnum = self.get_opnum("goto_if_not/iL");
                 state.startpoints.insert(state.code.len());
                 state.code.push(opnum);

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -2122,6 +2122,7 @@ impl Assembler {
                 OpKind::CurrentTraceLength => "CurrentTraceLength",
                 OpKind::IsConstant { .. } => "IsConstant",
                 OpKind::IsVirtual { .. } => "IsVirtual",
+                OpKind::IsInstance { .. } => "IsInstance",
                 OpKind::ConditionalCall { .. } => "ConditionalCall",
                 OpKind::ConditionalCallValue { .. } => "ConditionalCallValue",
                 OpKind::RecordKnownResult { .. } => "RecordKnownResult",
@@ -3277,6 +3278,12 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::IsVirtual { kind_char, .. } => {
             format!("{}_isvirtual", kind_char_to_name(*kind_char))
         }
+        // Mirrors flowspace/operation.rs OpKind::IsInstance opname:
+        // the rtyper dispatches the `"isinstance"` string at
+        // rtyper.rs:2035 to InstanceRepr::rtype_isinstance, which
+        // resolves it to the per-class `ll_isinstance_const_*` or the
+        // unspecialised `ll_isinstance` helper.
+        OpKind::IsInstance { .. } => "isinstance".into(),
         OpKind::RecordKnownResult { result_kind, .. } => {
             format!("record_known_result_{result_kind}")
         }

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -6354,6 +6354,7 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         | OpKind::CurrentTraceLength
         | OpKind::IsConstant { .. }
         | OpKind::IsVirtual { .. }
+        | OpKind::IsInstance { .. }
         | OpKind::RecordKnownResult { .. }
         // jtransform.py:901-903 — `record_quasiimmut_field` is pure bookkeeping
         // that the metainterp converts into a guard; cannot raise.

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3441,9 +3441,7 @@ impl CallControl {
             // the candidate `Vec<CallPath>` directly; `target_to_path` only
             // names direct_call-equivalent sites.  `call.py:94-114` indirect
             // branch.
-            CallTarget::SyntheticTransparentCtor { .. }
-            | CallTarget::SyntheticTransparentClass { .. }
-            | CallTarget::Indirect { .. } => None,
+            CallTarget::SyntheticTransparentCtor { .. } | CallTarget::Indirect { .. } => None,
             CallTarget::UnsupportedExpr => None,
         }
     }

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3441,7 +3441,9 @@ impl CallControl {
             // the candidate `Vec<CallPath>` directly; `target_to_path` only
             // names direct_call-equivalent sites.  `call.py:94-114` indirect
             // branch.
-            CallTarget::SyntheticTransparentCtor { .. } | CallTarget::Indirect { .. } => None,
+            CallTarget::SyntheticTransparentCtor { .. }
+            | CallTarget::SyntheticTransparentClass { .. }
+            | CallTarget::Indirect { .. } => None,
             CallTarget::UnsupportedExpr => None,
         }
     }

--- a/majit/majit-translate/src/jit_codewriter/format.rs
+++ b/majit/majit-translate/src/jit_codewriter/format.rs
@@ -383,16 +383,6 @@ fn call_target_repr(target: &crate::model::CallTarget) -> String {
                 )
             }
         }
-        CallTarget::SyntheticTransparentClass { name, owner_path } => {
-            if owner_path.is_empty() {
-                format!("$<* synthetic-transparent-class '{name}'>")
-            } else {
-                format!(
-                    "$<* synthetic-transparent-class '{}.{name}'>",
-                    owner_path.join(".")
-                )
-            }
-        }
         CallTarget::Indirect {
             trait_root,
             method_name,

--- a/majit/majit-translate/src/jit_codewriter/format.rs
+++ b/majit/majit-translate/src/jit_codewriter/format.rs
@@ -383,6 +383,16 @@ fn call_target_repr(target: &crate::model::CallTarget) -> String {
                 )
             }
         }
+        CallTarget::SyntheticTransparentClass { name, owner_path } => {
+            if owner_path.is_empty() {
+                format!("$<* synthetic-transparent-class '{name}'>")
+            } else {
+                format!(
+                    "$<* synthetic-transparent-class '{}.{name}'>",
+                    owner_path.join(".")
+                )
+            }
+        }
         CallTarget::Indirect {
             trait_root,
             method_name,

--- a/majit/majit-translate/src/jit_codewriter/insns.rs
+++ b/majit/majit-translate/src/jit_codewriter/insns.rs
@@ -395,6 +395,14 @@ pub const BC_GETARRAYITEM_GC_I_PURE: u8 = 210;
 pub const BC_GETARRAYITEM_GC_R_PURE: u8 = 211;
 pub const BC_GETARRAYITEM_GC_F_PURE: u8 = 212;
 
+// `blackhole.py:559-561 bhimpl_int_between(a, b, c) -> i` —
+// `@arguments("i", "i", "i", returns="i")` gives canonical key
+// `int_between/iii>i`.  Pyre emits this from
+// `make_ll_isinstance`'s `has_subclasses` body
+// (`translator/rtyper/rtyper.rs::build_ll_isinstance_const_nonnull_graph`),
+// matching `rclass.py:1163-1167 ll_isinstance`'s range-check arm.
+pub const BC_INT_BETWEEN: u8 = 213;
+
 // pyre-only `abort/>r` — Ref-result variant of `abort/` (BC_ABORT = 13)
 // emitted by `Assembler::encode_op`'s default branch when an `OpKind::
 // Abort { result_kind: Ref }` reaches the assembler.  Lives in
@@ -742,6 +750,11 @@ pub fn wellknown_bh_insns() -> VecAssoc<&'static str, u8> {
     m.insert("uint_le/ii>i", BC_UINT_LE);
     m.insert("uint_gt/ii>i", BC_UINT_GT);
     m.insert("uint_ge/ii>i", BC_UINT_GE);
+    // `blackhole.py:559-561 bhimpl_int_between(a, b, c) -> i` —
+    // `a <= b < c` range check.  Emitted by
+    // `make_ll_isinstance`'s `has_subclasses` body
+    // (`rclass.py:1163-1167 ll_isinstance` range arm).
+    m.insert("int_between/iii>i", BC_INT_BETWEEN);
     // Ref/nullity primitives — `blackhole.py:584-610`.
     m.insert("ptr_eq/rr>i", BC_PTR_EQ);
     m.insert("ptr_ne/rr>i", BC_PTR_NE);

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -3892,7 +3892,8 @@ fn target_to_call_path(target: &CallTarget) -> crate::parse::CallPath {
             crate::parse::CallPath::from_segments(segments.iter().map(String::as_str))
         }
         CallTarget::Method { name, .. } => crate::parse::CallPath::from_segments([name.as_str()]),
-        CallTarget::SyntheticTransparentCtor { name, owner_path } => {
+        CallTarget::SyntheticTransparentCtor { name, owner_path }
+        | CallTarget::SyntheticTransparentClass { name, owner_path } => {
             let mut segs: Vec<&str> = owner_path.iter().map(String::as_str).collect();
             segs.push(name.as_str());
             crate::parse::CallPath::from_segments(segs)

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -3892,8 +3892,7 @@ fn target_to_call_path(target: &CallTarget) -> crate::parse::CallPath {
             crate::parse::CallPath::from_segments(segments.iter().map(String::as_str))
         }
         CallTarget::Method { name, .. } => crate::parse::CallPath::from_segments([name.as_str()]),
-        CallTarget::SyntheticTransparentCtor { name, owner_path }
-        | CallTarget::SyntheticTransparentClass { name, owner_path } => {
+        CallTarget::SyntheticTransparentCtor { name, owner_path } => {
             let mut segs: Vec<&str> = owner_path.iter().map(String::as_str).collect();
             segs.push(name.as_str());
             crate::parse::CallPath::from_segments(segs)
@@ -4241,7 +4240,11 @@ fn remap_op(
             value: remap_value(value, aliases),
             kind_char: *kind_char,
         },
-        OpKind::IsInstance { obj, class_carrier, result_ty } => OpKind::IsInstance {
+        OpKind::IsInstance {
+            obj,
+            class_carrier,
+            result_ty,
+        } => OpKind::IsInstance {
             obj: remap_value(obj, aliases),
             class_carrier: remap_value(class_carrier, aliases),
             result_ty: result_ty.clone(),

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -4240,6 +4240,11 @@ fn remap_op(
             value: remap_value(value, aliases),
             kind_char: *kind_char,
         },
+        OpKind::IsInstance { obj, class_carrier, result_ty } => OpKind::IsInstance {
+            obj: remap_value(obj, aliases),
+            class_carrier: remap_value(class_carrier, aliases),
+            result_ty: result_ty.clone(),
+        },
         OpKind::CallElidable {
             funcptr,
             descriptor,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -267,25 +267,6 @@ pub enum CallTarget {
         #[serde(default)]
         owner_path: Vec<String>,
     },
-    /// Rust frontend adaptation for *class-of-variant* references that
-    /// RPython lowers as `Constant(HostObject::Class)` directly.  Used
-    /// by the `match` tuple-struct cascade emitter
-    /// (`front/ast.rs::classify_match_tuple_struct_cascade`) to defer
-    /// the `HostObject::Class` lookup to a post-ast pre-rtyper fold
-    /// pass (`translator/rtyper/class_lookup_fold.rs`).  The fold pass
-    /// resolves `(owner_path, name)` via
-    /// `module_globals_lookup(parent).class_get(name)` and rewrites
-    /// the placeholder Call into `OpKind::ConstRef(HostObject::Class)`.
-    ///
-    /// `name` is the variant leaf (`"LoadFast"`).  `owner_path` is the
-    /// enclosing module/enum segments (`["Instruction"]`).  Joined
-    /// path is the qualifying identity for the class lookup, matching
-    /// RPython `getclassdef` keyed by the parent enum's classdef.
-    SyntheticTransparentClass {
-        name: String,
-        #[serde(default)]
-        owner_path: Vec<String>,
-    },
     /// RPython: `indirect_call` opname. Receiver's static type is a
     /// `dyn Trait` (Rust fat pointer); at JIT time the actual callee
     /// is resolved via vtable.  `trait_root` + `method_name` together
@@ -351,19 +332,6 @@ impl CallTarget {
         }
     }
 
-    /// Class-of-variant placeholder consumed by
-    /// `translator/rtyper/class_lookup_fold.rs`.  See the variant doc
-    /// comment for the lookup contract.
-    pub fn synthetic_transparent_class_with_owner(
-        owner_path: Vec<String>,
-        name: impl Into<String>,
-    ) -> Self {
-        Self::SyntheticTransparentClass {
-            name: name.into(),
-            owner_path,
-        }
-    }
-
     pub fn receiver_root(&self) -> Option<&str> {
         match self {
             CallTarget::Method { receiver_root, .. } => receiver_root.as_deref(),
@@ -383,11 +351,6 @@ impl CallTarget {
             // share segments and break any downstream caller that
             // uses `path_segments()` for qualified identity.
             CallTarget::SyntheticTransparentCtor { name, owner_path } => {
-                let mut segs: Vec<&str> = owner_path.iter().map(String::as_str).collect();
-                segs.push(name.as_str());
-                Some(segs)
-            }
-            CallTarget::SyntheticTransparentClass { name, owner_path } => {
                 let mut segs: Vec<&str> = owner_path.iter().map(String::as_str).collect();
                 segs.push(name.as_str());
                 Some(segs)
@@ -419,17 +382,6 @@ impl fmt::Display for CallTarget {
                     write!(
                         f,
                         "<synthetic-transparent-ctor {}::{name}>",
-                        owner_path.join("::")
-                    )
-                }
-            }
-            CallTarget::SyntheticTransparentClass { name, owner_path } => {
-                if owner_path.is_empty() {
-                    write!(f, "<synthetic-transparent-class {name}>")
-                } else {
-                    write!(
-                        f,
-                        "<synthetic-transparent-class {}::{name}>",
                         owner_path.join("::")
                     )
                 }

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -808,6 +808,23 @@ pub enum OpKind {
         value: crate::flowspace::model::Variable,
         kind_char: char,
     },
+    /// RPython `flowspace` `isinstance(obj, cls)` (annotator/unaryop.py +
+    /// rtyper.rs:2035 dispatch — `Repr.rtype_isinstance`). The
+    /// front-end emits this op at `match` cascade sites where the
+    /// variant pattern carries a payload (`TupleStruct`) and a
+    /// ptr_eq-against-singleton check would be insufficient.
+    /// `class_carrier` is typically a `ConstRef`-wrapped vtable
+    /// Constant resolved by the rtyper to a CLASSTYPE pointer; the
+    /// rtyper then dispatches to
+    /// [`InstanceRepr::rtype_isinstance`](crate::translator::rtyper::rclass::InstanceRepr::rtype_isinstance)
+    /// which mints either `ll_isinstance_const_{,nonnull}_<min>_<max>`
+    /// (Constant `class_carrier`) or the generic `ll_isinstance`
+    /// (Variable `class_carrier`).
+    IsInstance {
+        obj: crate::flowspace::model::Variable,
+        class_carrier: crate::flowspace::model::Variable,
+        result_ty: ValueType,
+    },
 
     // ── Conditional call ops (jtransform.py:1665-1688) ──────
     //

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -377,8 +377,21 @@ impl CallTarget {
             CallTarget::FunctionPath { segments } => {
                 Some(segments.iter().map(String::as_str).collect())
             }
-            CallTarget::SyntheticTransparentCtor { name, .. } => Some(vec![name.as_str()]),
-            CallTarget::SyntheticTransparentClass { name, .. } => Some(vec![name.as_str()]),
+            // `(owner_path, name)` is the lookup identity per the
+            // variant docs; collapsing onto the leaf alone would
+            // make `Instruction::LoadFast` and `OtherEnum::LoadFast`
+            // share segments and break any downstream caller that
+            // uses `path_segments()` for qualified identity.
+            CallTarget::SyntheticTransparentCtor { name, owner_path } => {
+                let mut segs: Vec<&str> = owner_path.iter().map(String::as_str).collect();
+                segs.push(name.as_str());
+                Some(segs)
+            }
+            CallTarget::SyntheticTransparentClass { name, owner_path } => {
+                let mut segs: Vec<&str> = owner_path.iter().map(String::as_str).collect();
+                segs.push(name.as_str());
+                Some(segs)
+            }
             CallTarget::Indirect { method_name, .. } => Some(vec![method_name.as_str()]),
             CallTarget::UnsupportedExpr => None,
         }

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -4130,6 +4130,22 @@ impl FunctionGraph {
     ///  block.closeblock(Link(false_args, if_false, False),
     ///                   Link(true_args,  if_true,  True))`
     /// (`flowspace/model.py:175-180` + `:304`).
+    ///
+    /// RPython `flowcontext.py:744-779` unconditionally evaluates
+    /// `op.bool(w_value).eval(self)` before `guessbool`, so every
+    /// `block.exitswitch` Variable is the result of a `bool` HighLevelOp.
+    /// The rtyper then specialises `bool` per repr (`rmodel.py:251-260
+    /// CanBeNull → ptr_nonzero`; `rint.py IntegerRepr → identity`;
+    /// `rstr.py → str_nonzero`; etc.).  Pyre's flatten consumer asserts
+    /// `block.exitswitch.concretetype == lltype.Bool`
+    /// (`flatten.py:248`) — without the unconditional `bool` wrap, a
+    /// composite-pattern `match` / `if let` scrutinee of `Ref` kind
+    /// reaches `FlatOp::GotoIfNot` (`assembler.rs:559-578`), the
+    /// hard-coded `goto_if_not/iL` opname forces the walker into the
+    /// wrong register bank, and every LoadAttr/StoreAttr arm aborts with
+    /// `RegisterOutOfRange` (issue #115).  Routing the cond through a
+    /// `bool` hop here re-establishes the upstream invariant in one
+    /// place; the rtyper handles the per-repr specialisation downstream.
     pub fn set_branch(
         &mut self,
         block: BlockId,
@@ -4139,6 +4155,22 @@ impl FunctionGraph {
         if_false: BlockId,
         false_args: Vec<crate::flowspace::model::Variable>,
     ) {
+        // upstream: `op.bool(w_value).eval(self)` — append `bool` hop to
+        // `block.operations` before installing it as exitswitch.  The
+        // wrap is idempotent (a `bool(bool(_))` chain folds to identity
+        // through `IntegerRepr::rtype_bool` / `BoolRepr::rtype_bool`),
+        // mirroring upstream which also wraps unconditionally.
+        let cond = self
+            .push_op_var(
+                block,
+                OpKind::UnaryOp {
+                    op: "bool".into(),
+                    operand: cond,
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .expect("UnaryOp { op: \"bool\", .. } produces a value");
         // `flowspace/model.py:114 Link.__init__` arity assert per
         // arm — same rationale as `set_goto`.
         let true_inputarg_count = self.block(if_true).inputargs.len();
@@ -4460,7 +4492,11 @@ mod tests {
         let next = graph.create_block();
         graph.set_branch(entry, cond_var, next, vec![], next, vec![]);
         assert_eq!(graph.blocks.len(), 4);
-        assert_eq!(graph.block(entry).operations.len(), 1);
+        // `set_branch` mirrors RPython `flowcontext.py:744-779`
+        // `op.bool(w_value).eval(self)` — every exitswitch is the result
+        // of an appended `bool` HighLevelOp, so a branching block carries
+        // the original Input op plus the bool wrap (2 ops total).
+        assert_eq!(graph.block(entry).operations.len(), 2);
         assert_eq!(graph.block(graph.returnblock).inputargs.len(), 1);
         assert_eq!(graph.block(graph.exceptblock).inputargs.len(), 2);
     }

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -4500,6 +4500,31 @@ impl FunctionGraph {
 mod tests {
     use super::*;
 
+    /// `CallTarget::SyntheticTransparentCtor::path_segments()` must
+    /// return the full `(owner_path..., name)` join — `front/mir.rs`
+    /// `Aggregate` / `ShallowInitBox` lowerings rely on the qualified
+    /// identity to distinguish same-leaf ctors across owner enums
+    /// (`StepResult::Continue` vs `JitAction::Continue`).  Collapsing
+    /// to the bare leaf would collide their `HostObject` /
+    /// `getdesc(pyobj)` keys (`bookkeeper.py:353`).
+    #[test]
+    fn synthetic_transparent_ctor_path_segments_preserve_owner_path() {
+        let bare = CallTarget::synthetic_transparent_ctor("Continue");
+        assert_eq!(bare.path_segments(), Some(vec!["Continue"]));
+
+        let owned = CallTarget::synthetic_transparent_ctor_with_owner(
+            vec!["StepResult".to_string()],
+            "Continue",
+        );
+        assert_eq!(owned.path_segments(), Some(vec!["StepResult", "Continue"]));
+
+        let nested = CallTarget::synthetic_transparent_ctor_with_owner(
+            vec!["outer".to_string(), "Inner".to_string()],
+            "Leaf",
+        );
+        assert_eq!(nested.path_segments(), Some(vec!["outer", "Inner", "Leaf"]));
+    }
+
     #[test]
     fn graph_allocates_values_and_blocks() {
         let mut graph = FunctionGraph::new("demo");

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -267,6 +267,25 @@ pub enum CallTarget {
         #[serde(default)]
         owner_path: Vec<String>,
     },
+    /// Rust frontend adaptation for *class-of-variant* references that
+    /// RPython lowers as `Constant(HostObject::Class)` directly.  Used
+    /// by the `match` tuple-struct cascade emitter
+    /// (`front/ast.rs::classify_match_tuple_struct_cascade`) to defer
+    /// the `HostObject::Class` lookup to a post-ast pre-rtyper fold
+    /// pass (`translator/rtyper/class_lookup_fold.rs`).  The fold pass
+    /// resolves `(owner_path, name)` via
+    /// `module_globals_lookup(parent).class_get(name)` and rewrites
+    /// the placeholder Call into `OpKind::ConstRef(HostObject::Class)`.
+    ///
+    /// `name` is the variant leaf (`"LoadFast"`).  `owner_path` is the
+    /// enclosing module/enum segments (`["Instruction"]`).  Joined
+    /// path is the qualifying identity for the class lookup, matching
+    /// RPython `getclassdef` keyed by the parent enum's classdef.
+    SyntheticTransparentClass {
+        name: String,
+        #[serde(default)]
+        owner_path: Vec<String>,
+    },
     /// RPython: `indirect_call` opname. Receiver's static type is a
     /// `dyn Trait` (Rust fat pointer); at JIT time the actual callee
     /// is resolved via vtable.  `trait_root` + `method_name` together
@@ -332,6 +351,19 @@ impl CallTarget {
         }
     }
 
+    /// Class-of-variant placeholder consumed by
+    /// `translator/rtyper/class_lookup_fold.rs`.  See the variant doc
+    /// comment for the lookup contract.
+    pub fn synthetic_transparent_class_with_owner(
+        owner_path: Vec<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self::SyntheticTransparentClass {
+            name: name.into(),
+            owner_path,
+        }
+    }
+
     pub fn receiver_root(&self) -> Option<&str> {
         match self {
             CallTarget::Method { receiver_root, .. } => receiver_root.as_deref(),
@@ -346,6 +378,7 @@ impl CallTarget {
                 Some(segments.iter().map(String::as_str).collect())
             }
             CallTarget::SyntheticTransparentCtor { name, .. } => Some(vec![name.as_str()]),
+            CallTarget::SyntheticTransparentClass { name, .. } => Some(vec![name.as_str()]),
             CallTarget::Indirect { method_name, .. } => Some(vec![method_name.as_str()]),
             CallTarget::UnsupportedExpr => None,
         }
@@ -373,6 +406,17 @@ impl fmt::Display for CallTarget {
                     write!(
                         f,
                         "<synthetic-transparent-ctor {}::{name}>",
+                        owner_path.join("::")
+                    )
+                }
+            }
+            CallTarget::SyntheticTransparentClass { name, owner_path } => {
+                if owner_path.is_empty() {
+                    write!(f, "<synthetic-transparent-class {name}>")
+                } else {
+                    write!(
+                        f,
+                        "<synthetic-transparent-class {}::{name}>",
                         owner_path.join("::")
                     )
                 }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1402,8 +1402,7 @@ pub fn specialize_legacy_graph_with_registry_returning_value_to_var(
                 let needs_seed = v.annotation.borrow().is_none();
                 if needs_seed {
                     let mut tmp = v.clone();
-                    annotator
-                        .setbinding(&mut tmp, crate::annotator::model::SomeValue::Impossible);
+                    annotator.setbinding(&mut tmp, crate::annotator::model::SomeValue::Impossible);
                 }
             }
         }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -563,7 +563,7 @@ fn compare_real_against_legacy(
 /// | `unimplemented operation`                  | Per-opname rtyper handlers.                                                  |
 /// | `variable used before definition`          | Cross-block locals threading.                                                |
 /// | `MissingRTypeAttribute`                    | Typed-Ref → SomeInstance(ClassDef).                                          |
-/// | `KeyError: no binding for arg`             | Annotator per-call coverage.                                                 |
+/// | `KeyError: no binding for arg`             | Rtyper bindingrepr gap on annotation-less Variable (e.g. `current_sp`).      |
 /// | `compute_at_fixpoint failed`               | PBC dispatch / call-family coverage (per-call).                              |
 /// | `post-rtyper jtransform variant`           | Per-variant emit-site retracing (rpbc / rclass / front-end).  Includes `OpKind::Abort` (pyre-only marker; retire every `Expr::ForLoop` / `stop_unsupported` / `continue_with_unknown` emit-site at the front-end). |
 /// | `adapter cross-block body Input`           | Final emit-site retirement.                                                  |
@@ -615,10 +615,15 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // `None` for it (intentionally fail-loud for "annotation gap"
         // so producers know which slot missed seeding, see
         // `seed_variable` at `flowspace_adapter.rs:96-115`).  Closing
-        // the gap means
-        // tightening the front-end / annotator producers so every
-        // slot has a non-`Unknown` annotation; the gate skips
-        // until then.
+        // the gap means tightening the front-end / annotator
+        // producers so every slot has a non-`Unknown` annotation; the
+        // gate skips until then.  The mergeinputargs-side flavour of
+        // this gap (raising subjects' `follow_raise_link` reaching an
+        // unannotated exceptblock seed) was resolved 2026-05-31 via
+        // `setbinding(Impossible)` pre-registration in
+        // `specialize_legacy_graph_with_registry_returning_value_to_var`;
+        // the remaining producer is the rtyper-side `bindingrepr`
+        // gap on synthesized `current_sp`-like graphs.
         || msg.contains("KeyError: no binding for arg")
         // TODO(annotator-fixpoint-fail-loud) — STRICT-PARITY REGRESSION
         // vs main / PyPy.  `bookkeeper.py:108-127` propagates fixpoint
@@ -1373,13 +1378,46 @@ pub fn specialize_legacy_graph_with_registry_returning_value_to_var(
     // `Variable.concretetype = ExceptionData.lltype_of_exception_*`
     // without reading `Variable.annotation`, so the block needs no
     // `flowin`; it only needs to appear in `annotator.annotated`.
+    //
+    // Additionally, seed each inputarg with a `setbinding`-level
+    // annotation (`Impossible` when none is already present) so that
+    // a raising subject's `follow_raise_link` — which reaches the
+    // same exceptblock via `addpendingblock` with `seen_before=true`
+    // and routes to `mergeinputargs` — does not panic on the unbound
+    // `seed_variable(legacy_v)` inputargs from
+    // `flowspace_adapter.rs:1839`.  `setbinding` widens via the
+    // lattice's `contains` check, so an `Integer`-already-annotated
+    // slot stays `Integer`; a `None`-annotated slot becomes
+    // `Impossible`, which any later `mergeinputargs` widens to the
+    // real cell.  The `annotated[block] = Some(graph)` bare insert
+    // (the next block) keeps the pre-fix `specialize_block` walk
+    // semantic intact — the block is treated as already annotated
+    // and never enters `complete_pending_blocks`.
+    {
+        let blk = exceptblock.borrow();
+        let inputargs: Vec<crate::flowspace::model::Hlvalue> = blk.inputargs.clone();
+        drop(blk);
+        for a in &inputargs {
+            if let crate::flowspace::model::Hlvalue::Variable(v) = a {
+                let needs_seed = v.annotation.borrow().is_none();
+                if needs_seed {
+                    let mut tmp = v.clone();
+                    annotator
+                        .setbinding(&mut tmp, crate::annotator::model::SomeValue::Impossible);
+                }
+            }
+        }
+    }
     {
         let bkey = crate::flowspace::model::BlockKey::of(&exceptblock);
         annotator
             .annotated
             .borrow_mut()
             .insert(bkey.clone(), Some(graph.clone()));
-        annotator.all_blocks.borrow_mut().insert(bkey, exceptblock);
+        annotator
+            .all_blocks
+            .borrow_mut()
+            .insert(bkey, exceptblock.clone());
     }
 
     // Callee blocks are seeded naturally with no explicit pre-seed:

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -3249,6 +3249,150 @@ mod tests {
     }
 
     #[test]
+    fn translate_op_isinstance_lowers_to_flowspace_isinstance() {
+        // OpKind::IsInstance arrives from the tuple-struct match
+        // cascade (`front/ast.rs:7467`).  Emit a single
+        // `isinstance(obj, cls)` flowspace op so the rtyper dispatches
+        // to `InstanceRepr::rtype_isinstance`.
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let graph = translate_op_test_graph(10);
+        let obj_hl_var = Variable::new();
+        let cls_hl_var = Variable::new();
+        let result_hl_var = Variable::new();
+        value_map.insert(
+            graph.must_variable_at(1),
+            Hlvalue::Variable(obj_hl_var.clone()),
+        );
+        value_map.insert(
+            graph.must_variable_at(2),
+            Hlvalue::Variable(cls_hl_var.clone()),
+        );
+        value_map.insert(
+            graph.must_variable_at(3),
+            Hlvalue::Variable(result_hl_var.clone()),
+        );
+        let op = SpaceOperation {
+            result: Some(graph.must_variable_at(3)),
+            kind: OpKind::IsInstance {
+                obj: graph.must_variable_at(1),
+                class_carrier: graph.must_variable_at(2),
+                result_ty: ValueType::Bool,
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry(), &graph)
+            .expect("OpKind::IsInstance must lower");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(
+            translated[0].opname, "isinstance",
+            "IsInstance must emit the flowspace `isinstance` opname",
+        );
+        assert_eq!(translated[0].args.len(), 2, "isinstance args: [obj, cls]");
+        match &translated[0].args[0] {
+            Hlvalue::Variable(v) => assert_eq!(v, &obj_hl_var, "args[0] must be obj"),
+            other => panic!("args[0] must be Variable, got {other:?}"),
+        }
+        match &translated[0].args[1] {
+            Hlvalue::Variable(v) => {
+                assert_eq!(v, &cls_hl_var, "args[1] must be class_carrier")
+            }
+            other => panic!("args[1] must be Variable, got {other:?}"),
+        }
+        match &translated[0].result {
+            Hlvalue::Variable(v) => {
+                assert_eq!(v, &result_hl_var, "result must follow value_map mapping")
+            }
+            other => panic!("result must be Variable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_op_call_synthetic_transparent_class_with_args_lowers_to_simple_call() {
+        // `SyntheticTransparentClass` with non-empty args falls back to
+        // the same `simple_call(HostObject::Class, args)` shape as
+        // `SyntheticTransparentCtor` — the annotator's
+        // `Bookkeeper::immutablevalue_hostobject` is_class arm absorbs
+        // both spellings.
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let graph = translate_op_test_graph(10);
+        value_map.insert(
+            graph.must_variable_at(1),
+            Hlvalue::Variable(Variable::new()),
+        );
+        value_map.insert(
+            graph.must_variable_at(2),
+            Hlvalue::Variable(Variable::new()),
+        );
+        let op = SpaceOperation {
+            result: Some(graph.must_variable_at(2)),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::SyntheticTransparentClass {
+                    name: "LoadFast".into(),
+                    owner_path: vec!["Instruction".into()],
+                },
+                args: vec![graph.must_variable_at(1)],
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry(), &graph)
+            .expect("Call::SyntheticTransparentClass with args must lower");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "simple_call");
+        let Hlvalue::Constant(ref callable) = translated[0].args[0] else {
+            panic!("simple_call callable must be a Constant");
+        };
+        let ConstValue::HostObject(ref host) = callable.value else {
+            panic!("class callable must be ConstValue::HostObject");
+        };
+        assert_eq!(
+            host.qualname(),
+            "Instruction.LoadFast",
+            "owner_path must qualify the class qualname",
+        );
+        assert!(host.is_class(), "callable must be a class HostObject");
+    }
+
+    #[test]
+    fn legacy_const_define_folds_zero_arg_synthetic_transparent_class_to_class_constant() {
+        // Empty-args `SyntheticTransparentClass` is the cascade
+        // tuple-struct *class carrier*.  `legacy_const_define_hlvalue`
+        // folds it directly to a class constant so the rtyper sees
+        // `Hlvalue::Constant(HostObject::Class)` instead of routing
+        // through `simple_call` (which would annotate to a new
+        // SomeInstance, not the class PBC `rtype_isinstance` needs).
+        let dummy = SpaceOperation {
+            result: Some(Variable::new()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::SyntheticTransparentClass {
+                    name: "LoadFast".into(),
+                    owner_path: vec!["Instruction".into()],
+                },
+                args: Vec::new(),
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let hl = legacy_const_define_hlvalue(&dummy)
+            .expect("zero-arg SyntheticTransparentClass must fold to a constant");
+        let Hlvalue::Constant(c) = hl else {
+            panic!("expected Hlvalue::Constant, got {hl:?}");
+        };
+        let ConstValue::HostObject(ref host) = c.value else {
+            panic!("expected ConstValue::HostObject, got {:?}", c.value);
+        };
+        assert!(host.is_class(), "class carrier must be a class HostObject");
+        assert_eq!(
+            host.qualname(),
+            "Instruction.LoadFast",
+            "owner_path must qualify the class qualname",
+        );
+        // `with_concretetype` carries CLASSTYPE so ClassRepr::convert_const
+        // can route through the constant arm.
+        assert!(
+            c.concretetype.is_some(),
+            "class carrier constant must carry CLASSTYPE concretetype",
+        );
+    }
+
+    #[test]
     fn translate_op_call_method_chains_getattr_simple_call() {
         // Call::Method `obj.method(args)` → 2-op chain `[getattr(obj,
         // "method") -> meth, simple_call(meth, args[1..])]`, mirroring

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -897,6 +897,33 @@ pub fn translate_op(
             )])
         }
 
+        // ─── `isinstance` — RPython `space.isinstance(obj, cls)` ───
+        // `flowspace/operation.py:259 isinstance → OpKind::IsInstance`.
+        // Emitted pre-rtyper by `front/ast.rs` at `TupleStruct` /
+        // composite match-cascade payload sites where a unit-variant
+        // ptr_eq does not suffice. The rtyper dispatches `"isinstance"`
+        // at `rtyper.rs:2035 translate_unary_operation` →
+        // `InstanceRepr::rtype_isinstance`, which mints either a
+        // per-class `ll_isinstance_const_*` helper (Constant
+        // `class_carrier`) or the generic `ll_isinstance` helper
+        // (Variable `class_carrier`).
+        OpKind::IsInstance {
+            obj,
+            class_carrier,
+            ..
+        } => {
+            let obj_vid = operand_value_id(graph, obj, op, "obj")?;
+            let cls_vid = operand_value_id(graph, class_carrier, op, "class_carrier")?;
+            let obj_hl = lookup_operand(value_map, obj_vid, op, "obj")?;
+            let cls_hl = lookup_operand(value_map, cls_vid, op, "class_carrier")?;
+            let result = resolve_result_hlvalue(op, value_map, graph)?;
+            Ok(vec![FlowspaceOp::new(
+                "isinstance",
+                vec![obj_hl, cls_hl],
+                result,
+            )])
+        }
+
         // ─── FieldRead / FieldWrite ports ───
         // RPython `flowspace/operation.py:617 GetAttr.opname = 'getattr'`
         // and `setattr` (operation.py: same module). The high-level
@@ -1486,6 +1513,7 @@ fn opkind_variant_name(kind: &OpKind) -> &'static str {
         OpKind::CurrentTraceLength => "CurrentTraceLength",
         OpKind::IsConstant { .. } => "IsConstant",
         OpKind::IsVirtual { .. } => "IsVirtual",
+        OpKind::IsInstance { .. } => "IsInstance",
         OpKind::ConditionalCall { .. } => "ConditionalCall",
         OpKind::ConditionalCallValue { .. } => "ConditionalCallValue",
         OpKind::RecordKnownResult { .. } => "RecordKnownResult",

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -912,11 +912,9 @@ pub fn translate_op(
             class_carrier,
             ..
         } => {
-            let obj_vid = operand_value_id(graph, obj, op, "obj")?;
-            let cls_vid = operand_value_id(graph, class_carrier, op, "class_carrier")?;
-            let obj_hl = lookup_operand(value_map, obj_vid, op, "obj")?;
-            let cls_hl = lookup_operand(value_map, cls_vid, op, "class_carrier")?;
-            let result = resolve_result_hlvalue(op, value_map, graph)?;
+            let obj_hl = lookup_operand(value_map, obj, op, "obj")?;
+            let cls_hl = lookup_operand(value_map, class_carrier, op, "class_carrier")?;
+            let result = resolve_result_hlvalue(op, value_map)?;
             Ok(vec![FlowspaceOp::new(
                 "isinstance",
                 vec![obj_hl, cls_hl],

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -592,13 +592,7 @@ fn fmt_op_result(op: &SpaceOperation) -> String {
 /// `true` iff `kind` is a 0-arg unit-variant transparent ctor
 /// (`StepResult::Continue`, `LoopResult::Done`, …) that [`translate_op`]
 /// pre-folds to a `Constant` and emits no `FlowspaceOp` (the unit-variant
-/// guard at the top of `translate_op`).  Also matches the 0-arg
-/// `SyntheticTransparentClass` placeholder emitted by the tuple-struct
-/// match cascade (`front/ast.rs:7456`): [`legacy_const_define_hlvalue`]
-/// folds it to a `Hlvalue::Constant(HostObject::Class)` so the
-/// `isinstance` HighLevelOp's `class_carrier` arrives at
-/// `InstanceRepr::rtype_isinstance` as a Constant — matching the
-/// `if isinstance(v_cls, Constant)` branch in `rclass.py:1019`.
+/// guard at the top of `translate_op`).
 ///
 /// [`op_canraise`] and [`translate_op`] consult the SAME predicate —
 /// `op_canraise` is false exactly when `translate_op` emits no op.
@@ -613,15 +607,6 @@ fn is_elided_unit_variant_ctor(kind: &OpKind) -> bool {
         let mut segments = owner_path.clone();
         segments.push(name.clone());
         return crate::front::syn_metadata::is_synthetic_unit_variant_path(&segments);
-    }
-    if let OpKind::Call {
-        target: crate::model::CallTarget::SyntheticTransparentClass { .. },
-        args,
-        ..
-    } = kind
-        && args.is_empty()
-    {
-        return true;
     }
     false
 }
@@ -922,9 +907,7 @@ pub fn translate_op(
         // `class_carrier`) or the generic `ll_isinstance` helper
         // (Variable `class_carrier`).
         OpKind::IsInstance {
-            obj,
-            class_carrier,
-            ..
+            obj, class_carrier, ..
         } => {
             let obj_hl = lookup_operand(value_map, obj, op, "obj")?;
             let cls_hl = lookup_operand(value_map, class_carrier, op, "class_carrier")?;
@@ -1312,29 +1295,6 @@ pub fn translate_op(
                     };
                     let callable =
                         Hlvalue::Constant(Constant::new(ConstValue::HostObject(callable_host)));
-                    let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
-                    call_args.push(callable);
-                    call_args.extend(arg_hls);
-                    Ok(vec![FlowspaceOp::new("simple_call", call_args, result)])
-                }
-                CallTarget::SyntheticTransparentClass { name, owner_path } => {
-                    // Class-of-variant placeholder fallback: the post-ast
-                    // pre-rtyper `class_lookup_fold` pass is expected to
-                    // rewrite this into `OpKind::ConstRef(HostObject::Class)`
-                    // before reaching the rtyper.  Surviving residuals
-                    // route through the same `simple_call(HostObject::Class)`
-                    // shape as `SyntheticTransparentCtor` — the
-                    // `Bookkeeper.immutablevalue_hostobject` is_class arm
-                    // (`bookkeeper.rs:1984`) absorbs both spellings into
-                    // a `SomePBC([ClassDesc])`.
-                    let qualname = if owner_path.is_empty() {
-                        name.clone()
-                    } else {
-                        format!("{}.{}", owner_path.join("."), name)
-                    };
-                    let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(
-                        HostObject::new_class(qualname, Vec::new()),
-                    )));
                     let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
                     call_args.push(callable);
                     call_args.extend(arg_hls);
@@ -1754,38 +1714,6 @@ fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
             Some(Hlvalue::Constant(Constant::with_concretetype(
                 ConstValue::HostObject(instance),
                 crate::translator::rtyper::rclass::OBJECTPTR.clone(),
-            )))
-        }
-        // Class-of-variant placeholder fold.  Tuple-struct match
-        // cascades (`front/ast.rs:7396 classify_match_tuple_struct_cascade`)
-        // emit `OpKind::Call { target: SyntheticTransparentClass, args: [] }`
-        // whose runtime semantics is "load the class object" — i.e. a
-        // PBC reference to the class itself, not a fresh instance.
-        // Without the fold, the residual call would route through
-        // `simple_call(HostObject::Class)` and the annotator's
-        // `ClassDesc::pycall` would return `SomeInstance` (a new instance)
-        // rather than `SomePBC([ClassDesc])` (the class itself), breaking
-        // `InstanceRepr::rtype_isinstance` which checks
-        // `if isinstance(v_cls, Constant)` against the class PBC.
-        //
-        // The fold materialises `Hlvalue::Constant(HostObject::new_class)`
-        // directly; `ClassRepr::convert_const` (`rclass.rs:1463`) then
-        // converts the HostObject to an `LLPtr(vtable)` for the
-        // `make_ll_isinstance` (`rclass.py:1149`) constant-arm path.
-        OpKind::Call {
-            target: crate::model::CallTarget::SyntheticTransparentClass { name, owner_path },
-            args,
-            ..
-        } if args.is_empty() => {
-            let qualname = if owner_path.is_empty() {
-                name.clone()
-            } else {
-                format!("{}.{}", owner_path.join("."), name)
-            };
-            let class_obj = crate::flowspace::model::HostObject::new_class(qualname, Vec::new());
-            Some(Hlvalue::Constant(Constant::with_concretetype(
-                ConstValue::HostObject(class_obj),
-                crate::translator::rtyper::rclass::CLASSTYPE.clone(),
             )))
         }
         _ => None,
@@ -3303,93 +3231,6 @@ mod tests {
             }
             other => panic!("result must be Variable, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn translate_op_call_synthetic_transparent_class_with_args_lowers_to_simple_call() {
-        // `SyntheticTransparentClass` with non-empty args falls back to
-        // the same `simple_call(HostObject::Class, args)` shape as
-        // `SyntheticTransparentCtor` — the annotator's
-        // `Bookkeeper::immutablevalue_hostobject` is_class arm absorbs
-        // both spellings.
-        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
-        let graph = translate_op_test_graph(10);
-        value_map.insert(
-            graph.must_variable_at(1),
-            Hlvalue::Variable(Variable::new()),
-        );
-        value_map.insert(
-            graph.must_variable_at(2),
-            Hlvalue::Variable(Variable::new()),
-        );
-        let op = SpaceOperation {
-            result: Some(graph.must_variable_at(2)),
-            kind: OpKind::Call {
-                target: crate::model::CallTarget::SyntheticTransparentClass {
-                    name: "LoadFast".into(),
-                    owner_path: vec!["Instruction".into()],
-                },
-                args: vec![graph.must_variable_at(1)],
-                result_ty: ValueType::Ref(None),
-            },
-        };
-        let translated = translate_op(&op, &value_map, &empty_call_registry(), &graph)
-            .expect("Call::SyntheticTransparentClass with args must lower");
-        assert_eq!(translated.len(), 1);
-        assert_eq!(translated[0].opname, "simple_call");
-        let Hlvalue::Constant(ref callable) = translated[0].args[0] else {
-            panic!("simple_call callable must be a Constant");
-        };
-        let ConstValue::HostObject(ref host) = callable.value else {
-            panic!("class callable must be ConstValue::HostObject");
-        };
-        assert_eq!(
-            host.qualname(),
-            "Instruction.LoadFast",
-            "owner_path must qualify the class qualname",
-        );
-        assert!(host.is_class(), "callable must be a class HostObject");
-    }
-
-    #[test]
-    fn legacy_const_define_folds_zero_arg_synthetic_transparent_class_to_class_constant() {
-        // Empty-args `SyntheticTransparentClass` is the cascade
-        // tuple-struct *class carrier*.  `legacy_const_define_hlvalue`
-        // folds it directly to a class constant so the rtyper sees
-        // `Hlvalue::Constant(HostObject::Class)` instead of routing
-        // through `simple_call` (which would annotate to a new
-        // SomeInstance, not the class PBC `rtype_isinstance` needs).
-        let dummy = SpaceOperation {
-            result: Some(Variable::new()),
-            kind: OpKind::Call {
-                target: crate::model::CallTarget::SyntheticTransparentClass {
-                    name: "LoadFast".into(),
-                    owner_path: vec!["Instruction".into()],
-                },
-                args: Vec::new(),
-                result_ty: ValueType::Ref(None),
-            },
-        };
-        let hl = legacy_const_define_hlvalue(&dummy)
-            .expect("zero-arg SyntheticTransparentClass must fold to a constant");
-        let Hlvalue::Constant(c) = hl else {
-            panic!("expected Hlvalue::Constant, got {hl:?}");
-        };
-        let ConstValue::HostObject(ref host) = c.value else {
-            panic!("expected ConstValue::HostObject, got {:?}", c.value);
-        };
-        assert!(host.is_class(), "class carrier must be a class HostObject");
-        assert_eq!(
-            host.qualname(),
-            "Instruction.LoadFast",
-            "owner_path must qualify the class qualname",
-        );
-        // `with_concretetype` carries CLASSTYPE so ClassRepr::convert_const
-        // can route through the constant arm.
-        assert!(
-            c.concretetype.is_some(),
-            "class carrier constant must carry CLASSTYPE concretetype",
-        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1305,6 +1305,29 @@ pub fn translate_op(
                     call_args.extend(arg_hls);
                     Ok(vec![FlowspaceOp::new("simple_call", call_args, result)])
                 }
+                CallTarget::SyntheticTransparentClass { name, owner_path } => {
+                    // Class-of-variant placeholder fallback: the post-ast
+                    // pre-rtyper `class_lookup_fold` pass is expected to
+                    // rewrite this into `OpKind::ConstRef(HostObject::Class)`
+                    // before reaching the rtyper.  Surviving residuals
+                    // route through the same `simple_call(HostObject::Class)`
+                    // shape as `SyntheticTransparentCtor` — the
+                    // `Bookkeeper.immutablevalue_hostobject` is_class arm
+                    // (`bookkeeper.rs:1984`) absorbs both spellings into
+                    // a `SomePBC([ClassDesc])`.
+                    let qualname = if owner_path.is_empty() {
+                        name.clone()
+                    } else {
+                        format!("{}.{}", owner_path.join("."), name)
+                    };
+                    let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                        HostObject::new_class(qualname, Vec::new()),
+                    )));
+                    let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
+                    call_args.push(callable);
+                    call_args.extend(arg_hls);
+                    Ok(vec![FlowspaceOp::new("simple_call", call_args, result)])
+                }
                 CallTarget::SyntheticTransparentCtor { name, owner_path } => {
                     // RPython parity: tagged-union ctor `Foo(x)` annotates as
                     // `SomePBC([ClassDesc(Foo)])` then `pair_simple_call`

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -592,11 +592,16 @@ fn fmt_op_result(op: &SpaceOperation) -> String {
 /// `true` iff `kind` is a 0-arg unit-variant transparent ctor
 /// (`StepResult::Continue`, `LoopResult::Done`, …) that [`translate_op`]
 /// pre-folds to a `Constant` and emits no `FlowspaceOp` (the unit-variant
-/// guard at the top of `translate_op`).  The `?` / Result / Option
-/// transparent-ctor handling has no RPython counterpart; this is the one
-/// shape that records nothing, so [`op_canraise`] and [`translate_op`]
-/// consult the SAME predicate — `op_canraise` is false exactly when
-/// `translate_op` emits no op.
+/// guard at the top of `translate_op`).  Also matches the 0-arg
+/// `SyntheticTransparentClass` placeholder emitted by the tuple-struct
+/// match cascade (`front/ast.rs:7456`): [`legacy_const_define_hlvalue`]
+/// folds it to a `Hlvalue::Constant(HostObject::Class)` so the
+/// `isinstance` HighLevelOp's `class_carrier` arrives at
+/// `InstanceRepr::rtype_isinstance` as a Constant — matching the
+/// `if isinstance(v_cls, Constant)` branch in `rclass.py:1019`.
+///
+/// [`op_canraise`] and [`translate_op`] consult the SAME predicate —
+/// `op_canraise` is false exactly when `translate_op` emits no op.
 fn is_elided_unit_variant_ctor(kind: &OpKind) -> bool {
     if let OpKind::Call {
         target: crate::model::CallTarget::SyntheticTransparentCtor { name, owner_path },
@@ -608,6 +613,15 @@ fn is_elided_unit_variant_ctor(kind: &OpKind) -> bool {
         let mut segments = owner_path.clone();
         segments.push(name.clone());
         return crate::front::syn_metadata::is_synthetic_unit_variant_path(&segments);
+    }
+    if let OpKind::Call {
+        target: crate::model::CallTarget::SyntheticTransparentClass { .. },
+        args,
+        ..
+    } = kind
+        && args.is_empty()
+    {
+        return true;
     }
     false
 }
@@ -1740,6 +1754,38 @@ fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
             Some(Hlvalue::Constant(Constant::with_concretetype(
                 ConstValue::HostObject(instance),
                 crate::translator::rtyper::rclass::OBJECTPTR.clone(),
+            )))
+        }
+        // Class-of-variant placeholder fold.  Tuple-struct match
+        // cascades (`front/ast.rs:7396 classify_match_tuple_struct_cascade`)
+        // emit `OpKind::Call { target: SyntheticTransparentClass, args: [] }`
+        // whose runtime semantics is "load the class object" — i.e. a
+        // PBC reference to the class itself, not a fresh instance.
+        // Without the fold, the residual call would route through
+        // `simple_call(HostObject::Class)` and the annotator's
+        // `ClassDesc::pycall` would return `SomeInstance` (a new instance)
+        // rather than `SomePBC([ClassDesc])` (the class itself), breaking
+        // `InstanceRepr::rtype_isinstance` which checks
+        // `if isinstance(v_cls, Constant)` against the class PBC.
+        //
+        // The fold materialises `Hlvalue::Constant(HostObject::new_class)`
+        // directly; `ClassRepr::convert_const` (`rclass.rs:1463`) then
+        // converts the HostObject to an `LLPtr(vtable)` for the
+        // `make_ll_isinstance` (`rclass.py:1149`) constant-arm path.
+        OpKind::Call {
+            target: crate::model::CallTarget::SyntheticTransparentClass { name, owner_path },
+            args,
+            ..
+        } if args.is_empty() => {
+            let qualname = if owner_path.is_empty() {
+                name.clone()
+            } else {
+                format!("{}.{}", owner_path.join("."), name)
+            };
+            let class_obj = crate::flowspace::model::HostObject::new_class(qualname, Vec::new());
+            Some(Hlvalue::Constant(Constant::with_concretetype(
+                ConstValue::HostObject(class_obj),
+                crate::translator::rtyper::rclass::CLASSTYPE.clone(),
             )))
         }
         _ => None,

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -356,7 +356,14 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         // Python `bool`.  RPython annotates them as `SomeBool`, not
         // `SomeInteger`.
         OpKind::IsConstant { .. } | OpKind::IsVirtual { .. } => ValueType::Bool,
-        OpKind::IsInstance { result_ty, .. } => result_ty.clone(),
+        // `isinstance(x, T)` is semantically a `bool`; the carried
+        // `result_ty` is only a constructor hint and may be left as
+        // `Unknown` by frontends that did not set it explicitly.
+        // Returning `Unknown` here widens phi merges and degrades
+        // downstream typing; enforce `Bool` directly so the inferred
+        // type matches `rclass.py InstanceRepr.rtype_isinstance`'s
+        // `LowLevelType::Bool` result.
+        OpKind::IsInstance { .. } => ValueType::Bool,
         // RPython: vtable entry is a `Ptr(FuncType)` address.
         OpKind::VtableMethodPtr { .. } => ValueType::Int,
         OpKind::IndirectCall { result_ty, .. } => result_ty.clone(),

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -356,6 +356,7 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         // Python `bool`.  RPython annotates them as `SomeBool`, not
         // `SomeInteger`.
         OpKind::IsConstant { .. } | OpKind::IsVirtual { .. } => ValueType::Bool,
+        OpKind::IsInstance { result_ty, .. } => result_ty.clone(),
         // RPython: vtable entry is a `Ptr(FuncType)` address.
         OpKind::VtableMethodPtr { .. } => ValueType::Int,
         OpKind::IndirectCall { result_ty, .. } => result_ty.clone(),

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -2876,6 +2876,29 @@ impl Repr for InstanceRepr {
         Ok(Some(Hlvalue::Variable(var)))
     }
 
+    /// RPython `InstanceRepr.rtype_bool(self, hop)` (rclass.py:866-868):
+    ///
+    /// ```python
+    /// def rtype_bool(self, hop):
+    ///     vinst, = hop.inputargs(self)
+    ///     return hop.genop('ptr_nonzero', [vinst], resulttype=Bool)
+    /// ```
+    ///
+    /// `InstanceRepr` does not inherit from `CanBeNull` upstream, so the
+    /// constant fast-path in [`crate::translator::rtyper::rmodel::can_be_null_rtype_bool`]
+    /// is intentionally absent here — a non-null instance always evaluates
+    /// to true and the lowleveltype carrier is a `Ptr(GcStruct)` that
+    /// `ptr_nonzero` lowers directly to a null comparison.
+    fn rtype_bool(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::translator::rtyper::rtyper::{ConvertedTo, GenopResult};
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        Ok(hop.genop(
+            "ptr_nonzero",
+            vlist,
+            GenopResult::LLType(LowLevelType::Bool),
+        ))
+    }
+
     /// RPython `InstanceRepr.rtype_isinstance(self, hop)` (rclass.py:1019-1032):
     ///
     /// ```python

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -2895,14 +2895,15 @@ impl Repr for InstanceRepr {
     ///         return hop.gendirectcall(ll_isinstance, v_obj, v_cls)
     /// ```
     ///
-    /// E.3 lands the variable branch (the unconditional
-    /// `gendirectcall(ll_isinstance, v_obj, v_cls)` path). The constant
-    /// branch with `make_ll_isinstance` per-class specialization lands
-    /// in E.4 — until then a Constant `v_cls` flows through the same
-    /// variable helper (correct, just one extra `ptr_nonzero`/
-    /// `int_between` per check).
+    /// Constant `v_cls` is recognised here and routed through
+    /// [`make_ll_isinstance`] (rclass.py:1149-1168) to pick up the
+    /// per-class `int_between` / `ptr_eq` specialisation. The choice
+    /// between `ll_isinstance_const` (null-checking) and
+    /// `ll_isinstance_const_nonnull` (assumes nonnull) is driven by
+    /// `hop.args_s[0].can_be_None`. Variable `v_cls` falls through to
+    /// the unspecialised `ll_isinstance` helper minted by E.1.
     fn rtype_isinstance(&self, hop: &HighLevelOp) -> RTypeResult {
-        use crate::translator::rtyper::rtyper::ConvertedTo;
+        use crate::translator::rtyper::rtyper::{ConvertedTo, make_ll_isinstance};
 
         // upstream: `class_repr = get_type_repr(hop.rtyper)`.
         let rtyper = self.rtyper.upgrade().ok_or_else(|| {
@@ -2920,9 +2921,42 @@ impl Repr for InstanceRepr {
         let v_obj = v_args[0].clone();
         let v_cls = v_args[1].clone();
 
+        // upstream: `if isinstance(v_cls, Constant):`.
+        if let Hlvalue::Constant(c) = &v_cls {
+            // upstream: `cls = v_cls.value`. The constant carries an
+            // `_ptr` to the vtable; subclassrange_{min,max} are read
+            // off it by make_ll_isinstance.
+            let ConstValue::LLPtr(c_ptr) = &c.value else {
+                return Err(TyperError::message(format!(
+                    "InstanceRepr.rtype_isinstance: constant v_cls must \
+                     carry an _ptr, got {:?}",
+                    c.value
+                )));
+            };
+            // upstream: `llf, llf_nonnull = make_ll_isinstance(self.rtyper, cls)`.
+            let (ll_const, ll_const_nonnull) = make_ll_isinstance(&rtyper, c_ptr)?;
+            // upstream: `if hop.args_s[0].can_be_None: ...`. The
+            // `can_be_None` flag rides on the annotator's
+            // SomeInstance / SomePBC carriers — None elsewhere means
+            // the obj is statically known non-null, so the nonnull
+            // variant skips the runtime branch.
+            let can_be_none = {
+                let args_s = hop.args_s.borrow();
+                match args_s.get(0) {
+                    Some(SomeValue::Instance(inst)) => inst.can_be_none,
+                    Some(SomeValue::PBC(pbc)) => pbc.can_be_none,
+                    _ => true,
+                }
+            };
+            let helper = if can_be_none {
+                ll_const
+            } else {
+                ll_const_nonnull
+            };
+            return hop.gendirectcall(&helper, vec![v_obj]);
+        }
+
         // upstream variable case: `gendirectcall(ll_isinstance, v_obj, v_cls)`.
-        // The constant case (E.4) will instead mint per-class helpers via
-        // make_ll_isinstance and dispatch on `hop.args_s[0].can_be_None`.
         let helper = rtyper.lowlevel_helper_function(
             "ll_isinstance",
             vec![OBJECTPTR.clone(), CLASSTYPE.clone()],

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -2084,6 +2084,25 @@ impl InstanceRepr {
         self.gcflavor
     }
 
+    /// RPython `InstanceRepr.common_repr(self)` (rclass.py:932-933):
+    ///
+    /// ```python
+    /// def common_repr(self):  # -> object or nongcobject reprs
+    ///     return getinstancerepr(self.rtyper, None, self.gcflavor)
+    /// ```
+    ///
+    /// Returns the root `InstanceRepr` for this instance's gcflavor —
+    /// the one whose `lowleveltype` is `OBJECTPTR` (or `NONGCOBJECTPTR`
+    /// for non-GC flavors). `rtype_isinstance` (rclass.py:1019-1021)
+    /// uses this to convert `v_obj` to the common base type before the
+    /// runtime check.
+    pub fn common_repr(&self) -> Result<Arc<InstanceRepr>, TyperError> {
+        let rtyper = self.rtyper.upgrade().ok_or_else(|| {
+            TyperError::message("InstanceRepr.common_repr: rtyper weak ref expired")
+        })?;
+        getinstancerepr(&rtyper, None, self.gcflavor)
+    }
+
     /// Read-only view of the instance-level `fields` dict populated by
     /// `_setup_repr`. RPython `self.fields` (rclass.py:557).
     pub fn fields(&self) -> std::cell::Ref<'_, HashMap<String, (String, Arc<dyn Repr>)>> {
@@ -2855,6 +2874,61 @@ impl Repr for InstanceRepr {
             ClassReprArc::Root(r) => r.getclsfield(Hlvalue::Variable(v_cls), &attr, &mut llops)?,
         };
         Ok(Some(Hlvalue::Variable(var)))
+    }
+
+    /// RPython `InstanceRepr.rtype_isinstance(self, hop)` (rclass.py:1019-1032):
+    ///
+    /// ```python
+    /// def rtype_isinstance(self, hop):
+    ///     class_repr = get_type_repr(hop.rtyper)
+    ///     instance_repr = self.common_repr()
+    ///
+    ///     v_obj, v_cls = hop.inputargs(instance_repr, class_repr)
+    ///     if isinstance(v_cls, Constant):
+    ///         cls = v_cls.value
+    ///         llf, llf_nonnull = make_ll_isinstance(self.rtyper, cls)
+    ///         if hop.args_s[0].can_be_None:
+    ///             return hop.gendirectcall(llf, v_obj)
+    ///         else:
+    ///             return hop.gendirectcall(llf_nonnull, v_obj)
+    ///     else:
+    ///         return hop.gendirectcall(ll_isinstance, v_obj, v_cls)
+    /// ```
+    ///
+    /// E.3 lands the variable branch (the unconditional
+    /// `gendirectcall(ll_isinstance, v_obj, v_cls)` path). The constant
+    /// branch with `make_ll_isinstance` per-class specialization lands
+    /// in E.4 — until then a Constant `v_cls` flows through the same
+    /// variable helper (correct, just one extra `ptr_nonzero`/
+    /// `int_between` per check).
+    fn rtype_isinstance(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::translator::rtyper::rtyper::ConvertedTo;
+
+        // upstream: `class_repr = get_type_repr(hop.rtyper)`.
+        let rtyper = self.rtyper.upgrade().ok_or_else(|| {
+            TyperError::message("InstanceRepr.rtype_isinstance: rtyper weak ref expired")
+        })?;
+        let class_repr = get_type_repr(&rtyper)?;
+        // upstream: `instance_repr = self.common_repr()`.
+        let instance_repr = self.common_repr()?;
+
+        // upstream: `v_obj, v_cls = hop.inputargs(instance_repr, class_repr)`.
+        let v_args = hop.inputargs(vec![
+            ConvertedTo::Repr(instance_repr.as_ref() as &dyn Repr),
+            ConvertedTo::Repr(class_repr.as_ref()),
+        ])?;
+        let v_obj = v_args[0].clone();
+        let v_cls = v_args[1].clone();
+
+        // upstream variable case: `gendirectcall(ll_isinstance, v_obj, v_cls)`.
+        // The constant case (E.4) will instead mint per-class helpers via
+        // make_ll_isinstance and dispatch on `hop.args_s[0].can_be_None`.
+        let helper = rtyper.lowlevel_helper_function(
+            "ll_isinstance",
+            vec![OBJECTPTR.clone(), CLASSTYPE.clone()],
+            LowLevelType::Bool,
+        )?;
+        hop.gendirectcall(&helper, vec![v_obj, v_cls])
     }
 
     /// RPython `InstanceRepr.convert_const(self, value)` (rclass.py:772-792):

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -2980,9 +2980,14 @@ impl Repr for InstanceRepr {
         }
 
         // upstream variable case: `gendirectcall(ll_isinstance, v_obj, v_cls)`.
+        // `v_obj` was coerced through `instance_repr.lowleveltype()`,
+        // which is `OBJECTPTR` for the GC flavor and `NONGCOBJECTPTR`
+        // for raw-flavor instances — hard-coding `OBJECTPTR` would
+        // mint a helper signature that mismatches the actual argument
+        // type for non-GC paths.
         let helper = rtyper.lowlevel_helper_function(
             "ll_isinstance",
-            vec![OBJECTPTR.clone(), CLASSTYPE.clone()],
+            vec![instance_repr.lowleveltype().clone(), CLASSTYPE.clone()],
             LowLevelType::Bool,
         )?;
         hop.gendirectcall(&helper, vec![v_obj, v_cls])

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -2957,7 +2957,13 @@ impl Repr for InstanceRepr {
                 )));
             };
             // upstream: `llf, llf_nonnull = make_ll_isinstance(self.rtyper, cls)`.
-            let (ll_const, ll_const_nonnull) = make_ll_isinstance(&rtyper, c_ptr)?;
+            // `v_obj` has been coerced through `instance_repr.lowleveltype()`
+            // (OBJECTPTR for gc flavor, NONGCOBJECTPTR for raw); pass it
+            // through so the minted helper's `obj` parameter type matches
+            // the actual `v_obj`'s lltype upstream's "obj should be cast
+            // to OBJECT or NONGCOBJECT" polymorphism (rclass.py:1143).
+            let (ll_const, ll_const_nonnull) =
+                make_ll_isinstance(&rtyper, c_ptr, instance_repr.lowleveltype())?;
             // upstream: `if hop.args_s[0].can_be_None: ...`. The
             // `can_be_None` flag rides on the annotator's
             // SomeInstance / SomePBC carriers — None elsewhere means

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3221,6 +3221,297 @@ fn lowlevel_isinstance_helper_graph(
     Ok(helper_pygraph_from_graph(graph, argnames, func))
 }
 
+/// RPython `make_ll_isinstance(rtyper, cls)` (rclass.py:1149-1168):
+///
+/// ```python
+/// def make_ll_isinstance(rtyper, cls):
+///     try:
+///         return rtyper.isinstance_helpers[cls._obj]
+///     except KeyError:
+///         minid = cls.subclassrange_min
+///         maxid = cls.subclassrange_max
+///         if minid.number_with_subclasses():
+///             def ll_isinstance_const_nonnull(obj):
+///                 objid = obj.typeptr.subclassrange_min
+///                 return llop.int_between(Bool, minid, objid, maxid)
+///         else:
+///             def ll_isinstance_const_nonnull(obj):
+///                 return obj.typeptr == cls
+///         def ll_isinstance_const(obj):
+///             if not obj:
+///                 return False
+///             return ll_isinstance_const_nonnull(obj)
+///         result = (ll_isinstance_const, ll_isinstance_const_nonnull)
+///         rtyper.isinstance_helpers[cls._obj] = result
+///         return result
+/// ```
+///
+/// Returns `(ll_isinstance_const, ll_isinstance_const_nonnull)`. The
+/// pair is cached implicitly under synthetic helper names
+/// `ll_isinstance_const_<min>_<max>` and
+/// `ll_isinstance_const_nonnull_<min>_<max>` in
+/// `rtyper.lowlevel_helper_graphs` — `(minid, maxid)` uniquely
+/// identifies the classdef after `normalizecalls.assign_inheritance_ids`
+/// has run, mirroring upstream's `rtyper.isinstance_helpers[cls._obj]`
+/// keying by vtable identity.
+///
+/// Upstream's `number_with_subclasses()` (whether the inheritance
+/// range covers any proper subclass) is `maxid > minid` — when false
+/// the class is leaf-unique and a direct `ptr_eq(obj.typeptr, cls)`
+/// replaces the `int_between` range check.
+pub(crate) fn make_ll_isinstance(
+    rtyper: &RPythonTyper,
+    cls_ptr: &_ptr,
+) -> Result<(LowLevelFunction, LowLevelFunction), TyperError> {
+    // upstream: `minid = cls.subclassrange_min; maxid = cls.subclassrange_max`.
+    let min_val = cls_ptr
+        .getattr("subclassrange_min")
+        .map_err(TyperError::message)?;
+    let max_val = cls_ptr
+        .getattr("subclassrange_max")
+        .map_err(TyperError::message)?;
+    let LowLevelValue::Signed(minid) = min_val else {
+        return Err(TyperError::message(format!(
+            "make_ll_isinstance: subclassrange_min must be Signed, got {min_val:?}",
+        )));
+    };
+    let LowLevelValue::Signed(maxid) = max_val else {
+        return Err(TyperError::message(format!(
+            "make_ll_isinstance: subclassrange_max must be Signed, got {max_val:?}",
+        )));
+    };
+    // upstream `minid.number_with_subclasses()` — true when the
+    // inheritance range covers proper subclasses (maxid > minid).
+    let has_subclasses = maxid > minid;
+
+    let nonnull_name = format!("ll_isinstance_const_nonnull_{minid}_{maxid}");
+    let const_name = format!("ll_isinstance_const_{minid}_{maxid}");
+
+    // Mint the non-null helper first so the const helper's direct_call
+    // can resolve it via the cache when its builder runs.
+    let nonnull_name_for_builder = nonnull_name.clone();
+    let cls_ptr_for_builder = cls_ptr.clone();
+    let ll_const_nonnull = rtyper.lowlevel_helper_function_with_builder(
+        nonnull_name.clone(),
+        vec![OBJECTPTR.clone()],
+        LowLevelType::Bool,
+        move |_rtyper, args, result| {
+            build_ll_isinstance_const_nonnull_graph(
+                &nonnull_name_for_builder,
+                args,
+                result,
+                minid,
+                maxid,
+                has_subclasses,
+                cls_ptr_for_builder,
+            )
+        },
+    )?;
+
+    let const_name_for_builder = const_name.clone();
+    let nonnull_name_for_call = nonnull_name.clone();
+    let ll_const = rtyper.lowlevel_helper_function_with_builder(
+        const_name,
+        vec![OBJECTPTR.clone()],
+        LowLevelType::Bool,
+        move |rtyper, args, result| {
+            build_ll_isinstance_const_graph(
+                &const_name_for_builder,
+                rtyper,
+                args,
+                result,
+                &nonnull_name_for_call,
+            )
+        },
+    )?;
+
+    Ok((ll_const, ll_const_nonnull))
+}
+
+/// Build the `ll_isinstance_const_nonnull(obj)` helper graph
+/// (rclass.py:1156-1161). `has_subclasses` toggles between the
+/// `int_between` range check (covers proper subclasses) and the
+/// `ptr_eq(obj.typeptr, cls)` exact-match check (leaf unique class).
+fn build_ll_isinstance_const_nonnull_graph(
+    name: &str,
+    args: &[LowLevelType],
+    result: &LowLevelType,
+    minid: i64,
+    maxid: i64,
+    has_subclasses: bool,
+    cls_ptr: _ptr,
+) -> Result<PyGraph, TyperError> {
+    if args != [OBJECTPTR.clone()] || result != &LowLevelType::Bool {
+        return Err(TyperError::message(format!(
+            "{name} expects (OBJECTPTR) -> Bool, got ({args:?}) -> {result:?}"
+        )));
+    }
+
+    let argnames = vec!["arg0".to_string()];
+    let obj = variable_with_lltype("arg0", OBJECTPTR.clone());
+    let obj_cls = variable_with_lltype("obj_cls", CLASSTYPE.clone());
+    let result_var = variable_with_lltype("result", LowLevelType::Bool);
+    let return_var = variable_with_lltype("result", LowLevelType::Bool);
+
+    let startblock = Block::shared(vec![Hlvalue::Variable(obj.clone())]);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // upstream both branches: `obj_cls = obj.typeptr`.
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(obj), void_field_const("typeptr")],
+        Hlvalue::Variable(obj_cls.clone()),
+    ));
+
+    if has_subclasses {
+        // upstream: `objid = obj_cls.subclassrange_min;
+        //   return int_between(Bool, minid, objid, maxid)`.
+        let objid = variable_with_lltype("objid", LowLevelType::Signed);
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "getfield",
+            vec![
+                Hlvalue::Variable(obj_cls),
+                void_field_const("subclassrange_min"),
+            ],
+            Hlvalue::Variable(objid.clone()),
+        ));
+        let c_min = constant_with_lltype(ConstValue::Int(minid), LowLevelType::Signed);
+        let c_max = constant_with_lltype(ConstValue::Int(maxid), LowLevelType::Signed);
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "int_between",
+            vec![c_min, Hlvalue::Variable(objid), c_max],
+            Hlvalue::Variable(result_var.clone()),
+        ));
+    } else {
+        // upstream: `return obj_cls == cls` — direct ptr_eq against
+        // the baked-in class pointer constant.
+        let c_cls = Constant::with_concretetype(
+            ConstValue::LLPtr(Box::new(cls_ptr)),
+            CLASSTYPE.clone(),
+        );
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "ptr_eq",
+            vec![Hlvalue::Variable(obj_cls), Hlvalue::Constant(c_cls)],
+            Hlvalue::Variable(result_var.clone()),
+        ));
+    }
+
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result_var)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, argnames, func))
+}
+
+/// Build the `ll_isinstance_const(obj)` helper graph
+/// (rclass.py:1162-1165) — null-check then tail-call the matching
+/// `ll_isinstance_const_nonnull` minted by
+/// [`make_ll_isinstance`].
+fn build_ll_isinstance_const_graph(
+    name: &str,
+    rtyper: &RPythonTyper,
+    args: &[LowLevelType],
+    result: &LowLevelType,
+    nonnull_name: &str,
+) -> Result<PyGraph, TyperError> {
+    if args != [OBJECTPTR.clone()] || result != &LowLevelType::Bool {
+        return Err(TyperError::message(format!(
+            "{name} expects (OBJECTPTR) -> Bool, got ({args:?}) -> {result:?}"
+        )));
+    }
+
+    let argnames = vec!["arg0".to_string()];
+    let obj0 = variable_with_lltype("arg0", OBJECTPTR.clone());
+    let is_nonnull = variable_with_lltype("is_nonnull", LowLevelType::Bool);
+    let obj1 = variable_with_lltype("obj", OBJECTPTR.clone());
+    let call_result = variable_with_lltype("result", LowLevelType::Bool);
+    let return_var = variable_with_lltype("result", LowLevelType::Bool);
+
+    let startblock = Block::shared(vec![Hlvalue::Variable(obj0.clone())]);
+    let callblock = Block::shared(vec![Hlvalue::Variable(obj1.clone())]);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // upstream: `if not obj: return False`.
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "ptr_nonzero",
+        vec![Hlvalue::Variable(obj0.clone())],
+        Hlvalue::Variable(is_nonnull.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_nonnull));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(obj0)],
+            Some(callblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )],
+            Some(graph.returnblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // upstream: `return ll_isinstance_const_nonnull(obj)` — cache hit
+    // (the non-null helper was minted just before this one in
+    // make_ll_isinstance, so the lookup never falls back to the
+    // dispatch table's synthetic-stub branch).
+    let callee = rtyper.lowlevel_helper_function(
+        nonnull_name.to_string(),
+        vec![OBJECTPTR.clone()],
+        LowLevelType::Bool,
+    )?;
+    callblock.borrow_mut().operations.push(direct_call_operation(
+        rtyper,
+        &callee,
+        vec![Hlvalue::Variable(obj1)],
+        call_result.clone(),
+    )?);
+    callblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(call_result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, argnames, func))
+}
+
 pub(crate) fn exception_args(exc_name: &str) -> Result<Vec<Hlvalue>, TyperError> {
     let exc_cls = HOST_ENV
         .lookup_exception_class(exc_name)

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3284,8 +3284,26 @@ pub(crate) fn make_ll_isinstance(
     // inheritance range covers proper subclasses (maxid > minid).
     let has_subclasses = maxid > minid;
 
-    let nonnull_name = format!("ll_isinstance_const_nonnull_{minid}_{maxid}");
-    let const_name = format!("ll_isinstance_const_{minid}_{maxid}");
+    // Pyre-port: the cache key suffix `_<min>_<max>` is unique post-
+    // `normalizecalls.assign_inheritance_ids` only.  Reading the vtable
+    // before assignment would observe the default `Signed(0)` for both
+    // markers and collide every uninitialised class onto a single
+    // helper.  Pin the underlying container's stable identity (the
+    // `_struct._identity` set at allocation, preserved across `_ptr`
+    // clones) into the name so distinct classes never share a helper
+    // even if their range markers do.  Upstream keys this cache by
+    // `cls._obj` identity (`rclass.py:1149`); the container identity
+    // is the analog.
+    let class_identity: u64 = match &cls_ptr._obj0 {
+        Ok(Some(crate::translator::rtyper::lltypesystem::lltype::_ptr_obj::Struct(s))) => {
+            s._identity as u64
+        }
+        _ => cls_ptr._hashable_identity(),
+    };
+
+    let nonnull_name =
+        format!("ll_isinstance_const_nonnull_{class_identity}_{minid}_{maxid}");
+    let const_name = format!("ll_isinstance_const_{class_identity}_{minid}_{maxid}");
 
     // Mint the non-null helper first so the const helper's direct_call
     // can resolve it via the cache when its builder runs.

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3272,9 +3272,12 @@ fn lowlevel_isinstance_helper_graph(
 /// keying by vtable identity.
 ///
 /// Upstream's `number_with_subclasses()` (whether the inheritance
-/// range covers any proper subclass) is `maxid > minid` — when false
-/// the class is leaf-unique and a direct `ptr_eq(obj.typeptr, cls)`
-/// replaces the `int_between` range check.
+/// range covers any proper subclass) — under the eager-marker integer
+/// scheme (`normalizecalls.assign_inheritance_ids` line 325) a leaf
+/// class gets `maxid == minid + 1`, so the predicate is
+/// `maxid > minid + 1`. When false the class is leaf-unique and a
+/// direct `ptr_eq(obj.typeptr, cls)` replaces the `int_between` range
+/// check.
 pub(crate) fn make_ll_isinstance(
     rtyper: &RPythonTyper,
     cls_ptr: &_ptr,

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3174,7 +3174,10 @@ fn lowlevel_isinstance_helper_graph(
     startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_nonnull));
     startblock.closeblock(vec![
         Link::new(
-            vec![Hlvalue::Variable(obj0.clone()), Hlvalue::Variable(cls0.clone())],
+            vec![
+                Hlvalue::Variable(obj0.clone()),
+                Hlvalue::Variable(cls0.clone()),
+            ],
             Some(callblock.clone()),
             Some(constant_with_lltype(
                 ConstValue::Bool(true),
@@ -3208,12 +3211,15 @@ fn lowlevel_isinstance_helper_graph(
         vec![CLASSTYPE.clone(), CLASSTYPE.clone()],
         LowLevelType::Bool,
     )?;
-    callblock.borrow_mut().operations.push(direct_call_operation(
-        rtyper,
-        &callee,
-        vec![Hlvalue::Variable(obj_cls), Hlvalue::Variable(cls1)],
-        call_result.clone(),
-    )?);
+    callblock
+        .borrow_mut()
+        .operations
+        .push(direct_call_operation(
+            rtyper,
+            &callee,
+            vec![Hlvalue::Variable(obj_cls), Hlvalue::Variable(cls1)],
+            call_result.clone(),
+        )?);
     callblock.closeblock(vec![
         Link::new(
             vec![Hlvalue::Variable(call_result)],
@@ -3437,10 +3443,8 @@ fn build_ll_isinstance_const_nonnull_graph(
     } else {
         // upstream: `return obj_cls == cls` — direct ptr_eq against
         // the baked-in class pointer constant.
-        let c_cls = Constant::with_concretetype(
-            ConstValue::LLPtr(Box::new(cls_ptr)),
-            CLASSTYPE.clone(),
-        );
+        let c_cls =
+            Constant::with_concretetype(ConstValue::LLPtr(Box::new(cls_ptr)), CLASSTYPE.clone());
         startblock.borrow_mut().operations.push(SpaceOperation::new(
             "ptr_eq",
             vec![Hlvalue::Variable(obj_cls), Hlvalue::Constant(c_cls)],
@@ -3542,12 +3546,15 @@ fn build_ll_isinstance_const_graph(
         vec![obj_lltype.clone()],
         LowLevelType::Bool,
     )?;
-    callblock.borrow_mut().operations.push(direct_call_operation(
-        rtyper,
-        &callee,
-        vec![Hlvalue::Variable(obj1)],
-        call_result.clone(),
-    )?);
+    callblock
+        .borrow_mut()
+        .operations
+        .push(direct_call_operation(
+            rtyper,
+            &callee,
+            vec![Hlvalue::Variable(obj1)],
+            call_result.clone(),
+        )?);
     callblock.closeblock(vec![
         Link::new(
             vec![Hlvalue::Variable(call_result)],

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3296,9 +3296,10 @@ pub(crate) fn make_ll_isinstance(
             "make_ll_isinstance: subclassrange_max must be Signed, got {max_val:?}",
         )));
     };
-    // upstream `minid.number_with_subclasses()` — true when the
-    // inheritance range covers proper subclasses (maxid > minid).
-    let has_subclasses = maxid > minid;
+    // upstream `minid.number_with_subclasses()` — true only when the
+    // inheritance ID scheme places at least one descendant inheritance
+    // marker between this class's start and end markers.
+    let has_subclasses = maxid > minid + 1;
 
     // Pyre-port: the cache key suffix `_<min>_<max>` is unique post-
     // `normalizecalls.assign_inheritance_ids` only.  Reading the vtable

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -2939,6 +2939,7 @@ fn lowlevel_helper_graph(
             "lllong_eq",
         ),
         "ll_issubclass" => lowlevel_issubclass_helper_graph(name, args, result),
+        "ll_isinstance" => lowlevel_isinstance_helper_graph(rtyper, name, args, result),
         "ll_type" => lowlevel_type_helper_graph(name, args, result),
         _ => Ok(synthetic_lowlevel_helper_graph(name, args, result)),
     }
@@ -3089,6 +3090,123 @@ fn lowlevel_type_helper_graph(
     startblock.closeblock(vec![
         Link::new(
             vec![Hlvalue::Variable(typeptr)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, argnames, func))
+}
+
+/// RPython `ll_isinstance(obj, cls)` (rclass.py:1143-1147):
+///
+/// ```python
+/// def ll_isinstance(obj, cls):  # obj should be cast to OBJECT or NONGCOBJECT
+///     if not obj:
+///         return False
+///     obj_cls = obj.typeptr
+///     return ll_issubclass(obj_cls, cls)
+/// ```
+///
+/// Helper signature `(OBJECTPTR, CLASSTYPE) -> Bool`. The body branches on
+/// `ptr_nonzero(obj)`: the null arm returns `False` directly, the non-null
+/// arm reads `obj.typeptr` and tail-calls the minted `ll_issubclass`
+/// helper graph via `direct_call`.
+fn lowlevel_isinstance_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    args: &[LowLevelType],
+    result: &LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    if args != [OBJECTPTR.clone(), CLASSTYPE.clone()] || result != &LowLevelType::Bool {
+        return Err(TyperError::message(format!(
+            "{name} expects (OBJECTPTR, CLASSTYPE) -> Bool, got ({args:?}) -> {result:?}"
+        )));
+    }
+
+    let argnames = vec!["arg0".to_string(), "arg1".to_string()];
+    let obj0 = variable_with_lltype("arg0", OBJECTPTR.clone());
+    let cls0 = variable_with_lltype("arg1", CLASSTYPE.clone());
+    let is_nonnull = variable_with_lltype("is_nonnull", LowLevelType::Bool);
+    let obj1 = variable_with_lltype("obj", OBJECTPTR.clone());
+    let cls1 = variable_with_lltype("cls", CLASSTYPE.clone());
+    let obj_cls = variable_with_lltype("obj_cls", CLASSTYPE.clone());
+    let call_result = variable_with_lltype("result", LowLevelType::Bool);
+    let return_var = variable_with_lltype("result", LowLevelType::Bool);
+
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(obj0.clone()),
+        Hlvalue::Variable(cls0.clone()),
+    ]);
+    let callblock = Block::shared(vec![
+        Hlvalue::Variable(obj1.clone()),
+        Hlvalue::Variable(cls1.clone()),
+    ]);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // upstream: `if not obj:` — emit `ptr_nonzero(obj)` so the true link
+    // continues with the typeptr read and the false link returns False.
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "ptr_nonzero",
+        vec![Hlvalue::Variable(obj0.clone())],
+        Hlvalue::Variable(is_nonnull.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_nonnull));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(obj0.clone()), Hlvalue::Variable(cls0.clone())],
+            Some(callblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )],
+            Some(graph.returnblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // upstream: `obj_cls = obj.typeptr`.
+    callblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(obj1), void_field_const("typeptr")],
+        Hlvalue::Variable(obj_cls.clone()),
+    ));
+    // upstream: `return ll_issubclass(obj_cls, cls)`.
+    let callee = rtyper.lowlevel_helper_function(
+        "ll_issubclass",
+        vec![CLASSTYPE.clone(), CLASSTYPE.clone()],
+        LowLevelType::Bool,
+    )?;
+    callblock.borrow_mut().operations.push(direct_call_operation(
+        rtyper,
+        &callee,
+        vec![Hlvalue::Variable(obj_cls), Hlvalue::Variable(cls1)],
+        call_result.clone(),
+    )?);
+    callblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(call_result)],
             Some(graph.returnblock.clone()),
             None,
         )

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -38,7 +38,8 @@ use crate::translator::rtyper::lltypesystem::lltype::{
     _ptr, LowLevelType, LowLevelValue, PtrTarget, getfunctionptr,
 };
 use crate::translator::rtyper::rclass::{
-    CLASSTYPE, Flavor, InstanceRepr, InstanceReprKey, OBJECTPTR, RootClassRepr, getinstancerepr,
+    CLASSTYPE, Flavor, InstanceRepr, InstanceReprKey, NONGCOBJECTPTR, OBJECTPTR, RootClassRepr,
+    getinstancerepr,
 };
 use crate::translator::rtyper::rmodel::{
     RTypeResult, Repr, ReprKey, inputconst, inputconst_from_lltype, rtyper_makekey, rtyper_makerepr,
@@ -3124,17 +3125,26 @@ fn lowlevel_isinstance_helper_graph(
     args: &[LowLevelType],
     result: &LowLevelType,
 ) -> Result<PyGraph, TyperError> {
-    if args != [OBJECTPTR.clone(), CLASSTYPE.clone()] || result != &LowLevelType::Bool {
+    // Upstream `ll_isinstance(obj, cls)` (rclass.py:1143) is
+    // polymorphic over `obj`'s flavor — `# obj should be cast to
+    // OBJECT or NONGCOBJECT`.  Accept either pointee so raw-flavor
+    // instances mint a helper whose body matches their lowleveltype.
+    if !(args.len() == 2
+        && (args[0] == *OBJECTPTR || args[0] == *NONGCOBJECTPTR)
+        && args[1] == *CLASSTYPE)
+        || result != &LowLevelType::Bool
+    {
         return Err(TyperError::message(format!(
-            "{name} expects (OBJECTPTR, CLASSTYPE) -> Bool, got ({args:?}) -> {result:?}"
+            "{name} expects ((OBJECTPTR|NONGCOBJECTPTR), CLASSTYPE) -> Bool, got ({args:?}) -> {result:?}"
         )));
     }
+    let obj_lltype = args[0].clone();
 
     let argnames = vec!["arg0".to_string(), "arg1".to_string()];
-    let obj0 = variable_with_lltype("arg0", OBJECTPTR.clone());
+    let obj0 = variable_with_lltype("arg0", obj_lltype.clone());
     let cls0 = variable_with_lltype("arg1", CLASSTYPE.clone());
     let is_nonnull = variable_with_lltype("is_nonnull", LowLevelType::Bool);
-    let obj1 = variable_with_lltype("obj", OBJECTPTR.clone());
+    let obj1 = variable_with_lltype("obj", obj_lltype.clone());
     let cls1 = variable_with_lltype("cls", CLASSTYPE.clone());
     let obj_cls = variable_with_lltype("obj_cls", CLASSTYPE.clone());
     let call_result = variable_with_lltype("result", LowLevelType::Bool);
@@ -3262,7 +3272,13 @@ fn lowlevel_isinstance_helper_graph(
 pub(crate) fn make_ll_isinstance(
     rtyper: &RPythonTyper,
     cls_ptr: &_ptr,
+    obj_lltype: &LowLevelType,
 ) -> Result<(LowLevelFunction, LowLevelFunction), TyperError> {
+    if !(*obj_lltype == *OBJECTPTR || *obj_lltype == *NONGCOBJECTPTR) {
+        return Err(TyperError::message(format!(
+            "make_ll_isinstance: obj_lltype must be OBJECTPTR or NONGCOBJECTPTR, got {obj_lltype:?}"
+        )));
+    }
     // upstream: `minid = cls.subclassrange_min; maxid = cls.subclassrange_max`.
     let min_val = cls_ptr
         .getattr("subclassrange_min")
@@ -3301,8 +3317,17 @@ pub(crate) fn make_ll_isinstance(
         _ => cls_ptr._hashable_identity(),
     };
 
-    let nonnull_name = format!("ll_isinstance_const_nonnull_{class_identity}_{minid}_{maxid}");
-    let const_name = format!("ll_isinstance_const_{class_identity}_{minid}_{maxid}");
+    // Differentiate the cache name suffix by gc/raw flavor so the
+    // same class with both flavor witnesses (rare but legal) does
+    // not collide on a single helper body of the wrong obj type.
+    let flavor_tag = if *obj_lltype == *NONGCOBJECTPTR {
+        "raw"
+    } else {
+        "gc"
+    };
+    let nonnull_name =
+        format!("ll_isinstance_const_nonnull_{flavor_tag}_{class_identity}_{minid}_{maxid}");
+    let const_name = format!("ll_isinstance_const_{flavor_tag}_{class_identity}_{minid}_{maxid}");
 
     // Mint the non-null helper first so the const helper's direct_call
     // can resolve it via the cache when its builder runs.
@@ -3310,7 +3335,7 @@ pub(crate) fn make_ll_isinstance(
     let cls_ptr_for_builder = cls_ptr.clone();
     let ll_const_nonnull = rtyper.lowlevel_helper_function_with_builder(
         nonnull_name.clone(),
-        vec![OBJECTPTR.clone()],
+        vec![obj_lltype.clone()],
         LowLevelType::Bool,
         move |_rtyper, args, result| {
             build_ll_isinstance_const_nonnull_graph(
@@ -3329,7 +3354,7 @@ pub(crate) fn make_ll_isinstance(
     let nonnull_name_for_call = nonnull_name.clone();
     let ll_const = rtyper.lowlevel_helper_function_with_builder(
         const_name,
-        vec![OBJECTPTR.clone()],
+        vec![obj_lltype.clone()],
         LowLevelType::Bool,
         move |rtyper, args, result| {
             build_ll_isinstance_const_graph(
@@ -3358,14 +3383,19 @@ fn build_ll_isinstance_const_nonnull_graph(
     has_subclasses: bool,
     cls_ptr: _ptr,
 ) -> Result<PyGraph, TyperError> {
-    if args != [OBJECTPTR.clone()] || result != &LowLevelType::Bool {
+    // See `lowlevel_isinstance_helper_graph` — the obj parameter is
+    // polymorphic over OBJECTPTR / NONGCOBJECTPTR.
+    if !(args.len() == 1 && (args[0] == *OBJECTPTR || args[0] == *NONGCOBJECTPTR))
+        || result != &LowLevelType::Bool
+    {
         return Err(TyperError::message(format!(
-            "{name} expects (OBJECTPTR) -> Bool, got ({args:?}) -> {result:?}"
+            "{name} expects ((OBJECTPTR|NONGCOBJECTPTR)) -> Bool, got ({args:?}) -> {result:?}"
         )));
     }
+    let obj_lltype = args[0].clone();
 
     let argnames = vec!["arg0".to_string()];
-    let obj = variable_with_lltype("arg0", OBJECTPTR.clone());
+    let obj = variable_with_lltype("arg0", obj_lltype);
     let obj_cls = variable_with_lltype("obj_cls", CLASSTYPE.clone());
     let result_var = variable_with_lltype("result", LowLevelType::Bool);
     let return_var = variable_with_lltype("result", LowLevelType::Bool);
@@ -3445,16 +3475,21 @@ fn build_ll_isinstance_const_graph(
     result: &LowLevelType,
     nonnull_name: &str,
 ) -> Result<PyGraph, TyperError> {
-    if args != [OBJECTPTR.clone()] || result != &LowLevelType::Bool {
+    // See `lowlevel_isinstance_helper_graph` — the obj parameter is
+    // polymorphic over OBJECTPTR / NONGCOBJECTPTR.
+    if !(args.len() == 1 && (args[0] == *OBJECTPTR || args[0] == *NONGCOBJECTPTR))
+        || result != &LowLevelType::Bool
+    {
         return Err(TyperError::message(format!(
-            "{name} expects (OBJECTPTR) -> Bool, got ({args:?}) -> {result:?}"
+            "{name} expects ((OBJECTPTR|NONGCOBJECTPTR)) -> Bool, got ({args:?}) -> {result:?}"
         )));
     }
+    let obj_lltype = args[0].clone();
 
     let argnames = vec!["arg0".to_string()];
-    let obj0 = variable_with_lltype("arg0", OBJECTPTR.clone());
+    let obj0 = variable_with_lltype("arg0", obj_lltype.clone());
     let is_nonnull = variable_with_lltype("is_nonnull", LowLevelType::Bool);
-    let obj1 = variable_with_lltype("obj", OBJECTPTR.clone());
+    let obj1 = variable_with_lltype("obj", obj_lltype.clone());
     let call_result = variable_with_lltype("result", LowLevelType::Bool);
     let return_var = variable_with_lltype("result", LowLevelType::Bool);
 
@@ -3503,7 +3538,7 @@ fn build_ll_isinstance_const_graph(
     // dispatch table's synthetic-stub branch).
     let callee = rtyper.lowlevel_helper_function(
         nonnull_name.to_string(),
-        vec![OBJECTPTR.clone()],
+        vec![obj_lltype.clone()],
         LowLevelType::Bool,
     )?;
     callblock.borrow_mut().operations.push(direct_call_operation(
@@ -5817,6 +5852,66 @@ mod tests {
             panic!("generate_exception_match must return a Variable");
         };
         assert_eq!(res_var.concretetype().as_ref(), Some(&LowLevelType::Bool));
+    }
+
+    #[test]
+    fn make_ll_isinstance_leaf_class_uses_ptr_eq_nonnull_helper() {
+        let (_ann, rtyper) = make_live_rtyper();
+        let Hlvalue::Constant(cls_const) = make_const_etype(7, 8) else {
+            panic!("make_const_etype must return a Constant");
+        };
+        let ConstValue::LLPtr(cls_ptr) = &cls_const.value else {
+            panic!(
+                "make_const_etype must carry an LLPtr, got {:?}",
+                cls_const.value
+            );
+        };
+
+        let (_ll_const, ll_const_nonnull) =
+            make_ll_isinstance(&rtyper, cls_ptr, &OBJECTPTR.clone())
+                .expect("make_ll_isinstance leaf");
+        let pygraph = ll_const_nonnull.graph.expect("nonnull helper graph");
+        let graph = pygraph.graph.borrow();
+        let startblock = graph.startblock.clone();
+        drop(graph);
+
+        let ops: Vec<_> = startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect();
+        assert_eq!(ops, vec!["getfield", "ptr_eq"]);
+    }
+
+    #[test]
+    fn make_ll_isinstance_class_with_subclasses_uses_int_between_nonnull_helper() {
+        let (_ann, rtyper) = make_live_rtyper();
+        let Hlvalue::Constant(cls_const) = make_const_etype(7, 9) else {
+            panic!("make_const_etype must return a Constant");
+        };
+        let ConstValue::LLPtr(cls_ptr) = &cls_const.value else {
+            panic!(
+                "make_const_etype must carry an LLPtr, got {:?}",
+                cls_const.value
+            );
+        };
+
+        let (_ll_const, ll_const_nonnull) =
+            make_ll_isinstance(&rtyper, cls_ptr, &OBJECTPTR.clone())
+                .expect("make_ll_isinstance non-leaf");
+        let pygraph = ll_const_nonnull.graph.expect("nonnull helper graph");
+        let graph = pygraph.graph.borrow();
+        let startblock = graph.startblock.clone();
+        drop(graph);
+
+        let ops: Vec<_> = startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect();
+        assert_eq!(ops, vec!["getfield", "getfield", "int_between"]);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3301,8 +3301,7 @@ pub(crate) fn make_ll_isinstance(
         _ => cls_ptr._hashable_identity(),
     };
 
-    let nonnull_name =
-        format!("ll_isinstance_const_nonnull_{class_identity}_{minid}_{maxid}");
+    let nonnull_name = format!("ll_isinstance_const_nonnull_{class_identity}_{minid}_{maxid}");
     let const_name = format!("ll_isinstance_const_{class_identity}_{minid}_{maxid}");
 
     // Mint the non-null helper first so the const helper's direct_call

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1436,17 +1436,16 @@ fn int_between_record(
         (r, c)
     } else {
         let b4 = ctx.trace_ctx.record_op(OpCode::IntSub, &[b2, b1]);
-        let b4_concrete =
-            if let (Some(majit_ir::Value::Int(v2)), Some(majit_ir::Value::Int(v1))) =
-                (ctx.trace_ctx.box_value(b2), ctx.trace_ctx.box_value(b1))
-            {
-                let folded = majit_metainterp::eval_binop_i(OpCode::IntSub, v2, v1);
-                ctx.trace_ctx
-                    .set_opref_concrete(b4, majit_ir::Value::Int(folded));
-                Some(folded)
-            } else {
-                None
-            };
+        let b4_concrete = if let (Some(majit_ir::Value::Int(v2)), Some(majit_ir::Value::Int(v1))) =
+            (ctx.trace_ctx.box_value(b2), ctx.trace_ctx.box_value(b1))
+        {
+            let folded = majit_metainterp::eval_binop_i(OpCode::IntSub, v2, v1);
+            ctx.trace_ctx
+                .set_opref_concrete(b4, majit_ir::Value::Int(folded));
+            Some(folded)
+        } else {
+            None
+        };
         let r = ctx.trace_ctx.record_op(OpCode::UintLt, &[b4, b5]);
         let c = if let (Some(v4), Some(v5)) = (b4_concrete, b5_concrete) {
             let folded = majit_metainterp::eval_binop_i(OpCode::UintLt, v4, v5);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1361,6 +1361,99 @@ fn binop_int_record(
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 
+/// RPython `pyjitpl.py:588-595 opimpl_int_between`:
+///
+/// ```python
+/// b5 = self.execute(rop.INT_SUB, b3, b1)
+/// if isinstance(b5, ConstInt) and b5.getint() == 1:
+///     # int_between(a, b, a+1) -> b == a
+///     return self.execute(rop.INT_EQ, b2, b1)
+/// else:
+///     b4 = self.execute(rop.INT_SUB, b2, b1)
+///     return self.execute(rop.UINT_LT, b4, b5)
+/// ```
+///
+/// Decomposes `int_between(b1, b2, b3)` — i.e. `b1 <= b2 < b3` — at
+/// record time, matching upstream's choice to emit elementary
+/// `INT_SUB`/`INT_EQ`/`UINT_LT` into the trace rather than relying on
+/// the optimizer to lower `INT_BETWEEN`.  The blackhole semantics
+/// (`blackhole.py:560-561 bhimpl_int_between(a, b, c): return a <= b
+/// < c`) are preserved through the same decomposition.
+///
+/// Operand layout `iii>i`: 3B sources + 1B dst (=4 operand bytes after
+/// the opcode).  Concrete-value propagation mirrors
+/// [`binop_int_record`]: every intermediate (`b4`, `b5`) and the final
+/// result get folded when their operand pair has a known
+/// `box_value(...)`.  This is what enables the `ConstInt(1)` fast path
+/// at line 590 — the walker sees the folded `b5` and emits `INT_EQ`
+/// instead of the generic `INT_SUB + UINT_LT` pair.
+fn int_between_record(
+    code: &[u8],
+    op: &DecodedOp,
+    ctx: &mut WalkContext<'_, '_>,
+) -> Result<(DispatchOutcome, usize), DispatchError> {
+    let b1 = read_int_reg(code, op, 0, ctx)?;
+    let b2 = read_int_reg(code, op, 1, ctx)?;
+    let b3 = read_int_reg(code, op, 2, ctx)?;
+
+    // b5 = INT_SUB(b3, b1)
+    let b5 = ctx.trace_ctx.record_op(OpCode::IntSub, &[b3, b1]);
+    let b5_concrete = if let (Some(majit_ir::Value::Int(v3)), Some(majit_ir::Value::Int(v1))) =
+        (ctx.trace_ctx.box_value(b3), ctx.trace_ctx.box_value(b1))
+    {
+        let folded = majit_metainterp::eval_binop_i(OpCode::IntSub, v3, v1);
+        ctx.trace_ctx
+            .set_opref_concrete(b5, majit_ir::Value::Int(folded));
+        Some(folded)
+    } else {
+        None
+    };
+
+    // pyjitpl.py:590 ConstInt(1) fast path emits INT_EQ; otherwise
+    // emit the generic INT_SUB + UINT_LT pair.
+    let (result, concrete) = if b5_concrete == Some(1) {
+        let r = ctx.trace_ctx.record_op(OpCode::IntEq, &[b2, b1]);
+        let c = if let (Some(majit_ir::Value::Int(va)), Some(majit_ir::Value::Int(vb))) =
+            (ctx.trace_ctx.box_value(b2), ctx.trace_ctx.box_value(b1))
+        {
+            let folded = majit_metainterp::eval_binop_i(OpCode::IntEq, va, vb);
+            ctx.trace_ctx
+                .set_opref_concrete(r, majit_ir::Value::Int(folded));
+            ConcreteValue::Int(folded)
+        } else {
+            ConcreteValue::Null
+        };
+        (r, c)
+    } else {
+        let b4 = ctx.trace_ctx.record_op(OpCode::IntSub, &[b2, b1]);
+        let b4_concrete =
+            if let (Some(majit_ir::Value::Int(v2)), Some(majit_ir::Value::Int(v1))) =
+                (ctx.trace_ctx.box_value(b2), ctx.trace_ctx.box_value(b1))
+            {
+                let folded = majit_metainterp::eval_binop_i(OpCode::IntSub, v2, v1);
+                ctx.trace_ctx
+                    .set_opref_concrete(b4, majit_ir::Value::Int(folded));
+                Some(folded)
+            } else {
+                None
+            };
+        let r = ctx.trace_ctx.record_op(OpCode::UintLt, &[b4, b5]);
+        let c = if let (Some(v4), Some(v5)) = (b4_concrete, b5_concrete) {
+            let folded = majit_metainterp::eval_binop_i(OpCode::UintLt, v4, v5);
+            ctx.trace_ctx
+                .set_opref_concrete(r, majit_ir::Value::Int(folded));
+            ConcreteValue::Int(folded)
+        } else {
+            ConcreteValue::Null
+        };
+        (r, c)
+    };
+
+    let dst = code[op.pc + 4] as usize;
+    write_int_reg(ctx, op.pc, dst, result, concrete)?;
+    Ok((DispatchOutcome::Continue, op.next_pc))
+}
+
 /// RPython `pyjitpl.py:597-617 opimpl_switch`:
 ///
 /// * read the traced value box and concrete `valuebox.getint()`
@@ -5310,6 +5403,12 @@ fn handle(
         // semantically a bool but Int-typed on the bank (matches the
         // codewriter's `>i` destination shape).
         "int_is_true/i>i" => unop_int_record(code, op, ctx, OpCode::IntIsTrue),
+        // `int_between/iii>i` decomposes a 3-arg range check at record
+        // time per `pyjitpl.py:588-595 opimpl_int_between` into
+        // `INT_SUB + (INT_EQ on ConstInt(1) fast path | INT_SUB +
+        // UINT_LT generic)`. Surfaces in `make_ll_isinstance`'s
+        // range-covering branch (`rclass.py:1149-1168`).
+        "int_between/iii>i" => int_between_record(code, op, ctx),
         // `int_floordiv/ii>i` and `int_mod/ii>i` intentionally absent:
         // `jtransform.py:575-577` rewrites both to
         // `direct_call(ll_int_py_*)` before jitcode emission.  The

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1396,71 +1396,68 @@ fn int_between_record(
     let b2 = read_int_reg(code, op, 1, ctx)?;
     let b3 = read_int_reg(code, op, 2, ctx)?;
 
-    // b5 = INT_SUB(b3, b1)
-    let b5 = ctx.trace_ctx.record_op(OpCode::IntSub, &[b3, b1]);
-    let b5_concrete = if let (Some(majit_ir::Value::Int(v3)), Some(majit_ir::Value::Int(v1))) =
-        (ctx.trace_ctx.box_value(b3), ctx.trace_ctx.box_value(b1))
-    {
-        let folded = majit_metainterp::eval_binop_i(OpCode::IntSub, v3, v1);
-        ctx.trace_ctx
-            .set_opref_concrete(b5, majit_ir::Value::Int(folded));
-        Some(folded)
+    // b5 = execute(INT_SUB, b3, b1)
+    let b5 = execute_pure_binop_i(ctx, OpCode::IntSub, b3, b1);
+
+    // pyjitpl.py:590 `if isinstance(b5, ConstInt) and b5.getint() == 1`
+    // — the `ConstInt(1)` fast path emits INT_EQ; otherwise the
+    // generic INT_SUB + UINT_LT pair.  `inline_const_to_value` returns
+    // `Some(_)` exactly when `b5` is an inline-Const OpRef, mirroring
+    // `isinstance(b5, ConstInt)`.
+    let result = if let Some(majit_ir::Value::Int(1)) = b5.inline_const_to_value() {
+        // execute(INT_EQ, b2, b1)
+        execute_pure_binop_i(ctx, OpCode::IntEq, b2, b1)
     } else {
-        None
+        // b4 = execute(INT_SUB, b2, b1); execute(UINT_LT, b4, b5)
+        let b4 = execute_pure_binop_i(ctx, OpCode::IntSub, b2, b1);
+        execute_pure_binop_i(ctx, OpCode::UintLt, b4, b5)
     };
 
-    // pyjitpl.py:590 ConstInt(1) fast path emits INT_EQ; otherwise
-    // emit the generic INT_SUB + UINT_LT pair.  Upstream gates the
-    // specialization on `isinstance(b5, ConstInt)` where
-    // `b5 = execute(rop.INT_SUB, b3, b1)` returns a `ConstInt` only
-    // when both inputs are themselves `ConstInt`; equivalently both
-    // `b3` and `b1` must be constant.  `box_value()` alone exposes
-    // any *observed* concrete value (including those riding on a
-    // non-Const OpRef that lacks a value guard), so checking it
-    // would specialize on a runtime sample without recording the
-    // `b3 - b1 == 1` guard — miscompiling future executions where
-    // the same boxes carry different live values.
-    let inputs_const = b1.is_constant() && b3.is_constant();
-    let (result, concrete) = if inputs_const && b5_concrete == Some(1) {
-        let r = ctx.trace_ctx.record_op(OpCode::IntEq, &[b2, b1]);
-        let c = if let (Some(majit_ir::Value::Int(va)), Some(majit_ir::Value::Int(vb))) =
-            (ctx.trace_ctx.box_value(b2), ctx.trace_ctx.box_value(b1))
-        {
-            let folded = majit_metainterp::eval_binop_i(OpCode::IntEq, va, vb);
-            ctx.trace_ctx
-                .set_opref_concrete(r, majit_ir::Value::Int(folded));
-            ConcreteValue::Int(folded)
-        } else {
-            ConcreteValue::Null
-        };
-        (r, c)
-    } else {
-        let b4 = ctx.trace_ctx.record_op(OpCode::IntSub, &[b2, b1]);
-        let b4_concrete = if let (Some(majit_ir::Value::Int(v2)), Some(majit_ir::Value::Int(v1))) =
-            (ctx.trace_ctx.box_value(b2), ctx.trace_ctx.box_value(b1))
-        {
-            let folded = majit_metainterp::eval_binop_i(OpCode::IntSub, v2, v1);
-            ctx.trace_ctx
-                .set_opref_concrete(b4, majit_ir::Value::Int(folded));
-            Some(folded)
-        } else {
-            None
-        };
-        let r = ctx.trace_ctx.record_op(OpCode::UintLt, &[b4, b5]);
-        let c = if let (Some(v4), Some(v5)) = (b4_concrete, b5_concrete) {
-            let folded = majit_metainterp::eval_binop_i(OpCode::UintLt, v4, v5);
-            ctx.trace_ctx
-                .set_opref_concrete(r, majit_ir::Value::Int(folded));
-            ConcreteValue::Int(folded)
-        } else {
-            ConcreteValue::Null
-        };
-        (r, c)
+    let concrete = match result.inline_const_to_value() {
+        Some(majit_ir::Value::Int(v)) => ConcreteValue::Int(v),
+        _ => match ctx.trace_ctx.box_value(result) {
+            Some(majit_ir::Value::Int(v)) => ConcreteValue::Int(v),
+            _ => ConcreteValue::Null,
+        },
     };
 
     let dst = code[op.pc + 4] as usize;
     write_int_reg(ctx, op.pc, dst, result, concrete)?;
     Ok((DispatchOutcome::Continue, op.next_pc))
+}
+
+/// `pyjitpl.py:2648-2662 execute_and_record` for pure integer binops.
+/// When both operands are inline-Const, fold to a `ConstInt` OpRef
+/// (no `record_op` call); otherwise record the op and stamp the
+/// observed concrete value if both sides have one.
+///
+/// PyPy's `execute_and_record` short-circuits `_record_helper` via
+/// `executor.wrap_constant(resvalue)` when `_all_constants(*argboxes)`
+/// holds for a pure opcode.  Mirroring that here keeps the trace
+/// free of all-constant subexpressions exactly where upstream keeps
+/// it free — `opimpl_int_between` chains three such pure binops.
+fn execute_pure_binop_i(
+    ctx: &mut WalkContext<'_, '_>,
+    opcode: OpCode,
+    a: OpRef,
+    b: OpRef,
+) -> OpRef {
+    if let (Some(majit_ir::Value::Int(va)), Some(majit_ir::Value::Int(vb))) =
+        (a.inline_const_to_value(), b.inline_const_to_value())
+    {
+        let folded = majit_metainterp::eval_binop_i(opcode, va, vb);
+        return ctx.trace_ctx.const_int(folded);
+    }
+
+    let result = ctx.trace_ctx.record_op(opcode, &[a, b]);
+    if let (Some(majit_ir::Value::Int(va)), Some(majit_ir::Value::Int(vb))) =
+        (ctx.trace_ctx.box_value(a), ctx.trace_ctx.box_value(b))
+    {
+        let folded = majit_metainterp::eval_binop_i(opcode, va, vb);
+        ctx.trace_ctx
+            .set_opref_concrete(result, majit_ir::Value::Int(folded));
+    }
+    result
 }
 
 /// RPython `pyjitpl.py:597-617 opimpl_switch`:
@@ -9143,52 +9140,61 @@ mod tests {
         (new_ops, dst_post, arg_b1)
     }
 
-    /// pyjitpl.py:588-595: when `b3 - b1 == 1` AND both inputs are
-    /// constants, the fast-path emits `INT_SUB` (for b5) + `INT_EQ`
-    /// — two ops total, no `UINT_LT`.
+    /// `pyjitpl.py:2648-2662 execute_and_record` — when every argbox
+    /// is `ConstInt`, a pure op like `INT_SUB` / `INT_EQ` is folded
+    /// via `wrap_constant` and never reaches `_record_helper`.
+    /// `opimpl_int_between(ConstInt, ConstInt, ConstInt)` chains three
+    /// pure binops on all-Const inputs, so 0 ops must be recorded and
+    /// the destination must hold the folded ConstInt result.
     #[test]
     fn int_between_const_inputs_with_unit_width_takes_inteq_fast_path() {
-        let (ops, _, _) = drive_int_between(
+        let (ops, dst_post, _) = drive_int_between(
             BetweenOperand::ConstInt(5),
             BetweenOperand::ConstInt(7),
             BetweenOperand::ConstInt(6),
         );
+        assert!(
+            ops.is_empty(),
+            "all-Const inputs must fold without recording — got {ops:?}",
+        );
+        // `b5 = 6 - 5 = 1` → fast path → `IntEq(b2=7, b1=5) = 0`.
         assert_eq!(
-            ops,
-            vec![majit_ir::OpCode::IntSub, majit_ir::OpCode::IntEq],
-            "ConstInt(1) fast path must record [IntSub(b5), IntEq] — got {ops:?}",
+            dst_post.inline_const_to_value(),
+            Some(majit_ir::Value::Int(0)),
+            "ConstInt(1) fast path on all-Const inputs must fold to ConstInt(0)",
         );
     }
 
-    /// pyjitpl.py:588-595 generic path: when the gate fails the
-    /// recorder emits `INT_SUB` (b5) + `INT_SUB` (b4) + `UINT_LT` —
-    /// three ops total.
+    /// All-Const generic path: `pyjitpl.py:2648-2662` folds the three
+    /// pure binops without recording.  Destination must carry the
+    /// folded UINT_LT result.
     #[test]
     fn int_between_const_inputs_with_wide_range_takes_uintlt_generic_path() {
-        let (ops, _, _) = drive_int_between(
+        let (ops, dst_post, _) = drive_int_between(
             BetweenOperand::ConstInt(5),
             BetweenOperand::ConstInt(7),
             BetweenOperand::ConstInt(10),
         );
+        assert!(
+            ops.is_empty(),
+            "all-Const inputs must fold without recording — got {ops:?}",
+        );
+        // `b5 = 10 - 5 = 5` (not 1) → generic → `b4 = 7 - 5 = 2`,
+        // `UintLt(2, 5) = 1`.
         assert_eq!(
-            ops,
-            vec![
-                majit_ir::OpCode::IntSub,
-                majit_ir::OpCode::IntSub,
-                majit_ir::OpCode::UintLt,
-            ],
-            "wide-range generic path must record [IntSub, IntSub, UintLt] — got {ops:?}",
+            dst_post.inline_const_to_value(),
+            Some(majit_ir::Value::Int(1)),
+            "wide-range path on all-Const inputs must fold to ConstInt(1)",
         );
     }
 
-    /// Regression for the missing `is_constant` gate: when `b1`/`b3`
-    /// are non-constant OpRefs with observed concrete values
-    /// satisfying `b3-b1==1`, the recorder must still take the
-    /// generic `INT_SUB + UINT_LT` path.  Specializing to `INT_EQ`
-    /// would bake a `b3-b1==1` invariant without a runtime guard
-    /// (`box_value` only reports the observed sample), miscompiling
-    /// any future execution where the same boxes carry different
-    /// live values.
+    /// Regression: when `b1`/`b3` are non-constant OpRefs with
+    /// observed concrete values satisfying `b3-b1==1`, the recorder
+    /// must still take the generic `INT_SUB + UINT_LT` path.
+    /// Specializing to `INT_EQ` would bake a `b3-b1==1` invariant
+    /// without a runtime guard (`box_value` only reports the observed
+    /// sample), miscompiling any future execution where the same
+    /// boxes carry different live values.
     #[test]
     fn int_between_non_const_inputs_observing_unit_width_takes_generic_path() {
         let (ops, _, _) = drive_int_between(
@@ -9197,13 +9203,14 @@ mod tests {
             BetweenOperand::NonConstWithConcrete(6),
         );
         assert_eq!(
-            ops.last(),
-            Some(&majit_ir::OpCode::UintLt),
-            "non-const inputs must NOT take INT_EQ fast path; expected UintLt tail — got {ops:?}",
-        );
-        assert!(
-            !ops.contains(&majit_ir::OpCode::IntEq),
-            "INT_EQ fast path is unguarded for non-Const inputs — got {ops:?}",
+            ops,
+            vec![
+                majit_ir::OpCode::IntSub,
+                majit_ir::OpCode::IntSub,
+                majit_ir::OpCode::UintLt,
+            ],
+            "non-const inputs must NOT take INT_EQ fast path; expected \
+             [IntSub(b5), IntSub(b4), UintLt] — got {ops:?}",
         );
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9060,6 +9060,154 @@ mod tests {
         drive_int_binop("int_ge/ii>i", majit_ir::OpCode::IntGe);
     }
 
+    /// Drive `int_between/iii>i` and return the recorded ops plus
+    /// the post-handler `dst` slot.  `inputs` describes how the
+    /// three operand slots are populated.
+    enum BetweenOperand {
+        ConstInt(i64),
+        NonConstWithConcrete(i64),
+    }
+
+    fn drive_int_between(
+        b1: BetweenOperand,
+        b2: BetweenOperand,
+        b3: BetweenOperand,
+    ) -> (Vec<majit_ir::OpCode>, OpRef, OpRef) {
+        // `int_between/iii>i` is recorder-side only (decomposed at
+        // record time) and is not currently emitted into pyre's
+        // pipeline.insns table, so `insns_opname_to_byte()` lacks
+        // a byte for it.  Call `int_between_record` directly with a
+        // synthetic `DecodedOp` to exercise the handler.  Operand
+        // layout: `[opcode, src1, src2, src3, dst]` — opcode byte is
+        // unused by the handler (PC offsets into `code` from `op.pc`).
+        let code = [0x00u8, 0x02, 0x04, 0x06, 0x08];
+        let op = crate::jitcode_runtime::DecodedOp {
+            key: "int_between/iii>i",
+            opname: "int_between",
+            argcodes: "iii>i",
+            pc: 0,
+            next_pc: 5,
+        };
+        let mut tc = fresh_trace_ctx();
+        let mut regs_i = distinct_const_refs(&mut tc, 16);
+        let mint = |tc: &mut TraceCtx, op: &BetweenOperand| match op {
+            BetweenOperand::ConstInt(v) => tc.const_int(*v),
+            BetweenOperand::NonConstWithConcrete(v) => {
+                // Materialize a non-Const OpRef by recording a placeholder
+                // op, then stamp its concrete value.  IntAdd with two
+                // ConstInts is a valid stand-in carrier.
+                let lhs = tc.const_int(0);
+                let opref = tc.record_op(majit_ir::OpCode::IntAdd, &[lhs, lhs]);
+                tc.set_opref_concrete(opref, majit_ir::Value::Int(*v));
+                opref
+            }
+        };
+        regs_i[2] = mint(&mut tc, &b1);
+        regs_i[4] = mint(&mut tc, &b2);
+        regs_i[6] = mint(&mut tc, &b3);
+        let arg_b1 = regs_i[2];
+        let descr = done_descr_ref_for_tests();
+        let ops_before = tc.num_ops();
+        let mut wc = WalkContext {
+            registers_r: &mut [],
+            registers_i: &mut regs_i,
+            registers_f: &mut [],
+            concrete_registers_r: &mut [],
+            concrete_registers_i: &mut [],
+            descr_refs: &[],
+            trace_ctx: &mut tc,
+            done_with_this_frame_descr_ref: descr,
+            done_with_this_frame_descr_int: make_fail_descr(101),
+            done_with_this_frame_descr_float: make_fail_descr(102),
+            done_with_this_frame_descr_void: make_fail_descr(103),
+            exit_frame_with_exception_descr_ref: make_fail_descr(2),
+            is_top_level: true,
+            sub_jitcode_lookup: &no_sub_jitcodes,
+            last_exc_value: None,
+            last_exc_value_concrete: ConcreteValue::Null,
+            entry_py_pc: 0,
+            outer_jitcode_index: 0,
+            outer_active_boxes: Vec::new(),
+        };
+        let (outcome, next_pc) = int_between_record(&code, &op, &mut wc)
+            .expect("int_between_record must dispatch");
+        assert_eq!(outcome, DispatchOutcome::Continue);
+        assert_eq!(next_pc, 5, "operand layout `iii>i` consumes 4 bytes");
+        let dst_post = wc.registers_i[8];
+        drop(wc);
+        let new_ops: Vec<majit_ir::OpCode> = tc
+            .ops()
+            .iter()
+            .skip(ops_before)
+            .map(|op| op.opcode)
+            .collect();
+        (new_ops, dst_post, arg_b1)
+    }
+
+    /// pyjitpl.py:588-595: when `b3 - b1 == 1` AND both inputs are
+    /// constants, the fast-path emits `INT_SUB` (for b5) + `INT_EQ`
+    /// — two ops total, no `UINT_LT`.
+    #[test]
+    fn int_between_const_inputs_with_unit_width_takes_inteq_fast_path() {
+        let (ops, _, _) = drive_int_between(
+            BetweenOperand::ConstInt(5),
+            BetweenOperand::ConstInt(7),
+            BetweenOperand::ConstInt(6),
+        );
+        assert_eq!(
+            ops,
+            vec![majit_ir::OpCode::IntSub, majit_ir::OpCode::IntEq],
+            "ConstInt(1) fast path must record [IntSub(b5), IntEq] — got {ops:?}",
+        );
+    }
+
+    /// pyjitpl.py:588-595 generic path: when the gate fails the
+    /// recorder emits `INT_SUB` (b5) + `INT_SUB` (b4) + `UINT_LT` —
+    /// three ops total.
+    #[test]
+    fn int_between_const_inputs_with_wide_range_takes_uintlt_generic_path() {
+        let (ops, _, _) = drive_int_between(
+            BetweenOperand::ConstInt(5),
+            BetweenOperand::ConstInt(7),
+            BetweenOperand::ConstInt(10),
+        );
+        assert_eq!(
+            ops,
+            vec![
+                majit_ir::OpCode::IntSub,
+                majit_ir::OpCode::IntSub,
+                majit_ir::OpCode::UintLt,
+            ],
+            "wide-range generic path must record [IntSub, IntSub, UintLt] — got {ops:?}",
+        );
+    }
+
+    /// Regression for the missing `is_constant` gate: when `b1`/`b3`
+    /// are non-constant OpRefs with observed concrete values
+    /// satisfying `b3-b1==1`, the recorder must still take the
+    /// generic `INT_SUB + UINT_LT` path.  Specializing to `INT_EQ`
+    /// would bake a `b3-b1==1` invariant without a runtime guard
+    /// (`box_value` only reports the observed sample), miscompiling
+    /// any future execution where the same boxes carry different
+    /// live values.
+    #[test]
+    fn int_between_non_const_inputs_observing_unit_width_takes_generic_path() {
+        let (ops, _, _) = drive_int_between(
+            BetweenOperand::NonConstWithConcrete(5),
+            BetweenOperand::NonConstWithConcrete(7),
+            BetweenOperand::NonConstWithConcrete(6),
+        );
+        assert_eq!(
+            ops.last(),
+            Some(&majit_ir::OpCode::UintLt),
+            "non-const inputs must NOT take INT_EQ fast path; expected UintLt tail — got {ops:?}",
+        );
+        assert!(
+            !ops.contains(&majit_ir::OpCode::IntEq),
+            "INT_EQ fast path is unguarded for non-Const inputs — got {ops:?}",
+        );
+    }
+
     /// Drive a single `float_<binop>/ff>f` handler. Same shape as
     /// `drive_int_binop` but on the float bank.
     fn drive_float_binop(opname: &str, expected_opcode: majit_ir::OpCode) {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1410,8 +1410,18 @@ fn int_between_record(
     };
 
     // pyjitpl.py:590 ConstInt(1) fast path emits INT_EQ; otherwise
-    // emit the generic INT_SUB + UINT_LT pair.
-    let (result, concrete) = if b5_concrete == Some(1) {
+    // emit the generic INT_SUB + UINT_LT pair.  Upstream gates the
+    // specialization on `isinstance(b5, ConstInt)` where
+    // `b5 = execute(rop.INT_SUB, b3, b1)` returns a `ConstInt` only
+    // when both inputs are themselves `ConstInt`; equivalently both
+    // `b3` and `b1` must be constant.  `box_value()` alone exposes
+    // any *observed* concrete value (including those riding on a
+    // non-Const OpRef that lacks a value guard), so checking it
+    // would specialize on a runtime sample without recording the
+    // `b3 - b1 == 1` guard — miscompiling future executions where
+    // the same boxes carry different live values.
+    let inputs_const = b1.is_constant() && b3.is_constant();
+    let (result, concrete) = if inputs_const && b5_concrete == Some(1) {
         let r = ctx.trace_ctx.record_op(OpCode::IntEq, &[b2, b1]);
         let c = if let (Some(majit_ir::Value::Int(va)), Some(majit_ir::Value::Int(vb))) =
             (ctx.trace_ctx.box_value(b2), ctx.trace_ctx.box_value(b1))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1381,12 +1381,16 @@ fn binop_int_record(
 /// < c`) are preserved through the same decomposition.
 ///
 /// Operand layout `iii>i`: 3B sources + 1B dst (=4 operand bytes after
-/// the opcode).  Concrete-value propagation mirrors
-/// [`binop_int_record`]: every intermediate (`b4`, `b5`) and the final
-/// result get folded when their operand pair has a known
-/// `box_value(...)`.  This is what enables the `ConstInt(1)` fast path
-/// at line 590 — the walker sees the folded `b5` and emits `INT_EQ`
-/// instead of the generic `INT_SUB + UINT_LT` pair.
+/// the opcode).  Concrete-value propagation in [`execute_pure_binop_i`]
+/// runs in two layers: all-inline-Const operand pairs fold to a
+/// `const_int(...)` OpRef without recording (matching upstream
+/// `_all_constants` short-circuit at `pyjitpl.py:2654-2660`); the
+/// trailing concrete-tracked-pair path additionally stamps the recorded
+/// op via `set_opref_concrete`.  The `ConstInt(1)` fast path at
+/// `pyjitpl.py:590` keys on the inline-Const layer through
+/// `inline_const_to_value`, mirroring `isinstance(b5, ConstInt)` —
+/// box_value's concrete-stamp layer does not participate in that
+/// branch decision.
 fn int_between_record(
     code: &[u8],
     op: &DecodedOp,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9129,8 +9129,8 @@ mod tests {
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
         };
-        let (outcome, next_pc) = int_between_record(&code, &op, &mut wc)
-            .expect("int_between_record must dispatch");
+        let (outcome, next_pc) =
+            int_between_record(&code, &op, &mut wc).expect("int_between_record must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
         assert_eq!(next_pc, 5, "operand layout `iii>i` consumes 4 bytes");
         let dst_post = wc.registers_i[8];

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -24,7 +24,7 @@ pub mod state;
 pub mod super_inst_expand;
 mod trace_opcode;
 pub use pyjitcode::{PyJitCode, PyJitCodeMetadata};
-pub use trace_opcode::production_walker_handles;
+pub use trace_opcode::{production_blackhole_handles, production_walker_handles};
 pub mod trace;
 pub mod virtualizable_gen;
 pub mod virtualizable_spec;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7704,6 +7704,26 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
     )
 }
 
+/// Phase 5.B dispatch-unification predicate (companion to
+/// `production_walker_handles`).
+///
+/// Walker-handled opcodes whose arm body contains a non-elidable
+/// `residual_call` (e.g. `store_subscr_fn`, `set_current_exception`)
+/// cannot use the vable-only fast path at `eval.rs:3111`: walker
+/// recording skips concrete execution of impure residual_calls, and
+/// `eval_loop_jit` then skips `execute_opcode_step`, so the heap
+/// mutation never happens.  This predicate names the opcodes for which
+/// `eval_loop_jit` instead runs the arm jitcode through
+/// `BlackholeInterpreter` (`dispatch_arm_via_blackhole`), matching
+/// RPython `pyjitpl.py:_interpret`'s single-interpreter loop.
+///
+/// Returns `false` for every opcode today.  Slice 1 wires the
+/// predicate into `eval.rs` as a structural branch point; subsequent
+/// slices add opcodes once `dispatch_arm_via_blackhole` lands.
+pub fn production_blackhole_handles(_instruction: &Instruction) -> bool {
+    false
+}
+
 /// Apply the symbolic-tracker side effects of a walker-handled opcode.
 ///
 /// The walker arm records IR ops for stack pushes/pops by walking the

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7875,9 +7875,6 @@ fn apply_walker_stack_effect(state: &mut MIFrame, instruction: &Instruction) {
         | Instruction::LoadAttr { .. }
         | Instruction::StoreAttr { .. }
         | Instruction::StoreFastStoreFast { .. }
-        | Instruction::PopExcept
-        | Instruction::PushExcInfo
-        | Instruction::PopTop
         | Instruction::PushNull => {
             // Non-zero stack delta. The walker arm's
             // `setfield_vable_i(valuestackdepth)` emit routes through

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7544,31 +7544,32 @@ unsafe fn trace_check_exc_match_against(
 /// parent-frame chain.  The trait impl will be removed once every opcode
 /// is in this set and the inline-frame snapshot gap is closed.
 ///
-/// Current status: the allow-list is deliberately empty.  The Nop
-/// family (`Nop`, `ExtendedArg`, `Resume`, `Cache`, `NotTaken`) should
-/// be the first zero-op production batch, but the generated arms still
-/// carry the synthetic `Ok(StepResult::Continue)` return wrapper as a
-/// `residual_call_r_r/iRd>r` with a symbolic function address instead
-/// of a real callable.  Enabling those arms in production can therefore
-/// emit an invalid `CallR` before any optimizer/backend choice is
-/// involved.  Re-enable this set only after the arm bytes decode to the
-/// real no-op shape (`ref_return/r ...`) without residual-call wrapper
-/// ops.
+/// The pre-jtransform unit-variant fold
+/// (`translator/rtyper/unit_variant_fold.rs::fold_unit_variant_ctors`)
+/// unblocked the Nop family by rewriting zero-arg
+/// `SyntheticTransparentCtor` calls (`StepResult::Continue`,
+/// `LoopResult::Done`, …) to `OpKind::ConstRef(prebuilt_instance)` on
+/// `model::FunctionGraph` before `Transformer::transform` runs.  Arm
+/// bytes then decode to the real no-op shape (`ref_return/r …`) without
+/// residual-call wrappers, so the Nop batch — plus every entry below —
+/// is safe to dispatch via walker today.
 ///
 /// Subsequent batches grow this set until it covers every Python
-/// opcode, at which point the trait infra is deleted.
+/// opcode.  The remaining wall is execution-side, not recording-side:
+/// `eval.rs:3111` skips `execute_opcode_step` for walker-handled
+/// opcodes, which is correct only when the arm body's heap effects ride
+/// `vable_setfield` / `setarrayitem_vable_r`.  Arms with non-elidable
+/// `residual_call`s (e.g. `store_subscr_fn`,
+/// `set_current_exception`) require the Phase 5.B dispatch-unification
+/// path (`production_blackhole_handles` + `dispatch_arm_via_blackhole`)
+/// before they can join this set.  The trait infra is deleted only
+/// after both predicates cover every opcode.
 ///
 pub fn production_walker_handles(instruction: &Instruction) -> bool {
-    // The pre-jtransform unit-variant fold
-    // (`translator/rtyper/unit_variant_fold.rs::fold_unit_variant_ctors`)
-    // rewrites zero-arg `SyntheticTransparentCtor` calls
-    // (`StepResult::Continue`, `LoopResult::Done`, …) to
-    // `OpKind::ConstRef(prebuilt_instance)` on `model::FunctionGraph`
-    // before `Transformer::transform` runs.  The assembler lowers
-    // `ConstRef` through the existing `ref_copy/r>r` path
-    // (`assembler.rs::emit_const_r`), so arm bytes decode to the real
-    // no-op shape and walker activation no longer encounters
-    // residual-call wrappers around unit variants.
+    // The unit-variant fold rewrites `StepResult::Continue` &c. to
+    // `ConstRef(prebuilt_instance)`; the assembler lowers `ConstRef`
+    // through `ref_copy/r>r` (`assembler.rs::emit_const_r`), so arms
+    // decode without residual-call wrappers around unit variants.
     matches!(
         instruction,
         Instruction::Nop

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3109,32 +3109,35 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         }
         let mut next_instr = frame.next_instr();
         let step_result = if walker_dispatched_this_opcode {
-            // Walker arm already advanced PyFrame via
-            // `synchronize_virtualizable`; skip the interpreter-side
-            // execute step to avoid double-mutation.  pc advancement
-            // already happened above via `set_last_instr_from_next_instr
-            // (opcode_pc + 1)`.
-            //
-            // Correct only when every state-mutating effect of the arm
-            // body rides a `vable_setfield` / `setarrayitem_vable_r`
-            // write whose `synchronize_virtualizable` propagates back to
-            // the heap PyFrame.  For arms calling non-elidable / side-
-            // effecting residual_calls (e.g. `store_subscr_fn`,
-            // `set_current_exception`), the heap mutation never happens
-            // here AND never happens during walker recording (gated by
-            // `check_is_elidable` in
-            // `jitcode_dispatch::execute_residual_call`).  Expanding
-            // `production_walker_handles` past the vable-only set
-            // requires the Phase 5.B dispatch-unification path:
-            // `production_blackhole_handles(instruction)` →
-            // `dispatch_arm_via_blackhole(frame, instruction)` which
-            // runs the arm jitcode through `BlackholeInterpreter` so
-            // non-elidable residual_calls actually execute (see
-            // `project_issue73_phase5b_prereq_2026_05_20.md`).  Neither
-            // function exists yet; the current set is the vable-only
-            // subset, and StoreSubscr et al. are intentionally
-            // excluded until Phase 5.B lands.
-            Ok(StepResult::Continue)
+            if pyre_jit_trace::production_blackhole_handles(&instruction) {
+                // Phase 5.B path: arm body contains a non-elidable
+                // `residual_call` (e.g. `store_subscr_fn`,
+                // `set_current_exception`) whose heap mutation walker
+                // recording skipped (`check_is_elidable` gate in
+                // `jitcode_dispatch::execute_residual_call`).  Run the
+                // arm jitcode through `BlackholeInterpreter` so the
+                // mutation actually happens, matching RPython
+                // `pyjitpl.py:_interpret`'s single-interpreter loop.
+                //
+                // `dispatch_arm_via_blackhole` lands in a follow-up
+                // slice (issue #73 Phase 5.B); the predicate returns
+                // `false` everywhere until then, so this arm is
+                // unreachable today.
+                unreachable!(
+                    "production_blackhole_handles must return false \
+                     until dispatch_arm_via_blackhole lands; \
+                     instruction={instruction:?}",
+                );
+            } else {
+                // Vable-only fast path: walker arm advanced PyFrame
+                // via `vable_setfield` / `setarrayitem_vable_r` →
+                // `synchronize_virtualizable` (trace_ctx.rs:1224-1265),
+                // which propagates the shadow back to the heap
+                // PyFrame.  Running `execute_opcode_step` here would
+                // double-mutate.  pc already advanced above via
+                // `set_last_instr_from_next_instr(opcode_pc + 1)`.
+                Ok(StepResult::Continue)
+            }
         } else {
             execute_opcode_step(frame, code, instruction, op_arg, next_instr)
         };

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3114,6 +3114,26 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             // execute step to avoid double-mutation.  pc advancement
             // already happened above via `set_last_instr_from_next_instr
             // (opcode_pc + 1)`.
+            //
+            // Correct only when every state-mutating effect of the arm
+            // body rides a `vable_setfield` / `setarrayitem_vable_r`
+            // write whose `synchronize_virtualizable` propagates back to
+            // the heap PyFrame.  For arms calling non-elidable / side-
+            // effecting residual_calls (e.g. `store_subscr_fn`,
+            // `set_current_exception`), the heap mutation never happens
+            // here AND never happens during walker recording (gated by
+            // `check_is_elidable` in
+            // `jitcode_dispatch::execute_residual_call`).  Expanding
+            // `production_walker_handles` past the vable-only set
+            // requires the Phase 5.B dispatch-unification path:
+            // `production_blackhole_handles(instruction)` →
+            // `dispatch_arm_via_blackhole(frame, instruction)` which
+            // runs the arm jitcode through `BlackholeInterpreter` so
+            // non-elidable residual_calls actually execute (see
+            // `project_issue73_phase5b_prereq_2026_05_20.md`).  Neither
+            // function exists yet; the current set is the vable-only
+            // subset, and StoreSubscr et al. are intentionally
+            // excluded until Phase 5.B lands.
             Ok(StepResult::Continue)
         } else {
             execute_opcode_step(frame, code, instruction, op_arg, next_instr)


### PR DESCRIPTION
Fix #122
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an instanceof/isinstance-style check with class-aware helpers and synthetic class targets.
  * Per-variable partial-merge paths and filtered framestate support for safer merges.

* **Bug Fixes**
  * Clearer, context-rich error when input annotations are missing.
  * Fail-fast validation of branch-condition types.

* **Improvements**
  * Better typed-integer constant recognition, optimized match/variant lowering, explicit int-is-zero handling, and optimized integer-range tracing.

* **Chores**
  * Pre-seeded exception-block inputs to avoid uninitialized annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->