### PR TITLE
JIT: virtualize non-escaping exceptions to close the raise_catch gap (#129)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4090,173 +4090,6 @@ fn op_var_index(op: &Op, op_idx: usize, num_inputs: usize) -> usize {
     }
 }
 
-/// Pure-data opcodes whose result is a deterministic function of their
-/// operands (field/array loads + address arithmetic).  These are the only
-/// ops the body-direct entry will REPLAY to reconstruct a loop invariant
-/// that Cranelift auto-promoted into a body-block param (see
-/// `plan_body_direct`).  Anything outside this set (calls, guards, stores,
-/// allocations, overflow arithmetic) makes the loop body-direct-ineligible
-/// so we keep the safe preamble-only entry.
-fn is_replayable_invariant(opcode: OpCode) -> bool {
-    matches!(
-        opcode,
-        OpCode::GetfieldGcI
-            | OpCode::GetfieldGcR
-            | OpCode::GetfieldGcF
-            | OpCode::GetfieldGcPureI
-            | OpCode::GetfieldGcPureR
-            | OpCode::GetfieldGcPureF
-            | OpCode::GetfieldRawI
-            | OpCode::GetfieldRawR
-            | OpCode::GetfieldRawF
-            | OpCode::GetarrayitemGcI
-            | OpCode::GetarrayitemGcR
-            | OpCode::GetarrayitemGcF
-            | OpCode::GetarrayitemGcPureI
-            | OpCode::GetarrayitemGcPureR
-            | OpCode::GetarrayitemGcPureF
-            | OpCode::GetarrayitemRawI
-            | OpCode::GetarrayitemRawF
-            | OpCode::GcLoadI
-            | OpCode::GcLoadR
-            | OpCode::GcLoadF
-            | OpCode::GcLoadIndexedI
-            | OpCode::GcLoadIndexedR
-            | OpCode::GcLoadIndexedF
-            | OpCode::IntAdd
-            | OpCode::IntSub
-            | OpCode::IntMul
-    )
-}
-
-/// Static plan for the cranelift body-direct entry (the nbody entry-bridge
-/// fix).  A peeled loop is emitted as `[entry LABEL] preamble [body LABEL]
-/// body`; the body LABEL block is reached only via the preamble's
-/// computed jump, so an entry-bridge/closing-jump that supplies the body
-/// LABEL's full arg set still gets routed through the preamble (function
-/// entry) which re-derives the loop state from the few preamble inputs —
-/// producing wrong/NULL loop-carried values.  Body-direct entry reads the
-/// body LABEL's args straight from the frame and jumps to the body block.
-///
-/// The complication: Cranelift auto-promotes loop invariants the preamble
-/// computed (a preamble op-result OpRef use_var'd in the body, or a
-/// preamble ref-root spilled in the body) into EXTRA body-block params
-/// beyond the IR LABEL arity.  The body-direct path must reconstruct those
-/// from the body LABEL args.  This plans which preamble ops to replay.
-///
-/// Returns None when the loop is not body-direct-eligible: not the canonical
-/// 2-LABEL peeled shape (>2 LABELs need general br_table dispatch), or an
-/// invariant depends on a non-replayable op.
-struct BodyDirectPlan {
-    /// body LABEL arg OpRef raws, in slot order (== body block param order).
-    body_arg_oprefs: Vec<u32>,
-    /// preamble op indices to replay, in definition (ascending) order.
-    replay_ops: Vec<usize>,
-}
-
-fn plan_body_direct(
-    ops: &[Op],
-    label_indices: &[usize],
-    num_inputs: usize,
-    ref_root_oprefs: &VecSet<u32>,
-) -> Option<BodyDirectPlan> {
-    // Only the canonical peeled shape: exactly two LABELs (entry LABEL +
-    // body header). Linear/single-LABEL traces have no preamble to bypass;
-    // >2 LABELs need the general per-LABEL br_table dispatch.
-    if label_indices.len() != 2 {
-        return None;
-    }
-    // Target the FIRST LABEL, not the body LABEL: the interp-origin entry
-    // bridge JUMPs to the loop's first LABEL and writes that LABEL's args to
-    // the frame (its `fail_arg_refs` == the first LABEL's arity). Entering
-    // there with the supplied args bypasses the peeled preamble that would
-    // otherwise re-derive them (the crash source). The ops preceding the
-    // first LABEL are that preamble; their results that the rest of the loop
-    // (LABEL block and after) use are the invariants Cranelift promotes onto
-    // the LABEL block and must be replayed from the supplied LABEL args.
-    let target_label_idx = label_indices[0];
-
-    let body_arg_oprefs: Vec<u32> = ops[target_label_idx]
-        .getarglist()
-        .iter()
-        .map(|a| a.to_opref().raw())
-        .collect();
-    let body_arg_set: VecSet<u32> = body_arg_oprefs.iter().copied().collect();
-
-    // result OpRef raw -> defining op idx, preamble portion only (ops before
-    // the first LABEL).
-    let mut def_idx: VecAssoc<u32, usize> = VecAssoc::new();
-    for (i, op) in ops.iter().enumerate().take(target_label_idx) {
-        if op.result_type() != Type::Void {
-            def_idx.insert(op_var_index(op, i, num_inputs) as u32, i);
-        }
-    }
-
-    // Seed = preamble-results use_var'd at/after the first LABEL: explicit
-    // args/failargs, plus preamble-result ref-roots (the GC-root spill
-    // use_var's them, so Cranelift promotes them too).
-    let mut seed: VecSet<u32> = VecSet::new();
-    let mut consider = |raw: u32, seed: &mut VecSet<u32>| {
-        if def_idx.contains_key(&raw) && !body_arg_set.contains(&raw) {
-            seed.insert(raw);
-        }
-    };
-    for (i, op) in ops.iter().enumerate() {
-        if i < target_label_idx {
-            continue;
-        }
-        for a in op.getarglist().iter() {
-            if !a.is_none() && !a.is_constant() {
-                consider(a.to_opref().raw(), &mut seed);
-            }
-        }
-        for a in op.getfailargs().into_iter().flatten() {
-            if !a.is_none() && !a.is_constant() {
-                consider(a.to_opref().raw(), &mut seed);
-            }
-        }
-    }
-    for &raw in ref_root_oprefs.iter() {
-        consider(raw, &mut seed);
-    }
-
-    // Close under dependencies; verify each replayed op is pure.
-    let mut replay_set: VecSet<u32> = VecSet::new();
-    let mut stack: Vec<u32> = seed.iter().copied().collect();
-    while let Some(raw) = stack.pop() {
-        if replay_set.contains(&raw) {
-            continue;
-        }
-        let Some(&i) = def_idx.get(&raw) else {
-            continue;
-        };
-        if !is_replayable_invariant(ops[i].opcode) {
-            return None;
-        }
-        replay_set.insert(raw);
-        for a in ops[i].getarglist().iter() {
-            if a.is_none() || a.is_constant() {
-                continue;
-            }
-            let ar = a.to_opref().raw();
-            if def_idx.contains_key(&ar) && !body_arg_set.contains(&ar) && !replay_set.contains(&ar)
-            {
-                stack.push(ar);
-            }
-        }
-    }
-
-    let mut replay_ops: Vec<usize> = replay_set
-        .iter()
-        .filter_map(|raw| def_idx.get(raw).copied())
-        .collect();
-    replay_ops.sort_unstable();
-    Some(BodyDirectPlan {
-        body_arg_oprefs,
-        replay_ops,
-    })
-}
-
 /// rewrite.py:397-407 `optimize_GUARD_CLASS` parity:
 /// Pre-flight check that the OpRefs feeding pointer-dereferencing
 /// guard ops are bound to a defined value. RPython's box-identity
@@ -6361,33 +6194,6 @@ fn emit_guard_exit(
         let enabled = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
             && std::env::var_os("PYRE_CL_NO_CLOSING_JUMP").is_none();
         if enabled {
-            // Body-direct entry (nbody entry-bridge fix): set the target's
-            // entry_mode discriminator so its block0 reads the first LABEL's
-            // args from the frame and jumps straight to that LABEL block,
-            // bypassing the peeled preamble. A normal execute_token entry leaves
-            // the slot zero-filled (entry_mode == 0 -> preamble).
-            //
-            // The discriminator lives at slot `fail_arg_refs.len()` (= the
-            // target's `max_entry_inputs` for an entry-bridge JUMP, the slot its
-            // body-direct prologue reads the flag from). A loop only has a
-            // body-direct entry when it carries loop-body ops past its LABEL, so
-            // that slot always sits strictly below `max_output_slots` — a genuine
-            // output slot, in bounds and below the ref-root region at
-            // `[max_output_slots, max_output_slots + num_ref_roots)`. When the
-            // slot reaches `max_output_slots` the target has no body-direct entry
-            // to read it; storing there would overrun the frame (no ref roots) or
-            // clobber a GC ref root, so skip the write. `max_output_slots` is
-            // recovered from `ref_root_base_ofs = JF_FRAME_ITEM0_OFS +
-            // max_output_slots * 8`.
-            let disc_slot = info.fail_arg_refs.len();
-            let max_output_slots = ((ref_root_base_ofs - JF_FRAME_ITEM0_OFS) / 8) as usize;
-            if disc_slot < max_output_slots {
-                let one = builder.ins().iconst(cl_types::I64, 1);
-                let disc_ofs = JF_FRAME_ITEM0_OFS + (disc_slot as i32) * 8;
-                builder
-                    .ins()
-                    .store(MemFlags::trusted(), one, jf_ptr, disc_ofs);
-            }
             emit_attached_loop_dispatch(
                 builder,
                 jf_ptr,
@@ -7027,11 +6833,7 @@ fn run_compiled_code_inner(
             // as NULL (GuardNotForced checks jf_descr != 0), and zero the item
             // slots too. RPython's nursery allocation hands back zeroed memory
             // (zeroed once per nursery reset); ours does not, so a fresh frame
-            // must be cleared here. The body-direct dual entry relies on it:
-            // its entry_mode discriminator lives at frame slot max_entry_inputs,
-            // and a normal execute_token entry (which only writes num_inputs
-            // slots) must read 0 there to take the preamble arm rather than a
-            // stale value from a recycled slot.
+            // must be cleared here.
             std::ptr::write_bytes(gcref.0 as *mut u8, 0, payload_bytes);
             *((gcref.0 + JF_FRAME_LENGTH_OFS as usize) as *mut usize) = frame_depth;
         }
@@ -8519,7 +8321,6 @@ impl CraneliftBackend {
             .enumerate()
             .filter_map(|(idx, op)| (op.opcode == OpCode::Label).then_some(idx))
             .collect();
-        let has_entry_label = label_indices.first().copied() == Some(0);
 
         // descr.index() → label op's source-arity (args.len()).  Captured up
         // front because Cranelift's FunctionBuilder may auto-promote `def_var`
@@ -8542,23 +8343,6 @@ impl CraneliftBackend {
                 );
             }
         }
-
-        // Body-direct entry (nbody entry-bridge fix): give a peeled loop a
-        // second entry that reads the first LABEL's full arg set from the
-        // frame and jumps straight to that LABEL block, bypassing the peeled
-        // preamble that block0 would otherwise run to re-derive those args
-        // (the source of the entry-bridge re-entry crash). Eligible only for
-        // the canonical 2-LABEL peeled shape with purely-replayable invariants
-        // (see plan_body_direct); otherwise None and the loop keeps its single
-        // preamble entry. The discriminator that selects this entry is written
-        // only by the entry-bridge/closing-jump path, so when no bridge
-        // targets this loop the body-direct arm stays dead.
-        let ref_root_oprefs: VecSet<u32> = ref_root_slots.iter().map(|(raw, _)| *raw).collect();
-        let body_direct_plan: Option<BodyDirectPlan> =
-            plan_body_direct(ops, &label_indices, num_inputs, &ref_root_oprefs);
-        let body_direct_num_inputs = body_direct_plan
-            .as_ref()
-            .map_or(0, |p| p.body_arg_oprefs.len());
 
         // Collect all variable declarations into a map (index -> type)
         // before declaring them sequentially. Cranelift 0.130 declare_var
@@ -8744,26 +8528,12 @@ impl CraneliftBackend {
             *cell.borrow_mut() = Some(op_result_positions);
         });
 
-        let max_entry_inputs = num_inputs.max(body_direct_num_inputs);
-        // The dual-entry prologue loads the body LABEL args from frame slots
-        // `[0, body_direct_num_inputs)` and an `entry_mode` discriminator from
-        // slot `max_entry_inputs`. Those reads are in-bounds only while the
-        // highest one stays inside the frame payload `[0, max_output_slots +
-        // num_ref_roots)` (output slots followed by ref roots; see
-        // run_compiled_code_inner). A peeled loop whose first-LABEL arity
-        // exceeds the payload (large loop-carried set, few guard fail-args /
-        // ref roots) would read past the frame. Emit the body-direct entry
-        // only when the discriminator slot is in-bounds; otherwise fall back to
-        // the single preamble entry (entry_mode == 0). For typical loops the
-        // discriminator lands in the ref-root region, well within the payload.
-        let body_direct_entry = body_direct_num_inputs > 0
-            && max_entry_inputs < max_output_slots + ref_root_slots.len();
-        let load_count = if body_direct_entry {
-            max_entry_inputs + 1 // extra slot for entry_mode flag
-        } else {
-            num_inputs
-        };
-        let entry_input_vals: Vec<CValue> = (0..load_count)
+        // Load the inputarg boxes from frame slots `[0, num_inputs)` (the
+        // entry layout `run_compiled_code_inner` populated). The per-LABEL
+        // `br_table` re-entry path reads each LABEL's carried values directly
+        // from the frame in its loader, so the entry block only needs the
+        // host-entry inputs.
+        let entry_input_vals: Vec<CValue> = (0..num_inputs)
             .map(|i| {
                 let offset = JF_FRAME_ITEM0_OFS + (i as i32) * 8;
                 builder
@@ -8781,24 +8551,10 @@ impl CraneliftBackend {
         // entries land in the `[bridge_inputarg_base..)` slot the ops
         // reference.
         //
-        // ONLY real input boxes (oprefs) become located Variables here. The
-        // loads beyond `num_inputs` — the body-direct padding (extra body
-        // LABEL args) and the `entry_mode` flag — are transient frame reads
-        // consumed directly from `entry_input_vals`: the dual-entry `brif`
-        // reads the flag at index `max_entry_inputs`, and the body-direct arm
-        // feeds `entry_input_vals[..body_direct_num_inputs]` straight into the
-        // body block parameters. They are not oprefs, so they must not enter
-        // the Variable namespace. Routing a non-opref index through `var()`
-        // takes its pre-declaration fallback `Variable::from_u32(i)`, whose
-        // raw index space overlaps the sequentially-declared opref Variables
-        // and `jf_ptr_var`. `jf_ptr_var` is declared immediately after the
-        // opref map, so its index equals the opref count; a small frame whose
-        // op set is just its inputs makes `max_entry_inputs` equal that index,
-        // and def_var'ing the flag then overwrites the frame pointer with the
-        // flag value (0 on a normal entry) — every later `use_var(jf_ptr_var)`
-        // reads NULL. This mirrors the RPython box-location discipline: only
-        // boxes have locations; the jitframe pointer register (EBP) is
-        // reserved and never shares a slot with a value.
+        // Every loaded slot is a real input box (opref): only boxes become
+        // located Variables, mirroring the RPython box-location discipline.
+        // The jitframe pointer register (EBP, `jf_ptr_var`) is reserved and
+        // never shares a slot with a value.
         //
         // The inputarg→ref-root sync must NOT run in this pre-dispatch entry
         // block when the trace has LABELs: the per-LABEL loaders (the
@@ -8813,12 +8569,7 @@ impl CraneliftBackend {
         // no GC in between.
         let mut deferred_entry_root_syncs: Vec<(u32, CValue)> = Vec::new();
         let has_labels = !label_indices.is_empty();
-        for (i, val) in entry_input_vals
-            .iter()
-            .copied()
-            .take(num_inputs)
-            .enumerate()
-        {
+        for (i, val) in entry_input_vals.iter().copied().enumerate() {
             let slot = inputargs[i].index;
             builder.def_var(var(slot), val);
             if has_labels {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8754,6 +8754,20 @@ impl CraneliftBackend {
         // reads NULL. This mirrors the RPython box-location discipline: only
         // boxes have locations; the jitframe pointer register (EBP) is
         // reserved and never shares a slot with a value.
+        //
+        // The inputarg→ref-root sync must NOT run in this pre-dispatch entry
+        // block when the trace has LABELs: the per-LABEL loaders (the
+        // dispatch_key re-entry path) read each LABEL's carried values from
+        // the dense jitframe slots `JF_FRAME_ITEM0_OFS + i*8`, and when
+        // `max_output_slots < arity` those slots overlap the ref-root region
+        // (`ref_root_base_ofs + slot*8`). Syncing an inputarg to its root slot
+        // here would clobber a carried value before the loader reads it. Defer
+        // the sync to the preamble (key-0 host-entry) path, which is the only
+        // path that needs roots established before the preamble's own ops; the
+        // loader paths reach a LABEL block that re-syncs its carried roots with
+        // no GC in between.
+        let mut deferred_entry_root_syncs: Vec<(u32, CValue)> = Vec::new();
+        let has_labels = !label_indices.is_empty();
         for (i, val) in entry_input_vals
             .iter()
             .copied()
@@ -8762,15 +8776,19 @@ impl CraneliftBackend {
         {
             let slot = inputargs[i].index;
             builder.def_var(var(slot), val);
-            sync_ref_root_var(
-                &mut builder,
-                jf_ptr,
-                &ref_root_slots,
-                slot,
-                val,
-                ref_root_base_ofs,
-                &mut synced_ref_vars,
-            );
+            if has_labels {
+                deferred_entry_root_syncs.push((slot, val));
+            } else {
+                sync_ref_root_var(
+                    &mut builder,
+                    jf_ptr,
+                    &ref_root_slots,
+                    slot,
+                    val,
+                    ref_root_base_ofs,
+                    &mut synced_ref_vars,
+                );
+            }
         }
 
         // RPython parity: GC roots are registered by run_compiled_code()
@@ -8914,6 +8932,22 @@ impl CraneliftBackend {
             // in this block; first_label_entered_at_entry stays false.
             builder.switch_to_block(preamble_block);
             builder.seal_block(preamble_block);
+            // Establish the inputarg ref roots here (preamble path only), after
+            // the br_table — see the deferral note at the entry-block sync. The
+            // loaders read the dense carried-value slots, which can overlap this
+            // root region, so the sync must not precede the dispatch.
+            let cur_jf = builder.use_var(jf_ptr_var);
+            for &(slot, val) in &deferred_entry_root_syncs {
+                sync_ref_root_var(
+                    &mut builder,
+                    cur_jf,
+                    &ref_root_slots,
+                    slot,
+                    val,
+                    ref_root_base_ofs,
+                    &mut synced_ref_vars,
+                );
+            }
         } else if has_jump && loop_block != entry_block {
             let zero = builder.ins().iconst(cl_types::I64, 0);
             let vals: Vec<CValue> = (0..loop_param_count)

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6073,6 +6073,7 @@ fn emit_attached_loop_dispatch(
     label_block_id_addr: usize,
     target_frame_depth_addr: usize,
     ptr_type: cranelift_codegen::ir::Type,
+    call_conv: cranelift_codegen::isa::CallConv,
 ) {
     // `LoopTargetDescr::set_dispatch_target` (descr.rs:1308-1318)
     // releases `target_frame_depth` and `label_block_id` BEFORE
@@ -6154,19 +6155,60 @@ fn emit_attached_loop_dispatch(
     let frame_fits = builder
         .ins()
         .icmp(IntCC::SignedGreaterThanOrEqual, frame_len, target_depth);
+    // `take_block` carries `(target_code_ptr, frame_ptr)`: `frame_ptr` is the
+    // original `jf_ptr` when it already fits, or the reallocated wider frame.
     let take_block = builder.create_block();
-    builder.append_block_param(take_block, ptr_type);
+    builder.append_block_param(take_block, ptr_type); // target_code_ptr
+    builder.append_block_param(take_block, ptr_type); // frame to dispatch with
+    let realloc_block = builder.create_block();
+    builder.append_block_param(realloc_block, ptr_type); // target_code_ptr
     builder.ins().brif(
         frame_fits,
         take_block,
+        &[BlockArg::from(target_code_ptr), BlockArg::from(jf_ptr)],
+        realloc_block,
         &[BlockArg::from(target_code_ptr)],
-        miss_block,
-        &[],
+    );
+
+    // `assembler.py:910 _check_frame_depth` slow path (`IncreaseStackSlowPath`
+    // -> `_frame_realloc_slowpath`, assembler.py:143): the current frame is
+    // narrower than the target loop needs, so reallocate a wider JITFRAME in
+    // place — header and live slots copied, `jf_forward` threaded — and
+    // dispatch into the target with the new frame.  This is the bridge
+    // prologue's `_check_frame_depth` (compiler.rs:8371) applied to the
+    // closing-jump path: the loaders read the target LABEL's carried values
+    // from the new frame's slots `cranelift_realloc_frame` just copied.
+    // Falling back to the host `execute_token` instead would re-enter the
+    // target at the preamble (dispatch_key 0) and re-derive loop state from
+    // the elided fastlocals writeback (stale -> frozen counter).
+    builder.switch_to_block(realloc_block);
+    builder.seal_block(realloc_block);
+    let realloc_target_code_ptr = builder.block_params(realloc_block)[0];
+    let realloc_addr = builder
+        .ins()
+        .iconst(ptr_type, cranelift_realloc_frame as *const () as i64);
+    let mut realloc_sig = Signature::new(call_conv);
+    realloc_sig.params.push(AbiParam::new(ptr_type));
+    realloc_sig.params.push(AbiParam::new(cl_types::I64));
+    realloc_sig.returns.push(AbiParam::new(ptr_type));
+    let realloc_sig_ref = builder.import_signature(realloc_sig);
+    let realloc_call =
+        builder
+            .ins()
+            .call_indirect(realloc_sig_ref, realloc_addr, &[jf_ptr, target_depth]);
+    let new_jf = builder.inst_results(realloc_call)[0];
+    builder.ins().jump(
+        take_block,
+        &[
+            BlockArg::from(realloc_target_code_ptr),
+            BlockArg::from(new_jf),
+        ],
     );
 
     builder.switch_to_block(take_block);
     builder.seal_block(take_block);
     let target_code_ptr = builder.block_params(take_block)[0];
+    let dispatch_jf_ptr = builder.block_params(take_block)[1];
     // The earlier nbody_50k corruption (-0.03513214049650899 vs. the
     // reference -0.035132020348426815) and the per-dispatch SP growth were
     // both consequences of `emit_attached_bridge_dispatch` doing a nested
@@ -6194,9 +6236,11 @@ fn emit_attached_loop_dispatch(
     // body's entry `br_table` reserves dispatch_key 0 for its preamble, so a
     // re-entry at LABEL L passes `label_block_id + 1`.
     let dispatch_key = builder.ins().iadd_imm(lbid, 1);
-    builder
-        .ins()
-        .return_call_indirect(target_sig_ref, target_code_ptr, &[jf_ptr, dispatch_key]);
+    builder.ins().return_call_indirect(
+        target_sig_ref,
+        target_code_ptr,
+        &[dispatch_jf_ptr, dispatch_key],
+    );
 
     builder.switch_to_block(miss_block);
     builder.seal_block(miss_block);
@@ -6351,6 +6395,7 @@ fn emit_guard_exit(
                 label_block_id_addr,
                 target_frame_depth_addr,
                 ptr_type,
+                call_conv,
             );
         }
     }

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6034,11 +6034,15 @@ fn emit_attached_bridge_dispatch(
     emit_call_footer_shadowstack(builder, ptr_type);
     let mut bridge_sig = Signature::new(cranelift_codegen::isa::CallConv::Tail);
     bridge_sig.params.push(AbiParam::new(ptr_type));
+    bridge_sig.params.push(AbiParam::new(cl_types::I32)); // dispatch_key (LABEL id)
     bridge_sig.returns.push(AbiParam::new(ptr_type));
     let bridge_sig_ref = builder.import_signature(bridge_sig);
+    // A bridge is linear (no LABELs): it always enters at its start, so the
+    // dispatch_key is 0.
+    let bridge_dispatch_key = builder.ins().iconst(cl_types::I32, 0);
     builder
         .ins()
-        .return_call_indirect(bridge_sig_ref, bridge_body, &[jf_ptr]);
+        .return_call_indirect(bridge_sig_ref, bridge_body, &[jf_ptr, bridge_dispatch_key]);
 
     builder.switch_to_block(miss_block);
     builder.seal_block(miss_block);
@@ -6099,32 +6103,24 @@ fn emit_attached_loop_dispatch(
     builder.switch_to_block(check_block_id);
     builder.seal_block(check_block_id);
     let target_code_ptr = builder.block_params(check_block_id)[0];
-    // `assembler.py:990-993` per-LABEL `_ll_loop_code` parity gate:
-    // pyre's body function shares one entry across all LABELs in the
-    // trace, so the function entry's preamble decodes inputargs in the
-    // FIRST LABEL's layout.  Tail-calling into the entry is correct
-    // only when the JUMP targets the first LABEL (label_block_id == 0).
-    // For non-first LABELs, the target's inputarg count/layout
-    // differs (verified for nbody: trace_id=1 has labels with 24 and
-    // 15 inputargs), so we fall back to the deadframe exit and let
-    // the host loop re-enter the right wrapper via `execute_token`.
-    // Once cranelift's body-entry `br_table` per-LABEL dispatch lands,
-    // this gate can be relaxed.
+    // `assembler.py:990-993` per-LABEL `_ll_loop_code` parity: PyPy exposes
+    // one code address per LABEL and a JUMP branches straight to the target
+    // LABEL's address.  Cranelift exposes a single function entry, so the
+    // target LABEL is selected by the `dispatch_key` argument the body's
+    // entry `br_table`s on.  Load the target descr's `label_block_id` and
+    // pass it as `dispatch_key` (return_call below); the target re-enters at
+    // exactly that LABEL with its carried values read from the jitframe slots
+    // this JUMP's `emit_guard_exit` populated, instead of always re-running
+    // the first LABEL's preamble.
     let lbid_ptr = builder.ins().iconst(ptr_type, label_block_id_addr as i64);
     let lbid = builder
         .ins()
         .load(cl_types::I32, MemFlags::trusted(), lbid_ptr, 0);
-    let zero_i32 = builder.ins().iconst(cl_types::I32, 0);
-    let is_first_label = builder.ins().icmp(IntCC::Equal, lbid, zero_i32);
     let check_depth_block = builder.create_block();
     builder.append_block_param(check_depth_block, ptr_type);
-    builder.ins().brif(
-        is_first_label,
-        check_depth_block,
-        &[BlockArg::from(target_code_ptr)],
-        miss_block,
-        &[],
-    );
+    builder
+        .ins()
+        .jump(check_depth_block, &[BlockArg::from(target_code_ptr)]);
 
     builder.switch_to_block(check_depth_block);
     builder.seal_block(check_depth_block);
@@ -6190,11 +6186,17 @@ fn emit_attached_loop_dispatch(
     // received for its non-tail helper calls.
     let mut target_sig = Signature::new(cranelift_codegen::isa::CallConv::Tail);
     target_sig.params.push(AbiParam::new(ptr_type));
+    target_sig.params.push(AbiParam::new(cl_types::I32)); // dispatch_key (LABEL id)
     target_sig.returns.push(AbiParam::new(ptr_type));
     let target_sig_ref = builder.import_signature(target_sig);
+    // x86/regalloc.py:1397 per-TargetToken `_ll_loop_code` parity: re-enter the
+    // target at the LABEL the JUMP names, not always the first.  The target
+    // body's entry `br_table` reserves dispatch_key 0 for its preamble, so a
+    // re-entry at LABEL L passes `label_block_id + 1`.
+    let dispatch_key = builder.ins().iadd_imm(lbid, 1);
     builder
         .ins()
-        .return_call_indirect(target_sig_ref, target_code_ptr, &[jf_ptr]);
+        .return_call_indirect(target_sig_ref, target_code_ptr, &[jf_ptr, dispatch_key]);
 
     builder.switch_to_block(miss_block);
     builder.seal_block(miss_block);
@@ -8181,6 +8183,14 @@ impl CraneliftBackend {
 
         let mut sig = Signature::new(body_call_conv);
         sig.params.push(AbiParam::new(ptr_type)); // jf_ptr (read inputs, write outputs)
+        // x86/regalloc.py:1397 per-TargetToken `_ll_loop_code` parity: a JUMP
+        // re-enters the target at a SPECIFIC LABEL, not always the first.
+        // PyPy exposes one code address per LABEL; cranelift has a single
+        // function entry, so the target LABEL is selected by a `dispatch_key`
+        // argument (the LABEL's `label_block_id`) that the entry block
+        // `br_table`s on.  The host wrapper passes 0 (first LABEL); an
+        // in-code closing-jump passes the target descr's `label_block_id`.
+        sig.params.push(AbiParam::new(cl_types::I32)); // dispatch_key (LABEL id)
         // RPython _call_footer (assembler.py:1097): mov eax, ebp; ret
         sig.returns.push(AbiParam::new(ptr_type)); // returned jf_ptr
 
@@ -8841,291 +8851,69 @@ impl CraneliftBackend {
             }
         }
 
-        let mut first_label_entered_at_entry = false;
-        if let Some(&(entry_label_idx, entry_label_block)) = label_blocks.first() {
-            if body_direct_entry && label_blocks.len() >= 2 {
-                // Dual entry: branch on entry_mode (last input slot).
-                // entry_mode == 0 → preamble, entry_mode != 0 → body-direct.
-                // brif directly targets label blocks with their params.
-                let entry_mode = entry_input_vals[max_entry_inputs];
-                // Target the FIRST LABEL block: the entry bridge supplies that
-                // LABEL's args (slots 0..arity) and writes entry_mode just past
-                // them, so a body-direct entry jumps there and lets the loop
-                // run forward (peeled preamble bypassed). plan_body_direct keys
-                // on label_indices[0], so body_direct_num_inputs == this
-                // block's IR arity and the entry_mode read slot == the bridge's
-                // write slot (fail_arg_refs.len()).
-                let body_block = entry_label_block;
-
-                // Dual entry: branch on entry_mode. The invariant replay below
-                // dereferences the body LABEL args carried in entry_input_vals
-                // (frame slots), which only hold live values on a body-direct
-                // (entry_mode != 0) entry — on a normal execute_token entry
-                // those slots are zero, so the replay loads would NULL-deref.
-                // Emit the replay in a dedicated body-direct block reached only
-                // when entry_mode != 0; the preamble arm branches to a
-                // continuation the main op loop fills. entry_input_vals are
-                // defined in the dominating entry block, so both successors can
-                // use them directly. Seal each (single predecessor = this
-                // brif) so their use_var resolves through the entry block
-                // instead of promoting block params.
-                let body_direct_block = builder.create_block();
-                let preamble_cont = builder.create_block();
-                builder
-                    .ins()
-                    .brif(entry_mode, body_direct_block, &[], preamble_cont, &[]);
-                builder.switch_to_block(body_direct_block);
-                builder.seal_block(body_direct_block);
-
-                // Reconstruct the loop invariants Cranelift auto-promotes into
-                // body-block params (a preamble op-result use_var'd in the
-                // body, or a preamble ref-root spilled there). REPLAYED here
-                // from the body LABEL args via a local value map; def_var so
-                // FunctionBuilder fills body_block's promoted params from this
-                // predecessor. plan_body_direct guaranteed every replay op is a
-                // pure load / address arithmetic whose operands are body LABEL
-                // args, inputs, constants, or earlier replays.
-                let plan = body_direct_plan
-                    .as_ref()
-                    .expect("body_direct plan present when body_direct_num_inputs > 0");
-                let mut bd_slot: VecAssoc<u32, usize> = VecAssoc::new();
-                for (i, ia) in inputargs.iter().enumerate() {
-                    bd_slot.insert(ia.index, i);
-                }
-                for (slot, &raw) in plan.body_arg_oprefs.iter().enumerate() {
-                    bd_slot.insert(raw, slot);
-                }
-                let mut bd_mat: VecAssoc<u32, CValue> = VecAssoc::new();
-                for &rop_idx in &plan.replay_ops {
-                    let rop = &ops[rop_idx];
-                    let rvi = op_var_index(rop, rop_idx, num_inputs) as u32;
-                    let resolve = |builder: &mut FunctionBuilder,
-                                   bd_mat: &VecAssoc<u32, CValue>,
-                                   opref: OpRef|
-                     -> CValue {
-                        if let Some(c) = lookup_const_i64(&constants, opref) {
-                            return builder.ins().iconst(cl_types::I64, c);
-                        }
-                        if let Some(&v) = bd_mat.get(&opref.raw()) {
-                            return v;
-                        }
-                        if let Some(&slot) = bd_slot.get(&opref.raw()) {
-                            return entry_input_vals[slot];
-                        }
-                        panic!(
-                            "body-direct replay: unresolved opref {} (op {:?})",
-                            opref.raw(),
-                            rop.opcode
-                        );
-                    };
-                    let value = match rop.opcode {
-                        OpCode::GetfieldGcI
-                        | OpCode::GetfieldGcR
-                        | OpCode::GetfieldGcF
-                        | OpCode::GetfieldGcPureI
-                        | OpCode::GetfieldGcPureR
-                        | OpCode::GetfieldGcPureF
-                        | OpCode::GetfieldRawI
-                        | OpCode::GetfieldRawR
-                        | OpCode::GetfieldRawF => {
-                            let descr = rop.getdescr().expect("getfield op must have a descriptor");
-                            let fd = descr
-                                .as_field_descr()
-                                .expect("getfield descriptor must be a FieldDescr");
-                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
-                            let addr = builder.ins().iadd_imm(base, fd.offset() as i64);
-                            emit_load_from_addr(
-                                &mut builder,
-                                addr,
-                                fd.field_type(),
-                                fd.field_size(),
-                                fd.is_field_signed(),
-                                rop.opcode,
-                            )?
-                        }
-                        OpCode::GetarrayitemGcI
-                        | OpCode::GetarrayitemGcR
-                        | OpCode::GetarrayitemGcF
-                        | OpCode::GetarrayitemGcPureI
-                        | OpCode::GetarrayitemGcPureR
-                        | OpCode::GetarrayitemGcPureF
-                        | OpCode::GetarrayitemRawI
-                        | OpCode::GetarrayitemRawF => {
-                            let descr = rop
-                                .getdescr()
-                                .expect("getarrayitem op must have a descriptor");
-                            let ad = descr
-                                .as_array_descr()
-                                .expect("getarrayitem descriptor must be an ArrayDescr");
-                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
-                            let index = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
-                            let scale = ad.item_size() as i64;
-                            let scaled = match scale {
-                                0 => builder.ins().iconst(cl_types::I64, 0),
-                                1 => index,
-                                _ => {
-                                    let s = builder.ins().iconst(cl_types::I64, scale);
-                                    builder.ins().imul(index, s)
-                                }
-                            };
-                            let bo = ad.base_size() as i64;
-                            let off = if bo == 0 {
-                                scaled
-                            } else {
-                                builder.ins().iadd_imm(scaled, bo)
-                            };
-                            let addr = builder.ins().iadd(base, off);
-                            let signed = ad.item_type() == Type::Int && ad.is_item_signed();
-                            emit_load_from_addr(
-                                &mut builder,
-                                addr,
-                                ad.item_type(),
-                                ad.item_size(),
-                                signed,
-                                rop.opcode,
-                            )?
-                        }
-                        OpCode::GcLoadI | OpCode::GcLoadR | OpCode::GcLoadF => {
-                            let item_size = resolve_constant_i64(
-                                &constants,
-                                &known_values,
-                                rop.opcode,
-                                rop.arg(2).to_opref(),
-                                "GC_LOAD itemsize",
-                            )?;
-                            let value_type = match rop.opcode {
-                                OpCode::GcLoadI => Type::Int,
-                                OpCode::GcLoadR => Type::Ref,
-                                _ => Type::Float,
-                            };
-                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
-                            let offset = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
-                            let addr = builder.ins().iadd(base, offset);
-                            emit_load_from_addr(
-                                &mut builder,
-                                addr,
-                                value_type,
-                                item_size.unsigned_abs() as usize,
-                                item_size < 0,
-                                rop.opcode,
-                            )?
-                        }
-                        OpCode::GcLoadIndexedI
-                        | OpCode::GcLoadIndexedR
-                        | OpCode::GcLoadIndexedF => {
-                            let scale = resolve_constant_i64(
-                                &constants,
-                                &known_values,
-                                rop.opcode,
-                                rop.arg(2).to_opref(),
-                                "GC_LOAD_INDEXED scale",
-                            )?;
-                            let base_offset = resolve_constant_i64(
-                                &constants,
-                                &known_values,
-                                rop.opcode,
-                                rop.arg(3).to_opref(),
-                                "GC_LOAD_INDEXED base offset",
-                            )?;
-                            let item_size = resolve_constant_i64(
-                                &constants,
-                                &known_values,
-                                rop.opcode,
-                                rop.arg(4).to_opref(),
-                                "GC_LOAD_INDEXED itemsize",
-                            )?;
-                            let value_type = match rop.opcode {
-                                OpCode::GcLoadIndexedI => Type::Int,
-                                OpCode::GcLoadIndexedR => Type::Ref,
-                                _ => Type::Float,
-                            };
-                            let base = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
-                            let index = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
-                            let scaled = match scale {
-                                0 => builder.ins().iconst(cl_types::I64, 0),
-                                1 => index,
-                                _ => {
-                                    let s = builder.ins().iconst(cl_types::I64, scale);
-                                    builder.ins().imul(index, s)
-                                }
-                            };
-                            let off = if base_offset == 0 {
-                                scaled
-                            } else {
-                                builder.ins().iadd_imm(scaled, base_offset)
-                            };
-                            let addr = builder.ins().iadd(base, off);
-                            emit_load_from_addr(
-                                &mut builder,
-                                addr,
-                                value_type,
-                                item_size.unsigned_abs() as usize,
-                                item_size < 0,
-                                rop.opcode,
-                            )?
-                        }
-                        OpCode::IntAdd => {
-                            let a = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
-                            let b = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
-                            builder.ins().iadd(a, b)
-                        }
-                        OpCode::IntSub => {
-                            let a = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
-                            let b = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
-                            builder.ins().isub(a, b)
-                        }
-                        OpCode::IntMul => {
-                            let a = resolve(&mut builder, &bd_mat, rop.arg(0).to_opref());
-                            let b = resolve(&mut builder, &bd_mat, rop.arg(1).to_opref());
-                            builder.ins().imul(a, b)
-                        }
-                        other => {
-                            unreachable!("plan_body_direct admitted non-replayable op {other:?}")
-                        }
-                    };
-                    bd_mat.insert(rvi, value);
-                    builder.def_var(var(rvi), value);
-                }
-
-                let body_args = block_args_to(
-                    &mut builder,
-                    body_block,
-                    &entry_input_vals[..body_direct_num_inputs],
-                );
-                builder.ins().jump(body_block, &body_args);
-
-                // Preamble arm (entry_mode == 0): the first LABEL is NOT the
-                // function entry — its params are the peeled-preamble results
-                // computed by the ops preceding the LABEL. The main op-emission
-                // loop emits the preamble in preamble_cont and jumps to the
-                // first LABEL with all resolved args when it reaches the LABEL
-                // op. first_label_entered_at_entry stays false so the main loop
-                // owns that jump + binding.
-                builder.switch_to_block(preamble_cont);
-                builder.seal_block(preamble_cont);
-            } else if has_entry_label {
-                let vals: Vec<CValue> = entry_input_vals.clone();
-                let args = block_args_to(&mut builder, entry_label_block, &vals);
-                builder.ins().jump(entry_label_block, &args);
-                builder.switch_to_block(entry_label_block);
-                for (i, arg_ref) in ops[entry_label_idx].getarglist().iter().enumerate() {
-                    let param = builder.block_params(entry_label_block)[i];
-                    if !arg_ref.is_none() {
-                        builder.def_var(var(arg_ref.to_opref().raw()), param);
-                        let cur_jf = builder.use_var(jf_ptr_var);
-                        sync_ref_root_var(
-                            &mut builder,
-                            cur_jf,
-                            &ref_root_slots,
-                            arg_ref.to_opref().raw(),
-                            param,
-                            ref_root_base_ofs,
-                            &mut synced_ref_vars,
-                        );
-                    }
-                }
-                first_label_entered_at_entry = true;
+        let first_label_entered_at_entry = false;
+        if !label_blocks.is_empty() {
+            // x86/regalloc.py:1303-1409 per-TargetToken `_ll_loop_code` parity.
+            // RPython gives each LABEL its own code address and a JUMP branches
+            // straight to the target LABEL.  Cranelift exposes a single
+            // function entry, so the entry `br_table`s on `dispatch_key`:
+            //   key 0   → run the preamble linearly (host entry, the peeled
+            //             `start_label` path), falling into the first LABEL as
+            //             usual;
+            //   key L+1 → re-enter directly at LABEL L (a closing-jump from a
+            //             bridge or another loop), loading LABEL L's carried
+            //             values from the jitframe slots the incoming JUMP
+            //             populated (emit_guard_exit writes JUMP arg i → slot i,
+            //             the frame-slot subset of `remap_frame_layout_mixed`'s
+            //             arglocs) and skipping the preamble — which would
+            //             otherwise re-derive loop state from the now-elided
+            //             fastlocals writeback and read stale values.
+            // The closing-jump passes `label_block_id + 1`; key 0 is reserved
+            // for the preamble so it never collides with LABEL 0's re-entry.
+            let dispatch_key = builder.block_params(entry_block)[1];
+            let preamble_block = builder.create_block();
+            let loaders: Vec<cranelift_codegen::ir::Block> = label_blocks
+                .iter()
+                .map(|_| builder.create_block())
+                .collect();
+            // table = [preamble, loader_0, loader_1, ...]; default = preamble.
+            let mut targets: Vec<cranelift_codegen::ir::BlockCall> =
+                Vec::with_capacity(loaders.len() + 1);
+            targets.push(builder.func.dfg.block_call(preamble_block, &[]));
+            for &b in &loaders {
+                targets.push(builder.func.dfg.block_call(b, &[]));
             }
+            let default_call = builder.func.dfg.block_call(preamble_block, &[]);
+            let jt = builder.create_jump_table(cranelift_codegen::ir::JumpTableData::new(
+                default_call,
+                &targets,
+            ));
+            builder.ins().br_table(dispatch_key, jt);
+
+            // Each loader: load LABEL L's carried values from the jitframe
+            // slots and jump to LABEL L's block, skipping the preamble.
+            for (&(label_idx, label_block), &loader) in label_blocks.iter().zip(loaders.iter()) {
+                builder.switch_to_block(loader);
+                builder.seal_block(loader);
+                let arity = ops[label_idx].num_args();
+                let cur_jf = builder.use_var(jf_ptr_var);
+                let vals: Vec<CValue> = (0..arity)
+                    .map(|i| {
+                        let offset = JF_FRAME_ITEM0_OFS + (i as i32) * 8;
+                        builder
+                            .ins()
+                            .load(cl_types::I64, MemFlags::trusted(), cur_jf, offset)
+                    })
+                    .collect();
+                let args = block_args_to(&mut builder, label_block, &vals);
+                builder.ins().jump(label_block, &args);
+            }
+
+            // Host-entry / preamble path: the op loop starts at op 0 and emits
+            // the preamble (and every LABEL's arg binding + fall-through jump)
+            // in this block; first_label_entered_at_entry stays false.
+            builder.switch_to_block(preamble_block);
+            builder.seal_block(preamble_block);
         } else if has_jump && loop_block != entry_block {
             let zero = builder.ins().iconst(cl_types::I64, 0);
             let vals: Vec<CValue> = (0..loop_param_count)
@@ -13799,7 +13587,10 @@ impl CraneliftBackend {
             wb.seal_block(eb);
             let jf_ptr_in = wb.block_params(eb)[0];
             let body_ref = self.module.declare_func_in_func(func_id, wb.func);
-            let call_inst = wb.ins().call(body_ref, &[jf_ptr_in]);
+            // Host entry always enters at the FIRST LABEL (dispatch_key 0):
+            // run_compiled_code loaded the inputs into the first LABEL's slots.
+            let entry_dispatch_key = wb.ins().iconst(cl_types::I32, 0);
+            let call_inst = wb.ins().call(body_ref, &[jf_ptr_in, entry_dispatch_key]);
             let ret = wb.inst_results(call_inst)[0];
             wb.ins().return_(&[ret]);
             wb.finalize();

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -134,16 +134,31 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
     (obj_addr - GcHeader::SIZE) as *mut GcHeader
 }
 
-/// Allocate a value of type `T` behind a leading zeroed [`GcHeader`] and
-/// return the payload pointer (`block + GcHeader::SIZE`).
+/// Allocate a value of type `T` behind a leading [`GcHeader`] tagged with
+/// `type_id` and no flags, returning the payload pointer (`block + SIZE`).
 ///
 /// Mirrors incminimark's `malloc_fixedsize`: reserve `size_gc_header + size`
-/// bytes, initialise the header at the block start
-/// (`init_gc_object(result, typeid, flags=0)`), and return
-/// `obj = result + size_gc_header`. The header is zeroed (`tid = 0`, all
-/// flags clear) so a write barrier reading `*(obj - SIZE)` sees
-/// `TRACK_YOUNG_PTRS = 0` and skips the object: it is immortal (leaked), not
-/// tracked by the nursery or old generation.
+/// bytes, `init_gc_object(result, typeid, flags=0)` at the block start, and
+/// return `obj = result + size_gc_header`. Callers pass the object's real GC
+/// type id (`malloc_typed` threads `GcType::type_id()`; the untyped bridge
+/// and frames pass 0).
+///
+/// The header's flags are all clear, so a write barrier reading `*(obj - SIZE)`
+/// sees `TRACK_YOUNG_PTRS = 0` and skips the object.
+///
+/// SCOPE — this is a barrier-read-safety shim, not full prebuilt-object
+/// parity. incminimark stamps prebuilt/immortal objects with
+/// `NO_HEAP_PTRS | TRACK_YOUNG_PTRS` (incminimark.py:1202-1206) and records
+/// their first young-pointer write in `prebuilt_root_objects` via the barrier
+/// (:1524-1529). Reproducing that here would be unsound without the rest of
+/// the machinery — these objects have no GC-traceable residency yet, and a
+/// non-arena address in `old_objects_pointing_to_young` would be traced with
+/// no valid layout — so the flags are deliberately left clear and the barrier
+/// skips them. The consequence is the pre-existing gap that a young object
+/// reachable *only* through such a leaked object is not kept alive by the
+/// barrier (in practice such pointees stay live via the shadowstack); closing
+/// it is the GC-management migration, not this shim. Matches the existing
+/// `GcFrameSlot` "zeroed, layout parity only" frame shim.
 ///
 /// The allocation is intentionally leaked — these objects outlive every
 /// collection until the managed allocator takes them over. Callers MUST NOT
@@ -152,12 +167,15 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
 ///
 /// `T` must be word-aligned (`align_of::<T>() <= GcHeader::SIZE`), matching
 /// the fixed one-word header; a wider alignment would move the payload off
-/// the fixed `obj - SIZE` offset the barrier reads.
-pub fn alloc_with_gc_header<T>(value: T) -> *mut T {
-    debug_assert!(
-        std::mem::align_of::<T>() <= GcHeader::SIZE,
-        "object alignment exceeds GcHeader::SIZE; fixed header offset would break the write barrier",
-    );
+/// the fixed `obj - SIZE` offset the barrier reads. The `const` block rejects
+/// over-aligned `T` at monomorphisation rather than faulting at runtime.
+pub fn alloc_with_gc_header<T>(value: T, type_id: u32) -> *mut T {
+    const {
+        assert!(
+            std::mem::align_of::<T>() <= GcHeader::SIZE,
+            "alloc_with_gc_header: align_of::<T>() exceeds GcHeader::SIZE; the fixed obj - SIZE header offset would misalign the payload",
+        )
+    };
     let total = GcHeader::SIZE + std::mem::size_of::<T>();
     let align = std::mem::align_of::<T>().max(GcHeader::SIZE);
     let layout = std::alloc::Layout::from_size_align(total, align)
@@ -167,7 +185,7 @@ pub fn alloc_with_gc_header<T>(value: T) -> *mut T {
         if raw.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        (raw as *mut GcHeader).write(GcHeader::new(0));
+        (raw as *mut GcHeader).write(GcHeader::new(type_id));
         let ptr = raw.add(GcHeader::SIZE) as *mut T;
         ptr.write(value);
         ptr
@@ -224,15 +242,16 @@ mod tests {
     }
 
     #[test]
-    fn alloc_with_gc_header_prepends_zeroed_header() {
+    fn alloc_with_gc_header_prepends_header() {
         // Leaked intentionally — the managed/immortal allocation contract
         // forbids freeing the returned payload pointer.
-        let p = alloc_with_gc_header(0xABCD_u64);
+        let p = alloc_with_gc_header(0xABCD_u64, 0x1357);
         unsafe {
             assert_eq!(*p, 0xABCD);
             let hdr = header_of(p as usize);
-            // Zeroed header => barrier reads TRACK_YOUNG_PTRS=0 and skips.
-            assert_eq!((*hdr).tid_and_flags, 0);
+            // type_id is recorded; flags stay clear so the barrier skips it.
+            assert_eq!((*hdr).type_id(), 0x1357);
+            assert_eq!((*hdr).flags(), 0);
             assert!(!(*hdr).has_flag(flags::TRACK_YOUNG_PTRS));
         }
     }

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -134,41 +134,27 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
     (obj_addr - GcHeader::SIZE) as *mut GcHeader
 }
 
-/// Allocate a value of type `T` behind a leading [`GcHeader`] tagged with
-/// `type_id` and no flags, returning the payload pointer (`block + SIZE`).
+/// Allocate a value of type `T` behind a leading [`GcHeader`] and return the
+/// payload pointer (`block + SIZE`).
 ///
-/// Mirrors incminimark's `malloc_fixedsize`: reserve `size_gc_header + size`
-/// bytes, `init_gc_object(result, typeid, flags=0)` at the block start, and
-/// return `obj = result + size_gc_header`. Callers pass the object's real GC
-/// type id (`malloc_typed` threads `GcType::type_id()`; the untyped bridge
-/// and frames pass 0).
+/// `malloc_fixedsize` analog: reserve `size_gc_header + size` bytes,
+/// `init_gc_object(result, typeid, flags=0)` at the block start, and return
+/// `obj = result + size_gc_header`. A freshly allocated object carries no
+/// flags, so the header word is exactly `type_id` (`GcHeader::new`). Callers
+/// pass the object's GC type id (`malloc_typed` threads `GcType::type_id()`;
+/// the untyped bridge and frames pass the object-root id 0).
 ///
 /// The header's flags are all clear, so a write barrier reading `*(obj - SIZE)`
-/// sees `TRACK_YOUNG_PTRS = 0` and skips the object.
+/// sees `TRACK_YOUNG_PTRS = 0` and skips the object. These objects are not yet
+/// routed through the managed nursery allocator; they are leaked host
+/// allocations, and the header is what lets the barrier read `*(obj - SIZE)`
+/// without dereferencing foreign memory.
 ///
-/// SCOPE — this is a barrier-read-safety shim, not full prebuilt-object
-/// parity. incminimark stamps prebuilt/immortal objects with
-/// `NO_HEAP_PTRS | TRACK_YOUNG_PTRS` (incminimark.py:1202-1206) and records
-/// their first young-pointer write in `prebuilt_root_objects` via the barrier
-/// (:1524-1529). Reproducing that here would be unsound without the rest of
-/// the machinery — these objects have no GC-traceable residency yet, and a
-/// non-arena address in `old_objects_pointing_to_young` would be traced with
-/// no valid layout — so the flags are deliberately left clear and the barrier
-/// skips them. The consequence is the pre-existing gap that a young object
-/// reachable *only* through such a leaked object is not kept alive by the
-/// barrier (in practice such pointees stay live via the shadowstack); closing
-/// it is the GC-management migration, not this shim. Matches the existing
-/// `GcFrameSlot` "zeroed, layout parity only" frame shim.
-///
-/// The allocation is intentionally leaked — these objects outlive every
-/// collection until the managed allocator takes them over. Callers MUST NOT
-/// `Box::from_raw` the result: it points past the header, not at the
-/// allocation base.
-///
-/// `T` must be word-aligned (`align_of::<T>() <= GcHeader::SIZE`), matching
-/// the fixed one-word header; a wider alignment would move the payload off
-/// the fixed `obj - SIZE` offset the barrier reads. The `const` block rejects
-/// over-aligned `T` at monomorphisation rather than faulting at runtime.
+/// # Safety
+/// - The result points past the header; it MUST NOT be passed to
+///   `Box::from_raw` or freed at the payload pointer.
+/// - `align_of::<T>() <= GcHeader::SIZE`, enforced at monomorphisation: a
+///   wider alignment would move the payload off the fixed `obj - SIZE` offset.
 pub fn alloc_with_gc_header<T>(value: T, type_id: u32) -> *mut T {
     const {
         assert!(
@@ -243,13 +229,13 @@ mod tests {
 
     #[test]
     fn alloc_with_gc_header_prepends_header() {
-        // Leaked intentionally — the managed/immortal allocation contract
-        // forbids freeing the returned payload pointer.
+        // Leaked: the payload pointer points past the header, so it must not
+        // be freed.
         let p = alloc_with_gc_header(0xABCD_u64, 0x1357);
         unsafe {
             assert_eq!(*p, 0xABCD);
             let hdr = header_of(p as usize);
-            // type_id is recorded; flags stay clear so the barrier skips it.
+            // type id recorded; flags clear (init_gc_object flags=0).
             assert_eq!((*hdr).type_id(), 0x1357);
             assert_eq!((*hdr).flags(), 0);
             assert!(!(*hdr).has_flag(flags::TRACK_YOUNG_PTRS));

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -2939,7 +2939,15 @@ impl GcRewriter for GcRewriterImpl {
                 // can_collect does that (rewrite.py:699-711).
                 _ if op.opcode.is_guard() => {
                     let rewritten = st.rewrite_op(op);
-                    st.emit(rewritten);
+                    // GUARD_EXCEPTION carries a Ref result (the caught
+                    // exception value, pyjitpl.py:3385-3392 `last_exc_box =
+                    // op`). Emit through `emit_rewritten_from` so a non-Void
+                    // guard result keeps its original position and registers
+                    // a forwarding entry — otherwise `emit` would renumber it
+                    // and downstream uses (e.g. a SETFIELD_GC of the caught
+                    // exception) would dangle. Void-result guards are
+                    // unaffected (emit_rewritten_from defers to `emit`).
+                    st.emit_rewritten_from(op, rewritten);
                 }
 
                 // ── Everything else: pass through unchanged. ──

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2128,6 +2128,7 @@ impl<S: JitState> JitDriver<S> {
                 // Convert RdVirtualInfo → VirtualInfo for blackhole resume.
                 let rd_virtuals_converted: Option<Vec<crate::resume::VirtualInfo>> = {
                     let count = raw_values.len() as i32;
+                    let num_virtuals = storage.rd_virtuals.len();
                     Some(
                         storage
                             .rd_virtuals
@@ -2137,6 +2138,7 @@ impl<S: JitState> JitDriver<S> {
                                     rd,
                                     rd_consts_slice,
                                     count,
+                                    num_virtuals,
                                 )
                             })
                             .collect(),
@@ -3895,6 +3897,7 @@ impl<S: JitState> JitDriver<S> {
                 // Convert RdVirtualInfo → VirtualInfo for blackhole resume.
                 let rd_virtuals_converted: Option<Vec<crate::resume::VirtualInfo>> = {
                     let count = raw_values.len() as i32;
+                    let num_virtuals = storage.rd_virtuals.len();
                     Some(
                         storage
                             .rd_virtuals
@@ -3904,6 +3907,7 @@ impl<S: JitState> JitDriver<S> {
                                     rd,
                                     rd_consts_slice,
                                     count,
+                                    num_virtuals,
                                 )
                             })
                             .collect(),

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -40,7 +40,7 @@ impl OptEarlyForce {
     /// RPython exempt set: SETFIELD_GC, SETARRAYITEM_GC, SETARRAYITEM_RAW,
     /// QUASIIMMUT_FIELD, SAME_AS_I/R/F, and raw_free. Note that
     /// SETFIELD_RAW is NOT exempt in RPython.
-    fn should_force_args(op: &Op) -> bool {
+    pub(crate) fn should_force_args(op: &Op) -> bool {
         !matches!(
             op.opcode,
             OpCode::SetfieldGc

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -4933,13 +4933,19 @@ mod tests {
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
 
-        // force_all_lazy_setfields emits the lazy SetfieldGc at JUMP,
-        // which forces the virtual New to be materialized.
+        // force_all_lazy_setfields re-sends the lazy SetfieldGc through the
+        // chain with emit=False (heap.py:136 force_lazy_set). SETFIELD_GC is
+        // in the earlyforce exempt set, so its virtual value is NOT forced —
+        // the New stays virtual and the store is re-absorbed (dropped). Only
+        // the Jump survives; the field relationship is carried across the JUMP
+        // via the imported heap cache.
         let new_count = result.iter().filter(|op| op.opcode == OpCode::New).count();
         assert_eq!(
-            new_count, 1,
-            "virtual New should be materialized when lazy SetfieldGc is emitted at Jump; got {result:?}"
+            new_count, 0,
+            "virtual New stored via lazy SetfieldGc stays virtual at Jump (SETFIELD_GC is earlyforce-exempt); got {result:?}"
         );
+        let opcodes: Vec<_> = result.iter().map(|op| op.opcode).collect();
+        assert_eq!(opcodes, vec![OpCode::Jump]);
     }
 
     // OptHeap's `force_from_effectinfo` path (heap.rs:2584) selectively

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -842,6 +842,15 @@ impl OptString {
     }
 
     fn force_args_if_virtual(&mut self, op: &Op, ctx: &mut OptContext) {
+        // earlyforce.py exempt set: SETFIELD_GC, SETARRAYITEM_GC, SAME_AS_*,
+        // QUASIIMMUT_FIELD, raw_free do NOT force their args (the value of a
+        // store can stay virtual). OptString is not RPython's forcing pass —
+        // earlyforce is — so it must honor the same exemptions, else a virtual
+        // stored into a non-virtual object (e.g. the exc published to the EC)
+        // gets materialized here at pass 3 instead of routed to pendingfields.
+        if !crate::optimizeopt::earlyforce::OptEarlyForce::should_force_args(op) {
+            return;
+        }
         // Collect refs first to avoid borrow issues.
         let args: Vec<OpRef> = op
             .getarglist()

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -9992,9 +9992,17 @@ impl<M: Clone> MetaInterp<M> {
             fail_values.len() as i32
         };
         let rd_virtuals = storage.map(|s| {
+            let num_virtuals = s.rd_virtuals.len();
             s.rd_virtuals
                 .iter()
-                .map(|rd| crate::resume::rd_virtual_to_virtual_info(rd.as_ref(), rd_consts, count))
+                .map(|rd| {
+                    crate::resume::rd_virtual_to_virtual_info(
+                        rd.as_ref(),
+                        rd_consts,
+                        count,
+                        num_virtuals,
+                    )
+                })
                 .collect::<Vec<_>>()
         });
         let deadframe_types = self.get_recovery_slot_types(green_key, norm_tid, fail_index);

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -1274,7 +1274,12 @@ pub use majit_backend::VirtualFieldSource;
 /// `consts` is the rd_consts array. `count` is the number of fail_args
 /// (used for negative TAGBOX indices). Both come from the containing
 /// ResumeGuardDescr / EncodedResumeData.
-pub fn tagged_to_source(tagged: i16, consts: &[majit_ir::Const], count: i32) -> VirtualFieldSource {
+pub fn tagged_to_source(
+    tagged: i16,
+    consts: &[majit_ir::Const],
+    count: i32,
+    num_virtuals: usize,
+) -> VirtualFieldSource {
     if tagged_eq(tagged, UNASSIGNED) {
         return ResumeValueSource::Unavailable;
     }
@@ -1306,7 +1311,18 @@ pub fn tagged_to_source(tagged: i16, consts: &[majit_ir::Const], count: i32) -> 
             }
             ResumeValueSource::FailArg(idx as usize)
         }
-        TAGVIRTUAL => ResumeValueSource::Virtual(num as usize),
+        TAGVIRTUAL => {
+            // Negative nums (cached/nested virtuals from
+            // assign_number_to_virtual) index rd_virtuals from the end, as in
+            // RPython's Python list negative indexing. Mirror the serialization
+            // remap in _number_virtuals (rd_virtuals.len() + num).
+            let idx = if num >= 0 {
+                num as usize
+            } else {
+                (num_virtuals as i32 + num) as usize
+            };
+            ResumeValueSource::Virtual(idx)
+        }
         _ => ResumeValueSource::Unavailable,
     }
 }
@@ -1314,11 +1330,13 @@ pub fn tagged_to_source(tagged: i16, consts: &[majit_ir::Const], count: i32) -> 
 /// Convert an `RdVirtualInfo` (IR-level, from compile.rs/pyjitpl.rs)
 /// to a `VirtualInfo` (resume-level, used by ResumeDataDirectReader).
 ///
-/// `consts` and `count` are needed to decode tagged fieldnums.
+/// `consts` and `count` are needed to decode tagged fieldnums; `num_virtuals`
+/// (the total rd_virtuals count) remaps negative TAGVIRTUAL field references.
 pub fn rd_virtual_to_virtual_info(
     rd: &majit_ir::RdVirtualInfo,
     consts: &[majit_ir::Const],
     count: i32,
+    num_virtuals: usize,
 ) -> VirtualInfo {
     match rd {
         majit_ir::RdVirtualInfo::VirtualInfo {
@@ -1332,7 +1350,7 @@ pub fn rd_virtual_to_virtual_info(
             let fields = fielddescrs
                 .iter()
                 .zip(fieldnums.iter())
-                .map(|(fd, &tagged)| (fd.index, tagged_to_source(tagged, consts, count)))
+                .map(|(fd, &tagged)| (fd.index, tagged_to_source(tagged, consts, count, num_virtuals)))
                 .collect();
             VirtualInfo::VirtualObj {
                 descr: descr.clone(),
@@ -1353,7 +1371,7 @@ pub fn rd_virtual_to_virtual_info(
             let fields = fielddescrs
                 .iter()
                 .zip(fieldnums.iter())
-                .map(|(fd, &tagged)| (fd.index, tagged_to_source(tagged, consts, count)))
+                .map(|(fd, &tagged)| (fd.index, tagged_to_source(tagged, consts, count, num_virtuals)))
                 .collect();
             VirtualInfo::VStruct {
                 typedescr: typedescr.clone(),
@@ -1370,7 +1388,7 @@ pub fn rd_virtual_to_virtual_info(
         } => {
             let items = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count))
+                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
                 .collect();
             VirtualInfo::VArray {
                 arraydescr: arraydescr.clone(),
@@ -1385,7 +1403,7 @@ pub fn rd_virtual_to_virtual_info(
         } => {
             let items = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count))
+                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
                 .collect();
             VirtualInfo::VArray {
                 arraydescr: arraydescr.clone(),
@@ -1409,7 +1427,7 @@ pub fn rd_virtual_to_virtual_info(
                 let elem: Vec<(u32, VirtualFieldSource)> = chunk
                     .iter()
                     .enumerate()
-                    .map(|(j, &tagged)| (j as u32, tagged_to_source(tagged, consts, count)))
+                    .map(|(j, &tagged)| (j as u32, tagged_to_source(tagged, consts, count, num_virtuals)))
                     .collect();
                 element_fields.push(elem);
             }
@@ -1433,7 +1451,7 @@ pub fn rd_virtual_to_virtual_info(
             assert_eq!(offsets.len(), fieldnums.len());
             let values = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count))
+                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
                 .collect();
             VirtualInfo::VRawBuffer {
                 func: *func,
@@ -1446,7 +1464,7 @@ pub fn rd_virtual_to_virtual_info(
         majit_ir::RdVirtualInfo::VRawSliceInfo { offset, fieldnums } => {
             let parent = fieldnums
                 .first()
-                .map(|&tagged| tagged_to_source(tagged, consts, count))
+                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
                 .unwrap_or(ResumeValueSource::Unavailable);
             VirtualInfo::VRawSlice {
                 offset: *offset as i64,
@@ -1456,19 +1474,19 @@ pub fn rd_virtual_to_virtual_info(
         majit_ir::RdVirtualInfo::VStrPlainInfo { fieldnums } => {
             let chars = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count))
+                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
                 .collect();
             VirtualInfo::VStrPlain { chars }
         }
         majit_ir::RdVirtualInfo::VStrConcatInfo { fieldnums } => {
-            let left = Box::new(tagged_to_source(fieldnums[0], consts, count));
-            let right = Box::new(tagged_to_source(fieldnums[1], consts, count));
+            let left = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
+            let right = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
             VirtualInfo::VStrConcat { left, right }
         }
         majit_ir::RdVirtualInfo::VStrSliceInfo { fieldnums } => {
-            let source = Box::new(tagged_to_source(fieldnums[0], consts, count));
-            let start = Box::new(tagged_to_source(fieldnums[1], consts, count));
-            let length = Box::new(tagged_to_source(fieldnums[2], consts, count));
+            let source = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
+            let start = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
+            let length = Box::new(tagged_to_source(fieldnums[2], consts, count, num_virtuals));
             VirtualInfo::VStrSlice {
                 source,
                 start,
@@ -1478,19 +1496,19 @@ pub fn rd_virtual_to_virtual_info(
         majit_ir::RdVirtualInfo::VUniPlainInfo { fieldnums } => {
             let chars = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count))
+                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
                 .collect();
             VirtualInfo::VUniPlain { chars }
         }
         majit_ir::RdVirtualInfo::VUniConcatInfo { fieldnums } => {
-            let left = Box::new(tagged_to_source(fieldnums[0], consts, count));
-            let right = Box::new(tagged_to_source(fieldnums[1], consts, count));
+            let left = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
+            let right = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
             VirtualInfo::VUniConcat { left, right }
         }
         majit_ir::RdVirtualInfo::VUniSliceInfo { fieldnums } => {
-            let source = Box::new(tagged_to_source(fieldnums[0], consts, count));
-            let start = Box::new(tagged_to_source(fieldnums[1], consts, count));
-            let length = Box::new(tagged_to_source(fieldnums[2], consts, count));
+            let source = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
+            let start = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
+            let length = Box::new(tagged_to_source(fieldnums[2], consts, count, num_virtuals));
             VirtualInfo::VUniSlice {
                 source,
                 start,
@@ -3973,6 +3991,11 @@ impl ResumeDataLoopMemo {
                     fieldbox, box_opref
                 )
             });
+            // resume.py:359 register_virtual_fields: stamp the virtual fieldbox
+            // UNASSIGNEDVIRTUAL (overwriting the UNASSIGNED that register_box
+            // installed above) so _number_virtuals numbers it as a virtual
+            // rather than a livebox — otherwise it would be force-boxed.
+            self.register_virtual_box(fieldbox, &numb_state.liveboxes, &mut new_liveboxes);
             for &field_opref in &vf.field_oprefs {
                 self.register_box(field_opref, env, &numb_state.liveboxes, &mut new_liveboxes);
                 let resolved = env.get_box_replacement(field_opref);
@@ -6559,6 +6582,22 @@ impl<'a> ResumeDataDirectReader<'a> {
         }
     }
 
+    /// resume.py: TAGVIRTUAL num → rd_virtuals/virtuals_cache index.
+    ///
+    /// RPython indexes `self.rd_virtuals[num]` / `virtuals_cache.get_*(num)`
+    /// directly with a possibly-negative `num` and relies on Python list
+    /// negative indexing (cached/nested virtuals get negative nums from
+    /// `assign_number_to_virtual`). Rust's getvirtual_* take a `usize`, so
+    /// remap here, mirroring `_number_virtuals` (`rd_virtuals.len() + num`).
+    fn virtual_index(&self, num: i32) -> usize {
+        if num >= 0 {
+            num as usize
+        } else {
+            let len = self.rd_virtuals.map_or(0, |v| v.len()) as i32;
+            (len + num) as usize
+        }
+    }
+
     /// resume.py:1552 decode_int
     pub fn decode_int(&mut self, tagged: i16) -> i64 {
         let (num, tag) = untag(tagged);
@@ -6574,7 +6613,8 @@ impl<'a> ResumeDataDirectReader<'a> {
             }
             TAGVIRTUAL => {
                 // resume.py:1559
-                self.getvirtual_int(num as usize)
+                let idx = self.virtual_index(num);
+                self.getvirtual_int(idx)
             }
             TAGBOX => {
                 // resume.py:1561-1564
@@ -6604,7 +6644,8 @@ impl<'a> ResumeDataDirectReader<'a> {
             }
             TAGVIRTUAL => {
                 // resume.py:1573
-                self.getvirtual_ptr(num as usize)
+                let idx = self.virtual_index(num);
+                self.getvirtual_ptr(idx)
             }
             TAGBOX => {
                 // resume.py:1575-1578

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -1350,7 +1350,12 @@ pub fn rd_virtual_to_virtual_info(
             let fields = fielddescrs
                 .iter()
                 .zip(fieldnums.iter())
-                .map(|(fd, &tagged)| (fd.index, tagged_to_source(tagged, consts, count, num_virtuals)))
+                .map(|(fd, &tagged)| {
+                    (
+                        fd.index,
+                        tagged_to_source(tagged, consts, count, num_virtuals),
+                    )
+                })
                 .collect();
             VirtualInfo::VirtualObj {
                 descr: descr.clone(),
@@ -1371,7 +1376,12 @@ pub fn rd_virtual_to_virtual_info(
             let fields = fielddescrs
                 .iter()
                 .zip(fieldnums.iter())
-                .map(|(fd, &tagged)| (fd.index, tagged_to_source(tagged, consts, count, num_virtuals)))
+                .map(|(fd, &tagged)| {
+                    (
+                        fd.index,
+                        tagged_to_source(tagged, consts, count, num_virtuals),
+                    )
+                })
                 .collect();
             VirtualInfo::VStruct {
                 typedescr: typedescr.clone(),
@@ -1427,7 +1437,12 @@ pub fn rd_virtual_to_virtual_info(
                 let elem: Vec<(u32, VirtualFieldSource)> = chunk
                     .iter()
                     .enumerate()
-                    .map(|(j, &tagged)| (j as u32, tagged_to_source(tagged, consts, count, num_virtuals)))
+                    .map(|(j, &tagged)| {
+                        (
+                            j as u32,
+                            tagged_to_source(tagged, consts, count, num_virtuals),
+                        )
+                    })
                     .collect();
                 element_fields.push(elem);
             }

--- a/pyre/bench/raise_catch_loop.py
+++ b/pyre/bench/raise_catch_loop.py
@@ -1,7 +1,7 @@
 def main():
     s = 0
     i = 0
-    while i < 1000000:
+    while i < 10000000:
         try:
             if i % 7 == 0:
                 raise ValueError("v")

--- a/pyre/bench/synth/exception_args_virtual.py
+++ b/pyre/bench/synth/exception_args_virtual.py
@@ -1,0 +1,35 @@
+N = 250000
+
+
+def may_fail(i):
+    # Object-strategy args (str + int + float): the args list is built
+    # inline in the trace and virtualizes when the exception is caught
+    # without reading e.args.
+    if (i & 31) == 0:
+        raise ValueError("boom", i, 0.5)
+    return i & 7
+
+
+def main():
+    i = 0
+    acc = 0
+    read = 0
+    while i < N:
+        try:
+            acc = acc + may_fail(i)
+        except ValueError as e:
+            # Every 4th raise reads e.args, forcing the virtualized
+            # list to materialize; the rest never touch it.
+            if (i & 127) == 0:
+                a, b, c = e.args
+                acc = acc + len(a) + (b & 15) + int(c * 2)
+                read = read + 1
+            else:
+                acc = acc + 1
+        finally:
+            acc = acc + 1
+        i = i + 1
+    print(acc, read)
+
+
+main()

--- a/pyre/bench/synth/exception_oserror_fields.py
+++ b/pyre/bench/synth/exception_oserror_fields.py
@@ -1,0 +1,29 @@
+N = 200000
+
+
+def main():
+    # OSError / FileNotFoundError have a non-trivial constructor: it sets
+    # errno / strerror / filename and removes filename from args. The
+    # traced inline constructor only reproduces kind/w_class/args_w, so
+    # these kinds must fall back to the full runtime constructor — this
+    # bench locks in that the special fields survive under the JIT.
+    errno_sum = 0
+    fname_ok = 0
+    arglen = 0
+    i = 0
+    while i < N:
+        try:
+            if (i & 1) == 0:
+                raise OSError(2, "no such file", "/tmp/a")
+            else:
+                raise FileNotFoundError(2, "missing", "/tmp/b")
+        except OSError as e:
+            errno_sum = errno_sum + e.errno
+            if e.filename is not None:
+                fname_ok = fname_ok + 1
+            arglen = arglen + len(e.args)
+        i = i + 1
+    print(errno_sum, fname_ok, arglen)
+
+
+main()

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1774,26 +1774,11 @@ fn builtin_issubclass(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 macro_rules! exc_constructor {
     ($fn_name:ident, $kind:expr) => {
         fn $fn_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-            let exc = if args.len() == 1 && unsafe { pyre_object::is_str(args[0]) } {
-                // Single str argument: store the message in WTF-8 so a
-                // lone surrogate (e.g. `ValueError('\udcff')`) survives
-                // construction.
-                let w = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-                pyre_object::excobject::w_exception_new_wtf8($kind, w)
-            } else {
-                let msg: String = if args.is_empty() {
-                    String::new()
-                } else if args.len() == 1 {
-                    unsafe { crate::display::py_str(args[0]) }
-                } else {
-                    let parts: Vec<String> = args
-                        .iter()
-                        .map(|&a| unsafe { crate::display::py_repr(a) })
-                        .collect();
-                    format!("({})", parts.join(", "))
-                };
-                pyre_object::excobject::w_exception_new($kind, &msg)
-            };
+            // `interp_exceptions.py:121-124 W_BaseException.descr_init`:
+            // `self.args_w = args_w`.  The string form of the exception
+            // is derived from `args_w` on demand (`descr_str`), so the
+            // constructor only captures the args — no eager message copy.
+            let exc = pyre_object::excobject::w_exception_new_empty($kind);
             let args_list = pyre_object::w_list_new(args.to_vec());
             unsafe {
                 pyre_object::excobject::w_exception_set_args(exc, args_list);

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -477,17 +477,10 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> String {
                     parts.join(", ")
                 }
             } else {
-                let msg = pyre_object::excobject::w_exception_get_message(obj);
-                match msg.as_str() {
-                    Ok(s) => {
-                        if s.is_empty() {
-                            String::new()
-                        } else {
-                            format!("'{s}'")
-                        }
-                    }
-                    Err(_) => String::new(),
-                }
+                // `w_exception_get_args` always yields a tuple (empty for
+                // an argless exception), so the args branch above covers
+                // every case; nothing left to render here.
+                String::new()
             };
             format!("{class_name}({inner})")
         } else if std::ptr::eq(tp, &TYPE_TYPE as *const PyType) {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -733,20 +733,11 @@ impl PyError {
     pub unsafe fn from_exc_object(obj: PyObjectRef) -> Self {
         unsafe {
             let kind = pyre_object::excobject::w_exception_get_kind(obj);
-            let msg = pyre_object::excobject::w_exception_get_message(obj);
-            let message = match msg.as_str() {
-                Ok(s) => s.to_string(),
-                Err(_) => {
-                    // Lone-surrogate message (rare) → lossy UTF-8 for
-                    // the Rust-side error string; `exc_object` keeps the
-                    // exact value for `str(e)` / `repr(e)`.
-                    let mut out = String::new();
-                    for cp in msg.code_points() {
-                        out.push(cp.to_char().unwrap_or('\u{FFFD}'));
-                    }
-                    out
-                }
-            };
+            // `W_BaseException.descr_str` derives the string from
+            // `args_w`; `exc_object` keeps the exact value for
+            // `str(e)` / `repr(e)`, while this Rust-side string is the
+            // lossy-UTF-8 rendering used by `PyError`'s `Display`.
+            let message = crate::display::py_str(obj);
             PyError {
                 kind: Self::kind_from_exc(kind),
                 message,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -39,10 +39,10 @@ impl Code {
     }
 }
 
-// Thread-local current exception for bare `raise` (RAISE_VARARGS 0).
-// PyPy: executioncontext.py sys_exc_info — the current active exception.
+// The current active exception (`sys.exc_info()` / bare `raise`) now lives
+// on the per-thread `ExecutionContext` (`sys_exc_value`), reached via
+// `get_current_exception` / `set_current_exception`; see those.
 thread_local! {
-    static CURRENT_EXCEPTION: Cell<PyObjectRef> = const { Cell::new(PY_NULL) };
     pub(crate) static CURRENT_FRAME: Cell<*mut PyFrame> = const { Cell::new(std::ptr::null_mut()) };
 }
 use crate::pyframe::PyFrame;
@@ -211,6 +211,12 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             if !ec.is_null() {
                 let top_slot = unsafe { &mut (*ec).topframeref as *mut *mut PyFrame };
                 visitor(unsafe { &mut *(top_slot as *mut majit_ir::GcRef) });
+                // `sys_exc_value` holds the active handler exception, which
+                // is nursery-allocated and may move; forward it so the EC
+                // slot is updated on a minor collection (the value-stack
+                // copy alone is not authoritative for later EC reads).
+                let exc_slot = unsafe { &mut (*ec).sys_exc_value as *mut PyObjectRef };
+                visitor(unsafe { &mut *(exc_slot as *mut majit_ir::GcRef) });
             }
         }
         while !frame.is_null() {
@@ -349,11 +355,21 @@ pub fn register_pyframe_root_walker() {
 }
 
 pub fn get_current_exception() -> PyObjectRef {
-    CURRENT_EXCEPTION.with(|current| current.get())
+    let ec = crate::call::getexecutioncontext();
+    if ec.is_null() {
+        return PY_NULL;
+    }
+    unsafe { (*ec).sys_exc_value }
 }
 
 pub fn set_current_exception(exc: PyObjectRef) {
-    CURRENT_EXCEPTION.with(|current| current.set(exc));
+    let ec = crate::call::getexecutioncontext() as *mut PyExecutionContext;
+    if ec.is_null() {
+        return;
+    }
+    unsafe {
+        (*ec).sys_exc_value = exc;
+    }
 }
 
 /// `pyopcode.py:1524-1532 DICT_UPDATE` — update `dict` from a mapping
@@ -518,7 +534,7 @@ pub fn attach_raise_cause(exc: PyObjectRef, cause: Option<PyObjectRef>) -> Resul
     // `__context__` and `__cause__`/`__suppress_context__` writes land
     // in the typed slots on `W_ExceptionObject` per
     // `interp_exceptions.py:113-117`.
-    let active = CURRENT_EXCEPTION.with(|c| c.get());
+    let active = get_current_exception();
     if !active.is_null()
         && active != exc
         && unsafe { !pyre_object::is_none(active) }
@@ -2055,7 +2071,7 @@ impl OpcodeStepExecutor for PyFrame {
             0 => {
                 // Bare `raise` — re-raise current exception
                 // PyPy: executioncontext.py sys_exc_info
-                let exc = CURRENT_EXCEPTION.with(|c| c.get());
+                let exc = get_current_exception();
                 if exc.is_null() || unsafe { pyre_object::is_none(exc) } {
                     Err(PyError::runtime_error("No active exception to reraise"))
                 } else if unsafe { pyre_object::is_exception(exc) } {
@@ -2352,8 +2368,8 @@ impl OpcodeStepExecutor for PyFrame {
     fn push_exc_info(&mut self) -> Result<(), PyError> {
         let exc = self.pop();
         // Save previous exception, set current
-        let prev = CURRENT_EXCEPTION.with(|c| c.get());
-        CURRENT_EXCEPTION.with(|c| c.set(exc));
+        let prev = get_current_exception();
+        set_current_exception(exc);
         // Push "previous exception" for later restore
         self.push(prev);
         // Push the exception value back
@@ -2388,7 +2404,7 @@ impl OpcodeStepExecutor for PyFrame {
     fn pop_except(&mut self) -> Result<(), PyError> {
         // Restore previous exc_info from stack
         let prev_exc = self.pop();
-        CURRENT_EXCEPTION.with(|c| c.set(prev_exc));
+        set_current_exception(prev_exc);
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -755,9 +755,21 @@ pub struct ExecutionContext {
     /// pointer into the leaked action owned by `module::_signal`
     /// (`install_signal_handling`); `None` until installed.
     pub check_signal_action: Option<*mut dyn AsyncActionOps>,
+    /// `executioncontext.py sys_exc_operror` — the active exception for
+    /// `sys.exc_info()` / bare `raise`, saved/restored across handler
+    /// regions by PUSH_EXC_INFO / POP_EXCEPT.  Single source of truth
+    /// (replaces the former `eval::CURRENT_EXCEPTION` thread-local), so
+    /// the JIT can read/write it as a GETFIELD_GC/SETFIELD_GC slot on the
+    /// per-thread EC pointer and the optimizer can dead-store-eliminate a
+    /// balanced save/restore.  GC-rooted via `walk_pyframe_roots`.
+    pub sys_exc_value: PyObjectRef,
 }
 
 pub type PyExecutionContext = ExecutionContext;
+
+/// Byte offset of `sys_exc_value` within `ExecutionContext`, for the JIT's
+/// GETFIELD_GC/SETFIELD_GC lowering of PUSH_EXC_INFO / POP_EXCEPT.
+pub const EC_SYS_EXC_VALUE_OFFSET: usize = std::mem::offset_of!(ExecutionContext, sys_exc_value);
 
 impl Default for ExecutionContext {
     fn default() -> Self {
@@ -794,6 +806,7 @@ impl ExecutionContext {
             builtins_module,
             builtin_dict_cache: std::cell::Cell::new(pyre_object::PY_NULL),
             check_signal_action: None,
+            sys_exc_value: pyre_object::PY_NULL,
         }
     }
 

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -771,6 +771,11 @@ pub type PyExecutionContext = ExecutionContext;
 /// GETFIELD_GC/SETFIELD_GC lowering of PUSH_EXC_INFO / POP_EXCEPT.
 pub const EC_SYS_EXC_VALUE_OFFSET: usize = std::mem::offset_of!(ExecutionContext, sys_exc_value);
 
+/// Size of `ExecutionContext`, for the JIT's StructPtrInfo SizeDescr
+/// describing the (non-GC) EC struct.  The EC is never JIT-allocated;
+/// this size only backs the field-tracking SizeDescr.
+pub const EC_SIZE: usize = std::mem::size_of::<ExecutionContext>();
+
 impl Default for ExecutionContext {
     fn default() -> Self {
         Self::new()

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -154,7 +154,11 @@ fn fixed_array_alloc_size(len: usize) -> usize {
 
 #[inline]
 fn fixed_array_layout(len: usize) -> std::alloc::Layout {
-    std::alloc::Layout::from_size_align(fixed_array_alloc_size(len), 8).unwrap()
+    // Track the header alignment (the block leads with a GcHeader the barrier
+    // reads at `obj - SIZE`), not a hardcoded 8.
+    let align = std::mem::align_of::<majit_gc::header::GcHeader>()
+        .max(std::mem::align_of::<FixedObjectArray>());
+    std::alloc::Layout::from_size_align(fixed_array_alloc_size(len), align).unwrap()
 }
 
 /// Allocate a fixed-length GcArray-shaped `FixedObjectArray` with all

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1647,8 +1647,8 @@ pub fn make_array_descr_with_full_id(
 
 use pyre_interpreter::{DICT_STORAGE_VALUES_LEN_OFFSET, DICT_STORAGE_VALUES_OFFSET};
 use pyre_object::excobject::{
-    EXC_ARGS_W_OFFSET, EXC_KIND_COUNT, EXC_KIND_OFFSET, ExcKind, W_EXCEPTION_OBJECT_SIZE,
-    exc_kind_to_pytype,
+    EXC_ARGS_W_OFFSET, EXC_KIND_COUNT, EXC_KIND_OFFSET, EXC_W_CONTEXT_OFFSET, ExcKind,
+    W_EXCEPTION_OBJECT_SIZE, exc_kind_to_pytype,
 };
 use pyre_object::floatobject::{FLOAT_FLOATVAL_OFFSET, W_FloatObject};
 use pyre_object::intobject::W_IntObject;
@@ -1984,6 +1984,19 @@ fn build_w_exception_group(kind: ExcKind) -> PyreObjectDescrGroup {
                 false,
                 false,
             ),
+            // `w_context` (`__context__`): a GC pointer slot.  Written by
+            // the RAISE_VARARGS `__context__` chaining lowering
+            // (`exc.w_context = ec.sys_exc_value`) so the optimizer can
+            // track it on the virtual exception; carried at field index 3.
+            (
+                "W_ExceptionObject.w_context",
+                EXC_W_CONTEXT_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
         ],
         // Empty name: the per-kind vtable means a shared "W_ExceptionObject"
         // name-registry slot would be first-write-wins and lose the other
@@ -2012,6 +2025,21 @@ pub fn w_exception_descrs(kind: ExcKind) -> (DescrRef, DescrRef, DescrRef, Descr
         field_descr_from_group(group, 1),
         field_descr_from_group(group, 2),
     )
+}
+
+/// Field descr for `W_ExceptionObject.w_context` (the `__context__`
+/// slot), index 3 of the per-kind exception descr group.  Used by the
+/// RAISE_VARARGS `__context__` chaining lowering; shares the same parent
+/// `SizeDescr` as the `NewWithVtable` emit so the optimizer recognises
+/// the store as a field of the virtual exception.
+pub fn w_exception_context_descr(kind: ExcKind) -> DescrRef {
+    let idx = kind as u8 as usize;
+    let mut cache = W_EXCEPTION_DESCR_CACHE.lock().unwrap();
+    if cache[idx].is_none() {
+        cache[idx] = Some(build_w_exception_group(kind));
+    }
+    let group = cache[idx].as_ref().unwrap();
+    field_descr_from_group(group, 3)
 }
 
 /// Field descr for `ExecutionContext::sys_exc_value`, used by the JIT

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1648,7 +1648,11 @@ pub fn make_array_descr_with_full_id(
 use pyre_interpreter::{DICT_STORAGE_VALUES_LEN_OFFSET, DICT_STORAGE_VALUES_OFFSET};
 use pyre_object::floatobject::{FLOAT_FLOATVAL_OFFSET, W_FloatObject};
 use pyre_object::intobject::W_IntObject;
-use pyre_object::pyobject::OB_TYPE_OFFSET;
+use pyre_object::excobject::{
+    EXC_ARGS_W_OFFSET, EXC_KIND_COUNT, EXC_KIND_OFFSET, ExcKind, W_EXCEPTION_OBJECT_SIZE,
+    exc_kind_to_pytype,
+};
+use pyre_object::pyobject::{OB_TYPE_OFFSET, W_CLASS_OFFSET};
 use pyre_object::rangeobject::{
     RANGE_ITER_CURRENT_OFFSET, RANGE_ITER_STEP_OFFSET, RANGE_ITER_STOP_OFFSET,
 };
@@ -1937,6 +1941,77 @@ pub fn specialised_tuple_ff_size_descr() -> DescrRef {
 /// Size descriptor for `W_SpecialisedTupleObject_oo`.
 pub fn specialised_tuple_oo_size_descr() -> DescrRef {
     SPECIALISED_TUPLE_OO_DESCR_GROUP.size_descr.clone()
+}
+
+/// SizeDescr + field descrs for `W_ExceptionObject` allocation via
+/// NewWithVtable, one set per `ExcKind`.  The vtable (`ob_type`) differs
+/// per kind (`exc_kind_to_pytype`), so each kind owns its group; the
+/// three SetField'd fields — `kind`, `w_class`, `args_w` — share the
+/// same offsets across kinds.  `w_cause`/`w_context`/… stay zeroed by
+/// the `NewWithVtable` memzero (PY_NULL), matching
+/// `w_exception_new_empty`.
+fn build_w_exception_group(kind: ExcKind) -> PyreObjectDescrGroup {
+    build_object_descr_group_with_def_path(
+        W_EXCEPTION_OBJECT_SIZE,
+        W_EXCEPTION_GC_TYPE_ID,
+        exc_kind_to_pytype(kind) as *const _ as usize,
+        &[
+            // `kind` is a `u8` tag (1 byte, unsigned).
+            (
+                "W_ExceptionObject.kind",
+                EXC_KIND_OFFSET,
+                1,
+                Type::Int,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_ExceptionObject.w_class",
+                W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "W_ExceptionObject.args_w",
+                EXC_ARGS_W_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+        ],
+        // Empty name: the per-kind vtable means a shared "W_ExceptionObject"
+        // name-registry slot would be first-write-wins and lose the other
+        // kinds' vtables.  NewWithVtable embeds the SizeDescr in the op, so
+        // the name-registry publish is not needed here.
+        "",
+        "",
+    )
+}
+
+static W_EXCEPTION_DESCR_CACHE: LazyLock<Mutex<Vec<Option<PyreObjectDescrGroup>>>> =
+    LazyLock::new(|| Mutex::new((0..EXC_KIND_COUNT).map(|_| None).collect()));
+
+/// Field descrs for the exception construction emit: `(size, kind,
+/// w_class, args_w)`.  Built and cached per `ExcKind` on first use.
+pub fn w_exception_descrs(kind: ExcKind) -> (DescrRef, DescrRef, DescrRef, DescrRef) {
+    let idx = kind as u8 as usize;
+    let mut cache = W_EXCEPTION_DESCR_CACHE.lock().unwrap();
+    if cache[idx].is_none() {
+        cache[idx] = Some(build_w_exception_group(kind));
+    }
+    let group = cache[idx].as_ref().unwrap();
+    (
+        group.size_descr.clone() as DescrRef,
+        field_descr_from_group(group, 0),
+        field_descr_from_group(group, 1),
+        field_descr_from_group(group, 2),
+    )
 }
 
 /// Size descriptor for W_SliceObject allocation via NewWithVtable.

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1646,12 +1646,12 @@ pub fn make_array_descr_with_full_id(
 // ── Range iterator field descriptors ─────────────────────────────────
 
 use pyre_interpreter::{DICT_STORAGE_VALUES_LEN_OFFSET, DICT_STORAGE_VALUES_OFFSET};
-use pyre_object::floatobject::{FLOAT_FLOATVAL_OFFSET, W_FloatObject};
-use pyre_object::intobject::W_IntObject;
 use pyre_object::excobject::{
     EXC_ARGS_W_OFFSET, EXC_KIND_COUNT, EXC_KIND_OFFSET, ExcKind, W_EXCEPTION_OBJECT_SIZE,
     exc_kind_to_pytype,
 };
+use pyre_object::floatobject::{FLOAT_FLOATVAL_OFFSET, W_FloatObject};
+use pyre_object::intobject::W_IntObject;
 use pyre_object::pyobject::{OB_TYPE_OFFSET, W_CLASS_OFFSET};
 use pyre_object::rangeobject::{
     RANGE_ITER_CURRENT_OFFSET, RANGE_ITER_STEP_OFFSET, RANGE_ITER_STOP_OFFSET,
@@ -2012,6 +2012,51 @@ pub fn w_exception_descrs(kind: ExcKind) -> (DescrRef, DescrRef, DescrRef, Descr
         field_descr_from_group(group, 1),
         field_descr_from_group(group, 2),
     )
+}
+
+/// Field descr for `ExecutionContext::sys_exc_value`, used by the JIT
+/// lowering of PUSH_EXC_INFO / POP_EXCEPT to GETFIELD_GC_R / SETFIELD_GC.
+///
+/// `field_type = Ref` so the optimizer tracks the value as a GC
+/// reference (virtual-defer + correct resume), but the `flag` is
+/// deliberately NON-pointer so `is_pointer_field()` is false and the GC
+/// rewrite emits NO write barrier (`rewrite.rs handle_write_barrier_setfield`
+/// gates the barrier on `is_pointer_field() && val_is_ref`).  That is
+/// correct here: the EC is a non-GC `Rc`-owned struct whose
+/// `sys_exc_value` slot is forwarded directly as a GC root every
+/// collection (`eval::walk_pyframe_roots`), so the generational
+/// remembered-set barrier is unnecessary.  A single cached Arc gives the
+/// PUSH and POP ops the same `descr_identity`, so the heap optimizer
+/// dead-store-eliminates a balanced save/restore (and the stored
+/// exception, if it never otherwise escapes, stays virtual and DCEs).
+pub fn ec_sys_exc_value_descr() -> DescrRef {
+    static EC_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLock::new(|| {
+        use majit_ir::descr::{ArrayFlag, SimpleFieldDescrSpec};
+        // type_id 0 + vtable 0 → SimpleSizeDescr::is_object() == false, so
+        // the optimizer builds a StructPtrInfo for the (non-GC) EC pointer.
+        // The single field is Ref-typed (ref value tracking) but
+        // Unsigned-flagged (is_pointer_field() == false → no write barrier;
+        // the slot is a forwarded GC root, see eval::walk_pyframe_roots).
+        majit_ir::descr::make_simple_descr_group(
+            u32::MAX,
+            pyre_interpreter::EC_SIZE,
+            0,
+            0,
+            &[SimpleFieldDescrSpec {
+                index: 0,
+                name: "ExecutionContext.sys_exc_value".to_string(),
+                offset: pyre_interpreter::EC_SYS_EXC_VALUE_OFFSET,
+                field_size: 8,
+                field_type: Type::Ref,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                flag: ArrayFlag::Unsigned,
+                virtualizable: false,
+                index_in_parent: 0,
+            }],
+        )
+    });
+    EC_DESCR_GROUP.field_descrs[0].clone() as DescrRef
 }
 
 /// Size descriptor for W_SliceObject allocation via NewWithVtable.

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1743,6 +1743,14 @@ pub fn object_mutable_cell_value_descr() -> DescrRef {
     field_descr_from_group(&W_OBJECT_MUTABLE_CELL_DESCR_GROUP, 0)
 }
 
+/// Size descriptor for `W_ListObject` allocation via NewWithVtable.
+/// vtable = &LIST_TYPE; the Object-strategy fields `length` / `items` /
+/// `strategy` are SetField'd after; `int_items` / `float_items` stay at the
+/// NewWithVtable memzero (== empty, never read under the Object strategy).
+pub fn w_list_size_descr() -> DescrRef {
+    W_LIST_DESCR_GROUP.size_descr.clone()
+}
+
 /// rlist.py:116 `l.length` — live length of a list under the Object
 /// strategy. Under Integer/Float strategies this field is 0 and
 /// consumers must dispatch on `list.strategy` first.

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -671,6 +671,39 @@ pub fn emit_box_int_inline(
     new_op
 }
 
+/// Emit inline `W_ExceptionObject` creation (NewWithVtable + SetfieldGc
+/// for `kind` / `w_class` / `args_w`), so a builtin exception built by a
+/// Python `raise Type(args)` becomes traced New+SetField ops the
+/// optimizer can virtualize when the exception never escapes — instead
+/// of the opaque residual `jit_call_callable_N` constructor call.
+///
+/// Mirrors the runtime construction:
+/// `w_exception_new_empty(kind)` (zeroed slots) + `exc_new_wrapper`
+/// (`w_class = the called type`) + `descr_init` (`args_w = args list`).
+/// `w_cause`/`w_context`/… stay PY_NULL from the NewWithVtable memzero.
+pub fn emit_exception_new_inline(
+    ctx: &mut TraceCtx,
+    kind: pyre_object::excobject::ExcKind,
+    w_class: OpRef,
+    args_w: OpRef,
+) -> OpRef {
+    let (size_descr, kind_descr, w_class_descr, args_w_descr) =
+        crate::descr::w_exception_descrs(kind);
+    let new_op = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], size_descr);
+    ctx.heap_cache_mut().new_object(new_op);
+    let kind_const = ctx.const_int(kind as u8 as i64);
+    let kind_idx = kind_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, kind_const], kind_descr);
+    ctx.heapcache_setfield_cached(new_op, kind_idx, kind_const);
+    let w_class_idx = w_class_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, w_class], w_class_descr);
+    ctx.heapcache_setfield_cached(new_op, w_class_idx, w_class);
+    let args_w_idx = args_w_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, args_w], args_w_descr);
+    ctx.heapcache_setfield_cached(new_op, args_w_idx, args_w);
+    new_op
+}
+
 /// Emit inline `space.newslice(w_start, w_end, w_step)` creation
 /// (NewWithVtable + 3 SetfieldGc).
 ///

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -704,6 +704,77 @@ pub fn emit_exception_new_inline(
     new_op
 }
 
+/// Emit inline Object-strategy `W_ListObject` creation for the exception
+/// `args_w` list, so a `raise Type(a, b, ...)` builds its argument list
+/// as traced `NewArrayClear` + `SetarrayitemGc` + `NewWithVtable` +
+/// `SetfieldGc` ops the optimizer can virtualize when the exception (and
+/// therefore its args list) never escapes — instead of the opaque
+/// residual `jit_build_list` CallR.
+///
+/// Mirrors `listobject.rs::w_list_new` for the Object strategy:
+///   - `items` points at an `ItemsBlock` GcArray (capacity == `len`);
+///     `pyobject_gcarray_descr` is byte-compatible with the runtime
+///     `ItemsBlock` (`base_size = ITEMS_BLOCK_ITEMS_OFFSET = 8`).
+///   - `length` = `items.len()`.
+///   - `strategy` = `Object` (0). `NewWithVtable` already zero-fills the
+///     payload (`int_items` / `float_items` stay empty, never read under
+///     the Object strategy); the explicit store keeps the heap cache and
+///     optimizer field model in agreement.
+///
+/// Caller must restrict to Object-strategy-eligible args (non-empty AND
+/// not all-int AND not all-float); the typed Integer / Float strategies
+/// use `int_items` / `float_items` with `items` null and are NOT emitted
+/// here.
+pub fn emit_exception_args_list_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> OpRef {
+    use crate::descr::{
+        list_items_descr, list_length_descr, list_strategy_descr, w_list_size_descr,
+    };
+    use crate::state::pyobject_gcarray_descr;
+
+    let len = items.len();
+    // Step 1 — allocate the ItemsBlock GcArray (capacity == len). Clear
+    // so the GcArray walker sees valid refs in every slot.
+    let len_ref = ctx.const_int(len as i64);
+    let array_descr = pyobject_gcarray_descr();
+    let items_block =
+        ctx.record_op_with_descr(OpCode::NewArrayClear, &[len_ref], array_descr.clone());
+    ctx.heap_cache_mut().new_object(items_block);
+
+    // Step 2 — items_block[i] = items[i].
+    for (i, &item) in items.iter().enumerate() {
+        let idx = ctx.const_int(i as i64);
+        ctx.record_op_with_descr(
+            OpCode::SetarrayitemGc,
+            &[items_block, idx, item],
+            array_descr.clone(),
+        );
+    }
+
+    // Step 3 — allocate the W_ListObject wrapper.
+    let list = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], w_list_size_descr());
+    ctx.heap_cache_mut().new_object(list);
+
+    // Step 4 — length / items / strategy SetfieldGc, mirroring the
+    // Object-strategy arm of `w_list_new`.
+    let length_descr = list_length_descr();
+    let length_idx = length_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, len_ref], length_descr);
+    ctx.heapcache_setfield_cached(list, length_idx, len_ref);
+
+    let items_descr = list_items_descr();
+    let items_idx = items_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, items_block], items_descr);
+    ctx.heapcache_setfield_cached(list, items_idx, items_block);
+
+    let strategy_const = ctx.const_int(pyre_object::listobject::ListStrategy::Object as i64);
+    let strategy_descr = list_strategy_descr();
+    let strategy_idx = strategy_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, strategy_const], strategy_descr);
+    ctx.heapcache_setfield_cached(list, strategy_idx, strategy_const);
+
+    list
+}
+
 /// Emit inline `space.newslice(w_start, w_end, w_step)` creation
 /// (NewWithVtable + 3 SetfieldGc).
 ///

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1624,6 +1624,15 @@ pub struct PyreSym {
     /// by handle_possible_exception after GUARD_EXCEPTION, then consumed
     /// by finishframe_exception for stack push.
     pub(crate) last_exc_box: OpRef,
+    /// E1: maps the OpRef of a trace-built (fresh `NewWithVtable`)
+    /// exception to its trace-time concrete instance.  `RAISE_VARARGS`
+    /// reuses the instance to take the instance fast path — skip the
+    /// residual `normalize_raise_varargs_jit` publish + `GUARD_EXCEPTION`
+    /// round-trip so the exception stays virtualizable — and to apply the
+    /// unconditional `__context__ = ec.sys_exc_value` chaining that is
+    /// valid only for a freshly constructed exception (w_context still
+    /// null, self-cycle impossible).
+    pub(crate) trace_built_exc: majit_ir::VecAssoc<OpRef, pyre_object::PyObjectRef>,
     /// Symbolic mirror of executioncontext.current_exception/sys_exc_info.
     /// Used by PUSH_EXC_INFO / POP_EXCEPT to preserve nested handler state.
     pub(crate) current_exc_value: pyre_object::PyObjectRef,
@@ -3048,6 +3057,7 @@ impl PyreSym {
             last_exc_value: std::ptr::null_mut(),
             class_of_last_exc_is_const: false,
             last_exc_box: OpRef::NONE,
+            trace_built_exc: majit_ir::VecAssoc::new(),
             current_exc_value: pyre_interpreter::eval::get_current_exception(),
             current_exc_box: OpRef::NONE,
             virtualref_boxes: Vec::new(),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8792,6 +8792,14 @@ mod tests {
         let prev_exc = pyre_interpreter::PyError::value_error("prev").to_exc_object();
         let caught_exc = pyre_interpreter::PyError::runtime_error("caught").to_exc_object();
 
+        // get/set_current_exception read/write `(*ec).sys_exc_value` on the
+        // thread's current EC; production establishes it via
+        // `set_last_exec_ctx(frame.execution_context)` (eval.rs:841). Mirror
+        // that here so the save/restore round-trips like a real frame, and
+        // restore the prior ctx at the end to avoid leaking into sibling tests.
+        let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();
+        pyre_interpreter::call::set_last_exec_ctx(frame.execution_context);
+
         let mut ctx = TraceCtx::for_test(1);
         let prev_exc_ref = ctx.const_ref(prev_exc as i64);
         let caught_exc_ref = ctx.const_ref(caught_exc as i64);
@@ -8830,10 +8838,10 @@ mod tests {
         assert_eq!(pushed_exc.opref, caught_exc_ref);
         let restored_prev = <MIFrame as SharedOpcodeHandler>::pop_value(&mut state)
             .expect("previous exception should be underneath the caught exception");
-        // push_exc_info emits a residual `trace_get_current_exception_jit`
-        // call (pyopcode.py:786 runtime save-restore parity) so the
-        // previous-exception slot carries a fresh OpRef from that call.
-        // Only the concrete value survives across the save/restore.
+        // push_exc_info emits `GetfieldGcR(ec)` on `ec.sys_exc_value`
+        // (pyopcode.py:786 runtime save-restore parity), so the previous-
+        // exception slot carries that op's OpRef and its concrete value is
+        // read back from the EC field — `prev_exc`, which the test seeded.
         assert_ne!(restored_prev.opref, OpRef::NONE);
         assert_eq!(restored_prev.concrete.to_pyobj(), prev_exc);
 
@@ -8844,6 +8852,7 @@ mod tests {
         assert_eq!(state.sym().current_exc_box, restored_prev.opref);
         assert_eq!(pyre_interpreter::eval::get_current_exception(), prev_exc);
         pyre_interpreter::eval::set_current_exception(PY_NULL);
+        pyre_interpreter::call::set_last_exec_ctx(saved_ctx);
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6384,8 +6384,10 @@ impl MIFrame {
     /// (`rewrite.rs gen_malloc_nursery` / `gen_initialize_tid` /
     /// `gen_initialize_vtable`), so the result is a fully GC-managed
     /// `W_ExceptionObject` identical to the runtime `malloc_typed` +
-    /// `exc_new_wrapper` + `descr_init` path.  `args_w` is built as a
-    /// residual list for now.
+    /// `exc_new_wrapper` + `descr_init` path.  `args_w` is built inline
+    /// (`emit_exception_args_list_inline`) when `w_list_new` would pick
+    /// the Object strategy, so the args list virtualizes too; Empty /
+    /// Integer / Float strategies fall back to a residual list.
     ///
     /// Restricted to a callable that is exactly
     /// `lookup_exc_class_for_kind(kind)`: user subclasses (whose ctor may
@@ -6431,7 +6433,18 @@ impl MIFrame {
         self.with_ctx(|this, ctx| {
             this.implement_guard_value(ctx, callable, concrete_callable as i64);
         });
-        let args_list = TraceHelperAccess::trace_build_list(self, args)?;
+        // Build `args_w` inline when `w_list_new` would pick the Object
+        // strategy (non-empty, mixed/non-numeric) — then the whole list
+        // (W_ListObject + ItemsBlock) virtualizes alongside the exception.
+        // Empty / Integer / Float strategies fall back to the residual
+        // `trace_build_list`, which builds the matching typed storage.
+        let args_list = if pyre_object::listobject::list_strategy_for(concrete_args)
+            == pyre_object::listobject::ListStrategy::Object
+        {
+            self.with_ctx(|_this, ctx| crate::helpers::emit_exception_args_list_inline(ctx, args))
+        } else {
+            TraceHelperAccess::trace_build_list(self, args)?
+        };
         let new_op = self.with_ctx(|_this, ctx| {
             crate::helpers::emit_exception_new_inline(ctx, kind, callable, args_list)
         });

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6435,6 +6435,13 @@ impl MIFrame {
         let new_op = self.with_ctx(|_this, ctx| {
             crate::helpers::emit_exception_new_inline(ctx, kind, callable, args_list)
         });
+        // E1: record the fresh instance keyed by the New op so a following
+        // RAISE_VARARGS can recover the concrete exception (the type-call
+        // result carries concrete=Null) and take the instance fast path —
+        // skip the residual publish + GUARD_EXCEPTION so the exception
+        // stays virtualizable.  Trace-time only; the runtime value is the
+        // per-iteration New op.
+        self.sym_mut().trace_built_exc.insert(new_op, exc);
         Ok(Some(new_op))
     }
 
@@ -9390,6 +9397,15 @@ impl OpcodeStepExecutor for MIFrame {
             (exc_val, None, null_cause)
         };
         let exc = exc_val.concrete.to_pyobj();
+        // E1: a trace-built exception (`try_trace_exception_new`) leaves the
+        // type-call result with concrete=Null; recover the fresh instance
+        // recorded at construction so the raise takes the instance fast path.
+        let trace_built = self.sym().trace_built_exc.get(&exc_val.opref).copied();
+        let exc = if exc.is_null() {
+            trace_built.unwrap_or(exc)
+        } else {
+            exc
+        };
         let emit_runtime_raise = |slf: &mut Self| {
             slf.with_ctx(|this, ctx| {
                 ctx.call_ref_typed_with_effect(
@@ -9407,7 +9423,45 @@ impl OpcodeStepExecutor for MIFrame {
         unsafe {
             if pyre_object::is_exception(exc) {
                 // `eval.rs:1053-1055 / :1096-1098`: already an instance.
-                let _ = emit_runtime_raise(self);
+                //
+                // E1 fast path: a freshly trace-built exception
+                // (`NewWithVtable`) raised with no explicit cause needs
+                // neither the residual `normalize_raise_varargs_jit` publish
+                // nor `GUARD_EXCEPTION`.  `seed_raised_exception` sets
+                // `last_exc_box`, so the dispatch routes through
+                // `handle_raise_varargs` → `finishframe_exception` (a local
+                // handler continues with `last_exc_box`; a root-frame escape
+                // FINISHes with it via `compile_exit_frame_with_exception`).
+                // Skipping the publish leaves the New op with no escape, so the
+                // optimizer can virtualize it.
+                //
+                // `__context__` chaining is emitted as a SetField on the
+                // (virtualizable) exception instead of inside the residual: for
+                // a fresh exception `w_context` is null and the self-cycle is
+                // impossible, so `attach_raise_cause`'s conditional
+                // `w_context = active` reduces to an unconditional
+                // `exc.w_context = ec.sys_exc_value` (storing null when no
+                // exception is active is a no-op that DCEs).
+                if trace_built.is_some() && cause.is_none() {
+                    let kind = pyre_object::excobject::w_exception_get_kind(exc);
+                    let ec = self.with_ctx(|this, ctx| this.ensure_execution_context(ctx));
+                    let active = self.with_ctx(|_this, ctx| {
+                        ctx.record_op_with_descr(
+                            majit_ir::OpCode::GetfieldGcR,
+                            &[ec],
+                            crate::descr::ec_sys_exc_value_descr(),
+                        )
+                    });
+                    self.with_ctx(|_this, ctx| {
+                        ctx.record_op_with_descr(
+                            majit_ir::OpCode::SetfieldGc,
+                            &[exc_val.opref, active],
+                            crate::descr::w_exception_context_descr(kind),
+                        );
+                    });
+                } else {
+                    let _ = emit_runtime_raise(self);
+                }
                 attach_raise_cause(exc, cause)?;
                 self.seed_raised_exception(exc_val.opref, exc);
                 return Err(PyError::from_exc_object(exc));

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6408,6 +6408,14 @@ impl MIFrame {
         if !is_exc_class || concrete_args.iter().any(|a| a.is_null()) {
             return Ok(None);
         }
+        // Reject user subclasses before the probe construction below:
+        // their Python `__init__` would run concretely an extra time per
+        // trace attempt (a user-visible side effect on top of the real
+        // execution).  Canonical per-kind classes have a pure Rust
+        // `descr_init`, so probing them is unobservable.
+        if !pyre_object::excobject::is_canonical_exc_class(concrete_callable) {
+            return Ok(None);
+        }
         // Build the exception concretely on the plain eval loop (no tracer
         // re-entry) to read its kind and confirm a flat builtin instance.
         // The instance is trace-time only and is discarded after the read.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9196,35 +9196,30 @@ impl OpcodeStepExecutor for MIFrame {
     fn push_exc_info(&mut self) -> Result<(), PyError> {
         let exc = <Self as SharedOpcodeHandler>::pop_value(self)?;
         let exc_obj = exc.concrete.to_pyobj();
-        // Emit the residual save/restore pair BEFORE mutating concrete
-        // CURRENT_EXCEPTION so the compiled bridge performs the same
-        // `prev = CURRENT_EXCEPTION; CURRENT_EXCEPTION = exc` sequence at
-        // runtime (pyopcode.py:786 / eval.rs:1220-1229). Folding a
-        // trace-time `ctx.const_ref(prev_exc as i64)` into the bridge
-        // silently breaks nested exception state on re-entry.
-        // `trace_get_current_exception_jit` (line 165) is a flat TLS read
-        // of `CURRENT_EXCEPTION` — `EF_CANNOT_RAISE` (`call.py:303 else`
-        // branch). Matches the codewriter-side classification of
-        // `get_current_exception_fn` at
-        // `pyre-jit/src/jit/codewriter.rs:2159-2163 PlainCannotRaise`.
+        // Emit the save/restore pair as GETFIELD_GC_R / SETFIELD_GC on the
+        // per-thread EC's `sys_exc_value` slot (the single source of truth;
+        // see eval::get_current_exception). This performs the same
+        // `prev = ec.sys_exc_value; ec.sys_exc_value = exc` sequence at
+        // runtime (pyopcode.py:786 / eval.rs:1220-1229) as the former
+        // residual TLS helpers, but as heap ops the optimizer can reason
+        // about: a balanced PUSH_EXC_INFO save + POP_EXCEPT restore with no
+        // intervening read is dead-store-eliminated, so a non-escaping
+        // exception stays virtual. `ec_sys_exc_value_descr` is a non-pointer
+        // flagged Ref field, so SETFIELD_GC emits NO write barrier (the EC
+        // is non-GC and its slot is a forwarded GC root — see the descr).
+        let ec = self.with_ctx(|this, ctx| this.ensure_execution_context(ctx));
         let prev_exc_opref = self.with_ctx(|_this, ctx| {
-            ctx.call_ref_typed_with_effect(
-                trace_get_current_exception_jit as *const (),
-                &[],
-                &[],
-                CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+            ctx.record_op_with_descr(
+                majit_ir::OpCode::GetfieldGcR,
+                &[ec],
+                crate::descr::ec_sys_exc_value_descr(),
             )
         });
-        // `trace_set_current_exception_jit` (line 172) is a flat TLS
-        // write — same `EF_CANNOT_RAISE` rationale, mirroring
-        // `set_current_exception_fn` at `codewriter.rs:2165-2168
-        // PlainCannotRaise`.
         self.with_ctx(|_this, ctx| {
-            ctx.call_void_typed_with_effect(
-                trace_set_current_exception_jit as *const (),
-                &[exc.opref],
-                &[Type::Ref],
-                CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+            ctx.record_op_with_descr(
+                majit_ir::OpCode::SetfieldGc,
+                &[ec, exc.opref],
+                crate::descr::ec_sys_exc_value_descr(),
             );
         });
         let prev_exc = get_current_exception();
@@ -9249,17 +9244,17 @@ impl OpcodeStepExecutor for MIFrame {
 
     fn pop_except(&mut self) -> Result<(), PyError> {
         let prev_exc = <Self as SharedOpcodeHandler>::pop_value(self)?;
-        // Emit the residual restore so the compiled bridge writes back the
-        // saved sys_exc_info at runtime (pyopcode.py:778 / eval.rs:1243-1249).
-        // Flat TLS write — `EF_CANNOT_RAISE` matching the codewriter-side
-        // `set_current_exception_fn` at `codewriter.rs:2165-2168
-        // PlainCannotRaise`.
+        // Restore the saved sys_exc_info as SETFIELD_GC on the EC's
+        // `sys_exc_value` slot (pyopcode.py:778 / eval.rs:1243-1249).
+        // Paired with the PUSH_EXC_INFO save above on the same EC field,
+        // this lets the heap optimizer dead-store-eliminate a balanced,
+        // never-read save/restore (no write barrier — see the descr).
+        let ec = self.with_ctx(|this, ctx| this.ensure_execution_context(ctx));
         self.with_ctx(|_this, ctx| {
-            ctx.call_void_typed_with_effect(
-                trace_set_current_exception_jit as *const (),
-                &[prev_exc.opref],
-                &[Type::Ref],
-                CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+            ctx.record_op_with_descr(
+                majit_ir::OpCode::SetfieldGc,
+                &[ec, prev_exc.opref],
+                crate::descr::ec_sys_exc_value_descr(),
             );
         });
         set_current_exception(prev_exc.concrete.to_pyobj());

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6428,6 +6428,15 @@ impl MIFrame {
         if pyre_object::excobject::lookup_exc_class_for_kind(kind) != concrete_callable {
             return Ok(None);
         }
+        // The inline constructor reproduces only kind / w_class / args_w.
+        // Kinds whose descr_init stores extra fields (OSError errno /
+        // strerror / filename; the Unicode errors' object / start / end /
+        // reason / encoding — and OSError's args_w rewrite) cannot be
+        // rebuilt from those three alone, so defer them to the full
+        // runtime constructor via the residual call path.
+        if !kind.has_trivial_args_constructor() {
+            return Ok(None);
+        }
         // Pin the callable identity so the trace-time kind / vtable stay
         // valid across iterations.
         self.with_ctx(|this, ctx| {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6363,7 +6363,79 @@ impl MIFrame {
             }
         }
 
+        if let Some(new_op) =
+            self.try_trace_exception_new(callable, args, concrete_callable, concrete_args)?
+        {
+            return Ok(new_op);
+        }
+
         self.trace_call_callable(callable, args)
+    }
+
+    /// `Type(args)` for a *canonical* builtin exception class: emit the
+    /// allocation as traced `NewWithVtable` + `SetfieldGc` (kind /
+    /// w_class / args_w) so the optimizer can virtualize it when the
+    /// exception never escapes, instead of the opaque residual
+    /// `jit_call_callable_N` constructor call
+    /// (`helpers::emit_trace_call_callable`).
+    ///
+    /// The GC rewrite pass lowers the `NewWithVtable` to a nursery
+    /// allocation carrying the `W_EXCEPTION` type id + per-kind vtable
+    /// (`rewrite.rs gen_malloc_nursery` / `gen_initialize_tid` /
+    /// `gen_initialize_vtable`), so the result is a fully GC-managed
+    /// `W_ExceptionObject` identical to the runtime `malloc_typed` +
+    /// `exc_new_wrapper` + `descr_init` path.  `args_w` is built as a
+    /// residual list for now.
+    ///
+    /// Restricted to a callable that is exactly
+    /// `lookup_exc_class_for_kind(kind)`: user subclasses (whose ctor may
+    /// run a Python `__init__`, and whose `w_class` differs from the
+    /// per-kind builtin class) fall through to the generic call path.
+    fn try_trace_exception_new(
+        &mut self,
+        callable: OpRef,
+        args: &[OpRef],
+        concrete_callable: PyObjectRef,
+        concrete_args: &[PyObjectRef],
+    ) -> Result<Option<OpRef>, PyError> {
+        let is_exc_class = unsafe {
+            pyre_interpreter::baseobjspace::exception_is_valid_obj_as_class_w(concrete_callable)
+        };
+        // Concrete positional args only — the residual `args_w` list must
+        // match the runtime `descr_init` list exactly.
+        if !is_exc_class || concrete_args.iter().any(|a| a.is_null()) {
+            return Ok(None);
+        }
+        // Build the exception concretely on the plain eval loop (no tracer
+        // re-entry) to read its kind and confirm a flat builtin instance.
+        // The instance is trace-time only and is discarded after the read.
+        let exc = {
+            let _plain_guard = pyre_interpreter::call::force_plain_eval();
+            pyre_interpreter::call::call_function_impl_result(concrete_callable, concrete_args)
+        };
+        let Ok(exc) = exc else { return Ok(None) };
+        let kind = unsafe {
+            if !pyre_object::is_exception(exc) {
+                return Ok(None);
+            }
+            pyre_object::excobject::w_exception_get_kind(exc)
+        };
+        // Only the canonical per-kind builtin class maps to the flat
+        // NewWithVtable layout; a user subclass resolves to its builtin
+        // parent here and is rejected.
+        if pyre_object::excobject::lookup_exc_class_for_kind(kind) != concrete_callable {
+            return Ok(None);
+        }
+        // Pin the callable identity so the trace-time kind / vtable stay
+        // valid across iterations.
+        self.with_ctx(|this, ctx| {
+            this.implement_guard_value(ctx, callable, concrete_callable as i64);
+        });
+        let args_list = TraceHelperAccess::trace_build_list(self, args)?;
+        let new_op = self.with_ctx(|_this, ctx| {
+            crate::helpers::emit_exception_new_inline(ctx, kind, callable, args_list)
+        });
+        Ok(Some(new_op))
     }
 
     fn build_pending_inline_frame(

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -229,7 +229,7 @@ const ARENA_CAP: usize = 64;
 /// Single source of truth: [`majit_gc::header::GcHeader::SIZE`].
 const GC_HEADER_SIZE: usize = majit_gc::header::GcHeader::SIZE;
 
-/// Arena slot with prepended GcHeader (zeroed, layout parity only).
+/// Arena slot: leading GcHeader (tid 0, flags 0) then the frame payload.
 #[repr(C)]
 struct GcFrameSlot {
     gc_header: majit_gc::header::GcHeader,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1366,9 +1366,10 @@ pub fn blackhole_resume_via_rd_numb(
     // for lazy materialization in getvirtual_ptr/getvirtual_int.
     let count = deadframe.len() as i32;
     let rd_virtuals_converted: Option<Vec<resume::VirtualInfo>> = rd_virtuals.map(|rd_virts| {
+        let num_virtuals = rd_virts.len();
         rd_virts
             .iter()
-            .map(|rd| resume::rd_virtual_to_virtual_info(rd, rd_consts, count))
+            .map(|rd| resume::rd_virtual_to_virtual_info(rd, rd_consts, count, num_virtuals))
             .collect()
     });
     let rd_virtuals_slice = rd_virtuals_converted.as_deref();
@@ -3483,8 +3484,9 @@ pub fn cranelift_resumedata_deopt(
     //    VirtualInfo so the decoder can materialise lazily.
     let count = outputs.len() as i32;
     let rd_virtuals_converted: Option<Vec<resume::VirtualInfo>> = rd_virtuals_rcs.map(|rcs| {
+        let num_virtuals = rcs.len();
         rcs.iter()
-            .map(|rd| resume::rd_virtual_to_virtual_info(rd, rd_consts, count))
+            .map(|rd| resume::rd_virtual_to_virtual_info(rd, rd_consts, count, num_virtuals))
             .collect()
     });
     let rd_virtuals_slice = rd_virtuals_converted.as_deref();

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -232,14 +232,14 @@ const GC_HEADER_SIZE: usize = majit_gc::header::GcHeader::SIZE;
 /// Arena slot with prepended GcHeader (zeroed, layout parity only).
 #[repr(C)]
 struct GcFrameSlot {
-    gc_header: u64,
+    gc_header: majit_gc::header::GcHeader,
     frame: MaybeUninit<PyFrame>,
 }
 
 impl GcFrameSlot {
     const fn zeroed() -> Self {
         GcFrameSlot {
-            gc_header: 0,
+            gc_header: majit_gc::header::GcHeader { tid_and_flags: 0 },
             frame: MaybeUninit::uninit(),
         }
     }
@@ -248,13 +248,13 @@ impl GcFrameSlot {
 /// Heap-allocated frame with prepended GcHeader.
 #[repr(C)]
 struct GcPyFrame {
-    gc_header: u64,
+    gc_header: majit_gc::header::GcHeader,
     frame: PyFrame,
 }
 
 fn heap_alloc_frame(frame: PyFrame) -> *mut PyFrame {
     let gc_frame = Box::into_raw(Box::new(GcPyFrame {
-        gc_header: 0,
+        gc_header: majit_gc::header::GcHeader { tid_and_flags: 0 },
         frame,
     }));
     unsafe { &mut (*gc_frame).frame as *mut PyFrame }

--- a/pyre/pyre-object/src/excobject.rs
+++ b/pyre/pyre-object/src/excobject.rs
@@ -905,7 +905,6 @@ pub unsafe fn w_exception_get_kind(obj: PyObjectRef) -> ExcKind {
     unsafe { (*(obj as *const W_ExceptionObject)).kind }
 }
 
-
 /// Get the Python type name string for an ExcKind.
 pub fn exc_kind_name(kind: ExcKind) -> &'static str {
     match kind {
@@ -1064,7 +1063,10 @@ mod tests {
             let args = w_exception_get_args(obj);
             assert_eq!(crate::tupleobject::w_tuple_len(args), 1);
             let arg0 = crate::tupleobject::w_tuple_getitem(args, 0).unwrap();
-            assert_eq!(crate::strobject::w_str_get_wtf8(arg0), Wtf8::new("bad value"));
+            assert_eq!(
+                crate::strobject::w_str_get_wtf8(arg0),
+                Wtf8::new("bad value")
+            );
         }
     }
 

--- a/pyre/pyre-object/src/excobject.rs
+++ b/pyre/pyre-object/src/excobject.rs
@@ -12,7 +12,7 @@
 //! it via the assigned `subclassrange_{min,max}`.
 
 use crate::pyobject::*;
-use rustpython_wtf8::{Wtf8, Wtf8Buf};
+use rustpython_wtf8::Wtf8;
 
 pub static EXCEPTION_TYPE: PyType = crate::pyobject::new_pytype("BaseException");
 pub static EXC_EXCEPTION_TYPE: PyType = crate::pyobject::new_pytype("Exception");
@@ -180,7 +180,7 @@ pub enum ExcKind {
     UnicodeTranslateError = 28,
 }
 
-/// Layout: `[ob_header | kind: ExcKind | message: *mut String | args_w: PyObjectRef]`
+/// Layout: `[ob_header | kind: ExcKind | args_w: PyObjectRef | …]`
 ///
 /// `args_w` mirrors `pypy/module/exceptions/interp_exceptions.py:121-124`
 /// `W_BaseException.descr_init`:
@@ -207,9 +207,6 @@ pub enum ExcKind {
 pub struct W_ExceptionObject {
     pub ob_header: PyObject,
     pub kind: ExcKind,
-    /// `WTF-8` so a lone-surrogate message (e.g. `ValueError('\udcff')`)
-    /// survives construction; `&str` cannot represent surrogates.
-    pub message: *mut Wtf8Buf,
     pub args_w: PyObjectRef,
     /// `interp_exceptions.py:114 W_BaseException.w_cause = None` —
     /// `raise X from Y` cause set by `descr_setcause` (line 167-174).
@@ -275,7 +272,6 @@ pub struct W_ExceptionObject {
 }
 
 pub const EXC_KIND_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, kind);
-pub const EXC_MESSAGE_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, message);
 pub const EXC_ARGS_W_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, args_w);
 pub const EXC_W_CAUSE_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, w_cause);
 pub const EXC_W_CONTEXT_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, w_context);
@@ -341,18 +337,36 @@ impl crate::lltype::GcType for W_ExceptionObject {
 /// placeholder, matching the legacy "internal `w_exception_new`"
 /// path.
 pub fn w_exception_new(kind: ExcKind, message: &str) -> PyObjectRef {
-    let message = crate::lltype::malloc_raw(Wtf8Buf::from_string(message.to_string()));
-    w_exception_new_from_message_ptr(kind, message)
+    let exc = w_exception_new_empty(kind);
+    // `oefmt(space.w_ValueError, "...")` parity — an internal raise with
+    // a message stores it as the single constructor arg
+    // (`args_w = [space.newtext(msg)]`); `descr_str` then derives the
+    // string lazily.  Empty message → no args (the `args_w` stays
+    // `PY_NULL` so `args` reads as `()`), matching the prebuilt
+    // singletons (`MemoryError`, `StopIteration`).
+    if !message.is_empty() {
+        let arg = crate::strobject::w_str_new(message);
+        unsafe { w_exception_set_args(exc, crate::listobject::w_list_new(vec![arg])) };
+    }
+    exc
 }
 
 /// Like `w_exception_new` but stores an arbitrary WTF-8 message,
 /// preserving lone surrogates that a `&str` message cannot carry.
 pub fn w_exception_new_wtf8(kind: ExcKind, message: &Wtf8) -> PyObjectRef {
-    let message = crate::lltype::malloc_raw(message.to_wtf8_buf());
-    w_exception_new_from_message_ptr(kind, message)
+    let exc = w_exception_new_empty(kind);
+    if !message.is_empty() {
+        let arg = crate::strobject::w_str_from_wtf8(message.to_wtf8_buf());
+        unsafe { w_exception_set_args(exc, crate::listobject::w_list_new(vec![arg])) };
+    }
+    exc
 }
 
-fn w_exception_new_from_message_ptr(kind: ExcKind, message: *mut Wtf8Buf) -> PyObjectRef {
+/// Allocate a `W_ExceptionObject` of `kind` with no constructor args
+/// (`args_w = PY_NULL`).  The public Python `__new__` path
+/// (`exc_constructor`) and the message helpers above attach `args_w`
+/// afterwards via `w_exception_set_args`.
+pub fn w_exception_new_empty(kind: ExcKind) -> PyObjectRef {
     let w_class = lookup_exc_class_for_kind(kind);
     let w_class = if w_class != PY_NULL {
         w_class
@@ -365,7 +379,6 @@ fn w_exception_new_from_message_ptr(kind: ExcKind, message: *mut Wtf8Buf) -> PyO
             w_class,
         },
         kind,
-        message,
         args_w: PY_NULL,
         w_cause: PY_NULL,
         w_context: PY_NULL,
@@ -892,14 +905,6 @@ pub unsafe fn w_exception_get_kind(obj: PyObjectRef) -> ExcKind {
     unsafe { (*(obj as *const W_ExceptionObject)).kind }
 }
 
-/// Get the exception message.
-///
-/// # Safety
-/// `obj` must point to a valid `W_ExceptionObject`.
-#[inline]
-pub unsafe fn w_exception_get_message(obj: PyObjectRef) -> &'static Wtf8 {
-    unsafe { &*(*(obj as *const W_ExceptionObject)).message }
-}
 
 /// Get the Python type name string for an ExcKind.
 pub fn exc_kind_name(kind: ExcKind) -> &'static str {
@@ -1055,7 +1060,11 @@ mod tests {
         unsafe {
             assert!(is_exception(obj));
             assert_eq!(w_exception_get_kind(obj), ExcKind::ValueError);
-            assert_eq!(w_exception_get_message(obj), Wtf8::new("bad value"));
+            // The message is stored as the single constructor arg.
+            let args = w_exception_get_args(obj);
+            assert_eq!(crate::tupleobject::w_tuple_len(args), 1);
+            let arg0 = crate::tupleobject::w_tuple_getitem(args, 0).unwrap();
+            assert_eq!(crate::strobject::w_str_get_wtf8(arg0), Wtf8::new("bad value"));
         }
     }
 
@@ -1136,7 +1145,8 @@ mod tests {
         unsafe {
             assert!(is_exception(a));
             assert_eq!(w_exception_get_kind(a), ExcKind::MemoryError);
-            assert_eq!(w_exception_get_message(a), Wtf8::new(""));
+            // Empty message → no constructor args (`args == ()`).
+            assert_eq!(crate::tupleobject::w_tuple_len(w_exception_get_args(a)), 0);
         }
     }
 

--- a/pyre/pyre-object/src/excobject.rs
+++ b/pyre/pyre-object/src/excobject.rs
@@ -476,6 +476,13 @@ pub fn lookup_exc_class_for_kind(kind: ExcKind) -> PyObjectRef {
     EXC_CLASS_BY_KIND.with(|cell| cell.get()[kind as u8 as usize])
 }
 
+/// True when `cls` is one of the canonical per-kind builtin exception
+/// classes registered via `register_exc_class_for_kind` — i.e. its
+/// constructor is the Rust `descr_init` (no Python `__init__`).
+pub fn is_canonical_exc_class(cls: PyObjectRef) -> bool {
+    !cls.is_null() && EXC_CLASS_BY_KIND.with(|cell| cell.get().contains(&cls))
+}
+
 /// `interp_exceptions.py:153 W_BaseException.descr_getargs` parity —
 ///
 /// ```python

--- a/pyre/pyre-object/src/excobject.rs
+++ b/pyre/pyre-object/src/excobject.rs
@@ -180,6 +180,37 @@ pub enum ExcKind {
     UnicodeTranslateError = 28,
 }
 
+impl ExcKind {
+    /// True when this kind's constructor is the trivial
+    /// `W_BaseException.descr_init` (`self.args_w = args_w`) — i.e. it
+    /// stores nothing beyond `args_w`.
+    ///
+    /// False for the kinds whose `descr_init` parses arguments and stores
+    /// extra flattened fields (and, for `OSError`, rewrites `args_w`):
+    /// `OSError` / `FileNotFoundError` set `errno` / `strerror` /
+    /// `filename` / `filename2` (`builtins.rs::os_error_init`,
+    /// interp_exceptions.py:552/629); `UnicodeDecodeError` /
+    /// `UnicodeEncodeError` / `UnicodeTranslateError` set `w_object` /
+    /// `start` / `end` / `reason` (and `encoding` for the codec errors)
+    /// (`builtins.rs::exc_unicode_*_error_init`,
+    /// interp_exceptions.py:433/1041/1159).
+    ///
+    /// A caller that reconstructs an exception from only
+    /// `kind` / `w_class` / `args_w` (e.g. the traced inline
+    /// constructor) must reject the non-trivial kinds and defer to the
+    /// full runtime constructor, which initializes those fields.
+    pub fn has_trivial_args_constructor(self) -> bool {
+        !matches!(
+            self,
+            ExcKind::OSError
+                | ExcKind::FileNotFoundError
+                | ExcKind::UnicodeDecodeError
+                | ExcKind::UnicodeEncodeError
+                | ExcKind::UnicodeTranslateError
+        )
+    }
+}
+
 /// Layout: `[ob_header | kind: ExcKind | args_w: PyObjectRef | …]`
 ///
 /// `args_w` mirrors `pypy/module/exceptions/interp_exceptions.py:121-124`

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -347,6 +347,22 @@ unsafe fn switch_to_correct_strategy(list: &mut W_ListObject, w_item: PyObjectRe
     }
 }
 
+/// The strategy `w_list_new` picks for a given item set.
+///
+/// listobject.py:1092 EmptyListStrategy: a freshly created list with no
+/// items uses Empty until first append picks a typed strategy.
+pub fn list_strategy_for(items: &[PyObjectRef]) -> ListStrategy {
+    if items.is_empty() {
+        ListStrategy::Empty
+    } else if all_ints(items) {
+        ListStrategy::Integer
+    } else if all_floats(items) {
+        ListStrategy::Float
+    } else {
+        ListStrategy::Object
+    }
+}
+
 /// Allocate a new W_ListObject from a Vec of items.
 pub fn w_list_new(items: Vec<PyObjectRef>) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`):
@@ -362,17 +378,7 @@ pub fn w_list_new(items: Vec<PyObjectRef>) -> PyObjectRef {
         crate::gc_roots::pin_root(item);
     }
 
-    // listobject.py:1092 EmptyListStrategy: a freshly created list with no
-    // items uses Empty until first append picks a typed strategy.
-    let strategy = if items.is_empty() {
-        ListStrategy::Empty
-    } else if all_ints(&items) {
-        ListStrategy::Integer
-    } else if all_floats(&items) {
-        ListStrategy::Float
-    } else {
-        ListStrategy::Object
-    };
+    let strategy = list_strategy_for(&items);
     let (length, items_block, int_items, float_items) = match strategy {
         ListStrategy::Empty | ListStrategy::Integer | ListStrategy::Float => {
             let int_items = if let ListStrategy::Integer = strategy {

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -194,16 +194,20 @@ pub trait PyreClassPyTypeOf {
 /// adaptation of RPython's API to Rust's value-construction model.
 #[inline]
 pub fn malloc<T>(value: T) -> *mut T {
-    majit_gc::header::alloc_with_gc_header(value)
+    // Untyped bridge: no registered GC type id, so the header carries 0.
+    majit_gc::header::alloc_with_gc_header(value, 0)
 }
 
-/// Typed variant of [`malloc`]: requires `T: GcType` so the future
-/// managed allocator can read `T::TYPE_ID` and `T::SIZE` without a
-/// runtime registry lookup. Shares [`malloc`]'s body — the
-/// `alloc_with_gc_header` prepend — and will later route through the
-/// GC-managed allocator with proper `push_roots` / `pop_roots` brackets
-/// (`framework.py:853-856`), writing the real `T::TYPE_ID` into the
-/// header instead of the current zeroed placeholder.
+/// Typed variant of [`malloc`]: requires `T: GcType` so the allocator can
+/// stamp the header with `T::type_id()` and check `T::SIZE` without a runtime
+/// registry lookup. Shares [`malloc`]'s body — the `alloc_with_gc_header`
+/// prepend — but passes the real GC type id (`init_gc_object(result, typeid,
+/// flags=0)` parity, `framework.py:807-811`) instead of the untyped bridge's
+/// 0. Auto-id types still resolving deliver `TypeIdCell::UNASSIGNED` until the
+/// JIT driver registers them, so that value is clamped to 0 — `u32::MAX` would
+/// index the type table out of bounds (`trace.rs` `registry.get`) if such an
+/// object were ever traced. Will later route through the GC-managed allocator
+/// with proper `push_roots` / `pop_roots` brackets (`framework.py:853-856`).
 ///
 /// New call sites should prefer [`malloc_typed`] over [`malloc`]
 /// once their `T` has an assigned GC type id; the untyped variant
@@ -215,7 +219,15 @@ pub fn malloc_typed<T: GcType>(value: T) -> *mut T {
         T::SIZE,
         "GcType::SIZE drift from std::mem::size_of"
     );
-    majit_gc::header::alloc_with_gc_header(value)
+    // Auto-id types resolve to UNASSIGNED (u32::MAX) until the JIT driver
+    // registers them. Clamp that to 0 so a stray GC trace of such an object
+    // indexes the type table in-bounds (get(0)) instead of panicking on
+    // get(u32::MAX); the real id lands once the type is registered.
+    let type_id = match T::type_id() {
+        TypeIdCell::UNASSIGNED => 0,
+        id => id,
+    };
+    majit_gc::header::alloc_with_gc_header(value, type_id)
 }
 
 /// `lltype.malloc(T, flavor='raw')` parity. Non-GC heap allocation;
@@ -299,6 +311,10 @@ mod tests {
         let p = malloc_typed(DummyPayload(7));
         unsafe {
             assert_eq!((*p).0, 7);
+            // The header carries the real GC type id, not a 0 placeholder.
+            let hdr = majit_gc::header::header_of(p as usize);
+            assert_eq!((*hdr).type_id(), 0xDEAD_BEEF);
+            assert_eq!((*hdr).flags(), 0);
         }
     }
 }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -26,17 +26,16 @@
 //! 1. Object constructors are single allocation calls without
 //!    per-callsite TLS hooks or conditional branches.
 //! 2. Future GC integration replaces the body of [`malloc`] without
-//!    changing any caller — the "common allocation lowering" the
-//!    2026-04-25 review explicitly endorsed as an alternative to a
-//!    full structural GC transform.
+//!    changing any caller.
 //!
 //! Current body: [`majit_gc::header::alloc_with_gc_header`] — the
-//! `malloc_fixedsize` analog that prepends a zeroed [`GcHeader`] and
-//! returns the payload pointer, so the write barrier reads a valid header
-//! (`TRACK_YOUNG_PTRS = 0`) and skips these still-leaked objects. The GC
-//! owns the header (incminimark defines its own `HDR`); the object model
-//! delegates and stays header-agnostic. Future work routes through the
-//! same allocator with nursery management and proper root push/pop.
+//! `malloc_fixedsize` analog that prepends a [`GcHeader`] (type id,
+//! `flags=0`) and returns the payload pointer, so the write barrier reads a
+//! valid header instead of foreign memory. The GC owns the header
+//! (incminimark defines its own `HDR`); the object model delegates and stays
+//! header-agnostic. These objects are still leaked host allocations; routing
+//! them through the nursery allocator with root push/pop is the remaining
+//! GC work.
 //!
 //! [`GcHeader`]: majit_gc::header::GcHeader
 
@@ -177,41 +176,36 @@ pub trait PyreClassPyTypeOf {
     const PYNAME: &'static str;
 }
 
-/// `lltype.malloc(T, flavor='gc')` parity, *untyped* (no `GcType` impl
-/// required). Allocates a fixed-size GC-managed object on the heap and
-/// returns a raw pointer the caller owns until the GC takes over.
+/// `lltype.malloc(T, flavor='gc')` parity, *untyped* (no `GcType` bound).
+/// Allocates a fixed-size GC object and returns a raw pointer the caller
+/// owns until the GC takes over.
 ///
-/// Prefer [`malloc_typed`] for any `T` with a registered GC type id —
-/// the untyped variant exists only as a temporary bridge for types
-/// that have not yet been wired into the per-type metadata table.
-/// Non-PyObject heap allocations (Strings, raw `Vec`s manually freed
-/// via `Box::from_raw`) belong on [`malloc_raw`], not here, because
-/// they must NOT migrate to the managed allocator.
+/// The header type id is 0 — `OBJECT_GC_TYPE_ID`, the object root. The sole
+/// production caller is `W_InstanceObject`, which aliases that root id on
+/// purpose (a separate id would duplicate the inheritance root and break the
+/// `subclass_range` preorder invariants). Any `T` with its own assigned id
+/// must use [`malloc_typed`].
 ///
-/// In Rust the construction and allocation collapse into a single
-/// step: callers build the value first and pass it in, instead of
-/// PyPy's allocate-then-fill-fields pattern. This is the smallest
-/// adaptation of RPython's API to Rust's value-construction model.
+/// Non-PyObject heap allocations (Strings, raw `Vec`s freed via
+/// `Box::from_raw`) belong on [`malloc_raw`], not here: they must NOT migrate
+/// to the managed allocator.
 #[inline]
 pub fn malloc<T>(value: T) -> *mut T {
-    // Untyped bridge: no registered GC type id, so the header carries 0.
+    // Object-root type id (OBJECT_GC_TYPE_ID = 0).
     majit_gc::header::alloc_with_gc_header(value, 0)
 }
 
-/// Typed variant of [`malloc`]: requires `T: GcType` so the allocator can
-/// stamp the header with `T::type_id()` and check `T::SIZE` without a runtime
-/// registry lookup. Shares [`malloc`]'s body — the `alloc_with_gc_header`
-/// prepend — but passes the real GC type id (`init_gc_object(result, typeid,
-/// flags=0)` parity, `framework.py:807-811`) instead of the untyped bridge's
-/// 0. Auto-id types still resolving deliver `TypeIdCell::UNASSIGNED` until the
-/// JIT driver registers them, so that value is clamped to 0 — `u32::MAX` would
-/// index the type table out of bounds (`trace.rs` `registry.get`) if such an
-/// object were ever traced. Will later route through the GC-managed allocator
-/// with proper `push_roots` / `pop_roots` brackets (`framework.py:853-856`).
+/// Typed variant of [`malloc`]: `T: GcType` lets the allocator stamp the
+/// header with `T::type_id()` and assert `T::SIZE` without a runtime registry
+/// lookup. Same body as [`malloc`] (the `alloc_with_gc_header` prepend),
+/// passing the real GC type id — `init_gc_object(result, typeid, flags=0)`
+/// (`framework.py:807-811`).
 ///
-/// New call sites should prefer [`malloc_typed`] over [`malloc`]
-/// once their `T` has an assigned GC type id; the untyped variant
-/// remains as a temporary bridge for types not yet registered.
+/// `T::type_id()` is `TypeIdCell::UNASSIGNED` (`u32::MAX`) until the JIT
+/// driver registers an auto-id type. That sentinel is not a real id and is
+/// written as 0, since `u32::MAX` would index the type table out of bounds in
+/// the trace path (`registry.get`); the real id lands once the type is
+/// registered.
 #[inline]
 pub fn malloc_typed<T: GcType>(value: T) -> *mut T {
     debug_assert_eq!(
@@ -219,11 +213,9 @@ pub fn malloc_typed<T: GcType>(value: T) -> *mut T {
         T::SIZE,
         "GcType::SIZE drift from std::mem::size_of"
     );
-    // Auto-id types resolve to UNASSIGNED (u32::MAX) until the JIT driver
-    // registers them. Clamp that to 0 so a stray GC trace of such an object
-    // indexes the type table in-bounds (get(0)) instead of panicking on
-    // get(u32::MAX); the real id lands once the type is registered.
     let type_id = match T::type_id() {
+        // UNASSIGNED is a sentinel, not a real type id; write the object-root
+        // id 0 until the JIT driver assigns the real one.
         TypeIdCell::UNASSIGNED => 0,
         id => id,
     };


### PR DESCRIPTION
Fix #129

## Summary

Closes the `raise_catch` performance blocker (#129): pyre **materialized the
exception on every raise** (~35x slower than PyPy per raise), where PyPy
**virtualizes** a non-escaping exception and elides the whole construction.
This PR meta-traces exception construction as `New` + `SetField` ops so the
existing virtualizer removes it when the exception never escapes — the
PyPy-faithful approach rather than a special-case lowering.

**Exception model / construction**
- Drop the eager `message: *mut Wtf8Buf` field from `W_ExceptionObject`;
  derive `str`/`repr` lazily from `args_w` (PyPy `W_BaseException` has no
  message — `descr_init` only sets `args_w`). Internal raises now carry
  `args=(msg,)`, matching CPython exactly. Removes one of three per-raise
  allocations (the leaked Wtf8Buf copy).
- Trace builtin-exception construction as `NewWithVtable(W_ExceptionObject)`
  + `SetfieldGc` (kind / w_class / args_w / w_context) instead of the opaque
  residual `jit_call_callable_N`, restricted to the canonical per-kind
  builtin class (user subclasses keep the generic call path).
- Build the Object-strategy `args_w` list inline (`NewArrayClear` ItemsBlock
  + `NewWithVtable(W_ListObject)` + `SetfieldGc`) so the args list
  virtualizes alongside the exception; Empty/Integer/Float strategies keep
  the residual list builder.

**Exception state / raise path**
- Move `sys.exc_info` state off the thread-local `CURRENT_EXCEPTION` Cell onto
  `ExecutionContext.sys_exc_value` (GC-root-scanned); `PUSH_EXC_INFO` /
  `POP_EXCEPT` emit `GetfieldGc` / `SetfieldGc` on that field instead of
  residual calls, so the writes are DSE/virtualization-visible.
- Skip `GuardException` + the `normalize_raise_varargs_jit` publish when a
  trace-built exception is caught by a **local** handler (provably-true
  guard); the root-escape path still finishes via
  `compile_exit_frame_with_exception`.

**Optimizer / resume**
- `OptString::force_args_if_virtual` skips earlyforce-exempt ops
  (`SetfieldGc`/`SetarrayitemGc`/`SameAs`), so the EC store no longer forces
  the virtual exception.
- Blackhole resume resolves negative-indexed (cached/nested) virtuals
  (`rd_virtuals[num]` Python-style negative indexing), so a virtual exception
  reconstructed from a pending field on an ordinary guard failure no longer
  goes out of bounds.

**Cranelift bridge→loop re-entry (unblocks the gate)**
- Per-`LABEL` `br_table` re-entry keyed on a `dispatch_key`, frame realloc on
  closing-jump depth miss, entry ref-root sync deferral, and deletion of the
  dead `body_direct` dual-entry machinery. This fixes the cranelift infinite
  loop that previously made the virtualization gate hang, so both backends
  now virtualize identically.

**GC**
- GC header shim carries the real `type_id` + aligned `GcHeader` fields; the
  GC rewrite forwards the `GUARD_EXCEPTION` result (its Ref result was
  renumbered without forwarding, dangling the consumer).

### Results

- `raise_catch` ≈ **1.9x PyPy** (down from ~35x per raise), faster than
  CPython; main hot loop traces with **0 `New`** and the raise bridge
  virtualizes the exception, args list and ItemsBlock away.
- `check.py` **45/45 on both dynasm and cranelift** (MAJIT_STRICT=1);
  `e.args` materializes byte-identical to CPython/PyPy on the escape path;
  exception `str`/`repr`/`args` match CPython across 0/1/N-arg cases.
- New `bench/synth/exception_args_virtual.py` regression covers the
  Object-strategy args path (escaping + non-escaping raises).

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline exception construction in JIT traces for faster, allocation-aware raises.

* **Bug Fixes**
  * Preserved guard result positions to avoid miswired references.
  * Fixed resume-data decoding so virtual fields remap correctly during resume.

* **Refactor**
  * Active-exception storage moved into per-thread execution context (reliable exception handling across GC).
  * Loop dispatch and re-entry now support targeted re-entry into labeled blocks.

* **Chores**
  * Added synthetic benchmarks for exception scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->