### PR TITLE
Box-identity: retire to_opref crutches + Forwarded::Box, add Operand union (#47)

### DIFF
--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -732,7 +732,9 @@ impl RewriteState {
         }
         if let Some(fail_args) = rewritten.fail_args_mut() {
             for arg in fail_args.iter_mut() {
-                *arg = Operand::Box(self.resolve(arg.to_boxref()));
+                // Same shed as `setarg` above: a forwarding target bound to
+                // its producer stays a live-tracking operand.
+                *arg = Operand::from_boxref(&self.resolve(arg.to_boxref()));
             }
         }
         rewritten.pos.set(OpRef::NONE);

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -12,6 +12,7 @@
 use majit_ir::Type;
 use majit_ir::box_ref::BoxRef;
 use majit_ir::descr::{DescrRef, FieldDescr, SizeDescr};
+use majit_ir::operand::Operand;
 use majit_ir::resoperation::{Op, OpCode, OpRef};
 use majit_ir::{Value, VecAssoc, VecSet};
 
@@ -731,7 +732,7 @@ impl RewriteState {
         }
         if let Some(fail_args) = rewritten.fail_args_mut() {
             for arg in fail_args.iter_mut() {
-                *arg = self.resolve(arg.clone());
+                *arg = Operand::Box(self.resolve(arg.to_boxref()));
             }
         }
         rewritten.pos.set(OpRef::NONE);
@@ -954,7 +955,7 @@ impl GcRewriterImpl {
         // guard for the next iteration to pick up.
         let mut new_guard = op.clone();
         if let Some(fa) = new_guard.fail_args_mut() {
-            fa[idx] = same_pos;
+            fa[idx] = Operand::Box(same_pos);
         }
         // pos is reassigned when emit/emit_result runs on the substituted op.
         new_guard.pos.set(OpRef::NONE);

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -19,11 +19,10 @@
 //!   the borrow scope immediately after reading.
 //! - `BoxRef`'s `Eq` / `Hash` use `Rc::ptr_eq` / `Rc::as_ptr` — equivalent
 //!   to RPython's use of object identity as a dict key.
-//! - When `Forwarded::Box(BoxRef)` carries a BoxRef whose kind is
-//!   `BoxKind::Const(...)`, that mirrors RPython's
-//!   `box.set_forwarded(constbox)`. Constants are split into
-//!   `Forwarded::Const(Const)` separately so chain walkers terminate on
-//!   the inline value without needing a `BoxKind::Const` carrier.
+//! - A constant forwarding target mirrors RPython's
+//!   `box.set_forwarded(constbox)` via the `Forwarded::Const(Const)`
+//!   variant, so chain walkers terminate on the inline value without
+//!   needing a `BoxKind::Const` carrier.
 
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
@@ -88,7 +87,7 @@ pub enum BoxKind {
     /// RPython counterpart on `AbstractResOpOrInputArg` (which carries
     /// only `_forwarded`); it stores the index where the box lands in the
     /// pool so the chain walker can reconstruct an `OpRef::op_typed(pos,
-    /// type)` when advancing through `Forwarded::Box(target)`. Set by
+    /// type)` when advancing through a `Forwarded::Op` chain step. Set by
     /// `opencoder.py Trace.record()` (and the recorder's `record_op_*`
     /// family in pyre) at construction; updated by `optimizer.rs:2783`
     /// const-pool compaction via `BoxRef::set_position`. RPython has no
@@ -134,11 +133,6 @@ pub enum BoxKind {
 #[derive(Clone, Debug)]
 pub enum Forwarded {
     None,
-
-    /// Forwarding to another `AbstractResOpOrInputArg`. Const targets
-    /// route through [`Forwarded::Const`] instead; `ResOp` targets route
-    /// through [`Forwarded::Op`] once C.5 retires this variant.
-    Box(BoxRef),
 
     /// `resoperation.py:250 AbstractResOp` forwarding — direct
     /// `Weak<Op>` reference, no `BoxRef`/`BoxKind::ResOp` carrier.
@@ -614,45 +608,6 @@ impl BoxRef {
         Forwarded::None
     }
 
-    /// `resoperation.py:53 set_forwarded(forwarded_to)` — Box variant.
-    pub fn set_forwarded_box(&self, target: BoxRef) {
-        // `assert forwarded_to is not self` (resoperation.py:241).
-        // Always-on assert so a release build can't accept a one-node
-        // forwarding cycle that would make `get_box_replacement()` spin.
-        // After `bind_op` / `bind_inputarg` two distinct `Rc<Box>`
-        // wrappers can share the same canonical bound `OpRc`/`InputArgRc`;
-        // the `Rc::ptr_eq` on `self.0` alone misses that case, so also
-        // compare the bound handles when both sides carry one.
-        assert!(!Rc::ptr_eq(&self.0, &target.0));
-        if let (Some(self_op), Some(target_op)) = (self.bound_op(), target.bound_op()) {
-            assert!(
-                !Rc::ptr_eq(&self_op, &target_op),
-                "set_forwarded_box on a BoxRef that wraps the same bound \
-                 Op as the target creates a one-node chain cycle"
-            );
-        }
-        if let (Some(self_ia), Some(target_ia)) = (self.bound_inputarg(), target.bound_inputarg()) {
-            assert!(
-                !Rc::ptr_eq(&self_ia, &target_ia),
-                "set_forwarded_box on a BoxRef that wraps the same bound \
-                 InputArg as the target creates a one-node chain cycle"
-            );
-        }
-        // RPython AbstractValue invariant: `Const` is not a subclass of
-        // `AbstractResOpOrInputArg` (history.py:182), so `set_forwarded`
-        // is undefined on Const objects (resoperation.py:50 default
-        // raises). The Rust port unifies the layout into a single struct
-        // shape; this assertion preserves the invariant. PyPy raises
-        // unconditionally, so the check is always-on (not `debug_assert!`).
-        assert!(
-            !matches!(self.0.kind, BoxKind::Const { .. }),
-            "set_forwarded_box on Const violates RPython AbstractValue \
-             invariant (Const has no _forwarded slot)"
-        );
-        let next = Forwarded::Box(target);
-        self.write_forwarded(next);
-    }
-
     /// `optimizer.py:394 op.set_forwarded(newop)` — InputArg variant.
     /// Targets an `AbstractInputArg` identity directly via
     /// `Weak<InputArg>`. Mirror of `set_forwarded_op` for the InputArg
@@ -841,12 +796,6 @@ impl BoxRef {
         loop {
             match cur.get_forwarded() {
                 Forwarded::None | Forwarded::Info(_) => return cur,
-                Forwarded::Box(b) => {
-                    if not_const && b.is_constant() {
-                        return cur;
-                    }
-                    cur = b;
-                }
                 Forwarded::Op(weak) => {
                     let Some(op_rc) = weak.upgrade() else {
                         // Dropped target: PyPy has no analog (Python
@@ -1151,7 +1100,6 @@ mod tests {
     /// `_forwarded` host per resoperation.py:233). The OpRc must outlive
     /// every write through the returned BoxRef.
     fn bound_resop(tp: Type, position: u32) -> (BoxRef, OpRc) {
-        let b = BoxRef::new_resop(tp, position);
         let opcode = match tp {
             Type::Int => OpCode::SameAsI,
             Type::Float => OpCode::SameAsF,
@@ -1160,7 +1108,12 @@ mod tests {
         };
         let op = std::rc::Rc::new(Op::new(opcode, &[]));
         op.pos.set(OpRef::op_typed(position, tp));
-        b.bind_op(&op);
+        // Canonical resolver: binds the box AND memoizes it on
+        // `op.box_cache`, so the chain walker's `from_bound_op`
+        // re-resolution of a `Forwarded::Op` step returns this same
+        // `Rc<Box>` (matches production, where every box comes from
+        // `from_bound_op`).
+        let b = BoxRef::from_bound_op(&op);
         (b, op)
     }
 
@@ -1268,10 +1221,10 @@ mod tests {
     #[test]
     fn forwarded_chain_walk_returns_terminal() {
         let (a, _ao) = bound_resop(Type::Int, 0);
-        let (b, _bo) = bound_resop(Type::Int, 1);
-        let (c, _co) = bound_resop(Type::Int, 2);
-        a.set_forwarded_box(b.clone());
-        b.set_forwarded_box(c.clone());
+        let (b, bo) = bound_resop(Type::Int, 1);
+        let (c, co) = bound_resop(Type::Int, 2);
+        a.set_forwarded_op(&bo);
+        b.set_forwarded_op(&co);
         assert_eq!(a.get_box_replacement(false), c);
         assert_eq!(b.get_box_replacement(false), c);
         assert_eq!(c.get_box_replacement(false), c);
@@ -1280,8 +1233,8 @@ mod tests {
     #[test]
     fn forwarded_chain_stops_at_info() {
         let (a, _ao) = bound_resop(Type::Int, 0);
-        let (b, _bo) = bound_resop(Type::Int, 1);
-        a.set_forwarded_box(b.clone());
+        let (b, bo) = bound_resop(Type::Int, 1);
+        a.set_forwarded_op(&bo);
         b.set_forwarded_info(OpInfo::Unknown);
         assert_eq!(a.get_box_replacement(false), b);
     }
@@ -1289,12 +1242,15 @@ mod tests {
     #[test]
     fn forwarded_chain_not_const_stops_before_const() {
         let (a, _ao) = bound_resop(Type::Int, 0);
-        let (b, _bo) = bound_resop(Type::Int, 1);
-        let c = BoxRef::new_const(Value::Int(42));
-        a.set_forwarded_box(b.clone());
-        b.set_forwarded_box(c.clone());
+        let (b, bo) = bound_resop(Type::Int, 1);
+        a.set_forwarded_op(&bo);
+        b.set_forwarded_const(Const::Int(42));
+        // not_const=true stops at the box before stepping into the Const;
+        // not_const=false materializes the terminal Const box.
         assert_eq!(a.get_box_replacement(true), b);
-        assert_eq!(a.get_box_replacement(false), c);
+        let term = a.get_box_replacement(false);
+        assert!(term.is_constant());
+        assert_eq!(term.const_value(), Some(Value::Int(42)));
     }
 
     #[test]
@@ -1346,8 +1302,8 @@ mod tests {
     #[test]
     fn clear_forwarded_resets_slot() {
         let (a, _ao) = bound_resop(Type::Int, 0);
-        let (b, _bo) = bound_resop(Type::Int, 0);
-        a.set_forwarded_box(b.clone());
+        let (_b, bo) = bound_resop(Type::Int, 0);
+        a.set_forwarded_op(&bo);
         a.clear_forwarded();
         assert_eq!(a.get_box_replacement(false), a);
         assert!(matches!(a.get_forwarded(), Forwarded::None));
@@ -1387,8 +1343,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn set_forwarded_to_self_panics() {
-        let a = BoxRef::new_resop(Type::Int, 0);
-        a.set_forwarded_box(a.clone());
+        let (a, ao) = bound_resop(Type::Int, 0);
+        a.set_forwarded_op(&ao);
     }
 
     #[test]
@@ -1406,10 +1362,10 @@ mod tests {
     }
 
     #[test]
-    fn ptr_info_returns_none_for_box_forwarded() {
+    fn ptr_info_returns_none_for_op_forwarded() {
         let (a, _ao) = bound_resop(Type::Ref, 0);
-        let (b, _bo) = bound_resop(Type::Ref, 0);
-        a.set_forwarded_box(b.clone());
+        let (_b, bo) = bound_resop(Type::Ref, 0);
+        a.set_forwarded_op(&bo);
         assert!(a.ptr_info().is_none());
     }
 
@@ -1436,10 +1392,10 @@ mod tests {
     }
 
     #[test]
-    fn int_bound_returns_none_for_box_forwarded() {
+    fn int_bound_returns_none_for_op_forwarded() {
         let (a, _ao) = bound_resop(Type::Int, 0);
-        let (b, _bo) = bound_resop(Type::Int, 0);
-        a.set_forwarded_box(b.clone());
+        let (_b, bo) = bound_resop(Type::Int, 0);
+        a.set_forwarded_op(&bo);
         assert!(a.int_bound().is_none());
     }
 
@@ -1516,16 +1472,6 @@ mod tests {
         b.clear_forwarded();
         assert!(matches!(b.get_forwarded(), Forwarded::None));
         assert!(matches!(*op.forwarded.borrow(), Forwarded::None));
-
-        // set_forwarded_box → both slots carry the target.
-        let target = BoxRef::new_resop(Type::Int, 1);
-        b.set_forwarded_box(target.clone());
-        match (&b.get_forwarded(), &*op.forwarded.borrow()) {
-            (Forwarded::Box(box_target), Forwarded::Box(op_target)) => {
-                assert_eq!(box_target, op_target);
-            }
-            _ => panic!("expected Forwarded::Box on both slots"),
-        }
     }
 
     /// `bind_inputarg` panics on a non-InputArg box (same contract as
@@ -1568,14 +1514,6 @@ mod tests {
         b.set_forwarded_info(OpInfo::int_bound(IntBound::from_constant(99)));
         assert!(matches!(b.get_forwarded(), Forwarded::Info(_)));
         assert!(matches!(*ia.forwarded.borrow(), Forwarded::Info(_)));
-
-        // Box write should also reach the InputArg slot.
-        let target = BoxRef::new_resop(Type::Int, 5);
-        b.set_forwarded_box(target.clone());
-        match (&b.get_forwarded(), &*ia.forwarded.borrow()) {
-            (Forwarded::Box(bt), Forwarded::Box(iat)) => assert_eq!(bt, iat),
-            _ => panic!("expected Forwarded::Box on both slots"),
-        }
 
         // Clear reaches the InputArg slot.
         b.clear_forwarded();

--- a/majit/majit-ir/src/field_entry.rs
+++ b/majit/majit-ir/src/field_entry.rs
@@ -35,7 +35,7 @@ pub struct PreambleOp {
     pub invented_name: bool,
     /// RPython: PreambleOp.preamble_op — the actual replay operation
     /// for the short preamble. Always present (RPython parity).
-    pub preamble_op: Op,
+    pub preamble_op: crate::resoperation::OpRc,
 }
 
 /// RPython _fields[] element — either a concrete value or a PreambleOp sentinel.

--- a/majit/majit-ir/src/field_entry.rs
+++ b/majit/majit-ir/src/field_entry.rs
@@ -25,11 +25,12 @@ use crate::{Op, OpRef};
 #[derive(Clone, Debug)]
 pub struct PreambleOp {
     /// RPython `PreambleOp.op` — the carried Box (= `self.res` from the
-    /// short_op). For non-invented entries this is the body-visible
-    /// OpRef directly; for invented entries (CompoundOp alternates)
-    /// `op` forwards to the carried Box via `make_equal_to(source, op)`
-    /// so `get_box_replacement(op)` reaches the body-visible OpRef.
-    pub op: OpRef,
+    /// short_op). For non-invented entries this resolves to the
+    /// body-visible position directly; for invented entries (CompoundOp
+    /// alternates) `op` forwards to the carried Box via
+    /// `make_equal_to(source, op)` so resolving `op` reaches the
+    /// body-visible position.
+    pub op: crate::box_ref::BoxRef,
     /// RPython: PreambleOp.invented_name
     pub invented_name: bool,
     /// RPython: PreambleOp.preamble_op — the actual replay operation
@@ -86,7 +87,7 @@ impl FieldEntry {
     pub fn as_seen_opref(&self) -> OpRef {
         match self {
             FieldEntry::Value(opref) => *opref,
-            FieldEntry::Preamble(pop) => pop.op,
+            FieldEntry::Preamble(pop) => pop.op.to_opref(),
         }
     }
 

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -9,6 +9,7 @@ pub mod intbound;
 pub mod op_descr;
 pub mod op_info;
 pub mod op_type_index;
+pub mod operand;
 pub mod optimize;
 pub mod ptr_info;
 pub mod rawbuffer;

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -295,7 +295,10 @@ impl Op {
     /// peel pass.  pyre's matching call lives in `unroll.rs` and
     /// rebuilds the SmallVec rather than pushing onto `args`.
     pub fn initarglist(&self, args: smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>) {
-        *self.args.borrow_mut() = args.iter().map(crate::operand::Operand::from_boxref).collect();
+        *self.args.borrow_mut() = args
+            .iter()
+            .map(crate::operand::Operand::from_boxref)
+            .collect();
     }
 
     /// `resoperation.py:290 AbstractResOp.setarg` parity — position-wise

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -173,7 +173,10 @@ impl Op {
     /// avoids the `Ref<[T]>` ergonomics tax for callers that chain through
     /// `.into_iter().flatten()` or `.iter()` patterns.
     pub fn getfailargs(&self) -> Option<smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>> {
-        self.fail_args.borrow().clone()
+        self.fail_args
+            .borrow()
+            .as_ref()
+            .map(|fa| fa.iter().map(|o| o.to_boxref()).collect())
     }
 
     /// `resoperation.py:492 GuardResOp.getfailargs_copy` parity.
@@ -192,7 +195,7 @@ impl Op {
                  fail-loud shape (resoperation.py:492)"
             )
         });
-        fa.iter().cloned().collect()
+        fa.iter().map(|o| o.to_boxref()).collect()
     }
 
     /// `resoperation.py:495 GuardResOp.setfailargs` parity — overwrite
@@ -200,7 +203,15 @@ impl Op {
     /// optimizer can stamp fail_args onto a shared `Op` reached through
     /// `Rc<Op>`.
     pub fn setfailargs(&self, fail_args: smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>) {
-        *self.fail_args.borrow_mut() = Some(fail_args);
+        // MIGRATION (#9): freeze to `Operand::Box` (position snapshot,
+        // byte-identical to the previous `BoxRef` storage); the bound
+        // shed follows the `args` sequence in a later slice.
+        *self.fail_args.borrow_mut() = Some(
+            fail_args
+                .into_iter()
+                .map(crate::operand::Operand::Box)
+                .collect(),
+        );
     }
 
     /// In-place mutable view of the fail_args slot.  Lets callers iterate
@@ -211,7 +222,7 @@ impl Op {
     /// the copy, and call `setfailargs`.
     pub fn fail_args_mut(
         &mut self,
-    ) -> Option<&mut smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>> {
+    ) -> Option<&mut smallvec::SmallVec<[crate::operand::Operand; 3]>> {
         self.fail_args.get_mut().as_mut()
     }
 

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -261,24 +261,27 @@ impl Op {
         self.fail_arg_types.borrow().is_some()
     }
 
-    /// `resoperation.py:281 AbstractResOp.getarglist` parity — returns
-    /// a `Ref` view into the operand vector.  Subclass mixins (`UnaryOp`,
-    /// `BinaryOp`, ..., `N_aryOp`) implement this differently; pyre
-    /// collapses them into a single SmallVec slot.  The `RefCell` borrow
-    /// guard is required because `args` is interior-mutable so that
-    /// `setarg` / `initarglist` can write through a shared `Op` reached
-    /// via `Rc<Op>` (RPython writes `op._args[i] = ...` on the same
-    /// Python object the trace list, optimizer state, and backend
-    /// observe).
-    pub fn getarglist(&self) -> std::cell::Ref<'_, [crate::box_ref::BoxRef]> {
-        std::cell::Ref::map(self.args.borrow(), |a| a.as_slice())
+    /// `resoperation.py:281 AbstractResOp.getarglist` parity — the operand
+    /// list as `BoxRef`s.  Subclass mixins (`UnaryOp`, `BinaryOp`, ...,
+    /// `N_aryOp`) implement this differently; pyre collapses them into a
+    /// single SmallVec slot.
+    ///
+    /// `#9` operand-union flip: `args` now stores [`Operand`], so this
+    /// materializes an owned `SmallVec` of `BoxRef`s (convert-on-read via
+    /// `Operand::to_boxref`) rather than borrowing the slot — the old `Ref`
+    /// view is no longer expressible. The owned `SmallVec` derefs to
+    /// `&[BoxRef]`, so iterate/index/`&`-coercion callers are unchanged; it
+    /// also drops the `RefCell` borrow at the call boundary, so a caller may
+    /// freely `setarg` afterwards.
+    pub fn getarglist(&self) -> smallvec::SmallVec<[crate::box_ref::BoxRef; 3]> {
+        self.args.borrow().iter().map(|o| o.to_boxref()).collect()
     }
 
     /// `resoperation.py:284 AbstractResOp.getarglist_copy` parity —
     /// `N_aryOp.getarglist_copy` returns `self._args[:]`; pyre returns
-    /// an owned `SmallVec` clone for the same effect.
+    /// an owned `SmallVec` of `BoxRef`s (convert-on-read).
     pub fn getarglist_copy(&self) -> smallvec::SmallVec<[crate::box_ref::BoxRef; 3]> {
-        self.args.borrow().clone()
+        self.args.borrow().iter().map(|o| o.to_boxref()).collect()
     }
 
     /// `resoperation.py:277 AbstractResOp.initarglist` parity — bulk
@@ -292,13 +295,13 @@ impl Op {
     /// peel pass.  pyre's matching call lives in `unroll.rs` and
     /// rebuilds the SmallVec rather than pushing onto `args`.
     pub fn initarglist(&self, args: smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>) {
-        *self.args.borrow_mut() = args;
+        *self.args.borrow_mut() = args.iter().map(crate::operand::Operand::from_boxref).collect();
     }
 
     /// `resoperation.py:290 AbstractResOp.setarg` parity — position-wise
     /// in-place arg mutation.  Subclass mixins index `_arg0/_arg1/...`
     /// or `_args[i]`; pyre indexes the SmallVec directly.
     pub fn setarg(&self, i: usize, box_: crate::box_ref::BoxRef) {
-        self.args.borrow_mut()[i] = box_;
+        self.args.borrow_mut()[i] = crate::operand::Operand::from_boxref(&box_);
     }
 }

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -203,13 +203,15 @@ impl Op {
     /// optimizer can stamp fail_args onto a shared `Op` reached through
     /// `Rc<Op>`.
     pub fn setfailargs(&self, fail_args: smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>) {
-        // MIGRATION (#9): freeze to `Operand::Box` (position snapshot,
-        // byte-identical to the previous `BoxRef` storage); the bound
-        // shed follows the `args` sequence in a later slice.
+        // `GuardResOp._fail_args` holds the Box objects themselves
+        // (resoperation.py:483); shed genuinely-bound boxes to their
+        // live-tracking producer operand, exactly like `Op.args`
+        // (`Operand::from_boxref`). Position-only / Const boxes stay
+        // `Operand::Box` until their writers bind producers.
         *self.fail_args.borrow_mut() = Some(
             fail_args
-                .into_iter()
-                .map(crate::operand::Operand::Box)
+                .iter()
+                .map(crate::operand::Operand::from_boxref)
                 .collect(),
         );
     }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -201,24 +201,57 @@ impl Operand {
         }
     }
 
-    /// Classify a [`BoxRef`] into an [`Operand`] for the storage flip.
+    /// Classify a [`BoxRef`] into an [`Operand`] for storage.
     ///
-    /// This slice is strictly behavior-preserving, so it sheds only the
-    /// identity-free `None` sentinel; every value-carrying box is kept verbatim
-    /// as `Operand::Box`, whose `to_boxref` returns the same `Rc<Box>` —
-    /// preserving box identity, the `Cell`-backed GC walk, AND the box's
-    /// snapshot `position` field. The last point matters: a bound `ResOp`
-    /// box's `to_opref` reads its own frozen `BoxKind::ResOp.position` Cell,
-    /// NOT the producer's live `op.pos`, and the optimizer's position-remap
-    /// (`optimizer.rs`) deliberately mutates `op.pos` before reading operand
-    /// positions — so shedding a bound `ResOp` to a live-tracking
-    /// `Operand::Op` here would double-remap. Shedding `Box` → `Op`/`InputArg`/
-    /// `Const` (and adapting those remap consumers) is a later slice.
+    /// A genuinely-bound box sheds to its live-tracking producer `Rc`
+    /// (`Operand::Op` / `Operand::InputArg`) — the operand IS the producer
+    /// (`resoperation.py` `N_aryOp._args` holds the `AbstractResOp` /
+    /// `AbstractInputArg` directly). Its `to_opref` then reads the producer's
+    /// live `op.pos`, so renumbering the producer auto-propagates without a
+    /// snapshot rewrite. The two position-remap passes
+    /// (`optimizer.rs` `new_operations` / `exported_short_boxes`) mutate
+    /// `op.pos` and must therefore SKIP bound operands
+    /// ([`Operand::is_bound`]) and rewrite only position-only snapshots —
+    /// otherwise a bound operand reading the already-remapped live pos would
+    /// double-remap.
+    ///
+    /// A position-only box (no bound handle — e.g. `from_opref`) and a Const
+    /// box (value-typed, GC-walked in place through its `Cell`) carry no
+    /// producer to track and stay `Operand::Box`, whose `to_boxref` returns
+    /// the same `Rc<Box>` (identity, `Cell`-backed GC walk, frozen position
+    /// snapshot all preserved).
     pub fn from_boxref(b: &BoxRef) -> Operand {
         if b.is_none() {
             return Operand::None;
         }
+        // Shed a genuinely-bound box to its live-tracking producer `Rc`: the
+        // operand IS the producer (resoperation.py `N_aryOp._args` holds the
+        // `AbstractResOp`/`AbstractInputArg` directly), so its position
+        // auto-tracks the producer's `op.pos` and its forwarding resolves
+        // through the canonical `Op`/`InputArg`. The strong `Rc` keeps the
+        // producer alive (acyclic on the SSA use-before-def DAG). A
+        // position-only box (no bound handle) and a Const box (value-typed,
+        // GC-walked in place via its `Cell`) have no producer to carry and
+        // stay `Operand::Box`.
+        if let Some(op) = b.bound_op() {
+            return Operand::Op(op);
+        }
+        if let Some(ia) = b.bound_inputarg() {
+            return Operand::InputArg(ia);
+        }
         Operand::Box(b.clone())
+    }
+
+    /// True only for the live-tracking bound variants (`Op` / `InputArg`),
+    /// whose `to_opref()` reads the producer's CURRENT `op.pos`. Excludes the
+    /// frozen `Operand::Box` snapshot even when it wraps a ResOp / InputArg
+    /// box — unlike [`Operand::is_resop`] / [`Operand::is_inputarg`], which
+    /// fold the snapshot case in. The position-remap passes use this to skip
+    /// operands that auto-track a renumbered producer (no snapshot rewrite
+    /// needed); only position-only `Operand::Box` operands carry a stale
+    /// position the remap table must rewrite.
+    pub fn is_bound(&self) -> bool {
+        matches!(self, Operand::Op(_) | Operand::InputArg(_))
     }
 
     /// GC walk over any inline `ConstPtr` reachable from this operand
@@ -250,7 +283,10 @@ mod tests {
     #[test]
     fn to_opref_round_trips_each_variant() {
         let op = op_at(3, Type::Int);
-        assert_eq!(Operand::from_bound_op(&op).to_opref(), OpRef::op_typed(3, Type::Int));
+        assert_eq!(
+            Operand::from_bound_op(&op).to_opref(),
+            OpRef::op_typed(3, Type::Int)
+        );
 
         let ia = Rc::new(InputArg::from_type(Type::Ref, 2));
         assert_eq!(
@@ -258,7 +294,10 @@ mod tests {
             OpRef::input_arg_typed(2, Type::Ref),
         );
 
-        assert_eq!(Operand::const_(Const::Int(7)).to_opref(), OpRef::const_int(7));
+        assert_eq!(
+            Operand::const_(Const::Int(7)).to_opref(),
+            OpRef::const_int(7)
+        );
         assert_eq!(Operand::none().to_opref(), OpRef::NONE);
     }
 
@@ -324,45 +363,49 @@ mod tests {
     }
 
     #[test]
-    fn from_boxref_is_byte_identical_keeps_every_value_box() {
-        // Behavior-preserving storage flip: every value-carrying box is kept
-        // verbatim as Operand::Box, returning the identical Rc<Box> on read so
-        // identity, type, position, and const value all round-trip exactly.
-
-        // Bound op -> kept as Box (its frozen `position` snapshot is preserved,
-        // not replaced by the producer's live op.pos).
+    fn from_boxref_sheds_bound_keeps_const_and_position_only() {
+        // Bound op -> Operand::Op (live-tracking). is_resop stays true;
+        // is_bound is true. to_boxref re-resolves through the memoized
+        // from_bound_op, so the canonical box is ptr-equal to the original.
         let op = op_at(8, Type::Int);
         let bound = BoxRef::from_bound_op(&op);
         let o = Operand::from_boxref(&bound);
-        assert!(matches!(o, Operand::Box(_)));
+        assert!(matches!(o, Operand::Op(_)));
         assert!(o.is_resop());
+        assert!(o.is_bound());
         assert_eq!(o.to_boxref().as_ptr(), bound.as_ptr());
 
-        // Bound input arg -> kept as Box.
+        // Bound input arg -> Operand::InputArg (live-tracking, bound).
         let ia = Rc::new(InputArg::from_type(Type::Ref, 2));
         let bia = BoxRef::from_bound_inputarg(&ia);
         let o = Operand::from_boxref(&bia);
-        assert!(matches!(o, Operand::Box(_)));
+        assert!(matches!(o, Operand::InputArg(_)));
         assert!(o.is_inputarg());
+        assert!(o.is_bound());
         assert_eq!(o.to_boxref().as_ptr(), bia.as_ptr());
 
-        // Const -> kept as Box (Cell-backed), round-trips to the same box.
+        // Const -> kept as Box (Cell-backed, value-typed); NOT bound.
         let cbox = BoxRef::new_const(Value::Int(11));
         let o = Operand::from_boxref(&cbox);
         assert!(matches!(o, Operand::Box(_)));
         assert!(o.is_constant());
+        assert!(!o.is_bound());
         assert_eq!(o.const_int(), Some(11));
         assert_eq!(o.to_boxref().as_ptr(), cbox.as_ptr());
 
-        // Position-only box (from_opref, no live producer) -> kept as Box,
-        // returns the identical Rc<Box> on read.
+        // Position-only box (from_opref, no live producer) -> kept as Box
+        // (no bound handle to shed onto); NOT bound, frozen position survives.
         let pos_only = BoxRef::from_opref(OpRef::op_typed(4, Type::Int));
         let o = Operand::from_boxref(&pos_only);
         assert!(matches!(o, Operand::Box(_)));
+        assert!(!o.is_bound());
         assert_eq!(o.position(), Some(4));
         assert_eq!(o.to_boxref().as_ptr(), pos_only.as_ptr());
 
-        // None sentinel -> Operand::None (identity-free, byte-identical).
-        assert!(matches!(Operand::from_boxref(&BoxRef::none()), Operand::None));
+        // None sentinel -> Operand::None.
+        assert!(matches!(
+            Operand::from_boxref(&BoxRef::none()),
+            Operand::None
+        ));
     }
 }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -31,7 +31,7 @@ use std::rc::Rc;
 /// strong `Rc` instead of a flat position: `Op` ⇆ `OpRef::*Op`, `InputArg`
 /// ⇆ `OpRef::InputArg*`, `Const` ⇆ the inline `OpRef::Const*`, and `None` ⇆
 /// `OpRef::None` (an absent `fail_args` slot).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Operand {
     /// Absent slot — the mirror of `OpRef::None`.
     None,
@@ -201,26 +201,22 @@ impl Operand {
         }
     }
 
-    /// Classify a [`BoxRef`] into an [`Operand`] for the storage flip. Cleanly
-    /// bound producers shed the wrapper — a live `bound_op`/`bound_inputarg`
-    /// becomes a pure `Op`/`InputArg` (the `#9` win); the `None` sentinel
-    /// becomes `Operand::None`. Everything else — `Const` (kept `Cell`-backed
-    /// for the GC walk) and position-only boxes minted by `from_opref` with no
-    /// live producer to bind — is preserved verbatim as `Operand::Box`, so
-    /// `to_boxref` returns the same `Rc<Box>` and the flip is byte-identical.
-    /// Later slices grind the `Box` residue to zero.
+    /// Classify a [`BoxRef`] into an [`Operand`] for the storage flip.
+    ///
+    /// This slice is strictly behavior-preserving, so it sheds only the
+    /// identity-free `None` sentinel; every value-carrying box is kept verbatim
+    /// as `Operand::Box`, whose `to_boxref` returns the same `Rc<Box>` —
+    /// preserving box identity, the `Cell`-backed GC walk, AND the box's
+    /// snapshot `position` field. The last point matters: a bound `ResOp`
+    /// box's `to_opref` reads its own frozen `BoxKind::ResOp.position` Cell,
+    /// NOT the producer's live `op.pos`, and the optimizer's position-remap
+    /// (`optimizer.rs`) deliberately mutates `op.pos` before reading operand
+    /// positions — so shedding a bound `ResOp` to a live-tracking
+    /// `Operand::Op` here would double-remap. Shedding `Box` → `Op`/`InputArg`/
+    /// `Const` (and adapting those remap consumers) is a later slice.
     pub fn from_boxref(b: &BoxRef) -> Operand {
         if b.is_none() {
             return Operand::None;
-        }
-        if !b.is_constant() {
-            if b.is_inputarg() {
-                if let Some(ia) = b.bound_inputarg() {
-                    return Operand::InputArg(ia);
-                }
-            } else if let Some(op) = b.bound_op() {
-                return Operand::Op(op);
-            }
         }
         Operand::Box(b.clone())
     }
@@ -328,20 +324,26 @@ mod tests {
     }
 
     #[test]
-    fn from_boxref_sheds_wrapper_for_bound_keeps_box_for_rest() {
-        // Bound op -> pure Op, round-trips to the SAME memoized Rc<Box>.
+    fn from_boxref_is_byte_identical_keeps_every_value_box() {
+        // Behavior-preserving storage flip: every value-carrying box is kept
+        // verbatim as Operand::Box, returning the identical Rc<Box> on read so
+        // identity, type, position, and const value all round-trip exactly.
+
+        // Bound op -> kept as Box (its frozen `position` snapshot is preserved,
+        // not replaced by the producer's live op.pos).
         let op = op_at(8, Type::Int);
         let bound = BoxRef::from_bound_op(&op);
         let o = Operand::from_boxref(&bound);
+        assert!(matches!(o, Operand::Box(_)));
         assert!(o.is_resop());
-        assert!(matches!(o, Operand::Op(_)));
         assert_eq!(o.to_boxref().as_ptr(), bound.as_ptr());
 
-        // Bound input arg -> pure InputArg.
+        // Bound input arg -> kept as Box.
         let ia = Rc::new(InputArg::from_type(Type::Ref, 2));
         let bia = BoxRef::from_bound_inputarg(&ia);
         let o = Operand::from_boxref(&bia);
-        assert!(matches!(o, Operand::InputArg(_)));
+        assert!(matches!(o, Operand::Box(_)));
+        assert!(o.is_inputarg());
         assert_eq!(o.to_boxref().as_ptr(), bia.as_ptr());
 
         // Const -> kept as Box (Cell-backed), round-trips to the same box.
@@ -360,7 +362,7 @@ mod tests {
         assert_eq!(o.position(), Some(4));
         assert_eq!(o.to_boxref().as_ptr(), pos_only.as_ptr());
 
-        // None sentinel -> Operand::None.
+        // None sentinel -> Operand::None (identity-free, byte-identical).
         assert!(matches!(Operand::from_boxref(&BoxRef::none()), Operand::None));
     }
 }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -39,17 +39,24 @@ pub enum Operand {
     Op(OpRc),
     /// An input-arg producer (`resoperation.py` `AbstractInputArg`).
     InputArg(InputArgRc),
-    /// An inline constant (`history.py` `Const*`); value identity, never
-    /// `Rc::ptr_eq`.
-    Const(Const),
+    /// A constant (`history.py:227/268/314` `ConstInt`/`ConstFloat`/
+    /// `ConstPtr`). Upstream `Const` is a heap object — `_args[i]` returns
+    /// the stored object, `==` is Python `is`, and value equality is the
+    /// explicit `same_constant` (history.py:211) — so the operand carries
+    /// the const box by `Rc` (object identity across reads of one slot,
+    /// `Cell`-backed GC walk of an inline `ConstPtr`), NOT a bare value.
+    /// The carrier is the const-kind [`BoxRef`] for the migration window;
+    /// it type-narrows to a dedicated const-box `Rc` when the `BoxRef`
+    /// wrapper is deleted (#9 endgame).
+    Const(BoxRef),
     /// MIGRATION-ONLY catch-all (`#9` operand-union flip): a not-yet-converted
     /// [`BoxRef`] for the operands `from_boxref` cannot yet lower to a pure
-    /// `Op`/`InputArg`/`Const` — const operands (kept `Cell`-backed for the GC
-    /// walk) and position-only operands minted by `BoxRef::from_opref` (no live
-    /// producer to bind). Holding the original `BoxRef` makes the storage flip
-    /// byte-identical: `to_boxref` clones the same `Rc<Box>` back, preserving
-    /// box identity and GC-walkability verbatim. Ground down to zero
-    /// (then deleted) as later slices bind/inline these.
+    /// `Op`/`InputArg`/`Const` — position-only operands minted by
+    /// `BoxRef::from_opref` (no live producer to bind). Holding the original
+    /// `BoxRef` makes the storage flip byte-identical: `to_boxref` clones the
+    /// same `Rc<Box>` back, preserving box identity and GC-walkability
+    /// verbatim. Ground down to zero (then deleted) as later slices bind
+    /// these.
     Box(BoxRef),
 }
 
@@ -67,9 +74,11 @@ impl Operand {
         Operand::InputArg(Rc::clone(ia))
     }
 
-    /// An inline-constant operand.
+    /// A constant operand — mints a fresh const box (`history.py:227`
+    /// `ConstInt(value)` object construction; identity starts here and is
+    /// shared by every read of the slot).
     pub fn const_(value: Const) -> Operand {
-        Operand::Const(value)
+        Operand::Const(BoxRef::new_const(value.to_value()))
     }
 
     /// The absent-slot sentinel.
@@ -89,11 +98,9 @@ impl Operand {
             Operand::None => OpRef::NONE,
             Operand::Op(op) => op.pos.get(),
             Operand::InputArg(ia) => OpRef::input_arg_typed(ia.index, ia.tp),
-            Operand::Const(c) => match *c {
-                Const::Int(v) => OpRef::const_int(v),
-                Const::Float(v) => OpRef::const_float(v),
-                Const::Ref(v) => OpRef::const_ptr(v),
-            },
+            // Re-encodes from the box's live `Cell` value, so a GC-moved
+            // `ConstPtr` reads back at its post-move address.
+            Operand::Const(b) => b.to_opref(),
             Operand::Box(b) => b.to_opref(),
         }
     }
@@ -114,7 +121,7 @@ impl Operand {
         match self {
             Operand::Op(op) => op.pos.get().ty().unwrap_or(Type::Void),
             Operand::InputArg(ia) => ia.tp,
-            Operand::Const(c) => c.get_type(),
+            Operand::Const(b) => b.type_(),
             Operand::Box(b) => b.type_(),
             Operand::None => Type::Void,
         }
@@ -124,7 +131,7 @@ impl Operand {
     /// `None` for non-`Const`.
     pub fn const_value(&self) -> Option<Value> {
         match self {
-            Operand::Const(c) => Some(c.to_value()),
+            Operand::Const(b) => b.const_value(),
             Operand::Box(b) => b.const_value(),
             _ => None,
         }
@@ -134,7 +141,7 @@ impl Operand {
     /// parity).
     pub fn const_int(&self) -> Option<i64> {
         match self {
-            Operand::Const(Const::Int(v)) => Some(*v),
+            Operand::Const(b) => b.const_int(),
             Operand::Box(b) => b.const_int(),
             _ => None,
         }
@@ -196,7 +203,9 @@ impl Operand {
             Operand::None => BoxRef::none(),
             Operand::Op(op) => BoxRef::from_bound_op(op),
             Operand::InputArg(ia) => BoxRef::from_bound_inputarg(ia),
-            Operand::Const(c) => BoxRef::new_const(c.to_value()),
+            // The SAME `Rc<Box>` back — `_args[i]` returns the stored
+            // Const object, never a fresh equal-valued one.
+            Operand::Const(b) => b.clone(),
             Operand::Box(b) => b.clone(),
         }
     }
@@ -239,6 +248,12 @@ impl Operand {
         if let Some(ia) = b.bound_inputarg() {
             return Operand::InputArg(ia);
         }
+        // A Const box lowers to the terminal `Operand::Const` carrying the
+        // same `Rc<Box>` (history.py Const object identity + `Cell`-backed
+        // GC walk preserved). Only position-only boxes remain `Operand::Box`.
+        if b.is_constant() {
+            return Operand::Const(b.clone());
+        }
         Operand::Box(b.clone())
     }
 
@@ -256,14 +271,13 @@ impl Operand {
 
     /// GC walk over any inline `ConstPtr` reachable from this operand
     /// (`resoperation.py` `walk_const_ptr_refs`). Const / position-only
-    /// operands are held `Cell`-backed via `Operand::Box`, so their `GcRef`
+    /// operands are held `Cell`-backed in their box, so their `GcRef`
     /// updates in place; pure `Op` / `InputArg` carry no inline const (their
-    /// own `value` slot is walked at the producer); pure `Operand::Const`
-    /// is value-typed with no in-place slot and is not produced by
-    /// `from_boxref` during the migration window.
+    /// own `value` slot is walked at the producer).
     pub fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        if let Operand::Box(b) = self {
-            b.walk_const_ptr_refs(visitor);
+        match self {
+            Operand::Const(b) | Operand::Box(b) => b.walk_const_ptr_refs(visitor),
+            Operand::None | Operand::Op(_) | Operand::InputArg(_) => {}
         }
     }
 }
@@ -384,10 +398,11 @@ mod tests {
         assert!(o.is_bound());
         assert_eq!(o.to_boxref().as_ptr(), bia.as_ptr());
 
-        // Const -> kept as Box (Cell-backed, value-typed); NOT bound.
+        // Const -> Operand::Const carrying the SAME const box (history.py
+        // Const object identity; Cell-backed GC walk); NOT bound.
         let cbox = BoxRef::new_const(Value::Int(11));
         let o = Operand::from_boxref(&cbox);
-        assert!(matches!(o, Operand::Box(_)));
+        assert!(matches!(o, Operand::Const(_)));
         assert!(o.is_constant());
         assert!(!o.is_bound());
         assert_eq!(o.const_int(), Some(11));

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -1,0 +1,264 @@
+//! `Operand` — the operand-union successor to [`BoxRef`] for `Op.args` /
+//! `Op.fail_args` (#9 / S-11).
+//!
+//! `resoperation.py:281` `N_aryOp._args` stores operands as the
+//! `AbstractValue` objects themselves — a result op, an input arg, or a
+//! constant — with no integer-position indirection. `Operand` is the Rust
+//! shape of that: a strong-ref union carrying the producer directly, so
+//! operand identity is `Rc::ptr_eq` and forwarding reads straight off the
+//! carried producer's `_forwarded` slot — with no `find_producer_op`
+//! position→producer registry, no `Op::box_cache` memoization, and no
+//! `BoxRef::from_opref` position fabrication.
+//!
+//! Strong `Rc` (not the `Weak` of [`Forwarded`](crate::box_ref::Forwarded)):
+//! operands must keep their producers alive. The trace already holds the 1st
+//! strong ref in `Trace.ops: Vec<OpRc>` (#103); an operand `Rc<Op>` is a 2nd
+//! strong ref on the acyclic SSA use-before-def DAG (operands reference
+//! predecessors only), so no `Rc` cycle can form.
+//!
+//! This module is the #9 foundation. `Op.args` still carries [`BoxRef`] until
+//! the storage flip; [`Operand::to_boxref`] and the `from_bound_*`
+//! constructors let the two representations coexist during the migration.
+
+use crate::box_ref::BoxRef;
+use crate::resoperation::{OpRc, OpRef};
+use crate::value::{Const, InputArgRc, Type, Value};
+use std::rc::Rc;
+
+/// An operand stored in `Op.args` / `Op.fail_args`.
+///
+/// Mirror of `OpRef`'s four logical cases, but carrying the producer by
+/// strong `Rc` instead of a flat position: `Op` ⇆ `OpRef::*Op`, `InputArg`
+/// ⇆ `OpRef::InputArg*`, `Const` ⇆ the inline `OpRef::Const*`, and `None` ⇆
+/// `OpRef::None` (an absent `fail_args` slot).
+#[derive(Clone)]
+pub enum Operand {
+    /// Absent slot — the mirror of `OpRef::None`.
+    None,
+    /// A result-op producer (`resoperation.py` `AbstractResOp`).
+    Op(OpRc),
+    /// An input-arg producer (`resoperation.py` `AbstractInputArg`).
+    InputArg(InputArgRc),
+    /// An inline constant (`history.py` `Const*`); value identity, never
+    /// `Rc::ptr_eq`.
+    Const(Const),
+}
+
+impl Operand {
+    /// Wrap a bound op as `Operand::Op` (`Rc::clone`, cheap). The successor
+    /// to [`BoxRef::from_bound_op`] — no `box_cache` memoization, the `Rc`
+    /// itself IS the stable identity.
+    pub fn from_bound_op(op: &OpRc) -> Operand {
+        Operand::Op(Rc::clone(op))
+    }
+
+    /// Wrap a bound input arg as `Operand::InputArg` (`Rc::clone`). Successor
+    /// to [`BoxRef::from_bound_inputarg`].
+    pub fn from_bound_inputarg(ia: &InputArgRc) -> Operand {
+        Operand::InputArg(Rc::clone(ia))
+    }
+
+    /// An inline-constant operand.
+    pub fn const_(value: Const) -> Operand {
+        Operand::Const(value)
+    }
+
+    /// The absent-slot sentinel.
+    pub fn none() -> Operand {
+        Operand::None
+    }
+
+    /// Flat-`OpRef` view for the OpRef-keyed side tables, `op.pos`
+    /// comparisons, and backend/gc encoding (`box_ref.rs:494` parity). This
+    /// is the PERMANENT handoff boundary where the optimizer's operand
+    /// identity converts to the backend's `OpRef` encoding; it is
+    /// re-expressed, never retired. An `Op` reads its (post-compaction)
+    /// position straight off `op.pos`; a `Const*` maps to the matching inline
+    /// `OpRef` (`history.py:227/268/314`).
+    pub fn to_opref(&self) -> OpRef {
+        match self {
+            Operand::None => OpRef::NONE,
+            Operand::Op(op) => op.pos.get(),
+            Operand::InputArg(ia) => OpRef::input_arg_typed(ia.index, ia.tp),
+            Operand::Const(c) => match *c {
+                Const::Int(v) => OpRef::const_int(v),
+                Const::Float(v) => OpRef::const_float(v),
+                Const::Ref(v) => OpRef::const_ptr(v),
+            },
+        }
+    }
+
+    /// `resoperation.py:233 _pos` accessor: the pool index for `Op` /
+    /// `InputArg`; `Const` / `None` have no canonical position.
+    pub fn position(&self) -> Option<u32> {
+        match self {
+            Operand::Op(op) => Some(op.pos.get().raw()),
+            Operand::InputArg(ia) => Some(ia.index),
+            Operand::Const(_) | Operand::None => None,
+        }
+    }
+
+    /// The operand's `Type` (`Int` / `Float` / `Ref` / `Void`).
+    pub fn type_(&self) -> Type {
+        match self {
+            Operand::Op(op) => op.pos.get().ty().unwrap_or(Type::Void),
+            Operand::InputArg(ia) => ia.tp,
+            Operand::Const(c) => c.get_type(),
+            Operand::None => Type::Void,
+        }
+    }
+
+    /// The inline constant value (`history.py:233` `Const.getint` family),
+    /// `None` for non-`Const`.
+    pub fn const_value(&self) -> Option<Value> {
+        match self {
+            Operand::Const(c) => Some(c.to_value()),
+            _ => None,
+        }
+    }
+
+    /// Raw `ConstInt` value with no `IntBound` synthesis (`box_ref.rs:480`
+    /// parity).
+    pub fn const_int(&self) -> Option<i64> {
+        match self {
+            Operand::Const(Const::Int(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// `resoperation.py:47 is_constant`.
+    pub fn is_constant(&self) -> bool {
+        matches!(self, Operand::Const(_))
+    }
+
+    pub fn is_inputarg(&self) -> bool {
+        matches!(self, Operand::InputArg(_))
+    }
+
+    pub fn is_resop(&self) -> bool {
+        matches!(self, Operand::Op(_))
+    }
+
+    /// True for the absent-slot sentinel — the mirror of `OpRef::is_none`.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Operand::None)
+    }
+
+    /// `resoperation.py:38 AbstractValue.same_box`: pointer identity
+    /// (`Rc::ptr_eq`) for `Op` / `InputArg`, value comparison for `Const`
+    /// (`history.py:211 same_constant`), and the `None` sentinel matches only
+    /// itself.
+    pub fn same_box(&self, other: &Operand) -> bool {
+        match (self, other) {
+            (Operand::None, Operand::None) => true,
+            (Operand::Op(a), Operand::Op(b)) => Rc::ptr_eq(a, b),
+            (Operand::InputArg(a), Operand::InputArg(b)) => Rc::ptr_eq(a, b),
+            (Operand::Const(a), Operand::Const(b)) => a == b,
+            _ => false,
+        }
+    }
+
+    /// Faithful [`BoxRef`] view of this operand, for the migration window
+    /// while `Op.args` still carries `BoxRef`. `Op` / `InputArg` route
+    /// through the memoizing `from_bound_*` (so the view round-trips to the
+    /// SAME `Rc<Box>`); `Const` mints an inline const box; `None` is the
+    /// sentinel. The inverse of the `from_bound_*` constructors modulo the
+    /// `BoxRef` wrapper.
+    pub fn to_boxref(&self) -> BoxRef {
+        match self {
+            Operand::None => BoxRef::none(),
+            Operand::Op(op) => BoxRef::from_bound_op(op),
+            Operand::InputArg(ia) => BoxRef::from_bound_inputarg(ia),
+            Operand::Const(c) => BoxRef::new_const(c.to_value()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resoperation::{Op, OpCode};
+    use crate::value::{Const, InputArg, Type, Value};
+
+    fn op_at(pos: u32, tp: Type) -> OpRc {
+        let op = Rc::new(Op::new(OpCode::SameAsI, &[]));
+        op.pos.set(OpRef::op_typed(pos, tp));
+        op
+    }
+
+    #[test]
+    fn to_opref_round_trips_each_variant() {
+        let op = op_at(3, Type::Int);
+        assert_eq!(Operand::from_bound_op(&op).to_opref(), OpRef::op_typed(3, Type::Int));
+
+        let ia = Rc::new(InputArg::from_type(Type::Ref, 2));
+        assert_eq!(
+            Operand::from_bound_inputarg(&ia).to_opref(),
+            OpRef::input_arg_typed(2, Type::Ref),
+        );
+
+        assert_eq!(Operand::const_(Const::Int(7)).to_opref(), OpRef::const_int(7));
+        assert_eq!(Operand::none().to_opref(), OpRef::NONE);
+    }
+
+    #[test]
+    fn accessors_match_variant() {
+        let op = op_at(5, Type::Int);
+        let o_op = Operand::from_bound_op(&op);
+        assert!(o_op.is_resop());
+        assert_eq!(o_op.position(), Some(5));
+        assert_eq!(o_op.type_(), Type::Int);
+        assert_eq!(o_op.const_value(), None);
+
+        let ia = Rc::new(InputArg::from_type(Type::Float, 1));
+        let o_ia = Operand::from_bound_inputarg(&ia);
+        assert!(o_ia.is_inputarg());
+        assert_eq!(o_ia.position(), Some(1));
+        assert_eq!(o_ia.type_(), Type::Float);
+
+        let o_c = Operand::const_(Const::Int(9));
+        assert!(o_c.is_constant());
+        assert_eq!(o_c.position(), None);
+        assert_eq!(o_c.type_(), Type::Int);
+        assert_eq!(o_c.const_value(), Some(Value::Int(9)));
+        assert_eq!(o_c.const_int(), Some(9));
+
+        let o_n = Operand::none();
+        assert!(o_n.is_none());
+        assert_eq!(o_n.position(), None);
+        assert_eq!(o_n.type_(), Type::Void);
+    }
+
+    #[test]
+    fn same_box_is_pointer_identity_for_producers_value_for_const() {
+        let op = op_at(0, Type::Int);
+        // Same Rc -> same box.
+        assert!(Operand::from_bound_op(&op).same_box(&Operand::from_bound_op(&op)));
+        // Distinct ops at the same position -> distinct boxes.
+        let op_other = op_at(0, Type::Int);
+        assert!(!Operand::from_bound_op(&op).same_box(&Operand::from_bound_op(&op_other)));
+
+        // Equal-valued constants -> same box (value identity).
+        assert!(Operand::const_(Const::Int(4)).same_box(&Operand::const_(Const::Int(4))));
+        assert!(!Operand::const_(Const::Int(4)).same_box(&Operand::const_(Const::Int(5))));
+
+        // None matches only None.
+        assert!(Operand::none().same_box(&Operand::none()));
+        assert!(!Operand::none().same_box(&Operand::const_(Const::Int(0))));
+    }
+
+    #[test]
+    fn to_boxref_preserves_identity_and_value() {
+        let op = op_at(8, Type::Int);
+        let via_operand = Operand::from_bound_op(&op).to_boxref();
+        // The BoxRef bridge round-trips to the SAME memoized Rc<Box> as a
+        // direct from_bound_op (box_cache identity).
+        assert_eq!(via_operand.as_ptr(), BoxRef::from_bound_op(&op).as_ptr());
+        assert_eq!(via_operand.to_opref(), OpRef::op_typed(8, Type::Int));
+
+        let c = Operand::const_(Const::Int(11)).to_boxref();
+        assert_eq!(c.const_int(), Some(11));
+
+        assert!(Operand::none().to_boxref().is_none());
+    }
+}

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -22,7 +22,7 @@
 
 use crate::box_ref::BoxRef;
 use crate::resoperation::{OpRc, OpRef};
-use crate::value::{Const, InputArgRc, Type, Value};
+use crate::value::{Const, GcRef, InputArgRc, Type, Value};
 use std::rc::Rc;
 
 /// An operand stored in `Op.args` / `Op.fail_args`.
@@ -42,6 +42,15 @@ pub enum Operand {
     /// An inline constant (`history.py` `Const*`); value identity, never
     /// `Rc::ptr_eq`.
     Const(Const),
+    /// MIGRATION-ONLY catch-all (`#9` operand-union flip): a not-yet-converted
+    /// [`BoxRef`] for the operands `from_boxref` cannot yet lower to a pure
+    /// `Op`/`InputArg`/`Const` — const operands (kept `Cell`-backed for the GC
+    /// walk) and position-only operands minted by `BoxRef::from_opref` (no live
+    /// producer to bind). Holding the original `BoxRef` makes the storage flip
+    /// byte-identical: `to_boxref` clones the same `Rc<Box>` back, preserving
+    /// box identity and GC-walkability verbatim. Ground down to zero
+    /// (then deleted) as later slices bind/inline these.
+    Box(BoxRef),
 }
 
 impl Operand {
@@ -85,6 +94,7 @@ impl Operand {
                 Const::Float(v) => OpRef::const_float(v),
                 Const::Ref(v) => OpRef::const_ptr(v),
             },
+            Operand::Box(b) => b.to_opref(),
         }
     }
 
@@ -94,6 +104,7 @@ impl Operand {
         match self {
             Operand::Op(op) => Some(op.pos.get().raw()),
             Operand::InputArg(ia) => Some(ia.index),
+            Operand::Box(b) => b.position(),
             Operand::Const(_) | Operand::None => None,
         }
     }
@@ -104,6 +115,7 @@ impl Operand {
             Operand::Op(op) => op.pos.get().ty().unwrap_or(Type::Void),
             Operand::InputArg(ia) => ia.tp,
             Operand::Const(c) => c.get_type(),
+            Operand::Box(b) => b.type_(),
             Operand::None => Type::Void,
         }
     }
@@ -113,6 +125,7 @@ impl Operand {
     pub fn const_value(&self) -> Option<Value> {
         match self {
             Operand::Const(c) => Some(c.to_value()),
+            Operand::Box(b) => b.const_value(),
             _ => None,
         }
     }
@@ -122,40 +135,54 @@ impl Operand {
     pub fn const_int(&self) -> Option<i64> {
         match self {
             Operand::Const(Const::Int(v)) => Some(*v),
+            Operand::Box(b) => b.const_int(),
             _ => None,
         }
     }
 
     /// `resoperation.py:47 is_constant`.
     pub fn is_constant(&self) -> bool {
-        matches!(self, Operand::Const(_))
+        match self {
+            Operand::Const(_) => true,
+            Operand::Box(b) => b.is_constant(),
+            _ => false,
+        }
     }
 
     pub fn is_inputarg(&self) -> bool {
-        matches!(self, Operand::InputArg(_))
+        match self {
+            Operand::InputArg(_) => true,
+            Operand::Box(b) => b.is_inputarg(),
+            _ => false,
+        }
     }
 
     pub fn is_resop(&self) -> bool {
-        matches!(self, Operand::Op(_))
+        match self {
+            Operand::Op(_) => true,
+            Operand::Box(b) => b.is_resop(),
+            _ => false,
+        }
     }
 
     /// True for the absent-slot sentinel — the mirror of `OpRef::is_none`.
     pub fn is_none(&self) -> bool {
-        matches!(self, Operand::None)
+        match self {
+            Operand::None => true,
+            Operand::Box(b) => b.is_none(),
+            _ => false,
+        }
     }
 
     /// `resoperation.py:38 AbstractValue.same_box`: pointer identity
     /// (`Rc::ptr_eq`) for `Op` / `InputArg`, value comparison for `Const`
     /// (`history.py:211 same_constant`), and the `None` sentinel matches only
-    /// itself.
+    /// itself. Routed through [`BoxRef::same_box`] (the canonical predicate) so
+    /// the migration `Box` variant compares uniformly against pure variants —
+    /// the `from_bound_*` view is memoized, so two operands holding the same op
+    /// still resolve to the same `Rc<Box>` and stay `ptr_eq`.
     pub fn same_box(&self, other: &Operand) -> bool {
-        match (self, other) {
-            (Operand::None, Operand::None) => true,
-            (Operand::Op(a), Operand::Op(b)) => Rc::ptr_eq(a, b),
-            (Operand::InputArg(a), Operand::InputArg(b)) => Rc::ptr_eq(a, b),
-            (Operand::Const(a), Operand::Const(b)) => a == b,
-            _ => false,
-        }
+        self.to_boxref().same_box(&other.to_boxref())
     }
 
     /// Faithful [`BoxRef`] view of this operand, for the migration window
@@ -170,6 +197,44 @@ impl Operand {
             Operand::Op(op) => BoxRef::from_bound_op(op),
             Operand::InputArg(ia) => BoxRef::from_bound_inputarg(ia),
             Operand::Const(c) => BoxRef::new_const(c.to_value()),
+            Operand::Box(b) => b.clone(),
+        }
+    }
+
+    /// Classify a [`BoxRef`] into an [`Operand`] for the storage flip. Cleanly
+    /// bound producers shed the wrapper — a live `bound_op`/`bound_inputarg`
+    /// becomes a pure `Op`/`InputArg` (the `#9` win); the `None` sentinel
+    /// becomes `Operand::None`. Everything else — `Const` (kept `Cell`-backed
+    /// for the GC walk) and position-only boxes minted by `from_opref` with no
+    /// live producer to bind — is preserved verbatim as `Operand::Box`, so
+    /// `to_boxref` returns the same `Rc<Box>` and the flip is byte-identical.
+    /// Later slices grind the `Box` residue to zero.
+    pub fn from_boxref(b: &BoxRef) -> Operand {
+        if b.is_none() {
+            return Operand::None;
+        }
+        if !b.is_constant() {
+            if b.is_inputarg() {
+                if let Some(ia) = b.bound_inputarg() {
+                    return Operand::InputArg(ia);
+                }
+            } else if let Some(op) = b.bound_op() {
+                return Operand::Op(op);
+            }
+        }
+        Operand::Box(b.clone())
+    }
+
+    /// GC walk over any inline `ConstPtr` reachable from this operand
+    /// (`resoperation.py` `walk_const_ptr_refs`). Const / position-only
+    /// operands are held `Cell`-backed via `Operand::Box`, so their `GcRef`
+    /// updates in place; pure `Op` / `InputArg` carry no inline const (their
+    /// own `value` slot is walked at the producer); pure `Operand::Const`
+    /// is value-typed with no in-place slot and is not produced by
+    /// `from_boxref` during the migration window.
+    pub fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut GcRef)) {
+        if let Operand::Box(b) = self {
+            b.walk_const_ptr_refs(visitor);
         }
     }
 }
@@ -260,5 +325,42 @@ mod tests {
         assert_eq!(c.const_int(), Some(11));
 
         assert!(Operand::none().to_boxref().is_none());
+    }
+
+    #[test]
+    fn from_boxref_sheds_wrapper_for_bound_keeps_box_for_rest() {
+        // Bound op -> pure Op, round-trips to the SAME memoized Rc<Box>.
+        let op = op_at(8, Type::Int);
+        let bound = BoxRef::from_bound_op(&op);
+        let o = Operand::from_boxref(&bound);
+        assert!(o.is_resop());
+        assert!(matches!(o, Operand::Op(_)));
+        assert_eq!(o.to_boxref().as_ptr(), bound.as_ptr());
+
+        // Bound input arg -> pure InputArg.
+        let ia = Rc::new(InputArg::from_type(Type::Ref, 2));
+        let bia = BoxRef::from_bound_inputarg(&ia);
+        let o = Operand::from_boxref(&bia);
+        assert!(matches!(o, Operand::InputArg(_)));
+        assert_eq!(o.to_boxref().as_ptr(), bia.as_ptr());
+
+        // Const -> kept as Box (Cell-backed), round-trips to the same box.
+        let cbox = BoxRef::new_const(Value::Int(11));
+        let o = Operand::from_boxref(&cbox);
+        assert!(matches!(o, Operand::Box(_)));
+        assert!(o.is_constant());
+        assert_eq!(o.const_int(), Some(11));
+        assert_eq!(o.to_boxref().as_ptr(), cbox.as_ptr());
+
+        // Position-only box (from_opref, no live producer) -> kept as Box,
+        // returns the identical Rc<Box> on read.
+        let pos_only = BoxRef::from_opref(OpRef::op_typed(4, Type::Int));
+        let o = Operand::from_boxref(&pos_only);
+        assert!(matches!(o, Operand::Box(_)));
+        assert_eq!(o.position(), Some(4));
+        assert_eq!(o.to_boxref().as_ptr(), pos_only.as_ptr());
+
+        // None sentinel -> Operand::None.
+        assert!(matches!(Operand::from_boxref(&BoxRef::none()), Operand::None));
     }
 }

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -490,7 +490,7 @@ impl PtrInfo {
             match entry {
                 FieldEntry::Value(opref) => visit_opref(opref, visitor),
                 FieldEntry::Preamble(pop) => {
-                    visit_opref(&mut pop.op, visitor);
+                    pop.op.walk_const_ptr_refs(visitor);
                     pop.preamble_op.walk_const_ptr_refs_mut(visitor);
                 }
             }

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -7,6 +7,7 @@
 use smallvec::SmallVec;
 
 use crate::box_ref::{BoxRef, Forwarded};
+use crate::operand::Operand;
 use crate::descr::DescrRef;
 use crate::value::{GcRef, Type, Value};
 
@@ -1252,7 +1253,14 @@ pub struct Op {
     /// via `Rc<Op>` — RPython writes
     /// `op._args[i] = ...` on the same Python object the trace list,
     /// optimizer state, and backend input lists all observe.
-    pub args: std::cell::RefCell<SmallVec<[BoxRef; 3]>>,
+    ///
+    /// `#9` operand-union flip: each slot is an [`Operand`] (a bound
+    /// producer carried by `Rc`, an inline `Const`, or — during the
+    /// migration window — a `Operand::Box` wrapping a not-yet-converted
+    /// `BoxRef`). The `BoxRef`-keyed accessors (`arg`, `getarglist`, ...)
+    /// convert on read/write via `Operand::to_boxref` / `from_boxref`, so
+    /// the flip is behavior-preserving while callers migrate.
+    pub args: std::cell::RefCell<SmallVec<[Operand; 3]>>,
     /// `resoperation.py:460 ResOpWithDescr._descr` parity.  `RefCell`
     /// so the optimizer can stamp a descr onto a shared `Op` reached
     /// through `Rc<Op>`: RPython's
@@ -1468,7 +1476,7 @@ impl Op {
     pub fn new(opcode: OpCode, args: &[BoxRef]) -> Self {
         Op {
             opcode,
-            args: std::cell::RefCell::new(args.iter().cloned().collect()),
+            args: std::cell::RefCell::new(args.iter().map(Operand::from_boxref).collect()),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             type_: opcode.result_type(),
@@ -1485,7 +1493,7 @@ impl Op {
     pub fn with_descr(opcode: OpCode, args: &[BoxRef], descr: DescrRef) -> Self {
         Op {
             opcode,
-            args: std::cell::RefCell::new(args.iter().cloned().collect()),
+            args: std::cell::RefCell::new(args.iter().map(Operand::from_boxref).collect()),
             descr: std::cell::RefCell::new(Some(descr)),
             pos: std::cell::Cell::new(OpRef::NONE),
             type_: opcode.result_type(),
@@ -1500,7 +1508,7 @@ impl Op {
     }
 
     pub fn arg(&self, idx: usize) -> BoxRef {
-        self.args.borrow()[idx].clone()
+        self.args.borrow()[idx].to_boxref()
     }
 
     pub fn num_args(&self) -> usize {
@@ -1542,8 +1550,8 @@ impl Op {
         args: Option<&[BoxRef]>,
         descr: Option<Option<DescrRef>>,
     ) -> Op {
-        let new_args: SmallVec<[BoxRef; 3]> = match args {
-            Some(a) => a.iter().cloned().collect(),
+        let new_args: SmallVec<[Operand; 3]> = match args {
+            Some(a) => a.iter().map(Operand::from_boxref).collect(),
             None => self.args.borrow().clone(),
         };
         let new_descr = match descr {
@@ -4750,7 +4758,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1)), BoxRef::from_opref(OpRef::int_op(2))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4761,7 +4769,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(3)), BoxRef::from_opref(OpRef::int_op(10_000))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(3))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4772,7 +4780,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Jump,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(4)), BoxRef::from_opref(OpRef::int_op(3))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(4))), Operand::Box(BoxRef::from_opref(OpRef::int_op(3)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -4795,7 +4803,7 @@ mod tests {
     fn test_op_display_int_result() {
         let op = op! {
             opcode: OpCode::IntAdd,
-            args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1)), BoxRef::from_opref(OpRef::int_op(2))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::int_op(6)),
             fail_args: std::cell::RefCell::new(None),
@@ -4812,7 +4820,7 @@ mod tests {
     fn test_op_display_void() {
         let op = op! {
             opcode: OpCode::SetfieldGc,
-            args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             fail_args: std::cell::RefCell::new(None),
@@ -4829,7 +4837,7 @@ mod tests {
     fn test_op_display_guard_with_fail_args() {
         let op = op! {
             opcode: OpCode::GuardTrue,
-            args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))])),
@@ -4847,7 +4855,7 @@ mod tests {
     fn test_op_display_guard_without_fail_args() {
         let op = op! {
             opcode: OpCode::GuardTrue,
-            args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             fail_args: std::cell::RefCell::new(None),
@@ -4864,7 +4872,7 @@ mod tests {
     fn test_format_trace_constants_rendered_with_values() {
         let ops = vec![op! {
             opcode: OpCode::IntAdd,
-            args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(10_000))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::int_op(1)),
             fail_args: std::cell::RefCell::new(None),
@@ -4885,7 +4893,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(10_000))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(1)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4896,7 +4904,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))])),
@@ -4907,7 +4915,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Finish,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -4928,7 +4936,7 @@ mod tests {
     fn test_format_trace_constants_in_fail_args() {
         let ops = vec![op! {
             opcode: OpCode::GuardTrue,
-            args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(10_000))])),
@@ -4961,7 +4969,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::Label,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1)), BoxRef::from_opref(OpRef::int_op(2))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -4972,7 +4980,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1)), BoxRef::from_opref(OpRef::int_op(2))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4983,7 +4991,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(3)), BoxRef::from_opref(OpRef::int_op(10_000))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(3))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4994,7 +5002,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Jump,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(4)), BoxRef::from_opref(OpRef::int_op(3))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(4))), Operand::Box(BoxRef::from_opref(OpRef::int_op(3)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5028,7 +5036,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::IntSub,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(10_000))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(1)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5039,7 +5047,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntGt,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1)), BoxRef::from_opref(OpRef::int_op(10_001))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_001)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(2)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5050,7 +5058,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(2))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))])),
@@ -5061,7 +5069,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Finish,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5124,7 +5132,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::Label,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5135,7 +5143,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(2)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5146,7 +5154,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntLt,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(2)), BoxRef::from_opref(OpRef::int_op(10_000))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(2))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5157,7 +5165,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(3))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(3)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(2))])),
@@ -5168,7 +5176,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntSub,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(10_001))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_001)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5179,7 +5187,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Jump,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(4)), BoxRef::from_opref(OpRef::int_op(2))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(4))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5213,7 +5221,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0))])),
@@ -5224,7 +5232,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardFalse,
-                args: std::cell::RefCell::new(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1)), BoxRef::from_opref(OpRef::int_op(2))])),

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -7,8 +7,8 @@
 use smallvec::SmallVec;
 
 use crate::box_ref::{BoxRef, Forwarded};
-use crate::operand::Operand;
 use crate::descr::DescrRef;
+use crate::operand::Operand;
 use crate::value::{GcRef, Type, Value};
 
 /// Index into an operation list, used as a reference to an operation's
@@ -1509,6 +1509,15 @@ impl Op {
 
     pub fn arg(&self, idx: usize) -> BoxRef {
         self.args.borrow()[idx].to_boxref()
+    }
+
+    /// True iff argument `idx` is a live-tracking bound operand
+    /// (`Operand::Op` / `Operand::InputArg`) that reads its producer's
+    /// current `op.pos`, rather than a frozen `Operand::Box` snapshot. The
+    /// position-remap passes skip these — they auto-track a renumbered
+    /// producer and need no snapshot rewrite.
+    pub fn arg_is_bound(&self, idx: usize) -> bool {
+        self.args.borrow()[idx].is_bound()
     }
 
     pub fn num_args(&self) -> usize {

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1284,7 +1284,14 @@ pub struct Op {
     /// through `Rc<Op>`: RPython writes
     /// `op._fail_args = [...]` on the same Python object the trace list,
     /// optimizer state, and backend input list all see.
-    pub fail_args: std::cell::RefCell<Option<SmallVec<[BoxRef; 3]>>>,
+    ///
+    /// Stored as [`Operand`] (the same union as `args` — `GuardResOp.
+    /// _fail_args` holds the Box objects themselves, resoperation.py:483).
+    /// MIGRATION (#9): every write currently freezes to `Operand::Box`
+    /// (position snapshot, byte-identical to the previous `BoxRef`
+    /// storage); the bound-shed + skip-bound-in-remap follow-up mirrors
+    /// the `args` sequence.
+    pub fail_args: std::cell::RefCell<Option<SmallVec<[Operand; 3]>>>,
     /// Types of fail_args, set by the optimizer from constant_types.
     /// When present, the backend uses these instead of inferring types.
     /// `RefCell` so the optimizer can stamp types onto a shared `Op`
@@ -1647,7 +1654,7 @@ impl Op {
                 }
             }
         }
-        *self.fail_args.borrow_mut() = Some(boxes.into());
+        *self.fail_args.borrow_mut() = Some(boxes.into_iter().map(Operand::Box).collect());
     }
 }
 
@@ -4849,7 +4856,7 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))])),
+            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))])),
 
 
             fail_arg_types: std::cell::RefCell::new(None),
@@ -4916,7 +4923,7 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -4948,7 +4955,7 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(10_000))])),
+            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))])),
 
 
             fail_arg_types: std::cell::RefCell::new(None),
@@ -5070,7 +5077,7 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -5177,7 +5184,7 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(3)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(2))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -5233,7 +5240,7 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -5244,7 +5251,7 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(0)), BoxRef::from_opref(OpRef::int_op(1)), BoxRef::from_opref(OpRef::int_op(2))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))])),
 
 
                 fail_arg_types: std::cell::RefCell::new(None),

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1654,7 +1654,7 @@ impl Op {
                 }
             }
         }
-        *self.fail_args.borrow_mut() = Some(boxes.into_iter().map(Operand::Box).collect());
+        *self.fail_args.borrow_mut() = Some(boxes.iter().map(Operand::from_boxref).collect());
     }
 }
 

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1847,8 +1847,9 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             }
             if let Some(fail_args) = emitted.fail_args_mut() {
                 for arg in fail_args.iter_mut() {
-                    *arg =
-                        BoxRef::from_opref(get_local_box_replacement(forwarding, arg.to_opref()));
+                    *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(
+                        get_local_box_replacement(forwarding, arg.to_opref()),
+                    ));
                 }
             }
         }

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -559,6 +559,12 @@ impl TreeLoop {
             }
             if let Some(fa) = new_op.fail_args_mut() {
                 for arg in fa.iter_mut() {
+                    // Measured dead (PYRE_REMAP_PROBE 2026-06-11: 0 fires
+                    // across check.py corpus + lib tests) — post-cut ops
+                    // never carry fail_args at cut time; they are attached
+                    // later by store_final_boxes_in_guard. Rewrite kept as
+                    // a release safety net.
+                    debug_assert!(false, "cut-trace op carried fail_args: {:?}", new_op.opcode);
                     *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(remap_ref(
                         &arg.to_opref(),
                     )));

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -559,7 +559,9 @@ impl TreeLoop {
             }
             if let Some(fa) = new_op.fail_args_mut() {
                 for arg in fa.iter_mut() {
-                    *arg = BoxRef::from_opref(remap_ref(&arg.to_opref()));
+                    *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(remap_ref(
+                        &arg.to_opref(),
+                    )));
                 }
             }
             new_ops.push(new_op);

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -405,7 +405,9 @@ impl<'a> TraceIterator<'a> {
         }
         if let Some(fa) = res.fail_args_mut() {
             for arg in fa.iter_mut() {
-                *arg = BoxRef::from_opref(self._untag(arg.to_opref()));
+                *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(
+                    self._untag(arg.to_opref()),
+                ));
             }
         }
         // RPython opencoder.py:399-401:

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -87,10 +87,13 @@ impl Optimization for OptEarlyForce {
                     // potential_extra_ops are handled by Optimizer.force_box,
                     // but earlyforce only needs the virtual materialization.
                     if let Some(tracked) = ctx.take_potential_extra_op(arg) {
+                        // shortpreamble.py:434: the resolved Box is handed
+                        // to the builder; fall back to the operand's own box.
+                        let arg_b = arg_box.clone().unwrap_or_else(|| op.arg(i));
                         if let Some(builder) = ctx.active_short_preamble_producer_mut() {
-                            builder.add_preamble_op_from_pop(&tracked, arg);
+                            builder.add_preamble_op_from_pop(&tracked, arg_b);
                         } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {
-                            builder.add_preamble_op_from_pop(&tracked, arg);
+                            builder.add_preamble_op_from_pop(&tracked, arg_b);
                         }
                     }
                     let arg_box = ctx

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -391,7 +391,8 @@ impl CachedField {
                 .as_field_descr()
                 .map(|fd| OpCode::getfield_for_type(fd.field_type()))
                 .unwrap_or(OpCode::GetfieldGcI);
-            let mut op = Op::with_descr(opcode, &[BoxRef::from_opref(structbox)], descr.clone());
+            let mut op =
+                Op::with_descr(opcode, &[ctx.materialize_box_at(structbox)], descr.clone());
             op.pos.set(cached_val);
             sb.add_heap_op(op);
         }
@@ -630,11 +631,9 @@ impl ArrayCachedItem {
                 .as_array_descr()
                 .map(|array_descr| OpCode::getarrayitem_for_type(array_descr.item_type()))
                 .unwrap_or(OpCode::GetarrayitemGcI);
-            let mut op = Op::with_descr(
-                opcode,
-                &[BoxRef::from_opref(arraybox), BoxRef::from_opref(idx_ref)],
-                descr.clone(),
-            );
+            let arraybox_b = ctx.materialize_box_at(arraybox);
+            let idx_b = ctx.materialize_box_at(idx_ref);
+            let mut op = Op::with_descr(opcode, &[arraybox_b, idx_b], descr.clone());
             op.pos.set(cached_val);
             sb.add_heap_op(op);
         }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2184,7 +2184,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.get_box_replacement(pop.op).to_opref();
+                    let cached_seen = ctx.resolve_box_box(&pop.op).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -2325,7 +2325,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.get_box_replacement(pop.op).to_opref();
+                    let cached_seen = ctx.resolve_box_box(&pop.op).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -3836,7 +3836,7 @@ mod tests {
             info.set_preamble_field(
                 OptHeap::field_slot_index(descr),
                 PreambleOp {
-                    op: source,
+                    op: BoxRef::from_opref(source),
                     invented_name: false,
                     preamble_op,
                 },

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3838,7 +3838,7 @@ mod tests {
                 PreambleOp {
                     op: BoxRef::from_opref(source),
                     invented_name: false,
-                    preamble_op,
+                    preamble_op: std::rc::Rc::new(preamble_op),
                 },
             );
         })

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -5031,10 +5031,10 @@ mod tests {
             OpRef::ref_op(100),
             OpRef::ref_op(101),
         ]);
-        // Register input args so produce_arg can resolve them.
-        sb.add_short_input_arg(OpRef::ref_op(100), majit_ir::Type::Ref);
-        sb.add_short_input_arg(OpRef::ref_op(101), majit_ir::Type::Ref);
         let mut ctx = crate::optimizeopt::OptContext::new(256);
+        // Register input args so produce_arg can resolve them.
+        sb.add_short_input_arg(&mut ctx, OpRef::ref_op(100), majit_ir::Type::Ref);
+        sb.add_short_input_arg(&mut ctx, OpRef::ref_op(101), majit_ir::Type::Ref);
         // Seed PtrInfo._fields[idx] with the cached value so the
         // produce_potential_short_preamble_ops read path can find it.
         use crate::optimizeopt::info::PtrInfo;

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2079,13 +2079,9 @@ impl OptHeap {
             ctx.emit(op.clone());
             let zero_ref = ctx.make_constant_int(0);
             let cmp_pos = ctx.alloc_op_position_typed(OpCode::IntNe.result_type());
-            let mut cmp_op = Op::new(
-                OpCode::IntNe,
-                &[
-                    BoxRef::from_opref(op.pos.get()),
-                    BoxRef::from_opref(zero_ref),
-                ],
-            );
+            let cmp_arg0 = ctx.materialize_box_at(op.pos.get());
+            let cmp_arg1 = ctx.materialize_box_at(zero_ref);
+            let mut cmp_op = Op::new(OpCode::IntNe, &[cmp_arg0, cmp_arg1]);
             cmp_op.pos.set(cmp_pos);
             ctx.emit(cmp_op);
             // unroll.py:409 parity: synthetic guards inherit
@@ -2093,7 +2089,8 @@ impl OptHeap {
             // running GUARD_FUTURE_CONDITION). Without this, the guard
             // arrives at store_final_boxes_in_guard with -1 and would
             // be silently dropped under the patchguardop-only fallback.
-            let guard_op = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(cmp_pos)]);
+            let guard_arg = ctx.materialize_box_at(cmp_pos);
+            let guard_op = Op::new(OpCode::GuardTrue, &[guard_arg]);
             if let Some(ref patch) = ctx.patchguardop {
                 guard_op
                     .rd_resume_position

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -429,13 +429,18 @@ impl PtrInfoExt for PtrInfo {
                 Value::Void => panic!("alloc_const: ConstVoid not allowed"),
             };
             ctx.seed_constant(pos, value);
-            pos
+            ctx.materialize_box_at(pos)
         };
+        // info.py make_guards receives `op` as a Box object; bind the
+        // caller-resolved producer once. Guard args referencing ops pushed
+        // into `short` itself (lenop / eq_op below) stay position-only —
+        // their producer lives in `short`, not in ctx's registries.
+        let op_b = ctx.materialize_box_at(op);
         match self {
             // info.py:83-84: PtrInfo base — no-op
             PtrInfo::NonNull { .. } => {
                 // info.py:120-122: NonNullPtrInfo.make_guards
-                short.push(Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(op)]));
+                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
             }
             PtrInfo::Instance(info) => {
                 // info.py:336-353 InstancePtrInfo.make_guards line-by-line.
@@ -475,16 +480,16 @@ impl PtrInfoExt for PtrInfo {
                     // `cls_of_box()`.
                     let class_ref = alloc_const(ctx, Value::Int(cls));
                     if !ctx.remove_gctypeptr {
-                        short.push(Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(op)]));
-                        short.push(Op::new(OpCode::GuardIsObject, &[BoxRef::from_opref(op)]));
+                        short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                        short.push(Op::new(OpCode::GuardIsObject, &[op_b.clone()]));
                         short.push(Op::new(
                             OpCode::GuardClass,
-                            &[BoxRef::from_opref(op), BoxRef::from_opref(class_ref)],
+                            &[op_b.clone(), class_ref.clone()],
                         ));
                     } else {
                         short.push(Op::new(
                             OpCode::GuardNonnullClass,
-                            &[BoxRef::from_opref(op), BoxRef::from_opref(class_ref)],
+                            &[op_b.clone(), class_ref.clone()],
                         ));
                     }
                 } else if let Some(descr) = &info.descr {
@@ -493,18 +498,18 @@ impl PtrInfoExt for PtrInfo {
                         .map(|sd| sd.vtable() as i64)
                         .unwrap_or(0);
                     let vtable_const = alloc_const(ctx, Value::Int(vtable));
-                    short.push(Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(op)]));
+                    short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
                     if !ctx.remove_gctypeptr {
-                        short.push(Op::new(OpCode::GuardIsObject, &[BoxRef::from_opref(op)]));
+                        short.push(Op::new(OpCode::GuardIsObject, &[op_b.clone()]));
                     }
                     short.push(Op::new(
                         OpCode::GuardSubclass,
-                        &[BoxRef::from_opref(op), BoxRef::from_opref(vtable_const)],
+                        &[op_b.clone(), vtable_const.clone()],
                     ));
                 } else {
                     // info.py:353 fall-through with neither class nor
                     // descr — base NonNullPtrInfo.make_guards.
-                    short.push(Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(op)]));
+                    short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
                 }
             }
             PtrInfo::Struct(info) => {
@@ -519,19 +524,16 @@ impl PtrInfoExt for PtrInfo {
                     .map(|sd| sd.type_id() as i64)
                     .unwrap_or(0);
                 let type_id_const = alloc_const(ctx, Value::Int(type_id));
-                short.push(Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(op)]));
+                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
                 short.push(Op::new(
                     OpCode::GuardGcType,
-                    &[BoxRef::from_opref(op), BoxRef::from_opref(type_id_const)],
+                    &[op_b.clone(), type_id_const.clone()],
                 ));
             }
             PtrInfo::Constant(gcref) => {
                 // info.py:715-716: ConstPtrInfo.make_guards
                 let c = alloc_const(ctx, Value::Ref(*gcref));
-                short.push(Op::new(
-                    OpCode::GuardValue,
-                    &[BoxRef::from_opref(op), BoxRef::from_opref(c)],
-                ));
+                short.push(Op::new(OpCode::GuardValue, &[op_b.clone(), c.clone()]));
             }
             PtrInfo::Array(info) => {
                 // info.py:632-639: ArrayPtrInfo.make_guards.
@@ -541,7 +543,7 @@ impl PtrInfoExt for PtrInfo {
                 //       lenop = ARRAYLEN_GC[op] (descr=self.descr)
                 //       short.append(lenop)
                 //       self.lenbound.make_guards(lenop, short, optimizer)
-                short.push(Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(op)]));
+                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
                 let type_id = info
                     .descr
                     .as_array_descr()
@@ -550,18 +552,15 @@ impl PtrInfoExt for PtrInfo {
                 let type_id_const = alloc_const(ctx, Value::Int(type_id));
                 short.push(Op::new(
                     OpCode::GuardGcType,
-                    &[BoxRef::from_opref(op), BoxRef::from_opref(type_id_const)],
+                    &[op_b.clone(), type_id_const.clone()],
                 ));
                 // Always emit ARRAYLEN_GC + bound guards: pyre's
                 // ArrayPtrInfo.lenbound is a plain `IntBound`, not an
                 // `Option`, so the parity check is on `is_unbounded()`
                 // rather than `is None`.
                 if !info.lenbound.is_unbounded() {
-                    let mut lenop = Op::with_descr(
-                        OpCode::ArraylenGc,
-                        &[BoxRef::from_opref(op)],
-                        info.descr.clone(),
-                    );
+                    let mut lenop =
+                        Op::with_descr(OpCode::ArraylenGc, &[op_b.clone()], info.descr.clone());
                     // info.py:637 `lenop = ResOperation(ARRAYLEN_GC, [op])`
                     // followed by `lenbound.make_guards(lenop, ...)` — the
                     // `lenop` object is the consumer's box arg via Python
@@ -591,10 +590,7 @@ impl PtrInfoExt for PtrInfo {
             // `RawSlicePtrInfo` (info.py:459) inherit this override.
             PtrInfo::VirtualRawBuffer(_) | PtrInfo::VirtualRawSlice(_) => {
                 let zero = alloc_const(ctx, Value::Int(0));
-                let mut eq_op = Op::new(
-                    OpCode::IntEq,
-                    &[BoxRef::from_opref(op), BoxRef::from_opref(zero)],
-                );
+                let mut eq_op = Op::new(OpCode::IntEq, &[op_b.clone(), zero.clone()]);
                 // info.py:381 `op = ResOperation(INT_EQ, [...])` then
                 // `[op]` — INT_EQ result identity for GUARD_FALSE.
                 eq_op.pos.set(ctx.alloc_op_position_typed(Type::Int));
@@ -604,7 +600,7 @@ impl PtrInfoExt for PtrInfo {
             }
             PtrInfo::Str(sinfo) => {
                 // vstring.py:116-126: StrPtrInfo.make_guards
-                short.push(Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(op)]));
+                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
                 if let Some(ref bound) = sinfo.lenbound {
                     if bound.lower >= 1 {
                         let lenop_code = if sinfo.mode == 0 {
@@ -612,7 +608,7 @@ impl PtrInfoExt for PtrInfo {
                         } else {
                             OpCode::Unicodelen
                         };
-                        let mut lenop = Op::new(lenop_code, &[BoxRef::from_opref(op)]);
+                        let mut lenop = Op::new(lenop_code, &[op_b.clone()]);
                         // vstring.py:124 `lenop = ResOperation(STRLEN, [op])`
                         // is consumed by `bound.make_guards(lenop, ...)`.
                         // Materialize the producer result before the chain.

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1731,7 +1731,7 @@ mod tests {
         let pop = PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(88)),
             invented_name: false,
-            preamble_op: replay,
+            preamble_op: std::rc::Rc::new(replay),
         };
         info.set_preamble_item(1, pop.clone());
 
@@ -1760,7 +1760,7 @@ mod tests {
         let pop = PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(88)),
             invented_name: false,
-            preamble_op: replay,
+            preamble_op: std::rc::Rc::new(replay),
         };
         info.set_preamble_field(3, pop);
 

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1729,7 +1729,7 @@ mod tests {
         );
         replay.pos.set(OpRef::int_op(88));
         let pop = PreambleOp {
-            op: OpRef::int_op(88),
+            op: BoxRef::from_opref(OpRef::int_op(88)),
             invented_name: false,
             preamble_op: replay,
         };
@@ -1741,7 +1741,7 @@ mod tests {
         let recovered = info
             .take_preamble_item(1)
             .expect("preamble item should be recoverable");
-        assert_eq!(recovered.op, OpRef::int_op(88));
+        assert_eq!(recovered.op.to_opref(), OpRef::int_op(88));
         // After take_preamble_item, slot is Value(NONE)
         assert_eq!(
             info.getitem(1).and_then(|e| e.as_opref()),
@@ -1758,7 +1758,7 @@ mod tests {
             &[BoxRef::from_opref(OpRef::int_op(10))],
         );
         let pop = PreambleOp {
-            op: OpRef::int_op(88),
+            op: BoxRef::from_opref(OpRef::int_op(88)),
             invented_name: false,
             preamble_op: replay,
         };

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -963,10 +963,9 @@ fn force_box_impl(
                 let descr = descr.expect(
                     "force_box: field_idx must resolve through descr.get_all_fielddescrs()[i]",
                 );
-                let mut set_op = Op::new(
-                    OpCode::SetfieldGc,
-                    &[BoxRef::from_opref(alloc_ref), BoxRef::from_opref(value_ref)],
-                );
+                let arg_alloc = ctx.materialize_box_at(alloc_ref);
+                let arg_value = ctx.materialize_box_at(value_ref);
+                let mut set_op = Op::new(OpCode::SetfieldGc, &[arg_alloc, arg_value]);
                 set_op.setdescr(descr);
                 emit_op(ctx, set_op);
             }
@@ -1011,10 +1010,9 @@ fn force_box_impl(
                 let descr = descr.expect(
                     "force_box: field_idx must resolve through descr.get_all_fielddescrs()[i]",
                 );
-                let mut set_op = Op::new(
-                    OpCode::SetfieldGc,
-                    &[BoxRef::from_opref(alloc_ref), BoxRef::from_opref(value_ref)],
-                );
+                let arg_alloc = ctx.materialize_box_at(alloc_ref);
+                let arg_value = ctx.materialize_box_at(value_ref);
+                let mut set_op = Op::new(OpCode::SetfieldGc, &[arg_alloc, arg_value]);
                 set_op.setdescr(descr);
                 emit_op(ctx, set_op);
             }
@@ -1033,7 +1031,8 @@ fn force_box_impl(
             } else {
                 OpCode::NewArray
             };
-            let mut alloc_op = Op::new(alloc_opcode, &[BoxRef::from_opref(len_ref)]);
+            let arg_len = ctx.materialize_box_at(len_ref);
+            let mut alloc_op = Op::new(alloc_opcode, &[arg_len]);
             alloc_op.pos.set(opref);
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
@@ -1067,14 +1066,10 @@ fn force_box_impl(
                 }
                 let subbox = force_child(item_ref, ctx);
                 let idx_ref = ctx.emit_constant_int(i as i64);
-                let mut set_op = Op::new(
-                    OpCode::SetarrayitemGc,
-                    &[
-                        BoxRef::from_opref(alloc_ref),
-                        BoxRef::from_opref(idx_ref),
-                        BoxRef::from_opref(subbox),
-                    ],
-                );
+                let arg_alloc = ctx.materialize_box_at(alloc_ref);
+                let arg_idx = ctx.materialize_box_at(idx_ref);
+                let arg_sub = ctx.materialize_box_at(subbox);
+                let mut set_op = Op::new(OpCode::SetarrayitemGc, &[arg_alloc, arg_idx, arg_sub]);
                 set_op.setdescr(descr.clone());
                 emit_op(ctx, set_op);
             }
@@ -1093,7 +1088,8 @@ fn force_box_impl(
             ctx.set_ptr_info(&box_, PtrInfo::nonnull());
 
             let len_ref = ctx.emit_constant_int(num_elements as i64);
-            let mut alloc_op = Op::new(OpCode::NewArrayClear, &[BoxRef::from_opref(len_ref)]);
+            let arg_len = ctx.materialize_box_at(len_ref);
+            let mut alloc_op = Op::new(OpCode::NewArrayClear, &[arg_len]);
             alloc_op.pos.set(opref);
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
@@ -1127,13 +1123,12 @@ fn force_box_impl(
                         continue;
                     }
                     let subbox = force_child(value_ref, ctx);
+                    let arg_alloc = ctx.materialize_box_at(alloc_ref);
+                    let arg_idx = ctx.materialize_box_at(idx_ref);
+                    let arg_sub = ctx.materialize_box_at(subbox);
                     let mut set_op = Op::new(
                         OpCode::SetinteriorfieldGc,
-                        &[
-                            BoxRef::from_opref(alloc_ref),
-                            BoxRef::from_opref(idx_ref),
-                            BoxRef::from_opref(subbox),
-                        ],
+                        &[arg_alloc, arg_idx, arg_sub],
                     );
                     if let Some(d) = fielddescrs.get(field_idx as usize).cloned() {
                         set_op.setdescr(d);
@@ -1154,10 +1149,9 @@ fn force_box_impl(
             // info.py:148: emit CALL_I(func, ConstInt(size), descr=calldescr)
             let func_ref = ctx.emit_constant_int(func);
             let size_ref = ctx.emit_constant_int(size as i64);
-            let mut call_op = Op::new(
-                OpCode::CallI,
-                &[BoxRef::from_opref(func_ref), BoxRef::from_opref(size_ref)],
-            );
+            let arg_func = ctx.materialize_box_at(func_ref);
+            let arg_size = ctx.materialize_box_at(size_ref);
+            let mut call_op = Op::new(OpCode::CallI, &[arg_func, arg_size]);
             call_op.pos.set(opref);
             if let Some(d) = calldescr {
                 call_op.setdescr(d);
@@ -1174,21 +1168,18 @@ fn force_box_impl(
             }
 
             // info.py:425: CHECK_MEMORY_ERROR
-            let check_op = Op::new(OpCode::CheckMemoryError, &[BoxRef::from_opref(alloc_ref)]);
+            let arg_alloc = ctx.materialize_box_at(alloc_ref);
+            let check_op = Op::new(OpCode::CheckMemoryError, &[arg_alloc]);
             emit_op(ctx, check_op);
 
             // info.py:429-436: emit RAW_STORE for each buffered write
             for (offset, _length, descr, value) in entries {
                 let value_ref = force_child(value, ctx);
                 let offset_ref = ctx.emit_constant_int(offset);
-                let mut store_op = Op::new(
-                    OpCode::RawStore,
-                    &[
-                        BoxRef::from_opref(alloc_ref),
-                        BoxRef::from_opref(offset_ref),
-                        BoxRef::from_opref(value_ref),
-                    ],
-                );
+                let arg_alloc = ctx.materialize_box_at(alloc_ref);
+                let arg_offset = ctx.materialize_box_at(offset_ref);
+                let arg_value = ctx.materialize_box_at(value_ref);
+                let mut store_op = Op::new(OpCode::RawStore, &[arg_alloc, arg_offset, arg_value]);
                 store_op.setdescr(descr);
                 emit_op(ctx, store_op);
             }
@@ -1219,13 +1210,9 @@ fn force_box_impl(
             // `get_virtual_fields` / raw-guard path.
             let parent_forced = force_child(slice.parent, ctx);
             let offset_ref = ctx.emit_constant_int(slice.offset as i64);
-            let mut add_op = Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(parent_forced),
-                    BoxRef::from_opref(offset_ref),
-                ],
-            );
+            let arg_parent = ctx.materialize_box_at(parent_forced);
+            let arg_offset = ctx.materialize_box_at(offset_ref);
+            let mut add_op = Op::new(OpCode::IntAdd, &[arg_parent, arg_offset]);
             add_op.pos.set(opref);
             let new_ref = emit_op(ctx, add_op);
             // Preserve raw-slice identity; mark non-virtual via
@@ -1304,7 +1291,8 @@ fn force_box_impl(
             } else {
                 OpCode::Newstr
             };
-            let mut newstr_op = Op::new(new_opcode, &[BoxRef::from_opref(lengthbox)]);
+            let arg_length = ctx.materialize_box_at(lengthbox);
+            let mut newstr_op = Op::new(new_opcode, &[arg_length]);
             newstr_op.pos.set(opref);
             let newop = emit_op(ctx, newstr_op);
 
@@ -1349,14 +1337,11 @@ fn force_box_impl(
                                 .get_box_replacement_box(*ch_ref)
                                 .map(|b| b.to_opref())
                                 .unwrap_or(*ch_ref);
-                            let setitem_op = Op::new(
-                                set_opcode,
-                                &[
-                                    BoxRef::from_opref(newop),
-                                    BoxRef::from_opref(offset),
-                                    BoxRef::from_opref(ch_resolved),
-                                ],
-                            );
+                            let arg_newop = ctx.materialize_box_at(newop);
+                            let arg_offset = ctx.materialize_box_at(offset);
+                            let arg_ch = ctx.materialize_box_at(ch_resolved);
+                            let setitem_op =
+                                Op::new(set_opcode, &[arg_newop, arg_offset, arg_ch]);
                             emit_op(ctx, setitem_op);
                         }
                         offset = crate::optimizeopt::vstring::_int_add(offset, one, ctx);

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1126,10 +1126,8 @@ fn force_box_impl(
                     let arg_alloc = ctx.materialize_box_at(alloc_ref);
                     let arg_idx = ctx.materialize_box_at(idx_ref);
                     let arg_sub = ctx.materialize_box_at(subbox);
-                    let mut set_op = Op::new(
-                        OpCode::SetinteriorfieldGc,
-                        &[arg_alloc, arg_idx, arg_sub],
-                    );
+                    let mut set_op =
+                        Op::new(OpCode::SetinteriorfieldGc, &[arg_alloc, arg_idx, arg_sub]);
                     if let Some(d) = fielddescrs.get(field_idx as usize).cloned() {
                         set_op.setdescr(d);
                     }
@@ -1340,8 +1338,7 @@ fn force_box_impl(
                             let arg_newop = ctx.materialize_box_at(newop);
                             let arg_offset = ctx.materialize_box_at(offset);
                             let arg_ch = ctx.materialize_box_at(ch_resolved);
-                            let setitem_op =
-                                Op::new(set_opcode, &[arg_newop, arg_offset, arg_ch]);
+                            let setitem_op = Op::new(set_opcode, &[arg_newop, arg_offset, arg_ch]);
                             emit_op(ctx, setitem_op);
                         }
                         offset = crate::optimizeopt::vstring::_int_add(offset, one, ctx);

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -33,20 +33,13 @@ fn autogen_eq(box1: OpRef, bound1: &IntBound, box2: OpRef, bound2: &IntBound) ->
 /// comparison) instead of the OpRef-flat `==`, plus the same
 /// constant-bound equality fallback. Used by the `optimize_INT_*` bodies
 /// that resolve operands to their `_forwarded` terminal via `resolve_box`.
-///
-/// The `to_opref()` equality mirrors `OptContext::same_box`'s fallback for
-/// operands whose canonical box store is absent (test fixtures with dangling
-/// position refs): two fresh `materialize_box_at` materializations of the same
-/// position are not `Rc::ptr_eq` but denote the same operand. In production
-/// both operands resolve to one shared canonical box, so `same_box` already
-/// short-circuits.
 fn autogen_eq_b(
     box1: &crate::r#box::BoxRef,
     bound1: &IntBound,
     box2: &crate::r#box::BoxRef,
     bound2: &IntBound,
 ) -> bool {
-    if box1.same_box(box2) || box1.to_opref() == box2.to_opref() {
+    if box1.same_box(box2) {
         return true;
     }
     if bound1.is_constant()
@@ -1759,7 +1752,7 @@ impl OptIntBounds {
         let arg1 = self.resolve_box(op.arg(1), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         // intbounds.py:119-123: if arg0 is arg1: b = b0.lshift_bound(1) (x+x is even)
-        let b = if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
+        let b = if arg0.same_box(&arg1) {
             b0.lshift_bound(&IntBound::from_constant(1))
         } else {
             let b1 = self.getintbound_b(&arg1, ctx);
@@ -2102,7 +2095,7 @@ impl OptIntBounds {
         let arg0 = self.resolve_box(op.arg(0), ctx);
         let arg1 = self.resolve_box(op.arg(1), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
-        let b = if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
+        let b = if arg0.same_box(&arg1) {
             b0.mul2_bound_no_overflow()
         } else {
             let b1 = self.getintbound_b(&arg1, ctx);
@@ -2118,7 +2111,7 @@ impl OptIntBounds {
         // intbounds.py:278-279: b0/b1 are computed before the same_box check.
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
-        if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
+        if arg0.same_box(&arg1) {
             // intbounds.py:280: arg0.same_box(arg1) → x - x = 0
             self.make_constant_int(op, 0, ctx);
             return OptimizationResult::Remove;
@@ -2158,7 +2151,7 @@ impl OptIntBounds {
         let arg0 = self.resolve_box(op.arg(0), ctx);
         let arg1 = self.resolve_box(op.arg(1), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
-        let b = if arg0.same_box(&arg1) || arg0.to_opref() == arg1.to_opref() {
+        let b = if arg0.same_box(&arg1) {
             b0.square_bound_no_overflow()
         } else {
             let b1 = self.getintbound_b(&arg1, ctx);

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -60,12 +60,12 @@ fn autogen_eq_b(
 /// chained OptIntBounds rules (add_zero, int_is_zero, further reassoc)
 /// fire on the rewritten op. RPython's `send_extra_operation(opt=None)`
 /// (optimizer.py:567-589) is what the dispatcher's `Restart` arm models.
-fn replace_with(original: &Op, opcode: OpCode, args: &[OpRef]) -> OptimizationResult {
-    let ba: Vec<crate::r#box::BoxRef> = args
-        .iter()
-        .map(|a| crate::r#box::BoxRef::from_opref(*a))
-        .collect();
-    let mut new_op = Op::new(opcode, &ba);
+fn replace_with(
+    original: &Op,
+    opcode: OpCode,
+    args: &[crate::r#box::BoxRef],
+) -> OptimizationResult {
+    let mut new_op = Op::new(opcode, args);
     new_op.pos.set(original.pos.get());
     OptimizationResult::Restart(new_op)
 }
@@ -346,11 +346,11 @@ impl OptIntBounds {
         }
         // eq_zero: int_eq(0, x) => int_is_zero(x)
         if b0.is_constant() && b0.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsZero, &[arg1.to_opref()]);
+            return replace_with(op, OpCode::IntIsZero, &[arg1.clone()]);
         }
         // eq_zero: int_eq(x, 0) => int_is_zero(x)
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsZero, &[arg0.to_opref()]);
+            return replace_with(op, OpCode::IntIsZero, &[arg0.clone()]);
         }
         OptimizationResult::PassOn
     }
@@ -379,11 +379,11 @@ impl OptIntBounds {
         }
         // ne_zero: int_ne(0, x) => int_is_true(x)
         if b0.is_constant() && b0.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsTrue, &[arg1.to_opref()]);
+            return replace_with(op, OpCode::IntIsTrue, &[arg1.clone()]);
         }
         // ne_zero: int_ne(x, 0) => int_is_true(x)
         if b1.is_constant() && b1.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntIsTrue, &[arg0.to_opref()]);
+            return replace_with(op, OpCode::IntIsTrue, &[arg0.clone()]);
         }
         OptimizationResult::PassOn
     }
@@ -498,13 +498,21 @@ impl OptIntBounds {
                 if b_inner_0.is_constant() {
                     let folded = c_outer.wrapping_add(b_inner_0.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAdd, &[inner_1.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAdd,
+                        &[inner_1.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
                 // add_reassoc_consts: int_add(C2, int_add(x, C1)) => int_add(x, C1+C2)
                 if b_inner_1.is_constant() {
                     let folded = c_outer.wrapping_add(b_inner_1.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAdd,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             } else if let Some(arg1_sub) = self.as_operation_b(&arg1, OpCode::IntSub, ctx) {
                 let inner_0 = self.resolve_box(arg1_sub.arg(0), ctx);
@@ -515,13 +523,21 @@ impl OptIntBounds {
                 if b_inner_0.is_constant() {
                     let folded = c_outer.wrapping_add(b_inner_0.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[const_ref, inner_1.to_opref()]);
+                    return replace_with(
+                        op,
+                        OpCode::IntSub,
+                        &[ctx.materialize_box_at(const_ref), inner_1.clone()],
+                    );
                 }
                 // add_sub_x_c_c: int_add(C2, int_sub(x, C1)) => int_add(x, C2-C1)
                 if b_inner_1.is_constant() {
                     let folded = c_outer.wrapping_sub(b_inner_1.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAdd,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         } else {
@@ -537,13 +553,21 @@ impl OptIntBounds {
                     if b_inner_0.is_constant() {
                         let folded = b_inner_0.get_constant_int().wrapping_add(c_outer);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAdd, &[inner_1.to_opref(), const_ref]);
+                        return replace_with(
+                            op,
+                            OpCode::IntAdd,
+                            &[inner_1.clone(), ctx.materialize_box_at(const_ref)],
+                        );
                     }
                     // add_reassoc_consts: int_add(int_add(x, C1), C2) => int_add(x, C1+C2)
                     if b_inner_1.is_constant() {
                         let folded = b_inner_1.get_constant_int().wrapping_add(c_outer);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
+                        return replace_with(
+                            op,
+                            OpCode::IntAdd,
+                            &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                        );
                     }
                 }
             } else if let Some(arg0_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
@@ -557,13 +581,21 @@ impl OptIntBounds {
                     if b_inner_0.is_constant() {
                         let folded = b_inner_0.get_constant_int().wrapping_add(c_outer);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntSub, &[const_ref, inner_1.to_opref()]);
+                        return replace_with(
+                            op,
+                            OpCode::IntSub,
+                            &[ctx.materialize_box_at(const_ref), inner_1.clone()],
+                        );
                     }
                     // add_sub_x_c_c: int_add(int_sub(x, C1), C2) => int_add(x, C2-C1)
                     if b_inner_1.is_constant() {
                         let folded = c_outer.wrapping_sub(b_inner_1.get_constant_int());
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAdd, &[inner_0.to_opref(), const_ref]);
+                        return replace_with(
+                            op,
+                            OpCode::IntAdd,
+                            &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                        );
                     }
                 }
             }
@@ -647,13 +679,13 @@ impl OptIntBounds {
         }
         // sub_from_zero: int_sub(0, x) => int_neg(x)
         if b0.is_constant() && b0.get_constant_int() == 0 {
-            return replace_with(op, OpCode::IntNeg, &[arg1.to_opref()]);
+            return replace_with(op, OpCode::IntNeg, &[arg1.clone()]);
         }
         if let Some(arg0_int_invert) = self.as_operation_b(&arg0, OpCode::IntInvert, ctx) {
             let arg0_0 = self.resolve_box(arg0_int_invert.arg(0), ctx);
             // sub_invert_one: int_sub(int_invert(x), -1) => int_neg(x)
             if b1.is_constant() && b1.get_constant_int() == -1 {
-                return replace_with(op, OpCode::IntNeg, &[arg0_0.to_opref()]);
+                return replace_with(op, OpCode::IntNeg, &[arg0_0.clone()]);
             }
         } else if let Some(arg0_int_add) = self.as_operation_b(&arg0, OpCode::IntAdd, ctx) {
             let arg0_0 = self.resolve_box(arg0_int_add.arg(0), ctx);
@@ -666,13 +698,21 @@ impl OptIntBounds {
                 if b0_0.is_constant() {
                     let folded = c_outer.wrapping_sub(b0_0.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[arg0_1.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntSub,
+                        &[arg0_1.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
                 // sub_add_consts: int_sub(int_add(x, C1), C2) => int_sub(x, C-C1)
                 if b0_1.is_constant() {
                     let folded = c_outer.wrapping_sub(b0_1.get_constant_int());
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[arg0_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntSub,
+                        &[arg0_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         } else if let Some(arg0_int_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
@@ -686,13 +726,21 @@ impl OptIntBounds {
                 if b0_0.is_constant() {
                     let folded = b0_0.get_constant_int().wrapping_sub(c_outer);
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[const_ref, arg0_1.to_opref()]);
+                    return replace_with(
+                        op,
+                        OpCode::IntSub,
+                        &[ctx.materialize_box_at(const_ref), arg0_1.clone()],
+                    );
                 }
                 // sub_sub_left_x_c_c: int_sub(int_sub(x, C1), C2) => int_sub(x, C1+C2)
                 if b0_1.is_constant() {
                     let folded = b0_1.get_constant_int().wrapping_add(c_outer);
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntSub, &[arg0_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntSub,
+                        &[arg0_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         }
@@ -703,11 +751,11 @@ impl OptIntBounds {
             let b1_1 = self.getintbound_b(&arg1_1, ctx);
             // sub_add_neg: int_sub(y, int_add(x, y)) => int_neg(x)
             if autogen_eq_b(&arg1_1, &b1_1, &arg0, &b0) {
-                return replace_with(op, OpCode::IntNeg, &[arg1_0.to_opref()]);
+                return replace_with(op, OpCode::IntNeg, &[arg1_0.clone()]);
             }
             // sub_add_neg: int_sub(y, int_add(y, x)) => int_neg(x)
             if autogen_eq_b(&arg1_0, &b1_0, &arg0, &b0) {
-                return replace_with(op, OpCode::IntNeg, &[arg1_1.to_opref()]);
+                return replace_with(op, OpCode::IntNeg, &[arg1_1.clone()]);
             }
         }
         OptimizationResult::PassOn
@@ -752,14 +800,18 @@ impl OptIntBounds {
             let c = b0.get_constant_int();
             // mul_minus_one: int_mul(-1, x) => int_neg(x)
             if c == -1 {
-                return replace_with(op, OpCode::IntNeg, &[arg1.to_opref()]);
+                return replace_with(op, OpCode::IntNeg, &[arg1.clone()]);
             }
             // mul_pow2_const: int_mul(C, x) where C > 0 && (C & (C-1)) == 0
             // => int_lshift(x, highest_bit(C))
             if c > 0 && (c & c.wrapping_sub(1)) == 0 {
                 let shift = c.trailing_zeros() as i64;
                 let shift_ref = ctx.make_constant_int(shift);
-                return replace_with(op, OpCode::IntLshift, &[arg1.to_opref(), shift_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntLshift,
+                    &[arg1.clone(), ctx.materialize_box_at(shift_ref)],
+                );
             }
         } else if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
             // mul_lshift: int_mul(int_lshift(1, y), x) => int_lshift(x, y)
@@ -772,11 +824,7 @@ impl OptIntBounds {
                 && b_inner_1.known_ge_const(0)
                 && b_inner_1.known_le_const(64)
             {
-                return replace_with(
-                    op,
-                    OpCode::IntLshift,
-                    &[arg1.to_opref(), inner_1.to_opref()],
-                );
+                return replace_with(op, OpCode::IntLshift, &[arg1.clone(), inner_1.clone()]);
             }
         }
         // Outer const on arg1: mul_minus_one / mul_pow2_const
@@ -784,13 +832,17 @@ impl OptIntBounds {
             let c = b1.get_constant_int();
             // mul_minus_one: int_mul(x, -1) => int_neg(x)
             if c == -1 {
-                return replace_with(op, OpCode::IntNeg, &[arg0.to_opref()]);
+                return replace_with(op, OpCode::IntNeg, &[arg0.clone()]);
             }
             // mul_pow2_const: int_mul(x, C) where C > 0 && pow2
             if c > 0 && (c & c.wrapping_sub(1)) == 0 {
                 let shift = c.trailing_zeros() as i64;
                 let shift_ref = ctx.make_constant_int(shift);
-                return replace_with(op, OpCode::IntLshift, &[arg0.to_opref(), shift_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntLshift,
+                    &[arg0.clone(), ctx.materialize_box_at(shift_ref)],
+                );
             }
         } else if let Some(arg1_lshift) = self.as_operation_b(&arg1, OpCode::IntLshift, ctx) {
             // mul_lshift: int_mul(x, int_lshift(1, y)) => int_lshift(x, y)
@@ -803,11 +855,7 @@ impl OptIntBounds {
                 && b_inner_1.known_ge_const(0)
                 && b_inner_1.known_le_const(64)
             {
-                return replace_with(
-                    op,
-                    OpCode::IntLshift,
-                    &[arg0.to_opref(), inner_1.to_opref()],
-                );
+                return replace_with(op, OpCode::IntLshift, &[arg0.clone(), inner_1.clone()]);
             }
         }
         OptimizationResult::PassOn
@@ -888,13 +936,21 @@ impl OptIntBounds {
                 if b_inner_0.is_constant() {
                     let folded = b_inner_0.get_constant_int() & c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAnd,
+                        &[inner_1.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
                 // and_reassoc_consts: int_and(C2, int_and(x, C1)) => int_and(x, C1&C2)
                 if b_inner_1.is_constant() {
                     let folded = b_inner_1.get_constant_int() & c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAnd,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         } else if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
@@ -907,7 +963,11 @@ impl OptIntBounds {
                     // and_reassoc_consts: int_and(int_and(C1, x), C2) => int_and(x, C1&C2)
                     let folded = b_inner_0.get_constant_int() & b1.get_constant_int();
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAnd,
+                        &[inner_1.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
             if b_inner_1.is_constant() {
@@ -915,24 +975,20 @@ impl OptIntBounds {
                     // and_reassoc_consts: int_and(int_and(x, C1), C2) => int_and(x, C1&C2)
                     let folded = b_inner_1.get_constant_int() & b1.get_constant_int();
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAnd,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
             // and_absorb: int_and(int_and(a, b), a) => int_and(a, b)
             if autogen_eq_b(&arg1, &b1, &inner_0, &b_inner_0) {
-                return replace_with(
-                    op,
-                    OpCode::IntAnd,
-                    &[inner_0.to_opref(), inner_1.to_opref()],
-                );
+                return replace_with(op, OpCode::IntAnd, &[inner_0.clone(), inner_1.clone()]);
             }
             // and_absorb: int_and(int_and(b, a), a) => int_and(a, b)
             if autogen_eq_b(&arg1, &b1, &inner_1, &b_inner_1) {
-                return replace_with(
-                    op,
-                    OpCode::IntAnd,
-                    &[inner_1.to_opref(), inner_0.to_opref()],
-                );
+                return replace_with(op, OpCode::IntAnd, &[inner_1.clone(), inner_0.clone()]);
             }
         } else if let Some(arg0_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
             let inner_0 = self.resolve_box(arg0_or.arg(0), ctx);
@@ -941,11 +997,11 @@ impl OptIntBounds {
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_or: int_and(int_or(x, y), z) => int_and(x, z)
             if b_inner_1.and_bound(&b1).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), arg1.to_opref()]);
+                return replace_with(op, OpCode::IntAnd, &[inner_0.clone(), arg1.clone()]);
             }
             // and_or: int_and(int_or(y, x), z) => int_and(x, z)
             if b_inner_0.and_bound(&b1).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), arg1.to_opref()]);
+                return replace_with(op, OpCode::IntAnd, &[inner_1.clone(), arg1.clone()]);
             }
         }
         // Symmetric arm: producer on arg1.
@@ -956,11 +1012,11 @@ impl OptIntBounds {
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_absorb: int_and(a, int_and(a, b)) => int_and(a, b)
             if autogen_eq_b(&inner_0, &b_inner_0, &arg0, &b0) {
-                return replace_with(op, OpCode::IntAnd, &[arg0.to_opref(), inner_1.to_opref()]);
+                return replace_with(op, OpCode::IntAnd, &[arg0.clone(), inner_1.clone()]);
             }
             // and_absorb: int_and(a, int_and(b, a)) => int_and(a, b)
             if autogen_eq_b(&inner_1, &b_inner_1, &arg0, &b0) {
-                return replace_with(op, OpCode::IntAnd, &[arg0.to_opref(), inner_0.to_opref()]);
+                return replace_with(op, OpCode::IntAnd, &[arg0.clone(), inner_0.clone()]);
             }
         } else if let Some(arg1_or) = self.as_operation_b(&arg1, OpCode::IntOr, ctx) {
             let inner_0 = self.resolve_box(arg1_or.arg(0), ctx);
@@ -969,11 +1025,11 @@ impl OptIntBounds {
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_or: int_and(z, int_or(x, y)) => int_and(x, z)
             if b_inner_1.and_bound(&b0).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), arg0.to_opref()]);
+                return replace_with(op, OpCode::IntAnd, &[inner_0.clone(), arg0.clone()]);
             }
             // and_or: int_and(z, int_or(y, x)) => int_and(x, z)
             if b_inner_0.and_bound(&b0).known_eq_const(0) {
-                return replace_with(op, OpCode::IntAnd, &[inner_1.to_opref(), arg0.to_opref()]);
+                return replace_with(op, OpCode::IntAnd, &[inner_1.clone(), arg0.clone()]);
             }
         }
         OptimizationResult::PassOn
@@ -1040,13 +1096,21 @@ impl OptIntBounds {
                 if b_inner_0.is_constant() {
                     let folded = b_inner_0.get_constant_int() | c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntOr, &[inner_1.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntOr,
+                        &[inner_1.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
                 // or_reassoc_consts: int_or(C2, int_or(x, C1)) => int_or(x, C1|C2)
                 if b_inner_1.is_constant() {
                     let folded = b_inner_1.get_constant_int() | c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntOr, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntOr,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         } else if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
@@ -1070,7 +1134,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_1.to_opref(), const_ref],
+                                &[arg0_1.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                         // dead twin per autogenintrules.py:668-673
@@ -1080,7 +1144,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_1.to_opref(), const_ref],
+                                &[arg0_1.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                     }
@@ -1092,7 +1156,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_1.to_opref(), const_ref],
+                                &[arg0_1.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                         // dead twin per autogenintrules.py:684-689
@@ -1102,7 +1166,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_1.to_opref(), const_ref],
+                                &[arg0_1.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                     }
@@ -1123,7 +1187,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_0.to_opref(), const_ref],
+                                &[arg0_0.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                         // dead twin per autogenintrules.py:708-713
@@ -1133,7 +1197,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_0.to_opref(), const_ref],
+                                &[arg0_0.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                     }
@@ -1145,7 +1209,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_0.to_opref(), const_ref],
+                                &[arg0_0.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                         // dead twin per autogenintrules.py:724-729
@@ -1155,7 +1219,7 @@ impl OptIntBounds {
                             return replace_with(
                                 op,
                                 OpCode::IntAnd,
-                                &[arg0_0.to_opref(), const_ref],
+                                &[arg0_0.clone(), ctx.materialize_box_at(const_ref)],
                             );
                         }
                     }
@@ -1170,21 +1234,29 @@ impl OptIntBounds {
                 // or_reassoc_consts: int_or(int_or(C1, x), C2) => int_or(x, C1|C2)
                 let folded = b_arg0_0.get_constant_int() | b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntOr, &[arg0_1.to_opref(), const_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntOr,
+                    &[arg0_1.clone(), ctx.materialize_box_at(const_ref)],
+                );
             }
             if b_arg0_1.is_constant() && b1.is_constant() {
                 // or_reassoc_consts: int_or(int_or(x, C1), C2) => int_or(x, C1|C2)
                 let folded = b_arg0_1.get_constant_int() | b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntOr, &[arg0_0.to_opref(), const_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntOr,
+                    &[arg0_0.clone(), ctx.materialize_box_at(const_ref)],
+                );
             }
             // or_absorb: int_or(int_or(a, b), a) => int_or(a, b)
             if autogen_eq_b(&arg1, &b1, &arg0_0, &b_arg0_0) {
-                return replace_with(op, OpCode::IntOr, &[arg0_0.to_opref(), arg0_1.to_opref()]);
+                return replace_with(op, OpCode::IntOr, &[arg0_0.clone(), arg0_1.clone()]);
             }
             // or_absorb: int_or(int_or(b, a), a) => int_or(a, b)
             if autogen_eq_b(&arg1, &b1, &arg0_1, &b_arg0_1) {
-                return replace_with(op, OpCode::IntOr, &[arg0_1.to_opref(), arg0_0.to_opref()]);
+                return replace_with(op, OpCode::IntOr, &[arg0_1.clone(), arg0_0.clone()]);
             }
         }
         // Symmetric arm: producer on arg1.
@@ -1195,11 +1267,11 @@ impl OptIntBounds {
             let b_arg1_1 = self.getintbound_b(&arg1_1, ctx);
             // or_absorb: int_or(a, int_or(a, b)) => int_or(a, b)
             if autogen_eq_b(&arg1_0, &b_arg1_0, &arg0, &b0) {
-                return replace_with(op, OpCode::IntOr, &[arg0.to_opref(), arg1_1.to_opref()]);
+                return replace_with(op, OpCode::IntOr, &[arg0.clone(), arg1_1.clone()]);
             }
             // or_absorb: int_or(a, int_or(b, a)) => int_or(a, b)
             if autogen_eq_b(&arg1_1, &b_arg1_1, &arg0, &b0) {
-                return replace_with(op, OpCode::IntOr, &[arg0.to_opref(), arg1_0.to_opref()]);
+                return replace_with(op, OpCode::IntOr, &[arg0.clone(), arg1_0.clone()]);
             }
         }
         OptimizationResult::PassOn
@@ -1296,22 +1368,30 @@ impl OptIntBounds {
                 if b_inner_0.is_constant() {
                     let folded = b_inner_0.get_constant_int() ^ c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntXor, &[inner_1.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntXor,
+                        &[inner_1.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
                 // xor_reassoc_consts: int_xor(C2, int_xor(x, C1)) => int_xor(x, C1^C2)
                 if b_inner_1.is_constant() {
                     let folded = b_inner_1.get_constant_int() ^ c_outer;
                     let const_ref = ctx.make_constant_int(folded);
-                    return replace_with(op, OpCode::IntXor, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntXor,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
             // xor_minus_1: int_xor(-1, x) => int_invert(x)
             if c_outer == -1 {
-                return replace_with(op, OpCode::IntInvert, &[arg1.to_opref()]);
+                return replace_with(op, OpCode::IntInvert, &[arg1.clone()]);
             }
             // xor_is_not: int_xor(1, x) => int_is_zero(x)  (when x is bool)
             if c_outer == 1 && b1.is_bool() {
-                return replace_with(op, OpCode::IntIsZero, &[arg1.to_opref()]);
+                return replace_with(op, OpCode::IntIsZero, &[arg1.clone()]);
             }
         } else if let Some(arg0_xor) = self.as_operation_b(&arg0, OpCode::IntXor, ctx) {
             let inner_0 = self.resolve_box(arg0_xor.arg(0), ctx);
@@ -1322,13 +1402,21 @@ impl OptIntBounds {
                 // xor_reassoc_consts: int_xor(int_xor(C1, x), C2) => int_xor(x, C1^C2)
                 let folded = b_inner_0.get_constant_int() ^ b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntXor, &[inner_1.to_opref(), const_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntXor,
+                    &[inner_1.clone(), ctx.materialize_box_at(const_ref)],
+                );
             }
             if b_inner_1.is_constant() && b1.is_constant() {
                 // xor_reassoc_consts: int_xor(int_xor(x, C1), C2) => int_xor(x, C1^C2)
                 let folded = b_inner_1.get_constant_int() ^ b1.get_constant_int();
                 let const_ref = ctx.make_constant_int(folded);
-                return replace_with(op, OpCode::IntXor, &[inner_0.to_opref(), const_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntXor,
+                    &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                );
             }
         }
         // Constant-on-right arm (b_arg_1 constant): minus_1/is_not
@@ -1336,11 +1424,11 @@ impl OptIntBounds {
             let c = b1.get_constant_int();
             // xor_minus_1: int_xor(x, -1) => int_invert(x)
             if c == -1 {
-                return replace_with(op, OpCode::IntInvert, &[arg0.to_opref()]);
+                return replace_with(op, OpCode::IntInvert, &[arg0.clone()]);
             }
             // xor_is_not: int_xor(x, 1) => int_is_zero(x)  (when x is bool)
             if c == 1 && b0.is_bool() {
-                return replace_with(op, OpCode::IntIsZero, &[arg0.to_opref()]);
+                return replace_with(op, OpCode::IntIsZero, &[arg0.clone()]);
             }
         }
         OptimizationResult::PassOn
@@ -1425,7 +1513,11 @@ impl OptIntBounds {
                         if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                             let folded = c_arg0_0.wrapping_shl(c_r1 as u32);
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[r0.clone(), ctx.materialize_box_at(const_ref)],
+                            );
                         }
                     }
                 } else if let Some(urshift) = self.as_operation_b(&inner_1, OpCode::UintRshift, ctx)
@@ -1440,7 +1532,11 @@ impl OptIntBounds {
                         if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                             let folded = c_arg0_0.wrapping_shl(c_r1 as u32);
                             let const_ref = ctx.make_constant_int(folded);
-                            return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
+                            return replace_with(
+                                op,
+                                OpCode::IntAnd,
+                                &[r0.clone(), ctx.materialize_box_at(const_ref)],
+                            );
                         }
                     }
                 }
@@ -1456,7 +1552,11 @@ impl OptIntBounds {
                     if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                         let folded = c_arg0_1.wrapping_shl(c_r1 as u32);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
+                        return replace_with(
+                            op,
+                            OpCode::IntAnd,
+                            &[r0.clone(), ctx.materialize_box_at(const_ref)],
+                        );
                     }
                 }
             } else if let Some(urshift) = self.as_operation_b(&inner_0, OpCode::UintRshift, ctx) {
@@ -1471,7 +1571,11 @@ impl OptIntBounds {
                     if c_arg1 == c_r1 && (0..64).contains(&c_r1) {
                         let folded = c_arg0_1.wrapping_shl(c_r1 as u32);
                         let const_ref = ctx.make_constant_int(folded);
-                        return replace_with(op, OpCode::IntAnd, &[r0.to_opref(), const_ref]);
+                        return replace_with(
+                            op,
+                            OpCode::IntAnd,
+                            &[r0.clone(), ctx.materialize_box_at(const_ref)],
+                        );
                     }
                 }
             }
@@ -1490,7 +1594,7 @@ impl OptIntBounds {
                         return replace_with(
                             op,
                             OpCode::IntLshift,
-                            &[inner_0.to_opref(), const_ref],
+                            &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
                         );
                     }
                 }
@@ -1506,7 +1610,11 @@ impl OptIntBounds {
                 if c2 == c1 && (0..64).contains(&c1) {
                     let mask = (-1i64).wrapping_shl(c1 as u32);
                     let const_ref = ctx.make_constant_int(mask);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAnd,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         } else if let Some(arg0_urshift) = self.as_operation_b(&arg0, OpCode::UintRshift, ctx) {
@@ -1520,7 +1628,11 @@ impl OptIntBounds {
                 if c2 == c1 && (0..64).contains(&c1) {
                     let mask = (-1i64).wrapping_shl(c1 as u32);
                     let const_ref = ctx.make_constant_int(mask);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAnd,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         }
@@ -1586,7 +1698,7 @@ impl OptIntBounds {
                         return replace_with(
                             op,
                             OpCode::IntRshift,
-                            &[inner_0.to_opref(), const_ref],
+                            &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
                         );
                     }
                 }
@@ -1625,12 +1737,20 @@ impl OptIntBounds {
             // is_true_and_minint: int_is_true(int_and(MININT, x)) => int_lt(x, 0)
             if b_inner_0.is_constant() && b_inner_0.get_constant_int() == i64::MIN {
                 let zero_ref = ctx.make_constant_int(0);
-                return replace_with(op, OpCode::IntLt, &[inner_1.to_opref(), zero_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntLt,
+                    &[inner_1.clone(), ctx.materialize_box_at(zero_ref)],
+                );
             }
             // is_true_and_minint: int_is_true(int_and(x, MININT)) => int_lt(x, 0)
             if b_inner_1.is_constant() && b_inner_1.get_constant_int() == i64::MIN {
                 let zero_ref = ctx.make_constant_int(0);
-                return replace_with(op, OpCode::IntLt, &[inner_0.to_opref(), zero_ref]);
+                return replace_with(
+                    op,
+                    OpCode::IntLt,
+                    &[inner_0.clone(), ctx.materialize_box_at(zero_ref)],
+                );
             }
         }
         OptimizationResult::PassOn
@@ -1715,7 +1835,11 @@ impl OptIntBounds {
                 if c2 == c1 && (0..64).contains(&c1) {
                     let mask = ((((-1i64) as u64) << c1) >> c1) as i64;
                     let const_ref = ctx.make_constant_int(mask);
-                    return replace_with(op, OpCode::IntAnd, &[inner_0.to_opref(), const_ref]);
+                    return replace_with(
+                        op,
+                        OpCode::IntAnd,
+                        &[inner_0.clone(), ctx.materialize_box_at(const_ref)],
+                    );
                 }
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -6,7 +6,6 @@
 /// UINT_MUL_HIGH + shift operations, avoiding the expensive `idiv` instruction.
 use majit_ir::{Op, OpCode, OpRef};
 
-use crate::r#box::BoxRef;
 use crate::optimizeopt::OptContext;
 
 /// Compute magic numbers for division by constant `m`.
@@ -110,73 +109,58 @@ pub fn division_operations(
     if !known_nonneg {
         // t = n >> 63
         let shift63_ref = emit_constant_int(ctx, 63);
+        let arg_n = ctx.materialize_box_at(n_ref);
+        let arg_shift63 = ctx.materialize_box_at(shift63_ref);
         let t_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(
-                OpCode::IntRshift,
-                &[BoxRef::from_opref(n_ref), BoxRef::from_opref(shift63_ref)],
-            ),
+            Op::new(OpCode::IntRshift, &[arg_n, arg_shift63]),
         );
 
         // nt = n ^ t
-        let nt_ref = emit_op(
-            ctx,
-            pass_idx,
-            Op::new(
-                OpCode::IntXor,
-                &[BoxRef::from_opref(n_ref), BoxRef::from_opref(t_ref)],
-            ),
-        );
+        let arg_n = ctx.materialize_box_at(n_ref);
+        let arg_t = ctx.materialize_box_at(t_ref);
+        let nt_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[arg_n, arg_t]));
 
         // mul = UINT_MUL_HIGH(nt, k)
+        let arg_nt = ctx.materialize_box_at(nt_ref);
+        let arg_k = ctx.materialize_box_at(k_ref);
         let mul_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(
-                OpCode::UintMulHigh,
-                &[BoxRef::from_opref(nt_ref), BoxRef::from_opref(k_ref)],
-            ),
+            Op::new(OpCode::UintMulHigh, &[arg_nt, arg_k]),
         );
 
         // sh = UINT_RSHIFT(mul, i)
+        let arg_mul = ctx.materialize_box_at(mul_ref);
+        let arg_i = ctx.materialize_box_at(i_ref);
         let sh_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(
-                OpCode::UintRshift,
-                &[BoxRef::from_opref(mul_ref), BoxRef::from_opref(i_ref)],
-            ),
+            Op::new(OpCode::UintRshift, &[arg_mul, arg_i]),
         );
 
         // result = sh ^ t
-        emit_op(
-            ctx,
-            pass_idx,
-            Op::new(
-                OpCode::IntXor,
-                &[BoxRef::from_opref(sh_ref), BoxRef::from_opref(t_ref)],
-            ),
-        )
+        let arg_sh = ctx.materialize_box_at(sh_ref);
+        let arg_t = ctx.materialize_box_at(t_ref);
+        emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[arg_sh, arg_t]))
     } else {
         // mul = UINT_MUL_HIGH(n, k)
+        let arg_n = ctx.materialize_box_at(n_ref);
+        let arg_k = ctx.materialize_box_at(k_ref);
         let mul_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(
-                OpCode::UintMulHigh,
-                &[BoxRef::from_opref(n_ref), BoxRef::from_opref(k_ref)],
-            ),
+            Op::new(OpCode::UintMulHigh, &[arg_n, arg_k]),
         );
 
         // result = UINT_RSHIFT(mul, i)
+        let arg_mul = ctx.materialize_box_at(mul_ref);
+        let arg_i = ctx.materialize_box_at(i_ref);
         emit_op(
             ctx,
             pass_idx,
-            Op::new(
-                OpCode::UintRshift,
-                &[BoxRef::from_opref(mul_ref), BoxRef::from_opref(i_ref)],
-            ),
+            Op::new(OpCode::UintRshift, &[arg_mul, arg_i]),
         )
     }
 }
@@ -195,23 +179,17 @@ pub fn modulo_operations(
 
     // product = div_result * m
     let m_ref = emit_constant_int(ctx, m);
-    let product_ref = emit_op(
-        ctx,
-        pass_idx,
-        Op::new(
-            OpCode::IntMul,
-            &[BoxRef::from_opref(div_ref), BoxRef::from_opref(m_ref)],
-        ),
-    );
+    let arg_div = ctx.materialize_box_at(div_ref);
+    let arg_m = ctx.materialize_box_at(m_ref);
+    let product_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntMul, &[arg_div, arg_m]));
 
     // remainder = n - product
+    let arg_n = ctx.materialize_box_at(n_ref);
+    let arg_product = ctx.materialize_box_at(product_ref);
     emit_op(
         ctx,
         pass_idx,
-        Op::new(
-            OpCode::IntSub,
-            &[BoxRef::from_opref(n_ref), BoxRef::from_opref(product_ref)],
-        ),
+        Op::new(OpCode::IntSub, &[arg_n, arg_product]),
     )
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -148,11 +148,7 @@ pub fn division_operations(
         // mul = UINT_MUL_HIGH(n, k)
         let arg_n = ctx.materialize_box_at(n_ref);
         let arg_k = ctx.materialize_box_at(k_ref);
-        let mul_ref = emit_op(
-            ctx,
-            pass_idx,
-            Op::new(OpCode::UintMulHigh, &[arg_n, arg_k]),
-        );
+        let mul_ref = emit_op(ctx, pass_idx, Op::new(OpCode::UintMulHigh, &[arg_n, arg_k]));
 
         // result = UINT_RSHIFT(mul, i)
         let arg_mul = ctx.materialize_box_at(mul_ref);

--- a/majit/majit-metainterp/src/optimizeopt/intutils.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intutils.rs
@@ -73,7 +73,6 @@ impl IntBoundMakeGuards for IntBound {
         guards: &mut Vec<crate::optimizeopt::Op>,
         ctx: &mut crate::optimizeopt::OptContext,
     ) {
-        use crate::r#box::BoxRef;
         use crate::optimizeopt::Op;
         use majit_ir::{OpCode, Type, Value};
 
@@ -92,18 +91,16 @@ impl IntBoundMakeGuards for IntBound {
         };
         if self.is_constant() {
             let c = alloc_const(ctx, Value::Int(self.upper));
-            guards.push(Op::new(
-                OpCode::GuardValue,
-                &[BoxRef::from_opref(box_ref), BoxRef::from_opref(c)],
-            ));
+            let arg_box = ctx.materialize_box_at(box_ref);
+            let arg_c = ctx.materialize_box_at(c);
+            guards.push(Op::new(OpCode::GuardValue, &[arg_box, arg_c]));
             return;
         }
         if self.lower > i64::MIN {
             let bound = alloc_const(ctx, Value::Int(self.lower));
-            let mut op = Op::new(
-                OpCode::IntGe,
-                &[BoxRef::from_opref(box_ref), BoxRef::from_opref(bound)],
-            );
+            let arg_box = ctx.materialize_box_at(box_ref);
+            let arg_bound = ctx.materialize_box_at(bound);
+            let mut op = Op::new(OpCode::IntGe, &[arg_box, arg_bound]);
             // intutils.py:1275 `op = ResOperation(rop.INT_GE, ...)` then
             // `[op]` — RPython uses the ResOperation object as identity.
             // pyre allocates a fresh Int OpRef into `op.pos` so the next
@@ -112,35 +109,34 @@ impl IntBoundMakeGuards for IntBound {
             op.pos.set(ctx.alloc_op_position_typed(Type::Int));
             let op_pos = op.pos.get();
             guards.push(op);
-            guards.push(Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(op_pos)]));
+            let arg_op = ctx.materialize_box_at(op_pos);
+            guards.push(Op::new(OpCode::GuardTrue, &[arg_op]));
         }
         if self.upper < i64::MAX {
             let bound = alloc_const(ctx, Value::Int(self.upper));
-            let mut op = Op::new(
-                OpCode::IntLe,
-                &[BoxRef::from_opref(box_ref), BoxRef::from_opref(bound)],
-            );
+            let arg_box = ctx.materialize_box_at(box_ref);
+            let arg_bound = ctx.materialize_box_at(bound);
+            let mut op = Op::new(OpCode::IntLe, &[arg_box, arg_bound]);
             // intutils.py:1281 INT_LE producer identity — see comment above.
             op.pos.set(ctx.alloc_op_position_typed(Type::Int));
             let op_pos = op.pos.get();
             guards.push(op);
-            guards.push(Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(op_pos)]));
+            let arg_op = ctx.materialize_box_at(op_pos);
+            guards.push(Op::new(OpCode::GuardTrue, &[arg_op]));
         }
         if !self.are_knownbits_implied() {
             let mask = alloc_const(ctx, Value::Int(!self.tmask as i64));
-            let mut op = Op::new(
-                OpCode::IntAnd,
-                &[BoxRef::from_opref(box_ref), BoxRef::from_opref(mask)],
-            );
+            let arg_box = ctx.materialize_box_at(box_ref);
+            let arg_mask = ctx.materialize_box_at(mask);
+            let mut op = Op::new(OpCode::IntAnd, &[arg_box, arg_mask]);
             // intutils.py:1286 INT_AND producer identity — see comment above.
             op.pos.set(ctx.alloc_op_position_typed(Type::Int));
             let op_pos = op.pos.get();
             guards.push(op);
             let value = alloc_const(ctx, Value::Int(self.tvalue as i64));
-            guards.push(Op::new(
-                OpCode::GuardValue,
-                &[BoxRef::from_opref(op_pos), BoxRef::from_opref(value)],
-            ));
+            let arg_op = ctx.materialize_box_at(op_pos);
+            let arg_value = ctx.materialize_box_at(value);
+            guards.push(Op::new(OpCode::GuardValue, &[arg_op, arg_value]));
         }
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -499,7 +499,7 @@ impl ImportedShortPureOp {
             pop: crate::optimizeopt::info::PreambleOp {
                 op: pop_op,
                 invented_name,
-                preamble_op: replay,
+                preamble_op: std::rc::Rc::new(replay),
             },
         }
     }
@@ -2689,7 +2689,7 @@ impl OptContext {
                         entry.op.pos.get(),
                         crate::optimizeopt::shortpreamble::ProducedShortOp {
                             kind: entry.kind.clone(),
-                            preamble_op: entry.op.clone(),
+                            preamble_op: std::rc::Rc::new(entry.op.clone()),
                             invented_name: entry.invented_name,
                             same_as_source: entry.same_as_source.clone(),
                         },
@@ -2910,7 +2910,7 @@ impl OptContext {
                     }
                     let new_pop = ProducedShortOp {
                         kind: PreambleOpKind::Pure,
-                        preamble_op: op,
+                        preamble_op: std::rc::Rc::new(op),
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),
                     };
@@ -2948,7 +2948,7 @@ impl OptContext {
                             op.setdescr(descr);
                             ProducedShortOp {
                                 kind: PreambleOpKind::Heap,
-                                preamble_op: op,
+                                preamble_op: std::rc::Rc::new(op),
                                 invented_name: produced_op.invented_name,
                                 same_as_source: produced_op.same_as_source.clone(),
                             }
@@ -2986,7 +2986,7 @@ impl OptContext {
                             op.setdescr(descr);
                             ProducedShortOp {
                                 kind: PreambleOpKind::Heap,
-                                preamble_op: op,
+                                preamble_op: std::rc::Rc::new(op),
                                 invented_name: produced_op.invented_name,
                                 same_as_source: produced_op.same_as_source.clone(),
                             }
@@ -3023,7 +3023,7 @@ impl OptContext {
                     op.pos.set(replay_pos(*source, produced_op));
                     let new_pop = ProducedShortOp {
                         kind: PreambleOpKind::LoopInvariant,
-                        preamble_op: op,
+                        preamble_op: std::rc::Rc::new(op),
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),
                     };
@@ -9857,7 +9857,7 @@ mod imported_short_preamble_fallback_tests {
         let pop = crate::optimizeopt::info::PreambleOp {
             op: crate::r#box::BoxRef::from_opref(OpRef::int_op(41)),
             invented_name: false,
-            preamble_op: replay_op,
+            preamble_op: std::rc::Rc::new(replay_op),
         };
 
         let forced = ctx.force_op_from_preamble_op(&pop);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4135,10 +4135,21 @@ impl OptContext {
     /// still need an integer handle bridge back with `.to_opref()` (the
     /// remaining `Op.args` / fail-args boundary, retired at S-12).
     ///
-    /// Total over `opref`: an unresolvable root (sentinel / test baseline,
-    /// where `get_box_replacement_box` is `None`) falls back to a
-    /// position-only `BoxRef::from_opref`, so `get_box_replacement(o)
-    /// .to_opref() == o` there — preserving the prior `OpRef`-walker contract.
+    /// Total over `opref`: an unresolvable root falls back to a position-only
+    /// `BoxRef::from_opref`, so `get_box_replacement(o).to_opref() == o` there,
+    /// preserving the `OpRef`-walker contract. This fallback is **load-bearing**
+    /// (S0/#121 probe measured 530 hits over the corpus, all value-bearing): on
+    /// top of the sentinel / test-baseline roots, the peel-boundary
+    /// `get_box_replacement(x).to_opref()` idiom — `unroll.rs` `_expand_info` /
+    /// `import_state`, `optimizer.rs` short-preamble export, `virtualstate.rs`,
+    /// `opref_type` — resolves Phase-1 `OpRef`s whose producer `Op` is absent
+    /// from this rebuilt Phase-2 `OptContext`'s live stores (`find_producer_op`
+    /// misses). Those callers immediately re-`to_opref()` the result and only
+    /// need the round-tripped `OpRef`, so the position-only box suffices.
+    /// Converging this to the orthodox "never fabricate a box"
+    /// (resoperation.py:57-68) is blocked on the cross-phase resolution gap
+    /// (S9/#115): the Phase-1 producer must be reachable from the Phase-2
+    /// context before this can assert instead of mint.
     pub fn get_box_replacement(&self, opref: OpRef) -> crate::r#box::BoxRef {
         self.get_box_replacement_box(opref)
             .unwrap_or_else(|| crate::r#box::BoxRef::from_opref(opref))

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4342,6 +4342,20 @@ impl OptContext {
         self.get_box_replacement_impl(opref, true)
     }
 
+    /// Box-returning sibling of [`OptContext::get_box_replacement_not_const`]
+    /// — the RPython shape: `get_box_replacement(op, not_const=True)` hands
+    /// the caller the terminal Box object itself (resoperation.py:57-68),
+    /// not a position. `None` when the source is a Const / NONE or the
+    /// position resolves to no canonical box; callers keep their element
+    /// unchanged then, matching the `OpRef` variant's identity return.
+    pub fn get_box_replacement_not_const_box(&self, opref: OpRef) -> Option<crate::r#box::BoxRef> {
+        if opref.is_constant() || opref.is_none() {
+            return None;
+        }
+        let start = self.resolve_to_boxref(opref)?;
+        Some(start.get_box_replacement(true))
+    }
+
     /// `OpRef` round-trip view of [`OptContext::get_box_replacement`] for
     /// the remaining flat-`OpRef` bridge callers (the
     /// `get_box_replacement(o).to_opref()` idiom — RPython callers hold the
@@ -5921,9 +5935,17 @@ impl OptContext {
             })
             .collect();
 
+        // optimizer.py:712 liveboxes are the canonical Box objects returned
+        // by `resumedata.finish()`; resolve each numbering position to its
+        // canonical (possibly producer-bound) box so `store_final_boxes`
+        // can shed to a live-tracking operand. NONE holes and positions
+        // with no canonical box stay position-only.
         let liveboxes_b: Vec<crate::r#box::BoxRef> = liveboxes
             .iter()
-            .map(|a| crate::r#box::BoxRef::from_opref(*a))
+            .map(|a| {
+                self.resolve_to_boxref(*a)
+                    .unwrap_or_else(|| crate::r#box::BoxRef::from_opref(*a))
+            })
             .collect();
         op.store_final_boxes(liveboxes_b);
         op.set_fail_arg_types(new_types.clone());

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5672,7 +5672,11 @@ impl OptContext {
             .take_potential_extra_op(resolved)
             .or_else(|| self.take_potential_extra_op(opref));
         if let Some(preamble_op) = tracked {
-            let resolved_for_pop = self.get_replacement_opref(preamble_op.op);
+            // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
+            // — the resolved Box itself is handed to the builder.
+            let resolved_for_pop = self
+                .get_box_replacement_box(preamble_op.op)
+                .unwrap_or_else(|| crate::r#box::BoxRef::from_opref(preamble_op.op));
             if let Some(builder) = self.active_short_preamble_producer_mut() {
                 builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
             } else if let Some(builder) = self.imported_short_preamble_builder.as_mut() {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2273,10 +2273,8 @@ impl OptContext {
         } else {
             majit_ir::OpCode::Strlen
         };
-        let strlen_op = majit_ir::Op::new(
-            strlen_opcode,
-            &[crate::r#box::BoxRef::from_opref(op_resolved)],
-        );
+        let arg1 = self.materialize_box_at(op_resolved);
+        let strlen_op = majit_ir::Op::new(strlen_opcode, &[arg1]);
         let result = self.emit_extra(self.current_pass_idx, strlen_op);
         // vstring.py:116: lengthop.set_forwarded(self.getlenbound(mode))
         // `set_forwarded` writes the bound unconditionally; route through

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -490,7 +490,7 @@ impl ImportedShortPureOp {
         // pyre's `source` IS the alt identifier for invented (the synthetic
         // alias allocated by the compound-dedup pass at
         // shortpreamble.rs:478-491) and IS self.res for non-invented.
-        let pop_op = source;
+        let pop_op = ctx.materialize_box_at(source);
         ImportedShortPureOp {
             opcode,
             descr,
@@ -3054,7 +3054,7 @@ impl OptContext {
         &mut self,
         preamble_op: &crate::optimizeopt::info::PreambleOp,
     ) -> OpRef {
-        let preamble_source = preamble_op.op;
+        let preamble_source = preamble_op.op.to_opref();
         // RPython `return preamble_op.op` returns the carried Box. In majit,
         // `pop.op` stores the Phase 1 source position; `make_equal_to(source,
         // body_visible)` is called by the producer for invented Pure / Heap /
@@ -3062,7 +3062,7 @@ impl OptContext {
         // body-visible OpRef. Non-invented Pure has no forwarding installed,
         // so `get_box_replacement(source) == source` and the body references
         // source directly (RPython parity for non-invented `op = self.res`).
-        let result = self.get_replacement_opref(preamble_op.op);
+        let result = self.get_replacement_opref(preamble_source);
         let result_type = preamble_op.preamble_op.result_type();
         let is_constant = self
             .get_box_replacement_box(preamble_source)
@@ -5674,9 +5674,7 @@ impl OptContext {
         if let Some(preamble_op) = tracked {
             // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
             // — the resolved Box itself is handed to the builder.
-            let resolved_for_pop = self
-                .get_box_replacement_box(preamble_op.op)
-                .unwrap_or_else(|| crate::r#box::BoxRef::from_opref(preamble_op.op));
+            let resolved_for_pop = self.resolve_box_box(&preamble_op.op);
             if let Some(builder) = self.active_short_preamble_producer_mut() {
                 builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
             } else if let Some(builder) = self.imported_short_preamble_builder.as_mut() {
@@ -9876,7 +9874,7 @@ mod imported_short_preamble_fallback_tests {
         // pop.op carries the body-visible OpRef directly (no forwarding chain
         // installed for non-invented Pure).
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: OpRef::int_op(41),
+            op: crate::r#box::BoxRef::from_opref(OpRef::int_op(41)),
             invented_name: false,
             preamble_op: replay_op,
         };

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1766,7 +1766,25 @@ impl OptContext {
     /// stale stand-in slot, and the carry-over at emit migrates the wrong
     /// (empty) `_forwarded` — dropping the rewrite's bound.
     pub(crate) fn supersede_restart_producer(&mut self, restart_op: &majit_ir::OpRc) {
-        let pos = restart_op.pos.get();
+        self.install_canonical_producer(restart_op);
+    }
+
+    /// Make `op` the sole registered producer at its result position,
+    /// inheriting any superseded stand-in's accumulated `_forwarded`.
+    ///
+    /// optimizer.py:403-411 `replace_op_with`: after `newop =
+    /// op.copy_and_change(..)` it carries the prior host's info forward —
+    /// `opinfo = get_box_replacement(op).get_forwarded(); if opinfo is not
+    /// None: newop.set_forwarded(opinfo)` — and only then `op.set_forwarded(
+    /// newop)` makes `newop` the single box at that position. In pyre's
+    /// producer registry the equivalent is to drop the stand-in
+    /// `live_synthetics` entry, migrate its `_forwarded` onto `op` (so the
+    /// `IntBound`/`PtrInfo`/const facts accumulated before the rewrite survive),
+    /// then register `op` as the lone producer. The blind `_forwarded` clone
+    /// mirrors `emit`'s live_synthetics catch-up: a producer-less stand-in only
+    /// ever holds `None`/`Info`, never a redirect.
+    fn install_canonical_producer(&mut self, op: &majit_ir::OpRc) {
+        let pos = op.pos.get();
         if pos.is_none() || pos.is_constant() {
             return;
         }
@@ -1778,16 +1796,21 @@ impl OptContext {
         ) {
             return;
         }
-        // Drop the superseded stand-in at this position so the single
-        // `live_synthetics` entry the emit catch-up migrates is `restart_op`'s
-        // accumulated `_forwarded`, not the original's stale slot. At most one
-        // live stand-in exists per position (mod.rs::emit invariant), so a
-        // single removal is sufficient.
+        // Drop the superseded stand-in at this position and carry its
+        // accumulated `_forwarded` onto `op` (replace_op_with's `opinfo`
+        // hand-off). At most one live stand-in exists per position
+        // (mod.rs::emit invariant), so a single removal is sufficient. The
+        // `ptr_eq` guard skips the self-clone — and its `RefCell` double-borrow
+        // — when `op` is already the registered stand-in.
         if let Some(i) = self.live_synthetics.iter().position(|s| s.pos.get() == pos) {
-            self.live_synthetics.swap_remove(i);
+            let superseded = self.live_synthetics.swap_remove(i);
+            if !std::rc::Rc::ptr_eq(&superseded, op) {
+                let carried = superseded.forwarded.borrow().clone();
+                *op.forwarded.borrow_mut() = carried;
+            }
         }
-        self.resop_refs.insert(pos, restart_op.clone());
-        self.live_synthetics.push(restart_op.clone());
+        self.resop_refs.insert(pos, op.clone());
+        self.live_synthetics.push(op.clone());
     }
 
     /// S-8.A: read `_forwarded` for `opref` directly off the canonical
@@ -2594,6 +2617,30 @@ impl OptContext {
         pos_ref
     }
 
+    /// Register an op dispatched through the passes (`emit_extra` /
+    /// `send_extra_operation`) as the producer for its result position,
+    /// mirroring `bind_input_resops`. `find_producer_op(pos)` then resolves
+    /// box lookups for this position — `materialize_box_at(pos)` and operand
+    /// resolution alike — to this `OpRc`'s `_forwarded` host
+    /// (resoperation.py:233) instead of a freshly-minted stand-in, keeping a
+    /// single box identity per position. Without this, a pass that folds the
+    /// dispatched op via `make_equal_to(from_bound_op(op_rc), ..)` writes the
+    /// forwarding onto a private `Rc<Op>` that `find_producer_op` cannot
+    /// reach, so the replacement is silently dropped (RPython needs no analog:
+    /// the op IS its box, resoperation.py:233-248).
+    ///
+    /// `emit`'s `live_synthetics` catch-up upgrades the binding to the real
+    /// producer once the op is emitted; a folded op stays as the chain host.
+    /// When `materialize_box_at` already minted a stand-in for this position,
+    /// `op_rc` supersedes it (carrying its `_forwarded`) rather than skipping
+    /// registration — otherwise queued-pass reads resolve to the stale stand-in
+    /// while writes land on the unregistered `op_rc`, and emit's blind catch-up
+    /// then clobbers those writes with the stand-in's slot. (InputArg / const /
+    /// sentinel positions are excluded.)
+    pub(crate) fn register_extra_producer(&mut self, op_rc: &majit_ir::OpRc) {
+        self.install_canonical_producer(op_rc);
+    }
+
     /// RPython emit_extra(op, emit=False) parity: queue an operation to
     /// be processed through passes AFTER the calling pass. Skips earlier
     /// passes (including the caller) to avoid re-absorption loops.
@@ -2612,24 +2659,10 @@ impl OptContext {
         // its type without the side-table detour.
         Self::debug_assert_box_type_invariant(&op);
         let op_rc = std::rc::Rc::new(op);
-        // Register the queued op as the producer for its position, mirroring
-        // `bind_input_resops`: `find_producer_op(pos)` then resolves box lookups
-        // for this position — `materialize_box_at(pos)` and operand resolution alike —
-        // to this `OpRc`'s `_forwarded` host (resoperation.py:233) instead of a
-        // freshly-minted stand-in, keeping a single box identity per position.
-        // `emit`'s `live_synthetics` catch-up upgrades the binding to the real
-        // producer once the op is emitted; a folded op stays as the chain host.
-        if !pos_ref.is_none()
-            && !pos_ref.is_constant()
-            && !matches!(
-                pos_ref,
-                OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
-            )
-            && !self.resop_refs.contains_key(&pos_ref)
-        {
-            self.resop_refs.insert(pos_ref, op_rc.clone());
-            self.live_synthetics.push(op_rc.clone());
-        }
+        // Register the queued op as the producer for its position so a fold
+        // through `make_equal_to(from_bound_op(op_rc), ..)` reaches a host
+        // `find_producer_op` resolves to.
+        self.register_extra_producer(&op_rc);
         self.extra_operations_after
             .push_back((after_pass_idx + 1, op_rc));
         pos_ref

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -422,7 +422,13 @@ pub struct ImportedShortPureOp {
 
 impl ImportedShortPureOp {
     /// Construct with auto-generated PreambleOp from fields.
+    ///
+    /// `ctx` binds the replay op's operands to their canonical producers
+    /// (`materialize_box_at`) — shortpreamble.py:425 seeds the replay
+    /// `preamble_op` with the SAME Box objects the body sees, so the
+    /// operands must carry producer identity, not a position-only echo.
     pub fn new(
+        ctx: &mut OptContext,
         opcode: OpCode,
         descr: Option<DescrRef>,
         args: Vec<ImportedShortPureArg>,
@@ -439,7 +445,7 @@ impl ImportedShortPureOp {
             .collect();
         let replay_arg_boxes: Vec<crate::r#box::BoxRef> = replay_args
             .iter()
-            .map(|a| crate::r#box::BoxRef::from_opref(*a))
+            .map(|a| ctx.materialize_box_at(*a))
             .collect();
         let mut replay = majit_ir::Op::new(opcode, &replay_arg_boxes);
         // shortpreamble.py:112-126 PureOp.produce_op constructs TWO distinct

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5609,7 +5609,7 @@ impl OptContext {
     fn maybe_replace_guard_value(&self, op: &mut Op) {
         let arg0 = op.arg(0);
         // optimizer.py:755: if op.getarg(0).type == 'i'
-        let arg0_resolved = self.get_replacement_opref(arg0.to_opref());
+        let arg0_resolved = self.resolve_box_box(&arg0).to_opref();
         if self.opref_type(arg0_resolved) != Some(majit_ir::Type::Int) {
             return;
         }
@@ -7403,7 +7403,7 @@ impl OptContext {
     /// constant case lands on `const_infos[gcref]`; the regular case
     /// runs `ensure_ptr_info_arg0(op).as_mut().setfield(...)`.
     pub fn structinfo_setfield(&mut self, op: &Op, field_idx: u32, value: OpRef) {
-        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
+        let arg0 = self.resolve_box_box(&op.arg(0)).to_opref();
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -7432,7 +7432,7 @@ impl OptContext {
     /// constant arg0 path so the const_infos slot is created as
     /// `PtrInfo::Array` rather than `PtrInfo::Instance`.
     pub fn arrayinfo_setitem(&mut self, op: &Op, index: usize, value: OpRef) {
-        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
+        let arg0 = self.resolve_box_box(&op.arg(0)).to_opref();
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -7548,7 +7548,7 @@ impl OptContext {
     /// `arrayinfo.getlenbound(...)` patterns.
     pub fn ensure_ptr_info_arg0(&mut self, op: &Op) -> EnsuredPtrInfo {
         // optimizer.py:464: arg0 = self.get_box_replacement(op.getarg(0))
-        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
+        let arg0 = self.resolve_box_box(&op.arg(0)).to_opref();
         // optimizer.py:465-466: if arg0.is_constant(): return info.ConstPtrInfo(arg0)
         //
         // PyPy's `info.ConstPtrInfo(arg0)` wraps the constant box itself,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4168,8 +4168,106 @@ impl OptContext {
     /// (S9/#115): the Phase-1 producer must be reachable from the Phase-2
     /// context before this can assert instead of mint.
     pub fn get_box_replacement(&self, opref: OpRef) -> crate::r#box::BoxRef {
-        self.get_box_replacement_box(opref)
-            .unwrap_or_else(|| crate::r#box::BoxRef::from_opref(opref))
+        if let Some(b) = self.get_box_replacement_box(opref) {
+            return b;
+        }
+        // S9 scoping (env-gated, zero-impact when `PYRE_S9_PROBE` is unset):
+        // classify each `from_opref` fallback fire as category-a (producer-less
+        // by construction, resolve-to-self is correct) vs category-b
+        // (cross-phase: a producer Op survives but `find_producer_op`'s stores
+        // are not keyed to reach it) to size the S9 cross-phase resolution gap
+        // before deciding whether it has real registry work or redirects to the
+        // operand-union producer-less-arm design.
+        self.s9_probe_fire(opref);
+        crate::r#box::BoxRef::from_opref(opref)
+    }
+
+    /// S9 probe classifier for a `from_opref` fallback fire (see
+    /// [`OptContext::get_box_replacement`]). `&self`-only, no mutation.
+    ///
+    /// Precondition: `find_producer_op` already missed (full type-tagged
+    /// `OpRef` match across `new_operations` / `phase1_emit_ops` / `resop_refs`
+    /// / `input_ops`) and `resolve_to_boxref` returned `None`; `opref` is
+    /// non-`none`, non-`Const`.
+    ///
+    /// - `b-inputarg`: an InputArg position whose `inputarg_refs` slot is unbound.
+    /// - `b-typetag`: a producer Op exists at the same RAW position under a
+    ///   different type tag (the #97 type-tag divergence signal).
+    /// - `b-rekey-*`: the OpRef is named by a carried Phase-1 registry
+    ///   (`inputargs` / `imported_label_args` / `imported_virtual_args`), so a
+    ///   producer exists in Phase 1 but is not in a `find_producer_op` store.
+    /// - `b-shortpure`: the OpRef is the `result` of a carried
+    ///   `imported_short_pure_ops` entry — a short-preamble producer survives
+    ///   but `find_producer_op` does not consult that table.
+    /// - `a-producerless`: no producer Op for this position is reachable in any
+    ///   OptContext-local registry — correct-as-is (an unforwarded box returns
+    ///   itself, `resoperation.py:57-68`).
+    fn classify_s9_fallback(&self, opref: OpRef) -> &'static str {
+        match opref {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                return "b-inputarg";
+            }
+            _ => {}
+        }
+        let raw = opref.raw();
+        let raw_hit = self
+            .new_operations
+            .iter()
+            .chain(self.phase1_emit_ops.iter())
+            .chain(self.input_ops.iter())
+            .any(|op| op.pos.get().raw() == raw);
+        if raw_hit {
+            return "b-typetag";
+        }
+        if self.inputargs.iter().any(|o| *o == opref) {
+            return "b-rekey-inputargs";
+        }
+        if let Some(label_args) = self.imported_label_args.as_ref() {
+            if label_args.iter().any(|o| *o == opref) {
+                return "b-rekey-label";
+            }
+        }
+        if let Some((_, vargs)) = self.imported_virtual_args.as_ref() {
+            if vargs.iter().any(|o| *o == opref) {
+                return "b-rekey-vargs";
+            }
+        }
+        if self
+            .imported_short_pure_ops
+            .iter()
+            .any(|sp| sp.result == opref)
+        {
+            return "b-shortpure";
+        }
+        "a-producerless"
+    }
+
+    /// S9 probe sink (env-gated). No-op unless `PYRE_S9_PROBE` is set; appends
+    /// one classified line per `from_opref` fallback fire to
+    /// `/tmp/pyre_s9_probe.log`. Process-global file sink because the caller is
+    /// `&self` (no context-local counter). When the flag is unset, only a
+    /// cached bool is read and the sink is never opened.
+    fn s9_probe_fire(&self, opref: OpRef) {
+        use std::sync::{LazyLock, Mutex};
+        static ENABLED: LazyLock<bool> =
+            LazyLock::new(|| std::env::var_os("PYRE_S9_PROBE").is_some());
+        if !*ENABLED {
+            return;
+        }
+        static SINK: LazyLock<Mutex<std::fs::File>> = LazyLock::new(|| {
+            Mutex::new(
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open("/tmp/pyre_s9_probe.log")
+                    .expect("open /tmp/pyre_s9_probe.log"),
+            )
+        });
+        let cat = self.classify_s9_fallback(opref);
+        if let Ok(mut f) = SINK.lock() {
+            use std::io::Write;
+            let _ = writeln!(f, "cat={} opref={:?} raw={}", cat, opref, opref.raw());
+        }
     }
 
     /// `BoxRef`-addressed operand resolution seam. Callers holding the

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -873,7 +873,7 @@ pub struct OptBoxEnv<'a> {
 
 impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
     fn get_box_replacement(&self, opref: OpRef) -> OpRef {
-        self.ctx.get_box_replacement(opref).to_opref()
+        self.ctx.get_replacement_opref(opref)
     }
 
     fn get_box_replacement_not_const(&self, opref: OpRef) -> OpRef {
@@ -1001,7 +1001,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fields
                             .iter()
                             .find(|(field_idx, _)| *field_idx == fi as u32)
-                            .map(|(_, vref)| self.ctx.get_box_replacement(*vref).to_opref())
+                            .map(|(_, vref)| self.ctx.get_replacement_opref(*vref))
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect(),
@@ -1016,7 +1016,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fields
                             .iter()
                             .find(|(field_idx, _)| *field_idx == fi as u32)
-                            .map(|(_, vref)| self.ctx.get_box_replacement(*vref).to_opref())
+                            .map(|(_, vref)| self.ctx.get_replacement_opref(*vref))
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect(),
@@ -1027,7 +1027,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 field_oprefs: vi
                     .items
                     .iter()
-                    .map(|vref| self.ctx.get_box_replacement(*vref).to_opref())
+                    .map(|vref| self.ctx.get_replacement_opref(*vref))
                     .collect(),
             }),
             PtrInfo::VirtualArrayStruct(vi) => Some(majit_ir::VirtualFieldsInfo {
@@ -1040,7 +1040,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fielddescrs.iter().enumerate().map(|(fi, _)| {
                             ef.iter()
                                 .find(|(field_idx, _)| *field_idx == fi as u32)
-                                .map(|(_, vref)| self.ctx.get_box_replacement(*vref).to_opref())
+                                .map(|(_, vref)| self.ctx.get_replacement_opref(*vref))
                                 .unwrap_or(OpRef::NONE)
                         })
                     })
@@ -1053,7 +1053,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                     .buffer
                     .values()
                     .iter()
-                    .map(|vref| self.ctx.get_box_replacement(*vref).to_opref())
+                    .map(|vref| self.ctx.get_replacement_opref(*vref))
                     .collect(),
             }),
             // `info.py:478-482` `RawSlicePtrInfo._visitor_walk_recursive`:
@@ -1079,7 +1079,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 Some(majit_ir::VirtualFieldsInfo {
                     descr: None,
                     known_class: None,
-                    field_oprefs: vec![self.ctx.get_box_replacement(vi.parent).to_opref()],
+                    field_oprefs: vec![self.ctx.get_replacement_opref(vi.parent)],
                 })
             }
             // vstring.py:207-208 VStringPlainInfo._visitor_walk_recursive:
@@ -1106,20 +1106,20 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         ._chars
                         .iter()
                         .map(|slot| {
-                            slot.map(|r| self.ctx.get_box_replacement(r).to_opref())
+                            slot.map(|r| self.ctx.get_replacement_opref(r))
                                 .unwrap_or(OpRef::NONE)
                         })
                         .collect(),
                     // vstring.py:255-257: [self.s, self.start, self.lgtop].
                     VStringVariant::Slice(s) => vec![
-                        self.ctx.get_box_replacement(s.s).to_opref(),
-                        self.ctx.get_box_replacement(s.start).to_opref(),
-                        self.ctx.get_box_replacement(s.lgtop).to_opref(),
+                        self.ctx.get_replacement_opref(s.s),
+                        self.ctx.get_replacement_opref(s.start),
+                        self.ctx.get_replacement_opref(s.lgtop),
                     ],
                     // vstring.py:319-324: [self.vleft, self.vright].
                     VStringVariant::Concat(c) => vec![
-                        self.ctx.get_box_replacement(c.vleft).to_opref(),
-                        self.ctx.get_box_replacement(c.vright).to_opref(),
+                        self.ctx.get_replacement_opref(c.vleft),
+                        self.ctx.get_replacement_opref(c.vright),
                     ],
                     // Non-virtual `VStringVariant::Ptr` would not reach
                     // here because of the `is_virtual()` guard above.
@@ -2216,7 +2216,7 @@ impl OptContext {
     ///
     /// When both are the same, use `getstrlen_opref(opref, mode)` instead.
     pub fn getstrlen_for(&mut self, info_opref: OpRef, op_opref: OpRef, mode: u8) -> OpRef {
-        let resolved = self.get_box_replacement(info_opref).to_opref();
+        let resolved = self.get_replacement_opref(info_opref);
         let resolved_box = self.get_box_replacement_box(info_opref);
         // vstring.py:112/283: if self.lgtop is not None: return self.lgtop
         if let Some(info) = resolved_box.as_ref().and_then(|b| self.getptrinfo(b)) {
@@ -2267,7 +2267,7 @@ impl OptContext {
         // vstring.py:115-118: base StrPtrInfo — emit STRLEN/UNICODELEN
         // RPython: lengthop = ResOperation(mode.STRLEN, [op])
         // `op` comes from op_opref (the first arg to getstrlen in RPython).
-        let op_resolved = self.get_box_replacement(op_opref).to_opref();
+        let op_resolved = self.get_replacement_opref(op_opref);
         let strlen_opcode = if mode != 0 {
             majit_ir::OpCode::Unicodelen
         } else {
@@ -3057,7 +3057,7 @@ impl OptContext {
         // body-visible OpRef. Non-invented Pure has no forwarding installed,
         // so `get_box_replacement(source) == source` and the body references
         // source directly (RPython parity for non-invented `op = self.res`).
-        let result = self.get_box_replacement(preamble_op.op).to_opref();
+        let result = self.get_replacement_opref(preamble_op.op);
         let result_type = preamble_op.preamble_op.result_type();
         let is_constant = self
             .get_box_replacement_box(preamble_source)
@@ -3120,7 +3120,7 @@ impl OptContext {
             if !is_constant {
                 // unroll.py:35-36: invented_name → get_box_replacement(op)
                 let key = if preamble_op.invented_name {
-                    self.get_box_replacement(preamble_source).to_opref()
+                    self.get_replacement_opref(preamble_source)
                 } else {
                     preamble_source
                 };
@@ -3455,7 +3455,7 @@ impl OptContext {
             &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::info::OpInfo>,
         >,
     ) {
-        let op = self.get_box_replacement(op).to_opref();
+        let op = self.get_replacement_opref(op);
         // unroll.py:55: if op.get_forwarded() is not None: return
         // (covers Op redirect + Info + IntBound + Const states uniformly,
         // matching the sibling setinfo_from_preamble_item pattern below.)
@@ -3657,7 +3657,7 @@ impl OptContext {
     ) {
         use crate::optimizeopt::info::OpInfo;
         // unroll.py:53-54 `op = get_box_replacement(op)`
-        let target = self.get_box_replacement(op).to_opref();
+        let target = self.get_replacement_opref(op);
         // unroll.py:55-56 `if op.get_forwarded() is not None: return`
         if let Some(b) = self.get_box_replacement_box(op) {
             if self.has_forwarding(&b) {
@@ -3723,7 +3723,7 @@ impl OptContext {
         >,
     ) {
         use crate::optimizeopt::info::OpInfo;
-        let target = self.get_box_replacement(op).to_opref();
+        let target = self.get_replacement_opref(op);
         if self
             .get_box_replacement_box(target)
             .and_then(|cb| cb.const_value())
@@ -4150,32 +4150,32 @@ impl OptContext {
     /// still need an integer handle bridge back with `.to_opref()` (the
     /// remaining `Op.args` / fail-args boundary, retired at S-12).
     ///
-    /// Total over `opref`: an unresolvable root falls back to a position-only
-    /// `BoxRef::from_opref`, so `get_box_replacement(o).to_opref() == o` there,
-    /// preserving the `OpRef`-walker contract. This fallback is **load-bearing**
-    /// (S0/#121 probe measured 530 hits over the corpus, all value-bearing): on
-    /// top of the sentinel / test-baseline roots, the peel-boundary
-    /// `get_box_replacement(x).to_opref()` idiom — `unroll.rs` `_expand_info` /
-    /// `import_state`, `optimizer.rs` short-preamble export, `virtualstate.rs`,
-    /// `opref_type` — resolves Phase-1 `OpRef`s whose producer `Op` is absent
-    /// from this rebuilt Phase-2 `OptContext`'s live stores (`find_producer_op`
-    /// misses). Those callers immediately re-`to_opref()` the result and only
-    /// need the round-tripped `OpRef`, so the position-only box suffices.
-    /// Converging this to the orthodox "never fabricate a box"
-    /// (resoperation.py:57-68) is blocked on the cross-phase resolution gap
-    /// (S9/#115): the Phase-1 producer must be reachable from the Phase-2
-    /// context before this can assert instead of mint.
+    /// Total over `opref`, but the position-only `BoxRef::from_opref`
+    /// fallback is production-dead (#123/S2, probe-verified 0 fires over
+    /// the corpus): the round-trip callers that used to reach it moved to
+    /// [`OptContext::get_replacement_opref`] /
+    /// [`OptContext::replacement_for_operand`], and the import paths
+    /// materialize their carried refs (`import_state` targets, imported
+    /// short-pure results). What remains of the fallback serves unit
+    /// fixtures probing forwarding on unregistered baseline positions;
+    /// the `cfg(not(test))` debug assert enforces the orthodox "the box
+    /// always exists" (resoperation.py:57-68) on every production path.
     pub fn get_box_replacement(&self, opref: OpRef) -> crate::r#box::BoxRef {
         if let Some(b) = self.get_box_replacement_box(opref) {
             return b;
         }
+        #[cfg(not(test))]
+        debug_assert!(
+            false,
+            "get_box_replacement: no canonical box for {opref:?} \
+             (resoperation.py:57-68 — the box must exist; #123)"
+        );
         // S9 scoping (env-gated, zero-impact when `PYRE_S9_PROBE` is unset):
-        // classify each `from_opref` fallback fire as category-a (producer-less
+        // classify a `from_opref` fallback fire as category-a (producer-less
         // by construction, resolve-to-self is correct) vs category-b
         // (cross-phase: a producer Op survives but `find_producer_op`'s stores
-        // are not keyed to reach it) to size the S9 cross-phase resolution gap
-        // before deciding whether it has real registry work or redirects to the
-        // operand-union producer-less-arm design.
+        // are not keyed to reach it). Kept until the S13 instrumentation
+        // teardown as the regression tripwire for release builds.
         self.s9_probe_fire(opref);
         crate::r#box::BoxRef::from_opref(opref)
     }
@@ -4262,9 +4262,20 @@ impl OptContext {
             )
         });
         let cat = self.classify_s9_fallback(opref);
+        // `PYRE_S9_PROBE=bt` additionally captures the caller backtrace per
+        // fire, to attribute fallback fires to their `get_box_replacement`
+        // call sites.
+        static BT: LazyLock<bool> = LazyLock::new(|| {
+            std::env::var("PYRE_S9_PROBE")
+                .map(|v| v == "bt")
+                .unwrap_or(false)
+        });
         if let Ok(mut f) = SINK.lock() {
             use std::io::Write;
             let _ = writeln!(f, "cat={} opref={:?} raw={}", cat, opref, opref.raw());
+            if *BT {
+                let _ = writeln!(f, "{}", std::backtrace::Backtrace::force_capture());
+            }
         }
     }
 
@@ -4331,6 +4342,37 @@ impl OptContext {
     /// constants as TAGCONST.
     pub fn get_box_replacement_not_const(&self, opref: OpRef) -> OpRef {
         self.get_box_replacement_impl(opref, true)
+    }
+
+    /// `OpRef` round-trip view of [`OptContext::get_box_replacement`] for
+    /// the remaining flat-`OpRef` bridge callers (the
+    /// `get_box_replacement(o).to_opref()` idiom — RPython callers hold the
+    /// box and skip this step; the bridge retires with the operand union,
+    /// #9). Identical to that idiom observationally — an unresolvable root
+    /// returns `opref` unchanged (`from_opref(o).to_opref() == o`) — but
+    /// without fabricating the intermediate position-only box.
+    pub(crate) fn get_replacement_opref(&self, opref: OpRef) -> OpRef {
+        match self.get_box_replacement_box(opref) {
+            Some(b) => b.to_opref(),
+            None => opref,
+        }
+    }
+
+    /// `op.setarg(i, self.get_box_replacement(op.getarg(i)))`
+    /// (optimizer.py:346-348 emit-side operand refresh) — resolve an
+    /// operand to its chain terminal for writing back. Registry-first so a
+    /// legacy position-only operand upgrades to its bound producer; when
+    /// the position resolves nowhere, walk the operand's own bound chain
+    /// (RPython's direct `op.getarg(i).get_box_replacement()`) instead of
+    /// fabricating a position-only box.
+    pub(crate) fn replacement_for_operand(
+        &self,
+        arg: &crate::r#box::BoxRef,
+    ) -> crate::r#box::BoxRef {
+        match self.get_box_replacement_box(arg.to_opref()) {
+            Some(b) => b,
+            None => arg.get_box_replacement(false),
+        }
     }
 
     /// `Option`-exposing sibling of [`OptContext::get_box_replacement`]:
@@ -4789,7 +4831,7 @@ impl OptContext {
             "peek_intbound: expected 'i'-typed OpRef, got {:?}",
             self.opref_type(opref)
         );
-        let replaced = self.get_box_replacement(opref).to_opref();
+        let replaced = self.get_replacement_opref(opref);
         if let Some(Value::Int(v)) = self
             .get_box_replacement_box(replaced)
             .and_then(|cb| cb.const_value())
@@ -5369,7 +5411,7 @@ impl OptContext {
     /// a shared `BoxRef` per box, this collapses to
     /// `Rc::ptr_eq(&get_box_replacement(a), &get_box_replacement(b))`.
     pub fn box_is(&self, a: OpRef, b: OpRef) -> bool {
-        self.get_box_replacement(a).to_opref() == self.get_box_replacement(b).to_opref()
+        self.get_replacement_opref(a) == self.get_replacement_opref(b)
     }
 
     /// resoperation.py:38 `same_box` (non-Const: `self is other`) +
@@ -5541,7 +5583,7 @@ impl OptContext {
                         // regalloc.py:1206: Const objects skip forcing.
                         // Constant OpRefs may collide with virtual positions;
                         // forcing would corrupt the virtual's PtrInfo.
-                        let resolved = self.get_box_replacement(farg).to_opref();
+                        let resolved = self.get_replacement_opref(farg);
                         if !self
                             .get_box_replacement_box(resolved)
                             .and_then(|cb| cb.const_value())
@@ -5569,7 +5611,7 @@ impl OptContext {
     fn maybe_replace_guard_value(&self, op: &mut Op) {
         let arg0 = op.arg(0);
         // optimizer.py:755: if op.getarg(0).type == 'i'
-        let arg0_resolved = self.get_box_replacement(arg0.to_opref()).to_opref();
+        let arg0_resolved = self.get_replacement_opref(arg0.to_opref());
         if self.opref_type(arg0_resolved) != Some(majit_ir::Type::Int) {
             return;
         }
@@ -5610,12 +5652,12 @@ impl OptContext {
     /// through Phase 1 source directly, so the prior reverse-lookup 3rd
     /// key is no longer needed.
     fn force_box_inline(&mut self, opref: OpRef) -> OpRef {
-        let resolved = self.get_box_replacement(opref).to_opref();
+        let resolved = self.get_replacement_opref(opref);
         let tracked = self
             .take_potential_extra_op(resolved)
             .or_else(|| self.take_potential_extra_op(opref));
         if let Some(preamble_op) = tracked {
-            let resolved_for_pop = self.get_box_replacement(preamble_op.op).to_opref();
+            let resolved_for_pop = self.get_replacement_opref(preamble_op.op);
             if let Some(builder) = self.active_short_preamble_producer_mut() {
                 builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
             } else if let Some(builder) = self.imported_short_preamble_builder.as_mut() {
@@ -5629,7 +5671,7 @@ impl OptContext {
                     .clone()
                     .expect("is_virtual implies resolved_box is Some");
                 let forced = info.force_box(box_, self);
-                return self.get_box_replacement(forced).to_opref();
+                return self.get_replacement_opref(forced);
             }
         }
         resolved
@@ -5811,7 +5853,7 @@ impl OptContext {
                 .copied()
                 .map(|boxref| {
                     let boxref = boxref.opref;
-                    let resolved = self.get_box_replacement(boxref).to_opref();
+                    let resolved = self.get_replacement_opref(boxref);
                     let is_virtual = self
                         .get_box_replacement_box(boxref)
                         .as_ref()
@@ -5826,7 +5868,7 @@ impl OptContext {
                 .copied()
                 .map(|boxref| {
                     let boxref = boxref.opref;
-                    let resolved = self.get_box_replacement(boxref).to_opref();
+                    let resolved = self.get_replacement_opref(boxref);
                     let is_virtual = self
                         .get_box_replacement_box(boxref)
                         .as_ref()
@@ -6396,7 +6438,7 @@ impl OptContext {
     /// RPython's "unknown type" path and avoid making structural
     /// assumptions about it.
     pub fn opref_type(&self, opref: OpRef) -> Option<majit_ir::Type> {
-        let resolved = self.get_box_replacement(opref).to_opref();
+        let resolved = self.get_replacement_opref(opref);
         // 0. Inputarg slot (recorder-side `InputArg{Int,Ref,Float}.tp`,
         //    history.py:220 parity per resoperation.py:719/727/739).
         //    `inputarg_types[idx]` is the canonical Box.type source
@@ -7154,7 +7196,7 @@ impl OptContext {
     /// In majit, we follow the Op chain to the terminal OpRef and set Info there.
     fn ensure_ptr_info_preserve_forwarding(&mut self, opref: OpRef, info: PtrInfo) {
         use crate::optimizeopt::info::OpInfo;
-        let terminal = self.get_box_replacement(opref).to_opref();
+        let terminal = self.get_replacement_opref(opref);
         if terminal.is_constant() {
             return;
         }
@@ -7353,7 +7395,7 @@ impl OptContext {
     /// constant case lands on `const_infos[gcref]`; the regular case
     /// runs `ensure_ptr_info_arg0(op).as_mut().setfield(...)`.
     pub fn structinfo_setfield(&mut self, op: &Op, field_idx: u32, value: OpRef) {
-        let arg0 = self.get_box_replacement(op.arg(0).to_opref()).to_opref();
+        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -7382,7 +7424,7 @@ impl OptContext {
     /// constant arg0 path so the const_infos slot is created as
     /// `PtrInfo::Array` rather than `PtrInfo::Instance`.
     pub fn arrayinfo_setitem(&mut self, op: &Op, index: usize, value: OpRef) {
-        let arg0 = self.get_box_replacement(op.arg(0).to_opref()).to_opref();
+        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -7498,7 +7540,7 @@ impl OptContext {
     /// `arrayinfo.getlenbound(...)` patterns.
     pub fn ensure_ptr_info_arg0(&mut self, op: &Op) -> EnsuredPtrInfo {
         // optimizer.py:464: arg0 = self.get_box_replacement(op.getarg(0))
-        let arg0 = self.get_box_replacement(op.arg(0).to_opref()).to_opref();
+        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
         // optimizer.py:465-466: if arg0.is_constant(): return info.ConstPtrInfo(arg0)
         //
         // PyPy's `info.ConstPtrInfo(arg0)` wraps the constant box itself,
@@ -8352,7 +8394,7 @@ mod boxref_forwarding_tests {
         assert!(matches!(via_box, PtrInfo::NonNull { .. }));
 
         // Chain walk lands on target_p1.
-        let resolved = ctx.get_box_replacement(source_p2).to_opref();
+        let resolved = ctx.get_replacement_opref(source_p2);
         assert_eq!(resolved, target_p1);
 
         // Placeholder Box absorbed the mirror write, so its _forwarded now
@@ -8410,7 +8452,7 @@ mod boxref_forwarding_tests {
 
         // Legacy Vec reader: chain walks source → target_p1 → None
         // (Phase 2's fresh Vec has no entry for target_p1).
-        let resolved = ctx.get_box_replacement(source_p2).to_opref();
+        let resolved = ctx.get_replacement_opref(source_p2);
         assert_eq!(resolved, target_p1);
 
         // Placeholder Box was not mutated (no info import fired) — still None.

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -469,7 +469,7 @@ impl ImportedShortPureOp {
         //     the alt. In pyre, `produce_pure` calls
         //     `make_equal_to(source, canonical)` (shortpreamble.rs:1279) which
         //     overwrites the source box's `_forwarded` slot with
-        //     `Forwarded::Box(canonical_box)`.
+        //     a forwarding redirect to `canonical_box`.
         //     If `replay.pos` also pointed at `source`, the alt's
         //     replacement chain and the replay's info would share one slot
         //     and the info would be lost. We move `replay.pos` to the
@@ -738,7 +738,7 @@ pub struct OptContext {
     /// inside each `BoxRef.inputarg_handle` upgradable. `make_equal_to`
     /// then routes the chain step through `Forwarded::InputArg(_)`
     /// (`optimizer.py:394 op.set_forwarded(newop)`) instead of the
-    /// deprecated `Forwarded::Box(_)` fallback.
+    /// retired orphan-box forwarding fallback.
     pub(crate) inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// Synthetic `OpRc` stand-ins for ResOp BoxRef placeholders whose
     /// real producer has not been (and may never be) emitted, indexed
@@ -2487,15 +2487,15 @@ impl OptContext {
             //     is monotonic, so fresh positions are always above any
             //     raw trace op.pos the trace carries.
             //
-            // (c) `import_state` only creates `Forwarded::Box` chains on
-            //     inputarg slots (in `[inputarg_base..inputarg_base +
+            // (c) `import_state` only creates op/inputarg forwarding chains
+            //     on inputarg slots (in `[inputarg_base..inputarg_base +
             //     num_inputs)`) — never on op-result positions that a
             //     later `emit` would try to use.
             //
             // Together these guarantee that:
             //   - `new_operations` never contains two ops at the same pos
             //   - an op being emitted whose pos is a non-void result does
-            //     not already have a `Forwarded::Box` redirect set
+            //     not already have an op-forwarding redirect set
             //
             // Earlier majit revisions compensated for the broken invariant
             // with two reactive branches in `emit()` (a collision reassign
@@ -2522,7 +2522,7 @@ impl OptContext {
                 .map_or(false, |b| self.has_op_forwarding(&b));
             debug_assert!(
                 !(has_op_fwd && op.result_type() != majit_ir::Type::Void),
-                "emit: Forwarded::Box redirect set on non-void result position {:?} — \
+                "emit: op-forwarding redirect set on non-void result position {:?} — \
                  import_state should only forward inputarg slots in \
                  [inputarg_base..inputarg_base + num_inputs), and Phase 2 op results \
                  live in a disjoint range [p2_high_water..) (Commit D1).",
@@ -2775,7 +2775,7 @@ impl OptContext {
         // pyre's flat-OpRef model collapses the two onto one slot per OpRef,
         // so when `make_equal_to` is installed at `source`, the replay's
         // `_forwarded` slot must be moved to `result_opref` to avoid the
-        // `Forwarded::Box(target)` chain clobbering the seeded info.
+        // op-forwarding chain clobbering the seeded info.
         //
         //   * invented Pure → result_opref. `produce_pure` installs
         //     `make_equal_to(source, result_opref)` (Fix #3).
@@ -3379,9 +3379,9 @@ impl OptContext {
     ///
     /// `set_forwarded(None)` clears the slot so a second `use_box` for the
     /// same preamble op never re-fires `info.make_guards`. In majit's flat
-    /// OpRef model the slot is shared with the Box→Box replacement chain
-    /// (`Forwarded::Box`), which other code follows via
-    /// `get_box_replacement`; clearing that variant would silently break
+    /// OpRef model the slot is shared with the box replacement chain
+    /// (`Forwarded::Op` / `Forwarded::InputArg`), which other code follows
+    /// via `get_box_replacement`; clearing that variant would silently break
     /// downstream replacement, so only the info-bearing variants
     /// (Info / IntBound / Const) take + clear, matching PyPy's clear
     /// semantics on the info-bearing branches.
@@ -3393,7 +3393,7 @@ impl OptContext {
         // BoxRef-authoritative read. PyPy stores the replay op's forwarded
         // info directly on `preamble_op._forwarded`; pyre stores the same
         // state in the BoxRef slot keyed by `source`. Non-constant
-        // `Forwarded::Box(target)` is a replacement chain and is excluded.
+        // `Forwarded::Op`/`InputArg` is a replacement chain and is excluded.
         // Const targets can still appear from legacy bridge/fixture replay
         // paths; normalize them to the OpInfo shape consumed by
         // `setinfo_from_preamble_item_option`.
@@ -3949,7 +3949,7 @@ impl OptContext {
         // target, a heap/virtual cache entry) — is materialized to its
         // canonical `SameAs*` stand-in (`resoperation.py:233-248` "the box
         // always exists"). The forward then targets a bound `Op`/`InputArg`
-        // and never a position-only `Forwarded::Box` redirect. An unbound
+        // and never a position-only unbound-box redirect. An unbound
         // `newop` has no producer at its position, so it cannot alias the
         // bound chain head `op` (no self-cycle).
         let materialized_newop;
@@ -4005,12 +4005,12 @@ impl OptContext {
             // Unreachable: `newop` was normalized above to a constant or a
             // bound `Op`/`InputArg`, so the dispatch always resolves through
             // `set_forwarded_const` / `set_forwarded_op` / `set_forwarded_inputarg`.
-            // The orphan `Forwarded::Box` redirect — the last production writer
-            // of the `Forwarded::Box` variant — is retired.
+            // The orphan unbound-box redirect that the deleted `Forwarded::Box`
+            // variant once encoded no longer exists.
             unreachable!(
                 "make_equal_to: newop must be constant or bound after \
-                 materialize_box_at normalization (Forwarded::Box production \
-                 writer retired)"
+                 materialize_box_at normalization (orphan unbound-box \
+                 redirect retired)"
             );
         }
         // optimizer.py:395-396
@@ -4089,7 +4089,7 @@ impl OptContext {
     ///
     /// `_forwarded` is a single slot per `BoxRef` (matching RPython's
     /// single Python slot per box). The walker advances through
-    /// `Forwarded::Box(target)` and terminates at `None` /
+    /// `Forwarded::Op`/`Forwarded::InputArg` and terminates at `None` /
     /// `Forwarded::Info(_)` / a Const target's reconstructed
     /// `OpRef::const_int/float/ptr`.
     fn get_box_replacement_impl(&self, opref: OpRef, not_const: bool) -> OpRef {
@@ -4614,9 +4614,7 @@ impl OptContext {
         }
         matches!(
             &op.get_forwarded(),
-            crate::r#box::Forwarded::Op(_)
-                | crate::r#box::Forwarded::InputArg(_)
-                | crate::r#box::Forwarded::Box(_)
+            crate::r#box::Forwarded::Op(_) | crate::r#box::Forwarded::InputArg(_)
         )
     }
 
@@ -5310,7 +5308,7 @@ impl OptContext {
     /// ConstPtr(ConstPtr.value)`). True iff `op` resolves to a Ref-typed
     /// null constant. Walks the chain and reads the terminal's
     /// `const_value()` directly — Const-namespace OpRefs whose
-    /// `Forwarded::Box(target)` chain terminates at a `BoxKind::Const`
+    /// forwarding chain terminates at a `Forwarded::Const`
     /// with `Value::Ref(GcRef(0))` are detected here.
     pub fn is_const_null(&self, op: &crate::r#box::BoxRef) -> bool {
         matches!(
@@ -6546,9 +6544,9 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_) | Forwarded::Op(_) | Forwarded::InputArg(_) => {
+            Forwarded::Const(_) | Forwarded::Op(_) | Forwarded::InputArg(_) => {
                 unreachable!(
-                    "getrawptrinfo: chain terminal must not carry Forwarded::Box / Const \
+                    "getrawptrinfo: chain terminal must not carry Forwarded::Const \
                  (box.rs:295 get_box_replacement walker invariant)",
                 )
             }
@@ -6634,9 +6632,9 @@ impl OptContext {
             // or `Info(_)` per the chain walker (box.rs:295-322); a
             // `Forwarded::Const` terminal is materialized inline by the
             // walker into a fresh BoxRef whose own slot is None.
-            Forwarded::Box(_) | Forwarded::Const(_) | Forwarded::Op(_) | Forwarded::InputArg(_) => {
+            Forwarded::Const(_) | Forwarded::Op(_) | Forwarded::InputArg(_) => {
                 unreachable!(
-                    "getptrinfo: chain terminal must not carry Forwarded::Box / Const \
+                    "getptrinfo: chain terminal must not carry Forwarded::Const \
                  (box.rs:295 get_box_replacement walker invariant)",
                 )
             }
@@ -7002,10 +7000,7 @@ impl OptContext {
                     Forwarded::Info(_) => {
                         return crate::optimizeopt::intutils::IntBound::unbounded().getnullness();
                     }
-                    Forwarded::Box(_)
-                    | Forwarded::Const(_)
-                    | Forwarded::Op(_)
-                    | Forwarded::InputArg(_) => {
+                    Forwarded::Const(_) | Forwarded::Op(_) | Forwarded::InputArg(_) => {
                         unreachable!("chain walker terminal")
                     }
                     Forwarded::None => {}
@@ -8085,14 +8080,14 @@ mod boxref_forwarding_tests {
 
     /// `resoperation.py:57-68 get_box_replacement` + `history.py:188
     /// Const.is_constant()` parity: after the chain walker advances into
-    /// a `Forwarded::Box(constbox)` target, `is_constant()` on the
+    /// a `Forwarded::Const(constval)` target, `is_constant()` on the
     /// terminal box reports True. Covers both encodings of "this slot is
     /// a known constant": (a) Const-namespace OpRef terminus, and (b)
-    /// `Forwarded::Box(constbox)` produced by `optimizer.py:432
+    /// `Forwarded::Const(constval)` produced by `optimizer.py:432
     /// set_forwarded(constbox)` — equivalent to RPython's single
     /// `is_constant()` predicate after `get_box_replacement`.
     #[test]
-    fn audit_a_chain_walker_reaches_constant_through_forwarded_box() {
+    fn audit_a_chain_walker_reaches_constant_through_forwarded_const() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
         let (b0, _ia0) = bound_inputarg_box(Type::Int, 0);
         let (b1, _ia1) = bound_inputarg_box(Type::Int, 1);
@@ -8101,13 +8096,13 @@ mod boxref_forwarding_tests {
         let const_opref = OpRef::const_int(7);
         let const_box = ctx.materialize_box_at(const_opref);
         assert!(const_box.get_box_replacement(false).is_constant());
-        // (b) `Forwarded::Box(constbox)` chain on a non-Const-namespace OpRef.
+        // (b) `Forwarded::Const(constval)` chain on a non-Const-namespace OpRef.
         let b0_iarg = ctx.materialize_box_at(OpRef::input_arg_int(0));
         ctx.make_equal_to(&b0_iarg, &const_box);
         let b0_after = ctx.materialize_box_at(OpRef::input_arg_int(0));
         assert!(b0_after.get_box_replacement(false).is_constant());
-        // `Forwarded::Box(constbox)` planted directly via set_forwarded_box.
-        b1.set_forwarded_box(BoxRef::new_const(Value::Int(42)));
+        // `Forwarded::Const(constval)` planted directly via set_forwarded_const.
+        b1.set_forwarded_const(majit_ir::Const::Int(42));
         assert!(b1.get_box_replacement(false).is_constant());
         // Negative case: BoxRef with no constant forwarding.
         let (nb, _ia_nb) = bound_inputarg_box(Type::Int, 0);
@@ -8144,12 +8139,12 @@ mod boxref_forwarding_tests {
         }
     }
 
-    /// `make_equal_to(old, ConstX)` mirrors onto `old_box.set_forwarded_box(
-    /// fresh_const_box)`. Per RPython parity (`optimizer.py:393`,
+    /// `make_equal_to(old, ConstX)` mirrors onto `old_box.set_forwarded_const(
+    /// const_value)`. Per RPython parity (`optimizer.py:393`,
     /// `history.py:220` ConstInt construction), the const target is built
     /// fresh from `const_pool[const_index]` per call site — no dedup, value
-    /// equality via `same_constant`. The mirror must produce a Const-kind
-    /// BoxRef carrying the same Value as the seeded constant.
+    /// equality via `same_constant`. The mirror must record the same Value
+    /// as the seeded constant via `Forwarded::Const`.
     #[test]
     fn h3_4_replace_op_const_target_mirrors_value_box() {
         let (mut ctx, b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
@@ -9529,7 +9524,7 @@ mod ensure_ptr_info_arg0_tests {
     }
 
     /// optimizer.py:474 assertion: an unexpected forwarded info shape (e.g.
-    /// a `Forwarded::Box` redirect that resolved to a non-PtrInfo state)
+    /// an op-forwarding redirect that resolved to a non-PtrInfo state)
     /// must NOT silently overwrite. We seed an `Instance` PtrInfo, then
     /// hand it a field op with a different parent — the early-return path
     /// hits, and the existing Instance is returned without overwrite.
@@ -9817,8 +9812,8 @@ mod opt_box_env_tests {
         // `resoperation.py:250 AbstractResOp` are distinct classes
         // upstream — a Box materialised against `OpRef::InputArg*`
         // must be `is_inputarg()` so the chain walker reconstructs
-        // the same variant on the round-trip through
-        // `Forwarded::Box`.  Prior to the per-variant empty-slot
+        // the same variant on the round-trip through the
+        // forwarding chain.  Prior to the per-variant empty-slot
         // path, materialisation always emitted `new_resop`,
         // silently demoting the inputarg.
         // `with_inputarg_types` would seed the inputarg slots

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -654,6 +654,14 @@ pub struct OptContext {
     /// RPython shortpreamble.py: pass-collected preamble producers aligned to
     /// the exported loop-header inputargs.
     pub exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
+    /// unroll.py:480 `short_inputargs = sb.create_short_inputargs(label_args
+    /// + virtuals)` — the ShortBoxes-derived short-preamble inputargs,
+    /// carried from the preview pass (optimizer.rs, where the ShortBoxes
+    /// object lives) to `export_state_with_bounds` through the same channel
+    /// as `exported_short_boxes`. Position projection of the renamed
+    /// inputarg boxes; equals the export-site `label_args + virtuals`
+    /// recompute (measured identical across the corpus, 2026-06-11).
+    pub exported_short_inputargs: Vec<OpRef>,
     /// optimizer.py: `can_replace_guards` — disable guard replacement during
     /// bridge compilation. Defaults to true for preamble.
     pub can_replace_guards: bool,
@@ -1528,6 +1536,7 @@ impl OptContext {
             potential_extra_ops: Vec::new(),
             active_short_preamble_producer: None,
             exported_short_boxes: Vec::new(),
+            exported_short_inputargs: Vec::new(),
 
             imported_virtuals: Vec::new(),
             imported_label_args: None,
@@ -2044,6 +2053,7 @@ impl OptContext {
             potential_extra_ops: Vec::new(),
             active_short_preamble_producer: None,
             exported_short_boxes: Vec::new(),
+            exported_short_inputargs: Vec::new(),
 
             imported_virtuals: Vec::new(),
             imported_label_args: None,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2895,7 +2895,7 @@ impl OptContext {
                     }
                     let resolved_arg_boxes: Vec<crate::r#box::BoxRef> = resolved_args
                         .iter()
-                        .map(|a| crate::r#box::BoxRef::from_opref(*a))
+                        .map(|a| self.materialize_box_at(*a))
                         .collect();
                     let mut op = Op::new(
                         pure_call_opcode(produced_op.preamble_op.opcode),
@@ -2940,7 +2940,7 @@ impl OptContext {
                                 majit_ir::Type::Float => OpCode::GetfieldGcF,
                                 majit_ir::Type::Void => return false,
                             };
-                            let mut op = Op::new(opcode, &[crate::r#box::BoxRef::from_opref(obj)]);
+                            let mut op = Op::new(opcode, &[self.materialize_box_at(obj)]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             ProducedShortOp {
@@ -2976,13 +2976,9 @@ impl OptContext {
                                 Some(r) => r,
                                 None => return false,
                             };
-                            let mut op = Op::new(
-                                opcode,
-                                &[
-                                    crate::r#box::BoxRef::from_opref(obj),
-                                    crate::r#box::BoxRef::from_opref(index_opref),
-                                ],
-                            );
+                            let obj_b = self.materialize_box_at(obj);
+                            let index_b = self.materialize_box_at(index_opref);
+                            let mut op = Op::new(opcode, &[obj_b, index_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             ProducedShortOp {
@@ -3019,7 +3015,7 @@ impl OptContext {
                     }
                     let mut op = Op::new(
                         loop_invariant_opcode(result_type),
-                        &[crate::r#box::BoxRef::from_opref(func_opref)],
+                        &[self.materialize_box_at(func_opref)],
                     );
                     op.pos.set(replay_pos(*source, produced_op));
                     let new_pop = ProducedShortOp {
@@ -3302,13 +3298,9 @@ impl OptContext {
                 Value::Void => panic!("emit_const_guard: ConstVoid not allowed"),
             };
             ctx.seed_constant(c, value.clone());
-            guards.push(Op::new(
-                OpCode::GuardValue,
-                &[
-                    crate::r#box::BoxRef::from_opref(arg),
-                    crate::r#box::BoxRef::from_opref(c),
-                ],
-            ));
+            let arg_b = ctx.materialize_box_at(arg);
+            let c_b = ctx.materialize_box_at(c);
+            guards.push(Op::new(OpCode::GuardValue, &[arg_b, c_b]));
         };
         for entry in &arg_entries {
             match &entry.info {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3056,18 +3056,16 @@ impl OptContext {
     ) -> OpRef {
         let preamble_source = preamble_op.op.to_opref();
         // RPython `return preamble_op.op` returns the carried Box. In majit,
-        // `pop.op` stores the Phase 1 source position; `make_equal_to(source,
+        // `pop.op` carries the Phase 1 source box; `make_equal_to(source,
         // body_visible)` is called by the producer for invented Pure / Heap /
         // LoopInvariant, so walking the forwarding chain reaches the
         // body-visible OpRef. Non-invented Pure has no forwarding installed,
         // so `get_box_replacement(source) == source` and the body references
         // source directly (RPython parity for non-invented `op = self.res`).
-        let result = self.get_replacement_opref(preamble_source);
+        let resolved = self.resolve_box_box(&preamble_op.op);
+        let result = resolved.to_opref();
         let result_type = preamble_op.preamble_op.result_type();
-        let is_constant = self
-            .get_box_replacement_box(preamble_source)
-            .and_then(|cb| cb.const_value())
-            .is_some();
+        let is_constant = resolved.const_value().is_some();
         let first_use = !self.imported_short_preamble_used.contains(&preamble_source);
         if first_use {
             self.imported_short_preamble_used.push(preamble_source);
@@ -3125,7 +3123,7 @@ impl OptContext {
             if !is_constant {
                 // unroll.py:35-36: invented_name → get_box_replacement(op)
                 let key = if preamble_op.invented_name {
-                    self.get_replacement_opref(preamble_source)
+                    result
                 } else {
                     preamble_source
                 };

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3163,7 +3163,7 @@ impl OptContext {
     /// `info.make_guards(...)` uniformly.
     fn collect_use_box_guards(&mut self, preamble_op: &Op) -> (Vec<Op>, Vec<Op>) {
         // shortpreamble.py:383-396: guards for InputArg args only
-        let short_inputargs: Vec<OpRef> = self
+        let short_inputargs: Vec<crate::r#box::BoxRef> = self
             .imported_short_preamble_builder
             .as_ref()
             .map(|b| b.short_inputargs().to_vec())
@@ -3256,7 +3256,7 @@ impl OptContext {
             if arg.is_constant() || arg.is_none() {
                 continue;
             }
-            let is_input = short_inputargs.contains(&arg);
+            let is_input = short_inputargs.iter().any(|a| a.to_opref() == arg);
             if let Some(info) = snapshot_forwarded(self, arg) {
                 arg_entries.push(ArgEntry {
                     arg,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5220,32 +5220,15 @@ impl OptContext {
     /// resoperation.py:38 `same_box` (non-Const: `self is other`) +
     /// history.py:211 `Const.same_box` (value comparison via
     /// `same_constant`). Resolves both operands through
-    /// `get_box_replacement` then delegates to `BoxRef::same_box`. Falls
-    /// back to resolved-`OpRef` identity plus constant-value comparison
-    /// when either box is absent (test fixtures without populated canonical
-    /// stores).
+    /// `get_box_replacement_box` then delegates to `BoxRef::same_box`;
+    /// operands that do not resolve to a canonical box are not the same box.
     pub fn same_box(&self, query: OpRef, stored: OpRef) -> bool {
         match (
             self.get_box_replacement_box(query),
             self.get_box_replacement_box(stored),
         ) {
             (Some(ref a), Some(ref b)) => a.same_box(b),
-            _ => {
-                let query = self.get_box_replacement(query).to_opref();
-                let stored = self.get_box_replacement(stored).to_opref();
-                if query == stored {
-                    return true;
-                }
-                match (
-                    self.get_box_replacement_box(query)
-                        .and_then(|cb| cb.const_value()),
-                    self.get_box_replacement_box(stored)
-                        .and_then(|cb| cb.const_value()),
-                ) {
-                    (Some(a), Some(b)) => a == b,
-                    _ => false,
-                }
-            }
+            _ => false,
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4155,7 +4155,7 @@ impl OptContext {
     /// fallback is production-dead (#123/S2, probe-verified 0 fires over
     /// the corpus): the round-trip callers that used to reach it moved to
     /// [`OptContext::get_replacement_opref`] /
-    /// [`OptContext::replacement_for_operand`], and the import paths
+    /// [`OptContext::resolve_box_box`], and the import paths
     /// materialize their carried refs (`import_state` targets, imported
     /// short-pure results). What remains of the fallback serves unit
     /// fixtures probing forwarding on unregistered baseline positions;
@@ -4370,23 +4370,6 @@ impl OptContext {
         match self.get_box_replacement_box(opref) {
             Some(b) => b.to_opref(),
             None => opref,
-        }
-    }
-
-    /// `op.setarg(i, self.get_box_replacement(op.getarg(i)))`
-    /// (optimizer.py:346-348 emit-side operand refresh) — resolve an
-    /// operand to its chain terminal for writing back. Registry-first so a
-    /// legacy position-only operand upgrades to its bound producer; when
-    /// the position resolves nowhere, walk the operand's own bound chain
-    /// (RPython's direct `op.getarg(i).get_box_replacement()`) instead of
-    /// fabricating a position-only box.
-    pub(crate) fn replacement_for_operand(
-        &self,
-        arg: &crate::r#box::BoxRef,
-    ) -> crate::r#box::BoxRef {
-        match self.get_box_replacement_box(arg.to_opref()) {
-            Some(b) => b,
-            None => arg.get_box_replacement(false),
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -517,7 +517,10 @@ impl PartialEq for ImportedShortPureOp {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ImportedShortAlias {
     pub result: OpRef,
-    pub same_as_source: OpRef,
+    /// MIGRATION (#9): the canonical box of the SameAs source operand,
+    /// carried directly off `extra_same_as` instead of a positional
+    /// round-trip.
+    pub same_as_source: crate::r#box::BoxRef,
     pub same_as_opcode: OpCode,
 }
 
@@ -2688,7 +2691,7 @@ impl OptContext {
                             kind: entry.kind.clone(),
                             preamble_op: entry.op.clone(),
                             invented_name: entry.invented_name,
-                            same_as_source: entry.same_as_source,
+                            same_as_source: entry.same_as_source.clone(),
                         },
                     )
                 })
@@ -2909,7 +2912,7 @@ impl OptContext {
                         kind: PreambleOpKind::Pure,
                         preamble_op: op,
                         invented_name: produced_op.invented_name,
-                        same_as_source: produced_op.same_as_source,
+                        same_as_source: produced_op.same_as_source.clone(),
                     };
                     produced.push((*source, new_pop.clone()));
                     if *source != result_opref {
@@ -2947,7 +2950,7 @@ impl OptContext {
                                 kind: PreambleOpKind::Heap,
                                 preamble_op: op,
                                 invented_name: produced_op.invented_name,
-                                same_as_source: produced_op.same_as_source,
+                                same_as_source: produced_op.same_as_source.clone(),
                             }
                         }
                         OpCode::GetarrayitemGcI
@@ -2985,7 +2988,7 @@ impl OptContext {
                                 kind: PreambleOpKind::Heap,
                                 preamble_op: op,
                                 invented_name: produced_op.invented_name,
-                                same_as_source: produced_op.same_as_source,
+                                same_as_source: produced_op.same_as_source.clone(),
                             }
                         }
                         _ => continue,
@@ -3022,7 +3025,7 @@ impl OptContext {
                         kind: PreambleOpKind::LoopInvariant,
                         preamble_op: op,
                         invented_name: produced_op.invented_name,
-                        same_as_source: produced_op.same_as_source,
+                        same_as_source: produced_op.same_as_source.clone(),
                     };
                     produced.push((*source, new_pop.clone()));
                     if *source != result_opref {
@@ -3841,7 +3844,7 @@ impl OptContext {
                     .iter()
                     .map(|op| ImportedShortAlias {
                         result: op.pos.get(),
-                        same_as_source: op.arg(0).to_opref(),
+                        same_as_source: op.arg(0),
                         same_as_opcode: op.opcode,
                     })
                     .collect()

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5413,15 +5413,34 @@ impl OptContext {
     /// resoperation.py:38 `same_box` (non-Const: `self is other`) +
     /// history.py:211 `Const.same_box` (value comparison via
     /// `same_constant`). Resolves both operands through
-    /// `get_box_replacement_box` then delegates to `BoxRef::same_box`;
-    /// operands that do not resolve to a canonical box are not the same box.
+    /// `get_box_replacement_box` then delegates to `BoxRef::same_box`. Falls
+    /// back to resolved-`OpRef` identity plus constant-value comparison
+    /// when either box is absent: two references to the same unresolved
+    /// variable are still the same box (`self is other`), and a
+    /// producer-less position has no canonical `BoxRef` to compare by `Rc`
+    /// identity, so resolved-`OpRef` equality stands in for object identity.
     pub fn same_box(&self, query: OpRef, stored: OpRef) -> bool {
         match (
             self.get_box_replacement_box(query),
             self.get_box_replacement_box(stored),
         ) {
             (Some(ref a), Some(ref b)) => a.same_box(b),
-            _ => false,
+            _ => {
+                let query = self.get_box_replacement(query).to_opref();
+                let stored = self.get_box_replacement(stored).to_opref();
+                if query == stored {
+                    return true;
+                }
+                match (
+                    self.get_box_replacement_box(query)
+                        .and_then(|cb| cb.const_value()),
+                    self.get_box_replacement_box(stored)
+                        .and_then(|cb| cb.const_value()),
+                ) {
+                    (Some(a), Some(b)) => a == b,
+                    _ => false,
+                }
+            }
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3941,7 +3941,27 @@ impl OptContext {
             ) => Some(opinfo.clone()),
             _ => None,
         };
-        // optimizer.py:394 op.set_forwarded(newop)
+        // optimizer.py:394 op.set_forwarded(newop). RPython's `newop` is
+        // always a real box object. A position-only unbound BoxRef — the
+        // flat-OpRef artifact where a Phase-1 producer was not carried into
+        // this rebuilt Phase-2 OptContext (`find_producer_op` miss, the
+        // cross-phase resolution gap; e.g. `import_state`'s next-iteration
+        // target, a heap/virtual cache entry) — is materialized to its
+        // canonical `SameAs*` stand-in (`resoperation.py:233-248` "the box
+        // always exists"). The forward then targets a bound `Op`/`InputArg`
+        // and never a position-only `Forwarded::Box` redirect. An unbound
+        // `newop` has no producer at its position, so it cannot alias the
+        // bound chain head `op` (no self-cycle).
+        let materialized_newop;
+        let newop: &crate::r#box::BoxRef = if newop.is_constant()
+            || newop.bound_op().is_some()
+            || newop.bound_inputarg().is_some()
+        {
+            newop
+        } else {
+            materialized_newop = self.materialize_box_at(newop.to_opref());
+            &materialized_newop
+        };
         if newop.is_constant() {
             let value = newop
                 .const_value()
@@ -3982,19 +4002,16 @@ impl OptContext {
             }
             op.set_forwarded_inputarg(&target_ia);
         } else {
-            // Orphan unbound non-Const BoxRef target. Phase 1's per-iter
-            // `TraceIterator::next()` (opencoder.rs:500) plants
-            // `BoxRef::new_resop` slots in the pool *without* binding to
-            // an `OpRc`; when Phase 1 folds/drops the op before it lands
-            // in `new_operations` / `phase1_emit_ops`, the pool slot stays
-            // unbound. Chain walks via `Forwarded::Box(...)` can still
-            // reach it through `Box.forwarded` (the mirror is canonical
-            // for unbound slots), so the chain step terminates safely on
-            // a `Forwarded::Box(newop)` write — `get_box_replacement` will
-            // continue reading Phase 1's forwarded state off the same
-            // `Box`. Test fixtures that build `BoxRef::new_resop` /
-            // `new_inputarg` without binding also rely on this path.
-            op.set_forwarded_box(newop.clone());
+            // Unreachable: `newop` was normalized above to a constant or a
+            // bound `Op`/`InputArg`, so the dispatch always resolves through
+            // `set_forwarded_const` / `set_forwarded_op` / `set_forwarded_inputarg`.
+            // The orphan `Forwarded::Box` redirect — the last production writer
+            // of the `Forwarded::Box` variant — is retired.
+            unreachable!(
+                "make_equal_to: newop must be constant or bound after \
+                 materialize_box_at normalization (Forwarded::Box production \
+                 writer retired)"
+            );
         }
         // optimizer.py:395-396
         //   if opinfo is not None and not newop.is_constant():

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -923,10 +923,9 @@ impl Optimizer {
                         );
                         // ob_type (offset 0) class pointers are already Ref-typed
                         // by `import_virtual_state_value` (typed `RefOp` variant
-                        // tag) + Ref-typed `Forwarded::Box(BoxRef::new_const(
-                        // Value::Ref(class_gcref)))` from `make_constant`. The
-                        // BoxRef Ref-typed const forwarding is the
-                        // authoritative shape.
+                        // tag) + a Ref-typed `Forwarded::Const`
+                        // (`Value::Ref(class_gcref)`) from `make_constant`. The
+                        // Ref-typed const forwarding is the authoritative shape.
                         let _ = (field_descrs, known_class, field_idx);
                         (*field_idx, field_ref)
                     })
@@ -2081,8 +2080,8 @@ impl Optimizer {
         // optimizer.py:34 `self.inputargs = inputargs` parity.
         ctx.inputargs = self.trace_inputargs.clone();
         // Bind inputarg hosts so `make_equal_to` routes InputArg-targeted
-        // chain steps through `Forwarded::InputArg(_)` rather than the
-        // deprecated `Forwarded::Box(_)` fallback. Phase 2 enters with a
+        // chain steps through `Forwarded::InputArg(_)` (the orphan-box
+        // forwarding fallback has been retired). Phase 2 enters with a
         // fresh per-iteration inputarg set whose TreeLoop-owned strong
         // `InputArgRc`s were dropped, so re-bind them here.
         ctx.ensure_inputarg_bindings();

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2814,7 +2814,7 @@ impl Optimizer {
                         kind: produced.kind,
                         label_arg_idx: short_boxes.lookup_label_arg(canonical_result),
                         invented_name: produced.invented_name,
-                        same_as_source: produced.same_as_source,
+                        same_as_source: produced.same_as_source.clone(),
                     }
                 })
                 .collect();
@@ -3193,7 +3193,9 @@ impl Optimizer {
                         }
                     }
                     if let Some(ref mut src) = entry.same_as_source {
-                        remap_opref(src);
+                        let mut src_opref = src.to_opref();
+                        remap_opref(&mut src_opref);
+                        *src = BoxRef::from_opref(src_opref);
                     }
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1461,6 +1461,11 @@ impl Optimizer {
     /// inject additional operations.
     pub fn send_extra_operation(&mut self, op: &Op, ctx: &mut OptContext) {
         let op_rc = std::rc::Rc::new(op.clone());
+        // Register the producer for op_rc.pos before dispatch so a pass that
+        // folds it via make_equal_to(from_bound_op(op_rc), ..) writes the
+        // forwarding onto a host find_producer_op can reach (the normal trace
+        // path registers via bind_input_resops; emit_extra does the same).
+        ctx.register_extra_producer(&op_rc);
         self.propagate_from_pass(0, &op_rc, ctx);
     }
 
@@ -1474,6 +1479,7 @@ impl Optimizer {
         ctx: &mut OptContext,
     ) {
         let op_rc = std::rc::Rc::new(op.clone());
+        ctx.register_extra_producer(&op_rc);
         self.propagate_from_pass(after_pass_idx + 1, &op_rc, ctx);
     }
 
@@ -1741,13 +1747,14 @@ impl Optimizer {
     /// Takes `&mut OptContext` to mirror the upstream `getintbound`
     /// lazy-install side effect (optimizer.py:102-112).
     pub fn getnullness(ctx: &mut OptContext, opref: OpRef) -> i8 {
-        // optimizer.py:127-135 `getnullness` has no missing-Box branch —
-        // every `op` has a backing `AbstractValue` per `resoperation.py:
-        // 233-248 _forwarded`. `materialize_box_at` lazy-allocates the Box (or
-        // returns the const-namespace fresh) so the inlined
-        // `getintbound` side effect (`optimizer.py:110-113` unbounded
-        // install) materializes on first access, matching upstream's
-        // Box-always-exists invariant.
+        // optimizer.py:127-135 `getnullness` reads `getptrinfo` /
+        // `getintbound` of an existing box; the `'r'` arm uses
+        // `getptrinfo(create=False)`, so an absent info yields `INFO_UNKNOWN`
+        // without minting. Resolve the producer box and delegate — a
+        // producer-less position has no info and returns `INFO_UNKNOWN`, never
+        // a fresh stand-in (a nullness query must not pollute the producer
+        // registry). `ctx.getnullness` performs the per-type `getintbound`
+        // lazy-install on the resolved box.
         let Some(b) = ctx.get_box_replacement_box(opref) else {
             return crate::optimizeopt::INFO_UNKNOWN;
         };

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2807,7 +2807,7 @@ impl Optimizer {
                     preamble_op.pos.set(canonical_result);
                     // optimizer.py:651-652 force_box loop parity.
                     for i in 0..preamble_op.num_args() {
-                        preamble_op.setarg(i, ctx.replacement_for_operand(&preamble_op.arg(i)));
+                        preamble_op.setarg(i, ctx.resolve_box_box(&preamble_op.arg(i)));
                     }
                     if let Some(fail_args) = preamble_op.fail_args_mut() {
                         for arg in fail_args {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4241,26 +4241,23 @@ impl Optimizer {
                             // (caught at pyjitpl/mod.rs:3454) on
                             // either invariant violation rather
                             // than silently coercing to 0.
-                            let boxindex = ctx.resolve_box_box(&pf_op.arg(1)).to_opref();
-                            let idx = match ctx
-                                .get_box_replacement_box(boxindex)
-                                .and_then(|cb| cb.const_int())
-                            {
+                            let boxindex = ctx.resolve_box_box(&pf_op.arg(1));
+                            let idx = match boxindex.const_int() {
                                 Some(v) if (0..=i32::MAX as i64).contains(&v) => v,
                                 _ => std::panic::panic_any(crate::optimize::InvalidLoop(
                                     "_add_pending_fields: SETARRAYITEM_GC index \
                                              must be a non-negative Const i32 (TagOverflow)",
                                 )),
                             };
-                            (pf_op.arg(0).to_opref(), pf_op.arg(2).to_opref(), idx as i32)
+                            (pf_op.arg(0), pf_op.arg(2), idx as i32)
                         } else {
-                            (pf_op.arg(0).to_opref(), pf_op.arg(1).to_opref(), -1i32)
+                            (pf_op.arg(0), pf_op.arg(1), -1i32)
                         };
                         majit_ir::GuardPendingFieldEntry {
                             descr: pf_op.getdescr(),
                             item_index,
-                            target: ctx.get_replacement_opref(target),
-                            value: ctx.get_replacement_opref(value),
+                            target: ctx.resolve_box_box(&target).to_opref(),
+                            value: ctx.resolve_box_box(&value).to_opref(),
                             target_tagged: majit_ir::resumedata::UNASSIGNED,
                             value_tagged: majit_ir::resumedata::UNASSIGNED,
                         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2804,7 +2804,8 @@ impl Optimizer {
                     }
                     if let Some(fail_args) = preamble_op.fail_args_mut() {
                         for arg in fail_args {
-                            *arg = ctx.resolve_box_box(&arg);
+                            *arg =
+                                majit_ir::operand::Operand::Box(ctx.resolve_box_box(&arg.to_boxref()));
                         }
                     }
                     crate::optimizeopt::shortpreamble::PreambleOp {
@@ -3176,7 +3177,7 @@ impl Optimizer {
                         for arg in fa.iter_mut() {
                             let mut arg_opref = arg.to_opref();
                             remap_opref(&mut arg_opref);
-                            *arg = BoxRef::from_opref(arg_opref);
+                            *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(arg_opref));
                         }
                     }
                     if let Some(ref mut src) = entry.same_as_source {
@@ -4389,7 +4390,8 @@ impl Optimizer {
             for fa_idx in 0..fail_args.len() {
                 if !fail_args[fa_idx].is_none() {
                     let resolved = ctx.get_box_replacement_not_const(fail_args[fa_idx].to_opref());
-                    fail_args[fa_idx] = BoxRef::from_opref(resolved);
+                    fail_args[fa_idx] =
+                        majit_ir::operand::Operand::Box(BoxRef::from_opref(resolved));
                 }
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2421,7 +2421,7 @@ impl Optimizer {
             let resolved_args: Vec<OpRef> = terminal_op
                 .getarglist()
                 .iter()
-                .map(|arg| ctx.get_replacement_opref(arg.to_opref()))
+                .map(|arg| ctx.resolve_box_box(arg).to_opref())
                 .collect();
             for &resolved in &resolved_args {
                 self.force_box_for_end_of_preamble(resolved, &mut ctx);
@@ -2433,7 +2433,7 @@ impl Optimizer {
             //   for i in range(op.numargs()): op.setarg(i, force_box(...))
             for i in 0..terminal_op.num_args() {
                 let arg = terminal_op.arg(i);
-                let resolved = ctx.get_replacement_opref(arg.to_opref());
+                let resolved = ctx.resolve_box_box(&arg).to_opref();
                 let expected_ref =
                     i < inputargs.len() && inputargs[i].ty() == Some(majit_ir::Type::Ref);
                 // setup_optimizations seeds `trace_inputargs` into
@@ -2594,7 +2594,7 @@ impl Optimizer {
                 .map(|v| v.iter().map(|b| b.to_opref()).collect())
                 .unwrap_or_else(|| {
                     jump.getarglist().iter()
-                        .map(|a| ctx.get_replacement_opref(a.to_opref()))
+                        .map(|a| ctx.resolve_box_box(a).to_opref())
                         .collect()
                 });
             let mut resolved_args = original_jump_args.clone();
@@ -4241,7 +4241,7 @@ impl Optimizer {
                             // (caught at pyjitpl/mod.rs:3454) on
                             // either invariant violation rather
                             // than silently coercing to 0.
-                            let boxindex = ctx.get_replacement_opref(pf_op.arg(1).to_opref());
+                            let boxindex = ctx.resolve_box_box(&pf_op.arg(1)).to_opref();
                             let idx = match ctx
                                 .get_box_replacement_box(boxindex)
                                 .and_then(|cb| cb.const_int())

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1500,9 +1500,7 @@ impl Optimizer {
         if let Some(preamble_op) = tracked {
             // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
             // — the resolved Box itself is handed to the builder.
-            let resolved_for_pop = ctx
-                .get_box_replacement_box(preamble_op.op)
-                .unwrap_or_else(|| BoxRef::from_opref(preamble_op.op));
+            let resolved_for_pop = ctx.resolve_box_box(&preamble_op.op);
             if let Some(builder) = ctx.active_short_preamble_producer_mut() {
                 builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
             } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {
@@ -6182,7 +6180,7 @@ mod tests {
         ctx.set_potential_extra_op(
             OpRef::int_op(14),
             crate::optimizeopt::info::PreambleOp {
-                op: OpRef::int_op(14),
+                op: BoxRef::from_opref(OpRef::int_op(14)),
                 invented_name: false,
                 preamble_op: {
                     let mut op = majit_ir::Op::new(

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3067,6 +3067,14 @@ impl Optimizer {
             // applies only to body-namespace OpRefs (InputArg* / *Op).
             for op in &ctx.new_operations {
                 for i in 0..op.num_args() {
+                    // A bound operand (`Operand::Op` / `InputArg`) live-tracks
+                    // its producer's `op.pos`, already mutated to the new dense
+                    // slot above, so it needs no snapshot rewrite. Only
+                    // position-only `Operand::Box` operands carry a stale
+                    // pre-remap position the table must rewrite.
+                    if op.arg_is_bound(i) {
+                        continue;
+                    }
                     let arg = op.arg(i).to_opref();
                     if arg.is_constant() {
                         continue;
@@ -3150,6 +3158,13 @@ impl Optimizer {
                     remap_opref(&mut new_pos);
                     entry.op.pos.set(new_pos);
                     for i in 0..entry.op.num_args() {
+                        // Bound operands live-track their producer's already
+                        // remapped `op.pos` (the main loop set it above); only
+                        // position-only `Operand::Box` snapshots need the table
+                        // rewrite. Re-remapping a bound operand would double-map.
+                        if entry.op.arg_is_bound(i) {
+                            continue;
+                        }
                         let mut arg = entry.op.arg(i).to_opref();
                         remap_opref(&mut arg);
                         entry.op.setarg(i, BoxRef::from_opref(arg));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2804,8 +2804,9 @@ impl Optimizer {
                     }
                     if let Some(fail_args) = preamble_op.fail_args_mut() {
                         for arg in fail_args {
-                            *arg =
-                                majit_ir::operand::Operand::Box(ctx.resolve_box_box(&arg.to_boxref()));
+                            *arg = majit_ir::operand::Operand::from_boxref(
+                                &ctx.resolve_box_box(&arg.to_boxref()),
+                            );
                         }
                     }
                     crate::optimizeopt::shortpreamble::PreambleOp {
@@ -4400,9 +4401,11 @@ impl Optimizer {
         if let Some(fail_args) = op.fail_args_mut() {
             for fa_idx in 0..fail_args.len() {
                 if !fail_args[fa_idx].is_none() {
-                    let resolved = ctx.get_box_replacement_not_const(fail_args[fa_idx].to_opref());
-                    fail_args[fa_idx] =
-                        majit_ir::operand::Operand::Box(BoxRef::from_opref(resolved));
+                    if let Some(resolved) =
+                        ctx.get_box_replacement_not_const_box(fail_args[fa_idx].to_opref())
+                    {
+                        fail_args[fa_idx] = majit_ir::operand::Operand::from_boxref(&resolved);
+                    }
                 }
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3092,6 +3092,15 @@ impl Optimizer {
                         continue;
                     }
                     if let Some(&new_pos) = remap.get(&arg.raw()) {
+                        // Measured dead (PYRE_REMAP_PROBE 2026-06-11: 0 fires
+                        // across check.py corpus + lib tests) — every
+                        // non-const operand reaching const-compact is
+                        // producer-bound. The rewrite stays as a safety net
+                        // until the loop retires with OpRef demotion (#9).
+                        debug_assert!(
+                            false,
+                            "position-only non-const operand hit const-compact remap: {arg:?}"
+                        );
                         op.setarg(i, BoxRef::from_opref(arg.with_raw(new_pos)));
                     }
                 }
@@ -3108,6 +3117,12 @@ impl Optimizer {
                         let arg_opref = arg.to_opref();
                         if !arg_opref.is_constant() {
                             if let Some(&new_pos) = remap.get(&arg_opref.raw()) {
+                                // Measured dead, same evidence as the args
+                                // loop above.
+                                debug_assert!(
+                                    false,
+                                    "position-only failarg hit const-compact remap: {arg_opref:?}"
+                                );
                                 *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(
                                     arg_opref.with_raw(new_pos),
                                 ));
@@ -3183,7 +3198,16 @@ impl Optimizer {
                             continue;
                         }
                         let mut arg = entry.op.arg(i).to_opref();
+                        let pre = arg;
                         remap_opref(&mut arg);
+                        // Measured dead (PYRE_REMAP_PROBE 2026-06-11): no
+                        // position-only exported-short-box operand was ever
+                        // remapped; rewrite kept as a safety net until the
+                        // loop retires with OpRef demotion (#9).
+                        debug_assert!(
+                            arg == pre,
+                            "position-only exported-short-box arg remapped: {pre:?}"
+                        );
                         entry.op.setarg(i, BoxRef::from_opref(arg));
                     }
                     if let Some(fa) = entry.op.fail_args_mut() {
@@ -3195,7 +3219,13 @@ impl Optimizer {
                                 continue;
                             }
                             let mut arg_opref = arg.to_opref();
+                            let pre = arg_opref;
                             remap_opref(&mut arg_opref);
+                            // Measured dead, same evidence as the args loop.
+                            debug_assert!(
+                                arg_opref == pre,
+                                "position-only exported-short-box failarg remapped: {pre:?}"
+                            );
                             *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(arg_opref));
                         }
                     }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2795,6 +2795,15 @@ impl Optimizer {
             }
             self.produce_potential_short_preamble_ops(&mut short_boxes, &mut ctx);
             let produced = short_boxes.produced_ops(&mut ctx);
+            // unroll.py:480 `short_inputargs = sb.create_short_inputargs(
+            // label_args + virtuals)` — read off the ShortBoxes object and
+            // carry to export_state through the ctx channel (sibling of
+            // `exported_short_boxes` below).
+            ctx.exported_short_inputargs = short_boxes
+                .create_short_inputargs(&preview_short_args)
+                .iter()
+                .map(|b| b.to_opref())
+                .collect();
             ctx.exported_short_boxes = produced
                 .into_iter()
                 .map(|(result, produced)| {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2471,7 +2471,8 @@ impl Optimizer {
                         // allowing Ref -> Float/Int type substitution at the JUMP.
                     }
                 } else {
-                    terminal_op.setarg(i, BoxRef::from_opref(resolved));
+                    let arg = ctx.materialize_box_at(resolved);
+                    terminal_op.setarg(i, arg);
                 }
             }
             for i in force_needed {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3087,19 +3087,24 @@ impl Optimizer {
                         op.setarg(i, BoxRef::from_opref(arg.with_raw(new_pos)));
                     }
                 }
-                if let Some(mut fail_args) = op.getfailargs() {
-                    let mut changed = false;
+                if let Some(fail_args) = op.fail_args.borrow_mut().as_mut() {
                     for arg in fail_args.iter_mut() {
+                        // Same rule as the args loop above: a bound failarg
+                        // live-tracks its producer's already-remapped
+                        // `op.pos`; re-remapping would double-map. Only
+                        // position-only `Operand::Box` snapshots carry a
+                        // stale pre-remap position.
+                        if arg.is_bound() {
+                            continue;
+                        }
                         let arg_opref = arg.to_opref();
                         if !arg_opref.is_constant() {
                             if let Some(&new_pos) = remap.get(&arg_opref.raw()) {
-                                *arg = BoxRef::from_opref(arg_opref.with_raw(new_pos));
-                                changed = true;
+                                *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(
+                                    arg_opref.with_raw(new_pos),
+                                ));
                             }
                         }
-                    }
-                    if changed {
-                        op.setfailargs(fail_args);
                     }
                 }
             }
@@ -3175,6 +3180,12 @@ impl Optimizer {
                     }
                     if let Some(fa) = entry.op.fail_args_mut() {
                         for arg in fa.iter_mut() {
+                            // Bound failargs live-track the producer's
+                            // already-remapped pos (same rule as the args
+                            // loop above); re-remapping would double-map.
+                            if arg.is_bound() {
+                                continue;
+                            }
                             let mut arg_opref = arg.to_opref();
                             remap_opref(&mut arg_opref);
                             *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(arg_opref));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -694,7 +694,7 @@ impl Optimizer {
                 let pos = ctx.inputarg_base + iv.inputarg_index as u32;
                 let raw =
                     OpRef::input_arg_typed(pos, ctx.inputarg_type_at_strict(iv.inputarg_index));
-                let virtual_head = ctx.get_box_replacement(raw).to_opref();
+                let virtual_head = ctx.get_replacement_opref(raw);
                 walk_visited.insert(top_key, virtual_head);
                 let mut fields = Vec::new();
                 for (descr, field_info) in &iv.fields {
@@ -1095,7 +1095,7 @@ impl Optimizer {
                 if let Some(box_) = ctx.get_box_replacement_box(opref) {
                     Self::apply_imported_virtual_state(info, &box_, ctx);
                 }
-                ctx.get_box_replacement(opref).to_opref()
+                ctx.get_replacement_opref(opref)
             }
         }
     }
@@ -1491,14 +1491,18 @@ impl Optimizer {
     /// longer needed. Mirrors force_box_inline (mod.rs) contract.
     pub fn force_box(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
         // optimizer.py:346: op = get_box_replacement(op)
-        let resolved = ctx.get_box_replacement(opref).to_opref();
+        let resolved = ctx.get_replacement_opref(opref);
         // optimizer.py:351-359: potential_extra_ops.pop(op)
         // → sb.add_preamble_op(preamble_op)
         let tracked = ctx
             .take_potential_extra_op(resolved)
             .or_else(|| ctx.take_potential_extra_op(opref));
         if let Some(preamble_op) = tracked {
-            let resolved_for_pop = ctx.get_box_replacement(preamble_op.op).to_opref();
+            // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
+            // — the resolved Box itself is handed to the builder.
+            let resolved_for_pop = ctx
+                .get_box_replacement_box(preamble_op.op)
+                .unwrap_or_else(|| BoxRef::from_opref(preamble_op.op));
             if let Some(builder) = ctx.active_short_preamble_producer_mut() {
                 builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
             } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {
@@ -1525,7 +1529,7 @@ impl Optimizer {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
             let forced = info.force_box(resolved_box, ctx);
-            return ctx.get_box_replacement(forced).to_opref();
+            return ctx.get_replacement_opref(forced);
         }
         resolved
     }
@@ -1556,7 +1560,7 @@ impl Optimizer {
     /// `force_at_the_end_of_preamble` directly should route through
     /// this wrapper for RPython structural parity (unroll.py:126-127).
     pub fn force_box_for_end_of_preamble(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
-        let resolved = ctx.get_box_replacement(opref).to_opref();
+        let resolved = ctx.get_replacement_opref(opref);
         match ctx.opref_type(resolved) {
             // optimizer.py:307-313 — `box.type == 'r'` path.
             Some(majit_ir::Type::Ref) => {
@@ -1606,7 +1610,7 @@ impl Optimizer {
         ctx: &mut OptContext,
         rec: &mut majit_ir::vec_set::VecSet<OpRef>,
     ) -> OpRef {
-        let resolved = ctx.get_box_replacement(opref).to_opref();
+        let resolved = ctx.get_replacement_opref(opref);
         let resolved_box = ctx.get_box_replacement_box(opref);
         let Some(mut info) = resolved_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) else {
             return resolved;
@@ -2323,7 +2327,7 @@ impl Optimizer {
                         let raw = OpRef::input_arg_typed(raw_pos, tp);
                         eprintln!(
                             "[jit] import_state_resolved: raw={raw:?} resolved={:?}",
-                            ctx.get_box_replacement(raw).to_opref()
+                            ctx.get_replacement_opref(raw)
                         );
                     }
                 }
@@ -2419,7 +2423,7 @@ impl Optimizer {
             let resolved_args: Vec<OpRef> = terminal_op
                 .getarglist()
                 .iter()
-                .map(|arg| ctx.resolve_box_box(&arg).to_opref())
+                .map(|arg| ctx.get_replacement_opref(arg.to_opref()))
                 .collect();
             for &resolved in &resolved_args {
                 self.force_box_for_end_of_preamble(resolved, &mut ctx);
@@ -2431,7 +2435,7 @@ impl Optimizer {
             //   for i in range(op.numargs()): op.setarg(i, force_box(...))
             for i in 0..terminal_op.num_args() {
                 let arg = terminal_op.arg(i);
-                let resolved = ctx.resolve_box_box(&arg).to_opref();
+                let resolved = ctx.get_replacement_opref(arg.to_opref());
                 let expected_ref =
                     i < inputargs.len() && inputargs[i].ty() == Some(majit_ir::Type::Ref);
                 // setup_optimizations seeds `trace_inputargs` into
@@ -2440,7 +2444,7 @@ impl Optimizer {
                 // op/value_types chain. PtrInfo presence is an additional
                 // Ref-only side channel for inputargs not in `new_operations`.
                 let resolved_has_ptr_info = ctx
-                    .resolve_box_box_opt(&arg)
+                    .get_box_replacement_box(arg.to_opref())
                     .as_ref()
                     .map_or(false, |b| ctx.has_ptr_info(b));
                 let resolved_is_ref =
@@ -2453,7 +2457,7 @@ impl Optimizer {
                         .is_some()
                 {
                     let arg_is_virtual = ctx
-                        .resolve_box_box_opt(&arg)
+                        .get_box_replacement_box(arg.to_opref())
                         .as_ref()
                         .map_or(false, |b| ctx.is_virtual(b));
                     if arg_is_virtual {
@@ -2478,7 +2482,15 @@ impl Optimizer {
             for i in force_needed {
                 let original = terminal_op.arg(i);
                 let forced = self.force_box(original.to_opref(), &mut ctx);
-                terminal_op.setarg(i, ctx.get_box_replacement(forced));
+                // Operand writes carry the canonical box: resolve the chain
+                // terminal, materializing the host when the forced position
+                // has no producer yet (mirrors the materialize_box_at arm
+                // above; never a position-only fabrication).
+                let b_forced = match ctx.get_box_replacement_box(forced) {
+                    Some(b) => b,
+                    None => ctx.materialize_box_at(forced),
+                };
+                terminal_op.setarg(i, b_forced);
             }
             if self.skip_flush {
                 // flush=False: store for caller to consume.
@@ -2584,7 +2596,7 @@ impl Optimizer {
                 .map(|v| v.iter().map(|b| b.to_opref()).collect())
                 .unwrap_or_else(|| {
                     jump.getarglist().iter()
-                        .map(|a| ctx.resolve_box_box(&a).to_opref())
+                        .map(|a| ctx.get_replacement_opref(a.to_opref()))
                         .collect()
                 });
             let mut resolved_args = original_jump_args.clone();
@@ -2728,7 +2740,7 @@ impl Optimizer {
             // do in RPython.
             let post_force_args: Vec<OpRef> = resolved_args
                 .iter()
-                .map(|&a| ctx.get_box_replacement(a).to_opref())
+                .map(|&a| ctx.get_replacement_opref(a))
                 .collect();
             let preview_virtual_state =
                 crate::optimizeopt::virtualstate::export_state(&post_force_args, &ctx);
@@ -2788,7 +2800,7 @@ impl Optimizer {
             ctx.exported_short_boxes = produced
                 .into_iter()
                 .map(|(result, produced)| {
-                    let canonical_result = ctx.get_box_replacement(result).to_opref();
+                    let canonical_result = ctx.get_replacement_opref(result);
                     let mut preamble_op = produced.preamble_op;
                     // RPython parity: key and preamble_op.pos must be the
                     // same resolved value. Independent get_box_replacement
@@ -2797,15 +2809,12 @@ impl Optimizer {
                     preamble_op.pos.set(canonical_result);
                     // optimizer.py:651-652 force_box loop parity.
                     for i in 0..preamble_op.num_args() {
-                        preamble_op.setarg(
-                            i,
-                            ctx.resolve_box_box(&preamble_op.arg(i)),
-                        );
+                        preamble_op.setarg(i, ctx.replacement_for_operand(&preamble_op.arg(i)));
                     }
                     if let Some(fail_args) = preamble_op.fail_args_mut() {
                         for arg in fail_args {
                             *arg = majit_ir::operand::Operand::from_boxref(
-                                &ctx.resolve_box_box(&arg.to_boxref()),
+                                &ctx.get_box_replacement(arg.to_opref()),
                             );
                         }
                     }
@@ -3723,7 +3732,7 @@ impl Optimizer {
             // it to its terminal, so the stored arg is BOUND on every dispatch
             // path. A sentinel operand keeps its unbound arg box (const
             // operands resolve through the `Some` arm above).
-            let resolved = match ctx.resolve_box_box_opt(&arg) {
+            let resolved = match ctx.get_box_replacement_box(arg.to_opref()) {
                 Some(b) => b,
                 None => {
                     let argref = arg.to_opref();
@@ -4042,7 +4051,7 @@ impl Optimizer {
         //       if opinfo is not None and opinfo.is_constant():
         //           op.set_forwarded(ConstInt(opinfo.get_constant_int()))
         if op.result_type() == majit_ir::Type::Int {
-            let replaced = ctx.get_box_replacement(emitted).to_opref();
+            let replaced = ctx.get_replacement_opref(emitted);
             // BoxRef shim — peek_intbound_box takes &BoxRef per optimizer.py:99-113.
             let bound = ctx
                 .get_box_replacement_box(emitted)
@@ -4204,7 +4213,7 @@ impl Optimizer {
                             // (caught at pyjitpl/mod.rs:3454) on
                             // either invariant violation rather
                             // than silently coercing to 0.
-                            let boxindex = ctx.resolve_box_box(&pf_op.arg(1)).to_opref();
+                            let boxindex = ctx.get_replacement_opref(pf_op.arg(1).to_opref());
                             let idx = match ctx
                                 .get_box_replacement_box(boxindex)
                                 .and_then(|cb| cb.const_int())
@@ -4222,8 +4231,8 @@ impl Optimizer {
                         majit_ir::GuardPendingFieldEntry {
                             descr: pf_op.getdescr(),
                             item_index,
-                            target: ctx.get_box_replacement(target).to_opref(),
-                            value: ctx.get_box_replacement(value).to_opref(),
+                            target: ctx.get_replacement_opref(target),
+                            value: ctx.get_replacement_opref(value),
                             target_tagged: majit_ir::resumedata::UNASSIGNED,
                             value_tagged: majit_ir::resumedata::UNASSIGNED,
                         }
@@ -4463,7 +4472,7 @@ impl Optimizer {
         let mut loopinvariant_results = Vec::new();
         for pass in &self.passes {
             for (func_ptr, result) in pass.serialize_optrewrite() {
-                let replaced = ctx.get_box_replacement(result).to_opref();
+                let replaced = ctx.get_replacement_opref(result);
                 loopinvariant_results.push((func_ptr, replaced));
             }
         }
@@ -4527,7 +4536,7 @@ impl Optimizer {
         }
         // optimizer.py:756-757: b = self.getintbound(op.getarg(0)); if b.is_bool()
         let b = {
-            let b = ctx.resolve_box_box(&arg0);
+            let b = ctx.get_box_replacement(arg0.to_opref());
             ctx.getintbound_handle(&b).borrow().clone()
         };
         if !b.is_bool() {
@@ -6079,10 +6088,7 @@ mod tests {
         // The virtual is forced to a concrete allocation; the returned ref
         // is the allocation's position, which ctx.get_box_replacement(OpRef::int_op(10))
         // should resolve to.
-        assert_eq!(
-            result,
-            ctx.get_box_replacement(OpRef::int_op(10)).to_opref()
-        );
+        assert_eq!(result, ctx.get_replacement_opref(OpRef::int_op(10)));
         // After forcing, the struct's ptr_info reflects that field 1
         // (originally OpRef::int_op(11), forwarded to OpRef::int_op(20)) has been recursively forced.
         let result_box = ctx.get_box_replacement_box(result);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2781,7 +2781,7 @@ impl Optimizer {
                          (shortpreamble.py:255-259)"
                     );
                 }
-                short_boxes.add_short_input_arg(arg, raw_type);
+                short_boxes.add_short_input_arg(&mut ctx, arg, raw_type);
             }
             self.produce_potential_short_preamble_ops(&mut short_boxes, &mut ctx);
             let produced = short_boxes.produced_ops(&mut ctx);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3896,9 +3896,10 @@ impl Optimizer {
         // the same canonicalization the pass-entry resolver applies.
         for i in 0..op.num_args() {
             let forced = self.force_box(op.arg(i).to_opref(), ctx);
-            let resolved = ctx
-                .get_box_replacement_box(forced)
-                .unwrap_or_else(|| BoxRef::from_opref(forced));
+            let resolved = match ctx.get_box_replacement_box(forced) {
+                Some(b) => b,
+                None => ctx.materialize_box_at(forced),
+            };
             // The forced value is a chain terminal, so its canonical box's
             // OpRef identity equals `forced`; OpRef-keyed consumers (backend,
             // box_pool) see the same key, only the _forwarded info is added.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -775,7 +775,8 @@ impl Optimizer {
                 .opref_type(*label_arg)
                 .expect("imported virtual leaf missing box.type");
             let same_as_op = majit_ir::OpCode::same_as_for_type(tp);
-            let mut op = majit_ir::Op::new(same_as_op, &[BoxRef::from_opref(*label_arg)]);
+            let arg0 = ctx.materialize_box_at(*label_arg);
+            let mut op = majit_ir::Op::new(same_as_op, &[arg0]);
             op.pos.set(ctx.reserve_pos_typed(tp));
             let fresh = op.pos.get();
             // Op.type_ carries `tp` intrinsically (resoperation.py:1693
@@ -2649,7 +2650,8 @@ impl Optimizer {
                         .expect("propagate_from_pass_range SameAs: source OpRef missing Box.type");
                     let same_as = OpCode::same_as_for_type(arg_type);
                     let fresh = ctx.alloc_op_position_typed(arg_type);
-                    let mut op = Op::new(same_as, &[BoxRef::from_opref(orig)]);
+                    let arg0 = ctx.materialize_box_at(orig);
+                    let mut op = Op::new(same_as, &[arg0]);
                     op.pos.set(fresh);
                     // unroll.py:146 + compile.py:327 parity: accumulate the
                     // alias op in `extra_same_as` and splice it between the

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2799,7 +2799,9 @@ impl Optimizer {
                 .into_iter()
                 .map(|(result, produced)| {
                     let canonical_result = ctx.get_replacement_opref(result);
-                    let mut preamble_op = produced.preamble_op;
+                    // Deep-clone: dual map entries share the replay OpRc;
+                    // the pos/arg rewrites below must stay per-entry.
+                    let mut preamble_op = (*produced.preamble_op).clone();
                     // RPython parity: key and preamble_op.pos must be the
                     // same resolved value. Independent get_box_replacement
                     // calls can diverge when forwarding chains differ.
@@ -6215,7 +6217,7 @@ mod tests {
                         &[BoxRef::from_opref(OpRef::int_op(14))],
                     );
                     op.pos.set(OpRef::op_typed(14, op.result_type()));
-                    op
+                    std::rc::Rc::new(op)
                 },
             },
         );

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -961,10 +961,8 @@ impl Optimization for OptPure {
                 // ctx.emit() bypasses that optimizer path, so mirror the
                 // force_box step here before recording the postponed op.
                 for i in 0..postponed.num_args() {
-                    postponed.setarg(
-                        i,
-                        BoxRef::from_opref(self.force_box(postponed.arg(i).to_opref(), ctx)),
-                    );
+                    let forced = self.force_box(postponed.arg(i).to_opref(), ctx);
+                    postponed.setarg(i, ctx.materialize_box_at(forced));
                 }
                 // Record and emit both the OVF op and the guard.
                 self.cache.insert(key, postponed.pos.get());
@@ -973,10 +971,8 @@ impl Optimization for OptPure {
             } else {
                 // Not a GUARD_NO_OVERFLOW: emit the postponed op now.
                 for i in 0..postponed.num_args() {
-                    postponed.setarg(
-                        i,
-                        BoxRef::from_opref(self.force_box(postponed.arg(i).to_opref(), ctx)),
-                    );
+                    let forced = self.force_box(postponed.arg(i).to_opref(), ctx);
+                    postponed.setarg(i, ctx.materialize_box_at(forced));
                 }
                 ctx.emit(postponed);
             }

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1725,6 +1725,12 @@ mod tests {
         let mut ctx = OptContext::new(10);
         let mut pass = OptPure::new();
 
+        // Production binds the input operands a, b before the int_add is
+        // processed; bind them canonically here so same_box resolves both
+        // ops' args to one shared box.
+        ctx.materialize_box_at(OpRef::int_op(0));
+        ctx.materialize_box_at(OpRef::int_op(1));
+
         // Simulate: op0 = int_add(a, b)
         let op0 = Op::new(
             OpCode::IntAdd,
@@ -2452,6 +2458,7 @@ mod tests {
 
         // Cache `IntAdd(c5_a, x)` and look up `IntAdd(c5_b, x)`.
         let x = OpRef::int_op(7);
+        ctx.materialize_box_at(x);
         pass.pure_from_args2(OpCode::IntAdd, c5_a, x, OpRef::int_op(42));
 
         let mut q = Op::new(
@@ -2489,8 +2496,9 @@ mod tests {
         let other_arg = OpRef::int_op(9);
         let result = OpRef::int_op(42);
         let b_query = ctx.materialize_box_at(query_arg);
-        let b_canonical = ctx.get_box_replacement(canonical_arg);
+        let b_canonical = ctx.materialize_box_at(canonical_arg);
         ctx.make_equal_to(&b_query, &b_canonical);
+        ctx.materialize_box_at(other_arg);
 
         pass.pure_from_args2(OpCode::IntAdd, canonical_arg, other_arg, result);
 
@@ -2521,7 +2529,12 @@ mod tests {
         op.pos.set(OpRef::int_op(0));
         pass.pure(&op);
 
-        let ctx = OptContext::new(0);
+        let mut ctx = OptContext::new(0);
+        // Bind the operand positions canonically so same_box resolves the
+        // looked-up op's args to the same boxes the cache recorded.
+        for p in [10, 20, 30, 40] {
+            ctx.materialize_box_at(OpRef::int_op(p));
+        }
 
         // Should find it via get_pure_result
         let lookup_op = Op::new(
@@ -2580,7 +2593,10 @@ mod tests {
     #[test]
     fn test_known_result_call_pure_lookup() {
         let mut pass = OptPure::new();
-        let ctx = OptContext::with_num_inputs(4, 0);
+        let mut ctx = OptContext::with_num_inputs(4, 0);
+        // Bind the matched call args canonically so same_box resolves them.
+        ctx.materialize_box_at(OpRef::int_op(100));
+        ctx.materialize_box_at(OpRef::int_op(101));
 
         // pure.py:214: self.known_result_call_pure.append(op)
         pass.known_result_call_pure.push(super::KnownResultEntry {
@@ -2679,6 +2695,9 @@ mod tests {
     fn test_imported_short_call_pure_result_replays_into_pure_cache() {
         let mut pass = OptPure::new();
         let mut ctx = OptContext::with_num_inputs(8, 0);
+        // Bind the non-const call arg position so same_box resolves the
+        // dispatched op's arg to the same box the imported op recorded.
+        ctx.materialize_box_at(OpRef::int_op(0));
         let const_opref = OpRef::const_int(0x1234);
         let call_descr = majit_ir::descr::make_call_descr_full(
             77,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1327,18 +1327,18 @@ mod tests {
         // Keep the source result available to use_box() exactly like the
         // imported short preamble path does after unroll import.
         if source != OpRef::NONE {
-            ctx.set_potential_extra_op(
-                source,
-                crate::optimizeopt::info::PreambleOp {
-                    op: source,
-                    invented_name: false,
-                    preamble_op: {
-                        let mut same_as = Op::new(OpCode::SameAsI, &[BoxRef::from_opref(source)]);
-                        same_as.pos.set(source);
-                        same_as
-                    },
+            // PreambleOp.op carries the Box itself (shortpreamble.py:12).
+            let source_box = ctx.materialize_box_at(source);
+            let pop = crate::optimizeopt::info::PreambleOp {
+                op: source_box.clone(),
+                invented_name: false,
+                preamble_op: {
+                    let mut same_as = Op::new(OpCode::SameAsI, &[source_box]);
+                    same_as.pos.set(source);
+                    same_as
                 },
-            );
+            };
+            ctx.set_potential_extra_op(source, pop);
         }
     }
     use crate::optimizeopt::optimizer::Optimizer;

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1335,7 +1335,7 @@ mod tests {
                 preamble_op: {
                     let mut same_as = Op::new(OpCode::SameAsI, &[source_box]);
                     same_as.pos.set(source);
-                    same_as
+                    std::rc::Rc::new(same_as)
                 },
             };
             ctx.set_potential_extra_op(source, pop);
@@ -2718,7 +2718,11 @@ mod tests {
             OpRef::int_op(1),
             false,
         );
-        initialize_imported_short_pure_builder(&mut ctx, imported.pop.preamble_op.clone(), Some(1));
+        initialize_imported_short_pure_builder(
+            &mut ctx,
+            (*imported.pop.preamble_op).clone(),
+            Some(1),
+        );
         ctx.imported_short_pure_ops.push(imported);
 
         pass.setup();

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1252,16 +1252,12 @@ impl Optimization for OptPure {
                     continue;
                 }
             }
-            let imported_args = entry
-                .args
-                .iter()
-                .map(|a| match a {
-                    crate::optimizeopt::ImportedShortPureArg::OpRef(r) => BoxRef::from_opref(*r),
-                    crate::optimizeopt::ImportedShortPureArg::Const(_v, source) => {
-                        BoxRef::from_opref(*source)
-                    }
-                })
-                .collect::<Vec<BoxRef>>();
+            // The replay `preamble_op` was built by `ImportedShortPureOp::new`
+            // from the same arg list with producer-bound operands
+            // (shortpreamble.py:425 — the replay op carries the same Box
+            // objects); reuse them instead of re-deriving position-only
+            // echoes from the OpRef table.
+            let imported_args = entry.pop.preamble_op.getarglist();
             let mut imported_op = Op::new(entry.opcode, &imported_args);
             imported_op.pos.set(entry.result);
             if let Some(d) = entry.descr.clone() {
@@ -2652,21 +2648,22 @@ mod tests {
         // without any const_pool / known_constants bridge.
         let const_opref = OpRef::const_int(7);
         ctx.seed_constant(const_opref, majit_ir::Value::Int(7));
-        ctx.imported_short_pure_ops
-            .push(crate::optimizeopt::ImportedShortPureOp::new(
-                OpCode::IntAdd,
-                None,
-                vec![
-                    crate::optimizeopt::ImportedShortPureArg::OpRef(OpRef::int_op(0)),
-                    crate::optimizeopt::ImportedShortPureArg::Const(
-                        majit_ir::Value::Int(7),
-                        const_opref,
-                    ),
-                ],
-                OpRef::int_op(2),
-                OpRef::int_op(2),
-                false,
-            ));
+        let imported = crate::optimizeopt::ImportedShortPureOp::new(
+            &mut ctx,
+            OpCode::IntAdd,
+            None,
+            vec![
+                crate::optimizeopt::ImportedShortPureArg::OpRef(OpRef::int_op(0)),
+                crate::optimizeopt::ImportedShortPureArg::Const(
+                    majit_ir::Value::Int(7),
+                    const_opref,
+                ),
+            ],
+            OpRef::int_op(2),
+            OpRef::int_op(2),
+            false,
+        );
+        ctx.imported_short_pure_ops.push(imported);
 
         pass.setup();
         pass.install_preamble_pure_ops(&ctx);
@@ -2707,6 +2704,7 @@ mod tests {
             ),
         );
         let imported = crate::optimizeopt::ImportedShortPureOp::new(
+            &mut ctx,
             OpCode::CallPureI,
             Some(call_descr.clone()),
             vec![

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -64,7 +64,11 @@ impl Renamer {
                     })
                     .collect();
                 fail_args.clear();
-                fail_args.extend(cloned.into_iter().map(BoxRef::from_opref));
+                fail_args.extend(
+                    cloned
+                        .into_iter()
+                        .map(|r| majit_ir::operand::Operand::Box(BoxRef::from_opref(r))),
+                );
             }
         }
 

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3487,7 +3487,7 @@ impl Optimization for OptRewrite {
                             // `produce_loop_invariant` installs
                             // `make_equal_to(source, result_opref)`, so the source
                             // box's `_forwarded` slot now holds
-                            // `Forwarded::Box(result_box)`.
+                            // `Forwarded::Op(result_op)`.
                             // Build the synthetic SameAsI replay at
                             // `result_opref` (= get_box_replacement(source))
                             // so `take_preamble_forwarded_opinfo` reads the

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -1296,8 +1296,7 @@ impl OptRewrite {
                         {
                             let mask = self.emit_constant_int(ctx, (-1i64).wrapping_shl(c1 as u32));
                             let arg_mask = ctx.materialize_box_at(mask);
-                            let mut new_op =
-                                Op::new(OpCode::IntAnd, &[inner.arg(0), arg_mask]);
+                            let mut new_op = Op::new(OpCode::IntAnd, &[inner.arg(0), arg_mask]);
                             new_op.pos.set(op.pos.get());
                             return OptimizationResult::Emit(new_op);
                         }
@@ -1309,8 +1308,7 @@ impl OptRewrite {
                         {
                             let mask = self.emit_constant_int(ctx, (-1i64).wrapping_shl(c1 as u32));
                             let arg_mask = ctx.materialize_box_at(mask);
-                            let mut new_op =
-                                Op::new(OpCode::IntAnd, &[inner.arg(0), arg_mask]);
+                            let mut new_op = Op::new(OpCode::IntAnd, &[inner.arg(0), arg_mask]);
                             new_op.pos.set(op.pos.get());
                             return OptimizationResult::Emit(new_op);
                         }
@@ -1332,10 +1330,8 @@ impl OptRewrite {
                                     let mask =
                                         self.emit_constant_int(ctx, c2.wrapping_shl(c1 as u32));
                                     let arg_mask = ctx.materialize_box_at(mask);
-                                    let mut new_op = Op::new(
-                                        OpCode::IntAnd,
-                                        &[inner2.arg(0), arg_mask],
-                                    );
+                                    let mut new_op =
+                                        Op::new(OpCode::IntAnd, &[inner2.arg(0), arg_mask]);
                                     new_op.pos.set(op.pos.get());
                                     return OptimizationResult::Emit(new_op);
                                 }
@@ -1348,10 +1344,8 @@ impl OptRewrite {
                                     let mask =
                                         self.emit_constant_int(ctx, c2.wrapping_shl(c1 as u32));
                                     let arg_mask = ctx.materialize_box_at(mask);
-                                    let mut new_op = Op::new(
-                                        OpCode::IntAnd,
-                                        &[inner2.arg(0), arg_mask],
-                                    );
+                                    let mut new_op =
+                                        Op::new(OpCode::IntAnd, &[inner2.arg(0), arg_mask]);
                                     new_op.pos.set(op.pos.get());
                                     return OptimizationResult::Emit(new_op);
                                 }
@@ -1380,10 +1374,8 @@ impl OptRewrite {
                             if c < 64 {
                                 let cv = self.emit_constant_int(ctx, c);
                                 let arg_cv = ctx.materialize_box_at(cv);
-                                let mut new_op = Op::new(
-                                    OpCode::IntLshift,
-                                    &[inner.arg(0), arg_cv],
-                                );
+                                let mut new_op =
+                                    Op::new(OpCode::IntLshift, &[inner.arg(0), arg_cv]);
                                 new_op.pos.set(op.pos.get());
                                 return OptimizationResult::Emit(new_op);
                             }
@@ -1491,8 +1483,7 @@ impl OptRewrite {
                             let c = (c1 + c2).min(63);
                             let cv = self.emit_constant_int(ctx, c);
                             let arg_cv = ctx.materialize_box_at(cv);
-                            let mut new_op =
-                                Op::new(OpCode::IntRshift, &[inner.arg(0), arg_cv]);
+                            let mut new_op = Op::new(OpCode::IntRshift, &[inner.arg(0), arg_cv]);
                             new_op.pos.set(op.pos.get());
                             return OptimizationResult::Emit(new_op);
                         }
@@ -1578,10 +1569,7 @@ impl OptRewrite {
                         let mask = ((-1i64 as u64).wrapping_shl(c as u32) >> (c as u32)) as i64;
                         let mask_ref = self.emit_constant_int(ctx, mask);
                         let arg_mask = ctx.materialize_box_at(mask_ref);
-                        let mut new_op = Op::new(
-                            OpCode::IntAnd,
-                            &[inner.arg(0), arg_mask],
-                        );
+                        let mut new_op = Op::new(OpCode::IntAnd, &[inner.arg(0), arg_mask]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -1725,8 +1713,7 @@ impl OptRewrite {
                 {
                     let zero = self.emit_constant_int(ctx, 0);
                     let arg_zero = ctx.materialize_box_at(zero);
-                    let mut new_op =
-                        Op::new(OpCode::IntLt, &[inner.arg(0), arg_zero]);
+                    let mut new_op = Op::new(OpCode::IntLt, &[inner.arg(0), arg_zero]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }
@@ -2572,8 +2559,7 @@ impl OptRewrite {
                     };
                     if shiftbound.known_nonnegative() && shiftbound.known_lt_const(63) {
                         let arg_shift = ctx.materialize_box_at(shiftvar);
-                        let mut rshift_op =
-                            Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
+                        let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
                         rshift_op.pos.set(op.pos.get());
                         ctx.emit_extra(ctx.current_pass_idx, rshift_op);
                         ctx.last_op_removed = true;
@@ -2611,8 +2597,7 @@ impl OptRewrite {
             let shift = val.trailing_zeros() as i64;
             let shift_const = ctx.make_constant_int(shift);
             let arg_shift = ctx.materialize_box_at(shift_const);
-            let mut rshift_op =
-                Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
+            let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
             rshift_op.pos.set(op.pos.get());
             ctx.emit_extra(ctx.current_pass_idx, rshift_op);
             ctx.last_op_removed = true;
@@ -2847,10 +2832,7 @@ impl OptRewrite {
                 let arg_dest = ctx.materialize_box_at(dest_box);
                 let arg_idx = ctx.materialize_box_at(idx_const);
                 let arg_val = ctx.materialize_box_at(val);
-                let mut setop = Op::new(
-                    OpCode::SetarrayitemGc,
-                    &[arg_dest, arg_idx, arg_val],
-                );
+                let mut setop = Op::new(OpCode::SetarrayitemGc, &[arg_dest, arg_idx, arg_val]);
                 setop.setdescr(arraydescr.clone());
                 ctx.emit_extra(pass_idx, setop);
             }
@@ -3037,8 +3019,7 @@ impl OptRewrite {
                 if Self::is_exact_power_of_two(reciprocal) {
                     let recip_ref = self.emit_constant_float(ctx, reciprocal);
                     let arg_recip = ctx.materialize_box_at(recip_ref);
-                    let mut new_op =
-                        Op::new(OpCode::FloatMul, &[arg0, arg_recip]);
+                    let mut new_op = Op::new(OpCode::FloatMul, &[arg0, arg_recip]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -229,7 +229,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(0);
                         let c = self.emit_constant_int(ctx, c1.wrapping_add(c2));
-                        let mut new_op = Op::new(OpCode::IntAdd, &[x, BoxRef::from_opref(c)]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntAdd, &[x, arg_c]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -252,7 +253,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(0);
                         let c = self.emit_constant_int(ctx, c2.wrapping_sub(c1));
-                        let mut new_op = Op::new(OpCode::IntAdd, &[x, BoxRef::from_opref(c)]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntAdd, &[x, arg_c]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -275,7 +277,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(1);
                         let c = self.emit_constant_int(ctx, c1.wrapping_add(c2));
-                        let mut new_op = Op::new(OpCode::IntSub, &[BoxRef::from_opref(c), x]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntSub, &[arg_c, x]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -286,7 +289,8 @@ impl OptRewrite {
         // x + x -> x << 1
         if ctx.same_box(arg0.to_opref(), arg1.to_opref()) {
             let one = self.emit_constant_int(ctx, 1);
-            let mut new_op = Op::new(OpCode::IntLshift, &[arg0, BoxRef::from_opref(one)]);
+            let arg_one = ctx.materialize_box_at(one);
+            let mut new_op = Op::new(OpCode::IntLshift, &[arg0, arg_one]);
             new_op.pos.set(op.pos.get());
             return OptimizationResult::Emit(new_op);
         }
@@ -358,7 +362,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(0);
                         let c = self.emit_constant_int(ctx, c2.wrapping_sub(c1));
-                        let mut new_op = Op::new(OpCode::IntSub, &[x, BoxRef::from_opref(c)]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntSub, &[x, arg_c]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -406,7 +411,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(0);
                         let c = self.emit_constant_int(ctx, c1.wrapping_add(c2));
-                        let mut new_op = Op::new(OpCode::IntSub, &[x, BoxRef::from_opref(c)]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntSub, &[x, arg_c]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -416,7 +422,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(1);
                         let c = self.emit_constant_int(ctx, c1.wrapping_sub(c2));
-                        let mut new_op = Op::new(OpCode::IntSub, &[BoxRef::from_opref(c), x]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntSub, &[arg_c, x]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -548,7 +555,8 @@ impl OptRewrite {
             if c > 0 && (c & (c - 1)) == 0 {
                 let shift = c.trailing_zeros() as i64;
                 let shift_ref = self.emit_constant_int(ctx, shift);
-                let mut new_op = Op::new(OpCode::IntLshift, &[arg0, BoxRef::from_opref(shift_ref)]);
+                let arg_shift = ctx.materialize_box_at(shift_ref);
+                let mut new_op = Op::new(OpCode::IntLshift, &[arg0, arg_shift]);
                 new_op.pos.set(op.pos.get());
                 return OptimizationResult::Emit(new_op);
             }
@@ -564,11 +572,10 @@ impl OptRewrite {
                 if abs_c.is_power_of_two() {
                     let shift = abs_c.trailing_zeros() as i64;
                     let shift_ref = self.emit_constant_int(ctx, shift);
-                    let shifted = ctx.emit(Op::new(
-                        OpCode::IntLshift,
-                        &[arg0, BoxRef::from_opref(shift_ref)],
-                    ));
-                    let mut neg = Op::new(OpCode::IntNeg, &[BoxRef::from_opref(shifted)]);
+                    let arg_shift = ctx.materialize_box_at(shift_ref);
+                    let shifted = ctx.emit(Op::new(OpCode::IntLshift, &[arg0, arg_shift]));
+                    let arg_shifted = ctx.materialize_box_at(shifted);
+                    let mut neg = Op::new(OpCode::IntNeg, &[arg_shifted]);
                     neg.pos.set(op.pos.get());
                     return OptimizationResult::Emit(neg);
                 }
@@ -581,7 +588,8 @@ impl OptRewrite {
             if c > 0 && (c & (c - 1)) == 0 {
                 let shift = c.trailing_zeros() as i64;
                 let shift_ref = self.emit_constant_int(ctx, shift);
-                let mut new_op = Op::new(OpCode::IntLshift, &[arg1, BoxRef::from_opref(shift_ref)]);
+                let arg_shift = ctx.materialize_box_at(shift_ref);
+                let mut new_op = Op::new(OpCode::IntLshift, &[arg1, arg_shift]);
                 new_op.pos.set(op.pos.get());
                 return OptimizationResult::Emit(new_op);
             }
@@ -681,10 +689,8 @@ impl OptRewrite {
                 // Arithmetic right shift IS floor division for positive divisors.
                 let shift = divisor.trailing_zeros();
                 let shift_ref = self.emit_constant_int(ctx, shift as i64);
-                let result_ref = ctx.emit(Op::new(
-                    OpCode::IntRshift,
-                    &[arg0, BoxRef::from_opref(shift_ref)],
-                ));
+                let arg_shift = ctx.materialize_box_at(shift_ref);
+                let result_ref = ctx.emit(Op::new(OpCode::IntRshift, &[arg0, arg_shift]));
                 let b_old = BoxRef::from_bound_op(op_rc);
                 let b_res = ctx.get_box_replacement(result_ref);
                 ctx.make_equal_to(&b_old, &b_res);
@@ -872,7 +878,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(0);
                         let c = self.emit_constant_int(ctx, c1 & c2);
-                        let mut new_op = Op::new(OpCode::IntAnd, &[x, BoxRef::from_opref(c)]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntAnd, &[x, arg_c]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -1036,7 +1043,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(0);
                         let c = self.emit_constant_int(ctx, c1 | c2);
-                        let mut new_op = Op::new(OpCode::IntOr, &[x, BoxRef::from_opref(c)]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntOr, &[x, arg_c]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -1074,7 +1082,8 @@ impl OptRewrite {
                 ) {
                     let x = inner0.arg(0);
                     let c = self.emit_constant_int(ctx, c1 | c2);
-                    let mut new_op = Op::new(OpCode::IntAnd, &[x, BoxRef::from_opref(c)]);
+                    let arg_c = ctx.materialize_box_at(c);
+                    let mut new_op = Op::new(OpCode::IntAnd, &[x, arg_c]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }
@@ -1186,7 +1195,8 @@ impl OptRewrite {
                     {
                         let x = inner.arg(0);
                         let c = self.emit_constant_int(ctx, c1 ^ c2);
-                        let mut new_op = Op::new(OpCode::IntXor, &[x, BoxRef::from_opref(c)]);
+                        let arg_c = ctx.materialize_box_at(c);
+                        let mut new_op = Op::new(OpCode::IntXor, &[x, arg_c]);
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
                     }
@@ -1285,8 +1295,9 @@ impl OptRewrite {
                             == Some(c1)
                         {
                             let mask = self.emit_constant_int(ctx, (-1i64).wrapping_shl(c1 as u32));
+                            let arg_mask = ctx.materialize_box_at(mask);
                             let mut new_op =
-                                Op::new(OpCode::IntAnd, &[inner.arg(0), BoxRef::from_opref(mask)]);
+                                Op::new(OpCode::IntAnd, &[inner.arg(0), arg_mask]);
                             new_op.pos.set(op.pos.get());
                             return OptimizationResult::Emit(new_op);
                         }
@@ -1297,8 +1308,9 @@ impl OptRewrite {
                             == Some(c1)
                         {
                             let mask = self.emit_constant_int(ctx, (-1i64).wrapping_shl(c1 as u32));
+                            let arg_mask = ctx.materialize_box_at(mask);
                             let mut new_op =
-                                Op::new(OpCode::IntAnd, &[inner.arg(0), BoxRef::from_opref(mask)]);
+                                Op::new(OpCode::IntAnd, &[inner.arg(0), arg_mask]);
                             new_op.pos.set(op.pos.get());
                             return OptimizationResult::Emit(new_op);
                         }
@@ -1319,9 +1331,10 @@ impl OptRewrite {
                                 {
                                     let mask =
                                         self.emit_constant_int(ctx, c2.wrapping_shl(c1 as u32));
+                                    let arg_mask = ctx.materialize_box_at(mask);
                                     let mut new_op = Op::new(
                                         OpCode::IntAnd,
-                                        &[inner2.arg(0), BoxRef::from_opref(mask)],
+                                        &[inner2.arg(0), arg_mask],
                                     );
                                     new_op.pos.set(op.pos.get());
                                     return OptimizationResult::Emit(new_op);
@@ -1334,9 +1347,10 @@ impl OptRewrite {
                                 {
                                     let mask =
                                         self.emit_constant_int(ctx, c2.wrapping_shl(c1 as u32));
+                                    let arg_mask = ctx.materialize_box_at(mask);
                                     let mut new_op = Op::new(
                                         OpCode::IntAnd,
-                                        &[inner2.arg(0), BoxRef::from_opref(mask)],
+                                        &[inner2.arg(0), arg_mask],
                                     );
                                     new_op.pos.set(op.pos.get());
                                     return OptimizationResult::Emit(new_op);
@@ -1365,9 +1379,10 @@ impl OptRewrite {
                             let c = c1 + c2;
                             if c < 64 {
                                 let cv = self.emit_constant_int(ctx, c);
+                                let arg_cv = ctx.materialize_box_at(cv);
                                 let mut new_op = Op::new(
                                     OpCode::IntLshift,
-                                    &[inner.arg(0), BoxRef::from_opref(cv)],
+                                    &[inner.arg(0), arg_cv],
                                 );
                                 new_op.pos.set(op.pos.get());
                                 return OptimizationResult::Emit(new_op);
@@ -1475,8 +1490,9 @@ impl OptRewrite {
                         if (0..64).contains(&c1) && (0..64).contains(&c2) {
                             let c = (c1 + c2).min(63);
                             let cv = self.emit_constant_int(ctx, c);
+                            let arg_cv = ctx.materialize_box_at(cv);
                             let mut new_op =
-                                Op::new(OpCode::IntRshift, &[inner.arg(0), BoxRef::from_opref(cv)]);
+                                Op::new(OpCode::IntRshift, &[inner.arg(0), arg_cv]);
                             new_op.pos.set(op.pos.get());
                             return OptimizationResult::Emit(new_op);
                         }
@@ -1561,9 +1577,10 @@ impl OptRewrite {
                     {
                         let mask = ((-1i64 as u64).wrapping_shl(c as u32) >> (c as u32)) as i64;
                         let mask_ref = self.emit_constant_int(ctx, mask);
+                        let arg_mask = ctx.materialize_box_at(mask_ref);
                         let mut new_op = Op::new(
                             OpCode::IntAnd,
-                            &[inner.arg(0), BoxRef::from_opref(mask_ref)],
+                            &[inner.arg(0), arg_mask],
                         );
                         new_op.pos.set(op.pos.get());
                         return OptimizationResult::Emit(new_op);
@@ -1707,8 +1724,9 @@ impl OptRewrite {
                     == Some(i64::MIN)
                 {
                     let zero = self.emit_constant_int(ctx, 0);
+                    let arg_zero = ctx.materialize_box_at(zero);
                     let mut new_op =
-                        Op::new(OpCode::IntLt, &[inner.arg(0), BoxRef::from_opref(zero)]);
+                        Op::new(OpCode::IntLt, &[inner.arg(0), arg_zero]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }
@@ -2485,7 +2503,8 @@ impl OptRewrite {
         // RPython: replace_op_with + send_extra_operation (routes through passes).
         if val & (val - 1) == 0 {
             let mask = ctx.make_constant_int(val - 1);
-            let mut and_op = Op::new(OpCode::IntAnd, &[arg1, BoxRef::from_opref(mask)]);
+            let arg_mask = ctx.materialize_box_at(mask);
+            let mut and_op = Op::new(OpCode::IntAnd, &[arg1, arg_mask]);
             and_op.pos.set(op.pos.get());
             ctx.emit_extra(ctx.current_pass_idx, and_op);
             ctx.last_op_removed = true;
@@ -2552,8 +2571,9 @@ impl OptRewrite {
                         ctx.getintbound_handle(&b).borrow().clone()
                     };
                     if shiftbound.known_nonnegative() && shiftbound.known_lt_const(63) {
+                        let arg_shift = ctx.materialize_box_at(shiftvar);
                         let mut rshift_op =
-                            Op::new(OpCode::IntRshift, &[arg1, BoxRef::from_opref(shiftvar)]);
+                            Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
                         rshift_op.pos.set(op.pos.get());
                         ctx.emit_extra(ctx.current_pass_idx, rshift_op);
                         ctx.last_op_removed = true;
@@ -2590,8 +2610,9 @@ impl OptRewrite {
         if val & (val - 1) == 0 {
             let shift = val.trailing_zeros() as i64;
             let shift_const = ctx.make_constant_int(shift);
+            let arg_shift = ctx.materialize_box_at(shift_const);
             let mut rshift_op =
-                Op::new(OpCode::IntRshift, &[arg1, BoxRef::from_opref(shift_const)]);
+                Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
             rshift_op.pos.set(op.pos.get());
             ctx.emit_extra(ctx.current_pass_idx, rshift_op);
             ctx.last_op_removed = true;
@@ -2800,13 +2821,9 @@ impl OptRewrite {
                     .unwrap_or(majit_ir::Type::Int);
                 let opcode = OpCode::getarrayitem_for_type(item_type);
                 let idx_const = ctx.make_constant_int(index + source_start);
-                let mut getop = Op::new(
-                    opcode,
-                    &[
-                        BoxRef::from_opref(source_box),
-                        BoxRef::from_opref(idx_const),
-                    ],
-                );
+                let arg_source = ctx.materialize_box_at(source_box);
+                let arg_idx = ctx.materialize_box_at(idx_const);
+                let mut getop = Op::new(opcode, &[arg_source, arg_idx]);
                 getop.setdescr(arraydescr.clone());
                 let pos = ctx.emit_extra(pass_idx, getop);
                 Some(pos)
@@ -2827,13 +2844,12 @@ impl OptRewrite {
             } else {
                 // rewrite.py:666-670: emit SETARRAYITEM_GC
                 let idx_const = ctx.make_constant_int(index + dest_start);
+                let arg_dest = ctx.materialize_box_at(dest_box);
+                let arg_idx = ctx.materialize_box_at(idx_const);
+                let arg_val = ctx.materialize_box_at(val);
                 let mut setop = Op::new(
                     OpCode::SetarrayitemGc,
-                    &[
-                        BoxRef::from_opref(dest_box),
-                        BoxRef::from_opref(idx_const),
-                        BoxRef::from_opref(val),
-                    ],
+                    &[arg_dest, arg_idx, arg_val],
                 );
                 setop.setdescr(arraydescr.clone());
                 ctx.emit_extra(pass_idx, setop);
@@ -3020,8 +3036,9 @@ impl OptRewrite {
                 let reciprocal = 1.0 / divisor;
                 if Self::is_exact_power_of_two(reciprocal) {
                     let recip_ref = self.emit_constant_float(ctx, reciprocal);
+                    let arg_recip = ctx.materialize_box_at(recip_ref);
                     let mut new_op =
-                        Op::new(OpCode::FloatMul, &[arg0, BoxRef::from_opref(recip_ref)]);
+                        Op::new(OpCode::FloatMul, &[arg0, arg_recip]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3500,7 +3500,7 @@ impl Optimization for OptRewrite {
                                 LoopInvariantEntry::Preamble(PreambleOp {
                                     op: source_box,
                                     invented_name: false,
-                                    preamble_op: replay,
+                                    preamble_op: std::rc::Rc::new(replay),
                                 }),
                             );
                         }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3493,7 +3493,7 @@ impl Optimization for OptRewrite {
                             // dual-slot rule (mod.rs:1817 replay_pos).
                             let replay_pos = ctx.get_box_replacement(source).to_opref();
                             let mut replay =
-                                Op::new(OpCode::SameAsI, &[BoxRef::from_opref(source)]);
+                                Op::new(OpCode::SameAsI, &[ctx.materialize_box_at(source)]);
                             replay.pos.set(replay_pos);
                             self.loop_invariant_results.insert(
                                 func_val,

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3492,13 +3492,13 @@ impl Optimization for OptRewrite {
                             // info seeded at result_opref's slot per the
                             // dual-slot rule (mod.rs:1817 replay_pos).
                             let replay_pos = ctx.get_box_replacement(source).to_opref();
-                            let mut replay =
-                                Op::new(OpCode::SameAsI, &[ctx.materialize_box_at(source)]);
+                            let source_box = ctx.materialize_box_at(source);
+                            let mut replay = Op::new(OpCode::SameAsI, &[source_box.clone()]);
                             replay.pos.set(replay_pos);
                             self.loop_invariant_results.insert(
                                 func_val,
                                 LoopInvariantEntry::Preamble(PreambleOp {
-                                    op: source,
+                                    op: source_box,
                                     invented_name: false,
                                     preamble_op: replay,
                                 }),
@@ -3733,7 +3733,7 @@ impl Optimization for OptRewrite {
             .iter()
             .filter_map(|(func_ptr, entry)| match entry {
                 LoopInvariantEntry::Direct(r) => Some((*func_ptr, *r)),
-                LoopInvariantEntry::Preamble(pop) => Some((*func_ptr, pop.op)),
+                LoopInvariantEntry::Preamble(pop) => Some((*func_ptr, pop.op.to_opref())),
             })
             .collect()
     }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -162,7 +162,6 @@ impl ShortPreamble {
             info.walk_const_ptr_refs_mut(visitor);
         }
     }
-
 }
 
 impl ShortPreamble {
@@ -457,7 +456,14 @@ pub struct ShortBoxes {
     /// so we track which OpRefs correspond to constants here.
     known_constants: VecSet<OpRef>,
     /// shortpreamble.py: short_inputargs
-    short_inputargs: Vec<OpRef>,
+    ///
+    /// shortpreamble.py:256 `renamed = OpHelpers.inputarg_from_tp(box.type)`
+    /// mints a fresh producer-less InputArg box per label slot; the stored
+    /// boxes ARE the short preamble's Label args (shortpreamble.py:443).
+    /// pyre keeps the renamed box on the label arg's position (the rename
+    /// is positional), so each entry is a fresh position-only box minted
+    /// once here and compared by position.
+    short_inputargs: Vec<BoxRef>,
     /// shortpreamble.py: boxes_in_production — cycle-detection set
     /// for `materialize_one` recursion. Active set is bounded by
     /// recursion depth (linear scan suffices).
@@ -539,18 +545,20 @@ impl ShortBoxes {
     pub fn with_label_args(label_args: &[OpRef]) -> Self {
         let mut boxes = Self::new(label_args.len());
         for &arg in label_args.iter() {
-            boxes.short_inputargs.push(arg);
+            boxes.short_inputargs.push(BoxRef::from_opref(arg));
         }
         boxes
     }
 
     pub fn lookup_label_arg(&self, opref: OpRef) -> Option<usize> {
-        self.short_inputargs.iter().position(|&a| a == opref)
+        self.short_inputargs
+            .iter()
+            .position(|a| a.to_opref() == opref)
     }
 
     /// RPython parity: check if opref is reachable in the short preamble.
     pub fn is_reachable(&self, opref: OpRef) -> bool {
-        self.short_inputargs.contains(&opref)
+        self.short_inputargs.iter().any(|a| a.to_opref() == opref)
             || opref.is_constant()
             || self.potential_ops.iter().any(|(k, _)| *k == opref)
     }
@@ -668,7 +676,7 @@ impl ShortBoxes {
                 .map(|produced| produced.preamble_op.pos.get());
         }
         // Label args are always available as inputs (RPython: isinstance(op, InputArgIntOp))
-        if self.short_inputargs.contains(&opref) {
+        if self.short_inputargs.iter().any(|a| a.to_opref() == opref) {
             return Some(opref);
         }
         None
@@ -824,7 +832,7 @@ impl ShortBoxes {
     /// Unconditionally returns `self.short_inputargs`. The pyre fallback
     /// to `label_args.to_vec()` on empty was a TODO — empty
     /// short_inputargs is the legitimate empty-loop case in upstream.
-    pub fn create_short_inputargs(&self, _label_args: &[OpRef]) -> Vec<OpRef> {
+    pub fn create_short_inputargs(&self, _label_args: &[OpRef]) -> Vec<BoxRef> {
         self.short_inputargs.clone()
     }
 
@@ -1725,7 +1733,10 @@ struct AbstractShortPreambleBuilderState {
     used_boxes: Vec<OpRef>,
     short_preamble_jump: Vec<majit_ir::OpRc>,
     extra_same_as: Vec<Op>,
-    short_inputargs: Vec<OpRef>,
+    /// shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
+    /// the renamed InputArg boxes; reused verbatim as the Label args
+    /// (shortpreamble.py:443 `ResOperation(rop.LABEL, self.short_inputargs[:])`).
+    short_inputargs: Vec<BoxRef>,
     /// Known constant OpRefs. In RPython, isinstance(box, Const) is a type
     /// check. In majit, constant OpRefs must be explicitly tracked.
     known_constants: VecSet<OpRef>,
@@ -1785,11 +1796,7 @@ impl AbstractShortPreambleBuilderState {
 
     /// Internal: append preamble_op to short (with ovf guard).
     /// Used by add_op_to_short (recursive export-time path).
-    fn append_to_short(
-        &mut self,
-        _result: OpRef,
-        produced: &ProducedShortOp,
-    ) -> majit_ir::OpRc {
+    fn append_to_short(&mut self, _result: OpRef, produced: &ProducedShortOp) -> majit_ir::OpRc {
         let canonical_result = produced.preamble_op.pos.get();
         if self.short_results.contains(&canonical_result) {
             return produced.preamble_op.clone();
@@ -1832,7 +1839,7 @@ impl AbstractShortPreambleBuilderState {
             let arg = arg.to_opref();
             if self.short_results.contains(&arg)
                 || already_in_short.contains(&arg)
-                || self.short_inputargs.contains(&arg)
+                || self.short_inputargs.iter().any(|a| a.to_opref() == arg)
                 || self.known_constants.contains(&arg)
             {
                 continue;
@@ -1975,13 +1982,21 @@ impl ShortPreambleBuilder {
         for (k, v) in short_boxes {
             produced_short_boxes.insert(*k, v.clone());
         }
+        // shortpreamble.py:430 stores the renamed InputArg box objects.
+        // The OpRef slice arrives from exported (position-domain) data, so
+        // mint the position-only boxes once here; every later read (Label
+        // args, membership) shares these box objects.
+        let inputarg_oprefs = if short_inputargs.is_empty() {
+            label_args
+        } else {
+            short_inputargs
+        };
         ShortPreambleBuilder {
             state: AbstractShortPreambleBuilderState {
-                short_inputargs: if short_inputargs.is_empty() {
-                    label_args.to_vec()
-                } else {
-                    short_inputargs.to_vec()
-                },
+                short_inputargs: inputarg_oprefs
+                    .iter()
+                    .map(|&a| BoxRef::from_opref(a))
+                    .collect(),
                 ..AbstractShortPreambleBuilderState::default()
             },
             produced_short_boxes,
@@ -2110,13 +2125,10 @@ impl ShortPreambleBuilder {
 
     pub fn build_short_preamble(&self) -> Vec<Op> {
         let mut result = Vec::with_capacity(self.state.short.len() + 2);
-        let label_args: Vec<BoxRef> = self
-            .state
-            .short_inputargs
-            .iter()
-            .map(|a| BoxRef::from_opref(*a))
-            .collect();
-        result.push(Op::new(OpCode::Label, &label_args));
+        // shortpreamble.py:443 `ResOperation(rop.LABEL,
+        // self.short_inputargs[:])` — the Label args are the stored
+        // renamed-inputarg boxes themselves, not fresh mints.
+        result.push(Op::new(OpCode::Label, &self.state.short_inputargs));
         result.extend(self.state.short.iter().map(|op| (**op).clone()));
         let jump_args: Vec<BoxRef> = self
             .state
@@ -2135,8 +2147,16 @@ impl ShortPreambleBuilder {
             .iter()
             .map(|op| op.pos.get())
             .collect();
+        // ShortPreamble is the cross-phase (position-domain) export;
+        // shed the boxes to their positions at this boundary.
+        let short_inputargs: Vec<OpRef> = self
+            .state
+            .short_inputargs
+            .iter()
+            .map(|a| a.to_opref())
+            .collect();
         build_short_preamble_struct_from_ops(
-            &self.state.short_inputargs,
+            &short_inputargs,
             &self.state.short,
             &self.state.used_boxes,
             &jump_args,
@@ -2155,7 +2175,7 @@ impl ShortPreambleBuilder {
         &self.state.extra_same_as
     }
 
-    pub fn short_inputargs(&self) -> &[OpRef] {
+    pub fn short_inputargs(&self) -> &[BoxRef] {
         &self.state.short_inputargs
     }
 }
@@ -2167,7 +2187,7 @@ impl ShortPreambleBuilder {
 #[derive(Clone, Debug)]
 pub struct ExtendedShortPreambleBuilder {
     produced_short_boxes: VecAssoc<OpRef, ProducedShortOp>,
-    short_inputargs: Vec<OpRef>,
+    short_inputargs: Vec<BoxRef>,
     /// shortpreamble.py:460: self.short = short — single ops list (base + JUMP sentinel)
     short: Vec<Op>,
     /// Tracks which OpRefs are already in `short` (for dedup).
@@ -2216,7 +2236,9 @@ impl ExtendedShortPreambleBuilder {
         for (_, produced) in self.produced_short_boxes.iter_mut() {
             visit_produced(produced, visitor);
         }
-        visit_oprefs(&mut self.short_inputargs, visitor);
+        for arg in &self.short_inputargs {
+            arg.walk_const_ptr_refs(visitor);
+        }
         for op in &mut self.short {
             op.walk_const_ptr_refs_mut(visitor);
         }
@@ -2605,7 +2627,7 @@ impl ExtendedShortPreambleBuilder {
             for arg in preamble_op.getarglist().iter() {
                 let arg = arg.to_opref();
                 if self.short_results.contains(&arg)
-                    || self.short_inputargs.contains(&arg)
+                    || self.short_inputargs.iter().any(|a| a.to_opref() == arg)
                     || self.known_constants.contains(&arg)
                 {
                     continue;
@@ -2644,7 +2666,7 @@ impl ExtendedShortPreambleBuilder {
         self.produced_short_boxes.get(&result).cloned()
     }
 
-    pub fn short_inputargs(&self) -> &[OpRef] {
+    pub fn short_inputargs(&self) -> &[BoxRef] {
         &self.short_inputargs
     }
 
@@ -2654,8 +2676,12 @@ impl ExtendedShortPreambleBuilder {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
+        // ShortPreamble is the cross-phase (position-domain) export;
+        // shed the boxes to their positions at this boundary.
+        let short_inputargs: Vec<OpRef> =
+            self.short_inputargs.iter().map(|a| a.to_opref()).collect();
         let inputargs = if self.label_args.is_empty() {
-            &self.short_inputargs
+            &short_inputargs
         } else {
             &self.label_args
         };
@@ -2665,8 +2691,8 @@ impl ExtendedShortPreambleBuilder {
             &self.used_boxes,
             &self.short_jump_args,
         );
-        if inputargs != &self.short_inputargs {
-            sp.phase1_inputargs = Some(self.short_inputargs.clone());
+        if inputargs != &short_inputargs {
+            sp.phase1_inputargs = Some(short_inputargs);
         }
         sp
     }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -433,7 +433,7 @@ impl PreambleOp {
         };
         Some(ProducedShortOp {
             kind: self.kind.clone(),
-            preamble_op,
+            preamble_op: std::rc::Rc::new(preamble_op),
             invented_name: self.invented_name,
             same_as_source: self.same_as_source.clone(),
         })
@@ -804,7 +804,7 @@ impl ShortBoxes {
             new_op.pos.set(getfield_op.pos.get());
             // shortpreamble.py:279: ProducedShortOp(short_op, preamble_op)
             short_boxes.push(ProducedShortOp {
-                preamble_op: new_op,
+                preamble_op: std::rc::Rc::new(new_op),
                 kind: PreambleOpKind::Heap,
                 invented_name: false,
                 same_as_source: None,
@@ -1081,7 +1081,7 @@ pub struct ShortInputArg {
     /// The result OpRef.
     pub res: OpRef,
     /// The preamble operation that produces this value.
-    pub preamble_op: Op,
+    pub preamble_op: majit_ir::OpRc,
 }
 
 impl ShortInputArg {
@@ -1092,7 +1092,10 @@ impl ShortInputArg {
     pub fn add_op_to_short(&self) -> ProducedShortOp {
         ProducedShortOp {
             kind: PreambleOpKind::InputArg,
-            preamble_op: self.preamble_op.clone(),
+            // Deep-clone: the compound-alias path retags the produced
+            // entry's pos (alt.preamble_op.pos.set) and must not reach
+            // back into this ShortInputArg's stored op.
+            preamble_op: std::rc::Rc::new((*self.preamble_op).clone()),
             invented_name: false,
             same_as_source: None,
         }
@@ -1114,7 +1117,7 @@ pub struct ProducedShortOp {
     /// The short op classification.
     pub kind: PreambleOpKind,
     /// The preamble operation to replay.
-    pub preamble_op: Op,
+    pub preamble_op: majit_ir::OpRc,
     /// Whether this short op uses an invented SameAs result.
     pub invented_name: bool,
     /// Original result this invented name aliases.
@@ -1479,7 +1482,7 @@ impl ProducedShortOp {
             // PreambleOp.op carries the Box itself (shortpreamble.py:12).
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
-            preamble_op: getfield_op.clone(),
+            preamble_op: std::rc::Rc::new(getfield_op.clone()),
         };
         let parent_descr = getfield_op
             .with_field_descr(|fd| fd.get_parent_descr())
@@ -1599,7 +1602,7 @@ impl ProducedShortOp {
             // PreambleOp.op carries the Box itself (shortpreamble.py:12).
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
-            preamble_op: getarrayitem_op.clone(),
+            preamble_op: std::rc::Rc::new(getarrayitem_op.clone()),
         };
         if obj_resolved.is_constant()
             || ctx
@@ -1717,7 +1720,7 @@ impl ProducedShortOp {
 
 #[derive(Clone, Debug, Default)]
 struct AbstractShortPreambleBuilderState {
-    short: Vec<Op>,
+    short: Vec<majit_ir::OpRc>,
     short_results: VecSet<OpRef>,
     used_boxes: Vec<OpRef>,
     short_preamble_jump: Vec<Op>,
@@ -1782,7 +1785,11 @@ impl AbstractShortPreambleBuilderState {
 
     /// Internal: append preamble_op to short (with ovf guard).
     /// Used by add_op_to_short (recursive export-time path).
-    fn append_to_short(&mut self, _result: OpRef, produced: &ProducedShortOp) -> Op {
+    fn append_to_short(
+        &mut self,
+        _result: OpRef,
+        produced: &ProducedShortOp,
+    ) -> majit_ir::OpRc {
         let canonical_result = produced.preamble_op.pos.get();
         if self.short_results.contains(&canonical_result) {
             return produced.preamble_op.clone();
@@ -1791,7 +1798,8 @@ impl AbstractShortPreambleBuilderState {
         self.short_results.insert(canonical_result);
         self.short.push(preamble_op.clone());
         if preamble_op.opcode.is_ovf() {
-            self.short.push(Op::new(OpCode::GuardNoOverflow, &[]));
+            self.short
+                .push(std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[])));
         }
         preamble_op
     }
@@ -1806,7 +1814,7 @@ impl AbstractShortPreambleBuilderState {
     /// args whose Phase-2 OpRefs differ from `produced_short_boxes` keys.
     fn use_box(
         &mut self,
-        preamble_op: &Op,
+        preamble_op: &majit_ir::OpRc,
         already_in_short: &VecSet<OpRef>,
         all_produced: &VecAssoc<OpRef, ProducedShortOp>,
         pos_to_key: &VecAssoc<OpRef, OpRef>,
@@ -1817,7 +1825,7 @@ impl AbstractShortPreambleBuilderState {
         if self.short_results.contains(&canonical_result)
             || already_in_short.contains(&canonical_result)
         {
-            return preamble_op.clone();
+            return (**preamble_op).clone();
         }
         // shortpreamble.py:383-396: iterate preamble_op args
         for arg in preamble_op.getarglist().iter() {
@@ -1845,28 +1853,32 @@ impl AbstractShortPreambleBuilderState {
                     self.short_results.insert(dep_canonical);
                     self.short.push(dep.preamble_op.clone());
                     if dep.preamble_op.opcode.is_ovf() {
-                        self.short.push(Op::new(OpCode::GuardNoOverflow, &[]));
+                        self.short
+                            .push(std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[])));
                     }
                 }
             }
         }
         // shortpreamble.py:389,396: info.make_guards(arg, self.short, optimizer)
-        self.short.extend_from_slice(arg_guards);
+        self.short
+            .extend(arg_guards.iter().cloned().map(std::rc::Rc::new));
         // shortpreamble.py:398: self.short.append(preamble_op)
         self.short_results.insert(canonical_result);
         self.short.push(preamble_op.clone());
         if preamble_op.opcode.is_ovf() {
-            self.short.push(Op::new(OpCode::GuardNoOverflow, &[]));
+            self.short
+                .push(std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[])));
         }
         // shortpreamble.py:405-406: info.make_guards(preamble_op, self.short, optimizer)
-        self.short.extend_from_slice(result_guards);
-        preamble_op.clone()
+        self.short
+            .extend(result_guards.iter().cloned().map(std::rc::Rc::new));
+        (**preamble_op).clone()
     }
 }
 
 fn build_short_preamble_struct_from_ops(
     short_inputargs: &[OpRef],
-    ops: &[Op],
+    ops: &[majit_ir::OpRc],
     used_boxes: &[OpRef],
     jump_args: &[OpRef],
 ) -> ShortPreamble {
@@ -1874,7 +1886,7 @@ fn build_short_preamble_struct_from_ops(
         |arg: &OpRef| -> Option<usize> { short_inputargs.iter().position(|a| a == arg) };
     let entries = ops
         .iter()
-        .cloned()
+        .map(|op| (**op).clone())
         .map(|op| {
             let arg_mapping = op
                 .getarglist()
@@ -1980,7 +1992,11 @@ impl ShortPreambleBuilder {
         self.state.known_constants.insert(opref);
     }
 
-    fn use_box_recursive(&mut self, result: OpRef, visiting: &mut VecSet<OpRef>) -> Option<Op> {
+    fn use_box_recursive(
+        &mut self,
+        result: OpRef,
+        visiting: &mut VecSet<OpRef>,
+    ) -> Option<majit_ir::OpRc> {
         let produced = self.produced_short_boxes.get(&result)?.clone();
         let canonical_result = produced.preamble_op.pos.get();
         if self.state.short_results.contains(&canonical_result) {
@@ -2007,6 +2023,7 @@ impl ShortPreambleBuilder {
     /// export-time create_short_boxes to resolve transitive dependencies.
     pub fn add_op_to_short(&mut self, result: OpRef) -> Option<Op> {
         self.use_box_recursive(result, &mut VecSet::new())
+            .map(|op| (*op).clone())
     }
 
     /// shortpreamble.py:382-407: use_box(box, preamble_op, optimizer)
@@ -2024,19 +2041,19 @@ impl ShortPreambleBuilder {
         result_guards: &[Op],
     ) {
         let preamble_op = match self.produced_short_boxes.get(&source) {
-            Some(produced) => &produced.preamble_op,
+            Some(produced) => produced.preamble_op.clone(),
             None => {
                 if crate::optimizeopt::majit_log_enabled() {
                     eprintln!(
                         "[jit][use_box] produced_short_boxes miss for {source:?}, using fallback"
                     );
                 }
-                fallback_op
+                std::rc::Rc::new(fallback_op.clone())
             }
         };
         let pos_to_key = build_pos_to_key(&self.produced_short_boxes);
         self.state.use_box(
-            preamble_op,
+            &preamble_op,
             &VecSet::new(),
             &self.produced_short_boxes,
             &pos_to_key,
@@ -2100,7 +2117,7 @@ impl ShortPreambleBuilder {
             .map(|a| BoxRef::from_opref(*a))
             .collect();
         result.push(Op::new(OpCode::Label, &label_args));
-        result.extend(self.state.short.iter().cloned());
+        result.extend(self.state.short.iter().map(|op| (**op).clone()));
         let jump_args: Vec<BoxRef> = self
             .state
             .short_preamble_jump
@@ -2388,7 +2405,7 @@ impl ExtendedShortPreambleBuilder {
             return true;
         }
         // Remap dep args on-the-fly (don't mutate produced_short_boxes)
-        let mut dep_op = dep.preamble_op.clone();
+        let mut dep_op = (*dep.preamble_op).clone();
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..dep_op.num_args() {
             let a = dep_op.arg(i);
@@ -2417,7 +2434,7 @@ impl ExtendedShortPreambleBuilder {
         let produced = self.produced_short_boxes.get(&result)?.clone();
         let canonical_result = produced.preamble_op.pos.get();
         if self.short_results.contains(&canonical_result) {
-            return Some(produced.preamble_op);
+            return Some((*produced.preamble_op).clone());
         }
         if !visiting.insert(result) {
             return None;
@@ -2434,7 +2451,7 @@ impl ExtendedShortPreambleBuilder {
         }
         visiting.remove(&result);
         // Append to self.short directly
-        let preamble_op = produced.preamble_op.clone();
+        let preamble_op = (*produced.preamble_op).clone();
         self.short_results.insert(canonical_result);
         self.short.push(preamble_op.clone());
         if preamble_op.opcode.is_ovf() {
@@ -2490,7 +2507,7 @@ impl ExtendedShortPreambleBuilder {
             }
             self.label_args.push(op);
             self.short_jump_args.push(replay_op.pos.get());
-            self.short_preamble_jump.push(replay_op.clone());
+            self.short_preamble_jump.push((**replay_op).clone());
         }
     }
 
@@ -2521,7 +2538,8 @@ impl ExtendedShortPreambleBuilder {
         self.label_args.push(result.to_opref());
         self.used_boxes.push(current_result);
         self.short_jump_args.push(produced.preamble_op.pos.get());
-        self.short_preamble_jump.push(produced.preamble_op.clone());
+        self.short_preamble_jump
+            .push((*produced.preamble_op).clone());
     }
 
     pub fn add_preamble_op(&mut self, result: OpRef) -> bool {
@@ -2567,7 +2585,7 @@ impl ExtendedShortPreambleBuilder {
         result_guards: &[Op],
     ) {
         let raw_op = match self.produced_short_boxes.get(&source) {
-            Some(produced) => produced.preamble_op.clone(),
+            Some(produced) => (*produced.preamble_op).clone(),
             None => {
                 if crate::optimizeopt::majit_log_enabled() {
                     eprintln!(
@@ -2633,7 +2651,10 @@ impl ExtendedShortPreambleBuilder {
 
     pub fn build_short_preamble_struct(&self) -> ShortPreamble {
         // short[..len-1] excludes the JUMP sentinel
-        let ops: Vec<Op> = self.short[..self.short_ops_len()].to_vec();
+        let ops: Vec<majit_ir::OpRc> = self.short[..self.short_ops_len()]
+            .iter()
+            .map(|op| std::rc::Rc::new(op.clone()))
+            .collect();
         let inputargs = if self.label_args.is_empty() {
             &self.short_inputargs
         } else {
@@ -2867,7 +2888,7 @@ pub fn produced_short_boxes_from_exported_boxes(
                 preamble_op.pos.get(),
                 ProducedShortOp {
                     kind: entry.kind.clone(),
-                    preamble_op,
+                    preamble_op: std::rc::Rc::new(preamble_op),
                     invented_name: entry.invented_name,
                     same_as_source: entry.same_as_source.clone(),
                 },
@@ -3309,7 +3330,7 @@ mod tests {
                             ],
                         );
                         op.pos.set(OpRef::int_op(7));
-                        op
+                        std::rc::Rc::new(op)
                     },
                     invented_name: false,
                     same_as_source: None,
@@ -3328,7 +3349,7 @@ mod tests {
                             ],
                         );
                         op.pos.set(OpRef::int_op(8));
-                        op
+                        std::rc::Rc::new(op)
                     },
                     invented_name: false,
                     same_as_source: None,
@@ -3713,7 +3734,7 @@ mod tests {
         let pop = crate::optimizeopt::info::PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(14)),
             invented_name: true,
-            preamble_op: replay_op,
+            preamble_op: std::rc::Rc::new(replay_op),
         };
 
         builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));
@@ -3750,7 +3771,7 @@ mod tests {
         let pop = crate::optimizeopt::info::PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(14)),
             invented_name: true,
-            preamble_op: replay_op,
+            preamble_op: std::rc::Rc::new(replay_op),
         };
 
         builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -561,7 +561,10 @@ impl PotentialShortOp {
                         let alias = ctx.alloc_op_position_typed(tp);
                         alt.preamble_op.pos.set(alias);
                         alt.invented_name = true;
-                        alt.same_as_source = Some(BoxRef::from_opref(compound.res));
+                        // shortpreamble.py:328 `ResOperation(opnum, [shortop.res])`
+                        // — the alias source is the Box itself; resolve to
+                        // the canonical (possibly producer-bound) box.
+                        alt.same_as_source = Some(ctx.materialize_box_at(compound.res));
                         sb.produced_short_boxes.insert(alias, alt.clone());
                     }
                     Some(chosen)

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1527,7 +1527,8 @@ impl ProducedShortOp {
         // of that Box-identity invariant.
         getfield_op.pos.set(result_opref);
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: source,
+            // PreambleOp.op carries the Box itself (shortpreamble.py:12).
+            op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
             preamble_op: getfield_op.clone(),
         };
@@ -1646,7 +1647,8 @@ impl ProducedShortOp {
         // adaptation rationale.
         getarrayitem_op.pos.set(result_opref);
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: source,
+            // PreambleOp.op carries the Box itself (shortpreamble.py:12).
+            op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
             preamble_op: getarrayitem_op.clone(),
         };
@@ -2117,7 +2119,7 @@ impl ShortPreambleBuilder {
         preamble_op: &crate::optimizeopt::info::PreambleOp,
         resolved_op: crate::r#box::BoxRef,
     ) {
-        if let Some(produced) = self.produced_short_boxes.get(&preamble_op.op) {
+        if let Some(produced) = self.produced_short_boxes.get(&preamble_op.op.to_opref()) {
             self.state.record_preamble_use(resolved_op, produced);
         } else {
             // shortpreamble.py:432-440: same 4-line pattern via common helper.
@@ -2126,7 +2128,7 @@ impl ShortPreambleBuilder {
                 resolved_op,
                 replay_op,
                 preamble_op.invented_name,
-                Some(BoxRef::from_opref(preamble_op.op)),
+                Some(preamble_op.op.clone()),
             );
         }
     }
@@ -2519,7 +2521,7 @@ impl ExtendedShortPreambleBuilder {
         {
             resolved_key
         } else {
-            preamble_op.op
+            preamble_op.op.to_opref()
         };
         if let Some(produced) = self.produced_short_boxes.get(&lookup_key).cloned() {
             self.add_tracked_preamble_op(resolved_op, &produced);
@@ -2531,7 +2533,7 @@ impl ExtendedShortPreambleBuilder {
             }
             let op = resolved_key;
             if preamble_op.invented_name {
-                let source = BoxRef::from_opref(preamble_op.op);
+                let source = preamble_op.op.clone();
                 let mut same_as =
                     Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
                 same_as.pos.set(op);
@@ -3816,7 +3818,7 @@ mod tests {
         );
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: OpRef::int_op(14),
+            op: BoxRef::from_opref(OpRef::int_op(14)),
             invented_name: true,
             preamble_op: replay_op,
         };
@@ -3853,7 +3855,7 @@ mod tests {
         );
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: OpRef::int_op(14),
+            op: BoxRef::from_opref(OpRef::int_op(14)),
             invented_name: true,
             preamble_op: replay_op,
         };

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1405,15 +1405,16 @@ impl ProducedShortOp {
         // single-table `imported_short_pure_ops` covers both because
         // `pure.rs` consults it for both arms during `optimize_pure_op` and
         // `optimize_call_pure_*`.
-        ctx.imported_short_pure_ops
-            .push(crate::optimizeopt::ImportedShortPureOp::new(
-                opcode,
-                self.preamble_op.getdescr(),
-                args,
-                result_opref,
-                source,
-                self.invented_name,
-            ));
+        let imported = crate::optimizeopt::ImportedShortPureOp::new(
+            ctx,
+            opcode,
+            self.preamble_op.getdescr(),
+            args,
+            result_opref,
+            source,
+            self.invented_name,
+        );
+        ctx.imported_short_pure_ops.push(imported);
         // shortpreamble.py:432-440 add_preamble_op + 437-438 extra_same_as:
         // RPython collects the SameAs op into `short_preamble_producer.extra_same_as`
         // lazily at use-box time (force_op_from_preamble path).  majit's

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -187,7 +187,8 @@ impl ShortPreamble {
                 for (fail_arg_pos, label_idx) in &entry.fail_arg_mapping {
                     if let Some(bridge_ref) = bridge_args.get(*label_idx) {
                         if *fail_arg_pos < fail_args.len() {
-                            fail_args[*fail_arg_pos] = BoxRef::from_opref(*bridge_ref);
+                            fail_args[*fail_arg_pos] =
+                                majit_ir::operand::Operand::Box(BoxRef::from_opref(*bridge_ref));
                         }
                     }
                 }
@@ -2883,7 +2884,7 @@ pub fn produced_short_boxes_from_exported_boxes(
             if let Some(fail_args) = preamble_op.fail_args_mut() {
                 for arg in fail_args {
                     if let Some(renamed) = inputarg_rename(arg.to_opref()) {
-                        *arg = BoxRef::from_opref(renamed);
+                        *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(renamed));
                     }
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1797,7 +1797,7 @@ impl AbstractShortPreambleBuilderState {
     /// `same_as_source`: the original OpRef this invented name aliases.
     fn record_imported_preamble_use(
         &mut self,
-        op: OpRef,
+        op: crate::r#box::BoxRef,
         replay_op: &Op,
         invented_name: bool,
         same_as_source: Option<crate::r#box::BoxRef>,
@@ -1806,16 +1806,18 @@ impl AbstractShortPreambleBuilderState {
             return;
         }
         if invented_name {
-            let source = same_as_source.unwrap_or_else(|| BoxRef::from_opref(op));
+            // shortpreamble.py:436-437: extra_same_as carries the resolved
+            // box itself; a producer-bound box sheds to a live operand.
+            let source = same_as_source.unwrap_or_else(|| op.clone());
             let mut same_as = Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
-            same_as.pos.set(op);
+            same_as.pos.set(op.to_opref());
             self.extra_same_as.push(same_as);
         }
-        self.used_boxes.push(op);
+        self.used_boxes.push(op.to_opref());
         self.short_preamble_jump.push(replay_op.clone());
     }
 
-    fn record_preamble_use(&mut self, result: OpRef, produced: &ProducedShortOp) {
+    fn record_preamble_use(&mut self, result: crate::r#box::BoxRef, produced: &ProducedShortOp) {
         self.record_imported_preamble_use(
             result,
             &produced.preamble_op,
@@ -2110,7 +2112,7 @@ impl ShortPreambleBuilder {
     pub fn add_preamble_op_from_pop(
         &mut self,
         preamble_op: &crate::optimizeopt::info::PreambleOp,
-        resolved_op: OpRef,
+        resolved_op: crate::r#box::BoxRef,
     ) {
         if let Some(produced) = self.produced_short_boxes.get(&preamble_op.op) {
             self.state.record_preamble_use(resolved_op, produced);
@@ -2130,7 +2132,8 @@ impl ShortPreambleBuilder {
         let Some(produced) = self.produced_short_boxes.get(&result).cloned() else {
             return false;
         };
-        self.state.record_preamble_use(result, &produced);
+        self.state
+            .record_preamble_use(BoxRef::from_opref(result), &produced);
         true
     }
 
@@ -2503,14 +2506,15 @@ impl ExtendedShortPreambleBuilder {
     pub fn add_preamble_op_from_pop(
         &mut self,
         preamble_op: &crate::optimizeopt::info::PreambleOp,
-        resolved_op: OpRef,
+        resolved_op: crate::r#box::BoxRef,
     ) {
+        let resolved_key = resolved_op.to_opref();
         let lookup_key = if self
             .produced_short_boxes
             .iter()
-            .any(|(k, _)| *k == resolved_op)
+            .any(|(k, _)| *k == resolved_key)
         {
-            resolved_op
+            resolved_key
         } else {
             preamble_op.op
         };
@@ -2522,7 +2526,7 @@ impl ExtendedShortPreambleBuilder {
             if !self.recorded_canonical_results.insert(replay_op.pos.get()) {
                 return;
             }
-            let op = resolved_op;
+            let op = resolved_key;
             if preamble_op.invented_name {
                 let source = BoxRef::from_opref(preamble_op.op);
                 let mut same_as =
@@ -2537,16 +2541,22 @@ impl ExtendedShortPreambleBuilder {
     }
 
     /// shortpreamble.py:471-477: add_preamble_op (internal)
-    pub fn add_tracked_preamble_op(&mut self, result: OpRef, produced: &ProducedShortOp) {
+    pub fn add_tracked_preamble_op(
+        &mut self,
+        result: crate::r#box::BoxRef,
+        produced: &ProducedShortOp,
+    ) {
         let current_result = produced.preamble_op.pos.get();
         if !self.recorded_canonical_results.insert(current_result) {
             return;
         }
         if produced.invented_name {
+            // shortpreamble.py:436-437: the resolved box itself is the
+            // SameAs source; a producer-bound box sheds to a live operand.
             let source = produced
                 .same_as_source
                 .clone()
-                .unwrap_or_else(|| BoxRef::from_opref(result));
+                .unwrap_or_else(|| result.clone());
             let mut op = Op::new(
                 OpCode::same_as_for_type(produced.preamble_op.result_type()),
                 &[source],
@@ -2554,7 +2564,7 @@ impl ExtendedShortPreambleBuilder {
             op.pos.set(current_result);
             self.extra_same_as.push(op);
         }
-        self.label_args.push(result);
+        self.label_args.push(result.to_opref());
         self.used_boxes.push(current_result);
         self.short_jump_args.push(produced.preamble_op.pos.get());
         self.short_preamble_jump.push(produced.preamble_op.clone());
@@ -2564,7 +2574,7 @@ impl ExtendedShortPreambleBuilder {
         let Some(produced) = self.produced_short_boxes.get(&result).cloned() else {
             return false;
         };
-        self.add_tracked_preamble_op(result, &produced);
+        self.add_tracked_preamble_op(BoxRef::from_opref(result), &produced);
         true
     }
 
@@ -3808,7 +3818,7 @@ mod tests {
             preamble_op: replay_op,
         };
 
-        builder.add_preamble_op_from_pop(&pop, OpRef::int_op(41));
+        builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));
 
         assert_eq!(builder.used_boxes(), &[OpRef::int_op(41)]);
         assert_eq!(builder.short_preamble_jump().len(), 1);
@@ -3845,7 +3855,7 @@ mod tests {
             preamble_op: replay_op,
         };
 
-        builder.add_preamble_op_from_pop(&pop, OpRef::int_op(41));
+        builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));
 
         assert_eq!(builder.label_args(), &[OpRef::int_op(41)]);
         assert_eq!(builder.jump_args(), &[OpRef::int_op(14)]);

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1480,7 +1480,7 @@ impl ProducedShortOp {
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
         let descr_idx = descr.index();
-        let obj_resolved = ctx.get_box_replacement(obj).to_opref();
+        let obj_resolved = ctx.get_replacement_opref(obj);
         // shortpreamble.py:66-68: if g.getarg(0) in exported_infos:
         //     setinfo_from_preamble(g.getarg(0), exported_infos[...])
         // Pass the Rc handle (unroll.py:61 identity preservation).
@@ -1599,7 +1599,7 @@ impl ProducedShortOp {
         // without relying on the use-before-def assembly adaptation.
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
-        let obj_resolved = ctx.get_box_replacement(obj).to_opref();
+        let obj_resolved = ctx.get_replacement_opref(obj);
         // shortpreamble.py:68-71 applies to both getfield and
         // getarrayitem: if the base object has exported info, import it
         // before ensuring heap/array PtrInfo.

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -416,10 +416,11 @@ impl PreambleOp {
                 //   else:
                 //       preamble_op = ResOperation(sop.getopnum(), [preamble_arg, sop.getarg(1)], descr=sop.getdescr())
                 let preamble_arg = sb.produce_arg(ctx, self.op.arg(0).to_opref())?;
+                let preamble_arg = ctx.materialize_box_at(preamble_arg);
                 let args: smallvec::SmallVec<[BoxRef; 3]> = if self.op.opcode.is_getfield() {
-                    smallvec::smallvec![BoxRef::from_opref(preamble_arg)]
+                    smallvec::smallvec![preamble_arg]
                 } else {
-                    smallvec::smallvec![BoxRef::from_opref(preamble_arg), self.op.arg(1)]
+                    smallvec::smallvec![preamble_arg, self.op.arg(1)]
                 };
                 self.op.copy_and_change(self.op.opcode, Some(&args), None)
             }
@@ -435,7 +436,10 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()).map(BoxRef::from_opref))
+                    .map(|arg| {
+                        sb.produce_arg(ctx, arg.to_opref())
+                            .map(|r| ctx.materialize_box_at(r))
+                    })
                     .collect::<Option<smallvec::SmallVec<[BoxRef; 3]>>>()?;
                 let opnum = if self.op.opcode.is_call() {
                     match self.op.opcode {
@@ -459,7 +463,10 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()).map(BoxRef::from_opref))
+                    .map(|arg| {
+                        sb.produce_arg(ctx, arg.to_opref())
+                            .map(|r| ctx.materialize_box_at(r))
+                    })
                     .collect::<Option<smallvec::SmallVec<[BoxRef; 3]>>>()?;
                 let opnum = match self.op.opcode {
                     OpCode::CallI => OpCode::CallLoopinvariantI,
@@ -644,7 +651,12 @@ impl ShortBoxes {
         );
     }
 
-    pub(crate) fn add_short_input_arg(&mut self, arg: OpRef, arg_type: majit_ir::Type) {
+    pub(crate) fn add_short_input_arg(
+        &mut self,
+        ctx: &mut crate::optimizeopt::OptContext,
+        arg: OpRef,
+        arg_type: majit_ir::Type,
+    ) {
         // shortpreamble.py:255-259 parity: ShortInputArg's BoxType is the
         // intrinsic `box.type` (BoxInt → same_as_i, BoxRef → same_as_r,
         // BoxFloat → same_as_f). A `Void` reaching here is a parity
@@ -657,9 +669,11 @@ impl ShortBoxes {
             );
         }
         let label_arg_idx = self.lookup_label_arg(arg);
+        // shortpreamble.py:257 `ShortInputArg(box, renamed)` — the SAME_AS
+        // replay arg is the label-arg Box itself; bind its producer.
         let mut same_as = Op::new(
             OpCode::same_as_for_type(arg_type),
-            &[BoxRef::from_opref(arg)],
+            &[ctx.materialize_box_at(arg)],
         );
         same_as.pos.set(arg);
         self.potential_ops.insert(
@@ -795,7 +809,7 @@ impl ShortBoxes {
                     label_args.len()
                 )
             });
-            self.add_short_input_arg(arg, arg_type);
+            self.add_short_input_arg(ctx, arg, arg_type);
         }
 
         // shortpreamble.py:261: optimizer.produce_potential_short_preamble_ops(self)
@@ -822,7 +836,7 @@ impl ShortBoxes {
                 continue;
             };
             // shortpreamble.py:277-278: copy_and_change(opnum, [preamble_arg] + args[1:])
-            let mut new_args = vec![BoxRef::from_opref(preamble_arg)];
+            let mut new_args = vec![ctx.materialize_box_at(preamble_arg)];
             new_args.extend_from_slice(&getfield_op.getarglist()[1..]);
             let mut new_op = Op::with_descr(
                 getfield_op.opcode,
@@ -1492,7 +1506,7 @@ impl ProducedShortOp {
         }
         let mut getfield_op = Op::new(
             OpCode::getfield_for_type(result_type),
-            &[BoxRef::from_opref(obj_resolved)],
+            &[ctx.materialize_box_at(obj_resolved)],
         );
         getfield_op.setdescr(descr.clone());
         // Cat-2.2 dual-slot rule (mod.rs:1817 replay_pos): replay.pos =
@@ -1614,8 +1628,8 @@ impl ProducedShortOp {
         let mut getarrayitem_op = Op::new(
             OpCode::getarrayitem_for_type(result_type),
             &[
-                BoxRef::from_opref(obj_resolved),
-                BoxRef::from_opref(index_const),
+                ctx.materialize_box_at(obj_resolved),
+                ctx.materialize_box_at(index_const),
             ],
         );
         getarrayitem_op.setdescr(descr.clone());
@@ -3653,8 +3667,9 @@ mod tests {
 
     #[test]
     fn test_rpython_create_short_boxes_prefers_short_inputarg_over_heap_result() {
+        let mut ctx = crate::optimizeopt::OptContext::new(256);
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(30)]);
-        sb.add_short_input_arg(OpRef::int_op(10), majit_ir::Type::Int);
+        sb.add_short_input_arg(&mut ctx, OpRef::int_op(10), majit_ir::Type::Int);
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -393,7 +393,10 @@ pub struct PreambleOp {
     /// invented SameAs name because another producer won the original slot.
     pub invented_name: bool,
     /// Original result box this invented name aliases, if any.
-    pub same_as_source: Option<OpRef>,
+    /// MIGRATION (#9): carried as a [`BoxRef`] so the canonical
+    /// (possibly producer-bound) box travels with the struct instead
+    /// of being re-minted positionally at each use site.
+    pub same_as_source: Option<crate::r#box::BoxRef>,
 }
 
 impl PreambleOp {
@@ -483,7 +486,7 @@ impl PreambleOp {
             kind: self.kind.clone(),
             preamble_op,
             invented_name: self.invented_name,
-            same_as_source: self.same_as_source,
+            same_as_source: self.same_as_source.clone(),
         })
     }
 }
@@ -558,7 +561,7 @@ impl PotentialShortOp {
                         let alias = ctx.alloc_op_position_typed(tp);
                         alt.preamble_op.pos.set(alias);
                         alt.invented_name = true;
-                        alt.same_as_source = Some(compound.res);
+                        alt.same_as_source = Some(BoxRef::from_opref(compound.res));
                         sb.produced_short_boxes.insert(alias, alt.clone());
                     }
                     Some(chosen)
@@ -1163,7 +1166,8 @@ pub struct ProducedShortOp {
     /// Whether this short op uses an invented SameAs result.
     pub invented_name: bool,
     /// Original result this invented name aliases.
-    pub same_as_source: Option<OpRef>,
+    /// MIGRATION (#9): carried as a [`BoxRef`]; see [`PreambleOp::same_as_source`].
+    pub same_as_source: Option<crate::r#box::BoxRef>,
 }
 
 /// Phase B B.1: helper used by `ProducedShortOp::produce_op` to seed a
@@ -1796,17 +1800,14 @@ impl AbstractShortPreambleBuilderState {
         op: OpRef,
         replay_op: &Op,
         invented_name: bool,
-        same_as_source: Option<OpRef>,
+        same_as_source: Option<crate::r#box::BoxRef>,
     ) {
         if !self.recorded_canonical_results.insert(replay_op.pos.get()) {
             return;
         }
         if invented_name {
-            let source = same_as_source.unwrap_or(op);
-            let mut same_as = Op::new(
-                OpCode::same_as_for_type(replay_op.result_type()),
-                &[BoxRef::from_opref(source)],
-            );
+            let source = same_as_source.unwrap_or_else(|| BoxRef::from_opref(op));
+            let mut same_as = Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
             same_as.pos.set(op);
             self.extra_same_as.push(same_as);
         }
@@ -1819,7 +1820,7 @@ impl AbstractShortPreambleBuilderState {
             result,
             &produced.preamble_op,
             produced.invented_name,
-            produced.same_as_source,
+            produced.same_as_source.clone(),
         );
     }
 
@@ -2120,7 +2121,7 @@ impl ShortPreambleBuilder {
                 resolved_op,
                 replay_op,
                 preamble_op.invented_name,
-                Some(preamble_op.op),
+                Some(BoxRef::from_opref(preamble_op.op)),
             );
         }
     }
@@ -2233,8 +2234,8 @@ impl ExtendedShortPreambleBuilder {
 
         fn visit_produced(produced: &mut ProducedShortOp, visitor: &mut dyn FnMut(&mut GcRef)) {
             produced.preamble_op.walk_const_ptr_refs_mut(visitor);
-            if let Some(source) = produced.same_as_source.as_mut() {
-                visit_opref(source, visitor);
+            if let Some(source) = produced.same_as_source.as_ref() {
+                source.walk_const_ptr_refs(visitor);
             }
         }
 
@@ -2523,11 +2524,9 @@ impl ExtendedShortPreambleBuilder {
             }
             let op = resolved_op;
             if preamble_op.invented_name {
-                let source = preamble_op.op;
-                let mut same_as = Op::new(
-                    OpCode::same_as_for_type(replay_op.result_type()),
-                    &[BoxRef::from_opref(source)],
-                );
+                let source = BoxRef::from_opref(preamble_op.op);
+                let mut same_as =
+                    Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
                 same_as.pos.set(op);
                 self.extra_same_as.push(same_as);
             }
@@ -2544,10 +2543,13 @@ impl ExtendedShortPreambleBuilder {
             return;
         }
         if produced.invented_name {
-            let source = produced.same_as_source.unwrap_or(result);
+            let source = produced
+                .same_as_source
+                .clone()
+                .unwrap_or_else(|| BoxRef::from_opref(result));
             let mut op = Op::new(
                 OpCode::same_as_for_type(produced.preamble_op.result_type()),
-                &[BoxRef::from_opref(source)],
+                &[source],
             );
             op.pos.set(current_result);
             self.extra_same_as.push(op);
@@ -2894,7 +2896,7 @@ pub fn produced_short_boxes_from_exported_boxes(
                     kind: entry.kind.clone(),
                     preamble_op,
                     invented_name: entry.invented_name,
-                    same_as_source: entry.same_as_source,
+                    same_as_source: entry.same_as_source.clone(),
                 },
             )
         })
@@ -3612,7 +3614,10 @@ mod tests {
             .unwrap();
         assert_eq!(alias.1.kind, PreambleOpKind::Heap);
         assert!(alias.1.invented_name);
-        assert_eq!(alias.1.same_as_source, Some(OpRef::int_op(10)));
+        assert_eq!(
+            alias.1.same_as_source.as_ref().map(|b| b.to_opref()),
+            Some(OpRef::int_op(10))
+        );
     }
 
     #[test]
@@ -3659,11 +3664,9 @@ mod tests {
             .collect();
         assert_eq!(aliases.len(), 2);
         assert!(aliases.iter().all(|(_, produced)| produced.invented_name));
-        assert!(
-            aliases
-                .iter()
-                .all(|(_, produced)| produced.same_as_source == Some(OpRef::int_op(20)))
-        );
+        assert!(aliases.iter().all(|(_, produced)| {
+            produced.same_as_source.as_ref().map(|b| b.to_opref()) == Some(OpRef::int_op(20))
+        }));
     }
 
     #[test]
@@ -3697,7 +3700,10 @@ mod tests {
             .unwrap();
         assert_eq!(alias.1.kind, PreambleOpKind::Heap);
         assert!(alias.1.invented_name);
-        assert_eq!(alias.1.same_as_source, Some(OpRef::int_op(10)));
+        assert_eq!(
+            alias.1.same_as_source.as_ref().map(|b| b.to_opref()),
+            Some(OpRef::int_op(10))
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -163,60 +163,9 @@ impl ShortPreamble {
         }
     }
 
-    /// Generate the operations to prepend when a bridge enters the loop.
-    ///
-    /// `bridge_args` are the OpRefs that the bridge provides as values
-    /// for each label arg. The short preamble ops are instantiated with
-    /// these concrete references.
-    pub fn instantiate(&self, bridge_args: &[OpRef]) -> Vec<Op> {
-        let mut result: Vec<Op> = Vec::with_capacity(self.ops.len());
-
-        for entry in &self.ops {
-            let mut op = entry.op.clone();
-
-            // Remap arguments: replace label arg indices with bridge's concrete refs
-            for (arg_pos, label_idx) in &entry.arg_mapping {
-                if let Some(bridge_ref) = bridge_args.get(*label_idx) {
-                    if *arg_pos < op.num_args() {
-                        op.setarg(*arg_pos, BoxRef::from_opref(*bridge_ref));
-                    }
-                }
-            }
-
-            if let Some(fail_args) = op.fail_args_mut() {
-                for (fail_arg_pos, label_idx) in &entry.fail_arg_mapping {
-                    if let Some(bridge_ref) = bridge_args.get(*label_idx) {
-                        if *fail_arg_pos < fail_args.len() {
-                            fail_args[*fail_arg_pos] =
-                                majit_ir::operand::Operand::Box(BoxRef::from_opref(*bridge_ref));
-                        }
-                    }
-                }
-            }
-
-            if op.opcode.is_guard_overflow()
-                && !matches!(result.last(), Some(prev) if prev.opcode.is_ovf())
-            {
-                continue;
-            }
-
-            result.push(op);
-        }
-
-        result
-    }
 }
 
 impl ShortPreamble {
-    /// shortpreamble.py: apply to bridge — prepend instantiated short preamble
-    /// ops to a bridge trace, creating a complete trace that the optimizer
-    /// can process with full preamble context.
-    pub fn apply_to_bridge(&self, bridge_args: &[OpRef], bridge_ops: &[Op]) -> Vec<Op> {
-        let mut result = self.instantiate(bridge_args);
-        result.extend_from_slice(bridge_ops);
-        result
-    }
-
     /// Count guards in the short preamble.
     pub fn num_guards(&self) -> usize {
         self.ops.iter().filter(|e| e.op.opcode.is_guard()).count()
@@ -2901,6 +2850,15 @@ pub fn produced_short_boxes_from_exported_boxes(
             if let Some(fail_args) = preamble_op.fail_args_mut() {
                 for arg in fail_args {
                     if let Some(renamed) = inputarg_rename(arg.to_opref()) {
+                        // Measured dead (PYRE_REMAP_PROBE 2026-06-11: 0 fires
+                        // across check.py corpus + lib tests) — exported short
+                        // boxes carry pure ops/guards without fail_args
+                        // referencing label args. Rewrite kept as a release
+                        // safety net.
+                        debug_assert!(
+                            false,
+                            "imported short-box fail_arg hit inputarg rename: {arg:?}"
+                        );
                         *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(renamed));
                     }
                 }
@@ -3245,71 +3203,6 @@ mod tests {
         assert_eq!(sp.ops[1].op.opcode, OpCode::GuardNonnull);
         assert_eq!(sp.ops[2].op.opcode, OpCode::GuardClass);
         assert_eq!(sp.ops[3].op.opcode, OpCode::IntAdd);
-    }
-
-    #[test]
-    fn test_roundtrip_extract_and_instantiate() {
-        // Full round-trip: peel → extract short preamble → instantiate for bridge
-        let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(
-                OpCode::GuardClass,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::Label,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops, 0);
-
-        let sp = extract_short_preamble(&ops);
-
-        // Instantiate for bridge with new values
-        let bridge_args = &[OpRef::int_op(500), OpRef::int_op(501)];
-        let instantiated = sp.instantiate(bridge_args);
-
-        // 2 guards + 1 pure IntAdd
-        assert_eq!(instantiated.len(), 3);
-
-        // Guard_true now checks bridge's v500 (was v100 → label arg 0)
-        assert_eq!(instantiated[0].opcode, OpCode::GuardTrue);
-        assert_eq!(instantiated[0].arg(0).to_opref(), OpRef::int_op(500));
-
-        // Guard_class now checks bridge's v501 against constant v200
-        assert_eq!(instantiated[1].opcode, OpCode::GuardClass);
-        assert_eq!(instantiated[1].arg(0).to_opref(), OpRef::int_op(501)); // remapped
-        assert_eq!(instantiated[1].arg(1).to_opref(), OpRef::int_op(200)); // constant, unchanged
-
-        // IntAdd with remapped args
-        assert_eq!(instantiated[2].opcode, OpCode::IntAdd);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1723,7 +1723,7 @@ struct AbstractShortPreambleBuilderState {
     short: Vec<majit_ir::OpRc>,
     short_results: VecSet<OpRef>,
     used_boxes: Vec<OpRef>,
-    short_preamble_jump: Vec<Op>,
+    short_preamble_jump: Vec<majit_ir::OpRc>,
     extra_same_as: Vec<Op>,
     short_inputargs: Vec<OpRef>,
     /// Known constant OpRefs. In RPython, isinstance(box, Const) is a type
@@ -1755,7 +1755,7 @@ impl AbstractShortPreambleBuilderState {
     fn record_imported_preamble_use(
         &mut self,
         op: crate::r#box::BoxRef,
-        replay_op: &Op,
+        replay_op: &majit_ir::OpRc,
         invented_name: bool,
         same_as_source: Option<crate::r#box::BoxRef>,
     ) {
@@ -2122,7 +2122,7 @@ impl ShortPreambleBuilder {
             .state
             .short_preamble_jump
             .iter()
-            .map(|op| BoxRef::from_opref(op.pos.get()))
+            .map(BoxRef::from_bound_op)
             .collect();
         result.push(Op::new(OpCode::Jump, &jump_args));
         result
@@ -2147,7 +2147,7 @@ impl ShortPreambleBuilder {
         &self.state.used_boxes
     }
 
-    pub fn short_preamble_jump(&self) -> &[Op] {
+    pub fn short_preamble_jump(&self) -> &[majit_ir::OpRc] {
         &self.state.short_preamble_jump
     }
 
@@ -2175,7 +2175,7 @@ pub struct ExtendedShortPreambleBuilder {
     /// Constants tracked for RPython isinstance(arg, Const) checks.
     known_constants: VecSet<OpRef>,
     extra_same_as: Vec<Op>,
-    short_preamble_jump: Vec<Op>,
+    short_preamble_jump: Vec<majit_ir::OpRc>,
     base_extra_same_as: Vec<Op>,
     label_args: Vec<OpRef>,
     used_boxes: Vec<OpRef>,
@@ -2507,7 +2507,7 @@ impl ExtendedShortPreambleBuilder {
             }
             self.label_args.push(op);
             self.short_jump_args.push(replay_op.pos.get());
-            self.short_preamble_jump.push((**replay_op).clone());
+            self.short_preamble_jump.push(replay_op.clone());
         }
     }
 
@@ -2538,8 +2538,7 @@ impl ExtendedShortPreambleBuilder {
         self.label_args.push(result.to_opref());
         self.used_boxes.push(current_result);
         self.short_jump_args.push(produced.preamble_op.pos.get());
-        self.short_preamble_jump
-            .push((*produced.preamble_op).clone());
+        self.short_preamble_jump.push(produced.preamble_op.clone());
     }
 
     pub fn add_preamble_op(&mut self, result: OpRef) -> bool {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1171,14 +1171,14 @@ impl UnrollOptimizer {
                     // dispatcher, matching optimizer.py:306-319.
                     let resolved_jump_args: Vec<OpRef> = body_jump_args
                         .iter()
-                        .map(|&arg| final_ctx.get_box_replacement(arg).to_opref())
+                        .map(|&arg| final_ctx.get_replacement_opref(arg))
                         .collect();
                     for &arg in &resolved_jump_args {
                         let _ = opt_p2.force_box_for_end_of_preamble(arg, &mut final_ctx);
                     }
                     let forced_jump_args: Vec<OpRef> = body_jump_args
                         .iter()
-                        .map(|&arg| final_ctx.get_box_replacement(arg).to_opref())
+                        .map(|&arg| final_ctx.get_replacement_opref(arg))
                         .collect();
                     let current_vs = crate::optimizeopt::virtualstate::export_state(
                         &forced_jump_args,
@@ -1258,7 +1258,7 @@ impl UnrollOptimizer {
                                 continue;
                             }
                             visited_force.insert(arg);
-                            let resolved = final_ctx.get_box_replacement(arg).to_opref();
+                            let resolved = final_ctx.get_replacement_opref(arg);
                             let needs_force = final_ctx
                                 .potential_extra_ops
                                 .iter()
@@ -1810,9 +1810,7 @@ impl UnrollOptimizer {
     /// unroll.py: _check_no_forwarding(lsts)
     /// Debug assertion: verify no OpRef in the lists has been forwarded.
     pub fn check_no_forwarding(ctx: &crate::optimizeopt::OptContext, oprefs: &[OpRef]) -> bool {
-        oprefs
-            .iter()
-            .all(|&r| ctx.get_box_replacement(r).to_opref() == r)
+        oprefs.iter().all(|&r| ctx.get_replacement_opref(r) == r)
     }
 
     /// unroll.py: disable_retracing_if_max_retrace_guards(ops, target_token)
@@ -2825,7 +2823,7 @@ impl OptUnroll {
         let end_args: Vec<OpRef> = ctx.preamble_end_args.clone().unwrap_or_else(|| {
             original_label_args
                 .iter()
-                .map(|&a| ctx.get_box_replacement(a).to_opref())
+                .map(|&a| ctx.get_replacement_opref(a))
                 .collect()
         });
         // unroll.py:457 `virtual_state = self.get_virtual_state(end_args)`
@@ -2904,7 +2902,7 @@ impl OptUnroll {
         // unroll.py:458 `end_args = [get_box_replacement(arg) for arg in end_args]`.
         let resolved_next_iteration_args: Vec<OpRef> = end_args
             .iter()
-            .map(|&a| ctx.get_box_replacement(a).to_opref())
+            .map(|&a| ctx.get_replacement_opref(a))
             .collect();
         // Phase B B1: `produced_short_boxes` is derived from
         // `exported_short_boxes` lazily at the consumer site
@@ -3028,7 +3026,7 @@ impl OptUnroll {
             crate::optimizeopt::info::OpInfo,
         >,
     ) {
-        let resolved = ctx.get_box_replacement(arg).to_opref();
+        let resolved = ctx.get_replacement_opref(arg);
         if infos.contains_key(&resolved) {
             // Also store under the original key so import_state can
             // find the info using the unresolved next_iteration_args key.
@@ -3217,7 +3215,7 @@ impl OptUnroll {
             .unwrap_or_else(|| crate::optimizeopt::virtualstate::export_state(jump_args, ctx));
         let mut args: Vec<OpRef> = jump_args
             .iter()
-            .map(|&a| ctx.get_box_replacement(a).to_opref())
+            .map(|&a| ctx.get_replacement_opref(a))
             .collect();
 
         for (tt_idx, target_token) in target_tokens.iter_mut().enumerate() {
@@ -3348,7 +3346,7 @@ impl OptUnroll {
                     if force_boxes {
                         args = jump_args
                             .iter()
-                            .map(|&a| ctx.get_box_replacement(a).to_opref())
+                            .map(|&a| ctx.get_replacement_opref(a))
                             .collect();
                         virtual_state = crate::optimizeopt::virtualstate::export_state(&args, ctx);
                     }
@@ -3698,7 +3696,7 @@ impl OptUnroll {
                         } else {
                             *mapping.get(jump_arg).expect("mapping missing jump_arg")
                         };
-                        ctx.get_box_replacement(mapped).to_opref()
+                        ctx.get_replacement_opref(mapped)
                     })
                     .collect();
                 // unroll.py:419-421
@@ -3722,7 +3720,7 @@ impl OptUnroll {
             .iter()
             .map(|&jump_arg| {
                 let mapped = mapping.get(&jump_arg).copied().unwrap_or(jump_arg);
-                ctx.get_box_replacement(mapped).to_opref()
+                ctx.get_replacement_opref(mapped)
             })
             .collect()
     }
@@ -3792,7 +3790,16 @@ impl OptUnroll {
             let b_source = ctx
                 .get_box_replacement_box(source)
                 .expect("import_state source must have a materialized BoxRef slot");
-            let b_target = ctx.get_box_replacement(*target);
+            // `target` is a Phase-1 next-iteration ref whose producer may not
+            // be carried into this rebuilt context; materialize its canonical
+            // host instead of fabricating a position-only box (`make_equal_to`
+            // would re-materialize the unbound target internally anyway —
+            // resolve-or-materialize here keeps the chain target canonical
+            // from the start).
+            let b_target = match ctx.get_box_replacement_box(*target) {
+                Some(b) => b,
+                None => ctx.materialize_box_at(*target),
+            };
             ctx.make_equal_to(&b_source, &b_target);
             if crate::debug::have_debug_prints() {
                 crate::debug::log_one(
@@ -3902,6 +3909,17 @@ impl OptUnroll {
                 | crate::optimizeopt::shortpreamble::PreambleOpKind::Guard => None,
             };
             if let Some(result) = result {
+                // shortpreamble.py:327: `self.res` is a Box object that
+                // exists from import time. The freshly allocated
+                // body-visible result slots (the `alloc_op_position_typed`
+                // arms above) have no producer yet; mint their canonical
+                // `SameAs*` stand-in here so a later `get_box_replacement`
+                // resolves them instead of fabricating a position-only box.
+                // Slot-mapped results (`short_args[slot]`) are already bound
+                // inputargs and resolve without minting.
+                if ctx.get_box_replacement_box(result).is_none() {
+                    ctx.mint_box_at(result);
+                }
                 result_map.insert(*source, result);
             }
         }
@@ -3988,7 +4006,7 @@ impl OptUnroll {
         >,
     ) -> Option<crate::optimizeopt::info::OpInfo> {
         use crate::optimizeopt::info::{OpInfo, PtrInfo};
-        let resolved = ctx.get_box_replacement(opref).to_opref();
+        let resolved = ctx.get_replacement_opref(opref);
         // unroll.py:432-443 `_expand_info` calls `self.optimizer.getinfo(arg)`
         // which itself runs `get_box_replacement` first, so a non-constant
         // OpRef forwarded to a Const surfaces the corresponding constant
@@ -4536,9 +4554,11 @@ fn assemble_peeled_trace_with_jump_args(
                 // Label carries the forwarded Box, but first fall-through
                 // only has the preamble source; pyre's flat OpRef model
                 // needs an explicit SameAs bridge before the Label.
-                if let Some(source) = preamble_defs.iter().copied().find(|&source| {
-                    source != arg && ctx.get_box_replacement(source).to_opref() == arg
-                }) {
+                if let Some(source) = preamble_defs
+                    .iter()
+                    .copied()
+                    .find(|&source| source != arg && ctx.get_replacement_opref(source) == arg)
+                {
                     let tp = ctx
                         .opref_type(arg)
                         .or_else(|| ctx.opref_type(source))
@@ -4660,7 +4680,14 @@ fn assemble_peeled_trace_with_jump_args(
         if let Some(&jump_source) = filtered_extra_jump_args.get(i) {
             if !jump_source.is_none() && jump_source != source_slot {
                 let b_js = ctx.materialize_box_at(jump_source);
-                let b_ela = ctx.get_box_replacement(extended_label_arg);
+                // Chain target: resolve-or-materialize the canonical host
+                // (make_equal_to materializes an unbound target internally;
+                // doing it here keeps the target off the position-only
+                // fabrication path).
+                let b_ela = match ctx.get_box_replacement_box(extended_label_arg) {
+                    Some(b) => b,
+                    None => ctx.materialize_box_at(extended_label_arg),
+                };
                 ctx.make_equal_to(&b_js, &b_ela);
                 assembly_alias_remap.insert(jump_source, extended_label_arg);
             }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3669,7 +3669,7 @@ impl OptUnroll {
                 } else if let Some(fail_args) = new_op.fail_args_mut() {
                     for arg in fail_args.iter_mut() {
                         if let Some(&mapped) = mapping.get(&arg.to_opref()) {
-                            *arg = BoxRef::from_opref(mapped);
+                            *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(mapped));
                         }
                     }
                 }
@@ -4938,7 +4938,7 @@ fn assemble_peeled_trace_with_jump_args(
                     if seen_body_defs.contains(&a.to_opref())
                         && !visible_before_label.contains(&a.to_opref())
                     {
-                        *a = BoxRef::from_opref(mapped);
+                        *a = majit_ir::operand::Operand::Box(BoxRef::from_opref(mapped));
                     }
                 }
             }
@@ -5127,7 +5127,7 @@ impl OptUnroll {
             if let Some(fa) = peeled.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                        *arg = BoxRef::from_opref(new_ref);
+                        *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(new_ref));
                     }
                 }
             }
@@ -5174,7 +5174,7 @@ impl OptUnroll {
             if let Some(fa) = body_op.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                        *arg = BoxRef::from_opref(new_ref);
+                        *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(new_ref));
                     }
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2851,6 +2851,22 @@ impl OptUnroll {
         }
         let mut short_args = label_args.to_vec();
         short_args.extend(virtuals);
+        // unroll.py:480 `short_inputargs = sb.create_short_inputargs(
+        // label_args + virtuals)` — read the ShortBoxes-derived list off the
+        // ctx channel. The preview pass computed it from the same
+        // `label_args + virtuals` (measured identical across the corpus);
+        // paths that never ran the preview (test ExportedState setups) fall
+        // back to the local recompute.
+        let short_inputargs = if ctx.exported_short_inputargs.is_empty() {
+            short_args.clone()
+        } else {
+            debug_assert_eq!(
+                ctx.exported_short_inputargs, short_args,
+                "preview-pass create_short_inputargs diverged from the \
+                 export-site label_args + virtuals recompute"
+            );
+            ctx.exported_short_inputargs.clone()
+        };
         let exported_short_boxes = ctx.exported_short_boxes.clone();
         // unroll.py:466-473 line-by-line:
         //
@@ -2873,7 +2889,7 @@ impl OptUnroll {
         let short_boxes_for_info =
             crate::optimizeopt::shortpreamble::produced_short_boxes_from_exported_boxes(
                 &label_args,
-                &short_args,
+                &short_inputargs,
                 &exported_short_boxes,
             );
         for (_, produced_op) in &short_boxes_for_info {
@@ -2917,7 +2933,7 @@ impl OptUnroll {
             infos,
             exported_short_boxes,
             renamed_inputargs.to_vec(),
-            short_args,
+            short_inputargs,
         );
         // `OptContext::next_pos` is the strict upper bound on raw OpRefs
         // Phase 1 allocated, including intermediates folded / forwarded

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3453,8 +3453,10 @@ impl OptUnroll {
             // unroll.py:357-359: emit JUMP to target
             let mut jump_args = target_args;
             jump_args.extend(extra);
-            let jump_args_box: Vec<BoxRef> =
-                jump_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+            let mut jump_args_box: Vec<BoxRef> = Vec::with_capacity(jump_args.len());
+            for a in &jump_args {
+                jump_args_box.push(ctx.materialize_box_at(*a));
+            }
             let mut jump = Op::new(OpCode::Jump, &jump_args_box);
             jump.setdescr(target_token.as_jump_target_descr());
             optimizer.send_extra_operation(&jump, ctx);
@@ -4358,10 +4360,10 @@ fn assemble_peeled_trace_with_jump_args(
     };
 
     if let Some(start_label_descr) = start_label_descr {
-        let start_label_args_box: Vec<BoxRef> = start_label_args
-            .iter()
-            .map(|a| BoxRef::from_opref(*a))
-            .collect();
+        let mut start_label_args_box: Vec<BoxRef> = Vec::with_capacity(start_label_args.len());
+        for a in start_label_args {
+            start_label_args_box.push(ctx.materialize_box_at(*a));
+        }
         let mut start_label = Op::new(OpCode::Label, &start_label_args_box);
         start_label.pos.set(OpRef::NONE);
         start_label.setdescr(start_label_descr);
@@ -4551,8 +4553,9 @@ fn assemble_peeled_trace_with_jump_args(
                             )
                         });
                     if tp != Type::Void {
+                        let arg_source = ctx.materialize_box_at(source);
                         let mut same_as =
-                            Op::new(OpCode::same_as_for_type(tp), &[BoxRef::from_opref(source)]);
+                            Op::new(OpCode::same_as_for_type(tp), &[arg_source]);
                         same_as.pos.set(arg);
                         fallthrough_aliases.push(same_as);
                     }
@@ -4566,10 +4569,10 @@ fn assemble_peeled_trace_with_jump_args(
         }
     }
 
-    let full_label_args_box: Vec<BoxRef> = full_label_args
-        .iter()
-        .map(|a| BoxRef::from_opref(*a))
-        .collect();
+    let mut full_label_args_box: Vec<BoxRef> = Vec::with_capacity(full_label_args.len());
+    for a in &full_label_args {
+        full_label_args_box.push(ctx.materialize_box_at(*a));
+    }
     let mut label_op = Op::new(OpCode::Label, &full_label_args_box);
     // resoperation.py:260 AbstractResOp.type = 'v' default — Label has no
     // result Box, so its OpRef position carries the Void tag rather than
@@ -4812,10 +4815,11 @@ fn assemble_peeled_trace_with_jump_args(
                 extended_args.push(mapped_arg);
                 original_args.push(BoxRef::from_opref(source_arg));
             }
-            let extended_args_box: smallvec::SmallVec<[BoxRef; 3]> = extended_args
-                .iter()
-                .map(|a| BoxRef::from_opref(*a))
-                .collect();
+            let mut extended_args_box: smallvec::SmallVec<[BoxRef; 3]> =
+                smallvec::SmallVec::with_capacity(extended_args.len());
+            for a in &extended_args {
+                extended_args_box.push(ctx.materialize_box_at(*a));
+            }
             new_op.initarglist(extended_args_box);
         }
         if new_op.opcode == OpCode::Jump {
@@ -4891,8 +4895,11 @@ fn assemble_peeled_trace_with_jump_args(
                 }
             }
             // unroll.py-style bulk replace: jump arity is finalized here.
-            let jump_args_box: smallvec::SmallVec<[BoxRef; 3]> =
-                jump_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+            let mut jump_args_box: smallvec::SmallVec<[BoxRef; 3]> =
+                smallvec::SmallVec::with_capacity(jump_args.len());
+            for a in &jump_args {
+                jump_args_box.push(ctx.materialize_box_at(*a));
+            }
             new_op.initarglist(jump_args_box);
         }
         // RPython resume.py parity: fail_args capture guard-point state

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5596,7 +5596,10 @@ mod tests {
             old_ref,
             ProducedShortOp {
                 kind: PreambleOpKind::Pure,
-                preamble_op: Op::new(OpCode::SameAsR, &[BoxRef::from_opref(old_ref)]),
+                preamble_op: std::rc::Rc::new(Op::new(
+                    OpCode::SameAsR,
+                    &[BoxRef::from_opref(old_ref)],
+                )),
                 invented_name: false,
                 same_as_source: Some(BoxRef::from_opref(old_ref)),
             },

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4554,8 +4554,7 @@ fn assemble_peeled_trace_with_jump_args(
                         });
                     if tp != Type::Void {
                         let arg_source = ctx.materialize_box_at(source);
-                        let mut same_as =
-                            Op::new(OpCode::same_as_for_type(tp), &[arg_source]);
+                        let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[arg_source]);
                         same_as.pos.set(arg);
                         fallthrough_aliases.push(same_as);
                     }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2104,8 +2104,8 @@ impl ExportedState {
             visitor: &mut dyn FnMut(&mut GcRef),
         ) {
             visit_op(&entry.op, visitor);
-            if let Some(source) = entry.same_as_source.as_mut() {
-                visit_opref(source, visitor);
+            if let Some(source) = entry.same_as_source.as_ref() {
+                source.walk_const_ptr_refs(visitor);
             }
         }
 
@@ -2114,8 +2114,8 @@ impl ExportedState {
             visitor: &mut dyn FnMut(&mut GcRef),
         ) {
             visit_op(&produced.preamble_op, visitor);
-            if let Some(source) = produced.same_as_source.as_mut() {
-                visit_opref(source, visitor);
+            if let Some(source) = produced.same_as_source.as_ref() {
+                source.walk_const_ptr_refs(visitor);
             }
         }
 
@@ -2212,8 +2212,8 @@ impl ExportedState {
 
         for preamble_op in &self.exported_short_boxes {
             visit_op(&preamble_op.op, &mut visit);
-            if let Some(source) = preamble_op.same_as_source {
-                visit(source);
+            if let Some(source) = preamble_op.same_as_source.as_ref() {
+                visit(source.to_opref());
             }
         }
 
@@ -4305,10 +4305,7 @@ fn emit_alias_same_as_for_imports(
     imported_short_aliases: &[crate::optimizeopt::ImportedShortAlias],
 ) {
     for alias in imported_short_aliases {
-        let mut op = Op::new(
-            alias.same_as_opcode,
-            &[BoxRef::from_opref(alias.same_as_source)],
-        );
+        let mut op = Op::new(alias.same_as_opcode, &[alias.same_as_source.clone()]);
         op.pos.set(alias.result);
         result.push(op);
     }
@@ -5578,7 +5575,7 @@ mod tests {
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
-                same_as_source: Some(old_ref),
+                same_as_source: Some(BoxRef::from_opref(old_ref)),
             }],
             vec![old_ref],
             vec![old_ref],
@@ -5589,7 +5586,7 @@ mod tests {
                 kind: PreambleOpKind::Pure,
                 preamble_op: Op::new(OpCode::SameAsR, &[BoxRef::from_opref(old_ref)]),
                 invented_name: false,
-                same_as_source: Some(old_ref),
+                same_as_source: Some(BoxRef::from_opref(old_ref)),
             },
         ));
         state.short_box_const_values = short_box_const_values;
@@ -5628,14 +5625,23 @@ mod tests {
         assert_eq!(state.runtime_boxes[0], new_ref);
         assert!(state.exported_infos.get(&new_ref).is_some());
         assert_eq!(state.exported_short_boxes[0].op.arg(0).to_opref(), new_ref);
-        assert_eq!(state.exported_short_boxes[0].same_as_source, Some(new_ref));
+        assert_eq!(
+            state.exported_short_boxes[0]
+                .same_as_source
+                .as_ref()
+                .map(|b| b.to_opref()),
+            Some(new_ref)
+        );
         let produced = state
             .short_boxes
             .iter()
             .find_map(|(key, produced)| (*key == new_ref).then_some(produced))
             .expect("short_boxes key must be forwarded");
         assert_eq!(produced.preamble_op.arg(0).to_opref(), new_ref);
-        assert_eq!(produced.same_as_source, Some(new_ref));
+        assert_eq!(
+            produced.same_as_source.as_ref().map(|b| b.to_opref()),
+            Some(new_ref)
+        );
         assert_eq!(
             state.short_box_const_values.get(&new_ref),
             Some(&Value::Ref(new))
@@ -6725,7 +6731,7 @@ mod tests {
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: true,
-                same_as_source: Some(OpRef::int_op(14)),
+                same_as_source: Some(BoxRef::from_opref(OpRef::int_op(14))),
             });
 
         let exported = export_state(
@@ -6762,7 +6768,7 @@ mod tests {
         let _ = optimizer.force_box(forced, &mut ctx2);
         let aliases = ctx2.used_imported_short_aliases();
         assert_eq!(aliases.len(), 1);
-        assert_eq!(aliases[0].same_as_source, OpRef::int_op(14));
+        assert_eq!(aliases[0].same_as_source.to_opref(), OpRef::int_op(14));
         assert_eq!(aliases[0].same_as_opcode, OpCode::SameAsI);
     }
 
@@ -6804,7 +6810,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: OpRef::int_op(10),
+                same_as_source: BoxRef::from_opref(OpRef::int_op(10)),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecAssoc::new(),
@@ -7022,7 +7028,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: OpRef::int_op(10),
+                same_as_source: BoxRef::from_opref(OpRef::int_op(10)),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecAssoc::new(),
@@ -7183,7 +7189,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: OpRef::int_op(10),
+                same_as_source: BoxRef::from_opref(OpRef::int_op(10)),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecAssoc::new(),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6416,20 +6416,19 @@ mod tests {
         // directly.
         let fresh_const = OpRef::const_ptr(ptr);
         assert_eq!(ctx2.get_constant(fresh_const), Some(Value::Ref(ptr)));
-        assert_eq!(
-            ctx2.imported_short_pure_ops,
-            vec![crate::optimizeopt::ImportedShortPureOp::new(
-                OpCode::GetfieldGcPureI,
-                Some(field_descr.clone()),
-                vec![crate::optimizeopt::ImportedShortPureArg::Const(
-                    Value::Ref(ptr),
-                    fresh_const,
-                )],
-                OpRef::int_op(11),
-                OpRef::int_op(11),
-                false
-            )]
+        let expected = crate::optimizeopt::ImportedShortPureOp::new(
+            &mut ctx2,
+            OpCode::GetfieldGcPureI,
+            Some(field_descr.clone()),
+            vec![crate::optimizeopt::ImportedShortPureArg::Const(
+                Value::Ref(ptr),
+                fresh_const,
+            )],
+            OpRef::int_op(11),
+            OpRef::int_op(11),
+            false,
         );
+        assert_eq!(ctx2.imported_short_pure_ops, vec![expected]);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4016,7 +4016,7 @@ impl OptUnroll {
                 return synthesize_const_info(value);
             }
         }
-        // make_constant mirrors optimizer.py:432 as `Forwarded::Box(constbox)`.
+        // make_constant mirrors optimizer.py:432 as `Forwarded::Const(constval)`.
         // The walker has advanced to the constbox terminal — surface RPython's
         // ConstPtrInfo / FloatConstInfo / IntBound dispatch via const_value().
         let resolved_box = ctx.get_box_replacement_box(opref);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6371,7 +6371,7 @@ mod tests {
             .flatten();
         assert!(pop.is_some(), "PreambleOp must be in PtrInfo._fields");
         let pop = pop.unwrap();
-        assert_eq!(pop.op, OpRef::int_op(11)); // Phase 1 source — pop.op
+        assert_eq!(pop.op.to_opref(), OpRef::int_op(11)); // Phase 1 source — pop.op
         // forwards via make_equal_to to the body-visible OpRef.
         drop(parent);
     }
@@ -6580,7 +6580,7 @@ mod tests {
             .produced_short_op(OpRef::int_op(20))
             .unwrap();
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: OpRef::int_op(20),
+            op: BoxRef::from_opref(OpRef::int_op(20)),
             invented_name: produced.invented_name,
             preamble_op: produced.preamble_op,
         };
@@ -6673,7 +6673,7 @@ mod tests {
         let b_tgt = ctx.get_box_replacement(OpRef::ref_op(14));
         ctx.make_equal_to(&b_src, &b_tgt);
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: OpRef::ref_op(19),
+            op: b_src.clone(),
             invented_name: produced.invented_name,
             preamble_op: produced.preamble_op,
         };

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3669,6 +3669,18 @@ impl OptUnroll {
                 } else if let Some(fail_args) = new_op.fail_args_mut() {
                     for arg in fail_args.iter_mut() {
                         if let Some(&mapped) = mapping.get(&arg.to_opref()) {
+                            // Measured dead (PYRE_REMAP_PROBE 2026-06-11: 0
+                            // fires across check.py corpus + lib tests) —
+                            // only guards carry fail_args and guards take the
+                            // clearfailargs arm above, matching unroll.py:
+                            // 405-414 which has no fail_args handling on the
+                            // non-guard path. Rewrite kept as a release
+                            // safety net.
+                            debug_assert!(
+                                false,
+                                "non-guard short-preamble op carried fail_args: {:?}",
+                                new_op.opcode
+                            );
                             *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(mapped));
                         }
                     }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -1625,13 +1625,9 @@ impl OptVirtualize {
         // `vrefinfo.descr_forced` (the cached `cpu.fielddescrof(...)`
         // Arc from `virtualref.py:42`).
         if !obj_is_null {
-            let mut set_forced = Op::new(
-                OpCode::SetfieldGc,
-                &[
-                    crate::r#box::BoxRef::from_opref(vref_ref),
-                    crate::r#box::BoxRef::from_opref(obj_ref),
-                ],
-            );
+            let arg_vref = ctx.materialize_box_at(vref_ref);
+            let arg_obj = ctx.materialize_box_at(obj_ref);
+            let mut set_forced = Op::new(OpCode::SetfieldGc, &[arg_vref, arg_obj]);
             set_forced.setdescr(self.vrefinfo.descr_forced.clone());
             ctx.emit_extra(ctx.current_pass_idx, set_forced);
         }
@@ -1639,13 +1635,9 @@ impl OptVirtualize {
         // virtualize.py:155-158: set 'virtual_token' to CONST_NULL via
         // `vrefinfo.descr_virtual_token` (`virtualref.py:40-41`).
         let null_ref = ctx.emit_constant_ref(majit_ir::GcRef(0));
-        let mut set_token = Op::new(
-            OpCode::SetfieldGc,
-            &[
-                crate::r#box::BoxRef::from_opref(vref_ref),
-                crate::r#box::BoxRef::from_opref(null_ref),
-            ],
-        );
+        let arg_vref = ctx.materialize_box_at(vref_ref);
+        let arg_null = ctx.materialize_box_at(null_ref);
+        let mut set_token = Op::new(OpCode::SetfieldGc, &[arg_vref, arg_null]);
         set_token.setdescr(self.vrefinfo.descr_virtual_token.clone());
         ctx.emit_extra(ctx.current_pass_idx, set_token);
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -2291,10 +2291,9 @@ impl GuardRequirement {
                 // `ConstInt(ptr2int(obj.typeptr))`, and backend regalloc
                 // reads `op.getarg(1).getint()`.
                 let class_const = ctx.make_constant_int(*expected_class);
-                let mut op = Op::new(
-                    OpCode::GuardClass,
-                    &[BoxRef::from_opref(arg), BoxRef::from_opref(class_const)],
-                );
+                let arg_b = ctx.materialize_box_at(arg);
+                let class_b = ctx.materialize_box_at(class_const);
+                let mut op = Op::new(OpCode::GuardClass, &[arg_b, class_b]);
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2315,10 +2314,9 @@ impl GuardRequirement {
                 // The class operand is the same ConstInt vtable address used
                 // by GUARD_CLASS.
                 let class_const = ctx.make_constant_int(*expected_class);
-                let mut op = Op::new(
-                    OpCode::GuardNonnullClass,
-                    &[BoxRef::from_opref(arg), BoxRef::from_opref(class_const)],
-                );
+                let arg_b = ctx.materialize_box_at(arg);
+                let class_b = ctx.materialize_box_at(class_const);
+                let mut op = Op::new(OpCode::GuardNonnullClass, &[arg_b, class_b]);
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2334,7 +2332,7 @@ impl GuardRequirement {
                         None => return Vec::new(),
                     }
                 };
-                let mut op = Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(arg)]);
+                let mut op = Op::new(OpCode::GuardNonnull, &[ctx.materialize_box_at(arg)]);
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2363,10 +2361,9 @@ impl GuardRequirement {
                     Value::Ref(r) => ctx.make_constant_ref(*r),
                     Value::Void => unreachable!("LEVEL_CONSTANT cannot be Void"),
                 };
-                let mut op = Op::new(
-                    OpCode::GuardValue,
-                    &[BoxRef::from_opref(arg), BoxRef::from_opref(val_const)],
-                );
+                let arg_b = ctx.materialize_box_at(arg);
+                let val_b = ctx.materialize_box_at(val_const);
+                let mut op = Op::new(OpCode::GuardValue, &[arg_b, val_b]);
                 op.setfailargs(Default::default());
                 vec![op]
             }

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -860,7 +860,7 @@ impl VirtualState {
                             .as_ref()
                             .and_then(|info| info.getfield(*field_idx))
                             .and_then(|e| e.as_opref())
-                            .map(|f| ctx.get_box_replacement(f).to_opref())
+                            .map(|f| ctx.get_replacement_opref(f))
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect();
@@ -1011,7 +1011,7 @@ impl VirtualState {
                 //             else:
                 //                 raise VirtualStatesCantMatch
                 //     boxes[self.position_in_notvirtuals] = box
-                let resolved = ctx.get_box_replacement(opref).to_opref();
+                let resolved = ctx.get_replacement_opref(opref);
                 let forced = match ctx
                     .get_box_replacement_box(opref)
                     .as_ref()
@@ -1039,7 +1039,7 @@ impl VirtualState {
                      assigned by enum_top_level"
                 );
                 let slot = slot_i32 as usize;
-                let resolved_for_store = ctx.get_box_replacement(forced).to_opref();
+                let resolved_for_store = ctx.get_replacement_opref(forced);
                 // virtualstate.py:417 NotVirtualStateInfo{Int,Ptr}: Box.type
                 // immutability. RPython dispatches `isinstance(self,
                 // NotVirtualStateInfoInt)` vs `NotVirtualStateInfoPtr` on a
@@ -2493,7 +2493,7 @@ fn export_single_value(
     // distinct field-side OpRefs that resolve to the same forwarded box
     // would each receive their own Rc, breaking the dedup invariant
     // `enum_forced_boxes` and RPython matching rely on.
-    let opref = ctx.get_box_replacement(opref).to_opref();
+    let opref = ctx.get_replacement_opref(opref);
     // virtualstate.py:714-716: cache hit returns the cached state directly.
     if let Some(cached) = cache.finished.get(&opref) {
         return Rc::clone(cached);

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -725,10 +725,7 @@ impl OptString {
                             let pass_idx = ctx.current_pass_idx;
                             let arg_src = ctx.materialize_box_at(src_ref);
                             let arg_index = ctx.materialize_box_at(index_ref);
-                            ctx.emit_extra(
-                                pass_idx,
-                                Op::new(getitem_opcode, &[arg_src, arg_index]),
-                            )
+                            ctx.emit_extra(pass_idx, Op::new(getitem_opcode, &[arg_src, arg_index]))
                         };
                     if dst_virtual {
                         dst_chars.push(Some(char_ref));

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -60,10 +60,9 @@ pub fn _int_add(box1: OpRef, box2: OpRef, ctx: &mut OptContext) -> OpRef {
     {
         return box1;
     }
-    let op = Op::new(
-        OpCode::IntAdd,
-        &[BoxRef::from_opref(box1), BoxRef::from_opref(box2)],
-    );
+    let arg1 = ctx.materialize_box_at(box1);
+    let arg2 = ctx.materialize_box_at(box2);
+    let op = Op::new(OpCode::IntAdd, &[arg1, arg2]);
     ctx.emit_for_force(op)
 }
 
@@ -171,29 +170,23 @@ pub fn copy_str_content(
                         if let Some(ch_val) = from_const {
                             ctx.emit_constant_int(ch_val)
                         } else {
-                            let getitem_op = Op::new(
-                                get_opcode,
-                                &[BoxRef::from_opref(srcbox), BoxRef::from_opref(src_offset)],
-                            );
+                            let arg_src = ctx.materialize_box_at(srcbox);
+                            let arg_off = ctx.materialize_box_at(src_offset);
+                            let getitem_op = Op::new(get_opcode, &[arg_src, arg_off]);
                             ctx.emit_for_force(getitem_op)
                         }
                     } else {
-                        let getitem_op = Op::new(
-                            get_opcode,
-                            &[BoxRef::from_opref(srcbox), BoxRef::from_opref(src_offset)],
-                        );
+                        let arg_src = ctx.materialize_box_at(srcbox);
+                        let arg_off = ctx.materialize_box_at(src_offset);
+                        let getitem_op = Op::new(get_opcode, &[arg_src, arg_off]);
                         ctx.emit_for_force(getitem_op)
                     }
                 };
                 src_offset = _int_add(src_offset, one, ctx);
-                let setitem_op = Op::new(
-                    set_opcode,
-                    &[
-                        BoxRef::from_opref(targetbox),
-                        BoxRef::from_opref(dst_offset),
-                        BoxRef::from_opref(charbox),
-                    ],
-                );
+                let arg_target = ctx.materialize_box_at(targetbox);
+                let arg_dst_off = ctx.materialize_box_at(dst_offset);
+                let arg_char = ctx.materialize_box_at(charbox);
+                let setitem_op = Op::new(set_opcode, &[arg_target, arg_dst_off, arg_char]);
                 ctx.emit_for_force(setitem_op);
                 dst_offset = _int_add(dst_offset, one, ctx);
             }
@@ -207,15 +200,14 @@ pub fn copy_str_content(
     } else {
         offsetbox // caller doesn't need it
     };
+    let arg_src = ctx.materialize_box_at(srcbox);
+    let arg_target = ctx.materialize_box_at(targetbox);
+    let arg_srcoff = ctx.materialize_box_at(srcoffsetbox);
+    let arg_off = ctx.materialize_box_at(offsetbox);
+    let arg_len = ctx.materialize_box_at(lengthbox);
     let copy_op = Op::new(
         copy_opcode,
-        &[
-            BoxRef::from_opref(srcbox),
-            BoxRef::from_opref(targetbox),
-            BoxRef::from_opref(srcoffsetbox),
-            BoxRef::from_opref(offsetbox),
-            BoxRef::from_opref(lengthbox),
-        ],
+        &[arg_src, arg_target, arg_srcoff, arg_off, arg_len],
     );
     ctx.emit_for_force(copy_op);
     next_offset
@@ -287,14 +279,10 @@ pub fn string_copy_parts(
             for ch in &chars {
                 if let Some(ch_ref) = ch {
                     let ch_resolved = ctx.get_box_replacement(*ch_ref).to_opref();
-                    let setitem_op = Op::new(
-                        set_opcode,
-                        &[
-                            BoxRef::from_opref(targetbox),
-                            BoxRef::from_opref(offset),
-                            BoxRef::from_opref(ch_resolved),
-                        ],
-                    );
+                    let arg_target = ctx.materialize_box_at(targetbox);
+                    let arg_offset = ctx.materialize_box_at(offset);
+                    let arg_char = ctx.materialize_box_at(ch_resolved);
+                    let setitem_op = Op::new(set_opcode, &[arg_target, arg_offset, arg_char]);
                     ctx.emit_for_force(setitem_op);
                 }
                 offset = _int_add(offset, one, ctx);
@@ -734,12 +722,12 @@ impl OptString {
                         } else {
                             // vstring.py:580-581 → _strgetitem → emit_extra
                             let index_ref = ctx.make_constant_int(src_start + index);
+                            let pass_idx = ctx.current_pass_idx;
+                            let arg_src = ctx.materialize_box_at(src_ref);
+                            let arg_index = ctx.materialize_box_at(index_ref);
                             ctx.emit_extra(
-                                ctx.current_pass_idx,
-                                Op::new(
-                                    getitem_opcode,
-                                    &[BoxRef::from_opref(src_ref), BoxRef::from_opref(index_ref)],
-                                ),
+                                pass_idx,
+                                Op::new(getitem_opcode, &[arg_src, arg_index]),
                             )
                         };
                     if dst_virtual {
@@ -747,16 +735,13 @@ impl OptString {
                     } else {
                         // vstring.py:585-589: self.emit_extra(new_op)
                         let dst_index_ref = ctx.make_constant_int(dst_start + index);
+                        let pass_idx = ctx.current_pass_idx;
+                        let arg_dst = ctx.materialize_box_at(dst_ref);
+                        let arg_dst_index = ctx.materialize_box_at(dst_index_ref);
+                        let arg_char = ctx.materialize_box_at(char_ref);
                         ctx.emit_extra(
-                            ctx.current_pass_idx,
-                            Op::new(
-                                setitem_opcode,
-                                &[
-                                    BoxRef::from_opref(dst_ref),
-                                    BoxRef::from_opref(dst_index_ref),
-                                    BoxRef::from_opref(char_ref),
-                                ],
-                            ),
+                            pass_idx,
+                            Op::new(setitem_opcode, &[arg_dst, arg_dst_index, arg_char]),
                         );
                     }
                 }
@@ -815,10 +800,9 @@ impl OptString {
                 return self.emit_constant_int(va - vb, ctx);
             }
         }
-        let op = Op::new(
-            OpCode::IntSub,
-            &[BoxRef::from_opref(a), BoxRef::from_opref(b)],
-        );
+        let arg_a = ctx.materialize_box_at(a);
+        let arg_b = ctx.materialize_box_at(b);
+        let op = Op::new(OpCode::IntSub, &[arg_a, arg_b]);
         ctx.emit(op)
     }
 
@@ -1094,10 +1078,9 @@ impl OptString {
                     // vstring.py:747: lengthbox = i1.getstrlen(arg1, self, mode)
                     let lengthbox = ctx.getstrlen_opref(arg1, mode);
                     let zero = ctx.emit_constant_int(0);
-                    let mut eq_op = Op::new(
-                        OpCode::IntEq,
-                        &[BoxRef::from_opref(lengthbox), BoxRef::from_opref(zero)],
-                    );
+                    let arg_len = ctx.materialize_box_at(lengthbox);
+                    let arg_zero = ctx.materialize_box_at(zero);
+                    let mut eq_op = Op::new(OpCode::IntEq, &[arg_len, arg_zero]);
                     eq_op.pos.set(op.pos.get());
                     return Some(OptimizationResult::Emit(eq_op));
                 }
@@ -1120,10 +1103,9 @@ impl OptString {
                     let c1 = self.strgetitem(arg1, 0, ctx);
                     let c2 = self.strgetitem(arg2, 0, ctx);
                     if let (Some(ch1), Some(ch2)) = (c1, c2) {
-                        let mut eq_op = Op::new(
-                            OpCode::IntEq,
-                            &[BoxRef::from_opref(ch1), BoxRef::from_opref(ch2)],
-                        );
+                        let arg_ch1 = ctx.materialize_box_at(ch1);
+                        let arg_ch2 = ctx.materialize_box_at(ch2);
+                        let mut eq_op = Op::new(OpCode::IntEq, &[arg_ch1, arg_ch2]);
                         eq_op.pos.set(op.pos.get());
                         return Some(OptimizationResult::Emit(eq_op));
                     }
@@ -1157,10 +1139,9 @@ impl OptString {
             }
             // vstring.py:784: PTR_EQ against CONST_NULL (ref-null, not int-zero)
             let null_const = ctx.emit_constant_ref(majit_ir::GcRef::NULL);
-            let mut eq_op = Op::new(
-                OpCode::PtrEq,
-                &[BoxRef::from_opref(arg1), BoxRef::from_opref(null_const)],
-            );
+            let arg_a = ctx.materialize_box_at(arg1);
+            let arg_null = ctx.materialize_box_at(null_const);
+            let mut eq_op = Op::new(OpCode::PtrEq, &[arg_a, arg_null]);
             eq_op.pos.set(op.pos.get());
             return Some(OptimizationResult::Emit(eq_op));
         }
@@ -1265,7 +1246,10 @@ impl OptString {
         ctx.make_constant(func_const, Value::Int(func_addr as i64));
         let mut call_args = vec![func_const];
         call_args.extend_from_slice(args);
-        let call_args_box: Vec<BoxRef> = call_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let mut call_args_box: Vec<BoxRef> = Vec::with_capacity(call_args.len());
+        for a in &call_args {
+            call_args_box.push(ctx.materialize_box_at(*a));
+        }
         // vstring.py:854: replace_op_with(result, rop.CALL_I, [...], descr=calldescr)
         let mut call_op = match calldescr {
             Some(d) => Op::with_descr(OpCode::CallI, &call_args_box, d.clone()),

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -200,10 +200,12 @@ impl Trace {
     /// Resolve one operand `OpRef` to its canonical `BoxRef`. Const operands
     /// carry their `Value` inline on the `OpRef` (history.py:227/268/314) and
     /// are minted via `from_opref`; InputArg / ResOp operands resolve to the
-    /// producing `InputArg` / `Op` already held in `self.inputargs` / `self.ops`.
-    /// Falls back to the position-only `from_opref` view for any operand that
-    /// does not resolve to a recorded producer (preserving the prior behavior
-    /// rather than introducing a new index panic).
+    /// producing `InputArg` / `Op` already held in `self.inputargs` / `self.ops`,
+    /// which are dense by construction. A non-const operand that does not resolve
+    /// to a recorded producer is a recorder invariant violation and panics
+    /// (opencoder.py:635/640 assert position rather than mint); the S0/#121 probe
+    /// measured 0 hits across the corpus. `#[cfg(test)]` fixtures that build
+    /// position-only synthetic operands keep the `from_opref` view.
     fn box_for_operand(&self, r: OpRef) -> BoxRef {
         if r.is_none() || r.is_constant() {
             return BoxRef::from_opref(r);
@@ -212,6 +214,15 @@ impl Trace {
             if let Some(ia) = self.inputargs.get(r.raw() as usize) {
                 return BoxRef::from_bound_inputarg(ia);
             }
+            // S3/#124: inputargs are dense `[0, n)`, so an InputArg operand
+            // always resolves above (opencoder.py:635 asserts).
+            #[cfg(not(test))]
+            panic!(
+                "box_for_operand: InputArg operand {r:?} outside dense \
+                 inputargs[0,{}) (opencoder.py:635)",
+                self.inputargs.len()
+            );
+            #[cfg(test)]
             return BoxRef::from_opref(r);
         }
         // ResOp operand: positions are dense in op_count order — inputargs
@@ -226,6 +237,15 @@ impl Trace {
                 }
             }
         }
+        // S3/#124: a ResOp operand always has a dense producer in `ops`
+        // (positions are op_count order; opencoder.py:640 asserts).
+        #[cfg(not(test))]
+        panic!(
+            "box_for_operand: ResOp operand {r:?} has no dense producer in \
+             ops[0,{}) (opencoder.py:640)",
+            self.ops.len()
+        );
+        #[cfg(test)]
         BoxRef::from_opref(r)
     }
 

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -4106,7 +4106,7 @@ impl ResumeDataLoopMemo {
         // The numbering pass that produced this `liveboxes` list already
         // satisfied that invariant. The re-walk below exists for boxes that
         // were further forwarded between numbering and finish (e.g.
-        // `make_equal_to` writing `Forwarded::Box(next_box)`), so the
+        // `make_equal_to` writing a `Forwarded::Op`/`Const` redirect), so the
         // backend sees the final concrete position. It uses
         // get_box_replacement(not_const=True) parity and stops before a Const
         // target; Consts are represented by rd_numb TAGCONST, not backend


### PR DESCRIPTION
Part of #47

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

One step in the #47 box-identity program. It removes several long-standing
position-based fallbacks — `to_opref()`-comparison "crutches", non-canonical
`from_opref` box mints, and the `Forwarded::Box` redirect variant — so that
operand identity resolves only through canonical, `Rc`-bound boxes, and it
adds a new `majit-ir::operand::Operand` union as a **dormant** foundation for
the eventual `Op.args` storage flip.

This is **not** the completion of #47: the `Operand` type is added but not yet
wired into storage (`Op.args` is still `RefCell<SmallVec<[BoxRef; 3]>>` at this
PR's tip), and the side-table re-keying and the storage flip itself remain as
follow-up.

A few commits are behavior-changing on a path the commit messages claim was
empirically never hit (probes over the bench corpus + the metainterp lib
tests). Those "0-hit" / "530-hit" figures are commit-message assertions and are
not reproduced in the diffs themselves; weight them accordingly. Where a
previously-silent fallback is removed, the new code either routes through
canonical materialization or `panic!` / `unreachable!()`, so a wrong invariant
surfaces as a crash rather than a silent miscompile.

### `same_box` no longer falls back to position equality
- **`c6ba9c6`** — drops the OR-ed `|| a.to_opref() == b.to_opref()` arm from
  `intbounds.rs` (`autogen_eq_b` plus the four arithmetic postprocessors
  `postprocess_int_add`, `postprocess_int_add_ovf`, `optimize_int_sub_ovf`,
  `postprocess_int_mul_ovf` x+x / x−x checks), leaving the bare `same_box`
  form and removing the stale doc paragraph. The deleted arm could only ever
  return `true` in *more* cases, so dropping it is decisive exactly when two
  distinct (non-`Rc::ptr_eq`, non-both-const) boxes share a position+type;
  safety rests on the probe claim that this arm was never decisive.
- **`316cc62`** — reduces `OptContext::same_box` to the resolved-box case
  only: `true` only when both operands resolve via `get_box_replacement_box`
  and `BoxRef::same_box` agrees, `false` when either side fails to resolve —
  deleting the unresolved-OpRef-equality and const-value fallbacks (the const
  fallback was already largely redundant, since a `Const` OpRef resolves
  through `resolve_to_boxref` into the surviving `(Some, Some)` arm). The
  `pure.rs` edits are `#[cfg(test)]`-only fixture bindings.

### Canonicalization soundness (remove the last non-canonical box mints)
- **`aec52f3`** — extracts a shared `install_canonical_producer` helper and
  routes `supersede_restart_producer`, `register_extra_producer`,
  `emit_extra`, `send_extra_operation`, and `send_extra_operation_after`
  through it. Two real behavior changes: (1) a superseded stand-in's
  accumulated `_forwarded` is now *migrated* onto the new producer (cloned,
  `Rc::ptr_eq`-guarded against self-clone) instead of being dropped by the old
  `swap_remove`; (2) `register_extra_producer` no longer skips when a stand-in
  is already registered, so a queued/dispatched op now *supersedes* it. The
  migration is a blind `*op.forwarded.borrow_mut() = carried` overwrite whose
  correctness rests on a comment-only (not `debug_assert`-enforced) invariant
  that a producer-less stand-in holds only `None`/`Info`, never a redirect.
  The `getnullness` hunk is a comment-only rewrite.
- **`01df77e`** — makes the two non-const lookup-miss arms of
  `recorder.rs::box_for_operand` (InputArg, ResOp) `#[cfg(not(test))] panic!`
  instead of minting a position-only `BoxRef::from_opref`; `#[cfg(test)]`
  builds keep the fallback. This is wired into the production recorder
  (reached via `box_args` from `record_op` / `record_guard` / `record_jump` /
  `finish`), so a non-dense operand now crashes rather than silently
  fabricating a box. The paired `mod.rs` change is a `get_box_replacement`
  **doc-comment-only** rewrite — its runtime `from_opref` fallback (the
  load-bearing ~530-hit peel-boundary path) is explicitly left in place.
- **`69b3fc5`** — normalizes `newop` in `OptContext::make_equal_to` before
  forward dispatch: a non-constant box bound to neither an Op nor an InputArg
  is replaced by `materialize_box_at(newop.to_opref())`, and the former `else`
  arm (which did `op.set_forwarded_box(...)`) becomes `unreachable!()`. This
  retires the **last non-test production writer** of `Forwarded::Box`.

### Deletion of the `Forwarded::Box` variant
- **`a70de80`** — deletes the `Forwarded::Box(BoxRef)` enum variant and its
  sole (now test-only) writer `set_forwarded_box`, removes the
  `get_box_replacement_impl` chain-walk reader arm and the four metainterp
  reader arms (`has_op_forwarding`, `getrawptrinfo`, `getptrinfo`,
  `getnullness`), and migrates the `box_ref` / metainterp fixtures to
  `set_forwarded_op` / `set_forwarded_const`. Behavior-preserving for
  production — the production retirement already happened in `69b3fc5`, so this
  removes already-dead code; the bulk of the diff is comment rewording. Two
  caveats: the migrated dual-write tests drop their `Forwarded::Box`-slot
  mirror assertions rather than replacing them with `Forwarded::Op`
  equivalents (a small test-coverage reduction), and the always-on
  self-cycle / `Const` `assert!`s inside the deleted `set_forwarded_box` go
  with it (they guarded a test-only function).

### S9 measurement probe (diagnostic, behavior-preserving)
- **`7e14c0f`** — restructures `OptContext::get_box_replacement` into an
  explicit `if-let` that, on the `from_opref` fallback path, calls a new
  `&self` classifier (`classify_s9_fallback`) and an env-gated sink
  (`s9_probe_fire`) before returning the **same** `BoxRef::from_opref(opref)`
  as before. Pure instrument: both new methods are dead unless `PYRE_S9_PROBE`
  is set; when set, `s9_probe_fire` appends to a fixed `/tmp` path. The
  reported fire counts are commit-message-only. No re-keying is done here.

### Operand-union foundation (added, **not** wired into storage)
- **`00118ed`** — adds the dormant `majit-ir::operand::Operand` enum (`None` /
  `Op(OpRc)` / `InputArg(InputArgRc)` / `Const`) carrying producers by strong
  `Rc`, with accessors, constructors, `to_opref` / `to_boxref` / `same_box`,
  and unit tests; registers the module in `lib.rs`. **Zero non-test references
  outside its own module** — it changes no runtime behavior. (`same_box`'s
  `Const` branch uses derived `PartialEq` float equality, matching the
  pre-existing `BoxRef`-const behavior, so it is not a regression, though the
  "mirror" doc claim is imprecise for floats.)
- **`71b926b`** — adds the migration `Operand::Box(BoxRef)` catch-all variant
  with delegating accessor arms, a `from_boxref` classifier, an
  `Operand::walk_const_ptr_refs` (acts only on the `Box` arm), and rewrites
  `same_box` to route both sides through `to_boxref().same_box()`. Still
  dormant: `Op.args` remains `RefCell<SmallVec<[BoxRef; 3]>>` at this PR's tip,
  the GC walk still dispatches to `BoxRef::walk_const_ptr_refs`, and
  `from_boxref` / `Operand::walk_const_ptr_refs` have no non-test callers. The
  actual `Op.args` storage flip is a later commit, not included in this PR.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
"Structural adaptations."
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified forwarding and operand representation across the optimizer and interpreter, standardizing how values and producers are tracked and reducing subtle mismatches.
  * Emitted operations now consistently materialize argument values before use, improving optimization correctness and stability.

* **Public API**
  * Exposes a new operand abstraction module and adds a helper to check whether an argument slot is bound.

* **Tests**
  * Test suite updated to reflect the new forwarding and materialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->