### PR TITLE
JIT: nbody residency — function-entry traces as entry bridges into compiled loops (both backends)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8700,26 +8700,43 @@ impl CraneliftBackend {
         // Box Identity Phase E.2b: route the loaded jitframe slot value
         // into the variable indexed by `inputargs[i].index` so bridge
         // entries land in the `[bridge_inputarg_base..)` slot the ops
-        // reference. Slots beyond `num_inputs` (synthesized loop padding
-        // / `entry_mode` flag) keep the dense `var(i)` mapping.
-        for (i, val) in entry_input_vals.iter().copied().enumerate() {
-            let slot = if i < num_inputs {
-                inputargs[i].index
-            } else {
-                i as u32
-            };
+        // reference.
+        //
+        // ONLY real input boxes (oprefs) become located Variables here. The
+        // loads beyond `num_inputs` — the body-direct padding (extra body
+        // LABEL args) and the `entry_mode` flag — are transient frame reads
+        // consumed directly from `entry_input_vals`: the dual-entry `brif`
+        // reads the flag at index `max_entry_inputs`, and the body-direct arm
+        // feeds `entry_input_vals[..body_direct_num_inputs]` straight into the
+        // body block parameters. They are not oprefs, so they must not enter
+        // the Variable namespace. Routing a non-opref index through `var()`
+        // takes its pre-declaration fallback `Variable::from_u32(i)`, whose
+        // raw index space overlaps the sequentially-declared opref Variables
+        // and `jf_ptr_var`. `jf_ptr_var` is declared immediately after the
+        // opref map, so its index equals the opref count; a small frame whose
+        // op set is just its inputs makes `max_entry_inputs` equal that index,
+        // and def_var'ing the flag then overwrites the frame pointer with the
+        // flag value (0 on a normal entry) — every later `use_var(jf_ptr_var)`
+        // reads NULL. This mirrors the RPython box-location discipline: only
+        // boxes have locations; the jitframe pointer register (EBP) is
+        // reserved and never shares a slot with a value.
+        for (i, val) in entry_input_vals
+            .iter()
+            .copied()
+            .take(num_inputs)
+            .enumerate()
+        {
+            let slot = inputargs[i].index;
             builder.def_var(var(slot), val);
-            if i < num_inputs {
-                sync_ref_root_var(
-                    &mut builder,
-                    jf_ptr,
-                    &ref_root_slots,
-                    slot,
-                    val,
-                    ref_root_base_ofs,
-                    &mut synced_ref_vars,
-                );
-            }
+            sync_ref_root_var(
+                &mut builder,
+                jf_ptr,
+                &ref_root_slots,
+                slot,
+                val,
+                ref_root_base_ofs,
+                &mut synced_ref_vars,
+            );
         }
 
         // RPython parity: GC roots are registered by run_compiled_code()

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4090,6 +4090,173 @@ fn op_var_index(op: &Op, op_idx: usize, num_inputs: usize) -> usize {
     }
 }
 
+/// Pure-data opcodes whose result is a deterministic function of their
+/// operands (field/array loads + address arithmetic).  These are the only
+/// ops the body-direct entry will REPLAY to reconstruct a loop invariant
+/// that Cranelift auto-promoted into a body-block param (see
+/// `plan_body_direct`).  Anything outside this set (calls, guards, stores,
+/// allocations, overflow arithmetic) makes the loop body-direct-ineligible
+/// so we keep the safe preamble-only entry.
+fn is_replayable_invariant(opcode: OpCode) -> bool {
+    matches!(
+        opcode,
+        OpCode::GetfieldGcI
+            | OpCode::GetfieldGcR
+            | OpCode::GetfieldGcF
+            | OpCode::GetfieldGcPureI
+            | OpCode::GetfieldGcPureR
+            | OpCode::GetfieldGcPureF
+            | OpCode::GetfieldRawI
+            | OpCode::GetfieldRawR
+            | OpCode::GetfieldRawF
+            | OpCode::GetarrayitemGcI
+            | OpCode::GetarrayitemGcR
+            | OpCode::GetarrayitemGcF
+            | OpCode::GetarrayitemGcPureI
+            | OpCode::GetarrayitemGcPureR
+            | OpCode::GetarrayitemGcPureF
+            | OpCode::GetarrayitemRawI
+            | OpCode::GetarrayitemRawF
+            | OpCode::GcLoadI
+            | OpCode::GcLoadR
+            | OpCode::GcLoadF
+            | OpCode::GcLoadIndexedI
+            | OpCode::GcLoadIndexedR
+            | OpCode::GcLoadIndexedF
+            | OpCode::IntAdd
+            | OpCode::IntSub
+            | OpCode::IntMul
+    )
+}
+
+/// Static plan for the cranelift body-direct entry (the nbody entry-bridge
+/// fix).  A peeled loop is emitted as `[entry LABEL] preamble [body LABEL]
+/// body`; the body LABEL block is reached only via the preamble's
+/// computed jump, so an entry-bridge/closing-jump that supplies the body
+/// LABEL's full arg set still gets routed through the preamble (function
+/// entry) which re-derives the loop state from the few preamble inputs —
+/// producing wrong/NULL loop-carried values.  Body-direct entry reads the
+/// body LABEL's args straight from the frame and jumps to the body block.
+///
+/// The complication: Cranelift auto-promotes loop invariants the preamble
+/// computed (a preamble op-result OpRef use_var'd in the body, or a
+/// preamble ref-root spilled in the body) into EXTRA body-block params
+/// beyond the IR LABEL arity.  The body-direct path must reconstruct those
+/// from the body LABEL args.  This plans which preamble ops to replay.
+///
+/// Returns None when the loop is not body-direct-eligible: not the canonical
+/// 2-LABEL peeled shape (>2 LABELs need general br_table dispatch), or an
+/// invariant depends on a non-replayable op.
+struct BodyDirectPlan {
+    /// body LABEL arg OpRef raws, in slot order (== body block param order).
+    body_arg_oprefs: Vec<u32>,
+    /// preamble op indices to replay, in definition (ascending) order.
+    replay_ops: Vec<usize>,
+}
+
+fn plan_body_direct(
+    ops: &[Op],
+    label_indices: &[usize],
+    num_inputs: usize,
+    ref_root_oprefs: &VecSet<u32>,
+) -> Option<BodyDirectPlan> {
+    // Only the canonical peeled shape: exactly two LABELs (entry LABEL +
+    // body header). Linear/single-LABEL traces have no preamble to bypass;
+    // >2 LABELs need the general per-LABEL br_table dispatch.
+    if label_indices.len() != 2 {
+        return None;
+    }
+    // Target the FIRST LABEL, not the body LABEL: the interp-origin entry
+    // bridge JUMPs to the loop's first LABEL and writes that LABEL's args to
+    // the frame (its `fail_arg_refs` == the first LABEL's arity). Entering
+    // there with the supplied args bypasses the peeled preamble that would
+    // otherwise re-derive them (the crash source). The ops preceding the
+    // first LABEL are that preamble; their results that the rest of the loop
+    // (LABEL block and after) use are the invariants Cranelift promotes onto
+    // the LABEL block and must be replayed from the supplied LABEL args.
+    let target_label_idx = label_indices[0];
+
+    let body_arg_oprefs: Vec<u32> = ops[target_label_idx]
+        .getarglist()
+        .iter()
+        .map(|a| a.to_opref().raw())
+        .collect();
+    let body_arg_set: VecSet<u32> = body_arg_oprefs.iter().copied().collect();
+
+    // result OpRef raw -> defining op idx, preamble portion only (ops before
+    // the first LABEL).
+    let mut def_idx: VecAssoc<u32, usize> = VecAssoc::new();
+    for (i, op) in ops.iter().enumerate().take(target_label_idx) {
+        if op.result_type() != Type::Void {
+            def_idx.insert(op_var_index(op, i, num_inputs) as u32, i);
+        }
+    }
+
+    // Seed = preamble-results use_var'd at/after the first LABEL: explicit
+    // args/failargs, plus preamble-result ref-roots (the GC-root spill
+    // use_var's them, so Cranelift promotes them too).
+    let mut seed: VecSet<u32> = VecSet::new();
+    let mut consider = |raw: u32, seed: &mut VecSet<u32>| {
+        if def_idx.contains_key(&raw) && !body_arg_set.contains(&raw) {
+            seed.insert(raw);
+        }
+    };
+    for (i, op) in ops.iter().enumerate() {
+        if i < target_label_idx {
+            continue;
+        }
+        for a in op.getarglist().iter() {
+            if !a.is_none() && !a.is_constant() {
+                consider(a.to_opref().raw(), &mut seed);
+            }
+        }
+        for a in op.getfailargs().into_iter().flatten() {
+            if !a.is_none() && !a.is_constant() {
+                consider(a.to_opref().raw(), &mut seed);
+            }
+        }
+    }
+    for &raw in ref_root_oprefs.iter() {
+        consider(raw, &mut seed);
+    }
+
+    // Close under dependencies; verify each replayed op is pure.
+    let mut replay_set: VecSet<u32> = VecSet::new();
+    let mut stack: Vec<u32> = seed.iter().copied().collect();
+    while let Some(raw) = stack.pop() {
+        if replay_set.contains(&raw) {
+            continue;
+        }
+        let Some(&i) = def_idx.get(&raw) else {
+            continue;
+        };
+        if !is_replayable_invariant(ops[i].opcode) {
+            return None;
+        }
+        replay_set.insert(raw);
+        for a in ops[i].getarglist().iter() {
+            if a.is_none() || a.is_constant() {
+                continue;
+            }
+            let ar = a.to_opref().raw();
+            if def_idx.contains_key(&ar) && !body_arg_set.contains(&ar) && !replay_set.contains(&ar)
+            {
+                stack.push(ar);
+            }
+        }
+    }
+
+    let mut replay_ops: Vec<usize> = replay_set
+        .iter()
+        .filter_map(|raw| def_idx.get(raw).copied())
+        .collect();
+    replay_ops.sort_unstable();
+    Some(BodyDirectPlan {
+        body_arg_oprefs,
+        replay_ops,
+    })
+}
+
 /// rewrite.py:397-407 `optimize_GUARD_CLASS` parity:
 /// Pre-flight check that the OpRefs feeding pointer-dereferencing
 /// guard ops are bound to a defined value. RPython's box-identity
@@ -6148,6 +6315,22 @@ fn emit_guard_exit(
         let enabled = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
             && std::env::var_os("PYRE_CL_NO_CLOSING_JUMP").is_none();
         if enabled {
+            // Body-direct entry (nbody entry-bridge fix): set the target's
+            // entry_mode discriminator so its block0 reads the first LABEL's
+            // args from the frame and jumps straight to that LABEL block,
+            // bypassing the peeled preamble. The discriminator slot is just
+            // past this JUMP's fail_args; for an entry-bridge JUMP the source
+            // arg count equals the target's first-LABEL arity, which is the
+            // slot the target reads entry_mode from (= max_entry_inputs). A
+            // normal execute_token entry leaves that slot zero-filled
+            // (entry_mode == 0 -> preamble). When the target loop has no
+            // body-direct entry compiled, this store lands in an unused slot
+            // it never reads.
+            let one = builder.ins().iconst(cl_types::I64, 1);
+            let disc_ofs = JF_FRAME_ITEM0_OFS + (info.fail_arg_refs.len() as i32) * 8;
+            builder
+                .ins()
+                .store(MemFlags::trusted(), one, jf_ptr, disc_ofs);
             emit_attached_loop_dispatch(
                 builder,
                 jf_ptr,
@@ -6783,9 +6966,15 @@ fn run_compiled_code_inner(
         });
         unsafe {
             // jitframe.py:48 parity: zero the header so jf_descr starts
-            // as NULL (GuardNotForced checks jf_descr != 0).
-            // RPython's nursery allocation zeros memory; ours may not.
-            std::ptr::write_bytes(gcref.0 as *mut u8, 0, JF_FRAME_ITEM0_OFS as usize);
+            // as NULL (GuardNotForced checks jf_descr != 0), and zero the item
+            // slots too. RPython's nursery allocation hands back zeroed memory
+            // (zeroed once per nursery reset); ours does not, so a fresh frame
+            // must be cleared here. The body-direct dual entry relies on it:
+            // its entry_mode discriminator lives at frame slot max_entry_inputs,
+            // and a normal execute_token entry (which only writes num_inputs
+            // slots) must read 0 there to take the preamble arm rather than a
+            // stale value from a recycled slot.
+            std::ptr::write_bytes(gcref.0 as *mut u8, 0, payload_bytes);
             *((gcref.0 + JF_FRAME_LENGTH_OFS as usize) as *mut usize) = frame_depth;
         }
         (gcref, None)
@@ -8288,8 +8477,22 @@ impl CraneliftBackend {
             }
         }
 
-        // Body-direct entry disabled — requires bridge to provide full body args.
-        let body_direct_num_inputs = 0;
+        // Body-direct entry (nbody entry-bridge fix): give a peeled loop a
+        // second entry that reads the first LABEL's full arg set from the
+        // frame and jumps straight to that LABEL block, bypassing the peeled
+        // preamble that block0 would otherwise run to re-derive those args
+        // (the source of the entry-bridge re-entry crash). Eligible only for
+        // the canonical 2-LABEL peeled shape with purely-replayable invariants
+        // (see plan_body_direct); otherwise None and the loop keeps its single
+        // preamble entry. The discriminator that selects this entry is written
+        // only by the entry-bridge/closing-jump path, so when no bridge
+        // targets this loop the body-direct arm stays dead.
+        let ref_root_oprefs: VecSet<u32> = ref_root_slots.iter().map(|(raw, _)| *raw).collect();
+        let body_direct_plan: Option<BodyDirectPlan> =
+            plan_body_direct(ops, &label_indices, num_inputs, &ref_root_oprefs);
+        let body_direct_num_inputs = body_direct_plan
+            .as_ref()
+            .map_or(0, |p| p.body_arg_oprefs.len());
 
         // Collect all variable declarations into a map (index -> type)
         // before declaring them sequentially. Cranelift 0.130 declare_var
@@ -8604,45 +8807,261 @@ impl CraneliftBackend {
                 // entry_mode == 0 → preamble, entry_mode != 0 → body-direct.
                 // brif directly targets label blocks with their params.
                 let entry_mode = entry_input_vals[max_entry_inputs];
-                let body_block = label_blocks.last().unwrap().1;
+                // Target the FIRST LABEL block: the entry bridge supplies that
+                // LABEL's args (slots 0..arity) and writes entry_mode just past
+                // them, so a body-direct entry jumps there and lets the loop
+                // run forward (peeled preamble bypassed). plan_body_direct keys
+                // on label_indices[0], so body_direct_num_inputs == this
+                // block's IR arity and the entry_mode read slot == the bridge's
+                // write slot (fail_arg_refs.len()).
+                let body_block = entry_label_block;
+
+                // Dual entry: branch on entry_mode. The invariant replay below
+                // dereferences the body LABEL args carried in entry_input_vals
+                // (frame slots), which only hold live values on a body-direct
+                // (entry_mode != 0) entry — on a normal execute_token entry
+                // those slots are zero, so the replay loads would NULL-deref.
+                // Emit the replay in a dedicated body-direct block reached only
+                // when entry_mode != 0; the preamble arm branches to a
+                // continuation the main op loop fills. entry_input_vals are
+                // defined in the dominating entry block, so both successors can
+                // use them directly. Seal each (single predecessor = this
+                // brif) so their use_var resolves through the entry block
+                // instead of promoting block params.
+                let body_direct_block = builder.create_block();
+                let preamble_cont = builder.create_block();
+                builder
+                    .ins()
+                    .brif(entry_mode, body_direct_block, &[], preamble_cont, &[]);
+                builder.switch_to_block(body_direct_block);
+                builder.seal_block(body_direct_block);
+
+                // Reconstruct the loop invariants Cranelift auto-promotes into
+                // body-block params (a preamble op-result use_var'd in the
+                // body, or a preamble ref-root spilled there). REPLAYED here
+                // from the body LABEL args via a local value map; def_var so
+                // FunctionBuilder fills body_block's promoted params from this
+                // predecessor. plan_body_direct guaranteed every replay op is a
+                // pure load / address arithmetic whose operands are body LABEL
+                // args, inputs, constants, or earlier replays.
+                let plan = body_direct_plan
+                    .as_ref()
+                    .expect("body_direct plan present when body_direct_num_inputs > 0");
+                let mut bd_slot: VecAssoc<u32, usize> = VecAssoc::new();
+                for (i, ia) in inputargs.iter().enumerate() {
+                    bd_slot.insert(ia.index, i);
+                }
+                for (slot, &raw) in plan.body_arg_oprefs.iter().enumerate() {
+                    bd_slot.insert(raw, slot);
+                }
+                let mut bd_mat: VecAssoc<u32, CValue> = VecAssoc::new();
+                for &rop_idx in &plan.replay_ops {
+                    let rop = &ops[rop_idx];
+                    let rvi = op_var_index(rop, rop_idx, num_inputs) as u32;
+                    let resolve = |builder: &mut FunctionBuilder,
+                                   bd_mat: &VecAssoc<u32, CValue>,
+                                   opref: OpRef|
+                     -> CValue {
+                        if let Some(c) = lookup_const_i64(&constants, opref) {
+                            return builder.ins().iconst(cl_types::I64, c);
+                        }
+                        if let Some(&v) = bd_mat.get(&opref.raw()) {
+                            return v;
+                        }
+                        if let Some(&slot) = bd_slot.get(&opref.raw()) {
+                            return entry_input_vals[slot];
+                        }
+                        panic!(
+                            "body-direct replay: unresolved opref {} (op {:?})",
+                            opref.raw(),
+                            rop.opcode
+                        );
+                    };
+                    let value = match rop.opcode {
+                        OpCode::GetfieldGcI
+                        | OpCode::GetfieldGcR
+                        | OpCode::GetfieldGcF
+                        | OpCode::GetfieldGcPureI
+                        | OpCode::GetfieldGcPureR
+                        | OpCode::GetfieldGcPureF
+                        | OpCode::GetfieldRawI
+                        | OpCode::GetfieldRawR
+                        | OpCode::GetfieldRawF => {
+                            let descr = rop.getdescr().expect("getfield op must have a descriptor");
+                            let fd = descr
+                                .as_field_descr()
+                                .expect("getfield descriptor must be a FieldDescr");
+                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
+                            let addr = builder.ins().iadd_imm(base, fd.offset() as i64);
+                            emit_load_from_addr(
+                                &mut builder,
+                                addr,
+                                fd.field_type(),
+                                fd.field_size(),
+                                fd.is_field_signed(),
+                                rop.opcode,
+                            )?
+                        }
+                        OpCode::GetarrayitemGcI
+                        | OpCode::GetarrayitemGcR
+                        | OpCode::GetarrayitemGcF
+                        | OpCode::GetarrayitemGcPureI
+                        | OpCode::GetarrayitemGcPureR
+                        | OpCode::GetarrayitemGcPureF
+                        | OpCode::GetarrayitemRawI
+                        | OpCode::GetarrayitemRawF => {
+                            let descr = rop
+                                .getdescr()
+                                .expect("getarrayitem op must have a descriptor");
+                            let ad = descr
+                                .as_array_descr()
+                                .expect("getarrayitem descriptor must be an ArrayDescr");
+                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
+                            let index = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
+                            let scale = ad.item_size() as i64;
+                            let scaled = match scale {
+                                0 => builder.ins().iconst(cl_types::I64, 0),
+                                1 => index,
+                                _ => {
+                                    let s = builder.ins().iconst(cl_types::I64, scale);
+                                    builder.ins().imul(index, s)
+                                }
+                            };
+                            let bo = ad.base_size() as i64;
+                            let off = if bo == 0 {
+                                scaled
+                            } else {
+                                builder.ins().iadd_imm(scaled, bo)
+                            };
+                            let addr = builder.ins().iadd(base, off);
+                            let signed = ad.item_type() == Type::Int && ad.is_item_signed();
+                            emit_load_from_addr(
+                                &mut builder,
+                                addr,
+                                ad.item_type(),
+                                ad.item_size(),
+                                signed,
+                                rop.opcode,
+                            )?
+                        }
+                        OpCode::GcLoadI | OpCode::GcLoadR | OpCode::GcLoadF => {
+                            let item_size = resolve_constant_i64(
+                                &constants,
+                                &known_values,
+                                rop.opcode,
+                                rop.arg(2).to_opref(),
+                                "GC_LOAD itemsize",
+                            )?;
+                            let value_type = match rop.opcode {
+                                OpCode::GcLoadI => Type::Int,
+                                OpCode::GcLoadR => Type::Ref,
+                                _ => Type::Float,
+                            };
+                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
+                            let offset = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
+                            let addr = builder.ins().iadd(base, offset);
+                            emit_load_from_addr(
+                                &mut builder,
+                                addr,
+                                value_type,
+                                item_size.unsigned_abs() as usize,
+                                item_size < 0,
+                                rop.opcode,
+                            )?
+                        }
+                        OpCode::GcLoadIndexedI
+                        | OpCode::GcLoadIndexedR
+                        | OpCode::GcLoadIndexedF => {
+                            let scale = resolve_constant_i64(
+                                &constants,
+                                &known_values,
+                                rop.opcode,
+                                rop.arg(2).to_opref(),
+                                "GC_LOAD_INDEXED scale",
+                            )?;
+                            let base_offset = resolve_constant_i64(
+                                &constants,
+                                &known_values,
+                                rop.opcode,
+                                rop.arg(3).to_opref(),
+                                "GC_LOAD_INDEXED base offset",
+                            )?;
+                            let item_size = resolve_constant_i64(
+                                &constants,
+                                &known_values,
+                                rop.opcode,
+                                rop.arg(4).to_opref(),
+                                "GC_LOAD_INDEXED itemsize",
+                            )?;
+                            let value_type = match rop.opcode {
+                                OpCode::GcLoadIndexedI => Type::Int,
+                                OpCode::GcLoadIndexedR => Type::Ref,
+                                _ => Type::Float,
+                            };
+                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
+                            let index = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
+                            let scaled = match scale {
+                                0 => builder.ins().iconst(cl_types::I64, 0),
+                                1 => index,
+                                _ => {
+                                    let s = builder.ins().iconst(cl_types::I64, scale);
+                                    builder.ins().imul(index, s)
+                                }
+                            };
+                            let off = if base_offset == 0 {
+                                scaled
+                            } else {
+                                builder.ins().iadd_imm(scaled, base_offset)
+                            };
+                            let addr = builder.ins().iadd(base, off);
+                            emit_load_from_addr(
+                                &mut builder,
+                                addr,
+                                value_type,
+                                item_size.unsigned_abs() as usize,
+                                item_size < 0,
+                                rop.opcode,
+                            )?
+                        }
+                        OpCode::IntAdd => {
+                            let a = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
+                            let b = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
+                            builder.ins().iadd(a, b)
+                        }
+                        OpCode::IntSub => {
+                            let a = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
+                            let b = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
+                            builder.ins().isub(a, b)
+                        }
+                        OpCode::IntMul => {
+                            let a = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
+                            let b = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
+                            builder.ins().imul(a, b)
+                        }
+                        other => {
+                            unreachable!("plan_body_direct admitted non-replayable op {other:?}")
+                        }
+                    };
+                    bd_mat.insert(rvi, value);
+                    builder.def_var(var(rvi), value);
+                }
 
                 let body_args = block_args_to(
                     &mut builder,
                     body_block,
                     &entry_input_vals[..body_direct_num_inputs],
                 );
-                let preamble_args = block_args_to(
-                    &mut builder,
-                    entry_label_block,
-                    &entry_input_vals[..num_inputs],
-                );
-                builder.ins().brif(
-                    entry_mode,
-                    body_block,
-                    &body_args,
-                    entry_label_block,
-                    &preamble_args,
-                );
+                builder.ins().jump(body_block, &body_args);
 
-                // Continue with preamble label block for var binding
-                builder.switch_to_block(entry_label_block);
-                for (i, arg_ref) in ops[entry_label_idx].getarglist().iter().enumerate() {
-                    let param = builder.block_params(entry_label_block)[i];
-                    if !arg_ref.is_none() {
-                        builder.def_var(var(arg_ref.to_opref().raw()), param);
-                        let cur_jf = builder.use_var(jf_ptr_var);
-                        sync_ref_root_var(
-                            &mut builder,
-                            cur_jf,
-                            &ref_root_slots,
-                            arg_ref.to_opref().raw(),
-                            param,
-                            ref_root_base_ofs,
-                            &mut synced_ref_vars,
-                        );
-                    }
-                }
-                first_label_entered_at_entry = true;
+                // Preamble arm (entry_mode == 0): the first LABEL is NOT the
+                // function entry — its params are the peeled-preamble results
+                // computed by the ops preceding the LABEL. The main op-emission
+                // loop emits the preamble in preamble_cont and jumps to the
+                // first LABEL with all resolved args when it reaches the LABEL
+                // op. first_label_entered_at_entry stays false so the main loop
+                // owns that jump + binding.
+                builder.switch_to_block(preamble_cont);
+                builder.seal_block(preamble_cont);
             } else if has_entry_label {
                 let vals: Vec<CValue> = entry_input_vals.clone();
                 let args = block_args_to(&mut builder, entry_label_block, &vals);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6318,19 +6318,30 @@ fn emit_guard_exit(
             // Body-direct entry (nbody entry-bridge fix): set the target's
             // entry_mode discriminator so its block0 reads the first LABEL's
             // args from the frame and jumps straight to that LABEL block,
-            // bypassing the peeled preamble. The discriminator slot is just
-            // past this JUMP's fail_args; for an entry-bridge JUMP the source
-            // arg count equals the target's first-LABEL arity, which is the
-            // slot the target reads entry_mode from (= max_entry_inputs). A
-            // normal execute_token entry leaves that slot zero-filled
-            // (entry_mode == 0 -> preamble). When the target loop has no
-            // body-direct entry compiled, this store lands in an unused slot
-            // it never reads.
-            let one = builder.ins().iconst(cl_types::I64, 1);
-            let disc_ofs = JF_FRAME_ITEM0_OFS + (info.fail_arg_refs.len() as i32) * 8;
-            builder
-                .ins()
-                .store(MemFlags::trusted(), one, jf_ptr, disc_ofs);
+            // bypassing the peeled preamble. A normal execute_token entry leaves
+            // the slot zero-filled (entry_mode == 0 -> preamble).
+            //
+            // The discriminator lives at slot `fail_arg_refs.len()` (= the
+            // target's `max_entry_inputs` for an entry-bridge JUMP, the slot its
+            // body-direct prologue reads the flag from). A loop only has a
+            // body-direct entry when it carries loop-body ops past its LABEL, so
+            // that slot always sits strictly below `max_output_slots` — a genuine
+            // output slot, in bounds and below the ref-root region at
+            // `[max_output_slots, max_output_slots + num_ref_roots)`. When the
+            // slot reaches `max_output_slots` the target has no body-direct entry
+            // to read it; storing there would overrun the frame (no ref roots) or
+            // clobber a GC ref root, so skip the write. `max_output_slots` is
+            // recovered from `ref_root_base_ofs = JF_FRAME_ITEM0_OFS +
+            // max_output_slots * 8`.
+            let disc_slot = info.fail_arg_refs.len();
+            let max_output_slots = ((ref_root_base_ofs - JF_FRAME_ITEM0_OFS) / 8) as usize;
+            if disc_slot < max_output_slots {
+                let one = builder.ins().iconst(cl_types::I64, 1);
+                let disc_ofs = JF_FRAME_ITEM0_OFS + (disc_slot as i32) * 8;
+                builder
+                    .ins()
+                    .store(MemFlags::trusted(), one, jf_ptr, disc_ofs);
+            }
             emit_attached_loop_dispatch(
                 builder,
                 jf_ptr,

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8690,7 +8690,20 @@ impl CraneliftBackend {
         });
 
         let max_entry_inputs = num_inputs.max(body_direct_num_inputs);
-        let load_count = if body_direct_num_inputs > 0 {
+        // The dual-entry prologue loads the body LABEL args from frame slots
+        // `[0, body_direct_num_inputs)` and an `entry_mode` discriminator from
+        // slot `max_entry_inputs`. Those reads are in-bounds only while the
+        // highest one stays inside the frame payload `[0, max_output_slots +
+        // num_ref_roots)` (output slots followed by ref roots; see
+        // run_compiled_code_inner). A peeled loop whose first-LABEL arity
+        // exceeds the payload (large loop-carried set, few guard fail-args /
+        // ref roots) would read past the frame. Emit the body-direct entry
+        // only when the discriminator slot is in-bounds; otherwise fall back to
+        // the single preamble entry (entry_mode == 0). For typical loops the
+        // discriminator lands in the ref-root region, well within the payload.
+        let body_direct_entry = body_direct_num_inputs > 0
+            && max_entry_inputs < max_output_slots + ref_root_slots.len();
+        let load_count = if body_direct_entry {
             max_entry_inputs + 1 // extra slot for entry_mode flag
         } else {
             num_inputs
@@ -8830,7 +8843,7 @@ impl CraneliftBackend {
 
         let mut first_label_entered_at_entry = false;
         if let Some(&(entry_label_idx, entry_label_block)) = label_blocks.first() {
-            if body_direct_num_inputs > 0 && label_blocks.len() >= 2 {
+            if body_direct_entry && label_blocks.len() >= 2 {
                 // Dual entry: branch on entry_mode (last input slot).
                 // entry_mode == 0 → preamble, entry_mode != 0 → body-direct.
                 // brif directly targets label blocks with their params.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1160,8 +1160,30 @@ impl<S: JitState> JitDriver<S> {
 
     /// ResumeFromInterpDescr parity: data needed to compile an entry bridge
     /// from the currently active trace.
+    ///
+    /// Returns `Some` only for a function-entry trace (`header_pc == 0`, the
+    /// interpreter portal into the function). An entry bridge runs the
+    /// function prologue and closes with a JUMP into an already-compiled hot
+    /// loop. A trace rooted at a *loop header* (`header_pc != 0`) returns
+    /// `None`: closing it as an entry bridge into another loop would drop its
+    /// own back-edge, so its iterations would no longer run in compiled code
+    /// (the caller then falls back to compile_loop, which aborts cleanly).
     pub fn compile_trace_entry_data(&mut self) -> Option<(u64, S::Meta)> {
-        let original_green_key = self.meta.trace_ctx().map(|ctx| ctx.root_green_key())?;
+        // The interp-origin entry bridge closes by redirecting the function's
+        // entry into the compiled loop (compile_entry_bridge's
+        // redirect_call_assembler). The cranelift backend's preamble
+        // entry-mode calling convention does not yet accept a function-entry
+        // preamble entry from a redirected call, so the entry bridge is wired
+        // for dynasm only; on cranelift this returns None and the caller falls
+        // back to compile_loop (baseline behavior).
+        if cfg!(feature = "cranelift") {
+            return None;
+        }
+        let original_green_key = self
+            .meta
+            .trace_ctx()
+            .filter(|ctx| ctx.header_pc == 0)
+            .map(|ctx| ctx.root_green_key())?;
         let trace_meta = self.meta.trace_meta()?.clone();
         Some((original_green_key, trace_meta))
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1169,16 +1169,13 @@ impl<S: JitState> JitDriver<S> {
     /// own back-edge, so its iterations would no longer run in compiled code
     /// (the caller then falls back to compile_loop, which aborts cleanly).
     pub fn compile_trace_entry_data(&mut self) -> Option<(u64, S::Meta)> {
-        // The interp-origin entry bridge closes by redirecting the function's
-        // entry into the compiled loop (compile_entry_bridge's
-        // redirect_call_assembler). The cranelift backend's preamble
-        // entry-mode calling convention does not yet accept a function-entry
-        // preamble entry from a redirected call, so the entry bridge is wired
-        // for dynasm only; on cranelift this returns None and the caller falls
-        // back to compile_loop (baseline behavior).
-        if cfg!(feature = "cranelift") {
-            return None;
-        }
+        // Only a function-entry trace (header_pc == 0) closes as an entry
+        // bridge into an already-compiled hot loop. Both backends use this
+        // gate: dynasm jumps directly to the target LABEL via target_arglocs;
+        // cranelift's body-direct dual entry (compiler.rs) reads the LABEL
+        // args from the frame and jumps past the peeled preamble. A
+        // loop-header trace (header_pc != 0) returns None and the caller falls
+        // back to compile_loop, so its back-edge is never dropped.
         let original_green_key = self
             .meta
             .trace_ctx()

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -8891,6 +8891,24 @@ impl<M: Clone> MetaInterp<M> {
                     }
                     return false;
                 }
+                // unroll.py:119-123 `except SpeculativeError: raise InvalidLoop`
+                // — same as compile_bridge: optimize_bridge has no
+                // with_speculative_to_invalid_loop wrapper, so a speculative
+                // heap access proven ill-typed in a function-entry bridge must
+                // be caught here; otherwise the SpeculativeError re-unwinds past
+                // the extern "C" frames and aborts the process.
+                if payload
+                    .downcast_ref::<crate::optimize::SpeculativeError>()
+                    .is_some()
+                {
+                    if crate::majit_log_enabled() {
+                        eprintln!(
+                            "[jit] compile_entry_bridge: SpeculativeError->InvalidLoop target={} original={}",
+                            green_key, original_green_key
+                        );
+                    }
+                    return false;
+                }
                 std::panic::resume_unwind(payload);
             }
         };

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -5498,6 +5498,13 @@ impl<M: Clone> MetaInterp<M> {
         original_green_key: u64,
         entry_meta: M,
     ) -> CompileOutcome {
+        // ResumeFromInterpDescr.get_resumestorage() is None — an interp-origin
+        // entry bridge has no source-guard fail_args. Clear any pending
+        // frontend_boxes left by a previous guard-failure bridge (set at the
+        // guard-exit path) so they do not leak into this bridge's optimize and
+        // trip the bridgeopt.py:126 `len(frontend_boxes) == len(liveboxes)`
+        // assertion against the entry bridge's own inputargs.
+        self.pending_frontend_boxes = None;
         self.compile_trace_inner(
             green_key,
             finish_args,
@@ -8264,9 +8271,17 @@ impl<M: Clone> MetaInterp<M> {
     /// `is_invalidated` AND here.
     #[inline]
     pub fn has_compiled_loop(&self, green_key: u64) -> bool {
+        // warmstate.py:482-511 maybe_compile_and_run gates execution entry on
+        // `cell.get_procedure_token() is not None` (code present), NOT on
+        // has_compiled_targets. An entry bridge (ResumeFromInterpDescr) has
+        // compiled code but may carry 0 target_tokens; gating on
+        // has_target_tokens() refused to dispatch it, so the interp re-ticked
+        // the green key every back-edge -> bound_reached -> decay_all_counters
+        // flood that starved the guard-failure bridge counter. Gate on
+        // has_compiled_code() so a code-present token is entered directly.
         self.warm_state
             .get_procedure_token(green_key)
-            .map_or(false, |token| token.has_target_tokens())
+            .map_or(false, |token| token.has_compiled_code())
     }
 
     /// Check if any guard in the compiled trace has Float-typed fail_args.
@@ -9050,20 +9065,19 @@ impl<M: Clone> MetaInterp<M> {
                     },
                 );
 
+                // The entry bridge ends in a JUMP into `green_key`'s compiled
+                // loop, so it inherits THAT loop's TargetTokens (compile.py:286-296).
+                // `green_key` is guaranteed compiled (checked at the top). The
+                // prior logic inherited from `original_green_key` and fell back to
+                // an empty list when origin != target, leaving a cross-loop entry
+                // bridge (interp origin uncompiled, distinct from the compiled
+                // target) with no target tokens — hence non-dispatchable
+                // (has_compiled_loop stays false -> no nbody residency win).
                 let front_target_tokens = self
                     .compiled_loops
-                    .get(&original_green_key)
+                    .get(&green_key)
                     .map(|c| c.front_target_tokens.clone())
-                    .unwrap_or_else(|| {
-                        if original_green_key == green_key {
-                            self.compiled_loops
-                                .get(&green_key)
-                                .map(|c| c.front_target_tokens.clone())
-                                .unwrap_or_default()
-                        } else {
-                            Vec::new()
-                        }
-                    });
+                    .unwrap_or_default();
                 // `compile.py:286-296` — the bridge's destination JCT inherits
                 // the loop's TargetTokens.  Mirror them onto
                 // `JitCellToken.target_tokens` so `has_compiled_targets`

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -9438,6 +9438,25 @@ impl<M: Clone> MetaInterp<M> {
                     }
                     return false;
                 }
+                // unroll.py:119-123 `except SpeculativeError: raise InvalidLoop`
+                // — a speculative heap access proven ill-typed discards the
+                // trace exactly like InvalidLoop. The loop path converts at the
+                // optimize boundary (with_speculative_to_invalid_loop); the
+                // bridge path has no such wrapper, so without this the
+                // SpeculativeError re-unwinds past the extern "C" bh_call_r
+                // frames and aborts the process.
+                if payload
+                    .downcast_ref::<crate::optimize::SpeculativeError>()
+                    .is_some()
+                {
+                    if crate::majit_log_enabled() {
+                        eprintln!(
+                            "[jit] compile_bridge: SpeculativeError->InvalidLoop at key={} fail_index={}",
+                            green_key, fail_index
+                        );
+                    }
+                    return false;
+                }
                 std::panic::resume_unwind(payload);
             }
         };

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -640,7 +640,7 @@ pub fn trace_unbox_int(
     // unit tests (`pyre/pyre-jit/src/trace_verify.rs`) the GuardClass is
     // recorded with no resume context; the test asserts only on the
     // emitted opcode shape.
-    if !ctx.heap_cache().is_class_known(obj) {
+    if !obj.is_constant() && !ctx.heap_cache().is_class_known(obj) {
         let type_const = ctx.const_int(int_type_addr);
         ctx.record_guard_typed(OpCode::GuardClass, &[obj, type_const], Vec::new());
         ctx.heap_cache_mut()
@@ -861,7 +861,7 @@ pub fn trace_unbox_float(
     floatval_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
     use majit_ir::OpCode;
-    if !ctx.heap_cache().is_class_known(obj) {
+    if !obj.is_constant() && !ctx.heap_cache().is_class_known(obj) {
         let type_const = ctx.const_int(float_type_addr);
         ctx.record_guard_typed(OpCode::GuardClass, &[obj, type_const], Vec::new());
         ctx.heap_cache_mut()

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -377,7 +377,16 @@ class Check:
                 print("─── cargo stderr ───")
                 print(proc.stderr.rstrip())
             print("────────────────────")
-            self._print_cargo_diagnostics(cargo_path)
+            if "no LLBC source resolved" in (proc.stderr or ""):
+                # The JIT front-end has no MIR to lower because build/llbc/
+                # is empty. This is a setup step, not a toolchain fault — the
+                # rustup diagnostics below would be noise, so point at the
+                # producer instead.
+                print(red("LLBC artefacts are missing under build/llbc/."))
+                print("Run the extractor first, then re-run this script:")
+                print("    scripts/extract-llbc.sh")
+            else:
+                self._print_cargo_diagnostics(cargo_path)
             sys.exit(1)
         lines = (proc.stdout or "").strip().splitlines() + (proc.stderr or "").strip().splitlines()
         if lines:

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -400,9 +400,14 @@ impl PyreMetaInterp {
                         return false;
                     };
                     let ccode = unsafe { &*pyre_interpreter::pyframe_get_pycode(&**cf) };
-                    // exceptiontable offsets are byte offsets; the concrete
-                    // frame's next_instr is an instruction-word index (×2).
-                    let byte_off = (cf.next_instr() as u32).saturating_mul(2);
+                    // A suspended caller's concrete `next_instr` was advanced
+                    // past the CALL before its callee was pushed, so probe the
+                    // saved CALL site (`call_site_pc`) — mirroring
+                    // `finishframe_exception`. Frames with no outstanding inline
+                    // call fall back to `next_instr`. exceptiontable offsets are
+                    // byte offsets; the pc is an instruction-word index (×2).
+                    let lookup_pc = f.call_site_pc.unwrap_or_else(|| cf.next_instr());
+                    let byte_off = (lookup_pc as u32).saturating_mul(2);
                     pyre_interpreter::exception_table::lookup_exceptiontable(
                         &ccode.exceptiontable,
                         byte_off,

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -369,7 +369,47 @@ impl PyreMetaInterp {
                     .filter(|f| f.jitcode == top_jitcode)
                     .count()
                     >= 2;
-                if !is_recursive_chain {
+                // Skip the catch-up while any frame in the inline chain is
+                // executing inside an active exception-handler (try) range. A
+                // fused-compare catch-up lets an inlined callee proceed in the
+                // trace; if a later op in that callee raises, the exception
+                // unwinds into a CALLER's inlined except handler, and the
+                // blackhole resume of an inlined-callee raise into a caller
+                // catch-landing is malformed (the catch_exception target skips
+                // the landing's last_exc_value op, so the bound exception value
+                // reads NULL). Until that resume path is fixed, keep the prior
+                // graceful-abort behavior for these: the inline trace aborts,
+                // the callee stays a residual call, and the exception path runs
+                // correctly. Hot loops without active try blocks (the catch-up's
+                // intended target) are unaffected.
+                //
+                // TODO: fix the underlying blackhole/codewriter defect so this
+                // gate can be removed and try-protected callees inline too. When
+                // an inlined callee raises into a caller's inlined except, the
+                // resume catch-landing's `catch_exception` target resolves PAST
+                // the landing's `last_exc_value` op (op 90 never executes), so
+                // the bound exception value reads NULL. RPython sidesteps this
+                // because the raising block carries `exitswitch=c_last_exception`
+                // (its exception edges are non-trivial graph links); pyre models
+                // the catch as a byte-level `catch_exception/L`, NOT a graph
+                // link, so the trivial-link / inline-resume passes skip it. The
+                // proper fix emits/positions `last_exc_value` so the inlined
+                // catch target lands on it, restoring inlining for these.
+                let in_exception_handler = self.framestack.iter().any(|f| {
+                    let Some(ref cf) = f.owned_concrete_frame else {
+                        return false;
+                    };
+                    let ccode = unsafe { &*pyre_interpreter::pyframe_get_pycode(&**cf) };
+                    // exceptiontable offsets are byte offsets; the concrete
+                    // frame's next_instr is an instruction-word index (×2).
+                    let byte_off = (cf.next_instr() as u32).saturating_mul(2);
+                    pyre_interpreter::exception_table::lookup_exceptiontable(
+                        &ccode.exceptiontable,
+                        byte_off,
+                    )
+                    .is_some()
+                });
+                if !is_recursive_chain && !in_exception_handler {
                     let mut guard = 0u32;
                     loop {
                         let top = self.framestack.last_mut().unwrap();

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -335,6 +335,70 @@ impl PyreMetaInterp {
                     .unwrap_or_else(|| semantic_fallthrough_pc(code, pc));
                 // Concrete execution step
                 self.concrete_execute_step();
+                // Fused-compare concrete catch-up. A fused COMPARE+POP_JUMP
+                // (try_fused_compare_goto_if_not) records one branch guard and
+                // advances the symbolic pc PAST the POP_JUMP in a single trace
+                // step, but the concrete_execute_step above ran only the
+                // COMPARE. The inline-frame pc is read from the concrete
+                // frame's next_instr (interpret()), so leaving the concrete
+                // frame at the POP_JUMP re-steps the already-consumed branch
+                // (stack underflow during trace opcode → graceful abort,
+                // blocking inline tracing through the compare). Drive the
+                // concrete frame through the POP_JUMP — its concrete branch
+                // lands at the same `next_target` the fused step chose — until
+                // it reaches the symbolic pc. Trivia is positioned-past as
+                // interpret()'s prelude does (Cache/ExtendedArg/Nop/NotTaken,
+                // NOT Resume); only a real opcode strictly before the target
+                // (the fused POP_JUMP) is executed.
+                //
+                // Gated to NON-recursive inline frames. The catch-up is
+                // correct on its own (a non-recursive inlined callee with a
+                // compare traces cleanly with it), but letting a *recursive*
+                // inline chain proceed past the compare exposes a separate,
+                // pre-existing bug in the recursion-unroll machinery (the
+                // compiled trace fails to terminate). Until that is fixed,
+                // recursive inline frames keep the old behavior — the fused
+                // compare desyncs and the inline trace aborts gracefully, so
+                // recursion still JITs via the CALL_ASSEMBLER self-recursion
+                // path. `jitcode` appearing 2+ times on the framestack marks a
+                // recursive chain.
+                let top_jitcode = self.framestack.last().unwrap().jitcode;
+                let is_recursive_chain = self
+                    .framestack
+                    .iter()
+                    .filter(|f| f.jitcode == top_jitcode)
+                    .count()
+                    >= 2;
+                if !is_recursive_chain {
+                    let mut guard = 0u32;
+                    loop {
+                        let top = self.framestack.last_mut().unwrap();
+                        let target = top.pc;
+                        let Some(cf) = top.owned_concrete_frame.as_mut() else {
+                            break;
+                        };
+                        let ccode = unsafe { &*pyre_interpreter::pyframe_get_pycode(&**cf) };
+                        let mut ni = cf.next_instr();
+                        while ni < target {
+                            match pyre_interpreter::decode_instruction_at(ccode, ni) {
+                                Some((
+                                    Instruction::Cache
+                                    | Instruction::ExtendedArg
+                                    | Instruction::Nop
+                                    | Instruction::NotTaken,
+                                    _,
+                                )) => ni += 1,
+                                _ => break,
+                            }
+                        }
+                        cf.set_last_instr_from_next_instr(ni);
+                        if ni >= target || guard >= 16 {
+                            break;
+                        }
+                        self.concrete_execute_step();
+                        guard += 1;
+                    }
+                }
                 LoopAction::Continue
             }
             super::state::InlineTraceStepAction::Trace(TraceAction::Finish {

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
@@ -47,12 +47,50 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
                     .map(|b| (b.trace_id, b.fail_index));
                 let has_targets = driver.meta_interp().has_compiled_targets(back_edge_key);
                 if !has_partial && has_targets {
-                    let outcome = driver.meta_interp_mut().compile_trace(
-                        back_edge_key,
-                        &live_args,
-                        bridge_origin,
-                    );
-                    if matches!(outcome, majit_metainterp::CompileOutcome::Compiled { .. }) {
+                    let outcome = match bridge_origin {
+                        // Guard-origin: existing bridge path.
+                        Some(_) => Some(driver.meta_interp_mut().compile_trace(
+                            back_edge_key,
+                            &live_args,
+                            bridge_origin,
+                        )),
+                        // pyjitpl.py:3003-3007 interp-origin: close the trace as
+                        // an entry bridge (ResumeFromInterpDescr) jumping into the
+                        // already-compiled loop at `back_edge_key`, instead of
+                        // falling through to compile_loop -> has_compiled_targets
+                        // -> SwitchToBlackhole(ABORT_BAD_LOOP). compile_and_attach
+                        // installs an entry bridge ending in a JUMP to the target
+                        // loop (compile.py:1002-1021).
+                        None => {
+                            // `compile_trace_entry_data` returns `Some` only for
+                            // a function-entry trace (ResumeFromInterpDescr: the
+                            // interpreter portal into the function). Such a trace
+                            // runs the function prologue and closes with a JUMP
+                            // into the already-compiled hot loop at
+                            // `back_edge_key`. A trace rooted at a *loop header*
+                            // returns `None` here and falls through to
+                            // compile_loop, which aborts cleanly — closing one
+                            // loop header as an entry bridge into another would
+                            // drop the outer loop's back-edge (its iterations
+                            // would no longer run in compiled code).
+                            match driver.compile_trace_entry_data() {
+                                Some((original_green_key, entry_meta)) => {
+                                    Some(driver.meta_interp_mut().compile_trace_from_interp(
+                                        back_edge_key,
+                                        &live_args,
+                                        original_green_key,
+                                        entry_meta,
+                                    ))
+                                }
+                                None => Some(driver.meta_interp_mut().compile_trace(
+                                    back_edge_key,
+                                    &live_args,
+                                    None,
+                                )),
+                            }
+                        }
+                    };
+                    if matches!(outcome, Some(majit_metainterp::CompileOutcome::Compiled { .. })) {
                         if majit_metainterp::majit_log_enabled() {
                             eprintln!(
                                 "[jit][reached_loop_header] compile_trace success: key={} pc={} bridge={:?}",

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -534,12 +534,50 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
                     .map(|b| (b.trace_id, b.fail_index));
                 let has_targets = driver.meta_interp().has_compiled_targets(back_edge_key);
                 if !has_partial && has_targets {
-                    let outcome = driver.meta_interp_mut().compile_trace(
-                        back_edge_key,
-                        &live_args,
-                        bridge_origin,
-                    );
-                    if matches!(outcome, majit_metainterp::CompileOutcome::Compiled { .. }) {
+                    let outcome = match bridge_origin {
+                        // Guard-origin: existing bridge path.
+                        Some(_) => Some(driver.meta_interp_mut().compile_trace(
+                            back_edge_key,
+                            &live_args,
+                            bridge_origin,
+                        )),
+                        // pyjitpl.py:3003-3007 interp-origin: close the trace as
+                        // an entry bridge (ResumeFromInterpDescr) jumping into the
+                        // already-compiled loop at `back_edge_key`, instead of
+                        // falling through to compile_loop -> has_compiled_targets
+                        // -> SwitchToBlackhole(ABORT_BAD_LOOP). compile_and_attach
+                        // installs an entry bridge ending in a JUMP to the target
+                        // loop (compile.py:1002-1021).
+                        None => {
+                            // `compile_trace_entry_data` returns `Some` only for
+                            // a function-entry trace (ResumeFromInterpDescr: the
+                            // interpreter portal into the function). Such a trace
+                            // runs the function prologue and closes with a JUMP
+                            // into the already-compiled hot loop at
+                            // `back_edge_key`. A trace rooted at a *loop header*
+                            // returns `None` here and falls through to
+                            // compile_loop, which aborts cleanly — closing one
+                            // loop header as an entry bridge into another would
+                            // drop the outer loop's back-edge (its iterations
+                            // would no longer run in compiled code).
+                            match driver.compile_trace_entry_data() {
+                                Some((original_green_key, entry_meta)) => {
+                                    Some(driver.meta_interp_mut().compile_trace_from_interp(
+                                        back_edge_key,
+                                        &live_args,
+                                        original_green_key,
+                                        entry_meta,
+                                    ))
+                                }
+                                None => Some(driver.meta_interp_mut().compile_trace(
+                                    back_edge_key,
+                                    &live_args,
+                                    None,
+                                )),
+                            }
+                        }
+                    };
+                    if matches!(outcome, Some(majit_metainterp::CompileOutcome::Compiled { .. })) {
                         if majit_metainterp::majit_log_enabled() {
                             eprintln!(
                                 "[jit][reached_loop_header] compile_trace success: key={} pc={} bridge={:?}",


### PR DESCRIPTION
Fix #128 

## Summary

Lands the nbody JIT-residency epic — a hot function whose body contains a loop now stays in compiled code instead of falling back to the interpreter on each call.

- Close interpreter-origin **function-entry** traces (`header_pc == 0`) as entry bridges that redirect into the already-compiled loop, on **both** dynasm and cranelift (cranelift gains a first-label body-direct dual-entry).
- Drive the inlined callee's concrete frame through a fused `COMPARE`+`POP_JUMP` so a callee can be traced into its caller instead of staying a residual call.
- Skip orphan `GuardClass` on constant operands; discard a bridge on `SpeculativeError` (optimizer const-skip / panic-safety).
- Fix `synth/exceptions` "binary op on null operand": gate the fused-compare catch-up off while any inline frame is inside an active try range, so a try-protected callee reverts to a residual call (correct exception resume).

check.py 41/41 on both backends. The entry-bridge gate is function-entry only by design — redirecting a loop-header trace would drop its back-edge (guard storm / hang). Branch also carries the accumulated majit / Charon-MIR front-end foundation since the last `main` sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected trace/entry-bridge selection to avoid dropping loop back-edges.
  * Prevented stale frontend state from leaking into new bridges; improved bridge-failure handling for speculative errors.
  * Adjusted guard emission to avoid treating constant objects as unknown.

* **Performance**
  * Enabled a new body-direct loop entry path to reduce overhead and replay invariant computations when safe.
  * Improved inline-frame execution catch-up for fused compare/jump sequences.

* **Chores**
  * Improved build failure messaging to guide missing artefact recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->