### PR TITLE
Allocate heap PyFrames behind a GC header; gate write barrier on TRAC…

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1417,6 +1417,13 @@ impl MiniMarkGC {
     /// objects never have TRACK_YOUNG_PTRS, so the flag test alone selects the
     /// old-gen objects that may now point to young.
     pub fn do_write_barrier(&mut self, obj: GcRef) {
+        // incminimark's write_barrier receives a typed, non-null struct pointer.
+        // pyre's GcRef is nullable (GcRef::NULL is the sentinel) and reaches the
+        // safe `write_barrier`/`gc_write_barrier` entry points, so guard null
+        // before reading `header_of(obj)`; the card variant guards it likewise.
+        if obj.is_null() {
+            return;
+        }
         let hdr = unsafe { header_of(obj.0) };
         if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
             self.remember_young_pointer(obj);
@@ -2547,6 +2554,15 @@ mod tests {
         gc.do_write_barrier(GcRef(payload));
         assert_eq!(gc.remembered_set.len(), 0);
         drop(buf);
+    }
+
+    #[test]
+    fn write_barrier_null_is_noop() {
+        // GcRef::NULL reaches the safe write_barrier entry; it must not read a
+        // header at `0 - GcHeader::SIZE`.
+        let mut gc = test_gc(1024);
+        gc.do_write_barrier(GcRef(0));
+        assert_eq!(gc.remembered_set.len(), 0);
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -347,12 +347,9 @@ impl MiniMarkGC {
             if self.card_page_shift > 0 && has_gc_ptrs_in_var && length > 0 {
                 let extra_words = self.card_marking_words_for_length(length);
                 let chs = 8 * extra_words; // WORD * extra_words
-                (
-                    chs,
-                    flags::HAS_CARDS | flags::TRACK_YOUNG_PTRS | flags::OLDGEN_TRACKED,
-                )
+                (chs, flags::HAS_CARDS | flags::TRACK_YOUNG_PTRS)
             } else {
-                (0, flags::TRACK_YOUNG_PTRS | flags::OLDGEN_TRACKED)
+                (0, flags::TRACK_YOUNG_PTRS)
             };
 
         let ptr = self
@@ -427,44 +424,6 @@ impl MiniMarkGC {
     #[inline]
     fn is_managed_heap_object(&self, addr: usize) -> bool {
         self.nursery.contains(addr) || self.oldgen.contains(addr)
-    }
-
-    /// Whether `addr` carries a header that names a registered type — the
-    /// minimal proof that a barrier target is a real managed object rather
-    /// than a stale or wild pointer. Every legitimately-allocated object
-    /// (nursery/old-gen, Box-allocated PyFrames, leaked `malloc_typed` host
-    /// objects) carries a header whose `type_id` is `< types.len()`; the same
-    /// `type_id < types.len()` validity guard the rest of collection applies
-    /// before dereferencing a type entry.
-    ///
-    /// The leading guard is a cheap defensive filter: a real GcRef payload is
-    /// non-null, word-aligned, and well above the zero page, so a malformed
-    /// target (null, a small integer mistaken for a pointer, a misaligned
-    /// address) returns `false` instead of faulting in `header_of`.
-    #[inline]
-    fn has_valid_managed_header(&self, addr: usize) -> bool {
-        if addr < 0x1000 || addr & (GcHeader::SIZE - 1) != 0 {
-            return false;
-        }
-        (unsafe { (*header_of(addr)).type_id() } as usize) < self.types.len()
-    }
-
-    /// Whether `addr` is a real old-gen object that may enter the remembered
-    /// set. Callers have already ruled out null and nursery addresses.
-    ///
-    /// `OLDGEN_TRACKED` is set at every old-gen allocation/promotion; nursery
-    /// and leaked host objects carry a zeroed header and are excluded. But the
-    /// flag bit alone is not trustworthy: the JIT can present a stale or wild
-    /// barrier target (e.g. a bridge that holds a freed inline-callee frame
-    /// pointer as a SETFIELD base), and the foreign word read as the header may
-    /// happen to have `OLDGEN_TRACKED` set. Admitting such an address pushes
-    /// non-object memory into the remembered set, whose garbage `type_id`
-    /// panics the next minor collection. So validate the header names a real
-    /// type first, then read the flag — an O(1) header read either way.
-    #[inline]
-    fn is_oldgen_write_barrier_object(&self, addr: usize) -> bool {
-        self.has_valid_managed_header(addr)
-            && unsafe { (*header_of(addr)).has_flag(flags::OLDGEN_TRACKED) }
     }
 
     /// incminimark.py:1208 is_in_nursery parity.
@@ -558,8 +517,7 @@ impl MiniMarkGC {
         let ptr = self.oldgen.alloc(total_size);
         let hdr = unsafe { &mut *(ptr as *mut GcHeader) };
         // Old objects start with TRACK_YOUNG_PTRS set (they need write barrier).
-        // OLDGEN_TRACKED marks this as a GC-owned old-gen object for the barrier.
-        *hdr = GcHeader::with_flags(type_id, flags::TRACK_YOUNG_PTRS | flags::OLDGEN_TRACKED);
+        *hdr = GcHeader::with_flags(type_id, flags::TRACK_YOUNG_PTRS);
         self.bytes_made_old_since_cycle =
             self.bytes_made_old_since_cycle.saturating_add(total_size);
         GcRef((ptr as usize) + GcHeader::SIZE)
@@ -886,9 +844,11 @@ impl MiniMarkGC {
         let shadow_obj = shadow_hdr_ptr as usize + GcHeader::SIZE;
         unsafe {
             (*(shadow_hdr_ptr as *mut GcHeader)).tid_and_flags = (*hdr_ptr).tid_and_flags;
-            // The shadow lives in old-gen: tag it so the write barrier treats it
-            // as GC-owned even before the nursery object is copied into it.
-            (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::OLDGEN_TRACKED);
+            // The shadow lives in old-gen, so it carries TRACK_YOUNG_PTRS like
+            // every other old-gen object — the write barrier tracks it through
+            // that flag. (The source header was copied from the nursery object,
+            // which does not carry it.)
+            (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::TRACK_YOUNG_PTRS);
             if type_info.item_size > 0 {
                 let len_ofs = type_info.length_offset;
                 *((shadow_obj + len_ofs) as *mut usize) = *((obj_addr + len_ofs) as *const usize);
@@ -1019,14 +979,11 @@ impl MiniMarkGC {
         self.bytes_made_old_since_cycle =
             self.bytes_made_old_since_cycle.saturating_add(total_size);
 
-        // Set TRACK_YOUNG_PTRS on the new old-gen object, and OLDGEN_TRACKED so
-        // the write barrier recognises this promoted copy as a GC-owned old-gen
-        // object. (The source header was copied from the nursery object, which
-        // carries neither flag.)
+        // Set TRACK_YOUNG_PTRS on the new old-gen object. (The source header was
+        // copied from the nursery object, which does not carry it.)
         unsafe {
             let h = new_header_ptr as *mut GcHeader;
             (*h).set_flag(flags::TRACK_YOUNG_PTRS);
-            (*h).set_flag(flags::OLDGEN_TRACKED);
         }
 
         // Install forwarding pointer in the nursery copy.
@@ -1452,28 +1409,33 @@ impl MiniMarkGC {
         }
     }
 
-    /// Write barrier: call before storing a GC reference into an old-gen object.
-    ///
-    /// If the object has TRACK_YOUNG_PTRS set, we clear it and add the object
-    /// to the remembered set, because it might now point to a young object.
-    ///
-    /// The `is_managed_heap_object` guard is NOT in incminimark: RPython's
-    /// write_barrier() is only called with GC-managed objects. In pyre,
-    /// virtualizable objects such as PyFrame are Rust Box-allocated, while the
-    /// JIT rewriter still emits COND_CALL_GC_WB for Ref-typed SETFIELD_GC
-    /// stores. Keep those non-GC addresses out of the remembered set here.
+    /// incminimark.py:1489-1493 write_barrier(addr_struct):
+    /// if the object has GCFLAG_TRACK_YOUNG_PTRS, call remember_young_pointer.
+    /// The barrier is only ever called on header-bearing GC objects — every
+    /// heap PyFrame now carries a GcHeader via `FrameBox`, and every other
+    /// managed object via the GC allocator / `lltype::malloc_typed`. Nursery
+    /// objects never have TRACK_YOUNG_PTRS, so the flag test alone selects the
+    /// old-gen objects that may now point to young.
     pub fn do_write_barrier(&mut self, obj: GcRef) {
-        if obj.is_null()
-            || self.nursery.contains(obj.0)
-            || !self.is_oldgen_write_barrier_object(obj.0)
-        {
-            return;
-        }
         let hdr = unsafe { header_of(obj.0) };
         if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
-            unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
-            self.remembered_set.push(obj.0);
+            self.remember_young_pointer(obj);
         }
+    }
+
+    /// incminimark.py:1503-1529 _remember_young_pointer_inlined(addr):
+    /// append the object to the remembered set (`old_objects_pointing_to_young`)
+    /// and clear GCFLAG_TRACK_YOUNG_PTRS. Callers have already verified the flag
+    /// (the inline COND_CALL_GC_WB test, or `do_write_barrier`).
+    ///
+    /// The incminimark "if tid & GCFLAG_NO_HEAP_PTRS: prebuilt_root_objects
+    /// .append(addr)" branch has no counterpart: pyre allocates every GC object
+    /// at runtime and never sets GCFLAG_NO_HEAP_PTRS (there are no immortal
+    /// prebuilt objects from translation), so no object ever reaches that arm.
+    fn remember_young_pointer(&mut self, obj: GcRef) {
+        self.remembered_set.push(obj.0);
+        let hdr = unsafe { header_of(obj.0) };
+        unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
     }
 
     /// incminimark.py:1495-1501 write_barrier_from_array:
@@ -1502,10 +1464,8 @@ impl MiniMarkGC {
     ) {
         let hdr = unsafe { header_of(obj.0) };
         if unsafe { !(*hdr).has_flag(flags::HAS_CARDS) } {
-            // No cards — fall back to generic barrier.
-            // _remember_young_pointer_inlined clears TRACK_YOUNG_PTRS.
-            unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
-            self.remembered_set.push(obj.0);
+            // No cards — fall back to the generic _remember_young_pointer_inlined.
+            self.remember_young_pointer(obj);
             return;
         }
         // Card path: mark the specific card. TRACK_YOUNG_PTRS stays set
@@ -1518,13 +1478,6 @@ impl MiniMarkGC {
     /// but CARDS_SET is not. Tries to set CARDS_SET; otherwise falls
     /// back to remember_young_pointer (generic barrier).
     pub fn jit_remember_young_pointer_from_array(&mut self, obj: GcRef) {
-        // The JIT can present a stale or wild barrier target (e.g. a freed
-        // inline frame the bridge still holds as a SETARRAYITEM base). Reject
-        // it before touching the card byte / CARDS_SET, mirroring the validity
-        // guard `is_oldgen_write_barrier_object` applies on the no-cards path.
-        if !self.has_valid_managed_header(obj.0) {
-            return;
-        }
         let hdr = unsafe { header_of(obj.0) };
         if unsafe { (*hdr).has_flag(flags::HAS_CARDS) } {
             // incminimark.py:1614-1615
@@ -1728,21 +1681,12 @@ impl MiniMarkGC {
     /// JIT has already determined that the barrier is needed (via
     /// the inline flag test emitted by COND_CALL_GC_WB).
     ///
-    /// Equivalent to incminimark's `jit_remember_young_pointer()`.
-    ///
-    /// See `do_write_barrier` for why `is_managed_heap_object` is needed.
+    /// Equivalent to incminimark's `jit_remember_young_pointer()`: the JIT has
+    /// already passed the inline GCFLAG_TRACK_YOUNG_PTRS test emitted by
+    /// COND_CALL_GC_WB, so go straight to the inlined remember logic without
+    /// re-testing the flag.
     pub fn jit_remember_young_pointer(&mut self, obj: GcRef) {
-        if obj.is_null()
-            || self.nursery.contains(obj.0)
-            || !self.is_oldgen_write_barrier_object(obj.0)
-        {
-            return;
-        }
-        // Clear TRACK_YOUNG_PTRS so the object won't trigger the
-        // barrier again until it is re-processed in a minor collection.
-        let hdr = unsafe { header_of(obj.0) };
-        unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
-        self.remembered_set.push(obj.0);
+        self.remember_young_pointer(obj);
     }
 
     /// Returns true if the GC supports optimized conditional write barriers.
@@ -2542,34 +2486,32 @@ mod tests {
         assert_eq!(gc.remembered_set.len(), 1);
     }
 
-    // `is_oldgen_write_barrier_object` makes OLDGEN_TRACKED the entire old-gen
-    // eligibility test, so every path that places an object in old-gen must set
-    // the flag. These lock that invariant down across all four producers, plus
-    // a negative case so a stray TRACK_YOUNG_PTRS object stays out.
+    // incminimark gates the write barrier solely on GCFLAG_TRACK_YOUNG_PTRS:
+    // every old-gen producer sets it, and the barrier appends on the flag test
+    // alone. These lock that invariant down across all four producers, plus a
+    // zeroed-header case (no flag) that the barrier must skip.
 
     #[test]
-    fn oldgen_tracked_set_on_direct_oldgen_alloc() {
+    fn track_young_ptrs_set_on_direct_oldgen_alloc() {
         let mut gc = test_gc(1024);
         gc.register_type(TypeInfo::simple(16));
         let obj = gc.alloc_in_oldgen(0, GcHeader::SIZE + 16);
-        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::OLDGEN_TRACKED) });
-        assert!(gc.is_oldgen_write_barrier_object(obj.0));
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
     }
 
     #[test]
-    fn oldgen_tracked_set_on_card_alloc() {
+    fn track_young_ptrs_set_on_card_alloc() {
         let ptr_size = std::mem::size_of::<GcRef>();
         let mut gc = test_gc(1024);
         let tid = gc.register_type(TypeInfo::varsize(8, ptr_size, 0, true, Vec::new()));
         let length = 4usize;
         let total_size = GcHeader::SIZE + 8 + ptr_size * length;
         let obj = gc.alloc_in_oldgen_with_cards(tid, total_size, length, true);
-        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::OLDGEN_TRACKED) });
-        assert!(gc.is_oldgen_write_barrier_object(obj.0));
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
     }
 
     #[test]
-    fn oldgen_tracked_set_on_nursery_promotion() {
+    fn track_young_ptrs_set_on_nursery_promotion() {
         let mut gc = test_gc(4096);
         gc.register_type(TypeInfo::simple(16));
         let mut root = gc.alloc_with_type(0, 16);
@@ -2578,34 +2520,30 @@ mod tests {
         gc.collect_nursery();
         // `root` now holds the promoted old-gen address.
         assert!(!gc.is_in_nursery(root.0));
-        assert!(unsafe { (*header_of(root.0)).has_flag(flags::OLDGEN_TRACKED) });
-        assert!(gc.is_oldgen_write_barrier_object(root.0));
+        assert!(unsafe { (*header_of(root.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
         gc.roots.clear();
     }
 
     #[test]
-    fn oldgen_tracked_set_on_shadow_alloc() {
+    fn track_young_ptrs_set_on_shadow_alloc() {
         let mut gc = test_gc(4096);
         gc.register_type(TypeInfo::simple(16));
         let obj = gc.alloc_with_type(0, 16);
         let shadow = gc.allocate_shadow(obj.0);
-        assert!(unsafe { (*header_of(shadow)).has_flag(flags::OLDGEN_TRACKED) });
-        assert!(gc.is_oldgen_write_barrier_object(shadow));
+        assert!(unsafe { (*header_of(shadow)).has_flag(flags::TRACK_YOUNG_PTRS) });
     }
 
     #[test]
-    fn write_barrier_object_rejects_tracked_young_without_oldgen_tracked() {
+    fn write_barrier_skips_object_without_track_young_ptrs() {
         let mut gc = test_gc(1024);
         gc.register_type(TypeInfo::simple(16));
-        // A header-shaped Box allocation outside the GC heap (mirrors
-        // PyFrame-style host allocations during the migration window): it
-        // carries a GcHeader with TRACK_YOUNG_PTRS but no OLDGEN_TRACKED, so it
-        // must be rejected without entering the remembered set.
+        // A zeroed-header object (the shape every non-old-gen managed object
+        // carries: FrameBox frames, leaked host objects, nursery objects) has
+        // TRACK_YOUNG_PTRS clear, so the barrier reads the flag and skips it.
         let mut buf = Box::new([0u64; 2]);
         let base = buf.as_mut_ptr() as usize;
-        unsafe { *(base as *mut GcHeader) = GcHeader::with_flags(0, flags::TRACK_YOUNG_PTRS) };
+        unsafe { *(base as *mut GcHeader) = GcHeader::new(0) };
         let payload = base + GcHeader::SIZE;
-        assert!(!gc.is_oldgen_write_barrier_object(payload));
         gc.do_write_barrier(GcRef(payload));
         assert_eq!(gc.remembered_set.len(), 0);
         drop(buf);
@@ -2883,16 +2821,6 @@ mod tests {
         assert_eq!(val, 0x42424242);
 
         gc.roots.clear();
-    }
-
-    #[test]
-    fn test_null_ref_safety() {
-        let mut gc = test_gc(1024);
-        gc.register_type(TypeInfo::simple(8));
-
-        // Write barrier on null should be a no-op.
-        gc.do_write_barrier(GcRef::NULL);
-        assert!(gc.remembered_set.is_empty());
     }
 
     #[test]
@@ -4326,13 +4254,6 @@ mod tests {
         // deduplicate; the collector handles this during minor collection).
         gc.jit_remember_young_pointer(obj);
         assert_eq!(gc.remembered_set_len(), 2);
-    }
-
-    #[test]
-    fn test_jit_remember_young_pointer_null_is_noop() {
-        let mut gc = test_gc(4096);
-        gc.jit_remember_young_pointer(GcRef::NULL);
-        assert_eq!(gc.remembered_set_len(), 0);
     }
 
     #[test]

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -142,8 +142,8 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
 /// (`init_gc_object(result, typeid, flags=0)`), and return
 /// `obj = result + size_gc_header`. The header is zeroed (`tid = 0`, all
 /// flags clear) so a write barrier reading `*(obj - SIZE)` sees
-/// `TRACK_YOUNG_PTRS = 0` / `OLDGEN_TRACKED = 0` and skips the object: it is
-/// immortal (leaked), not tracked by the nursery or old generation.
+/// `TRACK_YOUNG_PTRS = 0` and skips the object: it is immortal (leaked), not
+/// tracked by the nursery or old generation.
 ///
 /// The allocation is intentionally leaked — these objects outlive every
 /// collection until the managed allocator takes them over. Callers MUST NOT
@@ -234,7 +234,6 @@ mod tests {
             // Zeroed header => barrier reads TRACK_YOUNG_PTRS=0 and skips.
             assert_eq!((*hdr).tid_and_flags, 0);
             assert!(!(*hdr).has_flag(flags::TRACK_YOUNG_PTRS));
-            assert!(!(*hdr).has_flag(flags::OLDGEN_TRACKED));
         }
     }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -53,17 +53,6 @@ pub mod flags {
     pub const SHADOW_INITIALIZED: u64 = 1 << 11;
     /// GCFLAG_DUMMY (bit 12)
     pub const DUMMY: u64 = 1 << 12;
-    // _GCFLAG_FIRST_UNUSED = first_gcflag << 13: the first bit incminimark
-    // leaves free. pyre-only flags must start here, above the whole upstream
-    // GCFLAG range, so they never alias an incminimark flag.
-    /// OLDGEN_TRACKED (bit 13, _GCFLAG_FIRST_UNUSED) — pyre extension, not an
-    /// incminimark GCFLAG. Set on every object allocated in (or promoted to)
-    /// the old gen, and only on those. The write barrier uses it to tell a
-    /// real old-gen object apart from a Box-allocated PyFrame (which carries a
-    /// GcHeader and TRACK_YOUNG_PTRS but must not enter the remembered set), so
-    /// the barrier's membership test is an O(1) flag read instead of a lookup
-    /// in a side table that scaled with old-gen size.
-    pub const OLDGEN_TRACKED: u64 = 1 << 13;
 }
 
 /// Write barrier descriptor — information the JIT needs to emit write barrier checks.

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -138,9 +138,9 @@ impl OldGen {
 
     /// Check whether `obj_addr` is the payload address of a tracked old-gen object.
     ///
-    /// Linear over `objects`; the write barrier no longer needs this (it reads
-    /// the `OLDGEN_TRACKED` header flag in O(1)), so the remaining callers are
-    /// cold paths (`is_managed_heap_object`, weakref scanning).
+    /// Linear over `objects`; the write barrier does not use this (it gates on
+    /// the `TRACK_YOUNG_PTRS` header flag), so the callers are cold paths
+    /// (`is_managed_heap_object`, weakref scanning).
     pub fn contains(&self, obj_addr: usize) -> bool {
         self.objects
             .iter()

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -428,26 +428,27 @@ fn call_user_function_with_eval(
     // PyPy: generator.py GeneratorIterator.__init__ wraps PyFrame.
     // RustPython compiler uses CodeFlags::GENERATOR instead of RETURN_GENERATOR opcode.
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
-        let mut gen_frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
+        let gen_frame =
+            crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
+                w_code,
+                &final_args,
+                globals,
+                w_globals_obj,
+                frame.execution_context,
+                closure,
+            )?);
+        return gen_frame.into_generator();
+    }
+
+    let mut func_frame =
+        crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
             w_code,
             &final_args,
             globals,
             w_globals_obj,
             frame.execution_context,
             closure,
-        )?;
-        gen_frame.fix_array_ptrs();
-        return gen_frame.run();
-    }
-
-    let mut func_frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        w_code,
-        &final_args,
-        globals,
-        w_globals_obj,
-        frame.execution_context,
-        closure,
-    )?;
+        )?);
     func_frame.fix_array_ptrs();
     let _caller_locals_root = FrameLocalsRoot::new(frame);
     let _callee_locals_root = FrameLocalsRoot::new_mut(&mut func_frame);
@@ -476,28 +477,29 @@ pub fn call_user_function_resolved(
 
     // Generator function
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
-        let mut gen_frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
+        let gen_frame =
+            crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
+                w_code,
+                args,
+                globals,
+                w_globals_obj,
+                frame.execution_context,
+                closure,
+            )?);
+        return gen_frame.into_generator();
+    }
+
+    let eval_fn = get_eval_fn();
+
+    let mut func_frame =
+        crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
             w_code,
             args,
             globals,
             w_globals_obj,
             frame.execution_context,
             closure,
-        )?;
-        gen_frame.fix_array_ptrs();
-        return gen_frame.run();
-    }
-
-    let eval_fn = get_eval_fn();
-
-    let mut func_frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        w_code,
-        args,
-        globals,
-        w_globals_obj,
-        frame.execution_context,
-        closure,
-    )?;
+        )?);
     func_frame.fix_array_ptrs();
     let _caller_locals_root = FrameLocalsRoot::new(frame);
     let _callee_locals_root = FrameLocalsRoot::new_mut(&mut func_frame);
@@ -633,26 +635,27 @@ pub fn call_user_function_plain_with_ctx(
     let final_args = fill_user_function_args(callable, code_ref, args)?;
 
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
-        let mut gen_frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
+        let gen_frame =
+            crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
+                w_code,
+                &final_args,
+                globals,
+                w_globals_obj,
+                execution_context,
+                closure,
+            )?);
+        return gen_frame.into_generator();
+    }
+
+    let mut func_frame =
+        crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
             w_code,
             &final_args,
             globals,
             w_globals_obj,
             execution_context,
             closure,
-        )?;
-        gen_frame.fix_array_ptrs();
-        return gen_frame.run();
-    }
-
-    let mut func_frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        w_code,
-        &final_args,
-        globals,
-        w_globals_obj,
-        execution_context,
-        closure,
-    )?;
+        )?);
     func_frame.fix_array_ptrs();
     let _callee_locals_root = FrameLocalsRoot::new_mut(&mut func_frame);
     func_frame.run()
@@ -1346,7 +1349,7 @@ pub fn call_with_kwargs(
             let globals = unsafe { function_get_globals(callable) };
             let w_globals_obj = unsafe { function_get_globals_obj(callable) };
             let closure = unsafe { function_get_closure(callable) };
-            let mut func_frame =
+            let mut func_frame = crate::pyframe::FrameBox::new(
                 crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
                     w_code,
                     &final_args,
@@ -1354,7 +1357,8 @@ pub fn call_with_kwargs(
                     w_globals_obj,
                     frame.execution_context,
                     closure,
-                )?;
+                )?,
+            );
             func_frame.fix_array_ptrs();
             let plain_mode = FORCE_PLAIN_EVAL.with(|c| c.get() > 0);
             let eval_fn = if plain_mode {
@@ -1753,7 +1757,33 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
 
     // Generator function: wrap frame in generator object
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
-        let mut gen_frame = match PyFrame::try_new_for_call_with_closure_and_globals_obj(
+        let gen_frame = crate::pyframe::FrameBox::new(
+            match PyFrame::try_new_for_call_with_closure_and_globals_obj(
+                w_code,
+                &final_args,
+                globals,
+                w_globals_obj,
+                exec_ctx,
+                closure,
+            ) {
+                Ok(f) => f,
+                Err(e) => {
+                    set_call_error(e);
+                    return PY_NULL;
+                }
+            },
+        );
+        return match gen_frame.into_generator() {
+            Ok(v) => v,
+            Err(e) => {
+                set_call_error(e);
+                PY_NULL
+            }
+        };
+    }
+
+    let mut frame = crate::pyframe::FrameBox::new(
+        match PyFrame::try_new_for_call_with_closure_and_globals_obj(
             w_code,
             &final_args,
             globals,
@@ -1766,31 +1796,8 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
                 set_call_error(e);
                 return PY_NULL;
             }
-        };
-        gen_frame.fix_array_ptrs();
-        return match gen_frame.run() {
-            Ok(v) => v,
-            Err(e) => {
-                set_call_error(e);
-                PY_NULL
-            }
-        };
-    }
-
-    let mut frame = match PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        w_code,
-        &final_args,
-        globals,
-        w_globals_obj,
-        exec_ctx,
-        closure,
-    ) {
-        Ok(f) => f,
-        Err(e) => {
-            set_call_error(e);
-            return PY_NULL;
-        }
-    };
+        },
+    );
     frame.fix_array_ptrs();
     match frame.execute_frame(None, None) {
         Ok(v) => v,
@@ -1823,17 +1830,18 @@ fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]
     };
     let code_ref = unsafe { &*func_code };
 
-    let mut frame = PyFrame::new_for_call_with_closure_and_globals_obj(
-        w_code,
-        args,
-        globals,
-        w_globals_obj,
-        exec_ctx,
-        closure,
-    );
+    let mut frame =
+        crate::pyframe::FrameBox::new(PyFrame::new_for_call_with_closure_and_globals_obj(
+            w_code,
+            args,
+            globals,
+            w_globals_obj,
+            exec_ctx,
+            closure,
+        ));
     frame.fix_array_ptrs();
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
-        return match frame.run() {
+        return match frame.into_generator() {
             Ok(v) => v,
             Err(e) => {
                 set_call_error(e);
@@ -2218,14 +2226,15 @@ fn build_class_inner(
         pyre_object::is_instance(w) && !crate::type_methods::resolve_dict_backing(w).is_null()
     });
 
-    let mut frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        w_code,
-        &[],
-        globals,
-        w_globals_obj,
-        exec_ctx,
-        closure,
-    )?;
+    let mut frame =
+        crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
+            w_code,
+            &[],
+            globals,
+            w_globals_obj,
+            exec_ctx,
+            closure,
+        )?);
     if let Some(w_ns) = mapping_namespace {
         frame.setdictscope_object(w_ns)?;
     } else {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3490,7 +3490,7 @@ mod tests {
         frame.execute_frame(None, None)
     }
 
-    fn run_exec_frame(source: &str) -> (PyResult, Box<PyFrame>) {
+    fn run_exec_frame(source: &str) -> (PyResult, crate::pyframe::FrameBox) {
         let code = compile_exec(source).expect("compile failed");
         let mut frame = PyFrame::new(code);
         let result = frame.execute_frame(None, None);

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2031,20 +2031,25 @@ fn _flat_pycall(
     let closure = unsafe { function_get_closure(func) };
 
     // function.py:208-209 — createframe(code, w_func_globals, self)
-    let mut new_frame = match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        code,
-        &[], // locals filled below directly from stack
-        globals,
-        w_globals_obj,
-        frame.execution_context,
-        closure,
-    ) {
-        Ok(f) => f,
-        Err(e) => {
-            crate::call::set_call_error(e);
-            return pyre_object::PY_NULL;
-        }
-    };
+    // FrameBox: the callee runs through the JIT, so it must be a
+    // header-bearing heap frame (write barrier reads a valid header at
+    // frame - GC_HEADER_SIZE) rather than a bare interpreter-stack frame.
+    let mut new_frame = crate::pyframe::FrameBox::new(
+        match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
+            code,
+            &[], // locals filled below directly from stack
+            globals,
+            w_globals_obj,
+            frame.execution_context,
+            closure,
+        ) {
+            Ok(f) => f,
+            Err(e) => {
+                crate::call::set_call_error(e);
+                return pyre_object::PY_NULL;
+            }
+        },
+    );
 
     // function.py:210-211 — copy from stack into locals directly
     // peekvalue(nargs-1-i) gives bottom-to-top order (matching local slot order)
@@ -2053,14 +2058,13 @@ fn _flat_pycall(
     }
     frame.dropvalues(dropvalues);
     new_frame.fix_array_ptrs();
-    let _caller_locals_root = FrameLocalsRoot::new(frame);
-    let _callee_locals_root = FrameLocalsRoot::new(&mut new_frame);
 
     // function.py:214 — return new_frame.run(self.name, self.qualname)
-    // Check generator/coroutine: run() wraps into generator object instead
-    // of executing the body. For normal functions, use the JIT-aware eval.
+    // Generator/coroutine: wrap the frame in a generator object and hand it
+    // ownership (no execution). Normal functions execute through the JIT-aware
+    // eval, which needs the locals roots registered for the duration.
     if new_frame._is_generator_or_coroutine() {
-        match new_frame.run() {
+        match new_frame.into_generator() {
             Ok(v) => v,
             Err(e) => {
                 crate::call::set_call_error(e);
@@ -2068,6 +2072,8 @@ fn _flat_pycall(
             }
         }
     } else {
+        let _caller_locals_root = FrameLocalsRoot::new(frame);
+        let _callee_locals_root = FrameLocalsRoot::new(&mut new_frame);
         let eval_fn = crate::call::get_eval_fn();
         match eval_fn(&mut new_frame) {
             Ok(v) => v,
@@ -2099,20 +2105,23 @@ fn _flat_pycall_defaults(
     let w_globals_obj = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
 
-    let mut new_frame = match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        code,
-        &[], // locals filled below
-        globals,
-        w_globals_obj,
-        frame.execution_context,
-        closure,
-    ) {
-        Ok(f) => f,
-        Err(e) => {
-            crate::call::set_call_error(e);
-            return pyre_object::PY_NULL;
-        }
-    };
+    // FrameBox: header-bearing heap frame for the JIT write barrier.
+    let mut new_frame = crate::pyframe::FrameBox::new(
+        match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
+            code,
+            &[], // locals filled below
+            globals,
+            w_globals_obj,
+            frame.execution_context,
+            closure,
+        ) {
+            Ok(f) => f,
+            Err(e) => {
+                crate::call::set_call_error(e);
+                return pyre_object::PY_NULL;
+            }
+        },
+    );
 
     // function.py:221-222 — copy positional args from stack
     for i in 0..nargs {
@@ -2134,12 +2143,10 @@ fn _flat_pycall_defaults(
 
     frame.dropvalues(dropvalues);
     new_frame.fix_array_ptrs();
-    let _caller_locals_root = FrameLocalsRoot::new(frame);
-    let _callee_locals_root = FrameLocalsRoot::new(&mut new_frame);
 
     // function.py:231 — return new_frame.run(self.name, self.qualname)
     if new_frame._is_generator_or_coroutine() {
-        match new_frame.run() {
+        match new_frame.into_generator() {
             Ok(v) => v,
             Err(e) => {
                 crate::call::set_call_error(e);
@@ -2147,6 +2154,8 @@ fn _flat_pycall_defaults(
             }
         }
     } else {
+        let _caller_locals_root = FrameLocalsRoot::new(frame);
+        let _callee_locals_root = FrameLocalsRoot::new(&mut new_frame);
         let eval_fn = crate::call::get_eval_fn();
         match eval_fn(&mut new_frame) {
             Ok(v) => v,

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -223,6 +223,110 @@ pub unsafe fn dealloc_array_with_gc_header(ptr: *mut FixedObjectArray) {
     }
 }
 
+/// Heap layout for a managed `PyFrame`: a leading GC header followed by
+/// the frame body. The header occupies [`GC_HEADER_SIZE`] bytes and stays
+/// zeroed (`type_id = 0`, `flags = 0`) so the write-barrier fast-path reads
+/// `TRACK_YOUNG_PTRS = 0` at `frame - GC_HEADER_SIZE` and skips the slow
+/// path. Mirrors `FixedObjectArray`'s header prefix and the callee-frame
+/// allocation in `pyre-jit::call_jit`, realising the documented invariant
+/// that every heap `PyFrame` is a header-bearing GC object.
+#[repr(C)]
+struct GcFramePrefix {
+    gc_header: u64,
+    frame: PyFrame,
+}
+
+// The frame must sit exactly GC_HEADER_SIZE bytes into the prefix: the write
+// barrier reads the header at `frame - GC_HEADER_SIZE`, and FrameBox::drop
+// reconstructs the owning Box from that same address. A future PyFrame field
+// with alignment greater than the header word would make `#[repr(C)]` pad the
+// frame to a larger offset and silently break both, so pin the offset here.
+const _: () = assert!(std::mem::offset_of!(GcFramePrefix, frame) == GC_HEADER_SIZE);
+
+/// Owning handle to a heap [`PyFrame`] allocated with a leading GC header.
+/// Dereferences to the inner `PyFrame`; the header lives at
+/// `self.ptr - GC_HEADER_SIZE`. Replaces the bare `Box<PyFrame>` so the
+/// frame the JIT treats as the virtualizable is a real GC object with a
+/// valid header at `frame - GC_HEADER_SIZE`.
+pub struct FrameBox {
+    ptr: *mut PyFrame,
+}
+
+impl FrameBox {
+    /// Move `frame` onto the heap behind a zeroed GC header.
+    pub fn new(frame: PyFrame) -> Self {
+        let raw = Box::into_raw(Box::new(GcFramePrefix {
+            gc_header: 0,
+            frame,
+        }));
+        let ptr = unsafe { std::ptr::addr_of_mut!((*raw).frame) };
+        FrameBox { ptr }
+    }
+
+    /// Relinquish ownership, returning the inner-frame pointer. The header
+    /// remains at `ptr - GC_HEADER_SIZE`; reclaim via [`FrameBox::from_raw`].
+    pub fn into_raw(self) -> *mut PyFrame {
+        let ptr = self.ptr;
+        std::mem::forget(self);
+        ptr
+    }
+
+    /// Reconstruct ownership from a pointer previously produced by
+    /// [`FrameBox::into_raw`].
+    ///
+    /// # Safety
+    /// `ptr` must originate from [`FrameBox::into_raw`] / [`FrameBox::new`]
+    /// and must not have been freed.
+    pub unsafe fn from_raw(ptr: *mut PyFrame) -> Self {
+        FrameBox { ptr }
+    }
+
+    /// Raw pointer to the inner frame (header at `ptr - GC_HEADER_SIZE`).
+    pub fn as_mut_ptr(&mut self) -> *mut PyFrame {
+        self.ptr
+    }
+
+    /// pyframe.py:259 initialize_as_generator — wrap this frame in a generator
+    /// object that takes ownership of it. PyPy does `GeneratorIterator(self)`:
+    /// the generator references the same frame, no copy. FrameBox already holds
+    /// the heap, header-bearing frame, so ownership transfers straight through
+    /// `into_raw` without the snapshot copy `PyFrame::initialize_as_generator`
+    /// needs for the borrowed-`&mut self` case.
+    pub fn into_generator(mut self) -> crate::PyResult {
+        self.fix_array_ptrs();
+        let frame_ptr = self.into_raw();
+        let generator = pyre_object::generatorobject::w_generator_new(frame_ptr as *mut u8);
+        unsafe {
+            (*frame_ptr).f_generator_nowref = generator;
+        }
+        Ok(generator)
+    }
+}
+
+impl std::ops::Deref for FrameBox {
+    type Target = PyFrame;
+    #[inline]
+    fn deref(&self) -> &PyFrame {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl std::ops::DerefMut for FrameBox {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut PyFrame {
+        unsafe { &mut *self.ptr }
+    }
+}
+
+impl Drop for FrameBox {
+    fn drop(&mut self) {
+        unsafe {
+            let prefix = (self.ptr as *mut u8).sub(GC_HEADER_SIZE) as *mut GcFramePrefix;
+            drop(Box::from_raw(prefix));
+        }
+    }
+}
+
 unsafe fn clone_debugdata_ptr(ptr: *mut FrameDebugData) -> *mut FrameDebugData {
     unsafe {
         if ptr.is_null() {
@@ -965,7 +1069,7 @@ impl PyFrame {
     /// `pyre-jit-trace` test modules) but routes the body through
     /// `createframe` (PyPy `baseobjspace.py:796`) so every heap-allocated
     /// `PyFrame` flows through the canonical entry point.
-    pub fn new(code: CodeObject) -> Box<Self> {
+    pub fn new(code: CodeObject) -> FrameBox {
         Self::new_with_context(code, Rc::new(PyExecutionContext::default()))
             .expect("PyFrame::new: test entry code must not carry freevars")
     }
@@ -994,7 +1098,7 @@ impl PyFrame {
     pub fn new_with_context(
         code: CodeObject,
         execution_context: Rc<PyExecutionContext>,
-    ) -> Result<Box<Self>, crate::PyError> {
+    ) -> Result<FrameBox, crate::PyError> {
         // `fresh_dict_storage` already seeds `__builtins__ = space
         // .builtin` (PyPy `main.py:45 / Module.__init__` parity).  Just
         // set `__name__` on top.
@@ -1080,8 +1184,8 @@ impl PyFrame {
     /// bytecodes concretely during tracing, so use an owned snapshot when
     /// recording a trace to keep the real frame state unchanged until the
     /// interpreter actually executes the same path.
-    pub fn snapshot_for_tracing(&self) -> Box<Self> {
-        let mut frame = Box::new(PyFrame {
+    pub fn snapshot_for_tracing(&self) -> FrameBox {
+        let mut frame = FrameBox::new(PyFrame {
             execution_context: self.execution_context,
             pycode: self.pycode,
             locals_cells_stack_w: unsafe { alloc_fixed_array_from_vec(self.locals_w().to_vec()) },
@@ -2259,14 +2363,11 @@ impl PyFrame {
     /// the right object.
     #[inline]
     pub fn initialize_as_generator(&mut self) -> crate::PyResult {
-        let mut gen_frame = self.snapshot_for_tracing();
-        gen_frame.fix_array_ptrs();
-        let gen_frame_ptr = Box::into_raw(gen_frame);
-        let generator = pyre_object::generatorobject::w_generator_new(gen_frame_ptr as *mut u8);
-        unsafe {
-            (*gen_frame_ptr).f_generator_nowref = generator;
-        }
-        Ok(generator)
+        // pyframe.py:259 wraps `self` directly. A borrowed `&mut self` cannot
+        // hand ownership to the generator, so snapshot into an owned FrameBox
+        // first. Callers that already own a FrameBox should use
+        // `FrameBox::into_generator` to skip this copy.
+        self.snapshot_for_tracing().into_generator()
     }
 
     #[inline]
@@ -2455,7 +2556,7 @@ pub fn createframe(
     w_globals: *mut DictStorage,
     execution_context: *const PyExecutionContext,
     outer_func: Option<PyObjectRef>,
-) -> Result<Box<PyFrame>, crate::PyError> {
+) -> Result<FrameBox, crate::PyError> {
     // pyframe.py:98-119 PyFrame.__init__ — line-by-line.
     //   self.space = space               (pyre: implicit, no field)
     //   self.pycode = code               (pycode field below)
@@ -2490,7 +2591,7 @@ pub fn createframe(
     } else {
         crate::baseobjspace::dict_storage_to_dict(w_globals)
     };
-    let mut frame = Box::new(PyFrame {
+    let mut frame = FrameBox::new(PyFrame {
         execution_context,
         pycode: code,
         locals_cells_stack_w: unsafe { alloc_fixed_array_with_header(size, PY_NULL) },

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -295,6 +295,13 @@ impl FrameBox {
     pub fn into_generator(mut self) -> crate::PyResult {
         self.fix_array_ptrs();
         let frame_ptr = self.into_raw();
+        // `w_generator_new` allocates and may trigger a collection. Until the
+        // generator owns `frame_ptr`, the frame's locals/args live only in its
+        // `locals_cells_stack_w` — the caller has already dropped them from its
+        // own stack — so root that slot across the allocation. The frame struct
+        // itself is a plain heap allocation (not a nursery object), so only the
+        // locals array needs protecting.
+        let _root = LocalsRoot::new(frame_ptr);
         let generator = pyre_object::generatorobject::w_generator_new(frame_ptr as *mut u8);
         unsafe {
             (*frame_ptr).f_generator_nowref = generator;
@@ -323,6 +330,33 @@ impl Drop for FrameBox {
         unsafe {
             let prefix = (self.ptr as *mut u8).sub(GC_HEADER_SIZE) as *mut GcFramePrefix;
             drop(Box::from_raw(prefix));
+        }
+    }
+}
+
+/// RAII guard registering a frame's `locals_cells_stack_w` slot as a GC root
+/// for the duration of an allocating frame-setup step. Mirrors the callee-locals
+/// root the eval path holds in `call.rs`: during setup the freshly-installed
+/// locals/cells live only in that array, so an intervening collection would
+/// drop or mis-forward them unless the slot is rooted.
+struct LocalsRoot {
+    slot: *mut *mut u8,
+    registered: bool,
+}
+
+impl LocalsRoot {
+    fn new(frame_ptr: *mut PyFrame) -> Self {
+        let slot =
+            unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
+        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
+        Self { slot, registered }
+    }
+}
+
+impl Drop for LocalsRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            pyre_object::gc_hook::try_gc_remove_root(self.slot);
         }
     }
 }
@@ -2619,7 +2653,13 @@ pub fn createframe(
     // so initialize_frame_scopes selects the `!OPTIMIZED && !NEWLOCALS`
     // arm and binds `w_locals = w_globals` per pyframe.py:233-235.
     let outer_ref = outer_func.unwrap_or(PY_NULL);
-    frame.initialize_frame_scopes(outer_ref, code)?;
+    // initialize_frame_scopes allocates (the locals dict and `w_cell_new`
+    // cells) and stores the cells into `locals_cells_stack_w`; root the slot so
+    // a collection mid-init can't drop the cells already written there.
+    {
+        let _root = LocalsRoot::new(frame.as_mut_ptr());
+        frame.initialize_frame_scopes(outer_ref, code)?;
+    }
 
     Ok(frame)
 }

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -29,8 +29,8 @@ pub struct MetaInterpFrame {
     /// `same_constant` iteration.
     pub greenkey: Option<(usize, usize)>,
     pub concrete_frame: usize,
-    /// Box for heap stability across Vec reallocs.
-    pub owned_concrete_frame: Option<Box<pyre_interpreter::pyframe::PyFrame>>,
+    /// Header-bearing heap frame, stable across Vec reallocs.
+    pub owned_concrete_frame: Option<pyre_interpreter::pyframe::FrameBox>,
     /// opencoder.py:819-834: accumulated parent frame chain.
     pub parent_frames: Vec<ResumeFrameState>,
     pub drop_frame_opref: Option<OpRef>,
@@ -440,7 +440,7 @@ impl PyreMetaInterp {
         let callee_code = pending.concrete_frame.pycode;
         let mut owned_sym = Box::new(pending.sym);
         let sym_ptr = owned_sym.as_mut() as *mut PyreSym;
-        let owned_cf = Box::new(pending.concrete_frame);
+        let owned_cf = pyre_interpreter::pyframe::FrameBox::new(pending.concrete_frame);
         let cf_addr = &*owned_cf as *const pyre_interpreter::pyframe::PyFrame as usize;
 
         // executioncontext.py:76 / pyjitpl.py:1789: virtual_ref for callee frame.

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -22,8 +22,8 @@ pub fn trace_bytecode(
     sym: &mut PyreSym,
     _code: &CodeObject,
     start_pc: usize,
-    mut concrete_frame: Box<pyre_interpreter::pyframe::PyFrame>,
-) -> (TraceAction, Box<pyre_interpreter::pyframe::PyFrame>) {
+    mut concrete_frame: pyre_interpreter::pyframe::FrameBox,
+) -> (TraceAction, pyre_interpreter::pyframe::FrameBox) {
     // `llmodel.py:557` parity — install pyre's `Cpu` impl so the
     // optimizer's `protect_speculative_string` / `bh_strlen` /
     // `bh_strgetitem` family routes through `W_StrObject`-shaped

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7101,7 +7101,7 @@ mod tests {
         live_locals: &[u32],
         live_stack_depths: &[usize],
         init: impl FnOnce(&mut PyFrame),
-    ) -> (Box<PyFrame>, *const (), usize) {
+    ) -> (pyre_interpreter::pyframe::FrameBox, *const (), usize) {
         use pyre_interpreter::compile_exec;
         use pyre_jit_trace::state as trace_state;
 
@@ -7146,7 +7146,7 @@ mod tests {
         function_name: &str,
         target_depth: u16,
         init: impl FnOnce(&mut PyFrame),
-    ) -> (Box<PyFrame>, *const (), usize) {
+    ) -> (pyre_interpreter::pyframe::FrameBox, *const (), usize) {
         use pyre_interpreter::compile_exec;
         use pyre_jit_trace::state as trace_state;
 


### PR DESCRIPTION
…K_YOUNG_PTRS only

Add FrameBox, an owning handle that places every heap PyFrame behind a leading zeroed GcHeader (GcFramePrefix). PyFrame::new, new_with_context, createframe, and snapshot_for_tracing now return FrameBox; the live-run frame-construction sites in call.rs and function.rs wrap their frames in FrameBox::new. eval.rs, trace.rs, metainterp.rs, and pyre-jit/eval.rs propagate the FrameBox return type. The frame the JIT treats as the virtualizable now has a valid header at frame - GC_HEADER_SIZE, so the inline COND_CALL_GC_WB flag read no longer touches foreign stack memory.

With every barrier target header-bearing, remove the OLDGEN_TRACKED flag and the is_oldgen_write_barrier_object / has_valid_managed_header guards. do_write_barrier and the JIT/array barrier paths now gate solely on TRACK_YOUNG_PTRS, and remember_young_pointer unconditionally appends to the remembered set and clears the flag (incminimark.py:1489-1529). Set TRACK_YOUNG_PTRS on old-gen allocations, nursery promotions, and shadow allocations in place of OLDGEN_TRACKED.

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified garbage-collection write-barrier and remembered-set to a single tracking mechanism, and removed an obsolete GC flag.
  * Reworked interpreter frame allocation so heap frames are GC-aware objects, improving memory-safety and GC integration.

* **Tests**
  * Updated tests to match the new GC tracking and frame allocation behavior; removed obsolete null-noop tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->