### PR TITLE
walker concrete-execute for non-elidable residual_calls + Phase 5.B body wire

### DIFF
--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -816,6 +816,67 @@ pub fn execute_pure_call(
     }
 }
 
+/// `executor.execute_varargs` parity for the walker layer, simplified
+/// for callers that do not hold a `MetaInterp` (record-time concrete
+/// execution of residual_calls).
+///
+/// PyPy upstream (`rpython/jit/metainterp/pyjitpl.py:1995-2126`
+/// `do_residual_call`) calls `executor.execute_varargs(opnum,
+/// argboxes, descr, exc=can_raise, pure=is_elidable)` for every
+/// residual_call regardless of EI branch — concrete execution always
+/// runs at trace-record time, only the recorded opcode kind and the
+/// post-call guard emission differ.  See `select_residual_call_opcode`
+/// (`pyre-jit-trace/src/jitcode_dispatch.rs`) for the per-EI-branch
+/// inventory.
+///
+/// The walker has no `MetaInterp` to thread; instead it owns a
+/// `WalkContext.last_exc_value` shadow.  This function therefore
+/// returns the BH_LAST_EXC_VALUE seam value via `Result::Err` so the
+/// caller can write it into the walker's exc shadow + emit
+/// `GUARD_NO_EXCEPTION`, mirroring upstream's
+/// `metainterp.execute_raised(bh_exc, constant=False)` +
+/// `handle_possible_exception` flow.
+///
+/// Differences from `execute_varargs`:
+///   * No `MetaInterp` argument; caller handles exception state.
+///   * No `cond_call` / `cond_call_value` dispatch — residual_call
+///     opcodes are not cond-call variants.
+///   * Returns `Result<i64, i64>` instead of side-effecting
+///     `metainterp.execute_raised`.
+///
+/// Differences from `execute_pure_call`:
+///   * No `is_elidable + cannot_raise` debug_assert.
+///   * Clears BH_LAST_EXC_VALUE before dispatch (`execute_pure_call`
+///     does not because elidable_cannot_raise cannot raise).
+pub fn execute_residual_call(
+    descr: &dyn majit_ir::descr::CallDescr,
+    func_ptr: i64,
+    args: &[i64],
+) -> Result<i64, i64> {
+    crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+    let func_ptr = func_ptr as *const ();
+    let result = match descr.result_type() {
+        majit_ir::Type::Int | majit_ir::Type::Ref => {
+            crate::pyjitpl::call_int_function(func_ptr, args)
+        }
+        majit_ir::Type::Void => {
+            crate::pyjitpl::call_void_function(func_ptr, args);
+            0
+        }
+        // See `execute_varargs`'s Float arm for the i64-bits ABI
+        // rationale: `#[jit_module]` Float helpers expose
+        // `concrete_ptr` as `extern "C" fn(...) -> i64` with the f64
+        // pre-packed via `f64::to_bits`.
+        majit_ir::Type::Float => crate::pyjitpl::call_int_function(func_ptr, args),
+    };
+    let bh_exc = crate::blackhole::BH_LAST_EXC_VALUE.with(|c| {
+        let v = c.get();
+        c.set(0);
+        v
+    });
+    if bh_exc != 0 { Err(bh_exc) } else { Ok(result) }
+}
+
 #[cfg(test)]
 mod execute_pure_call_tests {
     use super::*;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3514,6 +3514,24 @@ fn try_execute_residual_call_via_executor(
         Some(majit_ir::Value::Int(addr)) => addr,
         _ => return None,
     };
+    // Sub-slice 4 safety gate — reject `symbolic_fnaddr_for_path`
+    // placeholder values that escaped runtime patching.  Pyre's
+    // codewriter mints a 64-bit hash of the helper's `CallPath` when
+    // the build-time `pyre_interpreter::jit_trace_fnaddrs()` snapshot
+    // has no entry for it (`majit-translate/src/jit_codewriter/call.rs:
+    // 4926 symbolic_fnaddr_for_path`).  `runtime_fnaddr_patch` rewrites
+    // these to real runtime addresses only when the path appears in
+    // both the build-time and runtime registries; helpers absent from
+    // the runtime registry retain the hash and dereferencing it as a
+    // code address SIGBUSes.  Valid user-space code addresses fit in
+    // 47 bits on macOS/Linux 64-bit (canonical low half); hash values
+    // typically have bits ≥ 47 set.  Reject anything outside that
+    // range — both the symbolic-hash leak class AND any other stray
+    // non-fnptr value (e.g. an int constant mistakenly routed through
+    // the funcbox slot).
+    if (func_ptr as u64) >> 47 != 0 {
+        return None;
+    }
     if allboxes.len() - 1 > majit_translate::jit_codewriter::insns::MAX_HOST_CALL_ARITY {
         return None;
     }
@@ -4167,8 +4185,7 @@ fn walker_record_guard_exception(ctx: &mut WalkContext<'_, '_>, pc: usize) {
     let exc_obj = match ctx.last_exc_value_concrete {
         ConcreteValue::Ref(p) if !p.is_null() => p,
         _ => {
-            ctx.trace_ctx
-                .record_guard(OpCode::GuardNoException, &[], 0);
+            ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
             walker_capture_snapshot_for_last_guard(ctx, pc);
             return;
         }
@@ -4533,31 +4550,26 @@ fn dispatch_residual_call_iRd_kind(
         // their heap mutation because `eval.rs:3285-3308`'s walker-skip
         // path bypasses `execute_opcode_step` → SIGBUS on the next read
         // of the un-mutated container (M4 walker unactivated taxonomy).
-        // Task #390 sub-slice 3 activation is gated on `!can_raise`
-        // pending sub-slice 4's helper-side audit.  Empirical probe
-        // (commit history: sub-slice 4 probe) found the
-        // `can_raise=true` SIGBUS class is NOT walker-shadow staleness
-        // but UNPATCHED build-time fnaddrs in `constants_i` for some
-        // non-elidable helpers.  `runtime_fnaddr_patch` covers all
-        // helpers whose path appears in `pyre_interpreter::
-        // jit_trace_fnaddrs()`; helpers outside that registry retain
-        // garbage build-time values (e.g. `0xacc1d48d7993df7d` for
-        // `synth/bytes_ops`'s CallR).  Sub-slice 4 will extend the
-        // patcher registry or add a fnaddr-sanity gate before lifting.
-        let resid_raised = if !can_raise {
-            matches!(
-                try_execute_residual_call_via_executor(
-                    ctx,
-                    call_opcode,
-                    &allboxes,
-                    call_descr,
-                    recorded,
-                ),
-                Some(Err(_))
-            )
-        } else {
-            false
-        };
+        // Task #390 sub-slice 4: PyPy-orthodox activation.  PyPy's
+        // `_opimpl_residual_call*` concrete-executes EVERY residual
+        // call regardless of EI; the `exc` flag only selects the
+        // post-call guard shape (`GUARD_EXCEPTION` vs `GUARD_NO_EXCEPTION`)
+        // in `handle_possible_exception`.  Pyre matches by always
+        // invoking the executor — `try_execute_residual_call_via_executor`
+        // self-gates on a fnaddr-sanity check (rejecting unpatched
+        // `symbolic_fnaddr_for_path` hashes whose bits ≥ 47 are set)
+        // so unregistered helpers degrade gracefully to recording-only
+        // instead of SIGBUSing.
+        let resid_raised = matches!(
+            try_execute_residual_call_via_executor(
+                ctx,
+                call_opcode,
+                &allboxes,
+                call_descr,
+                recorded,
+            ),
+            Some(Err(_))
+        );
         debug_assert!(
             !resid_raised || can_raise,
             "dispatch_residual_call_iRd_kind: helper raised on a \
@@ -4772,31 +4784,26 @@ fn dispatch_residual_call_iIRd_kind(
 
         // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
         // — see `dispatch_residual_call_iRd_kind` for the full citation.
-        // Task #390 sub-slice 3 activation is gated on `!can_raise`
-        // pending sub-slice 4's helper-side audit.  Empirical probe
-        // (commit history: sub-slice 4 probe) found the
-        // `can_raise=true` SIGBUS class is NOT walker-shadow staleness
-        // but UNPATCHED build-time fnaddrs in `constants_i` for some
-        // non-elidable helpers.  `runtime_fnaddr_patch` covers all
-        // helpers whose path appears in `pyre_interpreter::
-        // jit_trace_fnaddrs()`; helpers outside that registry retain
-        // garbage build-time values (e.g. `0xacc1d48d7993df7d` for
-        // `synth/bytes_ops`'s CallR).  Sub-slice 4 will extend the
-        // patcher registry or add a fnaddr-sanity gate before lifting.
-        let resid_raised = if !can_raise {
-            matches!(
-                try_execute_residual_call_via_executor(
-                    ctx,
-                    call_opcode,
-                    &allboxes,
-                    call_descr,
-                    recorded,
-                ),
-                Some(Err(_))
-            )
-        } else {
-            false
-        };
+        // Task #390 sub-slice 4: PyPy-orthodox activation.  PyPy's
+        // `_opimpl_residual_call*` concrete-executes EVERY residual
+        // call regardless of EI; the `exc` flag only selects the
+        // post-call guard shape (`GUARD_EXCEPTION` vs `GUARD_NO_EXCEPTION`)
+        // in `handle_possible_exception`.  Pyre matches by always
+        // invoking the executor — `try_execute_residual_call_via_executor`
+        // self-gates on a fnaddr-sanity check (rejecting unpatched
+        // `symbolic_fnaddr_for_path` hashes whose bits ≥ 47 are set)
+        // so unregistered helpers degrade gracefully to recording-only
+        // instead of SIGBUSing.
+        let resid_raised = matches!(
+            try_execute_residual_call_via_executor(
+                ctx,
+                call_opcode,
+                &allboxes,
+                call_descr,
+                recorded,
+            ),
+            Some(Err(_))
+        );
         debug_assert!(
             !resid_raised || can_raise,
             "dispatch_residual_call_iIRd_kind: helper raised on a \
@@ -4944,31 +4951,26 @@ fn dispatch_residual_call_iIRFd_kind(
 
         // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
         // — see `dispatch_residual_call_iRd_kind` for the full citation.
-        // Task #390 sub-slice 3 activation is gated on `!can_raise`
-        // pending sub-slice 4's helper-side audit.  Empirical probe
-        // (commit history: sub-slice 4 probe) found the
-        // `can_raise=true` SIGBUS class is NOT walker-shadow staleness
-        // but UNPATCHED build-time fnaddrs in `constants_i` for some
-        // non-elidable helpers.  `runtime_fnaddr_patch` covers all
-        // helpers whose path appears in `pyre_interpreter::
-        // jit_trace_fnaddrs()`; helpers outside that registry retain
-        // garbage build-time values (e.g. `0xacc1d48d7993df7d` for
-        // `synth/bytes_ops`'s CallR).  Sub-slice 4 will extend the
-        // patcher registry or add a fnaddr-sanity gate before lifting.
-        let resid_raised = if !can_raise {
-            matches!(
-                try_execute_residual_call_via_executor(
-                    ctx,
-                    call_opcode,
-                    &allboxes,
-                    call_descr,
-                    recorded,
-                ),
-                Some(Err(_))
-            )
-        } else {
-            false
-        };
+        // Task #390 sub-slice 4: PyPy-orthodox activation.  PyPy's
+        // `_opimpl_residual_call*` concrete-executes EVERY residual
+        // call regardless of EI; the `exc` flag only selects the
+        // post-call guard shape (`GUARD_EXCEPTION` vs `GUARD_NO_EXCEPTION`)
+        // in `handle_possible_exception`.  Pyre matches by always
+        // invoking the executor — `try_execute_residual_call_via_executor`
+        // self-gates on a fnaddr-sanity check (rejecting unpatched
+        // `symbolic_fnaddr_for_path` hashes whose bits ≥ 47 are set)
+        // so unregistered helpers degrade gracefully to recording-only
+        // instead of SIGBUSing.
+        let resid_raised = matches!(
+            try_execute_residual_call_via_executor(
+                ctx,
+                call_opcode,
+                &allboxes,
+                call_descr,
+                recorded,
+            ),
+            Some(Err(_))
+        );
         debug_assert!(
             !resid_raised || can_raise,
             "dispatch_residual_call_iIRFd_kind: helper raised on a \

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4534,15 +4534,16 @@ fn dispatch_residual_call_iRd_kind(
         // path bypasses `execute_opcode_step` → SIGBUS on the next read
         // of the un-mutated container (M4 walker unactivated taxonomy).
         // Task #390 sub-slice 3 activation is gated on `!can_raise`
-        // pending a walker-shadow-vs-live-frame liveness audit (sub-slice
-        // 4).  Empirically, removing the gate SIGBUSes
-        // `synth/bytes_ops` + `synth/closures` on both backends —
-        // suspected stale-Ref shadow on receivers of `can_raise=true`
-        // object helpers (bytes slice / closure call dispatch).  The
-        // Err-arm infrastructure (walker_record_guard_exception, ctx
-        // last_exc_value/_concrete seeding, eval.rs BH_LAST_EXC_VALUE
-        // propagation) is in place so a future widening only needs to
-        // flip the gate once helper-side liveness is proven safe.
+        // pending sub-slice 4's helper-side audit.  Empirical probe
+        // (commit history: sub-slice 4 probe) found the
+        // `can_raise=true` SIGBUS class is NOT walker-shadow staleness
+        // but UNPATCHED build-time fnaddrs in `constants_i` for some
+        // non-elidable helpers.  `runtime_fnaddr_patch` covers all
+        // helpers whose path appears in `pyre_interpreter::
+        // jit_trace_fnaddrs()`; helpers outside that registry retain
+        // garbage build-time values (e.g. `0xacc1d48d7993df7d` for
+        // `synth/bytes_ops`'s CallR).  Sub-slice 4 will extend the
+        // patcher registry or add a fnaddr-sanity gate before lifting.
         let resid_raised = if !can_raise {
             matches!(
                 try_execute_residual_call_via_executor(
@@ -4772,15 +4773,16 @@ fn dispatch_residual_call_iIRd_kind(
         // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
         // — see `dispatch_residual_call_iRd_kind` for the full citation.
         // Task #390 sub-slice 3 activation is gated on `!can_raise`
-        // pending a walker-shadow-vs-live-frame liveness audit (sub-slice
-        // 4).  Empirically, removing the gate SIGBUSes
-        // `synth/bytes_ops` + `synth/closures` on both backends —
-        // suspected stale-Ref shadow on receivers of `can_raise=true`
-        // object helpers (bytes slice / closure call dispatch).  The
-        // Err-arm infrastructure (walker_record_guard_exception, ctx
-        // last_exc_value/_concrete seeding, eval.rs BH_LAST_EXC_VALUE
-        // propagation) is in place so a future widening only needs to
-        // flip the gate once helper-side liveness is proven safe.
+        // pending sub-slice 4's helper-side audit.  Empirical probe
+        // (commit history: sub-slice 4 probe) found the
+        // `can_raise=true` SIGBUS class is NOT walker-shadow staleness
+        // but UNPATCHED build-time fnaddrs in `constants_i` for some
+        // non-elidable helpers.  `runtime_fnaddr_patch` covers all
+        // helpers whose path appears in `pyre_interpreter::
+        // jit_trace_fnaddrs()`; helpers outside that registry retain
+        // garbage build-time values (e.g. `0xacc1d48d7993df7d` for
+        // `synth/bytes_ops`'s CallR).  Sub-slice 4 will extend the
+        // patcher registry or add a fnaddr-sanity gate before lifting.
         let resid_raised = if !can_raise {
             matches!(
                 try_execute_residual_call_via_executor(
@@ -4943,15 +4945,16 @@ fn dispatch_residual_call_iIRFd_kind(
         // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
         // — see `dispatch_residual_call_iRd_kind` for the full citation.
         // Task #390 sub-slice 3 activation is gated on `!can_raise`
-        // pending a walker-shadow-vs-live-frame liveness audit (sub-slice
-        // 4).  Empirically, removing the gate SIGBUSes
-        // `synth/bytes_ops` + `synth/closures` on both backends —
-        // suspected stale-Ref shadow on receivers of `can_raise=true`
-        // object helpers (bytes slice / closure call dispatch).  The
-        // Err-arm infrastructure (walker_record_guard_exception, ctx
-        // last_exc_value/_concrete seeding, eval.rs BH_LAST_EXC_VALUE
-        // propagation) is in place so a future widening only needs to
-        // flip the gate once helper-side liveness is proven safe.
+        // pending sub-slice 4's helper-side audit.  Empirical probe
+        // (commit history: sub-slice 4 probe) found the
+        // `can_raise=true` SIGBUS class is NOT walker-shadow staleness
+        // but UNPATCHED build-time fnaddrs in `constants_i` for some
+        // non-elidable helpers.  `runtime_fnaddr_patch` covers all
+        // helpers whose path appears in `pyre_interpreter::
+        // jit_trace_fnaddrs()`; helpers outside that registry retain
+        // garbage build-time values (e.g. `0xacc1d48d7993df7d` for
+        // `synth/bytes_ops`'s CallR).  Sub-slice 4 will extend the
+        // patcher registry or add a fnaddr-sanity gate before lifting.
         let resid_raised = if !can_raise {
             matches!(
                 try_execute_residual_call_via_executor(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3546,30 +3546,53 @@ fn try_execute_residual_call_via_executor(
     }
     let exec_result =
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args);
-    if let Ok(result_i64) = exec_result {
-        // pyjitpl.py:1392 `result_box.value = result` analogue — stamp
-        // the recorded OpRef with the executed concrete so downstream
-        // `concrete_of_opref` / `box_value` consumers see the folded
-        // value.  Void callees do not stamp (no result to record); the
-        // heap mutation has already happened via `call_void_function`.
-        match call_descr.result_type() {
-            majit_ir::Type::Int => {
-                ctx.trace_ctx
-                    .set_opref_concrete(recorded, majit_ir::Value::Int(result_i64));
+    match exec_result {
+        Ok(result_i64) => {
+            // pyjitpl.py:1392 `result_box.value = result` analogue — stamp
+            // the recorded OpRef with the executed concrete so downstream
+            // `concrete_of_opref` / `box_value` consumers see the folded
+            // value.  Void callees do not stamp (no result to record); the
+            // heap mutation has already happened via `call_void_function`.
+            match call_descr.result_type() {
+                majit_ir::Type::Int => {
+                    ctx.trace_ctx
+                        .set_opref_concrete(recorded, majit_ir::Value::Int(result_i64));
+                }
+                majit_ir::Type::Ref => {
+                    ctx.trace_ctx.set_opref_concrete(
+                        recorded,
+                        majit_ir::Value::Ref(majit_ir::GcRef(result_i64 as usize)),
+                    );
+                }
+                majit_ir::Type::Float => {
+                    ctx.trace_ctx.set_opref_concrete(
+                        recorded,
+                        majit_ir::Value::Float(f64::from_bits(result_i64 as u64)),
+                    );
+                }
+                majit_ir::Type::Void => {}
             }
-            majit_ir::Type::Ref => {
-                ctx.trace_ctx.set_opref_concrete(
-                    recorded,
-                    majit_ir::Value::Ref(majit_ir::GcRef(result_i64 as usize)),
-                );
-            }
-            majit_ir::Type::Float => {
-                ctx.trace_ctx.set_opref_concrete(
-                    recorded,
-                    majit_ir::Value::Float(f64::from_bits(result_i64 as u64)),
-                );
-            }
-            majit_ir::Type::Void => {}
+        }
+        Err(bh_exc) => {
+            // pyjitpl.py:1690-1696 `metainterp.execute_raised(exception,
+            // constant=False)` analogue — seed the standing exception
+            // state so downstream walker chain (`reraise/`,
+            // `last_exc_value/>r`, `handle_possible_exception` guard
+            // emission) sees a non-null `last_exc_value` and routes
+            // through the GuardException path.
+            //
+            // `execute_residual_call` cleared `BH_LAST_EXC_VALUE` on read;
+            // restore it so the eval-loop walker-skip path
+            // (`eval.rs:3285-3308`) can detect the pending exception and
+            // route into the bytecode-interpreter's exception handler
+            // via `PyError::from_exc_object` — matching RPython's
+            // metainterp framestack scan after a raising residual call
+            // (`pyjitpl.py:2156-2168 handle_possible_exception` +
+            // `pyjitpl.py:3380 finishframe_exception`).
+            ctx.last_exc_value = Some(ctx.trace_ctx.const_ref(bh_exc));
+            ctx.last_exc_value_concrete =
+                ConcreteValue::Ref(bh_exc as usize as pyre_object::PyObjectRef);
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(bh_exc));
         }
     }
     Some(exec_result)
@@ -4124,6 +4147,48 @@ fn walker_capture_snapshot_for_last_guard(ctx: &mut WalkContext<'_, '_>, op_pc: 
         );
 }
 
+/// Walker-side port of `pyjitpl.py:2156-2168 handle_possible_exception`'s
+/// exception branch (the trait-leg equivalent lives at
+/// `trace_opcode.rs:6962-7020 MIFrame::handle_possible_exception`).
+///
+/// Emit `GuardException(exc_type_const)` + snapshot, reading the
+/// exception's `ob_header.ob_type` from
+/// `WalkContext::last_exc_value_concrete` to pin the class.  Mirrors
+/// RPython's `class_of_box_known` shape: the guard recovery has the
+/// exact subclass available at replay, matching `opimpl_raise`'s
+/// `GUARD_CLASS(exc, cls_of_box(exc))` pattern (`pyjitpl.py:1687-1693`).
+///
+/// Falls back to `GuardNoException` when the concrete exception
+/// pointer is unavailable (sub-walk shadow gap or non-Ref concrete) —
+/// the residual call op stays in the trace and the optimizer's
+/// per-call guard-emission still catches exception divergence at
+/// replay, just without the class pin.
+fn walker_record_guard_exception(ctx: &mut WalkContext<'_, '_>, pc: usize) {
+    let exc_obj = match ctx.last_exc_value_concrete {
+        ConcreteValue::Ref(p) if !p.is_null() => p,
+        _ => {
+            ctx.trace_ctx
+                .record_guard(OpCode::GuardNoException, &[], 0);
+            walker_capture_snapshot_for_last_guard(ctx, pc);
+            return;
+        }
+    };
+    // `pyjitpl.py:3382-3384`: ALWAYS emit `GuardException` with a const
+    // class pin (`class_of_last_exc_is_const = True` after the emit).
+    // Pyre's `W_ExceptionObject.ob_header.ob_type` is the per-`ExcKind`
+    // `PyType` static (`excobject.rs::exc_kind_to_pytype`), matching
+    // upstream `OBJECT.typeptr = specific class` (`rclass.py:167-174`).
+    let exc_type_ptr = unsafe {
+        (*(exc_obj as *const pyre_object::excobject::W_ExceptionObject))
+            .ob_header
+            .ob_type as i64
+    };
+    let exc_type_const = ctx.trace_ctx.const_int(exc_type_ptr);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardException, &[exc_type_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, pc);
+}
+
 fn direct_call_release_gil(
     ctx: &mut WalkContext<'_, '_>,
     ei: &majit_ir::EffectInfo,
@@ -4457,21 +4522,46 @@ fn dispatch_residual_call_iRd_kind(
         // call opcodes.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
-        // pyjitpl.py:1346/1349/1354 `_opimpl_residual_call{1,2,3}`
-        // parity for the non-elidable shapes (Task #390 sub-slice 2.3).
-        // Activate only when `can_raise=false`: BH exception propagation
-        // through `WalkContext.last_exc_value` lands in sub-slice 3.
-        // M4 SIGBUS root cause (store_subscr_fn / set_current_exception)
-        // sits on `can_raise=true` paths and is unblocked once 3 lands.
-        if !can_raise {
-            let _ = try_execute_residual_call_via_executor(
-                ctx,
-                call_opcode,
-                &allboxes,
-                call_descr,
-                recorded,
-            );
-        }
+        // pyjitpl.py:1346/1349/1354 `_opimpl_residual_call{1,2,3}` parity
+        // for the non-elidable shapes (Task #390 sub-slice 3).  PyPy
+        // concrete-executes EVERY residual call regardless of EI — the
+        // `exc` flag only selects the *guard* shape downstream
+        // (`handle_possible_exception` → `GUARD_EXCEPTION` vs
+        // `GUARD_NO_EXCEPTION`), not whether the helper runs.  Without
+        // this, walker-recorded non-elidable helpers
+        // (`store_subscr_fn`, `set_current_exception`, …) would skip
+        // their heap mutation because `eval.rs:3285-3308`'s walker-skip
+        // path bypasses `execute_opcode_step` → SIGBUS on the next read
+        // of the un-mutated container (M4 walker unactivated taxonomy).
+        // Task #390 sub-slice 3 activation is gated on `!can_raise`
+        // pending a walker-shadow-vs-live-frame liveness audit (sub-slice
+        // 4).  Empirically, removing the gate SIGBUSes
+        // `synth/bytes_ops` + `synth/closures` on both backends —
+        // suspected stale-Ref shadow on receivers of `can_raise=true`
+        // object helpers (bytes slice / closure call dispatch).  The
+        // Err-arm infrastructure (walker_record_guard_exception, ctx
+        // last_exc_value/_concrete seeding, eval.rs BH_LAST_EXC_VALUE
+        // propagation) is in place so a future widening only needs to
+        // flip the gate once helper-side liveness is proven safe.
+        let resid_raised = if !can_raise {
+            matches!(
+                try_execute_residual_call_via_executor(
+                    ctx,
+                    call_opcode,
+                    &allboxes,
+                    call_descr,
+                    recorded,
+                ),
+                Some(Err(_))
+            )
+        } else {
+            false
+        };
+        debug_assert!(
+            !resid_raised || can_raise,
+            "dispatch_residual_call_iRd_kind: helper raised on a \
+             `!can_raise` EI — EffectInfo claim/reality mismatch"
+        );
 
         // pyjitpl.py:2659 `_record_helper_varargs` parity: every
         // recorded varargs op invalidates the heapcache via
@@ -4492,7 +4582,15 @@ fn dispatch_residual_call_iRd_kind(
         // the guard's fail_args snapshot reads the recorded OpRef in
         // the slot the resume position points at — otherwise raising
         // calls would surface NONE in fail_args for the `>X` slot.
-        write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, recorded)?;
+        //
+        // Skip on `resid_raised`: `recorded` carries no concrete
+        // result (helper raised before producing one); writing it to
+        // dst would propagate a stale-stamped OpRef into downstream
+        // walker chain (`pyjitpl.py:1392` only stamps `result_box.value`
+        // on the success path of `execute_varargs`).
+        if !resid_raised {
+            write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, recorded)?;
+        }
         // pyjitpl.py:2079 `metainterp.generate_guard(rop.GUARD_NOT_FORCED)`
         // — unconditionally on the forces-virtual-or-virtualizable branch.
         // Walker omits the `vable_after_residual_call(funcbox)`
@@ -4506,23 +4604,33 @@ fn dispatch_residual_call_iRd_kind(
             ctx.trace_ctx.record_guard(OpCode::GuardNotForced, &[], 0);
             walker_capture_snapshot_for_last_guard(ctx, op.pc);
         }
-        // pyjitpl.py:2082 `metainterp.handle_possible_exception()` emits
-        // `GUARD_NO_EXCEPTION` whenever the EffectInfo can raise.
-        // `walker_capture_snapshot_for_last_guard` ports
-        // `capture_resumedata(after_residual_call=True)`
-        // (`pyjitpl.py:2599-2603`) so the optimizer's
-        // `store_final_boxes_in_guard` finds a populated
-        // `rd_resume_position`.
+        // pyjitpl.py:2082 `metainterp.handle_possible_exception()` —
+        // emits `GUARD_EXCEPTION(exc_type)` when the recording-time
+        // helper raised (pinning the class for guard recovery), else
+        // `GUARD_NO_EXCEPTION`.  `walker_capture_snapshot_for_last_guard`
+        // ports `capture_resumedata(after_residual_call=True)`
+        // (`pyjitpl.py:2599-2603`).
         if can_raise {
-            ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
-            walker_capture_snapshot_for_last_guard(ctx, op.pc);
+            if resid_raised {
+                walker_record_guard_exception(ctx, op.pc);
+            } else {
+                ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
+                walker_capture_snapshot_for_last_guard(ctx, op.pc);
+            }
         }
 
         // pyjitpl.py:2109 `heapcache.call_loopinvariant_now_known`:
         // populate the cache so a subsequent matching call short-
         // circuits via the lookup above.  No-op for non-loopinvariant
         // EI per `loopinvariant_now_known`'s extraeffect check.
-        loopinvariant_now_known(ctx, ei, descr_key, funcptr, recorded);
+        //
+        // Skip on `resid_raised`: caching a `recorded` OpRef with no
+        // stamped concrete would propagate the un-stamped value into a
+        // subsequent loop iteration's `loopinvariant_lookup` hit,
+        // bypassing the actual helper call.
+        if !resid_raised {
+            loopinvariant_now_known(ctx, ei, descr_key, funcptr, recorded);
+        }
     }
 
     Ok((DispatchOutcome::Continue, op.next_pc))
@@ -4661,17 +4769,37 @@ fn dispatch_residual_call_iIRd_kind(
         // `dispatch_residual_call_iRd_kind` for the upstream walk.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
-        // Non-elidable concrete-execute parity (Task #390 sub-slice 2.3)
+        // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
         // — see `dispatch_residual_call_iRd_kind` for the full citation.
-        if !can_raise {
-            let _ = try_execute_residual_call_via_executor(
-                ctx,
-                call_opcode,
-                &allboxes,
-                call_descr,
-                recorded,
-            );
-        }
+        // Task #390 sub-slice 3 activation is gated on `!can_raise`
+        // pending a walker-shadow-vs-live-frame liveness audit (sub-slice
+        // 4).  Empirically, removing the gate SIGBUSes
+        // `synth/bytes_ops` + `synth/closures` on both backends —
+        // suspected stale-Ref shadow on receivers of `can_raise=true`
+        // object helpers (bytes slice / closure call dispatch).  The
+        // Err-arm infrastructure (walker_record_guard_exception, ctx
+        // last_exc_value/_concrete seeding, eval.rs BH_LAST_EXC_VALUE
+        // propagation) is in place so a future widening only needs to
+        // flip the gate once helper-side liveness is proven safe.
+        let resid_raised = if !can_raise {
+            matches!(
+                try_execute_residual_call_via_executor(
+                    ctx,
+                    call_opcode,
+                    &allboxes,
+                    call_descr,
+                    recorded,
+                ),
+                Some(Err(_))
+            )
+        } else {
+            false
+        };
+        debug_assert!(
+            !resid_raised || can_raise,
+            "dispatch_residual_call_iIRd_kind: helper raised on a \
+             `!can_raise` EI — EffectInfo claim/reality mismatch"
+        );
 
         // pyjitpl.py:2659 `_record_helper_varargs` parity — see
         // `dispatch_residual_call_iRd_kind` for the upstream-citation
@@ -4682,17 +4810,25 @@ fn dispatch_residual_call_iIRd_kind(
         // pyjitpl.py:1950 _opimpl_residual_call*: result writeback runs
         // BEFORE handle_possible_exception().  See
         // `dispatch_residual_call_iRd_kind` for the full citation.
-        write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, recorded)?;
+        if !resid_raised {
+            write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, recorded)?;
+        }
         if emit_guard_not_forced {
             ctx.trace_ctx.record_guard(OpCode::GuardNotForced, &[], 0);
             walker_capture_snapshot_for_last_guard(ctx, op.pc);
         }
         if can_raise {
-            ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
-            walker_capture_snapshot_for_last_guard(ctx, op.pc);
+            if resid_raised {
+                walker_record_guard_exception(ctx, op.pc);
+            } else {
+                ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
+                walker_capture_snapshot_for_last_guard(ctx, op.pc);
+            }
         }
 
-        loopinvariant_now_known(ctx, ei, descr_key, funcptr, recorded);
+        if !resid_raised {
+            loopinvariant_now_known(ctx, ei, descr_key, funcptr, recorded);
+        }
     }
 
     Ok((DispatchOutcome::Continue, op.next_pc))
@@ -4804,31 +4940,59 @@ fn dispatch_residual_call_iIRFd_kind(
         // `dispatch_residual_call_iRd_kind` for the upstream walk.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
-        // Non-elidable concrete-execute parity (Task #390 sub-slice 2.3)
+        // Non-elidable concrete-execute parity (Task #390 sub-slice 3)
         // — see `dispatch_residual_call_iRd_kind` for the full citation.
-        if !can_raise {
-            let _ = try_execute_residual_call_via_executor(
-                ctx,
-                call_opcode,
-                &allboxes,
-                call_descr,
-                recorded,
-            );
-        }
+        // Task #390 sub-slice 3 activation is gated on `!can_raise`
+        // pending a walker-shadow-vs-live-frame liveness audit (sub-slice
+        // 4).  Empirically, removing the gate SIGBUSes
+        // `synth/bytes_ops` + `synth/closures` on both backends —
+        // suspected stale-Ref shadow on receivers of `can_raise=true`
+        // object helpers (bytes slice / closure call dispatch).  The
+        // Err-arm infrastructure (walker_record_guard_exception, ctx
+        // last_exc_value/_concrete seeding, eval.rs BH_LAST_EXC_VALUE
+        // propagation) is in place so a future widening only needs to
+        // flip the gate once helper-side liveness is proven safe.
+        let resid_raised = if !can_raise {
+            matches!(
+                try_execute_residual_call_via_executor(
+                    ctx,
+                    call_opcode,
+                    &allboxes,
+                    call_descr,
+                    recorded,
+                ),
+                Some(Err(_))
+            )
+        } else {
+            false
+        };
+        debug_assert!(
+            !resid_raised || can_raise,
+            "dispatch_residual_call_iIRFd_kind: helper raised on a \
+             `!can_raise` EI — EffectInfo claim/reality mismatch"
+        );
 
         ctx.trace_ctx
             .heapcache_invalidate_caches_varargs(call_opcode, Some(ei), &allboxes);
-        write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, recorded)?;
+        if !resid_raised {
+            write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, recorded)?;
+        }
         if emit_guard_not_forced {
             ctx.trace_ctx.record_guard(OpCode::GuardNotForced, &[], 0);
             walker_capture_snapshot_for_last_guard(ctx, op.pc);
         }
         if can_raise {
-            ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
-            walker_capture_snapshot_for_last_guard(ctx, op.pc);
+            if resid_raised {
+                walker_record_guard_exception(ctx, op.pc);
+            } else {
+                ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
+                walker_capture_snapshot_for_last_guard(ctx, op.pc);
+            }
         }
 
-        loopinvariant_now_known(ctx, ei, descr_key, funcptr, recorded);
+        if !resid_raised {
+            loopinvariant_now_known(ctx, ei, descr_key, funcptr, recorded);
+        }
     }
 
     Ok((DispatchOutcome::Continue, op.next_pc))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3417,6 +3417,163 @@ fn try_fold_pure_call_via_executor(
     ctx.trace_ctx.set_opref_concrete(recorded, result_value);
 }
 
+/// PyPy `_opimpl_residual_call{1,2,3}` (pyjitpl.py:1346/1349/1354) port
+/// for the **non-elidable** call shapes — companion to
+/// [`try_fold_pure_call_via_executor`] which handles the elidable case.
+///
+/// Upstream calls `executor.execute_varargs(opnum, argboxes, descr,
+/// exc=can_raise, pure=False)` which dispatches through
+/// `cpu.bh_call_*` and clears/records BH exception state via
+/// `metainterp.clear_exception()` + `metainterp.execute_raised(...)`.
+/// This walker-friendly counterpart returns `Result<i64, i64>` directly
+/// (via [`majit_metainterp::executor::execute_residual_call`]) so the
+/// caller can wire the BH exception into `WalkContext.last_exc_value`
+/// without dragging in a `MetaInterp` seam.
+///
+/// **Why this exists** (Task #390 widening): walker's
+/// `production_walker_handles` arm skips `execute_opcode_step` for
+/// `eval.rs:3111` opcodes; for opcodes whose body contains a
+/// non-elidable `residual_call_*` (`store_subscr_fn` /
+/// `set_current_exception` / etc.), the helper is never invoked → heap
+/// mutation never happens → next read derefs stale container → SIGBUS
+/// (M4 walker unactivated taxonomy: 5 STORE_SUBSCR-hot benches).  The
+/// orthodox fix is to widen this function across `Call*` /
+/// `CallLoopinvariant*` shapes, mirroring PyPy's
+/// `_opimpl_residual_call*` which concrete-executes *every* residual
+/// call regardless of EI.
+///
+/// **Caller contract**:
+/// * `call_opcode` must be one of the non-elidable, non-may-force
+///   residual call shapes: `Call{I,R,F,N}` (the default arm) or
+///   `CallLoopinvariant{I,R,F,N}` (the `EF_LOOPINVARIANT` arm).
+///   * `CallPure*` is excluded — that's [`try_fold_pure_call_via_executor`]'s
+///     job.
+///   * `CallMayForce*` / `CallReleaseGil*` / `CallAssembler*` are
+///     intentionally excluded: their trace-recording-time invariants
+///     (force-virtual audit, GIL transitions, jitdriver re-entry)
+///     need a separate audit (Task #390 sub-slice 4).
+/// * `allboxes[0]` is the funcbox (per `build_allboxes` layout); the
+///   remaining slots are user args in `descr.arg_types()` ABI order.
+///
+/// **Return value**:
+/// * `Some(Ok(_))` — helper executed normally, `recorded` OpRef stamped
+///   with the concrete result.
+/// * `Some(Err(bh_exc))` — helper raised; `bh_exc` is the wrapped
+///   `PyError` pointer (from `BH_LAST_EXC_VALUE`).  Caller is
+///   responsible for routing into `WalkContext.last_exc_value` so the
+///   downstream `GuardNoException` walker handler picks it up; the
+///   `recorded` OpRef is NOT stamped (no concrete result).
+/// * `None` — fold declined (preconditions not met: opcode out of set,
+///   funcbox non-const, arity exceeds [`MAX_HOST_CALL_ARITY`], any
+///   operand lacks a concrete `box_value`, or any Ref arg is NULL).
+///   The trace still has the recorded call op for the optimizer to
+///   consume later; walker falls through as if this function did not
+///   exist.
+///
+/// **Wire status** (Task #390 sub-slice 2.2): this function is not yet
+/// invoked from any dispatch site.  Sub-slices 2.3+ wire it into the
+/// three dispatch entry points (`dispatch_residual_call_iRd_kind`,
+/// `dispatch_residual_call_iIRd_kind`, `dispatch_residual_call_iIRFd_kind`)
+/// alongside [`try_fold_pure_call_via_executor`].
+#[allow(dead_code)]
+fn try_execute_residual_call_via_executor(
+    ctx: &mut WalkContext<'_, '_>,
+    call_opcode: OpCode,
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    recorded: OpRef,
+) -> Option<Result<i64, i64>> {
+    if !matches!(
+        call_opcode,
+        OpCode::CallI
+            | OpCode::CallR
+            | OpCode::CallF
+            | OpCode::CallN
+            | OpCode::CallLoopinvariantI
+            | OpCode::CallLoopinvariantR
+            | OpCode::CallLoopinvariantF
+            | OpCode::CallLoopinvariantN
+    ) {
+        return None;
+    }
+    if allboxes.is_empty() {
+        return None;
+    }
+    // Same funcbox-must-be-const invariant as `try_fold_pure_call_via_executor`:
+    // a non-const funcbox carries a stale stamp and dereferencing it as a
+    // code address SEGVs.  pyjitpl.py:1346-1354 forces the funcbox through
+    // the executor's `cpu.bh_call_*` `ConstInt.getint()` path which
+    // implicitly requires constness too (residual_call descrs always
+    // carry a fixed funcptr at translation time).
+    if !allboxes[0].is_constant() {
+        return None;
+    }
+    let funcptr_val = ctx.trace_ctx.box_value(allboxes[0]);
+    let func_ptr = match funcptr_val {
+        Some(majit_ir::Value::Int(addr)) => addr,
+        _ => return None,
+    };
+    if allboxes.len() - 1 > majit_translate::jit_codewriter::insns::MAX_HOST_CALL_ARITY {
+        return None;
+    }
+    let mut args = Vec::with_capacity(allboxes.len() - 1);
+    for &arg in &allboxes[1..] {
+        let v = match ctx.trace_ctx.box_value(arg) {
+            Some(majit_ir::Value::Int(n)) => n,
+            Some(majit_ir::Value::Ref(r)) => {
+                if r == majit_ir::GcRef(usize::MAX) {
+                    return None;
+                }
+                r.as_usize() as i64
+            }
+            Some(majit_ir::Value::Float(f)) => f.to_bits() as i64,
+            Some(majit_ir::Value::Void) => 0,
+            None => return None,
+        };
+        args.push(v);
+    }
+    // NULL-Ref-arg refusal: same SEGV-avoidance contract as the pure
+    // path (see `try_fold_pure_call_via_executor`'s NULL guard).  Pyre's
+    // optimizer emits `guard_nonnull` after this walker fold, so a NULL
+    // receiver dereferences before that guard exists; fall through to
+    // recording the call op and let the optimizer's guard emission
+    // handle it at compile time.
+    for (i, &arg) in args.iter().enumerate() {
+        if matches!(call_descr.arg_types().get(i), Some(majit_ir::Type::Ref)) && arg == 0 {
+            return None;
+        }
+    }
+    let exec_result =
+        majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args);
+    if let Ok(result_i64) = exec_result {
+        // pyjitpl.py:1392 `result_box.value = result` analogue — stamp
+        // the recorded OpRef with the executed concrete so downstream
+        // `concrete_of_opref` / `box_value` consumers see the folded
+        // value.  Void callees do not stamp (no result to record); the
+        // heap mutation has already happened via `call_void_function`.
+        match call_descr.result_type() {
+            majit_ir::Type::Int => {
+                ctx.trace_ctx
+                    .set_opref_concrete(recorded, majit_ir::Value::Int(result_i64));
+            }
+            majit_ir::Type::Ref => {
+                ctx.trace_ctx.set_opref_concrete(
+                    recorded,
+                    majit_ir::Value::Ref(majit_ir::GcRef(result_i64 as usize)),
+                );
+            }
+            majit_ir::Type::Float => {
+                ctx.trace_ctx.set_opref_concrete(
+                    recorded,
+                    majit_ir::Value::Float(f64::from_bits(result_i64 as u64)),
+                );
+            }
+            majit_ir::Type::Void => {}
+        }
+    }
+    Some(exec_result)
+}
+
 /// `pyjitpl.py:3671-3681 MetaInterp.direct_call_release_gil` port.
 /// Sub-case of the forces-virtual-or-virtualizable branch
 /// (`pyjitpl.py:2063` `if effectinfo.is_call_release_gil()`): when the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2998,6 +2998,48 @@ fn decode_descr_index(code: &[u8], op: &DecodedOp, operand_offset: usize) -> usi
 /// (`check_can_raise(False)`), and whether the unconditional
 /// `GUARD_NOT_FORCED` from the forces branch (`pyjitpl.py:2079`)
 /// should fire.
+///
+/// ★ Task #390 sub-slice 1 — non-elidable concrete-execute inventory.
+///
+/// PyPy `do_residual_call` (pyjitpl.py:1995-2126) **always** calls
+/// `executor.execute_varargs(opnum, argboxes, descr, exc=can_raise,
+/// pure=is_elidable)` regardless of EI branch.  The recorded opcode
+/// kind selected above is for the IR trace; concrete execution always
+/// happens at trace-record time.  Pyre's walker only concrete-executes
+/// the `CallPure*` branch (via [`try_fold_pure_call_via_executor`]),
+/// so the other three branches surface as the M4 SIGBUS root cause
+/// (memory: M4 walker unactivated taxonomy).
+///
+/// Per-branch concrete-execute status today:
+///
+/// | EI branch | Selected op | PyPy `execute_varargs` | Pyre walker | Reachable via |
+/// |---|---|---|---|---|
+/// | `is_call_release_gil()` | (early-routed to `direct_call_release_gil`) | n/a — separate `do_call_release_gil` path | (release-gil IR only, no concrete exec) | not via this selector |
+/// | `check_forces_virtual_or_virtualizable()` | `CallMayForce*` + `GuardNotForced` | `pure=False, exc=can_raise` — runs the helper, may force virtualizable | **record-only** | dispatcher_iRd/iIRd/iIRFd_kind forces branch |
+/// | `extraeffect == LoopInvariant` | `CallLoopinvariant*` | `pure=False, exc=False` — runs on cache miss | record-only on cache miss, [`loopinvariant_lookup`] reuses cached OpRef on hit (no execute, no record) | same dispatchers |
+/// | `check_is_elidable()` | `CallPure*` | `pure=True, exc=can_raise` — runs the helper, caches result | [`try_fold_pure_call_via_executor`] (elidable_cannot_raise only — see its caveats) | same dispatchers |
+/// | default | `Call*` + (`GuardNoException` iff can_raise) | `pure=False, exc=can_raise` — runs the helper | **record-only** | same dispatchers |
+///
+/// **Walker-record sites for non-elidable concrete-execute gap:**
+///   * [`dispatch_residual_call_iRd_kind`] (`residual_call_r_*/iRd>{v,r,i,f}` ←
+///     pyjitpl.py:1346 `_opimpl_residual_call1` / 1348 / 1350 / 1352)
+///   * [`dispatch_residual_call_iIRd_kind`] (`residual_call_ir_*/iIRd>{v,r,i,f}` ←
+///     pyjitpl.py:1349 `_opimpl_residual_call2` / 1351 / 1353 / 1355)
+///   * [`dispatch_residual_call_iIRFd_kind`] (`residual_call_irf_*/iIRFd>{v,r,i,f}` ←
+///     pyjitpl.py:1354 `_opimpl_residual_call3` / 1355 / 1357 / 1359)
+///
+/// All three call [`select_residual_call_opcode`] then
+/// `record_op_with_descr` then [`try_fold_pure_call_via_executor`].
+/// The orthodox fix replaces the last call with a wider
+/// `try_execute_residual_call_via_executor(call_opcode, ei, ...)`
+/// whose body matches PyPy `executor.execute_varargs` per the
+/// branch table above.
+///
+/// **Priority order for sub-slice 2 (widen):** Call* (default — the
+/// store_subscr_fn / set_current_exception class, smallest blast
+/// radius, root cause of M4 SIGBUS) → CallLoopinvariant* (`pure=False
+/// exc=False` is safest) → CallMayForce* (riskiest — force-virtual
+/// audit precondition).
 fn select_residual_call_opcode(
     ei: &majit_ir::EffectInfo,
     dst_bank: char,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3470,12 +3470,13 @@ fn try_fold_pure_call_via_executor(
 ///   consume later; walker falls through as if this function did not
 ///   exist.
 ///
-/// **Wire status** (Task #390 sub-slice 2.2): this function is not yet
-/// invoked from any dispatch site.  Sub-slices 2.3+ wire it into the
-/// three dispatch entry points (`dispatch_residual_call_iRd_kind`,
+/// **Wire status** (Task #390 sub-slice 2.3): invoked from all three
+/// dispatch entry points (`dispatch_residual_call_iRd_kind`,
 /// `dispatch_residual_call_iIRd_kind`, `dispatch_residual_call_iIRFd_kind`)
-/// alongside [`try_fold_pure_call_via_executor`].
-#[allow(dead_code)]
+/// alongside [`try_fold_pure_call_via_executor`], gated on
+/// `!can_raise`.  Sub-slice 3 will widen the gate to `can_raise=true`
+/// once BH exception propagation through `WalkContext.last_exc_value`
+/// is in place.
 fn try_execute_residual_call_via_executor(
     ctx: &mut WalkContext<'_, '_>,
     call_opcode: OpCode,
@@ -4456,6 +4457,22 @@ fn dispatch_residual_call_iRd_kind(
         // call opcodes.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
+        // pyjitpl.py:1346/1349/1354 `_opimpl_residual_call{1,2,3}`
+        // parity for the non-elidable shapes (Task #390 sub-slice 2.3).
+        // Activate only when `can_raise=false`: BH exception propagation
+        // through `WalkContext.last_exc_value` lands in sub-slice 3.
+        // M4 SIGBUS root cause (store_subscr_fn / set_current_exception)
+        // sits on `can_raise=true` paths and is unblocked once 3 lands.
+        if !can_raise {
+            let _ = try_execute_residual_call_via_executor(
+                ctx,
+                call_opcode,
+                &allboxes,
+                call_descr,
+                recorded,
+            );
+        }
+
         // pyjitpl.py:2659 `_record_helper_varargs` parity: every
         // recorded varargs op invalidates the heapcache via
         // `heapcache.invalidate_caches_varargs(opnum, descr,
@@ -4644,6 +4661,18 @@ fn dispatch_residual_call_iIRd_kind(
         // `dispatch_residual_call_iRd_kind` for the upstream walk.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
+        // Non-elidable concrete-execute parity (Task #390 sub-slice 2.3)
+        // — see `dispatch_residual_call_iRd_kind` for the full citation.
+        if !can_raise {
+            let _ = try_execute_residual_call_via_executor(
+                ctx,
+                call_opcode,
+                &allboxes,
+                call_descr,
+                recorded,
+            );
+        }
+
         // pyjitpl.py:2659 `_record_helper_varargs` parity — see
         // `dispatch_residual_call_iRd_kind` for the upstream-citation
         // walkthrough.  Same invalidation semantics; only the
@@ -4774,6 +4803,18 @@ fn dispatch_residual_call_iIRFd_kind(
         // pyjitpl.py:1346-1400 `_record_helper_pure` parity — see
         // `dispatch_residual_call_iRd_kind` for the upstream walk.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
+
+        // Non-elidable concrete-execute parity (Task #390 sub-slice 2.3)
+        // — see `dispatch_residual_call_iRd_kind` for the full citation.
+        if !can_raise {
+            let _ = try_execute_residual_call_via_executor(
+                ctx,
+                call_opcode,
+                &allboxes,
+                call_descr,
+                recorded,
+            );
+        }
 
         ctx.trace_ctx
             .heapcache_invalidate_caches_varargs(call_opcode, Some(ei), &allboxes);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3207,6 +3207,43 @@ fn funcptr_concrete_int(ctx: &WalkContext<'_, '_>, funcptr: OpRef) -> Option<i64
 /// time via [`majit_metainterp::executor::execute_pure_call`] and stamp
 /// `recorded` with the result.
 ///
+/// ★ PyPy parity gap (Phase 5.B replacement candidate):
+/// PyPy `_opimpl_*` methods (e.g. `_opimpl_setitem`,
+/// `_opimpl_setfield_*`) concrete-execute every `do_residual_call`
+/// regardless of `check_is_elidable()` — the EI flag only selects the
+/// recorded opcode kind (`CALL_PURE_*` vs `CALL_*`), not whether the
+/// helper runs.  The result is that `synchronize_virtualizable`'s
+/// in-place PyFrame write at the end of `_opimpl_setfield_vable`
+/// coincides with the side-effecting heap mutation of the
+/// `store_subscr_fn` / `set_current_exception` helper — both happen
+/// at trace-record time on the live frame.
+///
+/// Pyre's walker concrete-executes only the elidable path (this
+/// function); non-elidable helpers like `store_subscr_fn` route
+/// through `select_residual_call_opcode`'s default arm and are
+/// recorded but never executed.  `eval_loop_jit`'s
+/// `walker_dispatched_this_opcode` skip of `execute_opcode_step`
+/// (eval.rs:3111) then leaves the non-vable heap unchanged → SIGBUS
+/// on the next read (memory: M4 walker unactivated taxonomy, 5
+/// STORE_SUBSCR-hot benches).
+///
+/// The Phase 5.B `dispatch_arm_via_blackhole` path is a workaround
+/// that runs the arm jitcode through `BlackholeInterpreter` to
+/// concrete-execute those helpers; the orthodox PyPy alignment is
+/// instead to widen this function (or its successor) to
+/// concrete-execute *every* residual_call with concrete-known args,
+/// mirroring upstream's `executor.execute_varargs(opnum, argboxes,
+/// descr, exc=can_raise, pure=is_elidable)`.  That removes the need
+/// for `production_blackhole_handles` entirely and brings
+/// `_opimpl_setfield_vable` shape into structural parity.
+///
+/// Out-of-scope here (multi-session epic): widening requires can-raise
+/// exception propagation through the walker, a GuardNoException
+/// emission policy that matches PyPy's `do_residual_call(..., exc=
+/// can_raise)`, and audit of every non-elidable helper for trace-
+/// recording-time invariants (no jitdriver re-entry, no thread state
+/// mutation).  See Task #390.
+///
 /// RPython upstream `_record_helper_pure` invokes
 /// `executor.execute_varargs(opnum, argboxes, descr, exc=False, pure=True)`
 /// which dispatches to `cpu.bh_call_*` and stores the result on

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -276,6 +276,68 @@ pub fn jitcode_for_instruction(instruction: &Instruction) -> Option<Arc<JitCode>
     jitcode_for_arm(arm_id_for_instruction(instruction)?)
 }
 
+thread_local! {
+    /// Per-thread cache of metainterp-runtime wrappers around build-time
+    /// canonical arm jitcodes.  The walker path consumes
+    /// `Arc<majit_translate::jitcode::JitCode>` (canonical core)
+    /// directly because recording only reads `.code` / `.constants`;
+    /// the production-blackhole path needs
+    /// `Arc<majit_metainterp::jitcode::JitCode>` because
+    /// `BlackholeInterpreter.jitcode` carries a per-jitcode descr pool
+    /// (`majit-metainterp/src/jitcode/mod.rs:394`).  Build-time
+    /// canonical arm jitcodes have no per-jitcode descrs (mod.rs:400-403
+    /// — they resolve through the global `ALL_DESCRS` table), so each
+    /// wrapper's `exec` field stays empty.
+    ///
+    /// `thread_local!` mirrors `ALL_JITCODES` above: `JitCode` payloads
+    /// transitively hold `!Sync` `Variable` cells.  Outer `OnceCell`
+    /// lazy-sizes the slot vector; per-slot `OnceCell` wraps the core
+    /// on first lookup, then hands out `Arc::clone`s.
+    static METAINTERP_JITCODE_CACHE: OnceCell<Vec<OnceCell<Arc<majit_metainterp::jitcode::JitCode>>>> =
+        const { OnceCell::new() };
+}
+
+/// Phase 5.B counterpart of `get_jitcode_by_index`: returns the
+/// metainterp-runtime `JitCode` wrapper for the canonical arm jitcode
+/// at `index`, suitable for installing on
+/// `BlackholeInterpreter.jitcode`.
+pub fn metainterp_jitcode_by_index(
+    index: usize,
+) -> Option<Arc<majit_metainterp::jitcode::JitCode>> {
+    METAINTERP_JITCODE_CACHE.with(|outer| {
+        let slots = outer.get_or_init(|| {
+            (0..all_jitcodes().len()).map(|_| OnceCell::new()).collect()
+        });
+        let slot = slots.get(index)?;
+        Some(Arc::clone(slot.get_or_init(|| {
+            let canonical = all_jitcodes()
+                .get(index)
+                .expect("index validated by slot lookup");
+            Arc::new(majit_metainterp::jitcode::JitCode::from_canonical(
+                (**canonical).clone(),
+            ))
+        })))
+    })
+}
+
+/// Phase 5.B counterpart of `jitcode_for_arm`.
+pub fn metainterp_jitcode_for_arm(
+    arm_id: usize,
+) -> Option<Arc<majit_metainterp::jitcode::JitCode>> {
+    let arm = get_arm(arm_id)?;
+    let idx = arm.entry_jitcode_index?;
+    metainterp_jitcode_by_index(idx)
+}
+
+/// Phase 5.B counterpart of `jitcode_for_instruction`.  The
+/// BlackholeInterpreter-side entry for production dispatch
+/// (`dispatch_arm_via_blackhole`).
+pub fn metainterp_jitcode_for_instruction(
+    instruction: &Instruction,
+) -> Option<Arc<majit_metainterp::jitcode::JitCode>> {
+    metainterp_jitcode_for_arm(arm_id_for_instruction(instruction)?)
+}
+
 /// Deserialized `pipeline.insns` overlaid with `pyre_extension_insns()`
 /// — the build-observed `Assembler::write_insn` emit set plus the
 /// `_pyre/P` adapter keys that pyre's production blackhole builder

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -305,9 +305,8 @@ pub fn metainterp_jitcode_by_index(
     index: usize,
 ) -> Option<Arc<majit_metainterp::jitcode::JitCode>> {
     METAINTERP_JITCODE_CACHE.with(|outer| {
-        let slots = outer.get_or_init(|| {
-            (0..all_jitcodes().len()).map(|_| OnceCell::new()).collect()
-        });
+        let slots =
+            outer.get_or_init(|| (0..all_jitcodes().len()).map(|_| OnceCell::new()).collect());
         let slot = slots.get(index)?;
         Some(Arc::clone(slot.get_or_init(|| {
             let canonical = all_jitcodes()

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3019,17 +3019,21 @@ fn dispatch_arm_via_blackhole(
     // `MIFrame::dispatch_via_walker_for_opcode`
     // (pyre-jit-trace/src/trace_opcode.rs:6602) — an entry on
     // `production_blackhole_handles` without a matching codewriter arm
-    // is a build-script wiring bug, not a user-visible error.
-    let _jitcode = pyre_jit_trace::jitcode_runtime::jitcode_for_instruction(instruction)
-        .ok_or_else(|| {
-            pyre_interpreter::PyError::new(
-                pyre_interpreter::PyErrorKind::SystemError,
-                format!(
-                    "dispatch_arm_via_blackhole: production_blackhole_handles \
-                     admitted instruction without codewriter arm: {instruction:?}",
-                ),
-            )
-        })?;
+    // is a build-script wiring bug, not a user-visible error.  The
+    // metainterp-runtime wrapper is the form `BlackholeInterpreter.
+    // jitcode` consumes (descr pool stays empty for build-time canonical
+    // arms; `majit-metainterp/src/jitcode/mod.rs:400-403`).
+    let _jitcode =
+        pyre_jit_trace::jitcode_runtime::metainterp_jitcode_for_instruction(instruction)
+            .ok_or_else(|| {
+                pyre_interpreter::PyError::new(
+                    pyre_interpreter::PyErrorKind::SystemError,
+                    format!(
+                        "dispatch_arm_via_blackhole: production_blackhole_handles \
+                         admitted instruction without codewriter arm: {instruction:?}",
+                    ),
+                )
+            })?;
     let _ = frame;
     unimplemented!(
         "dispatch_arm_via_blackhole: BlackholeInterpreter \

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3088,14 +3088,23 @@ fn dispatch_arm_via_blackhole(
         });
 
     if got_exception {
-        // Slice 3.6: BH exception with no handler in the arm body.
-        // Convert `exception_value` (i64 pointer to W_BaseException) to
-        // a `PyError` and propagate up to `eval_loop_jit`.
-        let _ = exception_value;
-        todo!(
-            "dispatch_arm_via_blackhole: BH exception → PyError \
-             propagation lands in slice 3.6"
-        );
+        // Mirrors `call_jit.rs:1486-1506` (BH chain-exit propagation):
+        // null `exception_value` means the arm raised without a
+        // payload (defensive RuntimeError); otherwise the value is a
+        // GC ref to a `W_BaseException` instance to re-wrap.
+        let err = if exception_value != 0 {
+            unsafe {
+                pyre_interpreter::PyError::from_exc_object(
+                    exception_value as pyre_object::PyObjectRef,
+                )
+            }
+        } else {
+            pyre_interpreter::PyError::new(
+                pyre_interpreter::PyErrorKind::RuntimeError,
+                "dispatch_arm_via_blackhole: arm raised exception with null exc_value",
+            )
+        };
+        return Err(err);
     }
     if mergepoint_args.is_some() {
         // `ContinueRunningNormally` is the JIT-exit path: an arm

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3015,12 +3015,27 @@ fn dispatch_arm_via_blackhole(
     frame: &mut pyre_interpreter::pyframe::PyFrame,
     instruction: &pyre_interpreter::Instruction,
 ) -> Result<StepResult<pyre_object::PyObjectRef>, pyre_interpreter::PyError> {
-    let _ = (frame, instruction);
+    // Mirrors the walker-side fallback in
+    // `MIFrame::dispatch_via_walker_for_opcode`
+    // (pyre-jit-trace/src/trace_opcode.rs:6602) — an entry on
+    // `production_blackhole_handles` without a matching codewriter arm
+    // is a build-script wiring bug, not a user-visible error.
+    let _jitcode = pyre_jit_trace::jitcode_runtime::jitcode_for_instruction(instruction)
+        .ok_or_else(|| {
+            pyre_interpreter::PyError::new(
+                pyre_interpreter::PyErrorKind::SystemError,
+                format!(
+                    "dispatch_arm_via_blackhole: production_blackhole_handles \
+                     admitted instruction without codewriter arm: {instruction:?}",
+                ),
+            )
+        })?;
+    let _ = frame;
     unimplemented!(
-        "dispatch_arm_via_blackhole: arm jitcode lookup + \
-         BlackholeInterpreter wiring lands in subsequent Phase 5.B \
-         slices.  `production_blackhole_handles` must remain `false` \
-         until the body is implemented."
+        "dispatch_arm_via_blackhole: BlackholeInterpreter \
+         acquire/release + register marshalling + `bh.run()` lands in \
+         subsequent Phase 5.B slices.  `production_blackhole_handles` \
+         must remain `false` until the body is complete."
     )
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2992,6 +2992,38 @@ fn trace_jit_bytecode(_pc: usize, _instruction_name: &str) {
 ///       jit_merge_point(...)      # thin inline check
 ///       next_instr = handle_bytecode(...)
 ///
+/// Phase 5.B dispatch-unification: run a single walker-handled
+/// opcode's arm jitcode through `BlackholeInterpreter` so its
+/// non-elidable `residual_call`s actually mutate heap, then return so
+/// `eval_loop_jit` advances to the next opcode.
+///
+/// RPython parity: `pyjitpl.py:_interpret` IS the execution loop —
+/// every opcode dispatches through the jitcode-bytecode path.  Pyre
+/// hosts the per-opcode loop in `eval_loop_jit` instead, so this
+/// helper bridges the two halves: walker-handled opcodes whose arms
+/// rely on impure residual_calls (e.g. `store_subscr_fn`,
+/// `set_current_exception`) route through here instead of the
+/// vable-only skip at `eval_loop_jit`'s walker-dispatched branch.
+///
+/// Selection gate: `pyre_jit_trace::production_blackhole_handles`
+/// (returns `false` everywhere today).  Subsequent Phase 5.B slices
+/// implement the body — arm jitcode lookup, BH builder
+/// acquire/release, PyFrame↔BH register marshalling, `interp.run()`
+/// — and grow the predicate per opcode.
+#[cold]
+fn dispatch_arm_via_blackhole(
+    frame: &mut pyre_interpreter::pyframe::PyFrame,
+    instruction: &pyre_interpreter::Instruction,
+) -> Result<StepResult<pyre_object::PyObjectRef>, pyre_interpreter::PyError> {
+    let _ = (frame, instruction);
+    unimplemented!(
+        "dispatch_arm_via_blackhole: arm jitcode lookup + \
+         BlackholeInterpreter wiring lands in subsequent Phase 5.B \
+         slices.  `production_blackhole_handles` must remain `false` \
+         until the body is implemented."
+    )
+}
+
 /// warmspot.py portal_runner parity: execute a frame through the JIT-enabled
 /// interpreter. Used by bhimpl_recursive_call (blackhole.py:1074-1093) for
 /// recursive portal depth. Returns PyObjectRef (NULL on void/exception).
@@ -3140,16 +3172,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // arm jitcode through `BlackholeInterpreter` so the
                 // mutation actually happens, matching RPython
                 // `pyjitpl.py:_interpret`'s single-interpreter loop.
-                //
-                // `dispatch_arm_via_blackhole` lands in a follow-up
-                // slice (issue #73 Phase 5.B); the predicate returns
-                // `false` everywhere until then, so this arm is
-                // unreachable today.
-                unreachable!(
-                    "production_blackhole_handles must return false \
-                     until dispatch_arm_via_blackhole lands; \
-                     instruction={instruction:?}",
-                );
+                dispatch_arm_via_blackhole(frame, &instruction)
             } else {
                 // Vable-only fast path: walker arm advanced PyFrame
                 // via `vable_setfield` / `setarrayitem_vable_r` →

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3058,8 +3058,14 @@ fn dispatch_arm_via_blackhole(
             let builder = &mut *cell.get();
             sync_control_opcodes(builder);
             let mut bh = builder.acquire_interp();
-            bh.jitcode = jitcode;
-            bh.position = 0;
+            // `setposition` (blackhole.py:312) initialises register
+            // banks + copies the constants pool into the upper portion
+            // of each bank.  Setting `jitcode` / `position` directly
+            // would leave the banks sized to the previous interp's
+            // jitcode (or empty on a fresh acquire), with no constants
+            // copied — wild reads at the first `bhimpl_*` that loads a
+            // constant.
+            bh.setposition(jitcode, 0);
             // Virtualizable wiring — mirrors `call_jit.rs:1400-1423`.
             // Single-arm dispatch has no caller chain so the
             // `nextblackholeinterp` propagation loop reduces to no-op.
@@ -3067,10 +3073,11 @@ fn dispatch_arm_via_blackhole(
                 frame as *mut pyre_interpreter::pyframe::PyFrame as i64;
             bh.virtualizable_info = get_virtualizable_info();
             // RPython MIFrame.setup parity: r0 = frame (per
-            // `trace_opcode.rs:6657-6660` walker-side seed).
-            // Remaining registers default to zero/null; per-arm stack
-            // peeks set them up inside the arm body via `bhimpl_*`
-            // operand decoding.
+            // `trace_opcode.rs:6657-6660` walker-side seed).  Remaining
+            // working-bank slots stay zero/null; per-arm stack peeks
+            // are issued inside the arm body via `bhimpl_*` operand
+            // decoding (vable_get/setarrayitem_r against PyFrame's
+            // `locals_cells_stack_w`).
             if !bh.registers_r.is_empty() {
                 bh.registers_r[0] = bh.virtualizable_ptr;
             }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3116,12 +3116,25 @@ fn dispatch_arm_via_blackhole(
              ContinueRunningNormally — only portal arms should",
         );
     }
-    // LeaveFrame, no exception.  Per-return-type result handling
-    // (Ref/Int/Float push back onto PyFrame stack; Void = no push)
-    // lands in slice 3.7; void-returning arms (STORE_SUBSCR &c.) are
-    // the StoreSubscr activation target and need no push.
-    let _ = return_type;
-    Ok(StepResult::Continue)
+    // LeaveFrame, no exception.  Dispatch on return_type per
+    // RPython `BlackholeInterpreter` (`blackhole.rs:696-701`):
+    //   Void  → arm already mutated heap via vable_setfield /
+    //           residual_call; stack push not needed.
+    //   Int/Ref/Float → result in `tmpreg_*` to push back onto
+    //           PyFrame stack; opcode-shape-specific marshalling
+    //           lands in slice 3.8.
+    match return_type {
+        majit_metainterp::blackhole::BhReturnType::Void => Ok(StepResult::Continue),
+        majit_metainterp::blackhole::BhReturnType::Int
+        | majit_metainterp::blackhole::BhReturnType::Ref
+        | majit_metainterp::blackhole::BhReturnType::Float => {
+            todo!(
+                "dispatch_arm_via_blackhole: non-void return-type \
+                 push lands in slice 3.8 (return_type={:?})",
+                return_type,
+            )
+        }
+    }
 }
 
 /// warmspot.py portal_runner parity: execute a frame through the JIT-enabled

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3023,7 +3023,7 @@ fn dispatch_arm_via_blackhole(
     // metainterp-runtime wrapper is the form `BlackholeInterpreter.
     // jitcode` consumes (descr pool stays empty for build-time canonical
     // arms; `majit-metainterp/src/jitcode/mod.rs:400-403`).
-    let _jitcode =
+    let jitcode =
         pyre_jit_trace::jitcode_runtime::metainterp_jitcode_for_instruction(instruction)
             .ok_or_else(|| {
                 pyre_interpreter::PyError::new(
@@ -3034,12 +3034,44 @@ fn dispatch_arm_via_blackhole(
                     ),
                 )
             })?;
+
+    // Thread-local BH pool — mirrors `call_jit.rs::blackhole_resume_via_
+    // rd_numb`'s `BH_BUILDER_RD` (call_jit.rs:1300-1315).  Separate
+    // builder from the resume-data path so the two cannot trip over each
+    // other's mutable borrow on re-entry; single-opcode arms don't go
+    // through `resume::blackhole_from_resumedata`.  Lazy-init on first
+    // dispatch; the predicate stays `false` everywhere today so the
+    // pool is never actually created in production.
+    thread_local! {
+        static BH_BUILDER_ARM: UnsafeCell<majit_metainterp::blackhole::BlackholeInterpBuilder> =
+            UnsafeCell::new(pyre_jit_trace::jitcode_runtime::build_pyre_production_bh_builder());
+    }
+    let sync_control_opcodes =
+        |builder: &mut majit_metainterp::blackhole::BlackholeInterpBuilder| {
+            let (op_live, op_catch_exception, op_rvmprof_code) =
+                pyre_jit_trace::state::blackhole_control_opcodes();
+            builder.setup_cached_control_opcodes(op_live, op_catch_exception, op_rvmprof_code);
+        };
+
+    BH_BUILDER_ARM.with(|cell| unsafe {
+        let builder = &mut *cell.get();
+        sync_control_opcodes(builder);
+        let mut bh = builder.acquire_interp();
+        bh.jitcode = jitcode;
+        bh.position = 0;
+        // Slice 3.4+ lands here: virtualizable_ptr / virtualizable_info
+        // wiring, PyFrame ↔ BH register marshalling, `bh.run()`, and
+        // the reverse marshal back into PyFrame stack.  Until then the
+        // path is unreachable (predicate `false`) so acquire/release is
+        // a no-op round trip.
+        builder.release_interp(bh);
+    });
+
     let _ = frame;
     unimplemented!(
-        "dispatch_arm_via_blackhole: BlackholeInterpreter \
-         acquire/release + register marshalling + `bh.run()` lands in \
-         subsequent Phase 5.B slices.  `production_blackhole_handles` \
-         must remain `false` until the body is complete."
+        "dispatch_arm_via_blackhole: register marshalling + \
+         `bh.run()` lands in slice 3.4+.  \
+         `production_blackhole_handles` must remain `false` until then."
     )
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3301,7 +3301,34 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // PyFrame.  Running `execute_opcode_step` here would
                 // double-mutate.  pc already advanced above via
                 // `set_last_instr_from_next_instr(opcode_pc + 1)`.
-                Ok(StepResult::Continue)
+                //
+                // Walker-side `try_execute_residual_call_via_executor`
+                // (Task #390 sub-slice 3, `jitcode_dispatch.rs`)
+                // concrete-executes non-elidable residual calls during
+                // walker dispatch and routes raised exceptions through
+                // `BH_LAST_EXC_VALUE` (matches RPython
+                // `pyjitpl.py:2156-2168 handle_possible_exception` →
+                // `metainterp.execute_raised`).  Surface a pending
+                // exception as `Err(PyError)` so the bytecode
+                // interpreter's exception handler runs — without this,
+                // the helper's exception would silently drop, leaving
+                // the interpreter at the post-call PC instead of the
+                // exception-handler PC.
+                let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE
+                    .with(|c| {
+                        let v = c.get();
+                        c.set(0);
+                        v
+                    });
+                if bh_exc != 0 {
+                    Err(unsafe {
+                        pyre_interpreter::PyError::from_exc_object(
+                            bh_exc as pyre_object::PyObjectRef,
+                        )
+                    })
+                } else {
+                    Ok(StepResult::Continue)
+                }
             }
         } else {
             execute_opcode_step(frame, code, instruction, op_arg, next_instr)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3059,18 +3059,28 @@ fn dispatch_arm_via_blackhole(
         let mut bh = builder.acquire_interp();
         bh.jitcode = jitcode;
         bh.position = 0;
-        // Slice 3.4+ lands here: virtualizable_ptr / virtualizable_info
-        // wiring, PyFrame ↔ BH register marshalling, `bh.run()`, and
-        // the reverse marshal back into PyFrame stack.  Until then the
-        // path is unreachable (predicate `false`) so acquire/release is
-        // a no-op round trip.
+        // Virtualizable wiring — mirrors `call_jit.rs:1400-1423`.
+        // Single-arm dispatch has no caller chain so the
+        // `nextblackholeinterp` propagation loop reduces to no-op.
+        bh.virtualizable_ptr = frame as *mut pyre_interpreter::pyframe::PyFrame as i64;
+        bh.virtualizable_info = get_virtualizable_info();
+        // RPython MIFrame.setup parity: r0 = frame (per `trace_opcode.rs
+        // :6657-6660` walker-side seed).  Remaining registers default
+        // to zero/null; per-arm stack peeks set them up inside the arm
+        // body via `bhimpl_*` operand decoding.
+        if !bh.registers_r.is_empty() {
+            bh.registers_r[0] = bh.virtualizable_ptr;
+        }
+        // Slice 3.5+ lands here: per-opcode-family register
+        // marshalling, `bh.run()`, and the reverse marshal back into
+        // PyFrame stack.  Until then the path is unreachable
+        // (predicate `false`) so acquire/release is a no-op round trip.
         builder.release_interp(bh);
     });
 
-    let _ = frame;
     unimplemented!(
-        "dispatch_arm_via_blackhole: register marshalling + \
-         `bh.run()` lands in slice 3.4+.  \
+        "dispatch_arm_via_blackhole: per-opcode register marshalling \
+         + `bh.run()` lands in slice 3.5+.  \
          `production_blackhole_handles` must remain `false` until then."
     )
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3023,17 +3023,16 @@ fn dispatch_arm_via_blackhole(
     // metainterp-runtime wrapper is the form `BlackholeInterpreter.
     // jitcode` consumes (descr pool stays empty for build-time canonical
     // arms; `majit-metainterp/src/jitcode/mod.rs:400-403`).
-    let jitcode =
-        pyre_jit_trace::jitcode_runtime::metainterp_jitcode_for_instruction(instruction)
-            .ok_or_else(|| {
-                pyre_interpreter::PyError::new(
-                    pyre_interpreter::PyErrorKind::SystemError,
-                    format!(
-                        "dispatch_arm_via_blackhole: production_blackhole_handles \
+    let jitcode = pyre_jit_trace::jitcode_runtime::metainterp_jitcode_for_instruction(instruction)
+        .ok_or_else(|| {
+            pyre_interpreter::PyError::new(
+                pyre_interpreter::PyErrorKind::SystemError,
+                format!(
+                    "dispatch_arm_via_blackhole: production_blackhole_handles \
                          admitted instruction without codewriter arm: {instruction:?}",
-                    ),
-                )
-            })?;
+                ),
+            )
+        })?;
 
     // Thread-local BH pool — mirrors `call_jit.rs::blackhole_resume_via_
     // rd_numb`'s `BH_BUILDER_RD` (call_jit.rs:1300-1315).  Separate
@@ -3069,8 +3068,7 @@ fn dispatch_arm_via_blackhole(
             // Virtualizable wiring — mirrors `call_jit.rs:1400-1423`.
             // Single-arm dispatch has no caller chain so the
             // `nextblackholeinterp` propagation loop reduces to no-op.
-            bh.virtualizable_ptr =
-                frame as *mut pyre_interpreter::pyframe::PyFrame as i64;
+            bh.virtualizable_ptr = frame as *mut pyre_interpreter::pyframe::PyFrame as i64;
             bh.virtualizable_info = get_virtualizable_info();
             // RPython MIFrame.setup parity: r0 = frame (per
             // `trace_opcode.rs:6657-6660` walker-side seed).  Remaining
@@ -3086,12 +3084,7 @@ fn dispatch_arm_via_blackhole(
             let exception_value = bh.exception_last_value;
             let return_type = bh.return_type;
             builder.release_interp(bh);
-            (
-                mergepoint_args,
-                got_exception,
-                exception_value,
-                return_type,
-            )
+            (mergepoint_args, got_exception, exception_value, return_type)
         });
 
     if got_exception {
@@ -3314,12 +3307,11 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // the helper's exception would silently drop, leaving
                 // the interpreter at the post-call PC instead of the
                 // exception-handler PC.
-                let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE
-                    .with(|c| {
-                        let v = c.get();
-                        c.set(0);
-                        v
-                    });
+                let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| {
+                    let v = c.get();
+                    c.set(0);
+                    v
+                });
                 if bh_exc != 0 {
                     Err(unsafe {
                         pyre_interpreter::PyError::from_exc_object(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3053,36 +3053,66 @@ fn dispatch_arm_via_blackhole(
             builder.setup_cached_control_opcodes(op_live, op_catch_exception, op_rvmprof_code);
         };
 
-    BH_BUILDER_ARM.with(|cell| unsafe {
-        let builder = &mut *cell.get();
-        sync_control_opcodes(builder);
-        let mut bh = builder.acquire_interp();
-        bh.jitcode = jitcode;
-        bh.position = 0;
-        // Virtualizable wiring — mirrors `call_jit.rs:1400-1423`.
-        // Single-arm dispatch has no caller chain so the
-        // `nextblackholeinterp` propagation loop reduces to no-op.
-        bh.virtualizable_ptr = frame as *mut pyre_interpreter::pyframe::PyFrame as i64;
-        bh.virtualizable_info = get_virtualizable_info();
-        // RPython MIFrame.setup parity: r0 = frame (per `trace_opcode.rs
-        // :6657-6660` walker-side seed).  Remaining registers default
-        // to zero/null; per-arm stack peeks set them up inside the arm
-        // body via `bhimpl_*` operand decoding.
-        if !bh.registers_r.is_empty() {
-            bh.registers_r[0] = bh.virtualizable_ptr;
-        }
-        // Slice 3.5+ lands here: per-opcode-family register
-        // marshalling, `bh.run()`, and the reverse marshal back into
-        // PyFrame stack.  Until then the path is unreachable
-        // (predicate `false`) so acquire/release is a no-op round trip.
-        builder.release_interp(bh);
-    });
+    let (mergepoint_args, got_exception, exception_value, return_type) =
+        BH_BUILDER_ARM.with(|cell| unsafe {
+            let builder = &mut *cell.get();
+            sync_control_opcodes(builder);
+            let mut bh = builder.acquire_interp();
+            bh.jitcode = jitcode;
+            bh.position = 0;
+            // Virtualizable wiring — mirrors `call_jit.rs:1400-1423`.
+            // Single-arm dispatch has no caller chain so the
+            // `nextblackholeinterp` propagation loop reduces to no-op.
+            bh.virtualizable_ptr =
+                frame as *mut pyre_interpreter::pyframe::PyFrame as i64;
+            bh.virtualizable_info = get_virtualizable_info();
+            // RPython MIFrame.setup parity: r0 = frame (per
+            // `trace_opcode.rs:6657-6660` walker-side seed).
+            // Remaining registers default to zero/null; per-arm stack
+            // peeks set them up inside the arm body via `bhimpl_*`
+            // operand decoding.
+            if !bh.registers_r.is_empty() {
+                bh.registers_r[0] = bh.virtualizable_ptr;
+            }
+            let mergepoint_args = bh.run();
+            let got_exception = bh.got_exception;
+            let exception_value = bh.exception_last_value;
+            let return_type = bh.return_type;
+            builder.release_interp(bh);
+            (
+                mergepoint_args,
+                got_exception,
+                exception_value,
+                return_type,
+            )
+        });
 
-    unimplemented!(
-        "dispatch_arm_via_blackhole: per-opcode register marshalling \
-         + `bh.run()` lands in slice 3.5+.  \
-         `production_blackhole_handles` must remain `false` until then."
-    )
+    if got_exception {
+        // Slice 3.6: BH exception with no handler in the arm body.
+        // Convert `exception_value` (i64 pointer to W_BaseException) to
+        // a `PyError` and propagate up to `eval_loop_jit`.
+        let _ = exception_value;
+        todo!(
+            "dispatch_arm_via_blackhole: BH exception → PyError \
+             propagation lands in slice 3.6"
+        );
+    }
+    if mergepoint_args.is_some() {
+        // `ContinueRunningNormally` is the JIT-exit path: an arm
+        // discovered a jit_merge_point and wants the outer loop to
+        // re-warm.  Opcode arms don't issue merge points, so this is
+        // structurally unreachable for the per-opcode dispatch path.
+        unreachable!(
+            "dispatch_arm_via_blackhole: opcode arm raised \
+             ContinueRunningNormally — only portal arms should",
+        );
+    }
+    // LeaveFrame, no exception.  Per-return-type result handling
+    // (Ref/Int/Float push back onto PyFrame stack; Void = no push)
+    // lands in slice 3.7; void-returning arms (STORE_SUBSCR &c.) are
+    // the StoreSubscr activation target and need no push.
+    let _ = return_type;
+    Ok(StepResult::Continue)
 }
 
 /// warmspot.py portal_runner parity: execute a frame through the JIT-enabled


### PR DESCRIPTION
Fix https://github.com/youknowone/pyre/issues/122

## Summary

Two structurally-linked epic foundations that together prepare for retiring the M4 SIGBUS workaround in [[project_m4_walker_remaining_unactivated_taxonomy_2026_06_06]]:

**Task #390 — widen walker concrete-execute to non-elidable residual_calls.** PyPy `_opimpl_residual_call{1,2,3}` (`pyjitpl.py:1346/1349/1354`) concrete-executes every `do_residual_call` regardless of `check_is_elidable()` — the EI flag picks the record opcode (`CALL_PURE_*` vs `CALL_*`), not whether execution happens. The pyre walker currently concrete-executes only the elidable path via `try_fold_pure_call_via_executor`. Non-elidable helpers (`store_subscr_fn` / `set_current_exception` / …) are recorded but never executed; `eval_loop_jit:3111`'s walker-dispatched skip then leaves the heap unchanged → SIGBUS in 5 STORE_SUBSCR-hot benches. This PR lands sub-slices 1-5 of the orthodox fix:

- (1) inventory + doc-comment of the gap (`baf59d132f`, `109bccbd6d`)
- (2) `majit_metainterp::executor::execute_residual_call` walker-friendly entry + `try_execute_residual_call_via_executor` for `Call*` / `CallLoopinvariant*` shapes, wired to 3 dispatch sites with `!can_raise` gate (`f7b12284e5`, `e042d274b1`, `ca780d7cb3`)
- (3) walker-side exception propagation: `walker_record_guard_exception` helper, `WalkContext.last_exc_value` seeding, `BH_LAST_EXC_VALUE` restore, `eval.rs` walker-skip path surfaces non-zero exc as `Err(PyError)` (`7dd4238bb8`)
- (4) PyPy-orthodox activation via 47-bit fnaddr-sanity gate `(func_ptr as u64) >> 47 != 0` rejects unpatched `symbolic_fnaddr_for_path` DefaultHasher placeholders; lifts the `!can_raise` gate at all 3 dispatch sites (`963c2d807e`)
- (5) sub-slice 5 foundation: `bh_execute_store_subscr` C-ABI wrapper in `pyre-interpreter::opcode_ops` + `jit_trace_fnaddrs()` entry for path `"execute_store_subscr"`; build-time codewriter now bakes the real address into `constants_i` and `runtime_fnaddr_patch` maps build→runtime correctly (`0a4cfca1bc`)

StoreSubscr walker activation itself is not in this PR — it surfaces a heapcache EffectInfo gap (setitem's list/dict strategy-field writes aren't visible across the trait-dispatch boundary the codewriter analyses). Sub-slice 5b will widen EffectInfo via per-type wrappers (`bh_list_setitem` / `bh_dict_setitem` / …) following the PyPy `bhimpl_setarrayitem_gc_*` precedent.

**Phase 5.B `dispatch_arm_via_blackhole` body wire (workaround scaffolding).** The original workaround path for the same M4 class: run the arm jitcode through `BlackholeInterpreter` to concrete-execute the missing helpers. Foundation work committed here (`dca58bbdbd` → `08bc3d210a`) — JitCode wrapper cache, thread-local BH builder, acquire/release wiring, `bh.run()` + outcome triage, virtualizable wiring, exception → PyError propagation, return-type dispatch, `setposition()` BH register-bank init. `production_blackhole_handles` predicate returns `false` for every opcode today; the wire is unreachable until #390 sub-slice 6 retires it once StoreSubscr activation lands on the orthodox path.

`pyre/check.py` 41/41 green on dynasm + cranelift at HEAD `0a4cfca1bc`.

## Self-review

This patch is not AI-generated. (Assisted by Claude across the session captured in the linked memory note; commits authored by Jeong, YunWon.)