### PR TITLE
hostenv: PyPy-orthodox argument converters across host modules + numeric subclass operator dispatch

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3555,9 +3555,10 @@ pub fn c_uid_t_w(obj: PyObjectRef) -> Result<u32, PyError> {
 
 /// baseobjspace.py:2063 c_filedescriptor_w — an int or an object exposing
 /// a `fileno()` method (deliberately NOT an `__int__`), coerced to a
-/// non-negative C int.
+/// non-negative C int.  `isinstance_w(w_fd, w_int)` accepts a long or an
+/// int subclass as well, so the membership test is `is_int_or_long`.
 pub fn c_filedescriptor_w(obj: PyObjectRef) -> Result<i32, PyError> {
-    let w_fd = if unsafe { pyre_object::pyobject::is_int(obj) } {
+    let w_fd = if unsafe { pyre_object::pyobject::is_int_or_long(obj) } {
         obj
     } else {
         let fileno = getattr_str(obj, "fileno").map_err(|e| {
@@ -3568,7 +3569,7 @@ pub fn c_filedescriptor_w(obj: PyObjectRef) -> Result<i32, PyError> {
             }
         })?;
         let w_fd = crate::builtins::call_and_check(fileno, &[])?;
-        if unsafe { !pyre_object::pyobject::is_int(w_fd) } {
+        if unsafe { !pyre_object::pyobject::is_int_or_long(w_fd) } {
             return Err(PyError::type_error("fileno() returned a non-integer"));
         }
         w_fd

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5654,7 +5654,7 @@ pub fn space_index(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     let Some(method) = (unsafe { lookup(obj, "__index__") }) else {
         return Err(PyError::type_error(format!(
             "'{}' object cannot be interpreted as an integer",
-            unsafe { (*(*obj).ob_type).name },
+            object_functionstr_type_name(obj),
         )));
     };
     let w_result = crate::builtins::call_and_check(method, &[obj])?;
@@ -5663,7 +5663,7 @@ pub fn space_index(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     }
     Err(PyError::type_error(format!(
         "__index__ returned non-int (type {})",
-        unsafe { (*(*w_result).ob_type).name },
+        object_functionstr_type_name(w_result),
     )))
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -639,7 +639,7 @@ pub fn is_true(obj: PyObjectRef) -> bool {
             return pyre_object::w_set_len(obj) > 0;
         }
         if pyre_object::is_w_range(obj) {
-            return pyre_object::w_range_len(obj) > 0;
+            return pyre_object::w_range_bool(obj);
         }
         if is_none(obj) {
             return false;
@@ -1045,43 +1045,139 @@ unsafe fn getitem_instance(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     )))
 }
 
-/// Read the `i64` value of an `int` or `bool` object.  `is_int` reports
-/// `True` for `bool` (a subtype of `int`), but `bool` stores its payload
-/// in a distinct struct layout, so the value must be read through the
-/// matching accessor rather than `w_int_get_value`.
-#[inline]
-unsafe fn int_or_bool_value(obj: PyObjectRef) -> i64 {
-    if is_bool(obj) {
-        w_bool_get_value(obj) as i64
-    } else {
-        w_int_get_value(obj)
-    }
-}
-
 #[inline(never)]
 /// `rangeobject.py W_RangeObject.descr_getitem` — integer index returns
 /// the member `start + i*step` (negative folded, bounds-checked); a slice
-/// returns a NEW `range` object, not a list.
+/// returns a NEW `range` object, not a list.  Indices and members are
+/// kept in bignum so a range past a machine word is still subscriptable.
 unsafe fn getitem_range(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
-    let (rstart, _rstop, rstep) = pyre_object::w_range_fields(obj);
-    let len = pyre_object::w_range_len(obj);
-    if is_int(index) {
-        return match pyre_object::w_range_getitem(obj, int_or_bool_value(index)) {
-            Some(v) => Ok(w_int_new(v)),
-            None => Err(PyError::new(
-                PyErrorKind::IndexError,
-                "range object index out of range",
-            )),
-        };
-    }
     if is_slice(index) {
-        let (sstart, sstop, sstep) = normalize_slice(index, len)?;
-        let new_start = rstart + sstart * rstep;
-        let new_stop = rstart + sstop * rstep;
-        let new_step = rstep * sstep;
-        return Ok(pyre_object::w_range_new(new_start, new_stop, new_step));
+        return range_compute_slice(obj, index);
     }
-    Err(index_type_error("range", index))
+    // `_compute_item` — `space.index(w_index)` then bounds-check.
+    let w_index = space_index(index)?;
+    let idx = pyre_object::range_obj_to_bigint(w_index);
+    match pyre_object::w_range_compute_item(obj, &idx) {
+        Some(v) => Ok(v),
+        None => Err(PyError::new(
+            PyErrorKind::IndexError,
+            "range object index out of range",
+        )),
+    }
+}
+
+/// `rangeobject.py compute_slice_indices3` — resolve a slice's
+/// (start, stop, step) against a wrapped `length`, in bignum.
+unsafe fn compute_slice_indices3_big(
+    slice: PyObjectRef,
+    length: &BigInt,
+) -> Result<(BigInt, BigInt, BigInt), PyError> {
+    use num_traits::{One, Zero};
+    let zero = BigInt::zero();
+    let one = BigInt::one();
+    let w_step = w_slice_get_step(slice);
+    let step = if is_none(w_step) {
+        one.clone()
+    } else {
+        let s = pyre_object::range_obj_to_bigint(space_index(w_step)?);
+        if s.is_zero() {
+            return Err(PyError::new(
+                PyErrorKind::ValueError,
+                "slice step cannot be zero",
+            ));
+        }
+        s
+    };
+    let negative_step = step < zero;
+    let w_start = w_slice_get_start(slice);
+    let start = if is_none(w_start) {
+        if negative_step {
+            length - &one
+        } else {
+            zero.clone()
+        }
+    } else {
+        let st = pyre_object::range_obj_to_bigint(space_index(w_start)?);
+        if st < zero {
+            let st = st + length;
+            if st < zero {
+                if negative_step {
+                    -one.clone()
+                } else {
+                    zero.clone()
+                }
+            } else {
+                st
+            }
+        } else if st >= *length {
+            if negative_step {
+                length - &one
+            } else {
+                length.clone()
+            }
+        } else {
+            st
+        }
+    };
+    let w_stop = w_slice_get_stop(slice);
+    let stop = if is_none(w_stop) {
+        if negative_step {
+            -one.clone()
+        } else {
+            length.clone()
+        }
+    } else {
+        let sp = pyre_object::range_obj_to_bigint(space_index(w_stop)?);
+        if sp < zero {
+            let sp = sp + length;
+            if sp < zero {
+                if negative_step {
+                    -one.clone()
+                } else {
+                    zero.clone()
+                }
+            } else {
+                sp
+            }
+        } else if sp >= *length {
+            if negative_step {
+                length - &one
+            } else {
+                length.clone()
+            }
+        } else {
+            sp
+        }
+    };
+    Ok((start, stop, step))
+}
+
+/// `rangeobject.py W_RangeObject._compute_slice` — build the NEW `range`
+/// a slice of `obj` denotes.
+unsafe fn range_compute_slice(obj: PyObjectRef, slice: PyObjectRef) -> PyResult {
+    use num_traits::Zero;
+    let len_b = pyre_object::range_obj_to_bigint(pyre_object::w_range_length(obj));
+    let (sl_start, sl_stop, sl_step) = compute_slice_indices3_big(slice, &len_b)?;
+    let (rstart, _rstop, rstep) = pyre_object::w_range_fields(obj);
+    let rstart_b = pyre_object::range_obj_to_bigint(rstart);
+    let rstep_b = pyre_object::range_obj_to_bigint(rstep);
+    let stop_is_zero = sl_stop.is_zero();
+    let substart = &rstart_b + &sl_start * &rstep_b;
+    let substep = &rstep_b * &sl_step;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let w_substart = pyre_object::range_bigint_to_obj(substart);
+    pyre_object::gc_roots::pin_root(w_substart);
+    let w_substep = pyre_object::range_bigint_to_obj(substep);
+    pyre_object::gc_roots::pin_root(w_substep);
+    let w_substop = if stop_is_zero {
+        w_substart
+    } else {
+        let substop = &rstart_b + &sl_stop * &rstep_b;
+        let o = pyre_object::range_bigint_to_obj(substop);
+        pyre_object::gc_roots::pin_root(o);
+        o
+    };
+    Ok(pyre_object::w_range_new(w_substart, w_substop, w_substep))
 }
 
 /// `range.count(value)` — `rangeobject.py W_RangeObject.descr_count`.
@@ -1096,45 +1192,47 @@ fn range_index_method(args: &[PyObjectRef]) -> PyResult {
     let obj = args[0];
     let needle = args.get(1).copied().unwrap_or(PY_NULL);
     unsafe {
-        let (start, _stop, step) = pyre_object::w_range_fields(obj);
-        let len = pyre_object::w_range_len(obj);
-        if is_int(needle) {
-            let v = int_or_bool_value(needle);
-            if pyre_object::w_range_contains_int(obj, v) {
-                return Ok(w_int_new((v - start) / step));
+        // int / bool / long needle → O(1) `(value - start) // step`.
+        if is_int(needle) || is_long(needle) {
+            let item = pyre_object::range_obj_to_bigint(needle);
+            if pyre_object::w_range_contains_bigint(obj, &item) {
+                return Ok(pyre_object::w_range_index_of(obj, &item));
             }
             return Err(PyError::value_error(format!(
                 "{} is not in range",
                 crate::display::py_repr(needle)
             )));
         }
-        for i in 0..len {
-            if is_true(compare(w_int_new(start + i * step), needle, CompareOp::Eq)?) {
-                return Ok(w_int_new(i));
+        // `space.sequence_index` — elementwise scan.
+        let it = iter(obj)?;
+        let mut i: i64 = 0;
+        loop {
+            match next(it) {
+                Ok(item) => {
+                    if is_true(compare(item, needle, CompareOp::Eq)?) {
+                        return Ok(w_int_new(i));
+                    }
+                    i += 1;
+                }
+                Err(e) if e.kind == PyErrorKind::StopIteration => break,
+                Err(e) => return Err(e),
             }
         }
     }
-    Err(PyError::value_error(
-        "sequence.index(x): x not in sequence".to_string(),
-    ))
+    Err(PyError::value_error(format!(
+        "{} is not in range",
+        unsafe { crate::display::py_repr(needle) }
+    )))
 }
 
-/// `range.__iter__()` — fresh `W_RangeIterator` cursor.
+/// `range.__iter__()` — fresh `rangeiterator` / `longrange_iterator`.
 fn range_iter_method(args: &[PyObjectRef]) -> PyResult {
     iter(args[0])
 }
 
 /// `range.__reversed__()` — `rangeobject.py W_RangeObject.descr_reversed`.
 fn range_reversed_method(args: &[PyObjectRef]) -> PyResult {
-    unsafe {
-        let (start, _stop, step) = pyre_object::w_range_fields(args[0]);
-        let len = pyre_object::w_range_len(args[0]);
-        if len == 0 {
-            return Ok(pyre_object::w_range_iter_new(0, 0, 1));
-        }
-        let last = start + (len - 1) * step;
-        Ok(pyre_object::w_range_iter_new(last, start - step, -step))
-    }
+    unsafe { Ok(pyre_object::w_range_reversed(args[0])) }
 }
 
 /// `range.__reduce__()` — `functional.py W_Range.descr_reduce`:
@@ -1143,7 +1241,7 @@ fn range_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let (start, stop, step) = unsafe { pyre_object::w_range_fields(args[0]) };
     let range_type =
         crate::typedef::gettypefor(&pyre_object::rangeobject::RANGE_TYPE).unwrap_or(PY_NULL);
-    let state = w_tuple_new(vec![w_int_new(start), w_int_new(stop), w_int_new(step)]);
+    let state = w_tuple_new(vec![start, stop, step]);
     Ok(w_tuple_new(vec![range_type, state]))
 }
 
@@ -1152,14 +1250,16 @@ fn range_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// for empty (`(len, None, None)`) and single-element (`(len, start,
 /// None)`) ranges so equal ranges hash equal.
 fn range_hash_method(args: &[PyObjectRef]) -> PyResult {
+    use num_traits::Zero;
     let (start, _stop, step) = unsafe { pyre_object::w_range_fields(args[0]) };
-    let len = unsafe { pyre_object::w_range_len(args[0]) };
-    let items = if len == 0 {
-        vec![w_int_new(0), w_none(), w_none()]
-    } else if len == 1 {
-        vec![w_int_new(1), w_int_new(start), w_none()]
+    let len_obj = unsafe { pyre_object::w_range_length(args[0]) };
+    let len = unsafe { pyre_object::range_obj_to_bigint(len_obj) };
+    let items = if len.is_zero() {
+        vec![len_obj, w_none(), w_none()]
+    } else if len == BigInt::from(1) {
+        vec![len_obj, start, w_none()]
     } else {
-        vec![w_int_new(len), w_int_new(start), w_int_new(step)]
+        vec![len_obj, start, step]
     };
     Ok(w_int_new(hash_w_strict(w_tuple_new(items))?))
 }
@@ -1522,8 +1622,20 @@ pub fn len(obj: PyObjectRef) -> PyResult {
                 pyre_object::bytesobject::bytes_like_len(obj) as i64
             ))
         } else if pyre_object::is_w_range(obj) {
-            // `rangeobject.py W_RangeObject.descr_len → self.w_length`.
-            Ok(w_int_new(pyre_object::w_range_len(obj)))
+            // `descr_len → self.w_length`, then `_check_len_result` →
+            // `getindex_w(w_int, w_OverflowError)`: `len()` must fit a
+            // machine word, so a bignum-length range raises OverflowError.
+            match pyre_object::w_range_length_i64(obj) {
+                Some(n) => Ok(w_int_new(n)),
+                None => Err(PyError::overflow_error(
+                    "cannot fit 'int' into an index-sized integer",
+                )),
+            }
+        } else if pyre_object::is_long_range_iter(obj) {
+            // `iterobject.py W_LongRangeIterator.descr_len → w_len - w_index`.
+            Ok(pyre_object::range_bigint_to_obj(
+                pyre_object::w_long_range_iter_len(obj),
+            ))
         } else if is_range_iter(obj) {
             // `iterobject.py W_AbstractSeqIterObject.descr_length_hint`
             // — the iterator reports its REMAINING count, derived from
@@ -1987,12 +2099,11 @@ pub fn getattr_str(obj: PyObjectRef, name: &str) -> PyResult {
             match name {
                 "start" | "stop" | "step" => {
                     let (start, stop, step) = pyre_object::w_range_fields(obj);
-                    let v = match name {
+                    return Ok(match name {
                         "start" => start,
                         "stop" => stop,
                         _ => step,
-                    };
-                    return Ok(w_int_new(v));
+                    });
                 }
                 _ => {}
             }
@@ -2024,6 +2135,7 @@ pub fn getattr_str(obj: PyObjectRef, name: &str) -> PyResult {
     unsafe {
         if is_seq_iter(obj)
             || is_range_iter(obj)
+            || pyre_object::is_long_range_iter(obj)
             || pyre_object::dictviewobject::is_dict_view_iterator(obj)
             || pyre_object::enumerateobject::is_enumerate(obj)
             || pyre_object::callableiteratorobject::is_callable_iterator(obj)
@@ -6326,6 +6438,7 @@ pub fn is_iterable(w_obj: PyObjectRef) -> bool {
             || is_dict(obj)
             || pyre_object::is_set_or_frozenset(obj)
             || is_range_iter(obj)
+            || pyre_object::is_long_range_iter(obj)
             || is_seq_iter(obj)
             || pyre_object::generatorobject::is_generator(obj)
             || pyre_object::itertoolsmodule::is_count(obj)
@@ -6467,13 +6580,16 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             let key_list = pyre_object::w_list_new(items);
             return Ok(pyre_object::w_seq_iter_new(key_list, len));
         }
-        // `range` sequence → fresh `W_RangeIterator` cursor.
+        // `range` sequence → a `rangeiterator` (machine-int, JIT) when the
+        // bounds fit a word, else a `longrange_iterator`.
         if pyre_object::is_w_range(obj) {
-            let (start, stop, step) = pyre_object::w_range_fields(obj);
-            return Ok(pyre_object::w_range_iter_new(start, stop, step));
+            return Ok(pyre_object::w_range_iter(obj));
         }
         // Already an iterator
-        if is_range_iter(obj) || is_seq_iter(obj) || pyre_object::generatorobject::is_generator(obj)
+        if is_range_iter(obj)
+            || pyre_object::is_long_range_iter(obj)
+            || is_seq_iter(obj)
+            || pyre_object::generatorobject::is_generator(obj)
         {
             return Ok(obj);
         }
@@ -6663,6 +6779,20 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 attach_tb: true,
                 reraise_lasti: -1,
             });
+        }
+        // `iterobject.py W_LongRangeIterator.descr_next` — bignum-bound
+        // range cursor (`start + index*step`).
+        if pyre_object::is_long_range_iter(obj) {
+            return match pyre_object::w_long_range_iter_next(obj) {
+                Some(v) => Ok(v),
+                None => Err(PyError {
+                    kind: PyErrorKind::StopIteration,
+                    message: "".to_string(),
+                    exc_object: std::ptr::null_mut(),
+                    attach_tb: true,
+                    reraise_lasti: -1,
+                }),
+            };
         }
         // Generator __next__ — PyPy: generator.py GeneratorIterator.next
         if pyre_object::generatorobject::is_generator(obj) {
@@ -7700,20 +7830,24 @@ pub fn contains(haystack: PyObjectRef, needle: PyObjectRef) -> Result<bool, PyEr
         }
     }
     // `rangeobject.py W_RangeObject.descr_contains` — O(1) membership for
-    // an int needle; any other type falls back to an elementwise scan.
+    // an int/long needle; any other type falls back to an elementwise scan.
     unsafe {
         if pyre_object::is_w_range(haystack) {
-            if is_int(needle) {
-                return Ok(pyre_object::w_range_contains_int(
-                    haystack,
-                    int_or_bool_value(needle),
-                ));
+            if is_int(needle) || is_long(needle) {
+                let item = pyre_object::range_obj_to_bigint(needle);
+                return Ok(pyre_object::w_range_contains_bigint(haystack, &item));
             }
-            let (start, _stop, step) = pyre_object::w_range_fields(haystack);
-            let len = pyre_object::w_range_len(haystack);
-            for i in 0..len {
-                if is_true(compare(w_int_new(start + i * step), needle, CompareOp::Eq)?) {
-                    return Ok(true);
+            // `space.sequence_contains` — elementwise scan.
+            let it = iter(haystack)?;
+            loop {
+                match next(it) {
+                    Ok(item) => {
+                        if is_true(compare(item, needle, CompareOp::Eq)?) {
+                            return Ok(true);
+                        }
+                    }
+                    Err(e) if e.kind == PyErrorKind::StopIteration => break,
+                    Err(e) => return Err(e),
                 }
             }
             return Ok(false);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5692,9 +5692,18 @@ pub fn float_w(obj: PyObjectRef) -> Result<f64, PyError> {
         }
         if pyre_object::pyobject::is_long(obj) {
             use num_traits::ToPrimitive;
-            return Ok(pyre_object::longobject::w_long_get_value(obj)
+            // longobject.py:131-135 `tofloat` — `rbigint.tofloat()` raises
+            // OverflowError "int too large to convert to float" when the
+            // value does not fit a C double.
+            let f = pyre_object::longobject::w_long_get_value(obj)
                 .to_f64()
-                .unwrap_or(f64::NAN));
+                .unwrap_or(f64::INFINITY);
+            if !f.is_finite() {
+                return Err(PyError::overflow_error(
+                    "int too large to convert to float",
+                ));
+            }
+            return Ok(f);
         }
     }
     let Some(method) = (unsafe { lookup(obj, "__float__") }) else {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3349,7 +3349,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str) -> PyResult {
 /// Note: `__trunc__` is NOT consulted here. `__trunc__` belongs to the
 /// `int(...)` builtin path (`intobject.py:989 _new_baseint`), not to
 /// `space.int()` / `space.int_w()`.
-fn space_int(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
+pub(crate) fn space_int(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     // baseobjspace.py:319 `w_impl = space.lookup(self, '__int__')`
     let w_impl = unsafe { lookup(obj, "__int__") }
         // baseobjspace.py:321-323 `w_impl = space.lookup(self, '__index__')`
@@ -5699,9 +5699,7 @@ pub fn float_w(obj: PyObjectRef) -> Result<f64, PyError> {
                 .to_f64()
                 .unwrap_or(f64::INFINITY);
             if !f.is_finite() {
-                return Err(PyError::overflow_error(
-                    "int too large to convert to float",
-                ));
+                return Err(PyError::overflow_error("int too large to convert to float"));
             }
             return Ok(f);
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5667,6 +5667,52 @@ pub fn space_index(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     )))
 }
 
+/// baseobjspace.py:1847 `float_w` — the `space.float` coercion
+/// (descroperation.py:870), i.e. apply `__float__` and unwrap to an
+/// interp-level f64. Unlike the `float()` constructor it neither parses
+/// strings nor consults `__index__`; a non-float operand raises
+/// TypeError "must be real number, not %T".
+pub fn float_w(obj: PyObjectRef) -> Result<f64, PyError> {
+    if obj.is_null() {
+        return Err(PyError::type_error("float_w: null object"));
+    }
+    unsafe {
+        if pyre_object::is_float(obj) {
+            return Ok(pyre_object::w_float_get_value(obj));
+        }
+        if pyre_object::pyobject::is_int(obj) {
+            return Ok(pyre_object::intobject::w_int_get_value(obj) as f64);
+        }
+        if pyre_object::pyobject::is_bool(obj) {
+            return Ok(if pyre_object::boolobject::w_bool_get_value(obj) {
+                1.0
+            } else {
+                0.0
+            });
+        }
+        if pyre_object::pyobject::is_long(obj) {
+            use num_traits::ToPrimitive;
+            return Ok(pyre_object::longobject::w_long_get_value(obj)
+                .to_f64()
+                .unwrap_or(f64::NAN));
+        }
+    }
+    let Some(method) = (unsafe { lookup(obj, "__float__") }) else {
+        return Err(PyError::type_error(format!(
+            "must be real number, not {}",
+            object_functionstr_type_name(obj)
+        )));
+    };
+    let w_result = crate::builtins::call_and_check(method, &[obj])?;
+    if unsafe { pyre_object::is_float(w_result) } {
+        return Ok(unsafe { pyre_object::w_float_get_value(w_result) });
+    }
+    Err(PyError::type_error(format!(
+        "__float__ returned non-float (type '{}')",
+        object_functionstr_type_name(w_result)
+    )))
+}
+
 /// baseobjspace.py:1564 `getindex_w` with `w_exception=None` — apply
 /// `space.index` (`__index__`) then convert to an i64, silently clamping
 /// to `i64::MAX` / `i64::MIN` on overflow rather than raising.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1075,7 +1075,9 @@ fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             // Only `stop` given — `w_start, w_stop = 0, w_start`.
             w_stop = w_start;
             w_start = w_int_new(0);
+            pyre_object::gc_roots::pin_root(w_start);
             w_step = w_int_new(1);
+            pyre_object::gc_roots::pin_root(w_step);
         } else {
             w_stop = range_index_bound(args[1])?;
             pyre_object::gc_roots::pin_root(w_stop);
@@ -1089,6 +1091,7 @@ fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 }
             } else {
                 w_step = w_int_new(1);
+                pyre_object::gc_roots::pin_root(w_step);
             }
         }
         Ok(pyre_object::w_range_new(w_start, w_stop, w_step))

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1034,26 +1034,21 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_none())
 }
 
-/// functional.py:452 — space.int_w / space.bigint_w
+/// functional.py:464-475 — `space.index` applies `__index__`, then the
+/// result is taken as a machine int (`space.int_w`).
 unsafe fn range_arg_to_i64(obj: PyObjectRef) -> Result<i64, crate::PyError> {
-    if is_int(obj) {
-        return Ok(w_int_get_value(obj));
+    let w_index = crate::baseobjspace::space_index(obj)?;
+    if is_int(w_index) {
+        return Ok(w_int_get_value(w_index));
     }
-    if is_long(obj) {
-        let val = w_long_get_value(obj);
-        // `W_Range` carries `i64` bounds, so a value that overflows is
-        // clamped toward the matching extreme — a negative bound must not
-        // flip to a huge positive one (`range(-10**30)` stays empty).
-        return Ok(val.to_i64().unwrap_or_else(|| match val.sign() {
-            malachite_bigint::Sign::Minus => i64::MIN,
-            _ => i64::MAX,
-        }));
-    }
-    let type_name = (*(*obj).ob_type).name;
-    Err(crate::PyError::type_error(format!(
-        "'{}' object cannot be interpreted as an integer",
-        type_name
-    )))
+    let val = w_long_get_value(w_index);
+    // `W_Range` carries `i64` bounds, so a value that overflows is
+    // clamped toward the matching extreme — a negative bound must not
+    // flip to a huge positive one (`range(-10**30)` stays empty).
+    Ok(val.to_i64().unwrap_or_else(|| match val.sign() {
+        malachite_bigint::Sign::Minus => i64::MIN,
+        _ => i64::MAX,
+    }))
 }
 
 /// `range(stop)` or `range(start, stop)` or `range(start, stop, step)`.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1034,6 +1034,20 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_none())
 }
 
+/// `space.index` re-wraps a result whose type is not exactly `int` (a
+/// bool, or a strict int subclass) as a plain int (descroperation.py:622
+/// `index`).  A range stores its bounds wrapped, so normalize each here —
+/// otherwise `range(True).stop` would expose `True` instead of `1`.
+///
+/// # Safety
+/// `obj` must be a valid object.
+unsafe fn range_index_bound(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let w = crate::baseobjspace::space_index(obj)?;
+    Ok(pyre_object::range_bigint_to_obj(
+        pyre_object::range_obj_to_bigint(w),
+    ))
+}
+
 /// `range(stop)` / `range(start, stop[, step])` — `functional.py
 /// W_Range.descr_new`.  Each bound passes through `space.index`
 /// (`__index__`) and is stored wrapped, so a range may span past a
@@ -1053,7 +1067,7 @@ fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        let mut w_start = crate::baseobjspace::space_index(args[0])?;
+        let mut w_start = range_index_bound(args[0])?;
         pyre_object::gc_roots::pin_root(w_start);
         let w_stop;
         let w_step;
@@ -1063,10 +1077,10 @@ fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             w_start = w_int_new(0);
             w_step = w_int_new(1);
         } else {
-            w_stop = crate::baseobjspace::space_index(args[1])?;
+            w_stop = range_index_bound(args[1])?;
             pyre_object::gc_roots::pin_root(w_stop);
             if n == 3 {
-                w_step = crate::baseobjspace::space_index(args[2])?;
+                w_step = range_index_bound(args[2])?;
                 pyre_object::gc_roots::pin_root(w_step);
                 if pyre_object::range_obj_to_bigint(w_step) == BigInt::from(0) {
                     return Err(crate::PyError::value_error(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1034,61 +1034,50 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_none())
 }
 
-/// functional.py:464-475 — `space.index` applies `__index__`, then the
-/// result is taken as a machine int (`space.int_w`).
-unsafe fn range_arg_to_i64(obj: PyObjectRef) -> Result<i64, crate::PyError> {
-    let w_index = crate::baseobjspace::space_index(obj)?;
-    if is_int(w_index) {
-        return Ok(w_int_get_value(w_index));
-    }
-    // pyre's range is i64-backed (`W_Range` keeps `start`/`stop`/`step` as
-    // i64 so the JIT can specialize `for i in range(n)` to register
-    // arithmetic), unlike PyPy's wrapped-int range.  A bound that does not
-    // fit a machine word saturates toward its own sign so a huge negative
-    // bound stays negative instead of flipping to a huge positive stop;
-    // raising here would break `range(1 << 1000)` constructions that the
-    // stdlib (`_collections_abc`) performs without ever materializing the
-    // value.
-    let big = w_long_get_value(w_index);
-    Ok(big.to_i64().unwrap_or_else(|| {
-        use num_traits::Signed;
-        if big.is_negative() { i64::MIN } else { i64::MAX }
-    }))
-}
-
-/// `range(stop)` or `range(start, stop)` or `range(start, stop, step)`.
-///
-/// Returns a `W_Range` sequence object; `iter()` produces a fresh
-/// `W_RangeIterator` cursor.
+/// `range(stop)` / `range(start, stop[, step])` — `functional.py
+/// W_Range.descr_new`.  Each bound passes through `space.index`
+/// (`__index__`) and is stored wrapped, so a range may span past a
+/// machine word; `iter()` then produces a `rangeiterator` (machine-int,
+/// JIT-specializable) or a `longrange_iterator` accordingly.
 fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    match args.len() {
-        0 => Err(crate::PyError::type_error(
+    let n = args.len();
+    if n == 0 {
+        return Err(crate::PyError::type_error(
             "range expected at least 1 argument, got 0",
-        )),
-        1 => {
-            let stop = unsafe { range_arg_to_i64(args[0]) }?;
-            Ok(pyre_object::w_range_new(0, stop, 1))
-        }
-        2 => {
-            let start = unsafe { range_arg_to_i64(args[0]) }?;
-            let stop = unsafe { range_arg_to_i64(args[1]) }?;
-            Ok(pyre_object::w_range_new(start, stop, 1))
-        }
-        3 => {
-            let start = unsafe { range_arg_to_i64(args[0]) }?;
-            let stop = unsafe { range_arg_to_i64(args[1]) }?;
-            let step = unsafe { range_arg_to_i64(args[2]) }?;
-            if step == 0 {
-                return Err(crate::PyError::value_error(
-                    "step argument must not be zero",
-                ));
+        ));
+    }
+    if n > 3 {
+        return Err(crate::PyError::type_error(format!(
+            "range expected at most 3 arguments, got {n}"
+        )));
+    }
+    unsafe {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let mut w_start = crate::baseobjspace::space_index(args[0])?;
+        pyre_object::gc_roots::pin_root(w_start);
+        let w_stop;
+        let w_step;
+        if n == 1 {
+            // Only `stop` given — `w_start, w_stop = 0, w_start`.
+            w_stop = w_start;
+            w_start = w_int_new(0);
+            w_step = w_int_new(1);
+        } else {
+            w_stop = crate::baseobjspace::space_index(args[1])?;
+            pyre_object::gc_roots::pin_root(w_stop);
+            if n == 3 {
+                w_step = crate::baseobjspace::space_index(args[2])?;
+                pyre_object::gc_roots::pin_root(w_step);
+                if pyre_object::range_obj_to_bigint(w_step) == BigInt::from(0) {
+                    return Err(crate::PyError::value_error(
+                        "step argument must not be zero",
+                    ));
+                }
+            } else {
+                w_step = w_int_new(1);
             }
-            Ok(pyre_object::w_range_new(start, stop, step))
         }
-        _ => Err(crate::PyError::type_error(format!(
-            "range expected at most 3 arguments, got {}",
-            args.len()
-        ))),
+        Ok(pyre_object::w_range_new(w_start, w_stop, w_step))
     }
 }
 
@@ -4841,13 +4830,7 @@ fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         // range: rangeobject.py W_RangeObject.descr_reversed — reflect
         // the span and hand back a fresh reverse-walking iterator.
         if pyre_object::is_w_range(obj) {
-            let (start, _stop, step) = pyre_object::w_range_fields(obj);
-            let len = pyre_object::w_range_len(obj);
-            if len == 0 {
-                return Ok(pyre_object::w_range_iter_new(0, 0, 1));
-            }
-            let last = start + (len - 1) * step;
-            return Ok(pyre_object::w_range_iter_new(last, start - step, -step));
+            return Ok(pyre_object::w_range_reversed(obj));
         }
         // range_iterator: a bare iterator (e.g. from `iter(range(n))`)
         // can also be reversed. rangeobject.py

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1041,13 +1041,18 @@ unsafe fn range_arg_to_i64(obj: PyObjectRef) -> Result<i64, crate::PyError> {
     if is_int(w_index) {
         return Ok(w_int_get_value(w_index));
     }
-    let val = w_long_get_value(w_index);
-    // `W_Range` carries `i64` bounds, so a value that overflows is
-    // clamped toward the matching extreme — a negative bound must not
-    // flip to a huge positive one (`range(-10**30)` stays empty).
-    Ok(val.to_i64().unwrap_or_else(|| match val.sign() {
-        malachite_bigint::Sign::Minus => i64::MIN,
-        _ => i64::MAX,
+    // pyre's range is i64-backed (`W_Range` keeps `start`/`stop`/`step` as
+    // i64 so the JIT can specialize `for i in range(n)` to register
+    // arithmetic), unlike PyPy's wrapped-int range.  A bound that does not
+    // fit a machine word saturates toward its own sign so a huge negative
+    // bound stays negative instead of flipping to a huge positive stop;
+    // raising here would break `range(1 << 1000)` constructions that the
+    // stdlib (`_collections_abc`) performs without ever materializing the
+    // value.
+    let big = w_long_get_value(w_index);
+    Ok(big.to_i64().unwrap_or_else(|| {
+        use num_traits::Signed;
+        if big.is_negative() { i64::MIN } else { i64::MAX }
     }))
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4522,19 +4522,21 @@ pub fn hash_value(obj: PyObjectRef) -> i64 {
             return _hash_frozenset(&hashes);
         }
         if pyre_object::is_w_range(obj) {
-            // functional.py W_Range.descr_hash — hash of the
-            // (length, start, step) tuple, with trailing fields set to
-            // None (hash 0) for empty and single-element ranges.
+            // `descr_hash` — `hash((length, start|None, step|None))` so two
+            // ranges denoting the same sequence hash equally.
+            let w_len = pyre_object::w_range_length(obj);
             let (start, _stop, step) = pyre_object::w_range_fields(obj);
-            let len = pyre_object::w_range_len(obj);
-            let hashes = if len == 0 {
-                [_hash_int(0), 0, 0]
-            } else if len == 1 {
-                [_hash_int(1), _hash_int(start), 0]
+            let len_b = pyre_object::range_obj_to_bigint(w_len);
+            let none = w_none();
+            let (a, b) = if len_b == BigInt::from(0) {
+                (none, none)
+            } else if len_b == BigInt::from(1) {
+                (start, none)
             } else {
-                [_hash_int(len), _hash_int(start), _hash_int(step)]
+                (start, step)
             };
-            return _hash_tuple_xx(&hashes);
+            let tup = pyre_object::w_tuple_new(vec![w_len, a, b]);
+            return hash_value(tup);
         }
         if pyre_object::is_instance(obj) {
             let w_type = pyre_object::w_instance_get_type(obj);

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -542,12 +542,20 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> String {
         } else if pyre_object::is_w_range(obj) {
             // `rangeobject.py W_AbstractRangeObject.descr_repr` —
             // `range(start, stop)`, with the step appended only when
-            // it is not 1.
+            // it is not 1.  Bounds may be bignum, so render each wrapped
+            // int rather than a machine word.
             let (start, stop, step) = pyre_object::w_range_fields(obj);
-            if step == 1 {
-                format!("range({start}, {stop})")
+            let step_is_one =
+                pyre_object::range_obj_to_bigint(step) == malachite_bigint::BigInt::from(1);
+            if step_is_one {
+                format!("range({}, {})", py_repr(start), py_repr(stop))
             } else {
-                format!("range({start}, {stop}, {step})")
+                format!(
+                    "range({}, {}, {})",
+                    py_repr(start),
+                    py_repr(stop),
+                    py_repr(step)
+                )
             }
         } else if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
             // Try __repr__ first, then __str__

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1435,14 +1435,14 @@ impl IterOpcodeHandler for PyFrame {
             // loop body, so the JIT's `for i in range(N)` fast path is
             // unaffected.
             if pyre_object::is_w_range(iter) {
-                let (start, stop, step) = pyre_object::w_range_fields(iter);
-                let it = pyre_object::w_range_iter_new(start, stop, step);
+                let it = pyre_object::w_range_iter(iter);
                 let tos = self.valuestackdepth - 1;
                 self.locals_w_mut()[tos] = it;
                 return Ok(());
             }
             // Already an iterator
             if pyre_object::is_range_iter(iter)
+                || pyre_object::is_long_range_iter(iter)
                 || pyre_object::is_seq_iter(iter)
                 || pyre_object::generatorobject::is_generator(iter)
                 || pyre_object::itertoolsmodule::is_repeat(iter)

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -401,11 +401,11 @@ pub fn register_module(ns: &mut DictStorage) {
                     let c = std::ffi::CString::new(sv.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null character"))?;
                     let out = rustpython_host_env::locale::strxfrm(&c, sv.len() + 1);
-                    // `interp_locale.py:143` returns `space.newtext(val)`; on
-                    // pyre's WTF-8 strings `charp2uni` preserves every libc
-                    // byte (surrogateescape) instead of replacing invalid
-                    // sequences with U+FFFD.
-                    Ok(crate::typedef::charp2uni(&out))
+                    // `interp_locale.py:139` returns `space.newtext(val)` —
+                    // a plain utf-8 decode (lossy), matching `setlocale`;
+                    // unlike `localeconv`/`nl_langinfo` it does not apply
+                    // surrogateescape.
+                    Ok(pyre_object::w_str_new(&String::from_utf8_lossy(&out)))
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]
                 {

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -401,7 +401,11 @@ pub fn register_module(ns: &mut DictStorage) {
                     let c = std::ffi::CString::new(sv.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null character"))?;
                     let out = rustpython_host_env::locale::strxfrm(&c, sv.len() + 1);
-                    Ok(pyre_object::w_str_new(&String::from_utf8_lossy(&out)))
+                    // `interp_locale.py:143` returns `space.newtext(val)`; on
+                    // pyre's WTF-8 strings `charp2uni` preserves every libc
+                    // byte (surrogateescape) instead of replacing invalid
+                    // sequences with U+FFFD.
+                    Ok(crate::typedef::charp2uni(&out))
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]
                 {

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -260,7 +260,7 @@ pub fn register_module(ns: &mut DictStorage) {
                 let c_locale = match locale_str.as_ref() {
                     Some(s) => Some(
                         std::ffi::CString::new(s.as_bytes())
-                            .map_err(|_| crate::PyError::value_error("embedded null"))?,
+                            .map_err(|_| crate::PyError::value_error("embedded null character"))?,
                     ),
                     None => None,
                 };
@@ -351,9 +351,9 @@ pub fn register_module(ns: &mut DictStorage) {
                     let s1 = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
                     let s2 = unsafe { pyre_object::w_str_get_value(args[1]).to_string() };
                     let c1 = std::ffi::CString::new(s1.as_bytes())
-                        .map_err(|_| crate::PyError::value_error("embedded null"))?;
+                        .map_err(|_| crate::PyError::value_error("embedded null character"))?;
                     let c2 = std::ffi::CString::new(s2.as_bytes())
-                        .map_err(|_| crate::PyError::value_error("embedded null"))?;
+                        .map_err(|_| crate::PyError::value_error("embedded null character"))?;
                     return Ok(pyre_object::w_int_new(
                         rustpython_host_env::locale::strcoll(&c1, &c2) as i64,
                     ));

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -18,6 +18,96 @@ fn locale_error(message: &str) -> crate::PyError {
     err
 }
 
+/// Numeric/monetary locale parameters decoded into owned buffers, the
+/// `lconv` fields `localeconv` exposes (`interp_locale.py:48`).
+struct LocaleConvData {
+    decimal_point: Vec<u8>,
+    thousands_sep: Vec<u8>,
+    grouping: Vec<i64>,
+    int_curr_symbol: Vec<u8>,
+    currency_symbol: Vec<u8>,
+    mon_decimal_point: Vec<u8>,
+    mon_thousands_sep: Vec<u8>,
+    mon_grouping: Vec<i64>,
+    positive_sign: Vec<u8>,
+    negative_sign: Vec<u8>,
+    int_frac_digits: i64,
+    frac_digits: i64,
+    p_cs_precedes: i64,
+    p_sep_by_space: i64,
+    n_cs_precedes: i64,
+    n_sep_by_space: i64,
+    p_sign_posn: i64,
+    n_sign_posn: i64,
+}
+
+/// Build the `localeconv()` result dict.  String fields decode the host
+/// bytes as UTF-8; grouping lists already carry the trailing 0 that
+/// `_w_copy_grouping` appends to a non-empty grouping
+/// (`interp_locale.py:36-40`).
+fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
+    let d = pyre_object::w_dict_new();
+    let put_str = |k: &str, b: &[u8]| unsafe {
+        pyre_object::w_dict_setitem_str(d, k, pyre_object::w_str_new(&String::from_utf8_lossy(b)));
+    };
+    let put_int = |k: &str, v: i64| unsafe {
+        pyre_object::w_dict_setitem_str(d, k, pyre_object::w_int_new(v));
+    };
+    let put_grouping = |k: &str, v: &[i64]| unsafe {
+        pyre_object::w_dict_setitem_str(
+            d,
+            k,
+            pyre_object::w_list_new(v.iter().map(|&x| pyre_object::w_int_new(x)).collect()),
+        );
+    };
+    put_str("decimal_point", &c.decimal_point);
+    put_str("thousands_sep", &c.thousands_sep);
+    put_grouping("grouping", &c.grouping);
+    put_str("int_curr_symbol", &c.int_curr_symbol);
+    put_str("currency_symbol", &c.currency_symbol);
+    put_str("mon_decimal_point", &c.mon_decimal_point);
+    put_str("mon_thousands_sep", &c.mon_thousands_sep);
+    put_grouping("mon_grouping", &c.mon_grouping);
+    put_str("positive_sign", &c.positive_sign);
+    put_str("negative_sign", &c.negative_sign);
+    put_int("int_frac_digits", c.int_frac_digits);
+    put_int("frac_digits", c.frac_digits);
+    put_int("p_cs_precedes", c.p_cs_precedes);
+    put_int("p_sep_by_space", c.p_sep_by_space);
+    put_int("n_cs_precedes", c.n_cs_precedes);
+    put_int("n_sep_by_space", c.n_sep_by_space);
+    put_int("p_sign_posn", c.p_sign_posn);
+    put_int("n_sign_posn", c.n_sign_posn);
+    d
+}
+
+/// POSIX "C" locale `localeconv` defaults for builds without libc; the
+/// char-typed fields default to `CHAR_MAX` (no value provided).
+#[cfg(not(all(unix, feature = "host_env")))]
+fn c_locale_conv() -> LocaleConvData {
+    const CHAR_MAX: i64 = 127;
+    LocaleConvData {
+        decimal_point: b".".to_vec(),
+        thousands_sep: Vec::new(),
+        grouping: Vec::new(),
+        int_curr_symbol: Vec::new(),
+        currency_symbol: Vec::new(),
+        mon_decimal_point: Vec::new(),
+        mon_thousands_sep: Vec::new(),
+        mon_grouping: Vec::new(),
+        positive_sign: Vec::new(),
+        negative_sign: Vec::new(),
+        int_frac_digits: CHAR_MAX,
+        frac_digits: CHAR_MAX,
+        p_cs_precedes: CHAR_MAX,
+        p_sep_by_space: CHAR_MAX,
+        n_cs_precedes: CHAR_MAX,
+        n_sep_by_space: CHAR_MAX,
+        p_sign_posn: CHAR_MAX,
+        n_sign_posn: CHAR_MAX,
+    }
+}
+
 /// `_locale` C-extension stub — PyPy: pypy/module/_locale/.
 ///
 /// Provides the 'C' locale defaults so locale.py's `from _locale import *`
@@ -86,83 +176,52 @@ pub fn register_module(ns: &mut DictStorage) {
     );
     crate::dict_storage_store(ns, "Error", w_error);
 
-    // localeconv() — returns the 'C' locale parameters as a dict.
+    // localeconv() — numeric/monetary parameters of the current locale.
     crate::dict_storage_store(
         ns,
         "localeconv",
         crate::make_builtin_function_with_arity(
             "localeconv",
             |_| {
-                let d = pyre_object::w_dict_new();
-                unsafe {
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "grouping",
-                        pyre_object::w_list_new(vec![pyre_object::w_int_new(127)]),
-                    );
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "currency_symbol",
-                        pyre_object::w_str_new(""),
-                    );
-                    pyre_object::w_dict_setitem_str(d, "n_sign_posn", pyre_object::w_int_new(127));
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "p_cs_precedes",
-                        pyre_object::w_int_new(127),
-                    );
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "n_cs_precedes",
-                        pyre_object::w_int_new(127),
-                    );
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "mon_grouping",
-                        pyre_object::w_list_new(vec![]),
-                    );
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "n_sep_by_space",
-                        pyre_object::w_int_new(127),
-                    );
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "decimal_point",
-                        pyre_object::w_str_new("."),
-                    );
-                    pyre_object::w_dict_setitem_str(d, "negative_sign", pyre_object::w_str_new(""));
-                    pyre_object::w_dict_setitem_str(d, "positive_sign", pyre_object::w_str_new(""));
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "p_sep_by_space",
-                        pyre_object::w_int_new(127),
-                    );
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "int_curr_symbol",
-                        pyre_object::w_str_new(""),
-                    );
-                    pyre_object::w_dict_setitem_str(d, "p_sign_posn", pyre_object::w_int_new(127));
-                    pyre_object::w_dict_setitem_str(d, "thousands_sep", pyre_object::w_str_new(""));
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "mon_thousands_sep",
-                        pyre_object::w_str_new(""),
-                    );
-                    pyre_object::w_dict_setitem_str(d, "frac_digits", pyre_object::w_int_new(127));
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "mon_decimal_point",
-                        pyre_object::w_str_new(""),
-                    );
-                    pyre_object::w_dict_setitem_str(
-                        d,
-                        "int_frac_digits",
-                        pyre_object::w_int_new(127),
-                    );
+                #[cfg(all(unix, feature = "host_env"))]
+                {
+                    let lc = rustpython_host_env::locale::localeconv_data();
+                    // `_w_copy_grouping` appends a trailing 0 to a non-empty
+                    // grouping; the host helper already strips the C
+                    // terminator (`interp_locale.py:36-40`).
+                    let grouping_of = |g: &[libc::c_char]| -> Vec<i64> {
+                        let mut v: Vec<i64> = g.iter().map(|&x| x as i64).collect();
+                        if !v.is_empty() {
+                            v.push(0);
+                        }
+                        v
+                    };
+                    let data = LocaleConvData {
+                        decimal_point: lc.decimal_point.clone(),
+                        thousands_sep: lc.thousands_sep.clone(),
+                        grouping: grouping_of(&lc.grouping),
+                        int_curr_symbol: lc.int_curr_symbol.clone(),
+                        currency_symbol: lc.currency_symbol.clone(),
+                        mon_decimal_point: lc.mon_decimal_point.clone(),
+                        mon_thousands_sep: lc.mon_thousands_sep.clone(),
+                        mon_grouping: grouping_of(&lc.mon_grouping),
+                        positive_sign: lc.positive_sign.clone(),
+                        negative_sign: lc.negative_sign.clone(),
+                        int_frac_digits: lc.int_frac_digits as i64,
+                        frac_digits: lc.frac_digits as i64,
+                        p_cs_precedes: lc.p_cs_precedes as i64,
+                        p_sep_by_space: lc.p_sep_by_space as i64,
+                        n_cs_precedes: lc.n_cs_precedes as i64,
+                        n_sep_by_space: lc.n_sep_by_space as i64,
+                        p_sign_posn: lc.p_sign_posn as i64,
+                        n_sign_posn: lc.n_sign_posn as i64,
+                    };
+                    Ok(localeconv_to_dict(&data))
                 }
-                Ok(d)
+                #[cfg(not(all(unix, feature = "host_env")))]
+                {
+                    Ok(localeconv_to_dict(&c_locale_conv()))
+                }
             },
             0,
         ),
@@ -335,7 +394,19 @@ pub fn register_module(ns: &mut DictStorage) {
                         "strxfrm() argument must be str",
                     ));
                 }
-                Ok(s)
+                #[cfg(all(unix, feature = "host_env"))]
+                {
+                    let sv = unsafe { pyre_object::w_str_get_value(s).to_string() };
+                    let c = std::ffi::CString::new(sv.as_bytes())
+                        .map_err(|_| crate::PyError::value_error("embedded null character"))?;
+                    let out = rustpython_host_env::locale::strxfrm(&c, sv.len() + 1);
+                    Ok(pyre_object::w_str_new(&String::from_utf8_lossy(&out)))
+                }
+                #[cfg(not(all(unix, feature = "host_env")))]
+                {
+                    // No libc collation available — the transform is identity.
+                    Ok(s)
+                }
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -42,13 +42,13 @@ struct LocaleConvData {
 }
 
 /// Build the `localeconv()` result dict.  String fields decode the host
-/// bytes as UTF-8; grouping lists already carry the trailing 0 that
-/// `_w_copy_grouping` appends to a non-empty grouping
-/// (`interp_locale.py:36-40`).
+/// bytes via `charp2uni` (utf-8 + surrogateescape, `interp_locale.py:42`);
+/// grouping lists already carry the trailing 0 that `_w_copy_grouping`
+/// appends to a non-empty grouping (`interp_locale.py:36-40`).
 fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
     let d = pyre_object::w_dict_new();
     let put_str = |k: &str, b: &[u8]| unsafe {
-        pyre_object::w_dict_setitem_str(d, k, pyre_object::w_str_new(&String::from_utf8_lossy(b)));
+        pyre_object::w_dict_setitem_str(d, k, crate::typedef::charp2uni(b));
     };
     let put_int = |k: &str, v: i64| unsafe {
         pyre_object::w_dict_setitem_str(d, k, pyre_object::w_int_new(v));
@@ -303,7 +303,7 @@ pub fn register_module(ns: &mut DictStorage) {
                     };
                     if item == libc::CODESET {
                         if let Some(bytes) = rustpython_host_env::locale::nl_langinfo_codeset() {
-                            return Ok(pyre_object::w_str_new(&String::from_utf8_lossy(&bytes)));
+                            return Ok(crate::typedef::charp2uni(&bytes));
                         }
                     }
                     // `interp_locale.py:151-154` — unknown items raise
@@ -314,8 +314,9 @@ pub fn register_module(ns: &mut DictStorage) {
                     if p.is_null() {
                         return Err(crate::PyError::value_error("unsupported langinfo constant"));
                     }
+                    // `interp_locale.py:153` decodes via utf-8 + surrogateescape.
                     let s = unsafe { std::ffi::CStr::from_ptr(p) };
-                    return Ok(pyre_object::w_str_new(&s.to_string_lossy()));
+                    return Ok(crate::typedef::charp2uni(s.to_bytes()));
                 }
                 #[cfg(not(all(
                     unix,

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2309,12 +2309,9 @@ fn init_socket_type(ns: &mut DictStorage) {
                     "integer argument expected, got float",
                 ));
             }
-            if !unsafe { pyre_object::is_int(fileno_obj) } {
-                return Err(crate::PyError::type_error(
-                    "socket: fileno must be an integer or None",
-                ));
-            }
-            let fd = unsafe { pyre_object::w_int_get_value(fileno_obj) };
+            // `interp_socket.py:255` — `space.int_w(w_fileno)` accepts ints,
+            // longs, and objects with `__int__` / `__index__`.
+            let fd = crate::baseobjspace::int_w(fileno_obj)?;
             if fd < 0 {
                 return Err(crate::PyError::value_error("negative file descriptor"));
             }

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2259,27 +2259,20 @@ fn init_socket_type(ns: &mut DictStorage) {
                 .get(3)
                 .copied()
                 .or_else(|| crate::builtins::kwarg_get(kwargs, "fileno"));
-            for (obj, label) in [(family_obj, "family"), (type_obj, "type"), (proto_obj, "proto")] {
-                if let Some(o) = obj {
-                    if !unsafe { pyre_object::is_int(o) } {
-                        return Err(crate::PyError::type_error(format!(
-                            "socket: {label} must be an integer"
-                        )));
-                    }
+            // `@unwrap_spec(family=int, type=int, proto=int)` — a present
+            // argument goes through the gateway int converter (`__index__` /
+            // `__int__`, OverflowError if it does not fit), defaulting to the
+            // -1 sentinel when omitted.
+            let int_arg =
+                |obj: Option<pyre_object::PyObjectRef>| -> Result<libc::c_int, crate::PyError> {
+                match obj {
+                    Some(o) => Ok(crate::baseobjspace::int_w(o)? as libc::c_int),
+                    None => Ok(-1),
                 }
-            }
-            let mut family = match family_obj {
-                Some(o) => unsafe { pyre_object::w_int_get_value(o) as libc::c_int },
-                None => -1,
             };
-            let mut ty = match type_obj {
-                Some(o) => unsafe { pyre_object::w_int_get_value(o) as libc::c_int },
-                None => -1,
-            };
-            let mut proto = match proto_obj {
-                Some(o) => unsafe { pyre_object::w_int_get_value(o) as libc::c_int },
-                None => -1,
-            };
+            let mut family = int_arg(family_obj)?;
+            let mut ty = int_arg(type_obj)?;
+            let mut proto = int_arg(proto_obj)?;
             let has_fileno = match fileno_obj {
                 Some(o) => !unsafe { pyre_object::is_none(o) },
                 None => false,

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -32,22 +32,19 @@ fn stat_result_seq_type() -> PyObjectRef {
                     "st_mode", "st_ino", "st_dev", "st_nlink", "st_uid", "st_gid", "st_size",
                     "_integer_atime", "_integer_mtime", "_integer_ctime",
                 ],
+                // `app_posix.py:38-69` — named-only extras ordered by their
+                // `structseqfield` index (11..13, 20..23, 40..42, 50..52).
+                // `structseq_descr_new` fills surplus sequence items into
+                // this list in order, so the list order must match PyPy's
+                // index sort, not the build-time population order.
                 &[
+                    // float times, indices 11..13.
                     "st_atime",
                     "st_mtime",
                     "st_ctime",
-                    "st_atime_ns",
-                    "st_mtime_ns",
-                    "st_ctime_ns",
-                    // `build_stat_result` (interp_posix.py:554-557) +
-                    // `rposix_stat.py STAT_FIELDS += ALL_STAT_FIELDS[-3:]`
-                    // — the sub-second nanosecond remainders, exposed on
-                    // every platform.
-                    "nsec_atime",
-                    "nsec_mtime",
-                    "nsec_ctime",
-                    // `app_posix.py:45-48` — present where the platform's
-                    // `struct stat` carries them (every Unix target).
+                    // `app_posix.py:45-52` — present where the platform's
+                    // `struct stat` carries them (every Unix target),
+                    // indices 20..23.
                     #[cfg(unix)]
                     "st_blksize",
                     #[cfg(unix)]
@@ -58,6 +55,16 @@ fn stat_result_seq_type() -> PyObjectRef {
                     // `struct stat` carries it (BSD family / macOS).
                     #[cfg(target_os = "macos")]
                     "st_flags",
+                    // `build_stat_result` (interp_posix.py:554-557) +
+                    // `rposix_stat.py STAT_FIELDS += ALL_STAT_FIELDS[-3:]`
+                    // — the sub-second nanosecond remainders, indices 40..42.
+                    "nsec_atime",
+                    "nsec_mtime",
+                    "nsec_ctime",
+                    // full nanosecond timestamps, indices 50..52.
+                    "st_atime_ns",
+                    "st_mtime_ns",
+                    "st_ctime_ns",
                 ],
             )
         })

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -298,8 +298,20 @@ pub fn register_module(ns: &mut DictStorage) {
                 // `interp_select.py:166` — EINTR retry, recomputing the
                 // remaining timeout each pass and rebuilding the fd sets
                 // (select() clobbers them on every call).
-                let deadline = timeout_secs
-                    .map(|s| std::time::Instant::now() + std::time::Duration::from_secs_f64(s));
+                // `Duration::from_secs_f64` panics on a NaN/inf/overflowing
+                // timeout; `float_w` lets such a value through, so convert it
+                // into a `ValueError` instead of aborting the host process.
+                let deadline = match timeout_secs {
+                    None => None,
+                    Some(s) => Some(
+                        std::time::Duration::try_from_secs_f64(s)
+                            .ok()
+                            .and_then(|d| std::time::Instant::now().checked_add(d))
+                            .ok_or_else(|| {
+                                crate::PyError::value_error("timeout is too large")
+                            })?,
+                    ),
+                };
                 let mut rset = host_select::FdSet::new();
                 let mut wset = host_select::FdSet::new();
                 let mut xset = host_select::FdSet::new();

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -260,6 +260,13 @@ pub fn register_module(ns: &mut DictStorage) {
                         // `interp_select.py:132 _build_fd_set` — each item is
                         // resolved through `space.c_filedescriptor_w`.
                         let fd = filedescriptor_w(item)?;
+                        // `fd >= FD_SETSIZE` is rejected: `FD_SET` on such an
+                        // fd writes outside the `fd_set` bitmap.
+                        if fd >= libc::FD_SETSIZE as i32 {
+                            return Err(crate::PyError::value_error(
+                                "file descriptor out of range in select()",
+                            ));
+                        }
                         out.push((item, fd));
                     }
                     Ok(out)

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -30,27 +30,28 @@ fn default_poll_events() -> i16 {
 #[cfg(all(unix, feature = "host_env"))]
 pub(crate) fn filedescriptor_w(w_fd: PyObjectRef) -> Result<i32, crate::PyError> {
     unsafe {
-        let fd_val = if pyre_object::is_int(w_fd) {
-            pyre_object::w_int_get_value(w_fd)
+        // A real int (or int subclass / bignum) is taken directly; otherwise
+        // `fileno()` is called.  An object with only `__int__` is rejected.
+        let w_int = if pyre_object::is_int_or_long(w_fd) {
+            w_fd
         } else {
             let fileno = crate::baseobjspace::getattr_str(w_fd, "fileno").map_err(|_| {
-                crate::PyError::type_error("argument must be an int, or have a fileno() method")
+                crate::PyError::type_error("argument must be an int, or have a fileno() method.")
             })?;
             let res = crate::call::call_function_impl_result(fileno, &[])?;
-            if !pyre_object::is_int(res) {
-                return Err(crate::PyError::type_error("fileno() must return an integer"));
+            if !pyre_object::is_int_or_long(res) {
+                return Err(crate::PyError::type_error("fileno() returned a non-integer"));
             }
-            pyre_object::w_int_get_value(res)
+            res
         };
-        if fd_val < 0 {
-            return Err(crate::PyError::value_error(
-                "file descriptor cannot be a negative integer",
-            ));
+        // `c_int_w` — OverflowError if it does not fit a 32-bit int.
+        let fd = crate::baseobjspace::c_int_w(w_int)?;
+        if fd < 0 {
+            return Err(crate::PyError::value_error(format!(
+                "file descriptor cannot be a negative integer ({fd})"
+            )));
         }
-        if fd_val > i32::MAX as i64 {
-            return Err(crate::PyError::overflow_error("file descriptor out of range"));
-        }
-        Ok(fd_val as i32)
+        Ok(fd)
     }
 }
 
@@ -256,36 +257,10 @@ pub fn register_module(ns: &mut DictStorage) {
                     let items = crate::baseobjspace::unpackiterable(seq, -1)?;
                     let mut out = Vec::with_capacity(items.len());
                     for item in items {
-                        let fd_val = unsafe {
-                            if pyre_object::is_int(item) {
-                                pyre_object::w_int_get_value(item)
-                            } else {
-                                let fileno =
-                                    crate::baseobjspace::getattr_str(item, "fileno").map_err(|_| {
-                                        crate::PyError::type_error(
-                                            "argument must be an int, or have a fileno() method",
-                                        )
-                                    })?;
-                                let res = crate::call::call_function_impl_result(fileno, &[])?;
-                                if !pyre_object::is_int(res) {
-                                    return Err(crate::PyError::type_error(
-                                        "fileno() must return an integer",
-                                    ));
-                                }
-                                pyre_object::w_int_get_value(res)
-                            }
-                        };
-                        if fd_val < 0 {
-                            return Err(crate::PyError::value_error(
-                                "file descriptor cannot be a negative integer",
-                            ));
-                        }
-                        if fd_val > i32::MAX as i64 {
-                            return Err(crate::PyError::overflow_error(
-                                "file descriptor out of range",
-                            ));
-                        }
-                        out.push((item, fd_val as i32));
+                        // `interp_select.py:132 _build_fd_set` — each item is
+                        // resolved through `space.c_filedescriptor_w`.
+                        let fd = filedescriptor_w(item)?;
+                        out.push((item, fd));
                     }
                     Ok(out)
                 }

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -278,23 +278,14 @@ pub fn register_module(ns: &mut DictStorage) {
                     }
                 }
 
-                // `interp_select.py:227-235` — `None` blocks forever, else a
-                // non-negative float second count.
+                // `interp_select.py:230-235` — `None` blocks forever, else
+                // `space.float_w` (applies `__float__`); a negative count is
+                // a ValueError.
                 let timeout_secs: Option<f64> = match args.get(3) {
                     None => None,
                     Some(&t) if unsafe { pyre_object::is_none(t) } => None,
                     Some(&t) => {
-                        let secs = unsafe {
-                            if pyre_object::is_float(t) {
-                                pyre_object::w_float_get_value(t)
-                            } else if pyre_object::is_int(t) {
-                                pyre_object::w_int_get_value(t) as f64
-                            } else {
-                                return Err(crate::PyError::type_error(
-                                    "timeout must be a float or None",
-                                ));
-                            }
-                        };
+                        let secs = crate::baseobjspace::float_w(t)?;
                         if secs < 0.0 {
                             return Err(crate::PyError::value_error(
                                 "timeout must be non-negative",

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -115,12 +115,8 @@ pub fn register_module(ns: &mut DictStorage) {
                 ));
             }
             let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-            if !unsafe { pyre_object::is_int(args[1]) } {
-                return Err(crate::PyError::type_error(
-                    "tcsetattr: when must be an integer",
-                ));
-            }
-            let when = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+            // `@unwrap_spec(when=int)`.
+            let when = crate::baseobjspace::int_w(args[1])? as i32;
             // interp_termios.py:24-27 — arg 3 must be a 7-element list,
             // unpacked via space.unpackiterable.
             let attrs = args[2];
@@ -219,12 +215,8 @@ pub fn register_module(ns: &mut DictStorage) {
                     ));
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                if !unsafe { pyre_object::is_int(args[1]) } {
-                    return Err(crate::PyError::type_error(
-                        "tcsendbreak: duration must be an integer",
-                    ));
-                }
-                let dur = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+                // `@unwrap_spec(duration=int)`.
+                let dur = crate::baseobjspace::int_w(args[1])? as i32;
                 host_termios::tcsendbreak(fd, dur).map_err(|e| {
                     termios_converted_error(
                         e.raw_os_error().unwrap_or(0),
@@ -269,12 +261,8 @@ pub fn register_module(ns: &mut DictStorage) {
                     return Err(crate::PyError::type_error("tcflush() requires 2 arguments"));
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                if !unsafe { pyre_object::is_int(args[1]) } {
-                    return Err(crate::PyError::type_error(
-                        "tcflush: queue must be an integer",
-                    ));
-                }
-                let q = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+                // `@unwrap_spec(queue=int)`.
+                let q = crate::baseobjspace::int_w(args[1])? as i32;
                 host_termios::tcflush(fd, q).map_err(|e| {
                     termios_converted_error(
                         e.raw_os_error().unwrap_or(0),
@@ -297,12 +285,8 @@ pub fn register_module(ns: &mut DictStorage) {
                     return Err(crate::PyError::type_error("tcflow() requires 2 arguments"));
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                if !unsafe { pyre_object::is_int(args[1]) } {
-                    return Err(crate::PyError::type_error(
-                        "tcflow: action must be an integer",
-                    ));
-                }
-                let action = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+                // `@unwrap_spec(action=int)`.
+                let action = crate::baseobjspace::int_w(args[1])? as i32;
                 host_termios::tcflow(fd, action).map_err(|e| {
                     termios_converted_error(
                         e.raw_os_error().unwrap_or(0),

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -683,8 +683,11 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
         ));
     };
 
+    // `interp_time.py:801` — `space.fixedview(w_tup)` accepts any sequence
+    // (tuple, list, struct_time), not only an exact tuple.
+    let tup_w = crate::baseobjspace::fixedview(tup, -1)?;
+    let len = tup_w.len();
     unsafe {
-        let len = w_tuple_len(tup);
         if len < 9 {
             return Err(crate::PyError::type_error(format!(
                 "argument must be sequence of at least length 9, not {len}"
@@ -693,7 +696,7 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
         // `baseobjspace.py:1976 c_int_w` — int_w with a 32-bit range check;
         // floats and non-integers raise rather than being truncated.
         let c_int_w = |i: usize| -> Result<i32, crate::PyError> {
-            crate::baseobjspace::c_int_w(w_tuple_getitem(tup, i as i64).unwrap())
+            crate::baseobjspace::c_int_w(tup_w[i])
         };
         let y = c_int_w(0)?;
         // A zero month / day / yday is normalized to 1 before the C-struct
@@ -732,7 +735,7 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
         // `tm_zone` (idx 9, via `utf8_w`) and length >=11 supplies
         // `tm_gmtoff` (idx 10).
         if len >= 10 {
-            tm.tm_zone = crate::baseobjspace::utf8_w(w_tuple_getitem(tup, 9).unwrap())?.to_string();
+            tm.tm_zone = crate::baseobjspace::utf8_w(tup_w[9])?.to_string();
         }
         if len >= 11 {
             tm.tm_gmtoff = c_int_w(10)? as i64;

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -119,12 +119,26 @@ pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             } else if is_bool(args[0]) {
                 boolobject::w_bool_get_value(args[0]) as i64
             } else {
-                let name = crate::typedef::r#type(args[0])
-                    .map(|tp| w_type_get_name(tp).to_string())
-                    .unwrap_or_else(|| "object".to_string());
-                return Err(crate::PyError::type_error(format!(
-                    "'{name}' object cannot be interpreted as an integer"
-                )));
+                // `timeutils.py:31` — `space.bigint_w(w_secs)` applies
+                // `space.int`, so an object with `__int__` / `__index__` is
+                // accepted and reduced to a longlong.
+                let has_int = crate::baseobjspace::lookup(args[0], "__int__").is_some()
+                    || crate::baseobjspace::lookup(args[0], "__index__").is_some();
+                if !has_int {
+                    let name = crate::typedef::r#type(args[0])
+                        .map(|tp| w_type_get_name(tp).to_string())
+                        .unwrap_or_else(|| "object".to_string());
+                    return Err(crate::PyError::type_error(format!(
+                        "'{name}' object cannot be interpreted as an integer"
+                    )));
+                }
+                let w_int = crate::baseobjspace::space_int(args[0])?;
+                if is_int(w_int) {
+                    w_int_get_value(w_int)
+                } else {
+                    i64::try_from(pyre_object::longobject::w_long_get_value(w_int))
+                        .map_err(|_| overflow())?
+                }
             };
             sec.checked_mul(SECS_TO_NS).ok_or_else(|| overflow())?
         }
@@ -695,9 +709,8 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
         }
         // `baseobjspace.py:1976 c_int_w` — int_w with a 32-bit range check;
         // floats and non-integers raise rather than being truncated.
-        let c_int_w = |i: usize| -> Result<i32, crate::PyError> {
-            crate::baseobjspace::c_int_w(tup_w[i])
-        };
+        let c_int_w =
+            |i: usize| -> Result<i32, crate::PyError> { crate::baseobjspace::c_int_w(tup_w[i]) };
         let y = c_int_w(0)?;
         // A zero month / day / yday is normalized to 1 before the C-struct
         // adjustment below.

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -782,6 +782,32 @@ pub fn gmtime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(_tm_to_tuple(&tm))
 }
 
+/// interp_time.py:861-879 `_checktm` — guard the C-adjusted `struct tm`
+/// fields that strftime()/asctime() index, so a bad value raises a
+/// ValueError instead of letting libc index out of bounds.  Year and
+/// wday are already handled in `_gettmarg`.
+fn _checktm(tm: &c_tm) -> Result<(), crate::PyError> {
+    if !(0..=11).contains(&tm.tm_mon) {
+        return Err(crate::PyError::value_error("month out of range"));
+    }
+    if !(1..=31).contains(&tm.tm_mday) {
+        return Err(crate::PyError::value_error("day of month out of range"));
+    }
+    if !(0..=23).contains(&tm.tm_hour) {
+        return Err(crate::PyError::value_error("hour out of range"));
+    }
+    if !(0..=59).contains(&tm.tm_min) {
+        return Err(crate::PyError::value_error("minute out of range"));
+    }
+    if !(0..=61).contains(&tm.tm_sec) {
+        return Err(crate::PyError::value_error("seconds out of range"));
+    }
+    if !(0..=365).contains(&tm.tm_yday) {
+        return Err(crate::PyError::value_error("day of year out of range"));
+    }
+    Ok(())
+}
+
 /// time.strftime(format[, tuple]) — interp_time.strftime
 pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let fmt = args
@@ -790,6 +816,7 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         .ok_or_else(|| crate::PyError::type_error("strftime() requires at least one argument"))?;
 
     let tm = _gettmarg(&args[1..], true)?;
+    _checktm(&tm)?;
 
     let fmt_str = unsafe {
         if !is_str(fmt) {
@@ -907,6 +934,7 @@ pub fn mktime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// time.asctime([tuple]) — interp_time.asctime
 pub fn asctime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let tm = _gettmarg(args, true)?;
+    _checktm(&tm)?;
     _asctime_from_tm(&tm)
 }
 

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -85,42 +85,60 @@ pub fn monotonic(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `std::thread::sleep` otherwise.
 pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     assert!(args.len() == 1, "sleep() takes exactly one argument");
-    // `timeutils.py:20-38 timestamp_w` — a float rejects NaN; everything
-    // else goes through `space.bigint_w`, so bools are accepted (int
-    // subclass) and any other type raises TypeError.
-    let secs = unsafe {
+    // `timeutils.py:20-38 timestamp_w` — reduce the argument to an integer
+    // number of nanoseconds. A float scales then `math.ceil`s, with an
+    // `ovfcheck_float_to_longlong` overflow guard and a NaN ValueError; an
+    // int (or bool, an int subclass) takes `bigint_w().tolonglong()` and
+    // multiplies by 10**9 under the same overflow guard; anything else is a
+    // TypeError.
+    const SECS_TO_NS: i64 = 1_000_000_000;
+    let timeout_ns: i64 = unsafe {
+        let overflow = || {
+            crate::PyError::overflow_error(format!(
+                "timestamp {} too large to convert to C _PyTime_t",
+                crate::py_repr(args[0])
+            ))
+        };
         if is_float(args[0]) {
-            let s = floatobject::w_float_get_value(args[0]);
-            if s.is_nan() {
+            let secs = floatobject::w_float_get_value(args[0]);
+            if secs.is_nan() {
                 return Err(crate::PyError::value_error("timestamp is nan"));
             }
-            s
-        } else if is_int(args[0]) {
-            w_int_get_value(args[0]) as f64
-        } else if is_bool(args[0]) {
-            if boolobject::w_bool_get_value(args[0]) {
-                1.0
-            } else {
-                0.0
+            // `rarithmetic.ovfcheck_float_to_longlong` bounds.
+            let result_float = (secs * SECS_TO_NS as f64).ceil();
+            if !(-9223372036854776832.0..9223372036854775296.0).contains(&result_float) {
+                return Err(overflow());
             }
+            result_float as i64
         } else {
-            let name = crate::typedef::r#type(args[0])
-                .map(|tp| w_type_get_name(tp).to_string())
-                .unwrap_or_else(|| "object".to_string());
-            return Err(crate::PyError::type_error(format!(
-                "'{name}' object cannot be interpreted as an integer"
-            )));
+            let sec = if is_int(args[0]) {
+                w_int_get_value(args[0])
+            } else if pyre_object::pyobject::is_long(args[0]) {
+                let big = pyre_object::longobject::w_long_get_value(args[0]);
+                i64::try_from(big).map_err(|_| overflow())?
+            } else if is_bool(args[0]) {
+                boolobject::w_bool_get_value(args[0]) as i64
+            } else {
+                let name = crate::typedef::r#type(args[0])
+                    .map(|tp| w_type_get_name(tp).to_string())
+                    .unwrap_or_else(|| "object".to_string());
+                return Err(crate::PyError::type_error(format!(
+                    "'{name}' object cannot be interpreted as an integer"
+                )));
+            };
+            sec.checked_mul(SECS_TO_NS).ok_or_else(|| overflow())?
         }
     };
-    if secs < 0.0 {
+    // `interp_time.py:624` — `if not (timeout >= 0)`.
+    if timeout_ns < 0 {
         return Err(crate::PyError::value_error(
             "sleep length must be non-negative",
         ));
     }
-    if secs == 0.0 {
+    if timeout_ns == 0 {
         return Ok(w_none());
     }
-    let dur = std::time::Duration::from_secs_f64(secs);
+    let dur = std::time::Duration::from_nanos(timeout_ns as u64);
     #[cfg(all(unix, feature = "host_env"))]
     {
         // `interp_time.py:622-710 time_sleep` — sleep toward a monotonic

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -690,49 +690,65 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
                 "argument must be sequence of at least length 9, not {len}"
             )));
         }
-        let get = |i: usize| -> i32 {
-            let item = w_tuple_getitem(tup, i as i64).unwrap();
-            if is_int(item) {
-                w_int_get_value(item) as i32
-            } else if is_float(item) {
-                floatobject::w_float_get_value(item) as i32
-            } else {
-                0
-            }
+        // `baseobjspace.py:1976 c_int_w` — int_w with a 32-bit range check;
+        // floats and non-integers raise rather than being truncated.
+        let c_int_w = |i: usize| -> Result<i32, crate::PyError> {
+            crate::baseobjspace::c_int_w(w_tuple_getitem(tup, i as i64).unwrap())
         };
+        let y = c_int_w(0)?;
+        // A zero month / day / yday is normalized to 1 before the C-struct
+        // adjustment below.
+        let mut tm_mon = c_int_w(1)?;
+        if tm_mon == 0 {
+            tm_mon = 1;
+        }
+        let mut tm_mday = c_int_w(2)?;
+        if tm_mday == 0 {
+            tm_mday = 1;
+        }
+        let mut tm_yday = c_int_w(7)?;
+        if tm_yday == 0 {
+            tm_yday = 1;
+        }
+        let tm_hour = c_int_w(3)?;
+        let tm_min = c_int_w(4)?;
+        let tm_sec = c_int_w(5)?;
+        let tm_wday = c_int_w(6)?;
+        let tm_isdst = c_int_w(8)?;
         let mut tm = c_tm {
-            tm_sec: 0,
-            tm_min: 0,
-            tm_hour: 0,
-            tm_mday: 0,
-            tm_mon: 0,
+            tm_sec,
+            tm_min,
+            tm_hour,
+            tm_mday,
+            tm_mon,
             tm_year: 0,
-            tm_wday: 0,
-            tm_yday: 0,
-            tm_isdst: 0,
+            tm_wday,
+            tm_yday,
+            tm_isdst,
             tm_gmtoff: 0,
             tm_zone: String::new(),
         };
-        tm.tm_year = get(0) - 1900;
-        tm.tm_mon = get(1) - 1;
-        tm.tm_mday = get(2);
-        tm.tm_hour = get(3);
-        tm.tm_min = get(4);
-        tm.tm_sec = get(5);
-        tm.tm_wday = (get(6) + 1) % 7; // Python Monday=0 → C Sunday=0
-        tm.tm_yday = get(7) - 1;
-        tm.tm_isdst = get(8);
         // interp_time.py:830-841 — a sequence of length >=10 supplies
-        // `tm_zone` (idx 9) and length >=11 supplies `tm_gmtoff` (idx 10).
+        // `tm_zone` (idx 9, via `utf8_w`) and length >=11 supplies
+        // `tm_gmtoff` (idx 10).
         if len >= 10 {
-            let item = w_tuple_getitem(tup, 9).unwrap();
-            if is_str(item) {
-                tm.tm_zone = w_str_get_value(item).to_string();
-            }
+            tm.tm_zone =
+                crate::baseobjspace::utf8_w(w_tuple_getitem(tup, 9).unwrap())?.to_string();
         }
         if len >= 11 {
-            tm.tm_gmtoff = get(10) as i64;
+            tm.tm_gmtoff = c_int_w(10)? as i64;
         }
+        // Bounds checked before the final field adjustments.
+        if (y as i64) < i32::MIN as i64 + 1900 {
+            return Err(crate::PyError::overflow_error("year out of range"));
+        }
+        if tm_wday < -1 {
+            return Err(crate::PyError::value_error("day of week out of range"));
+        }
+        tm.tm_year = y - 1900;
+        tm.tm_mon = tm_mon - 1;
+        tm.tm_wday = (tm_wday + 1) % 7; // Python Monday=0 → C Sunday=0
+        tm.tm_yday = tm_yday - 1;
         Ok(tm)
     }
 }

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -732,8 +732,7 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
         // `tm_zone` (idx 9, via `utf8_w`) and length >=11 supplies
         // `tm_gmtoff` (idx 10).
         if len >= 10 {
-            tm.tm_zone =
-                crate::baseobjspace::utf8_w(w_tuple_getitem(tup, 9).unwrap())?.to_string();
+            tm.tm_zone = crate::baseobjspace::utf8_w(w_tuple_getitem(tup, 9).unwrap())?.to_string();
         }
         if len >= 11 {
             tm.tm_gmtoff = c_int_w(10)? as i64;

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1361,7 +1361,8 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__floordiv__", "__rfloordiv__") {
-            if let Some(result) = try_dispatch_binary_special(a, b, "__floordiv__", "__rfloordiv__")?
+            if let Some(result) =
+                try_dispatch_binary_special(a, b, "__floordiv__", "__rfloordiv__")?
             {
                 return Ok(result);
             }
@@ -1438,7 +1439,8 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let b = unwrap_cell(b);
     unsafe {
         if needs_numeric_binop_dispatch(a, b, "__truediv__", "__rtruediv__") {
-            if let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")? {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")?
+            {
                 return Ok(result);
             }
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2453,11 +2453,7 @@ pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             && pyre_object::is_w_range(b)
             && matches!(op, CompareOp::Eq | CompareOp::Ne)
         {
-            let (astart, _astop, astep) = pyre_object::w_range_fields(a);
-            let (bstart, _bstop, bstep) = pyre_object::w_range_fields(b);
-            let la = pyre_object::w_range_len(a);
-            let lb = pyre_object::w_range_len(b);
-            let equal = la == lb && (la == 0 || (astart == bstart && (la == 1 || astep == bstep)));
+            let equal = pyre_object::w_range_eq(a, b);
             return Ok(w_bool_from(match op {
                 CompareOp::Eq => equal,
                 CompareOp::Ne => !equal,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1036,10 +1036,84 @@ unsafe fn bytes_operand_overrides(obj: PyObjectRef, fwd: &str, rev: &str) -> boo
     dunder_overridden(obj, fwd, t) || dunder_overridden(obj, rev, t)
 }
 
+/// True when numeric operand `obj` (int/long/float storage) has a Python
+/// class that overrides `dunder` relative to its builtin base — int/long
+/// against `int`, float against `float`.  Mirrors [`dunder_overridden`]
+/// with the numeric base selected per operand.  Only an *overriding*
+/// subclass routes through dispatch: a non-overriding subclass keeps the
+/// Rust fast path, which both matches the builtin result and avoids
+/// re-entering the inherited slot (it would recurse back into this op).
+unsafe fn numeric_operand_overrides(obj: PyObjectRef, dunder: &str, rdunder: &str) -> bool {
+    let base: *const pyre_object::PyType = if is_int(obj) || is_long(obj) {
+        &pyre_object::INT_TYPE
+    } else if is_float(obj) {
+        &pyre_object::FLOAT_TYPE
+    } else {
+        return false;
+    };
+    let Some(t) = crate::typedef::gettypefor(base) else {
+        return false;
+    };
+    dunder_overridden(obj, dunder, t) || dunder_overridden(obj, rdunder, t)
+}
+
+/// descroperation.py:708 `binop_impl` shortcut — the builtin numeric
+/// (int/long/float) fast path bypasses `__op__`/`__rop__` dispatch unless
+/// an operand is a subclass that actually overrides the forward or
+/// reflected special method.  The seq/bytes analogs are
+/// [`needs_seq_binop_dispatch`]/[`needs_bytes_binop_dispatch`].
+///
+/// `dont_look_inside`: the type-static + typeobject-registry loads stay in
+/// this residual helper, off the traced numeric graph; the hot int path is
+/// specialized separately via `guard_class` in the JIT.
+#[majit_macros::dont_look_inside]
+unsafe fn needs_numeric_binop_dispatch(
+    a: PyObjectRef,
+    b: PyObjectRef,
+    fwd: &str,
+    rev: &str,
+) -> bool {
+    numeric_operand_overrides(a, fwd, rev) || numeric_operand_overrides(b, fwd, rev)
+}
+
+/// Unary analog: true when numeric operand `a` overrides the unary
+/// special `dunder` relative to its builtin base.
+#[majit_macros::dont_look_inside]
+unsafe fn needs_numeric_unaryop_dispatch(a: PyObjectRef, dunder: &str) -> bool {
+    let base: *const pyre_object::PyType = if is_int(a) || is_long(a) {
+        &pyre_object::INT_TYPE
+    } else if is_float(a) {
+        &pyre_object::FLOAT_TYPE
+    } else {
+        return false;
+    };
+    let Some(t) = crate::typedef::gettypefor(base) else {
+        return false;
+    };
+    dunder_overridden(a, dunder, t)
+}
+
+/// Call the overriding unary special on a numeric subclass operand before
+/// the Rust fast path.  Returns `None` when `a` is an exact builtin
+/// numeric or does not override `dunder`, so the caller falls through.
+unsafe fn try_numeric_unaryop_override(a: PyObjectRef, dunder: &str) -> Option<PyResult> {
+    if !needs_numeric_unaryop_dispatch(a, dunder) {
+        return None;
+    }
+    let t = crate::typedef::r#type(a)?;
+    let method = lookup_in_type_where(t, dunder)?;
+    Some(crate::call::call_function_impl_result(method, &[a]))
+}
+
 pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__add__", "__radd__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_add(a, b);
         }
@@ -1128,6 +1202,11 @@ pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__sub__", "__rsub__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__sub__", "__rsub__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_sub(a, b);
         }
@@ -1176,6 +1255,11 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__mul__", "__rmul__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__mul__", "__rmul__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_mul(a, b);
         }
@@ -1276,6 +1360,12 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__floordiv__", "__rfloordiv__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__floordiv__", "__rfloordiv__")?
+            {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_floordiv(a, b);
         }
@@ -1303,6 +1393,11 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__mod__", "__rmod__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__mod__", "__rmod__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_mod(a, b);
         }
@@ -1342,6 +1437,11 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__truediv__", "__rtruediv__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")? {
+                return Ok(result);
+            }
+        }
         let a_num = is_int(a) || is_float(a) || is_long(a);
         let b_num = is_int(b) || is_float(b) || is_long(b);
         if a_num && b_num {
@@ -1377,6 +1477,11 @@ pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__pow__", "__rpow__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__pow__", "__rpow__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_pow(a, b);
         }
@@ -1817,6 +1922,11 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__lshift__", "__rlshift__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__lshift__", "__rlshift__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_lshift(a, b);
         }
@@ -1843,6 +1953,11 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__rshift__", "__rrshift__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__rshift__", "__rrshift__")? {
+                return Ok(result);
+            }
+        }
         if is_int_like(a) && is_int_like(b) {
             return int_rshift(a, b);
         }
@@ -1869,6 +1984,11 @@ pub fn and_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__and__", "__rand__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__and__", "__rand__")? {
+                return Ok(result);
+            }
+        }
         // boolobject.py:74 W_BoolObject.descr_and — both operands bool
         // → space.newbool(op(a, b)). MRO ensures this runs before the
         // W_IntObject.descr_and fallback in int_bitand.
@@ -1952,6 +2072,11 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         }
     };
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__or__", "__ror__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__or__", "__ror__")? {
+                return Ok(result);
+            }
+        }
         // boolobject.py:75 W_BoolObject.descr_or — both operands bool
         // → space.newbool(op(a, b)).
         if is_bool(a) && is_bool(b) {
@@ -2020,6 +2145,11 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     let b = unwrap_cell(b);
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__xor__", "__rxor__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__xor__", "__rxor__")? {
+                return Ok(result);
+            }
+        }
         if is_bool(a) && is_bool(b) {
             return Ok(pyre_object::bool_descr_xor(a, b));
         }
@@ -2420,6 +2550,9 @@ impl CompareOp {
 pub fn pos(a: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     unsafe {
+        if let Some(result) = try_numeric_unaryop_override(a, "__pos__") {
+            return result;
+        }
         if is_int(a) || is_bool(a) {
             return Ok(w_int_new(int_value(a)));
         }
@@ -2449,6 +2582,9 @@ pub fn pos(a: PyObjectRef) -> PyResult {
 pub fn neg(a: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     unsafe {
+        if let Some(result) = try_numeric_unaryop_override(a, "__neg__") {
+            return result;
+        }
         if is_int(a) || is_bool(a) {
             let v = int_value(a);
             return match v.checked_neg() {
@@ -2483,6 +2619,9 @@ pub fn neg(a: PyObjectRef) -> PyResult {
 pub fn invert(a: PyObjectRef) -> PyResult {
     let a = unwrap_cell(a);
     unsafe {
+        if let Some(result) = try_numeric_unaryop_override(a, "__invert__") {
+            return result;
+        }
         if is_int(a) || is_bool(a) {
             return Ok(w_int_new(!int_value(a)));
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1036,6 +1036,18 @@ unsafe fn bytes_operand_overrides(obj: PyObjectRef, fwd: &str, rev: &str) -> boo
     dunder_overridden(obj, fwd, t) || dunder_overridden(obj, rev, t)
 }
 
+/// The builtin numeric base type backing `obj`'s storage — `int` for
+/// int/long, `float` for float, `None` for a non-numeric operand.
+unsafe fn numeric_base_type(obj: PyObjectRef) -> Option<*const pyre_object::PyType> {
+    if is_int(obj) || is_long(obj) {
+        Some(&pyre_object::INT_TYPE)
+    } else if is_float(obj) {
+        Some(&pyre_object::FLOAT_TYPE)
+    } else {
+        None
+    }
+}
+
 /// True when numeric operand `obj` (int/long/float storage) has a Python
 /// class that overrides `dunder` relative to its builtin base — int/long
 /// against `int`, float against `float`.  Mirrors [`dunder_overridden`]
@@ -1044,11 +1056,7 @@ unsafe fn bytes_operand_overrides(obj: PyObjectRef, fwd: &str, rev: &str) -> boo
 /// Rust fast path, which both matches the builtin result and avoids
 /// re-entering the inherited slot (it would recurse back into this op).
 unsafe fn numeric_operand_overrides(obj: PyObjectRef, dunder: &str, rdunder: &str) -> bool {
-    let base: *const pyre_object::PyType = if is_int(obj) || is_long(obj) {
-        &pyre_object::INT_TYPE
-    } else if is_float(obj) {
-        &pyre_object::FLOAT_TYPE
-    } else {
+    let Some(base) = numeric_base_type(obj) else {
         return false;
     };
     let Some(t) = crate::typedef::gettypefor(base) else {
@@ -1080,11 +1088,7 @@ unsafe fn needs_numeric_binop_dispatch(
 /// special `dunder` relative to its builtin base.
 #[majit_macros::dont_look_inside]
 unsafe fn needs_numeric_unaryop_dispatch(a: PyObjectRef, dunder: &str) -> bool {
-    let base: *const pyre_object::PyType = if is_int(a) || is_long(a) {
-        &pyre_object::INT_TYPE
-    } else if is_float(a) {
-        &pyre_object::FLOAT_TYPE
-    } else {
+    let Some(base) = numeric_base_type(a) else {
         return false;
     };
     let Some(t) = crate::typedef::gettypefor(base) else {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -943,6 +943,9 @@ pub fn range_iter_continues(iter: PyObjectRef) -> Result<bool, PyError> {
         if is_range_iter(iter) {
             return Ok(w_range_iter_has_next(iter));
         }
+        if pyre_object::is_long_range_iter(iter) {
+            return Ok(pyre_object::w_long_range_iter_has_next(iter));
+        }
         if is_seq_iter(iter) {
             let si = &*(iter as *const W_SeqIterator);
             return Ok(si.index < si.length);
@@ -955,6 +958,9 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
     unsafe {
         if is_range_iter(iter) {
             return Ok(w_range_iter_next(iter).unwrap_or(PY_NULL));
+        }
+        if pyre_object::is_long_range_iter(iter) {
+            return Ok(pyre_object::w_long_range_iter_next(iter).unwrap_or(PY_NULL));
         }
         if is_seq_iter(iter) {
             let si = &mut *(iter as *mut W_SeqIterator);

--- a/pyre/pyre-interpreter/src/structseq.rs
+++ b/pyre/pyre-interpreter/src/structseq.rs
@@ -315,6 +315,19 @@ fn structseq_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         extras.push((ename.as_str(), value));
     }
 
+    // `app_posix.py:71-80 stat_result.__init__` — a tuple-constructed
+    // stat_result leaves the float `st_atime`/`st_mtime`/`st_ctime` extras
+    // as None; fall back to the integer timestamps at body slots 7..9.
+    if name == "os.stat_result" && body.len() > 9 {
+        for (slot, ename) in [(7usize, "st_atime"), (8, "st_mtime"), (9, "st_ctime")] {
+            if let Some(entry) = extras.iter_mut().find(|(n, _)| *n == ename) {
+                if unsafe { pyre_object::is_none(entry.1) } {
+                    entry.1 = body[slot];
+                }
+            }
+        }
+    }
+
     Ok(new_instance_with_extra(cls, body, extras))
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9319,8 +9319,8 @@ fn invalid_byte_2_of_4(ch1: u8, ch2: u8) -> bool {
 /// through and any other byte becomes a lone `0xDC00 + byte` surrogate.
 /// `surrogateescape` rescues every byte, so the decode never fails.
 pub(crate) fn charp2uni(data: &[u8]) -> PyObjectRef {
-    let decoded =
-        decode_utf8_with_errors(data, "surrogateescape").unwrap_or_else(|_| Wtf8Buf::new());
+    let decoded = decode_utf8_with_errors(data, "surrogateescape")
+        .expect("surrogateescape rescues every byte, so the decode never fails");
     pyre_object::w_str_from_wtf8(decoded)
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9310,6 +9310,16 @@ fn invalid_byte_2_of_4(ch1: u8, ch2: u8) -> bool {
     invalid_cont_byte(ch2) || (ch1 == 0xF0 && ch2 < 0x90) || (ch1 == 0xF4 && ch2 > 0x8F)
 }
 
+/// interp_locale.py:42-46 `charp2uni` — decode a C string the way
+/// `str(bytes, 'utf-8', 'surrogateescape')` does: valid UTF-8 passes
+/// through and any other byte becomes a lone `0xDC00 + byte` surrogate.
+/// `surrogateescape` rescues every byte, so the decode never fails.
+pub(crate) fn charp2uni(data: &[u8]) -> PyObjectRef {
+    let decoded =
+        decode_utf8_with_errors(data, "surrogateescape").unwrap_or_else(|_| Wtf8Buf::new());
+    pyre_object::w_str_from_wtf8(decoded)
+}
+
 /// unicodehelper.py:377-537 _str_decode_utf8_slowpath
 /// Structural port of PyPy's _utf8_code_length state machine.
 /// PyPy appends raw UTF-8 bytes to a StringBuilder; Rust reconstructs

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -583,6 +583,10 @@ pub fn init_typeobjects() {
             new_typeobject_with_base("iterator", |_| {}, object_type) as usize,
         );
         reg.insert(
+            &pyre_object::rangeobject::LONG_RANGE_ITER_TYPE as *const PyType as usize,
+            new_typeobject_with_base("longrange_iterator", |_| {}, object_type) as usize,
+        );
+        reg.insert(
             &pyre_object::cellobject::CELL_TYPE as *const PyType as usize,
             new_typeobject_with_base("cell", init_cell_type, object_type) as usize,
         );

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -1,10 +1,15 @@
-//! W_RangeIterator -- simplified range iterator.
+//! Range objects and their iterators.
 //!
-//! `range()` returns an iterator directly (no separate range object).
-//! The JIT specializes `for i in range(N)` to pure integer arithmetic
-//! by reading/writing `current`, `stop`, `step` via field descriptors.
+//! `range()` builds a `W_Range` sequence carrying wrapped `(start, stop,
+//! step, length)` bounds; `iter()` produces a `W_RangeIterator` (machine
+//! int, JIT-specializable) when every bound fits a word, else a
+//! `W_LongRangeIterator` (bignum), mirroring `rangeiterator` /
+//! `longrange_iterator`.  The JIT specializes `for i in range(N)` to pure
+//! integer arithmetic by reading/writing the iterator's `current`,
+//! `stop`, `step` via field descriptors.
 
 use crate::pyobject::*;
+use malachite_bigint::BigInt;
 use pyre_macros::pyre_class;
 
 /// Range iterator object.
@@ -189,21 +194,45 @@ mod tests {
 // ── Range sequence object ──
 //
 // `objspace/std/rangeobject.py W_AbstractRangeObject` / `W_RangeObject`:
-// an immutable arithmetic sequence carrying `(start, stop, step)`.
-// Distinct from `W_RangeIterator` (the cursor produced by `iter()`), so a
-// range is reusable, sized, indexable and comparable.
+// an immutable arithmetic sequence carrying `(start, stop, step)`.  PyPy
+// stores the three bounds as wrapped ints, so a range can describe values
+// beyond a machine word; pyre keeps the same three wrapped fields.
+//
+// The hot `for i in range(n)` loop never reads these fields — `iter()`
+// produces a `W_RangeIterator` (i64, JIT-specialized) when every bound
+// fits a machine word, and a `W_LongRangeIterator` otherwise, mirroring
+// PyPy's `rangeiterator` / `longrange_iterator` split.
 
 /// `range(start, stop, step)` sequence object.
+///
+/// `w_length` is precomputed once at construction (`descr_new` →
+/// `compute_range_length`) and read back by `descr_len` / `descr_bool`.
 #[pyre_class("range", type_id = 7, static_name = "RANGE")]
 pub struct W_Range {
-    pub start: i64,
-    pub stop: i64,
-    pub step: i64,
+    pub start: PyObjectRef,
+    pub stop: PyObjectRef,
+    pub step: PyObjectRef,
+    pub length: PyObjectRef,
 }
 
-/// Allocate a `W_Range`.  `step` must already be non-zero (the caller
-/// raises `ValueError` for a zero step before reaching here).
-pub fn w_range_new(start: i64, stop: i64, step: i64) -> PyObjectRef {
+/// Allocate a `W_Range` from three wrapped int/long bounds.  `step` must
+/// already be non-zero (the caller raises `ValueError` for a zero step
+/// before reaching here).  The element count is computed once here and
+/// stored, mirroring `descr_new`'s `compute_range_length`.
+pub fn w_range_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(start);
+    crate::gc_roots::pin_root(stop);
+    crate::gc_roots::pin_root(step);
+    let length = unsafe {
+        let len_big = range_length_big(
+            &range_obj_to_bigint(start),
+            &range_obj_to_bigint(stop),
+            &range_obj_to_bigint(step),
+        );
+        range_bigint_to_obj(len_big)
+    };
+    crate::gc_roots::pin_root(length);
     W_Range::allocate(W_Range {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -212,7 +241,17 @@ pub fn w_range_new(start: i64, stop: i64, step: i64) -> PyObjectRef {
         start,
         stop,
         step,
+        length,
     })
+}
+
+/// Convenience constructor wrapping three machine-int bounds.
+pub fn w_range_new_i64(start: i64, stop: i64, step: i64) -> PyObjectRef {
+    w_range_new(
+        crate::intobject::w_int_new(start),
+        crate::intobject::w_int_new(stop),
+        crate::intobject::w_int_new(step),
+    )
 }
 
 /// # Safety
@@ -222,14 +261,246 @@ pub unsafe fn is_w_range(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &RANGE_TYPE) }
 }
 
-/// Read the `(start, stop, step)` triple of a range object.
+/// Read the wrapped `(start, stop, step)` triple of a range object.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_Range`.
 #[inline]
-pub unsafe fn w_range_fields(obj: PyObjectRef) -> (i64, i64, i64) {
+pub unsafe fn w_range_fields(obj: PyObjectRef) -> (PyObjectRef, PyObjectRef, PyObjectRef) {
     let r = obj as *const W_Range;
     unsafe { ((*r).start, (*r).stop, (*r).step) }
+}
+
+/// Read an int/long/bool operand as a `BigInt`.
+///
+/// # Safety
+/// `obj` must be a valid int, long, or bool object.
+pub unsafe fn range_obj_to_bigint(obj: PyObjectRef) -> BigInt {
+    unsafe {
+        if is_int(obj) {
+            BigInt::from(crate::intobject::w_int_get_value(obj))
+        } else if is_bool(obj) {
+            BigInt::from(crate::boolobject::w_bool_get_value(obj) as i64)
+        } else {
+            crate::longobject::w_long_get_value(obj).clone()
+        }
+    }
+}
+
+/// Wrap a `BigInt` as a machine int when it fits, otherwise a long.
+pub fn range_bigint_to_obj(value: BigInt) -> PyObjectRef {
+    use num_traits::ToPrimitive;
+    match value.to_i64() {
+        Some(v) => crate::intobject::w_int_new(v),
+        None => crate::longobject::w_long_new(value),
+    }
+}
+
+/// A single int/long/bool bound as an i64 when it fits, else `None`.
+///
+/// # Safety
+/// `obj` must be a valid int/long/bool object.
+pub unsafe fn range_obj_as_i64(obj: PyObjectRef) -> Option<i64> {
+    unsafe {
+        if is_int(obj) {
+            Some(crate::intobject::w_int_get_value(obj))
+        } else if is_bool(obj) {
+            Some(crate::boolobject::w_bool_get_value(obj) as i64)
+        } else {
+            use num_traits::ToPrimitive;
+            crate::longobject::w_long_get_value(obj).to_i64()
+        }
+    }
+}
+
+/// The `(start, stop, step)` triple as machine ints when all three fit a
+/// machine word (the common case); `None` if any bound is a bignum.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+pub unsafe fn w_range_fields_i64(obj: PyObjectRef) -> Option<(i64, i64, i64)> {
+    unsafe {
+        let (s, e, t) = w_range_fields(obj);
+        Some((
+            range_obj_as_i64(s)?,
+            range_obj_as_i64(e)?,
+            range_obj_as_i64(t)?,
+        ))
+    }
+}
+
+/// The precomputed wrapped element count — `descr_len → self.w_length`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+#[inline]
+pub unsafe fn w_range_length(obj: PyObjectRef) -> PyObjectRef {
+    let r = obj as *const W_Range;
+    unsafe { (*r).length }
+}
+
+/// The element count as a machine int when it fits, else `None`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+#[inline]
+pub unsafe fn w_range_length_i64(obj: PyObjectRef) -> Option<i64> {
+    unsafe { range_obj_as_i64(w_range_length(obj)) }
+}
+
+/// `descr_bool → space.nonzero(self.w_length)` — a range is truthy iff it
+/// has at least one element.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+pub unsafe fn w_range_bool(obj: PyObjectRef) -> bool {
+    use num_traits::Zero;
+    unsafe { !range_obj_to_bigint(w_range_length(obj)).is_zero() }
+}
+
+/// `descr_iter` — a `rangeiterator` (`W_RangeIterator`, machine-int and
+/// JIT-specializable) when every bound fits a machine word, otherwise a
+/// `longrange_iterator` (`W_LongRangeIterator`).
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+pub unsafe fn w_range_iter(obj: PyObjectRef) -> PyObjectRef {
+    unsafe {
+        if let Some((start, stop, step)) = w_range_fields_i64(obj) {
+            w_range_iter_new(start, stop, step)
+        } else {
+            let (start, _stop, step) = w_range_fields(obj);
+            let len = w_range_length(obj);
+            w_long_range_iter_new(start, step, len)
+        }
+    }
+}
+
+/// `descr_reversed` — walk the span backwards.  The fast path keeps a
+/// machine-int `W_RangeIterator` so `for i in reversed(range(n))` stays
+/// JIT-specializable; otherwise a `W_LongRangeIterator` from
+/// `(start + (length-1)*step, -step, length)`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+pub unsafe fn w_range_reversed(obj: PyObjectRef) -> PyObjectRef {
+    use num_traits::One;
+    unsafe {
+        if let Some((start, stop, step)) = w_range_fields_i64(obj) {
+            let len = range_length(start, stop, step);
+            if len == 0 {
+                return w_range_iter_new(0, 0, 1);
+            }
+            let last = start + (len - 1) * step;
+            return w_range_iter_new(last, start - step, -step);
+        }
+        let (start, _stop, step) = w_range_fields(obj);
+        let len_obj = w_range_length(obj);
+        let start_b = range_obj_to_bigint(start);
+        let step_b = range_obj_to_bigint(step);
+        let len_b = range_obj_to_bigint(len_obj);
+        let lastitem = &start_b + (&len_b - BigInt::one()) * &step_b;
+        let _roots = crate::gc_roots::push_roots();
+        crate::gc_roots::pin_root(len_obj);
+        let w_lastitem = range_bigint_to_obj(lastitem);
+        crate::gc_roots::pin_root(w_lastitem);
+        let w_negstep = range_bigint_to_obj(-step_b);
+        crate::gc_roots::pin_root(w_negstep);
+        w_long_range_iter_new(w_lastitem, w_negstep, len_obj)
+    }
+}
+
+/// `_compute_item` — the member at `index` (negative folded against the
+/// length), or `None` when out of bounds (`IndexError` at the call site).
+/// `index` is the already-`__index__`'d operand as a `BigInt`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+pub unsafe fn w_range_compute_item(obj: PyObjectRef, index: &BigInt) -> Option<PyObjectRef> {
+    use num_traits::Zero;
+    unsafe {
+        let (start, _stop, step) = w_range_fields(obj);
+        let len_b = range_obj_to_bigint(w_range_length(obj));
+        let mut idx = index.clone();
+        if idx < BigInt::zero() {
+            idx += &len_b;
+        }
+        if idx >= len_b || idx < BigInt::zero() {
+            return None;
+        }
+        let value = range_obj_to_bigint(start) + idx * range_obj_to_bigint(step);
+        Some(range_bigint_to_obj(value))
+    }
+}
+
+/// `_contains_long` — O(1) membership test for an integer `item`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+pub unsafe fn w_range_contains_bigint(obj: PyObjectRef, item: &BigInt) -> bool {
+    use num_traits::Zero;
+    unsafe {
+        let (start, stop, step) = w_range_fields(obj);
+        let start_b = range_obj_to_bigint(start);
+        let stop_b = range_obj_to_bigint(stop);
+        let step_b = range_obj_to_bigint(step);
+        if step_b > BigInt::zero() {
+            // positive steps: start <= ob < stop
+            if !(start_b <= *item && *item < stop_b) {
+                return false;
+            }
+        } else {
+            // negative steps: stop < ob <= start
+            if !(stop_b < *item && *item <= start_b) {
+                return false;
+            }
+        }
+        // The stride must not invalidate membership.
+        ((item - &start_b) % &step_b).is_zero()
+    }
+}
+
+/// `descr_index` — the position of `item` (known to be in range), i.e.
+/// `(item - start) // step`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+pub unsafe fn w_range_index_of(obj: PyObjectRef, item: &BigInt) -> PyObjectRef {
+    unsafe {
+        let (start, _stop, step) = w_range_fields(obj);
+        let value = (item - range_obj_to_bigint(start)) / range_obj_to_bigint(step);
+        range_bigint_to_obj(value)
+    }
+}
+
+/// `descr_eq` — two ranges are equal iff they generate the same sequence:
+/// equal lengths, and for a non-empty range equal start and (for length
+/// > 1) equal step.  The caller has already established both operands are
+/// ranges.
+///
+/// # Safety
+/// `a` and `b` must point to valid `W_Range` objects.
+pub unsafe fn w_range_eq(a: PyObjectRef, b: PyObjectRef) -> bool {
+    use num_traits::One;
+    unsafe {
+        let la = range_obj_to_bigint(w_range_length(a));
+        let lb = range_obj_to_bigint(w_range_length(b));
+        if la != lb {
+            return false;
+        }
+        let (astart, _astop, astep) = w_range_fields(a);
+        let (bstart, _bstop, bstep) = w_range_fields(b);
+        if la == BigInt::from(0) {
+            return true;
+        }
+        if range_obj_to_bigint(astart) != range_obj_to_bigint(bstart) {
+            return false;
+        }
+        if la == BigInt::one() {
+            return true;
+        }
+        range_obj_to_bigint(astep) == range_obj_to_bigint(bstep)
+    }
 }
 
 /// Number of elements in a `(start, stop, step)` range —
@@ -248,47 +519,105 @@ pub fn range_length(start: i64, stop: i64, step: i64) -> i64 {
     }
 }
 
-/// Length of a `W_Range`.
-///
-/// # Safety
-/// `obj` must point to a valid `W_Range`.
-pub unsafe fn w_range_len(obj: PyObjectRef) -> i64 {
-    let (start, stop, step) = unsafe { w_range_fields(obj) };
-    range_length(start, stop, step)
-}
-
-/// `start + index * step` for an already-normalised, in-bounds `index`
-/// (`0 <= index < len`).  Returns `None` when out of range so the caller
-/// can raise `IndexError`; negative indices are folded by adding `len`.
-///
-/// # Safety
-/// `obj` must point to a valid `W_Range`.
-pub unsafe fn w_range_getitem(obj: PyObjectRef, index: i64) -> Option<i64> {
-    let (start, _stop, step) = unsafe { w_range_fields(obj) };
-    let len = unsafe { w_range_len(obj) };
-    let i = if index < 0 { index + len } else { index };
-    if i < 0 || i >= len {
-        None
-    } else {
-        Some(start + i * step)
-    }
-}
-
-/// Whether integer `value` is a member of the range —
-/// `rangeobject.py W_RangeObject.descr_contains` integer fast path.
-///
-/// # Safety
-/// `obj` must point to a valid `W_Range`.
-pub unsafe fn w_range_contains_int(obj: PyObjectRef, value: i64) -> bool {
-    let (start, stop, step) = unsafe { w_range_fields(obj) };
-    if step > 0 {
-        if value < start || value >= stop {
-            return false;
+/// Bignum `compute_range_length` — always non-negative.
+pub fn range_length_big(start: &BigInt, stop: &BigInt, step: &BigInt) -> BigInt {
+    use num_traits::{One, Zero};
+    let zero = BigInt::zero();
+    if *step > zero {
+        if *start < *stop {
+            (stop - start - BigInt::one()) / step + BigInt::one()
+        } else {
+            BigInt::zero()
         }
-    } else if value > start || value <= stop {
-        return false;
+    } else if *start > *stop {
+        (start - stop - BigInt::one()) / (-step) + BigInt::one()
+    } else {
+        BigInt::zero()
     }
-    (value - start) % step == 0
+}
+
+// ── Long range iterator ──
+//
+// `objspace/std/iterobject.py W_LongRangeIterator` — the cursor `iter()`
+// produces for a range whose bounds exceed a machine word.  `start`,
+// `step` and `len` stay wrapped (set once at construction); only the
+// machine-int `index` advances, so no GC pointer field is ever mutated.
+
+#[pyre_class("longrange_iterator", type_id = 8, static_name = "LONG_RANGE_ITER")]
+pub struct W_LongRangeIterator {
+    pub start: PyObjectRef,
+    pub step: PyObjectRef,
+    pub len: PyObjectRef,
+    pub index: i64,
+}
+
+/// Allocate a `W_LongRangeIterator`.
+pub fn w_long_range_iter_new(
+    start: PyObjectRef,
+    step: PyObjectRef,
+    len: PyObjectRef,
+) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(start);
+    crate::gc_roots::pin_root(step);
+    crate::gc_roots::pin_root(len);
+    W_LongRangeIterator::allocate(W_LongRangeIterator {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        start,
+        step,
+        len,
+        index: 0,
+    })
+}
+
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_long_range_iter(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &LONG_RANGE_ITER_TYPE) }
+}
+
+/// Number of elements not yet produced — `__length_hint__`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_LongRangeIterator`.
+pub unsafe fn w_long_range_iter_len(obj: PyObjectRef) -> BigInt {
+    unsafe {
+        let it = obj as *const W_LongRangeIterator;
+        let len = range_obj_to_bigint((*it).len);
+        let rem = len - BigInt::from((*it).index);
+        if rem < BigInt::from(0) {
+            BigInt::from(0)
+        } else {
+            rem
+        }
+    }
+}
+
+/// Advance the long-range iterator and return the next value, or `None`
+/// once exhausted — `start + index * step`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_LongRangeIterator`.
+pub unsafe fn w_long_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
+    unsafe {
+        let it = obj as *mut W_LongRangeIterator;
+        let index = (*it).index;
+        let len = range_obj_to_bigint((*it).len);
+        if BigInt::from(index) >= len {
+            return None;
+        }
+        let start = range_obj_to_bigint((*it).start);
+        let step = range_obj_to_bigint((*it).step);
+        let value = start + BigInt::from(index) * step;
+        // Only the machine-int index is mutated; the wrapped fields stay
+        // immutable, so no GC pointer field is overwritten.
+        (*it).index = index + 1;
+        Some(range_bigint_to_obj(value))
+    }
 }
 
 #[cfg(test)]
@@ -319,16 +648,29 @@ mod range_obj_tests {
     }
 
     #[test]
-    fn w_range_getitem_and_contains() {
-        let r = w_range_new(0, 10, 2);
+    fn w_range_fields_i64_roundtrip() {
+        let r = w_range_new_i64(0, 10, 2);
         unsafe {
-            assert_eq!(w_range_len(r), 5);
-            assert_eq!(w_range_getitem(r, 0), Some(0));
-            assert_eq!(w_range_getitem(r, 4), Some(8));
-            assert_eq!(w_range_getitem(r, -1), Some(8));
-            assert_eq!(w_range_getitem(r, 5), None);
-            assert!(w_range_contains_int(r, 4));
-            assert!(!w_range_contains_int(r, 5));
+            assert_eq!(w_range_fields_i64(r), Some((0, 10, 2)));
+        }
+    }
+
+    #[test]
+    fn long_range_iter_yields_values() {
+        let it = w_long_range_iter_new(
+            crate::intobject::w_int_new(5),
+            crate::intobject::w_int_new(2),
+            crate::intobject::w_int_new(3),
+        );
+        unsafe {
+            assert!(is_long_range_iter(it));
+            let v0 = w_long_range_iter_next(it).unwrap();
+            assert_eq!(crate::intobject::w_int_get_value(v0), 5);
+            let v1 = w_long_range_iter_next(it).unwrap();
+            assert_eq!(crate::intobject::w_int_get_value(v1), 7);
+            let v2 = w_long_range_iter_next(it).unwrap();
+            assert_eq!(crate::intobject::w_int_get_value(v2), 9);
+            assert!(w_long_range_iter_next(it).is_none());
         }
     }
 }

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -367,17 +367,25 @@ pub unsafe fn w_range_bool(obj: PyObjectRef) -> bool {
 pub unsafe fn w_range_iter(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
         // `descr_iter` takes the machine-int iterator only when start, stop,
-        // step AND length all fit a machine word; a span whose length exceeds
-        // a word (e.g. `range(-2**63, 2**63-1)`) needs the bignum iterator.
-        if let (Some((start, stop, step)), Some(_length)) =
+        // step AND length all fit a machine word.  `W_RangeIterator` stops
+        // when `current` crosses `stop`, advancing `current += step` after
+        // each element; the post-final `start + length*step` must therefore
+        // also fit a word, or the wrapped `current` would never reach `stop`
+        // (an infinite loop).  When it would overflow — or any bound/length
+        // exceeds a word — the bignum iterator is used instead, which stops
+        // on the wrapped length the way `W_IntRangeIterator` counts down its
+        // remaining.
+        if let (Some((start, stop, step)), Some(length)) =
             (w_range_fields_i64(obj), w_range_length_i64(obj))
         {
-            w_range_iter_new(start, stop, step)
-        } else {
-            let (start, _stop, step) = w_range_fields(obj);
-            let len = w_range_length(obj);
-            w_long_range_iter_new(start, step, len)
+            let one_past = start as i128 + length as i128 * step as i128;
+            if i64::try_from(one_past).is_ok() {
+                return w_range_iter_new(start, stop, step);
+            }
         }
+        let (start, _stop, step) = w_range_fields(obj);
+        let len = w_range_length(obj);
+        w_long_range_iter_new(start, step, len)
     }
 }
 
@@ -391,13 +399,26 @@ pub unsafe fn w_range_iter(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_range_reversed(obj: PyObjectRef) -> PyObjectRef {
     use num_traits::One;
     unsafe {
-        if let Some((start, stop, step)) = w_range_fields_i64(obj) {
-            let len = range_length(start, stop, step);
+        if let (Some((start, _stop, step)), Some(len)) =
+            (w_range_fields_i64(obj), w_range_length_i64(obj))
+        {
             if len == 0 {
                 return w_range_iter_new(0, 0, 1);
             }
-            let last = start + (len - 1) * step;
-            return w_range_iter_new(last, start - step, -step);
+            // The reversed machine-int iterator walks `last` down to `start`
+            // by `-step`, stopping past `start - step`; that one-past value,
+            // the negated step, and `last` must all fit a word or the
+            // wrapped `current` would loop forever — fall back to bignum.
+            let last = start as i128 + (len as i128 - 1) * step as i128;
+            let one_past = start as i128 - step as i128;
+            let neg_step = -(step as i128);
+            if let (Ok(last), Ok(stop_rev), Ok(neg_step)) = (
+                i64::try_from(last),
+                i64::try_from(one_past),
+                i64::try_from(neg_step),
+            ) {
+                return w_range_iter_new(last, stop_rev, neg_step);
+            }
         }
         let (start, _stop, step) = w_range_fields(obj);
         let len_obj = w_range_length(obj);
@@ -676,6 +697,25 @@ mod range_obj_tests {
             let v2 = w_long_range_iter_next(it).unwrap();
             assert_eq!(crate::intobject::w_int_get_value(v2), 9);
             assert!(w_long_range_iter_next(it).is_none());
+        }
+    }
+
+    #[test]
+    fn iter_routes_increment_overflow_to_longrange() {
+        unsafe {
+            // Word-fit bounds, but the forward `start + length*step` overflows
+            // i64, so a machine-int iterator would loop forever — must use the
+            // bignum iterator instead.
+            let fwd = w_range_new_i64(i64::MAX - 5, i64::MAX, 10);
+            assert!(is_long_range_iter(w_range_iter(fwd)));
+            // The reversed walk's one-past `start - step` underflows i64 here,
+            // so `reversed()` must likewise use the bignum iterator.
+            let rev = w_range_new_i64(i64::MIN, i64::MIN + 50, 10);
+            assert!(is_long_range_iter(w_range_reversed(rev)));
+            // A plain range stays on the machine-int (JIT) iterator both ways.
+            let n = w_range_new_i64(0, 10, 2);
+            assert!(is_range_iter(w_range_iter(n)));
+            assert!(is_range_iter(w_range_reversed(n)));
         }
     }
 }

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -411,11 +411,10 @@ pub unsafe fn w_range_reversed(obj: PyObjectRef) -> PyObjectRef {
             // wrapped `current` would loop forever — fall back to bignum.
             let last = start as i128 + (len as i128 - 1) * step as i128;
             let one_past = start as i128 - step as i128;
-            let neg_step = -(step as i128);
-            if let (Ok(last), Ok(stop_rev), Ok(neg_step)) = (
+            if let (Ok(last), Ok(stop_rev), Some(neg_step)) = (
                 i64::try_from(last),
                 i64::try_from(one_past),
-                i64::try_from(neg_step),
+                step.checked_neg(),
             ) {
                 return w_range_iter_new(last, stop_rev, neg_step);
             }

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -622,6 +622,17 @@ pub unsafe fn w_long_range_iter_len(obj: PyObjectRef) -> BigInt {
     }
 }
 
+/// Whether the long-range iterator has elements left — peek, non-mutating.
+///
+/// # Safety
+/// `obj` must point to a valid `W_LongRangeIterator`.
+pub unsafe fn w_long_range_iter_has_next(obj: PyObjectRef) -> bool {
+    unsafe {
+        let it = obj as *const W_LongRangeIterator;
+        BigInt::from((*it).index) < range_obj_to_bigint((*it).len)
+    }
+}
+
 /// Advance the long-range iterator and return the next value, or `None`
 /// once exhausted — `start + index * step`.
 ///

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -366,7 +366,12 @@ pub unsafe fn w_range_bool(obj: PyObjectRef) -> bool {
 /// `obj` must point to a valid `W_Range`.
 pub unsafe fn w_range_iter(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
-        if let Some((start, stop, step)) = w_range_fields_i64(obj) {
+        // `descr_iter` takes the machine-int iterator only when start, stop,
+        // step AND length all fit a machine word; a span whose length exceeds
+        // a word (e.g. `range(-2**63, 2**63-1)`) needs the bignum iterator.
+        if let (Some((start, stop, step)), Some(_length)) =
+            (w_range_fields_i64(obj), w_range_length_i64(obj))
+        {
             w_range_iter_new(start, stop, step)
         } else {
             let (start, _stop, step) = w_range_fields(obj);


### PR DESCRIPTION
Fix #82

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full bignum-safe range support: long-range iterators, O(1) integer membership/indexing, consistent hashing/repr, and a registered long-range iterator type.
  * Broader numeric protocol support and numeric-subclass-aware operator dispatch.

* **Bug Fixes**
  * Fixed stat_result time-field ordering and fallback initialization.
  * Hardened timeout parsing/overflow/NaN handling, select fd bounds and fileno validation, embedded-NUL error messages, and stricter sleep/time argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->