### PR TITLE
Fix raise catch bridge gc barrier

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -430,14 +430,21 @@ impl MiniMarkGC {
     }
 
     /// Whether `addr` is a real old-gen object that may enter the remembered
-    /// set. Callers have already ruled out null and nursery addresses, so the
-    /// only other thing reaching here is a Box-allocated PyFrame: it carries a
-    /// GcHeader and TRACK_YOUNG_PTRS but is not GC-owned and must be excluded.
-    ///
-    /// Old-gen objects are the only ones tagged `OLDGEN_TRACKED` (set at every
-    /// old-gen allocation/promotion), so the test is an O(1) header read.
-    /// Reading the header is safe: the inline COND_CALL_GC_WB already loads the
-    /// flag byte from this same header before calling into the barrier.
+    /// set. Callers have already ruled out null and nursery addresses. Every
+    /// pointer that can still reach here carries a GcHeader, so `header_of` is
+    /// always a valid read — incminimark's "barrier only sees header-bearing
+    /// objects" invariant, upheld at allocation rather than by a membership
+    /// gate:
+    ///   - GC objects (nursery/old-gen): header from the GC allocator;
+    ///   - Box-allocated PyFrames: header from `GcPyFrame` / the
+    ///     `alloc_with_gc_header` prepend;
+    ///   - leaked `malloc_typed` host objects (dicts, cells, functions):
+    ///     header from `lltype::malloc_typed` -> `alloc_with_gc_header`.
+    /// Of these, only true old-gen objects are tagged `OLDGEN_TRACKED` (set at
+    /// every old-gen allocation/promotion); the rest carry a zeroed header and
+    /// are excluded. So the test is an O(1) header read, also safe under the
+    /// inline COND_CALL_GC_WB, which loads the flag byte from this same header
+    /// before calling into the barrier.
     ///
     /// The leading guard is a cheap defensive filter, not a membership test: a
     /// real GcRef payload is non-null, word-aligned, and well above the zero

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -134,6 +134,46 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
     (obj_addr - GcHeader::SIZE) as *mut GcHeader
 }
 
+/// Allocate a value of type `T` behind a leading zeroed [`GcHeader`] and
+/// return the payload pointer (`block + GcHeader::SIZE`).
+///
+/// Mirrors incminimark's `malloc_fixedsize`: reserve `size_gc_header + size`
+/// bytes, initialise the header at the block start
+/// (`init_gc_object(result, typeid, flags=0)`), and return
+/// `obj = result + size_gc_header`. The header is zeroed (`tid = 0`, all
+/// flags clear) so a write barrier reading `*(obj - SIZE)` sees
+/// `TRACK_YOUNG_PTRS = 0` / `OLDGEN_TRACKED = 0` and skips the object: it is
+/// immortal (leaked), not tracked by the nursery or old generation.
+///
+/// The allocation is intentionally leaked — these objects outlive every
+/// collection until the managed allocator takes them over. Callers MUST NOT
+/// `Box::from_raw` the result: it points past the header, not at the
+/// allocation base.
+///
+/// `T` must be word-aligned (`align_of::<T>() <= GcHeader::SIZE`), matching
+/// the fixed one-word header; a wider alignment would move the payload off
+/// the fixed `obj - SIZE` offset the barrier reads.
+pub fn alloc_with_gc_header<T>(value: T) -> *mut T {
+    debug_assert!(
+        std::mem::align_of::<T>() <= GcHeader::SIZE,
+        "object alignment exceeds GcHeader::SIZE; fixed header offset would break the write barrier",
+    );
+    let total = GcHeader::SIZE + std::mem::size_of::<T>();
+    let align = std::mem::align_of::<T>().max(GcHeader::SIZE);
+    let layout = std::alloc::Layout::from_size_align(total, align)
+        .expect("alloc_with_gc_header: invalid layout");
+    unsafe {
+        let raw = std::alloc::alloc(layout);
+        if raw.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+        (raw as *mut GcHeader).write(GcHeader::new(0));
+        let ptr = raw.add(GcHeader::SIZE) as *mut T;
+        ptr.write(value);
+        ptr
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +221,21 @@ mod tests {
     #[test]
     fn test_header_size() {
         assert_eq!(GcHeader::SIZE, 8);
+    }
+
+    #[test]
+    fn alloc_with_gc_header_prepends_zeroed_header() {
+        // Leaked intentionally — the managed/immortal allocation contract
+        // forbids freeing the returned payload pointer.
+        let p = alloc_with_gc_header(0xABCD_u64);
+        unsafe {
+            assert_eq!(*p, 0xABCD);
+            let hdr = header_of(p as usize);
+            // Zeroed header => barrier reads TRACK_YOUNG_PTRS=0 and skips.
+            assert_eq!((*hdr).tid_and_flags, 0);
+            assert!(!(*hdr).has_flag(flags::TRACK_YOUNG_PTRS));
+            assert!(!(*hdr).has_flag(flags::OLDGEN_TRACKED));
+        }
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -135,36 +135,13 @@ pub struct PyFrame {
 /// drift panics on startup.
 pub const PYFRAME_GC_TYPE_ID: u32 = 37;
 
-/// GC header size in bytes.  Matches `majit_gc::header::GcHeader::SIZE`.
-/// Every PyObjectArray and PyFrame allocation prepends this many zero bytes
-/// so that RPython-style write barriers (`*(obj + wb_byteofs) & mask`) read a
-/// valid header with `TRACK_YOUNG_PTRS=0` and skip the slow path.
-pub const GC_HEADER_SIZE: usize = 8;
-
-/// Allocate a value of type `T` with a zeroed GC header prepended.
-///
-/// incminimark write barrier reads at `obj - HEADER_SIZE`;
-/// zeroed header => `TRACK_YOUNG_PTRS` clear => barrier fast-path skips.
-///
-/// RPython objects are GC-managed references. The frame holds non-owning
-/// pointers; the GC (or, in pyre's simplified model, the allocator) owns
-/// the allocation. Never manually free pointers returned by this function
-/// from frame code — that would violate the GC ref contract and cause
-/// dangling pointers when the JIT captures these refs in snapshots.
-unsafe fn alloc_with_gc_header<T>(value: T) -> *mut T {
-    unsafe {
-        let total = GC_HEADER_SIZE + std::mem::size_of::<T>();
-        let align = std::mem::align_of::<T>().max(8);
-        let layout = std::alloc::Layout::from_size_align(total, align).unwrap();
-        let raw = std::alloc::alloc_zeroed(layout);
-        if raw.is_null() {
-            std::alloc::handle_alloc_error(layout);
-        }
-        let ptr = raw.add(GC_HEADER_SIZE) as *mut T;
-        std::ptr::write(ptr, value);
-        ptr
-    }
-}
+/// GC header size in bytes — single source of truth is
+/// [`majit_gc::header::GcHeader::SIZE`]. Every `FixedObjectArray` and
+/// `PyFrame` allocation prepends this many zero bytes so RPython-style
+/// write barriers (`*(obj + wb_byteofs) & mask`) read a valid header with
+/// `TRACK_YOUNG_PTRS=0` and skip the slow path. Scalar `value`
+/// allocations route through [`majit_gc::header::alloc_with_gc_header`].
+pub const GC_HEADER_SIZE: usize = majit_gc::header::GcHeader::SIZE;
 
 /// Allocation size (in bytes, including the GC header) for a
 /// `FixedObjectArray` of the given length.
@@ -182,8 +159,8 @@ fn fixed_array_layout(len: usize) -> std::alloc::Layout {
 
 /// Allocate a fixed-length GcArray-shaped `FixedObjectArray` with all
 /// slots initialised to `fill`. The allocation is prefixed with a
-/// zeroed GC header (same convention as [`alloc_with_gc_header`]) so the
-/// write barrier fast-path sees `TRACK_YOUNG_PTRS=0`.
+/// zeroed GC header ([`GC_HEADER_SIZE`] bytes) so the write barrier
+/// fast-path sees `TRACK_YOUNG_PTRS=0`.
 ///
 /// The returned pointer points at the length prefix; items follow
 /// immediately in memory at `FIXED_ARRAY_ITEMS_OFFSET` — matching

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -222,10 +222,11 @@ pub fn arena_global_info_dynasm() -> majit_backend_dynasm::JitFrameLayoutInfo {
 
 const ARENA_CAP: usize = 64;
 
-/// PyPy GcStruct layout: [GcHeader (8 bytes)] [struct fields].
+/// GcStruct layout: [GcHeader (8 bytes)] [struct fields].
 /// Every GC object (including PyFrame / W_Root) is prepended by a
 /// zeroed GcHeader. Arena slots and heap fallbacks match this layout.
-const GC_HEADER_SIZE: usize = 8;
+/// Single source of truth: [`majit_gc::header::GcHeader::SIZE`].
+const GC_HEADER_SIZE: usize = majit_gc::header::GcHeader::SIZE;
 
 /// Arena slot with prepended GcHeader (zeroed, layout parity only).
 #[repr(C)]

--- a/pyre/pyre-object/Cargo.toml
+++ b/pyre/pyre-object/Cargo.toml
@@ -9,6 +9,7 @@ description = "Python object model for pyre interpreter"
 [dependencies]
 malachite-bigint = { workspace = true }
 num-traits = { workspace = true }
+majit-gc = { workspace = true }
 majit-macros = { workspace = true }
 pyre-macros = { workspace = true }
 indexmap = { workspace = true }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -30,9 +30,15 @@
 //!    2026-04-25 review explicitly endorsed as an alternative to a
 //!    full structural GC transform.
 //!
-//! Current body: `Box::into_raw(Box::new(value))` — the pre-existing
-//! leak baseline. Future work routes through a GC-managed
-//! allocator with proper root push/pop.
+//! Current body: [`majit_gc::header::alloc_with_gc_header`] — the
+//! `malloc_fixedsize` analog that prepends a zeroed [`GcHeader`] and
+//! returns the payload pointer, so the write barrier reads a valid header
+//! (`TRACK_YOUNG_PTRS = 0`) and skips these still-leaked objects. The GC
+//! owns the header (incminimark defines its own `HDR`); the object model
+//! delegates and stays header-agnostic. Future work routes through the
+//! same allocator with nursery management and proper root push/pop.
+//!
+//! [`GcHeader`]: majit_gc::header::GcHeader
 
 /// Per-type GC metadata, mirroring the compile-time constants that
 /// RPython's `gct_fv_gc_malloc` (`framework.py:807-811`) closes over:
@@ -188,14 +194,16 @@ pub trait PyreClassPyTypeOf {
 /// adaptation of RPython's API to Rust's value-construction model.
 #[inline]
 pub fn malloc<T>(value: T) -> *mut T {
-    Box::into_raw(Box::new(value))
+    majit_gc::header::alloc_with_gc_header(value)
 }
 
 /// Typed variant of [`malloc`]: requires `T: GcType` so the future
 /// managed allocator can read `T::TYPE_ID` and `T::SIZE` without a
-/// runtime registry lookup. Current body identical to [`malloc`];
-/// will later route through the GC-managed allocator with proper
-/// `push_roots` / `pop_roots` brackets (`framework.py:853-856`).
+/// runtime registry lookup. Shares [`malloc`]'s body — the
+/// `alloc_with_gc_header` prepend — and will later route through the
+/// GC-managed allocator with proper `push_roots` / `pop_roots` brackets
+/// (`framework.py:853-856`), writing the real `T::TYPE_ID` into the
+/// header instead of the current zeroed placeholder.
 ///
 /// New call sites should prefer [`malloc_typed`] over [`malloc`]
 /// once their `T` has an assigned GC type id; the untyped variant
@@ -207,15 +215,19 @@ pub fn malloc_typed<T: GcType>(value: T) -> *mut T {
         T::SIZE,
         "GcType::SIZE drift from std::mem::size_of"
     );
-    Box::into_raw(Box::new(value))
+    majit_gc::header::alloc_with_gc_header(value)
 }
 
 /// `lltype.malloc(T, flavor='raw')` parity. Non-GC heap allocation;
 /// caller manages lifetime via `Box::from_raw` later.
 ///
-/// Distinct from [`malloc`] only in intent today (both call
-/// `Box::into_raw`); future GC integration will keep this on the
-/// raw allocator while [`malloc`] moves to the managed allocator.
+/// Unlike [`malloc`] / [`malloc_typed`] (which now prepend a [`GcHeader`]
+/// via `alloc_with_gc_header`), this stays a bare `Box::into_raw` with no
+/// header, so `Box::from_raw` on its output remains sound. Used for
+/// `String`s, dict `dstorage`, and other allocations that must NOT migrate
+/// to the managed allocator.
+///
+/// [`GcHeader`]: majit_gc::header::GcHeader
 #[inline]
 pub fn malloc_raw<T>(value: T) -> *mut T {
     Box::into_raw(Box::new(value))
@@ -244,6 +256,18 @@ mod tests {
         let p = malloc(42u32);
         unsafe {
             assert_eq!(*p, 42);
+        }
+    }
+
+    #[test]
+    fn malloc_prepends_zeroed_gc_header() {
+        let p = malloc(0x1234_5678_u64);
+        unsafe {
+            assert_eq!(*p, 0x1234_5678);
+            // A zeroed GcHeader precedes the payload, so the write barrier
+            // reads `*(obj - SIZE)` as TRACK_YOUNG_PTRS=0 and skips it.
+            let hdr = majit_gc::header::header_of(p as usize);
+            assert_eq!((*hdr).tid_and_flags, 0);
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/youknowone/pyre/issues/129


<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized managed-object layout so all GC-flavored allocations are prepended with a consistent, zero-initialized GC header and header size is unified across components.

* **Tests**
  * Added unit tests verifying allocations include the expected zeroed header and that tracking flags are unset.

* **Documentation**
  * Clarified comments describing which pointer sources reach the write barrier and the header assumptions relied upon by fast paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->