### PR TITLE
JIT walker: direct dispatch for STORE_SUBSCR, CallMayForce, and Reraise

### DIFF
--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -854,6 +854,24 @@ impl TraceCtx {
         effectinfo: Option<&majit_ir::EffectInfo>,
         argboxes: &[OpRef],
     ) {
+        if std::env::var_os("PYRE_PROBE_SUBSCR").is_some() {
+            let ei_summary = effectinfo.map(|ei| {
+                format!(
+                    "extraeffect={:?} forces_vorv={} can_raise={} plain_call={} oopspec={:?}",
+                    ei.extraeffect,
+                    ei.check_forces_virtual_or_virtualizable(),
+                    ei.check_can_raise(false),
+                    opnum.is_plain_call(),
+                    ei.oopspecindex,
+                )
+            });
+            eprintln!(
+                "[PYRE_PROBE_SUBSCR] invalidate_caches_varargs opnum={:?} argboxes.len={} ei={:?}",
+                opnum,
+                argboxes.len(),
+                ei_summary
+            );
+        }
         let oracle: &dyn majit_trace::heapcache::SameConstantOracle =
             &crate::history::ConstOprefOracle;
         let const_value = |opref: OpRef| match opref.inline_const_to_value() {

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -1077,12 +1077,12 @@ pub fn generated_binary_int_value(
     let lhs_raw = if frame.value_type(a) == majit_ir::Type::Int {
         a
     } else {
-        crate::state::trace_unbox_int_with_resume(frame, ctx, a, int_type_addr)
+        crate::state::trace_unbox_int_with_resume(frame, a, int_type_addr)
     };
     let rhs_raw = if frame.value_type(b) == majit_ir::Type::Int {
         b
     } else {
-        crate::state::trace_unbox_int_with_resume(frame, ctx, b, int_type_addr)
+        crate::state::trace_unbox_int_with_resume(frame, b, int_type_addr)
     };
 
     // The inlined `_ovf_zer` wrapper (`rint.py:429 ll_int_py_div_
@@ -1309,7 +1309,7 @@ pub fn generated_binary_float_value(
             let raw_int = if frame.value_type(obj) == majit_ir::Type::Int {
                 obj
             } else {
-                crate::state::trace_unbox_int_with_resume(frame, ctx, obj, int_type_addr)
+                crate::state::trace_unbox_int_with_resume(frame, obj, int_type_addr)
             };
             let r = ctx.record_op(OpCode::CastIntToFloat, &[raw_int]);
             // Box(value) parity: derive concrete float from the int's
@@ -1405,14 +1405,14 @@ pub fn generated_compare_value_direct(
             } else if let Some(raw) = crate::state::try_trace_const_boxed_int(ctx, a, concrete_lhs) {
                 raw
             } else {
-                crate::state::trace_unbox_int_with_resume(frame, ctx, a, int_type_addr)
+                crate::state::trace_unbox_int_with_resume(frame, a, int_type_addr)
             };
             let rhs_raw = if frame.value_type(b) == majit_ir::Type::Int {
                 b
             } else if let Some(raw) = crate::state::try_trace_const_boxed_int(ctx, b, concrete_rhs) {
                 raw
             } else {
-                crate::state::trace_unbox_int_with_resume(frame, ctx, b, int_type_addr)
+                crate::state::trace_unbox_int_with_resume(frame, b, int_type_addr)
             };
             let truth = ctx.record_op(cmp, &[lhs_raw, rhs_raw]);
             // Box(value) parity: stamp the bool result from the operands'
@@ -1463,7 +1463,7 @@ pub fn generated_compare_value_direct(
                 let raw_int = if frame.value_type(a) == majit_ir::Type::Int {
                     a
                 } else {
-                    crate::state::trace_unbox_int_with_resume(frame, ctx, a, int_type_addr)
+                    crate::state::trace_unbox_int_with_resume(frame, a, int_type_addr)
                 };
                 let cast = ctx.record_op(majit_ir::OpCode::CastIntToFloat, &[raw_int]);
                 // Box(value) parity: derive concrete float from the int's
@@ -1473,7 +1473,7 @@ pub fn generated_compare_value_direct(
                 }
                 cast
             } else {
-                crate::state::trace_unbox_float_with_resume(frame, ctx, a, float_type_addr)
+                crate::state::trace_unbox_float_with_resume(frame, a, float_type_addr)
             };
             // Unbox rhs: same pattern
             let rhs_raw = if frame.value_type(b) == majit_ir::Type::Float {
@@ -1482,7 +1482,7 @@ pub fn generated_compare_value_direct(
                 let raw_int = if frame.value_type(b) == majit_ir::Type::Int {
                     b
                 } else {
-                    crate::state::trace_unbox_int_with_resume(frame, ctx, b, int_type_addr)
+                    crate::state::trace_unbox_int_with_resume(frame, b, int_type_addr)
                 };
                 let cast = ctx.record_op(majit_ir::OpCode::CastIntToFloat, &[raw_int]);
                 if let Some(majit_ir::Value::Int(n)) = ctx.box_value(raw_int) {
@@ -1490,7 +1490,7 @@ pub fn generated_compare_value_direct(
                 }
                 cast
             } else {
-                crate::state::trace_unbox_float_with_resume(frame, ctx, b, float_type_addr)
+                crate::state::trace_unbox_float_with_resume(frame, b, float_type_addr)
             };
             let truth = ctx.record_op(cmp, &[lhs_raw, rhs_raw]);
             // Box(value) parity: stamp the float-compare bool result.
@@ -1542,7 +1542,7 @@ pub fn generated_unary_int_value(
         value
     } else {
         let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-        crate::state::trace_unbox_int_with_resume(frame, ctx, value, int_type_addr)
+        crate::state::trace_unbox_int_with_resume(frame, value, int_type_addr)
     };
     // intobject.py int_neg: guard against INT_MIN (overflow to long).
     if matches!(opcode, OpCode::IntNeg) {
@@ -1766,7 +1766,7 @@ pub fn generated_list_setitem_by_strategy(
                 value
             } else {
                 let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
-                crate::state::trace_unbox_float_with_resume(frame, ctx, value, float_type_addr)
+                crate::state::trace_unbox_float_with_resume(frame, value, float_type_addr)
             };
             crate::state::trace_raw_float_array_setitem_value(ctx, items_ptr, index, raw);
         }
@@ -1899,10 +1899,10 @@ fn unbox_int_or_long_for_int_strategy(
     }
     if unbox_long {
         let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
-        crate::state::trace_unbox_long_with_resume(frame, ctx, value, long_type_addr)
+        crate::state::trace_unbox_long_with_resume(frame, value, long_type_addr)
     } else {
         let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-        crate::state::trace_unbox_int_with_resume(frame, ctx, value, int_type_addr)
+        crate::state::trace_unbox_int_with_resume(frame, value, int_type_addr)
     }
 }
 
@@ -1964,7 +1964,7 @@ pub fn generated_truth_value_direct(
             {
                 raw
             } else {
-                crate::state::trace_unbox_int_with_resume(frame, ctx, value, int_type_addr)
+                crate::state::trace_unbox_int_with_resume(frame, value, int_type_addr)
             };
             let zero = ctx.const_int(0);
             let truth = ctx.record_op(OpCode::IntNe, &[int_value, zero]);
@@ -1982,7 +1982,7 @@ pub fn generated_truth_value_direct(
                 raw
             } else {
                 crate::state::trace_unbox_int_with_resume_descr(
-                    frame, ctx, value, bool_type_addr,
+                    frame, value, bool_type_addr,
                     crate::descr::bool_boolval_descr(),
                 )
             };
@@ -2002,7 +2002,7 @@ pub fn generated_truth_value_direct(
         if pyre_object::is_float(concrete_val) {
             let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
             let float_value = crate::state::trace_unbox_float_with_resume(
-                frame, ctx, value, float_type_addr,
+                frame, value, float_type_addr,
             );
             let zero = ctx.const_int(0);
             let zero_float = ctx.record_op(OpCode::CastIntToFloat, &[zero]);
@@ -2167,7 +2167,7 @@ pub fn generated_list_append_by_strategy(
                 value
             } else {
                 let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
-                crate::state::trace_unbox_float_with_resume(frame, ctx, value, float_type_addr)
+                crate::state::trace_unbox_float_with_resume(frame, value, float_type_addr)
             };
             crate::state::trace_raw_float_array_setitem_value(ctx, items_ptr, len, raw);
         }
@@ -2672,7 +2672,7 @@ pub fn generated_tuple_getitem(
             key
         } else {
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-            crate::state::trace_unbox_int_with_resume(frame, ctx, key, int_type_addr)
+            crate::state::trace_unbox_int_with_resume(frame, key, int_type_addr)
         };
         frame.implement_guard_value(ctx, key_unboxed, concrete_key);
         let descr = if normalised == 0 {
@@ -2703,7 +2703,7 @@ pub fn generated_tuple_getitem(
             key
         } else {
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-            crate::state::trace_unbox_int_with_resume(frame, ctx, key, int_type_addr)
+            crate::state::trace_unbox_int_with_resume(frame, key, int_type_addr)
         };
         frame.implement_guard_value(ctx, key_unboxed, concrete_key);
         let descr = if normalised == 0 {
@@ -2732,7 +2732,7 @@ pub fn generated_tuple_getitem(
             key
         } else {
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-            crate::state::trace_unbox_int_with_resume(frame, ctx, key, int_type_addr)
+            crate::state::trace_unbox_int_with_resume(frame, key, int_type_addr)
         };
         frame.implement_guard_value(ctx, key_unboxed, concrete_key);
         let descr = if normalised == 0 {
@@ -2803,7 +2803,7 @@ pub fn opimpl_check_neg_index(
     let raw_index = if frame.value_type(indexbox) == majit_ir::Type::Int {
         indexbox
     } else {
-        crate::state::trace_unbox_int_with_resume(frame, ctx, indexbox, int_type_addr)
+        crate::state::trace_unbox_int_with_resume(frame, indexbox, int_type_addr)
     };
     // Box(value) parity: stamp the unboxed index with its concrete.
     ctx.set_opref_concrete(raw_index, majit_ir::Value::Int(concrete_key));
@@ -2868,7 +2868,7 @@ pub fn opimpl_check_resizable_neg_index(
     let raw_index = if frame.value_type(indexbox) == majit_ir::Type::Int {
         indexbox
     } else {
-        crate::state::trace_unbox_int_with_resume(frame, ctx, indexbox, int_type_addr)
+        crate::state::trace_unbox_int_with_resume(frame, indexbox, int_type_addr)
     };
     ctx.set_opref_concrete(raw_index, majit_ir::Value::Int(concrete_key));
     let zero = ctx.const_int(0);
@@ -2924,7 +2924,7 @@ pub fn generated_dynamic_list_index(
     let raw_index = if frame.value_type(key) == majit_ir::Type::Int {
         key
     } else {
-        crate::state::trace_unbox_int_with_resume(frame, ctx, key, int_type_addr)
+        crate::state::trace_unbox_int_with_resume(frame, key, int_type_addr)
     };
     ctx.set_opref_concrete(raw_index, majit_ir::Value::Int(concrete_key));
     let zero = ctx.const_int(0);

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -1720,9 +1720,8 @@ fn guard_pop_without_resize_le(
 /// strategy_id: 0 = object, 1 = int, 2 = float.
 /// For int/float strategies, the value is unboxed before writing.
 #[inline]
-pub fn generated_list_setitem_by_strategy(
-    frame: &mut crate::state::MIFrame,
-    ctx: &mut majit_metainterp::TraceCtx,
+pub fn generated_list_setitem_by_strategy<F: pyre_jit_trace::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     obj: majit_ir::OpRef,
     key: majit_ir::OpRef,
     value: majit_ir::OpRef,
@@ -1730,8 +1729,11 @@ pub fn generated_list_setitem_by_strategy(
     strategy_id: i64,
     unbox_long: bool,
 ) {
-    frame.guard_class(ctx, obj, &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType);
-    frame.guard_list_strategy(ctx, obj, strategy_id);
+    frame.guard_class(
+        obj,
+        &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType,
+    );
+    frame.guard_list_strategy(obj, strategy_id);
     let len_descr = match strategy_id {
         0 => crate::descr::list_length_descr(),
         1 => crate::descr::list_int_items_len_descr(),
@@ -1739,26 +1741,37 @@ pub fn generated_list_setitem_by_strategy(
         _ => unreachable!(),
     };
     // pyjitpl.py:841: opimpl_check_resizable_neg_index for index normalization
-    let index = opimpl_check_resizable_neg_index(frame, ctx, obj, key, len_descr, concrete_key);
+    let index = opimpl_check_resizable_neg_index(frame, obj, key, len_descr, concrete_key);
     match strategy_id {
         0 => {
             // pyjitpl.py:832: arraybox = opimpl_getfield_gc_r(listbox, itemsdescr)
             // followed by setarrayitem_gc(arraybox, index, value, arraydescr).
-            let items_block = load_items_block(ctx, obj, crate::descr::list_items_descr());
-            crate::state::trace_items_block_setitem_value(ctx, items_block, index, value);
+            let items_block =
+                load_items_block(frame.ctx_mut(), obj, crate::descr::list_items_descr());
+            crate::state::trace_items_block_setitem_value(
+                frame.ctx_mut(),
+                items_block,
+                index,
+                value,
+            );
         }
         1 => {
             let items_ptr = crate::state::opimpl_getfield_gc_i(
-                ctx,
+                frame.ctx_mut(),
                 obj,
                 crate::descr::list_int_items_ptr_descr(),
             );
-            let raw = unbox_int_or_long_for_int_strategy(frame, ctx, value, unbox_long);
-            crate::state::trace_raw_int_array_setitem_value(ctx, items_ptr, index, raw);
+            let raw = unbox_int_or_long_for_int_strategy(frame, value, unbox_long);
+            crate::state::trace_raw_int_array_setitem_value(
+                frame.ctx_mut(),
+                items_ptr,
+                index,
+                raw,
+            );
         }
         2 => {
             let items_ptr = crate::state::opimpl_getfield_gc_i(
-                ctx,
+                frame.ctx_mut(),
                 obj,
                 crate::descr::list_float_items_ptr_descr(),
             );
@@ -1768,7 +1781,12 @@ pub fn generated_list_setitem_by_strategy(
                 let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
                 crate::state::trace_unbox_float_with_resume(frame, value, float_type_addr)
             };
-            crate::state::trace_raw_float_array_setitem_value(ctx, items_ptr, index, raw);
+            crate::state::trace_raw_float_array_setitem_value(
+                frame.ctx_mut(),
+                items_ptr,
+                index,
+                raw,
+            );
         }
         _ => unreachable!(),
     }
@@ -1787,9 +1805,10 @@ pub fn generated_list_setitem_by_strategy(
 /// rather than risking an incorrect partial port of listobject.py's resizing
 /// and overlap rules.
 #[inline]
-pub fn generated_list_setslice_same_len_by_strategy(
-    frame: &mut crate::state::MIFrame,
-    ctx: &mut majit_metainterp::TraceCtx,
+pub fn generated_list_setslice_same_len_by_strategy<
+    F: pyre_jit_trace::walker_frame_ops::WalkerFrameOps,
+>(
+    frame: &mut F,
     obj: majit_ir::OpRef,
     value: majit_ir::OpRef,
     raw_start: i64,
@@ -1801,80 +1820,112 @@ pub fn generated_list_setslice_same_len_by_strategy(
     value_len: usize,
 ) {
     frame.guard_class(
-        ctx,
         obj,
         &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType,
     );
     frame.guard_class(
-        ctx,
         value,
         &pyre_object::pyobject::LIST_TYPE as *const _ as *const pyre_object::PyType,
     );
-    frame.guard_list_strategy(ctx, obj, strategy_id);
-    frame.guard_list_strategy(ctx, value, strategy_id);
+    frame.guard_list_strategy(obj, strategy_id);
+    frame.guard_list_strategy(value, strategy_id);
 
     let len_descr = list_len_descr_for_strategy(strategy_id);
-    let obj_len_box = crate::state::opimpl_getfield_gc_i(ctx, obj, len_descr.clone());
+    let obj_len_box =
+        crate::state::opimpl_getfield_gc_i(frame.ctx_mut(), obj, len_descr.clone());
     if raw_start == start && raw_stop == stop {
-        let raw_stop_box = ctx.const_int(raw_stop);
-        let lower_bound_ok =
-            ctx.record_op(majit_ir::OpCode::IntGe, &[obj_len_box, raw_stop_box]);
-        if let Some(majit_ir::Value::Int(ol)) = ctx.box_value(obj_len_box) {
-            ctx.set_opref_concrete(
+        let raw_stop_box = frame.ctx_mut().const_int(raw_stop);
+        let lower_bound_ok = frame
+            .ctx_mut()
+            .record_op(majit_ir::OpCode::IntGe, &[obj_len_box, raw_stop_box]);
+        let ol_opt = frame.ctx_mut().box_value(obj_len_box);
+        if let Some(majit_ir::Value::Int(ol)) = ol_opt {
+            frame.ctx_mut().set_opref_concrete(
                 lower_bound_ok,
                 majit_ir::Value::Int((ol >= raw_stop) as i64),
             );
         }
-        frame.generate_guard(ctx, majit_ir::OpCode::GuardTrue, &[lower_bound_ok]);
+        frame.generate_guard(majit_ir::OpCode::GuardTrue, &[lower_bound_ok]);
     } else {
-        frame.implement_guard_value(ctx, obj_len_box, obj_len as i64);
+        frame.implement_guard_value(obj_len_box, obj_len as i64);
     }
-    let value_len_box = crate::state::opimpl_getfield_gc_i(ctx, value, len_descr);
-    frame.implement_guard_value(ctx, value_len_box, value_len as i64);
+    let value_len_box = crate::state::opimpl_getfield_gc_i(frame.ctx_mut(), value, len_descr);
+    frame.implement_guard_value(value_len_box, value_len as i64);
 
     match strategy_id {
         0 => {
-            let dst_items = load_items_block(ctx, obj, crate::descr::list_items_descr());
-            let src_items = load_items_block(ctx, value, crate::descr::list_items_descr());
+            let dst_items =
+                load_items_block(frame.ctx_mut(), obj, crate::descr::list_items_descr());
+            let src_items =
+                load_items_block(frame.ctx_mut(), value, crate::descr::list_items_descr());
             for i in 0..value_len {
-                let src_idx = ctx.const_int(i as i64);
-                let dst_idx = ctx.const_int(start + i as i64);
-                let item = crate::state::trace_items_block_getitem_value(ctx, src_items, src_idx);
-                crate::state::trace_items_block_setitem_value(ctx, dst_items, dst_idx, item);
+                let src_idx = frame.ctx_mut().const_int(i as i64);
+                let dst_idx = frame.ctx_mut().const_int(start + i as i64);
+                let item = crate::state::trace_items_block_getitem_value(
+                    frame.ctx_mut(),
+                    src_items,
+                    src_idx,
+                );
+                crate::state::trace_items_block_setitem_value(
+                    frame.ctx_mut(),
+                    dst_items,
+                    dst_idx,
+                    item,
+                );
             }
         }
         1 => {
-            let dst_items =
-                crate::state::opimpl_getfield_gc_i(ctx, obj, crate::descr::list_int_items_ptr_descr());
+            let dst_items = crate::state::opimpl_getfield_gc_i(
+                frame.ctx_mut(),
+                obj,
+                crate::descr::list_int_items_ptr_descr(),
+            );
             let src_items = crate::state::opimpl_getfield_gc_i(
-                ctx,
+                frame.ctx_mut(),
                 value,
                 crate::descr::list_int_items_ptr_descr(),
             );
             for i in 0..value_len {
-                let src_idx = ctx.const_int(i as i64);
-                let dst_idx = ctx.const_int(start + i as i64);
-                let item = crate::state::trace_raw_int_array_getitem_value(ctx, src_items, src_idx);
-                crate::state::trace_raw_int_array_setitem_value(ctx, dst_items, dst_idx, item);
+                let src_idx = frame.ctx_mut().const_int(i as i64);
+                let dst_idx = frame.ctx_mut().const_int(start + i as i64);
+                let item = crate::state::trace_raw_int_array_getitem_value(
+                    frame.ctx_mut(),
+                    src_items,
+                    src_idx,
+                );
+                crate::state::trace_raw_int_array_setitem_value(
+                    frame.ctx_mut(),
+                    dst_items,
+                    dst_idx,
+                    item,
+                );
             }
         }
         2 => {
             let dst_items = crate::state::opimpl_getfield_gc_i(
-                ctx,
+                frame.ctx_mut(),
                 obj,
                 crate::descr::list_float_items_ptr_descr(),
             );
             let src_items = crate::state::opimpl_getfield_gc_i(
-                ctx,
+                frame.ctx_mut(),
                 value,
                 crate::descr::list_float_items_ptr_descr(),
             );
             for i in 0..value_len {
-                let src_idx = ctx.const_int(i as i64);
-                let dst_idx = ctx.const_int(start + i as i64);
-                let item =
-                    crate::state::trace_raw_float_array_getitem_value(ctx, src_items, src_idx);
-                crate::state::trace_raw_float_array_setitem_value(ctx, dst_items, dst_idx, item);
+                let src_idx = frame.ctx_mut().const_int(i as i64);
+                let dst_idx = frame.ctx_mut().const_int(start + i as i64);
+                let item = crate::state::trace_raw_float_array_getitem_value(
+                    frame.ctx_mut(),
+                    src_items,
+                    src_idx,
+                );
+                crate::state::trace_raw_float_array_setitem_value(
+                    frame.ctx_mut(),
+                    dst_items,
+                    dst_idx,
+                    item,
+                );
             }
         }
         _ => unreachable!(),
@@ -1888,9 +1939,8 @@ pub fn generated_list_setslice_same_len_by_strategy(
 /// accept fits_int W_LongObject (`listobject.py:1957-1958 IntegerListStrategy
 /// .is_correct_type` parity); `false` selects the default W_IntObject unbox.
 #[inline]
-fn unbox_int_or_long_for_int_strategy(
-    frame: &mut crate::state::MIFrame,
-    ctx: &mut majit_metainterp::TraceCtx,
+fn unbox_int_or_long_for_int_strategy<F: pyre_jit_trace::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     value: majit_ir::OpRef,
     unbox_long: bool,
 ) -> majit_ir::OpRef {
@@ -2154,7 +2204,7 @@ pub fn generated_list_append_by_strategy(
                 list,
                 crate::descr::list_int_items_ptr_descr(),
             );
-            let raw = unbox_int_or_long_for_int_strategy(frame, ctx, value, unbox_long);
+            let raw = unbox_int_or_long_for_int_strategy(frame, value, unbox_long);
             crate::state::trace_raw_int_array_setitem_value(ctx, items_ptr, len, raw);
         }
         2 => {
@@ -2854,9 +2904,8 @@ pub fn opimpl_check_neg_index(
 /// For resizable lists. Uses GETFIELD_GC for length (not ARRAYLEN_GC).
 /// Bounds guards added for raw-pointer safety.
 #[inline]
-pub fn opimpl_check_resizable_neg_index(
-    frame: &mut crate::state::MIFrame,
-    ctx: &mut majit_metainterp::TraceCtx,
+pub fn opimpl_check_resizable_neg_index<F: pyre_jit_trace::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     listbox: majit_ir::OpRef,
     indexbox: majit_ir::OpRef,
     lengthdescr: majit_ir::DescrRef,
@@ -2870,39 +2919,54 @@ pub fn opimpl_check_resizable_neg_index(
     } else {
         crate::state::trace_unbox_int_with_resume(frame, indexbox, int_type_addr)
     };
-    ctx.set_opref_concrete(raw_index, majit_ir::Value::Int(concrete_key));
-    let zero = ctx.const_int(0);
+    frame
+        .ctx_mut()
+        .set_opref_concrete(raw_index, majit_ir::Value::Int(concrete_key));
+    let zero = frame.ctx_mut().const_int(0);
     // pyjitpl.py:843-845
-    let negbox = ctx.record_op(OpCode::IntLt, &[raw_index, zero]);
-    ctx.set_opref_concrete(negbox, majit_ir::Value::Int((concrete_key < 0) as i64));
-    frame.implement_guard_value(ctx, negbox, if concrete_key < 0 { 1 } else { 0 });
+    let negbox = frame.ctx_mut().record_op(OpCode::IntLt, &[raw_index, zero]);
+    frame
+        .ctx_mut()
+        .set_opref_concrete(negbox, majit_ir::Value::Int((concrete_key < 0) as i64));
+    frame.implement_guard_value(negbox, if concrete_key < 0 { 1 } else { 0 });
     if concrete_key < 0 {
         // pyjitpl.py:848: lenbox = execute_and_record(GETFIELD_GC, lengthdescr, listbox)
-        let lenbox = crate::state::opimpl_getfield_gc_i(ctx, listbox, lengthdescr);
+        let lenbox = crate::state::opimpl_getfield_gc_i(frame.ctx_mut(), listbox, lengthdescr);
         // pyjitpl.py:850-851: indexbox = INT_ADD(indexbox, lenbox)
-        let indexbox = ctx.record_op(OpCode::IntAdd, &[raw_index, lenbox]);
-        if let Some(majit_ir::Value::Int(len)) = ctx.box_value(lenbox) {
-            ctx.set_opref_concrete(
+        let indexbox = frame
+            .ctx_mut()
+            .record_op(OpCode::IntAdd, &[raw_index, lenbox]);
+        let len_opt = frame.ctx_mut().box_value(lenbox);
+        if let Some(majit_ir::Value::Int(len)) = len_opt {
+            frame.ctx_mut().set_opref_concrete(
                 indexbox,
                 majit_ir::Value::Int(concrete_key.wrapping_add(len)),
             );
         }
         // bounds guard (raw-pointer safety)
-        let in_bounds = ctx.record_op(OpCode::IntGe, &[indexbox, zero]);
-        if let Some(majit_ir::Value::Int(idx)) = ctx.box_value(indexbox) {
-            ctx.set_opref_concrete(in_bounds, majit_ir::Value::Int((idx >= 0) as i64));
+        let in_bounds = frame.ctx_mut().record_op(OpCode::IntGe, &[indexbox, zero]);
+        let idx_opt = frame.ctx_mut().box_value(indexbox);
+        if let Some(majit_ir::Value::Int(idx)) = idx_opt {
+            frame
+                .ctx_mut()
+                .set_opref_concrete(in_bounds, majit_ir::Value::Int((idx >= 0) as i64));
         }
-        frame.generate_guard(ctx, OpCode::GuardTrue, &[in_bounds]);
+        frame.generate_guard(OpCode::GuardTrue, &[in_bounds]);
         indexbox
     } else {
         // RPython: no bounds check for positive index.
         // We add one for raw-pointer safety.
-        let lenbox = crate::state::opimpl_getfield_gc_i(ctx, listbox, lengthdescr);
-        let in_bounds = ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
-        if let Some(majit_ir::Value::Int(len)) = ctx.box_value(lenbox) {
-            ctx.set_opref_concrete(in_bounds, majit_ir::Value::Int((concrete_key < len) as i64));
+        let lenbox = crate::state::opimpl_getfield_gc_i(frame.ctx_mut(), listbox, lengthdescr);
+        let in_bounds = frame
+            .ctx_mut()
+            .record_op(OpCode::IntLt, &[raw_index, lenbox]);
+        let len_opt = frame.ctx_mut().box_value(lenbox);
+        if let Some(majit_ir::Value::Int(len)) = len_opt {
+            frame
+                .ctx_mut()
+                .set_opref_concrete(in_bounds, majit_ir::Value::Int((concrete_key < len) as i64));
         }
-        frame.generate_guard(ctx, OpCode::GuardTrue, &[in_bounds]);
+        frame.generate_guard(OpCode::GuardTrue, &[in_bounds]);
         raw_index
     }
 }
@@ -2982,7 +3046,7 @@ pub fn generated_list_getitem_by_strategy(
         2 => crate::descr::list_float_items_len_descr(),
         _ => unreachable!(),
     };
-    let index = opimpl_check_resizable_neg_index(frame, ctx, obj, key, len_descr, concrete_key);
+    let index = opimpl_check_resizable_neg_index(frame, obj, key, len_descr, concrete_key);
     match strategy_id {
         0 => {
             let items_block = load_items_block(ctx, obj, crate::descr::list_items_descr());
@@ -3069,9 +3133,8 @@ pub fn generated_binary_subscr_value(
 ///
 /// Returns true if handled, false if caller should fall back to residual.
 #[inline]
-pub fn generated_store_subscr_value(
-    frame: &mut crate::state::MIFrame,
-    ctx: &mut majit_metainterp::TraceCtx,
+pub fn generated_store_subscr_value<F: pyre_jit_trace::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     obj: majit_ir::OpRef,
     key: majit_ir::OpRef,
     value: majit_ir::OpRef,
@@ -3093,7 +3156,7 @@ pub fn generated_store_subscr_value(
                 let concrete_len = pyre_object::w_list_len(concrete_obj);
                 if check_index_in_bounds(index, concrete_len) {
                     generated_list_setitem_by_strategy(
-                        frame, ctx, obj, key, value, index, sid, unbox_long,
+                        frame, obj, key, value, index, sid, unbox_long,
                     );
                     return true;
                 }

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -591,7 +591,7 @@ class Check:
             for backend in ("dynasm", "cranelift"):
                 if self.enabled(backend):
                     self._record(backend, False, name, "pypy crash")
-                    self._append_comparison(backend, name, fmt_time(t_cpython), "-", "FAIL")
+                    self._append_comparison(backend, name, t_cpython, "-", "FAIL")
             return
         print(f"{dim('done')}  {t_pypy}s")
 
@@ -605,14 +605,14 @@ class Check:
                 sys.stdout.write(f"    {backend:<10s}")
                 print(dim("skip"))
                 self._append_comparison(
-                    backend, name, fmt_time(t_cpython), fmt_time(t_pypy), "skip",
+                    backend, name, t_cpython, t_pypy, "skip",
                 )
                 continue
             if vs_cpython and cpython_code != 0:
                 sys.stdout.write(f"    {backend:<10s}")
                 print(f"{red('FAIL')}  missing cpython baseline")
                 self._record(backend, False, name, "cpython crash")
-                self._append_comparison(backend, name, "-", fmt_time(t_pypy), "FAIL")
+                self._append_comparison(backend, name, "-", t_pypy, "FAIL")
                 continue
             self._run_backend_bench(
                 backend, name, script, timeout,
@@ -655,7 +655,7 @@ class Check:
             for backend in ("dynasm", "cranelift"):
                 if self.enabled(backend):
                     self._record(backend, False, name, "pypy crash")
-                    self._append_comparison(backend, name, fmt_time(t_cpython), "-", "FAIL")
+                    self._append_comparison(backend, name, t_cpython, "-", "FAIL")
             return
         t_pypy = f"{pypy_time:.2f}"
         print(f"{dim('done')}  {t_pypy}s")
@@ -666,7 +666,7 @@ class Check:
                 if self.enabled(backend):
                     self._record(backend, False, name, "cpython/pypy output mismatch")
                     self._append_comparison(
-                        backend, name, fmt_time(t_cpython), fmt_time(t_pypy), "BASEFAIL",
+                        backend, name, t_cpython, t_pypy, "BASEFAIL",
                     )
             return
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4880,18 +4880,23 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
             }
         }
     }
-    // Type objects: set to PY_NULL in class dict
-    // (DictStorage doesn't support removal, null slot acts as deleted)
+    // Type objects: remove the key from the class namespace.  Real
+    // removal (not a PY_NULL tombstone) keeps `cls.__dict__` membership,
+    // iteration, and length correct and back-mirrors the deletion into a
+    // materialized `__dict__`.  A missing key raises AttributeError, the
+    // same as the surrogate sibling `object_delattr_surrogate`.
     unsafe {
         if is_type(obj) {
             let dict_ptr = w_type_get_dict_ptr(obj) as *mut crate::DictStorage;
             if !dict_ptr.is_null() {
-                crate::dict_storage_store(&mut *dict_ptr, name, PY_NULL);
-                // typeobject.py:445 — `self.mutated(key)` mirrors the
-                // setattr branch's invalidation across the subclass
-                // tree.
-                mutated(obj, Some(name));
-                return Ok(w_none());
+                if crate::dict_storage_delete(&mut *dict_ptr, name) {
+                    // typeobject.py:445 — `self.mutated(key)` mirrors the
+                    // setattr branch's invalidation across the subclass
+                    // tree.
+                    mutated(obj, Some(name));
+                    return Ok(w_none());
+                }
+                return Err(raiseattrerror(obj, name));
             }
         }
     }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1089,6 +1089,25 @@ mod tests {
         assert_eq!(bindings["pyre_interpreter::jit_build_tuple_2"], tuple2);
     }
 
+    #[test]
+    fn jit_trace_fnaddrs_covers_store_subscr_helpers() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+
+        let execute_store_subscr =
+            crate::opcode_ops::bh_execute_store_subscr as *const () as usize as i64;
+        assert_eq!(bindings["execute_store_subscr"], execute_store_subscr);
+
+        let store_subscr_fn = crate::opcode_ops::bh_store_subscr_fn as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::opcode_ops::bh_store_subscr_fn"],
+            store_subscr_fn
+        );
+        assert_eq!(
+            bindings["pyre_interpreter::bh_store_subscr_fn"],
+            store_subscr_fn
+        );
+    }
+
     /// Negative parity guard: pyre intentionally does NOT publish a
     /// host fnaddr for `_ll_2_str_eq_nonnull` (see the comment block
     /// at `jit_trace_fnaddrs` next to the `cast_float_to_uint`

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -339,6 +339,27 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         crate::opcode_ops::jit_setattr as *const (),
     );
 
+    // Production walker's `Instruction::StoreSubscr` arm emits a
+    // `residual_call_r_r` whose funcptr resolves at codewriter time
+    // through the bare path `["execute_store_subscr"]` (the dispatch-
+    // table entry at `pyopcode.rs:2909`).  Without a runtime fnaddr
+    // entry the codewriter mints a `symbolic_fnaddr_for_path` hash
+    // that the `runtime_fnaddr_patch` cannot rewrite and sub-slice 4's
+    // 47-bit sanity gate rejects, causing the walker to skip the heap
+    // mutation and SIGBUS on the next read.  `bh_execute_store_subscr`
+    // is the C-ABI bridge over the generic
+    // `execute_store_subscr::<PyFrame>` whose `Result<StepResult<_>,
+    // PyError>` cannot ride the residual_call's single-register Ref
+    // result slot.  Registering the bare path here lets the codewriter
+    // bake the wrapper address directly into `JitCode.constants_i`,
+    // mirroring PyPy's `cpu.bh_call_*` -> linker-resolved C symbol
+    // contract (`pyjitpl.py:1346 _opimpl_residual_call*`).
+    push_fnaddr(
+        &mut entries,
+        "execute_store_subscr",
+        crate::opcode_ops::bh_execute_store_subscr as *const (),
+    );
+
     for (nargs, (module_path, root_path)) in CALLABLE_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::callable_call_helper(nargs) {
             push_alias_pair(&mut entries, module_path, root_path, fnptr);

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -360,6 +360,20 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         crate::opcode_ops::bh_execute_store_subscr as *const (),
     );
 
+    // `cpu.store_subscr_fn` binding (`pyre-jit/src/jit/cpu.rs:151`)
+    // bound via `pyre_interpreter::opcode_ops::bh_store_subscr_fn`
+    // (relocated from `pyre-jit/src/call_jit.rs` in 5.5c).
+    // Registered here so `pyre-jit-trace`'s walker specialization gate
+    // (`try_walker_store_subscr_specialization`) can recover the
+    // runtime address via `jit_trace_fnaddrs()` lookup without a
+    // cross-crate `pyre-jit-trace → pyre-jit` dependency edge.
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::opcode_ops::bh_store_subscr_fn",
+        "pyre_interpreter::bh_store_subscr_fn",
+        crate::opcode_ops::bh_store_subscr_fn as *const (),
+    );
+
     for (nargs, (module_path, root_path)) in CALLABLE_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::callable_call_helper(nargs) {
             push_alias_pair(&mut entries, module_path, root_path, fnptr);

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -253,6 +253,27 @@ pub extern "C" fn jit_setattr(obj: i64, name_ptr: i64, name_len: i64, value: i64
     }
 }
 
+/// C-ABI bridge for the `execute_store_subscr` arm helper consumed by the
+/// production walker.  Mirrors RPython's `bh_call_*` calling convention:
+/// a single `*mut PyFrame` arg widened to `i64`, success encoded as a
+/// non-zero `i64`, errors propagated via
+/// `majit_metainterp::blackhole::BH_LAST_EXC_VALUE`.  Required because
+/// `crate::execute_store_subscr` itself returns `Result<StepResult<_>,
+/// PyError>` whose fat-enum payload does not fit the residual_call's
+/// single-register Ref-result slot.
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn bh_execute_store_subscr(executor_ptr: i64) -> i64 {
+    let executor = unsafe { &mut *(executor_ptr as *mut crate::pyframe::PyFrame) };
+    match crate::pyopcode::execute_store_subscr(executor) {
+        Ok(_step_result) => 1,
+        Err(err) => {
+            let exc_obj = err.to_exc_object();
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+            0
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -300,7 +300,7 @@ pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {
     let obj = obj as pyre_object::PyObjectRef;
     let key = key as pyre_object::PyObjectRef;
     let value = value as pyre_object::PyObjectRef;
-    if obj.is_null() || key.is_null() {
+    if obj.is_null() || key.is_null() || value.is_null() {
         let err = crate::PyError::new(
             crate::PyErrorKind::TypeError,
             "store subscript on null operand".to_string(),

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -274,6 +274,48 @@ pub extern "C" fn bh_execute_store_subscr(executor_ptr: i64) -> i64 {
     }
 }
 
+/// C-ABI 3-arg `(obj, key, value) → i64` store_subscr helper bound by
+/// `pyre-jit::cpu.store_subscr_fn` (`pyre-jit/src/jit/cpu.rs:151`).
+/// The codewriter emits a `residual_call_r_v(store_subscr_fn, obj,
+/// key, value)` (`codewriter.rs:7042
+/// build_store_subscr_fn_residual_call_r_v_insn`); the runtime
+/// dispatcher calls this thin wrapper to mutate the heap via
+/// `baseobjspace::setitem`.
+///
+/// Sub-slice 5c step 5.5c relocation: previously lived in
+/// `pyre-jit/src/call_jit.rs` as `bh_store_subscr_fn`.  Moved here so
+/// the address can be reached from `pyre-jit-trace` (via
+/// `pyre_interpreter::jit_trace_fnaddrs()`'s build-time registry)
+/// without a cross-crate `pyre-jit-trace → pyre-jit` dep edge — pyre-
+/// jit-trace already depends on pyre-interpreter for the orthodox
+/// recording-time helpers (`jit_setitem`, `jit_getitem`, …).
+///
+/// Returns 1 on success, 0 on raise (exception object stashed in
+/// `BH_LAST_EXC_VALUE`).  The return-code polarity differs from the
+/// trait-side `jit_setitem` which returns 0 on success and panics on
+/// error — `bh_store_subscr_fn` is fail-soft because residual_call
+/// execution is not a panic site.
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {
+    let obj = obj as pyre_object::PyObjectRef;
+    let key = key as pyre_object::PyObjectRef;
+    let value = value as pyre_object::PyObjectRef;
+    if obj.is_null() || key.is_null() {
+        let err = crate::PyError::new(
+            crate::PyErrorKind::TypeError,
+            "store subscript on null operand".to_string(),
+        );
+        majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(err.to_exc_object() as i64));
+        return 0;
+    }
+    if let Err(err) = crate::baseobjspace::setitem(obj, key, value) {
+        let exc_obj = err.to_exc_object();
+        majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+        return 0;
+    }
+    1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4595,18 +4595,9 @@ fn try_walker_store_subscr_specialization(
     }
     // Specialized IR recorded.  Heap mutation: invoke the helper
     // concretely so the next read of the container sees the updated
-    // value.  `bh_store_subscr_fn(obj, key, value) -> i64` returns 0 on
-    // success, non-zero on raise.  STORE_SUBSCR's effect-info is
-    // `MayForce + CanRaise`; on raise the specialization gate is wrong
-    // (recorded IR assumes success), so abort the specialization by
-    // returning `None` to surface a SubRaise via the standard path.
-    //
-    // Step 5.5b will refactor the post-mutation raise handling to share
-    // the dispatcher's `walker_record_guard_exception` + `SubRaise`
-    // flow.  For 5.5a's env-gated rollout, decline on raise so the
-    // blackbox path handles it end-to-end.
-    // `bh_store_subscr_fn` returns 1 on success, 0 on raise
-    // (with the exception object stashed in `BH_LAST_EXC_VALUE`).
+    // value.  `bh_store_subscr_fn(obj, key, value) -> i64` returns 1 on
+    // success, 0 on raise (with the exception object stashed in
+    // `BH_LAST_EXC_VALUE`).
     let success = unsafe {
         let store_subscr_fn: extern "C" fn(i64, i64, i64) -> i64 =
             std::mem::transmute(expected_fn_addr as *const ());
@@ -4617,6 +4608,29 @@ fn try_walker_store_subscr_specialization(
         )
     };
     if success == 0 {
+        // `pyjitpl.py:2156-2168 handle_possible_exception` parity: drain
+        // the helper's stashed exception into `ctx.last_exc_value*`,
+        // record `GuardException` against the specialized IR, and
+        // surface `SubRaise` so the caller doesn't fall through to the
+        // generic residual-call path (which would re-record a second IR
+        // call against the same opcode position).
+        let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| {
+            let v = c.get();
+            c.set(0);
+            v
+        });
+        if bh_exc != 0 {
+            let exc = ctx.trace_ctx.const_ref(bh_exc);
+            let exc_concrete =
+                ConcreteValue::Ref(bh_exc as usize as pyre_object::PyObjectRef);
+            ctx.last_exc_value = Some(exc);
+            ctx.last_exc_value_concrete = exc_concrete;
+            walker_record_guard_exception(ctx, op.pc);
+            return Some(DispatchOutcome::SubRaise { exc, exc_concrete });
+        }
+        // Defensive: helper returned 0 but did not stash an exception.
+        // Decline specialization so the generic path's
+        // `execute_residual_call` decides the dispatch.
         return None;
     }
     // pyjitpl.py:2659 `_record_helper_varargs`: STORE_SUBSCR mutates the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4522,6 +4522,39 @@ fn dispatch_residual_call_iRd_kind(
     let allboxes = build_allboxes(funcptr, &r_args, &argbox_types, call_descr.arg_types());
     ensure_residual_call_args_bound(&allboxes, op.pc)?;
 
+    // Sub-slice 5c step 2 probe — surfaces funcptr + r-bank arg raw addrs for
+    // every iRd-shape residual_call.  The eventual STORE_SUBSCR specialization
+    // hook (steps 3-5) keys on a fn-pointer match against `bh_store_subscr_fn`
+    // and on `r_args.len() == 3` with `dst_bank == 'v'`.  Probe is env-gated so
+    // production paths see zero overhead.  PyObjectRef construction from the
+    // GcRef payload is deferred to step 4 (FrameOps lift), which lands
+    // alongside the specialization branch; this probe stays at the raw-usize
+    // layer to keep the conversion seam single-sourced.
+    if std::env::var_os("PYRE_PROBE_SUBSCR").is_some() {
+        let funcptr_addr =
+            ctx.trace_ctx
+                .box_value(funcptr)
+                .and_then(|v| match v {
+                    majit_ir::Value::Int(n) => Some(n as u64),
+                    _ => None,
+                });
+        let arg_addrs: Vec<Option<u64>> = r_args
+            .iter()
+            .map(|&op| ctx.trace_ctx.box_value(op).and_then(|v| match v {
+                majit_ir::Value::Ref(r) => Some(r.as_usize() as u64),
+                _ => None,
+            }))
+            .collect();
+        eprintln!(
+            "[PYRE_PROBE_SUBSCR] dispatch_residual_call_iRd_kind pc={} dst_bank={} r_args.len={} funcptr_addr={:?} arg_addrs={:?}",
+            op.pc,
+            dst_bank,
+            r_args.len(),
+            funcptr_addr.map(|a| format!("{:#x}", a)),
+            arg_addrs.iter().map(|o| o.map(|a| format!("{:#x}", a))).collect::<Vec<_>>(),
+        );
+    }
+
     let ei = call_descr.get_extra_info();
     // pyjitpl.py:2003-2005 OS_NOT_IN_TRACE guard — see helper docstring
     // for the convergence rationale.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4155,7 +4155,7 @@ fn collect_outer_active_boxes(
 /// `store_final_boxes_in_guard` (`optimizeopt/mod.rs:5033`) finds
 /// `rd_resume_position >= 0` and can derive `op.fail_args` from the
 /// snapshot via `op.store_final_boxes(liveboxes)` instead of panicking.
-fn walker_capture_snapshot_for_last_guard(ctx: &mut WalkContext<'_, '_>, op_pc: usize) {
+pub(crate) fn walker_capture_snapshot_for_last_guard(ctx: &mut WalkContext<'_, '_>, op_pc: usize) {
     // Snapshot semantics for walker-emitted guards
     // (`pyjitpl.py:2582-2603 generate_guard` + `capture_resumedata`):
     //

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4552,13 +4552,10 @@ fn try_walker_store_subscr_specialization(
         let s = s.to_str()?;
         parse_hex_or_decimal_usize(s)?
     };
-    let funcptr_addr = ctx
-        .trace_ctx
-        .box_value(funcptr)
-        .and_then(|v| match v {
-            majit_ir::Value::Int(n) => Some(n as usize),
-            _ => None,
-        })?;
+    let funcptr_addr = ctx.trace_ctx.box_value(funcptr).and_then(|v| match v {
+        majit_ir::Value::Int(n) => Some(n as usize),
+        _ => None,
+    })?;
     if funcptr_addr != expected_fn_addr {
         return None;
     }
@@ -4701,19 +4698,18 @@ fn dispatch_residual_call_iRd_kind(
     // alongside the specialization branch; this probe stays at the raw-usize
     // layer to keep the conversion seam single-sourced.
     if std::env::var_os("PYRE_PROBE_SUBSCR").is_some() {
-        let funcptr_addr =
-            ctx.trace_ctx
-                .box_value(funcptr)
-                .and_then(|v| match v {
-                    majit_ir::Value::Int(n) => Some(n as u64),
-                    _ => None,
-                });
+        let funcptr_addr = ctx.trace_ctx.box_value(funcptr).and_then(|v| match v {
+            majit_ir::Value::Int(n) => Some(n as u64),
+            _ => None,
+        });
         let arg_addrs: Vec<Option<u64>> = r_args
             .iter()
-            .map(|&op| ctx.trace_ctx.box_value(op).and_then(|v| match v {
-                majit_ir::Value::Ref(r) => Some(r.as_usize() as u64),
-                _ => None,
-            }))
+            .map(|&op| {
+                ctx.trace_ctx.box_value(op).and_then(|v| match v {
+                    majit_ir::Value::Ref(r) => Some(r.as_usize() as u64),
+                    _ => None,
+                })
+            })
             .collect();
         eprintln!(
             "[PYRE_PROBE_SUBSCR] dispatch_residual_call_iRd_kind pc={} dst_bank={} r_args.len={} funcptr_addr={:?} arg_addrs={:?}",
@@ -4721,7 +4717,10 @@ fn dispatch_residual_call_iRd_kind(
             dst_bank,
             r_args.len(),
             funcptr_addr.map(|a| format!("{:#x}", a)),
-            arg_addrs.iter().map(|o| o.map(|a| format!("{:#x}", a))).collect::<Vec<_>>(),
+            arg_addrs
+                .iter()
+                .map(|o| o.map(|a| format!("{:#x}", a)))
+                .collect::<Vec<_>>(),
         );
     }
 
@@ -4742,9 +4741,9 @@ fn dispatch_residual_call_iRd_kind(
     // deferred to 5.5b — `WalkContext.store_subscr_fn_addr`).  Without
     // the env var, gate decays to no-op and dispatcher falls through to
     // the existing blackbox CallN path.
-    if let Some(outcome) = try_walker_store_subscr_specialization(
-        ctx, code, op, funcptr, &r_args, dst_bank,
-    ) {
+    if let Some(outcome) =
+        try_walker_store_subscr_specialization(ctx, code, op, funcptr, &r_args, dst_bank)
+    {
         return Ok((outcome, op.next_pc));
     }
 
@@ -4915,10 +4914,7 @@ fn dispatch_residual_call_iRd_kind(
                     .last_exc_value
                     .expect("resid_raised implies last_exc_value seeded by the Err branch");
                 let exc_concrete = ctx.last_exc_value_concrete;
-                return Ok((
-                    DispatchOutcome::SubRaise { exc, exc_concrete },
-                    op.next_pc,
-                ));
+                return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, op.next_pc));
             } else {
                 ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
                 walker_capture_snapshot_for_last_guard(ctx, op.pc);
@@ -5130,10 +5126,7 @@ fn dispatch_residual_call_iIRd_kind(
                     .last_exc_value
                     .expect("resid_raised implies last_exc_value seeded by the Err branch");
                 let exc_concrete = ctx.last_exc_value_concrete;
-                return Ok((
-                    DispatchOutcome::SubRaise { exc, exc_concrete },
-                    op.next_pc,
-                ));
+                return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, op.next_pc));
             } else {
                 ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
                 walker_capture_snapshot_for_last_guard(ctx, op.pc);
@@ -5302,10 +5295,7 @@ fn dispatch_residual_call_iIRFd_kind(
                     .last_exc_value
                     .expect("resid_raised implies last_exc_value seeded by the Err branch");
                 let exc_concrete = ctx.last_exc_value_concrete;
-                return Ok((
-                    DispatchOutcome::SubRaise { exc, exc_concrete },
-                    op.next_pc,
-                ));
+                return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, op.next_pc));
             } else {
                 ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
                 walker_capture_snapshot_for_last_guard(ctx, op.pc);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4621,8 +4621,7 @@ fn try_walker_store_subscr_specialization(
         });
         if bh_exc != 0 {
             let exc = ctx.trace_ctx.const_ref(bh_exc);
-            let exc_concrete =
-                ConcreteValue::Ref(bh_exc as usize as pyre_object::PyObjectRef);
+            let exc_concrete = ConcreteValue::Ref(bh_exc as usize as pyre_object::PyObjectRef);
             ctx.last_exc_value = Some(exc);
             ctx.last_exc_value_concrete = exc_concrete;
             walker_record_guard_exception(ctx, op.pc);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1810,7 +1810,16 @@ pub fn dispatch_via_miframe(
             entry_py_pc,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
-            store_subscr_fn_addr: bh_store_subscr_fn_addr_cached(),
+            // This entry (test/fixture / shadow_walker) hard-codes
+            // `outer_jitcode_index = 0` and an empty `outer_active_boxes`
+            // rather than seeding them from `sym.jitcode` /
+            // `collect_outer_active_boxes` like
+            // `dispatch_via_miframe_at_opcode_entry` does.  A specialized
+            // `generated_store_subscr_value` guard captured via
+            // `walker_capture_snapshot_for_last_guard` would attach
+            // resume data pointing at the wrong frame, so keep
+            // STORE_SUBSCR specialization off on this entry.
+            store_subscr_fn_addr: None,
         };
         let outcome = walk(jitcode_code, position, &mut wc);
         // Read final last_exc_value before wc drops so the borrow

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4697,7 +4697,7 @@ fn dispatch_residual_call_iRd_kind(
     // GcRef payload is deferred to step 4 (FrameOps lift), which lands
     // alongside the specialization branch; this probe stays at the raw-usize
     // layer to keep the conversion seam single-sourced.
-    if std::env::var_os("PYRE_PROBE_SUBSCR").is_some() {
+    if crate::probe_subscr_enabled() {
         let funcptr_addr = ctx.trace_ctx.box_value(funcptr).and_then(|v| match v {
             majit_ir::Value::Int(n) => Some(n as u64),
             _ => None,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1810,7 +1810,7 @@ pub fn dispatch_via_miframe(
             entry_py_pc,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
-            store_subscr_fn_addr: None,
+            store_subscr_fn_addr: bh_store_subscr_fn_addr_cached(),
         };
         let outcome = walk(jitcode_code, position, &mut wc);
         // Read final last_exc_value before wc drops so the borrow
@@ -2025,7 +2025,7 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
             entry_py_pc,
             outer_jitcode_index,
             outer_active_boxes,
-            store_subscr_fn_addr: None,
+            store_subscr_fn_addr: bh_store_subscr_fn_addr_cached(),
         };
         let outcome = walk(entry_jitcode.code.as_slice(), 0, &mut wc);
         let final_last_exc = wc.last_exc_value;
@@ -4627,6 +4627,28 @@ fn parse_hex_or_decimal_usize(s: &str) -> Option<usize> {
     } else {
         s.parse::<usize>().ok()
     }
+}
+
+/// Sub-slice 5c step 5.5c — runtime resolution of
+/// `bh_store_subscr_fn` address via `pyre_interpreter::
+/// jit_trace_fnaddrs()` linear scan (cached in a `OnceLock`).  Returns
+/// `None` if the symbol is unregistered (which would indicate a
+/// jit_fnaddr.rs regression — the path is registered at
+/// `pyre-interpreter/src/jit_fnaddr.rs:362-371`).
+///
+/// Cached on first call.  Linear scan is acceptable because the table
+/// has ~150 entries and the cache miss happens once per process.
+pub(crate) fn bh_store_subscr_fn_addr_cached() -> Option<usize> {
+    static CACHE: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        const PATH: &str = "pyre_interpreter::opcode_ops::bh_store_subscr_fn";
+        for (name, addr) in pyre_interpreter::jit_trace_fnaddrs() {
+            if name == PATH {
+                return Some(addr as usize);
+            }
+        }
+        None
+    })
 }
 
 #[allow(non_snake_case)]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4568,7 +4568,9 @@ fn try_walker_store_subscr_specialization(
     // the dispatcher's `walker_record_guard_exception` + `SubRaise`
     // flow.  For 5.5a's env-gated rollout, decline on raise so the
     // blackbox path handles it end-to-end.
-    let raised = unsafe {
+    // `bh_store_subscr_fn` returns 1 on success, 0 on raise
+    // (with the exception object stashed in `BH_LAST_EXC_VALUE`).
+    let success = unsafe {
         let store_subscr_fn: extern "C" fn(i64, i64, i64) -> i64 =
             std::mem::transmute(expected_fn_addr as *const ());
         store_subscr_fn(
@@ -4577,7 +4579,7 @@ fn try_walker_store_subscr_specialization(
             concrete_value as usize as i64,
         )
     };
-    if raised != 0 {
+    if success == 0 {
         return None;
     }
     // pyjitpl.py:2659 `_record_helper_varargs`: STORE_SUBSCR mutates the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -471,6 +471,25 @@ pub struct WalkContext<'frame, 'static_a: 'frame> {
     /// nesting depth is shallow (2–3 levels), so the per-sub-walk
     /// clone cost is negligible.
     pub outer_active_boxes: Vec<OpRef>,
+    /// Sub-slice 5c step 5.5b — runtime address of `bh_store_subscr_fn`
+    /// (pyre-jit's `cpu.store_subscr_fn` binding) used by
+    /// `try_walker_store_subscr_specialization` to recognise the
+    /// 3-arg `residual_call_r_v(store_subscr_fn, obj, key, value)`
+    /// emitted by `codewriter.rs:7042
+    /// build_store_subscr_fn_residual_call_r_v_insn`.
+    ///
+    /// Populated by the production entry caller
+    /// (`MIFrame::dispatch_via_walker_for_opcode` →
+    /// `dispatch_via_miframe_at_opcode_entry`) which reaches the
+    /// address through pyre-jit's `cpu.store_subscr_fn`.  Sub-walks
+    /// inherit the parent's value.  `None` disables the field-based
+    /// specialization gate (test fixtures, default-test entries, or
+    /// production paths where the address hasn't been plumbed yet).
+    ///
+    /// `PYRE_WALKER_STORE_SUBSCR_FNADDR` env var (step 5.5a) is read
+    /// as the fallback when this field is `None` — the env var keeps
+    /// working for test fixtures and runtime override.
+    pub store_subscr_fn_addr: Option<usize>,
 }
 
 /// Outcome of dispatching one opcode. The walker uses this to decide
@@ -1791,6 +1810,7 @@ pub fn dispatch_via_miframe(
             entry_py_pc,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let outcome = walk(jitcode_code, position, &mut wc);
         // Read final last_exc_value before wc drops so the borrow
@@ -2005,6 +2025,7 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
             entry_py_pc,
             outer_jitcode_index,
             outer_active_boxes,
+            store_subscr_fn_addr: None,
         };
         let outcome = walk(entry_jitcode.code.as_slice(), 0, &mut wc);
         let final_last_exc = wc.last_exc_value;
@@ -4518,9 +4539,17 @@ fn try_walker_store_subscr_specialization(
     if dst_bank != 'v' || r_args.len() != 3 {
         return None;
     }
-    let expected_fn_addr_str = std::env::var_os("PYRE_WALKER_STORE_SUBSCR_FNADDR")?;
-    let expected_fn_addr_str = expected_fn_addr_str.to_str()?;
-    let expected_fn_addr = parse_hex_or_decimal_usize(expected_fn_addr_str)?;
+    // Prefer `WalkContext.store_subscr_fn_addr` (step 5.5b — populated
+    // from `cpu.store_subscr_fn` at the production entry); fall back to
+    // `PYRE_WALKER_STORE_SUBSCR_FNADDR` env var (step 5.5a) for test
+    // fixtures and runtime overrides.
+    let expected_fn_addr = if let Some(addr) = ctx.store_subscr_fn_addr {
+        addr
+    } else {
+        let s = std::env::var_os("PYRE_WALKER_STORE_SUBSCR_FNADDR")?;
+        let s = s.to_str()?;
+        parse_hex_or_decimal_usize(s)?
+    };
     let funcptr_addr = ctx
         .trace_ctx
         .box_value(funcptr)
@@ -5402,6 +5431,7 @@ fn dispatch_inline_call_dr_kind(
             entry_py_pc: ctx.entry_py_pc,
             outer_jitcode_index: ctx.outer_jitcode_index,
             outer_active_boxes: ctx.outer_active_boxes.clone(),
+            store_subscr_fn_addr: ctx.store_subscr_fn_addr,
         };
         walk(sub_body.code, 0, &mut sub_wc)?
     };
@@ -5583,6 +5613,7 @@ fn dispatch_inline_call_dir_kind(
             entry_py_pc: ctx.entry_py_pc,
             outer_jitcode_index: ctx.outer_jitcode_index,
             outer_active_boxes: ctx.outer_active_boxes.clone(),
+            store_subscr_fn_addr: ctx.store_subscr_fn_addr,
         };
         walk(sub_body.code, 0, &mut sub_wc)?
     };
@@ -5759,6 +5790,7 @@ fn dispatch_inline_call_dirf_kind(
             entry_py_pc: ctx.entry_py_pc,
             outer_jitcode_index: ctx.outer_jitcode_index,
             outer_active_boxes: ctx.outer_active_boxes.clone(),
+            store_subscr_fn_addr: ctx.store_subscr_fn_addr,
         };
         walk(sub_body.code, 0, &mut sub_wc)?
     };
@@ -6788,6 +6820,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
 
         // Synthesize a 2-byte op fixture: `<opcode_byte> <reg_idx>`.
@@ -6841,6 +6874,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         // `getfield_vable_i/rd>i`: operand 0 (the box) sits at code[pc+1].
         let code = [0u8, 0x00, 0x00, 0x00, 0x00];
@@ -6884,6 +6918,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         // `setfield_vable_i/rid`: operand 0 (the box) sits at code[pc+1].
         let code = [0u8, 0x00, 0x00, 0x00, 0x00];
@@ -7046,6 +7081,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("switch hit must dispatch");
@@ -7090,6 +7126,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("switch miss must dispatch");
@@ -7133,6 +7170,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
 
         let err = step(&code, 0, &mut wc).expect_err("non-constant switch value must not guess");
@@ -7185,6 +7223,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("truthy branch must dispatch");
@@ -7229,6 +7268,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("falsy branch must dispatch");
@@ -7272,6 +7312,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
 
         let err = step(&code, 0, &mut wc).expect_err("non-constant branch value must not guess");
@@ -7410,6 +7451,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, end_pc) =
             walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
@@ -7569,6 +7611,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_r_i must dispatch");
@@ -7673,6 +7716,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_ir_r must dispatch");
@@ -7771,6 +7815,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_irf_r must dispatch");
@@ -7858,6 +7903,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err =
             step(&caller_code, 0, &mut wc).expect_err("I-list overflow must surface typed error");
@@ -7942,6 +7988,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, _) = walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
         assert_eq!(
@@ -8007,6 +8054,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&caller_code, 0, &mut wc)
             .expect_err("FailDescr at inline_call's d-slot must hit ExpectedJitCodeDescr");
@@ -8051,6 +8099,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&caller_code, 0, &mut wc)
             .expect_err("missing sub-jitcode must hit SubJitCodeNotFound");
@@ -8091,6 +8140,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("live/ must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -8139,6 +8189,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_return/r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -8196,6 +8247,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("must surface RegisterOutOfRange");
         assert_eq!(
@@ -8245,6 +8297,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("int_return/i must dispatch");
@@ -8305,6 +8358,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = step(&code, 0, &mut wc).expect("int_return/i must dispatch");
@@ -8358,6 +8412,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("void_return/ must dispatch");
@@ -8415,6 +8470,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = step(&code, 0, &mut wc).expect("void_return/ must dispatch");
@@ -8458,6 +8514,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("raise/r must read its operand");
         assert_eq!(
@@ -8504,6 +8561,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("goto/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -8550,6 +8608,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("goto/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -8644,6 +8703,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("catch_exception/L with active exc must error");
@@ -8686,6 +8746,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("catch_exception/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -8740,6 +8801,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -8827,6 +8889,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, _next_pc) = step(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -8896,6 +8959,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("reraise/ must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -8959,6 +9023,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("reraise/ without last_exc_value must error");
         assert_eq!(err, DispatchError::ReraiseWithoutLastExcValue { pc: 0 });
@@ -9000,6 +9065,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(
@@ -9104,6 +9170,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, end_pc) =
             walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
@@ -9209,6 +9276,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
@@ -9265,6 +9333,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("int_copy/i>i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -9318,6 +9387,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("int_copy/i>i must dispatch");
         assert_eq!(
@@ -9362,6 +9432,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_copy dst OOR must surface a typed error");
         assert_eq!(
@@ -9405,6 +9476,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_copy/i>i must read its src operand");
         assert_eq!(
@@ -9469,6 +9541,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_copy/r>r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -9521,6 +9594,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("ref_copy/r>r must dispatch");
         assert_eq!(
@@ -9564,6 +9638,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("ref_copy dst OOR must surface a typed error");
         assert_eq!(
@@ -9606,6 +9681,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("ref_copy/r>r must read its src operand");
         assert_eq!(
@@ -9658,6 +9734,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -9838,6 +9915,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             int_between_record(&code, &op, &mut wc).expect("int_between_record must dispatch");
@@ -9962,6 +10040,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -10038,6 +10117,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("float_neg/f>f must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -10092,6 +10172,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -10171,6 +10252,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -10230,6 +10312,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("float_add must read its src operand");
         assert_eq!(
@@ -10272,6 +10355,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_add must read its src operand");
         assert_eq!(
@@ -10316,6 +10400,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_add dst OOR must surface a typed error");
         assert_eq!(
@@ -10368,6 +10453,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("unsupported opname must hit UnsupportedOpname");
@@ -10412,6 +10498,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ptr_nonzero must record PtrNe");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -10483,6 +10570,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("abort/>r must dispatch");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -10536,6 +10624,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("ref_guard_value must record GuardValue");
@@ -10605,6 +10694,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_guard_value Const arm");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -10687,6 +10777,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
@@ -10841,6 +10932,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -10900,6 +10992,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("OS_NOT_IN_TRACE must surface a typed error");
         assert_eq!(
@@ -10950,6 +11043,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("OS_JIT_FORCE_VIRTUAL must surface a typed error");
@@ -10995,6 +11089,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -11049,6 +11144,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -11105,6 +11201,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         // The dst slot must hold the OpRef of the recorded CallR. Each
@@ -11181,6 +11278,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -11246,6 +11344,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
@@ -11310,6 +11409,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("dst OOR must surface a typed error");
         assert_eq!(
@@ -11356,6 +11456,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("descr index 5 with pool size 2 must surface DescrIndexOutOfRange");
@@ -11440,6 +11541,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_i/iRd>i must dispatch");
@@ -11521,6 +11623,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_i/iRd>i must dispatch");
         drop(wc);
@@ -11612,6 +11715,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
@@ -11733,6 +11837,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
@@ -11790,6 +11895,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("FailDescr (not CallDescr) must surface ResidualCallDescrNotCallDescr");
@@ -11835,6 +11941,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("R-list member out of range must surface RegisterOutOfRange");
@@ -11904,6 +12011,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, end_pc) =
             walk(&jc.code, 0, &mut wc).expect("ReturnValue arm must walk to a terminator");
@@ -12018,6 +12126,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, end_pc) =
             walk(&jc.code, 0, &mut wc).expect("PopTop arm must walk to a terminator");
@@ -12108,6 +12217,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&caller_code, 0, &mut wc).expect_err("arity overflow must surface error");
         assert_eq!(
@@ -12197,6 +12307,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, _) =
             walk(&caller_code, 0, &mut wc).expect("inline_call_r_v with void callee must succeed");
@@ -12265,6 +12376,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_r_v with non-void callee must reject");
@@ -12336,6 +12448,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, _) =
             walk(&caller_code, 0, &mut wc).expect("inline_call_ir_v with void callee must succeed");
@@ -12405,6 +12518,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_ir_v with non-void callee must reject");
@@ -12480,6 +12594,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, _) = walk(&caller_code, 0, &mut wc)
             .expect("inline_call_irf_v with void callee must succeed");
@@ -12553,6 +12668,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_irf_v with non-void callee must reject");
@@ -12614,6 +12730,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -12696,6 +12813,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
         let dst_post = wc.registers_i[5];
@@ -12756,6 +12874,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("getfield_gc_r must dispatch");
         let dst_post = wc.registers_r[6];
@@ -12804,6 +12923,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let err = step(&code, 0, &mut wc).expect_err("getfield_gc must validate r-reg");
         assert_eq!(
@@ -12864,6 +12984,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_vable_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -12944,6 +13065,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("setfield_vable_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -13014,6 +13136,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_i must dispatch");
         drop(wc);
@@ -13062,6 +13185,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_i must dispatch");
         drop(wc);
@@ -13136,6 +13260,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_r must dispatch");
         drop(wc);
@@ -13193,6 +13318,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getarrayitem_gc_r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -13264,6 +13390,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let _ = step(&code, 0, &mut wc).expect("getarrayitem_gc_r must dispatch");
         let dst_post = wc.registers_r[5];
@@ -13323,6 +13450,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("getarrayitem_gc_r/rrd>r must dispatch");
@@ -13393,6 +13521,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("setarrayitem_gc_r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -13693,6 +13822,7 @@ mod tests {
             entry_py_pc: 0,
             outer_jitcode_index: 0,
             outer_active_boxes: Vec::new(),
+            store_subscr_fn_addr: None,
         };
         assert_eq!(
             walk(&code, 0, &mut wc),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4483,6 +4483,121 @@ fn direct_call_release_gil(
 ///     callee body slice.  Over-capture is correctness-preserving:
 ///     `store_final_boxes_in_guard` filters dead boxes from the
 ///     snapshot via the optimizer's liveness pass.
+/// Sub-slice 5c step 5.5a — STORE_SUBSCR strategy-aware walker
+/// specialization gate.  Returns `Some(DispatchOutcome::Continue)` if
+/// the residual_call was specialized into the trait-equivalent
+/// `guard_class + guard_list_strategy + setarrayitem-family` shape;
+/// `None` to fall through to the existing blackbox CallN path.
+///
+/// Gates (all must hold):
+/// 1. `dst_bank == 'v'` (STORE_SUBSCR returns void; trait emit is `Void`).
+/// 2. `r_args.len() == 3` (codewriter emits `[obj_reg, key_reg, value_reg]`).
+/// 3. `PYRE_WALKER_STORE_SUBSCR_FNADDR` env var present and parses as
+///    `0x<hex>` matching the runtime funcptr.  Step 5.5b will replace
+///    this with `WalkContext.store_subscr_fn_addr` populated from
+///    `cpu.store_subscr_fn` at dispatch entry.
+/// 4. All 3 concrete shadow slots (`concrete_registers_r[r_args[0..3]]`)
+///    are `ConcreteValue::Ref(_)`.
+/// 5. `generated_store_subscr_value` returns `true` (object is a list
+///    with int key, strategy-detectable value, in-bounds index — see
+///    `codegen.rs:3146-3168 generated_store_subscr_value` for the
+///    detail criteria mirroring `jtransform do_resizable_list_setitem`).
+///
+/// Decline (any gate `false`) → `None` → dispatcher falls through to
+/// `try_execute_residual_call_via_executor` which concrete-executes the
+/// helper and records the blackbox `CallMayForce*` IR.  No-op for
+/// non-STORE_SUBSCR residual calls.
+fn try_walker_store_subscr_specialization(
+    ctx: &mut WalkContext<'_, '_>,
+    code: &[u8],
+    op: &DecodedOp,
+    funcptr: OpRef,
+    r_args: &[OpRef],
+    dst_bank: char,
+) -> Option<DispatchOutcome> {
+    if dst_bank != 'v' || r_args.len() != 3 {
+        return None;
+    }
+    let expected_fn_addr_str = std::env::var_os("PYRE_WALKER_STORE_SUBSCR_FNADDR")?;
+    let expected_fn_addr_str = expected_fn_addr_str.to_str()?;
+    let expected_fn_addr = parse_hex_or_decimal_usize(expected_fn_addr_str)?;
+    let funcptr_addr = ctx
+        .trace_ctx
+        .box_value(funcptr)
+        .and_then(|v| match v {
+            majit_ir::Value::Int(n) => Some(n as usize),
+            _ => None,
+        })?;
+    if funcptr_addr != expected_fn_addr {
+        return None;
+    }
+    let r_args_concrete = read_ref_var_list_concrete(code, op, 1, ctx);
+    let concrete_obj = match r_args_concrete.first()? {
+        crate::state::ConcreteValue::Ref(p) => *p,
+        _ => return None,
+    };
+    let concrete_key = match r_args_concrete.get(1)? {
+        crate::state::ConcreteValue::Ref(p) => *p,
+        _ => return None,
+    };
+    let concrete_value = match r_args_concrete.get(2)? {
+        crate::state::ConcreteValue::Ref(p) => *p,
+        _ => return None,
+    };
+    let handled = crate::generated_store_subscr_value(
+        ctx,
+        r_args[0],
+        r_args[1],
+        r_args[2],
+        concrete_obj,
+        concrete_key,
+        concrete_value,
+    );
+    if !handled {
+        return None;
+    }
+    // Specialized IR recorded.  Heap mutation: invoke the helper
+    // concretely so the next read of the container sees the updated
+    // value.  `bh_store_subscr_fn(obj, key, value) -> i64` returns 0 on
+    // success, non-zero on raise.  STORE_SUBSCR's effect-info is
+    // `MayForce + CanRaise`; on raise the specialization gate is wrong
+    // (recorded IR assumes success), so abort the specialization by
+    // returning `None` to surface a SubRaise via the standard path.
+    //
+    // Step 5.5b will refactor the post-mutation raise handling to share
+    // the dispatcher's `walker_record_guard_exception` + `SubRaise`
+    // flow.  For 5.5a's env-gated rollout, decline on raise so the
+    // blackbox path handles it end-to-end.
+    let raised = unsafe {
+        let store_subscr_fn: extern "C" fn(i64, i64, i64) -> i64 =
+            std::mem::transmute(expected_fn_addr as *const ());
+        store_subscr_fn(
+            concrete_obj as usize as i64,
+            concrete_key as usize as i64,
+            concrete_value as usize as i64,
+        )
+    };
+    if raised != 0 {
+        return None;
+    }
+    // pyjitpl.py:2659 `_record_helper_varargs`: STORE_SUBSCR mutates the
+    // heap; the specialized IR shape's setarrayitem_gc ops already
+    // invalidate per-descr via the recorder, so no further explicit
+    // heap-cache invalidation is needed here.
+    Some(DispatchOutcome::Continue)
+}
+
+/// Parse `"0x<hex>"` or `"<decimal>"` into a `usize` address.  Helper
+/// for env-var-driven function-pointer gates (step 5.5a).
+fn parse_hex_or_decimal_usize(s: &str) -> Option<usize> {
+    let s = s.trim();
+    if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        usize::from_str_radix(rest, 16).ok()
+    } else {
+        s.parse::<usize>().ok()
+    }
+}
+
 #[allow(non_snake_case)]
 fn dispatch_residual_call_iRd_kind(
     code: &[u8],
@@ -4553,6 +4668,29 @@ fn dispatch_residual_call_iRd_kind(
             funcptr_addr.map(|a| format!("{:#x}", a)),
             arg_addrs.iter().map(|o| o.map(|a| format!("{:#x}", a))).collect::<Vec<_>>(),
         );
+    }
+
+    // Sub-slice 5c step 5.5a: STORE_SUBSCR strategy-aware specialization.
+    // Fires when funcptr matches the registered `store_subscr_fn` address
+    // (= `pyre-jit::call_jit::bh_store_subscr_fn`), r_args carries the
+    // 3-arg `[obj_reg, key_reg, value_reg]` shape codewriter emits
+    // (`codewriter.rs:7042 build_store_subscr_fn_residual_call_r_v_insn`),
+    // dst_bank is `'v'` (STORE_SUBSCR returns void), and all 3 concrete
+    // shadow slots are populated.  On success, records the specialized
+    // IR shape (guard_class + guard_strategy + setarrayitem-family) via
+    // the trait-equivalent `generated_store_subscr_value` helper (now
+    // generic over `WalkerFrameOps`, with `WalkContext` impl).
+    //
+    // Activation env-gated for the rollout: `PYRE_WALKER_STORE_SUBSCR_FNADDR=<hex>`
+    // supplies the expected funcptr address (cross-crate plumbing of the
+    // `bh_store_subscr_fn` symbol from pyre-jit into pyre-jit-trace is
+    // deferred to 5.5b — `WalkContext.store_subscr_fn_addr`).  Without
+    // the env var, gate decays to no-op and dispatcher falls through to
+    // the existing blackbox CallN path.
+    if let Some(outcome) = try_walker_store_subscr_specialization(
+        ctx, code, op, funcptr, &r_args, dst_bank,
+    ) {
+        return Ok((outcome, op.next_pc));
     }
 
     let ei = call_descr.get_extra_info();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3472,15 +3472,28 @@ fn try_fold_pure_call_via_executor(
 /// call regardless of EI.
 ///
 /// **Caller contract**:
-/// * `call_opcode` must be one of the non-elidable, non-may-force
-///   residual call shapes: `Call{I,R,F,N}` (the default arm) or
-///   `CallLoopinvariant{I,R,F,N}` (the `EF_LOOPINVARIANT` arm).
+/// * `call_opcode` must be one of the non-elidable residual call shapes:
+///   `Call{I,R,F,N}` (the default arm), `CallLoopinvariant{I,R,F,N}`
+///   (the `EF_LOOPINVARIANT` arm), or `CallMayForce{I,R,F,N}` (the
+///   `forces_virtual_or_virtualizable` arm — only when no active
+///   virtualizable is present, see force-virtual gate below).
 ///   * `CallPure*` is excluded — that's [`try_fold_pure_call_via_executor`]'s
 ///     job.
-///   * `CallMayForce*` / `CallReleaseGil*` / `CallAssembler*` are
-///     intentionally excluded: their trace-recording-time invariants
-///     (force-virtual audit, GIL transitions, jitdriver re-entry)
-///     need a separate audit (Task #390 sub-slice 4).
+///   * `CallReleaseGil*` / `CallAssembler*` are intentionally excluded:
+///     their trace-recording-time invariants (GIL transitions, jitdriver
+///     re-entry) need a separate audit (Task #390 sub-slice 4).
+///   * **`CallMayForce*` force-virtual gate**: PyPy `do_residual_call`
+///     (`pyjitpl.py:2017-2082`) concrete-executes every `CallMayForce*`
+///     via `executor.execute_varargs` and detects vable escape via the
+///     post-call `vinfo.tracing_after_residual_call(vbox)` heap probe.
+///     Pyre's walker leg lacks the post-call probe today (only the
+///     trait-driven leg has it at `state.rs MIFrame::vable_after_residual_call`,
+///     `trace_opcode.rs:2646`).  Until the walker counterpart lands,
+///     this function only admits `CallMayForce*` when the jitdriver has
+///     no active `standard_virtualizable_box()` — in that case there's
+///     no vable to force, so the after-check would be a no-op.  Active-
+///     vable `CallMayForce*` continues to decline (record-only), matching
+///     the current production behaviour.
 /// * `allboxes[0]` is the funcbox (per `build_allboxes` layout); the
 ///   remaining slots are user args in `descr.arg_types()` ABI order.
 ///
@@ -3513,7 +3526,7 @@ fn try_execute_residual_call_via_executor(
     call_descr: &dyn majit_ir::descr::CallDescr,
     recorded: OpRef,
 ) -> Option<Result<i64, i64>> {
-    if !matches!(
+    let plain_or_loopinvariant = matches!(
         call_opcode,
         OpCode::CallI
             | OpCode::CallR
@@ -3523,7 +3536,22 @@ fn try_execute_residual_call_via_executor(
             | OpCode::CallLoopinvariantR
             | OpCode::CallLoopinvariantF
             | OpCode::CallLoopinvariantN
-    ) {
+    );
+    // `CallMayForce*` is admitted only when no active virtualizable
+    // exists — otherwise the walker would need to call the missing
+    // `walker_vable_after_residual_call` post-check (see doc above).
+    // Mirrors `pyjitpl.py:2017-2082 do_residual_call`'s outer
+    // `forces_virtual_or_virtualizable` branch: with no vinfo box,
+    // `vable_after_residual_call` early-returns, so executing the
+    // helper here is safe.
+    let may_force_safe = matches!(
+        call_opcode,
+        OpCode::CallMayForceI
+            | OpCode::CallMayForceR
+            | OpCode::CallMayForceF
+            | OpCode::CallMayForceN
+    ) && ctx.trace_ctx.standard_virtualizable_box().is_none();
+    if !plain_or_loopinvariant && !may_force_safe {
         return None;
     }
     if allboxes.is_empty() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3022,14 +3022,27 @@ fn decode_descr_index(code: &[u8], op: &DecodedOp, operand_offset: usize) -> usi
 ///
 /// ★ Task #390 sub-slice 1 — non-elidable concrete-execute inventory.
 ///
-/// PyPy `do_residual_call` (pyjitpl.py:1995-2126) **always** calls
-/// `executor.execute_varargs(opnum, argboxes, descr, exc=can_raise,
-/// pure=is_elidable)` regardless of EI branch.  The recorded opcode
-/// kind selected above is for the IR trace; concrete execution always
-/// happens at trace-record time.  Pyre's walker only concrete-executes
+/// PyPy `do_residual_call` (pyjitpl.py:1995-2126) concrete-executes
+/// the helper at trace-record time across the **forces** /
+/// **loopinvariant** (cache miss) / **elidable** / **default**
+/// branches via `executor.execute_varargs(opnum, argboxes, descr,
+/// exc=can_raise, pure=is_elidable)`.  Two narrower branches sit
+/// outside this uniform call:
+///   * `OS_NOT_IN_TRACE` short-circuits through
+///     `do_not_in_trace_call` (`pyjitpl.py:2003-2006`) and never
+///     reaches `executor.execute_varargs`.
+///   * `is_call_release_gil()` runs the helper through
+///     `do_call_release_gil` (`pyjitpl.py:3671-3681`), invoking
+///     `executor.execute_varargs` directly **before** the recorded
+///     `CALL_RELEASE_GIL_*` op is emitted.
+/// The recorded opcode kind selected above is for the IR trace
+/// only; concrete execution either fired (or was intentionally
+/// skipped via the two narrow branches above) before the trace op
+/// hits the recorder.  Pyre's walker today concrete-executes only
 /// the `CallPure*` branch (via [`try_fold_pure_call_via_executor`]),
-/// so the other three branches surface as the M4 SIGBUS root cause
-/// (memory: M4 walker unactivated taxonomy).
+/// so the forces / loopinvariant-miss / default branches surface
+/// as the M4 SIGBUS root cause (memory: M4 walker unactivated
+/// taxonomy).
 ///
 /// Per-branch concrete-execute status today:
 ///
@@ -3587,6 +3600,20 @@ fn try_execute_residual_call_via_executor(
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args);
     match exec_result {
         Ok(result_i64) => {
+            // `pyjitpl.py:1685-1690 _opimpl_residual_call*` finishes its
+            // success arm with `metainterp.clear_exception()` (called
+            // implicitly through `do_residual_call`'s no-raise tail).
+            // Pyre's `ctx.last_exc_value` carries a sticky `OpRef` /
+            // concrete pointer from any prior raising helper in the
+            // same walk; if a later non-raising residual call did not
+            // clear it, downstream consumers (`last_exc_value/>r`,
+            // `reraise/`, `catch_exception/L`) would read the stale
+            // value as if a fresh exception had just landed.  Mirror
+            // `clear_exception()` here so the success arm only
+            // surfaces an active exception when the *current* call
+            // raised.
+            ctx.last_exc_value = None;
+            ctx.last_exc_value_concrete = ConcreteValue::Null;
             // pyjitpl.py:1392 `result_box.value = result` analogue — stamp
             // the recorded OpRef with the executed concrete so downstream
             // `concrete_of_opref` / `box_value` consumers see the folded
@@ -4647,6 +4674,25 @@ fn dispatch_residual_call_iRd_kind(
         if can_raise {
             if resid_raised {
                 walker_record_guard_exception(ctx, op.pc);
+                // `pyjitpl.py:2156-2168 handle_possible_exception` routes
+                // the raising branch through `finishframe_exception()`
+                // immediately after emitting `GUARD_EXCEPTION`, so the
+                // remaining bytes of the arm never run.  Surface the
+                // outcome to `walk_loop` as `SubRaise`: at top-level it
+                // emits the outer `FINISH(exc)` and Terminates the trace;
+                // at sub-walk depth it propagates up to the caller's
+                // `inline_call_*` handler.  Continuing past this point
+                // would record dead arm IR (e.g. the arm's tail
+                // `*_return`) onto an exception path and confuse the
+                // optimizer's guard-fail snapshot.
+                let exc = ctx
+                    .last_exc_value
+                    .expect("resid_raised implies last_exc_value seeded by the Err branch");
+                let exc_concrete = ctx.last_exc_value_concrete;
+                return Ok((
+                    DispatchOutcome::SubRaise { exc, exc_concrete },
+                    op.next_pc,
+                ));
             } else {
                 ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
                 walker_capture_snapshot_for_last_guard(ctx, op.pc);
@@ -4850,6 +4896,18 @@ fn dispatch_residual_call_iIRd_kind(
         if can_raise {
             if resid_raised {
                 walker_record_guard_exception(ctx, op.pc);
+                // pyjitpl.py:2156-2168 `handle_possible_exception`
+                // routes the raising branch through
+                // `finishframe_exception()` immediately after emitting
+                // GUARD_EXCEPTION — see iRd_kind for the full rationale.
+                let exc = ctx
+                    .last_exc_value
+                    .expect("resid_raised implies last_exc_value seeded by the Err branch");
+                let exc_concrete = ctx.last_exc_value_concrete;
+                return Ok((
+                    DispatchOutcome::SubRaise { exc, exc_concrete },
+                    op.next_pc,
+                ));
             } else {
                 ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
                 walker_capture_snapshot_for_last_guard(ctx, op.pc);
@@ -5010,6 +5068,18 @@ fn dispatch_residual_call_iIRFd_kind(
         if can_raise {
             if resid_raised {
                 walker_record_guard_exception(ctx, op.pc);
+                // pyjitpl.py:2156-2168 `handle_possible_exception`
+                // routes the raising branch through
+                // `finishframe_exception()` immediately after emitting
+                // GUARD_EXCEPTION — see iRd_kind for the full rationale.
+                let exc = ctx
+                    .last_exc_value
+                    .expect("resid_raised implies last_exc_value seeded by the Err branch");
+                let exc_concrete = ctx.last_exc_value_concrete;
+                return Ok((
+                    DispatchOutcome::SubRaise { exc, exc_concrete },
+                    op.next_pc,
+                ));
             } else {
                 ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
                 walker_capture_snapshot_for_last_guard(ctx, op.pc);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3304,42 +3304,16 @@ fn funcptr_concrete_int(ctx: &WalkContext<'_, '_>, funcptr: OpRef) -> Option<i64
 /// time via [`majit_metainterp::executor::execute_pure_call`] and stamp
 /// `recorded` with the result.
 ///
-/// ★ PyPy parity gap (Phase 5.B replacement candidate):
 /// PyPy `_opimpl_*` methods (e.g. `_opimpl_setitem`,
 /// `_opimpl_setfield_*`) concrete-execute every `do_residual_call`
 /// regardless of `check_is_elidable()` — the EI flag only selects the
 /// recorded opcode kind (`CALL_PURE_*` vs `CALL_*`), not whether the
-/// helper runs.  The result is that `synchronize_virtualizable`'s
-/// in-place PyFrame write at the end of `_opimpl_setfield_vable`
-/// coincides with the side-effecting heap mutation of the
-/// `store_subscr_fn` / `set_current_exception` helper — both happen
-/// at trace-record time on the live frame.
-///
-/// Pyre's walker concrete-executes only the elidable path (this
-/// function); non-elidable helpers like `store_subscr_fn` route
-/// through `select_residual_call_opcode`'s default arm and are
-/// recorded but never executed.  `eval_loop_jit`'s
-/// `walker_dispatched_this_opcode` skip of `execute_opcode_step`
-/// (eval.rs:3111) then leaves the non-vable heap unchanged → SIGBUS
-/// on the next read (memory: M4 walker unactivated taxonomy, 5
-/// STORE_SUBSCR-hot benches).
-///
-/// The Phase 5.B `dispatch_arm_via_blackhole` path is a workaround
-/// that runs the arm jitcode through `BlackholeInterpreter` to
-/// concrete-execute those helpers; the orthodox PyPy alignment is
-/// instead to widen this function (or its successor) to
-/// concrete-execute *every* residual_call with concrete-known args,
-/// mirroring upstream's `executor.execute_varargs(opnum, argboxes,
-/// descr, exc=can_raise, pure=is_elidable)`.  That removes the need
-/// for `production_blackhole_handles` entirely and brings
-/// `_opimpl_setfield_vable` shape into structural parity.
-///
-/// Out-of-scope here (multi-session epic): widening requires can-raise
-/// exception propagation through the walker, a GuardNoException
-/// emission policy that matches PyPy's `do_residual_call(..., exc=
-/// can_raise)`, and audit of every non-elidable helper for trace-
-/// recording-time invariants (no jitdriver re-entry, no thread state
-/// mutation).  See Task #390.
+/// helper runs.  This function covers the elidable arm; the
+/// non-elidable arms (`CallMayForce*`, `CallLoopinvariant*`, `Call*`)
+/// are concrete-executed by [`try_execute_residual_call_via_executor`]
+/// (Task #390 sub-slice 3), with raised exceptions surfaced through
+/// `BH_LAST_EXC_VALUE` so `eval_loop_jit` can route them into the
+/// bytecode exception handler.
 ///
 /// RPython upstream `_record_helper_pure` invokes
 /// `executor.execute_varargs(opnum, argboxes, descr, exc=False, pure=True)`

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -276,67 +276,6 @@ pub fn jitcode_for_instruction(instruction: &Instruction) -> Option<Arc<JitCode>
     jitcode_for_arm(arm_id_for_instruction(instruction)?)
 }
 
-thread_local! {
-    /// Per-thread cache of metainterp-runtime wrappers around build-time
-    /// canonical arm jitcodes.  The walker path consumes
-    /// `Arc<majit_translate::jitcode::JitCode>` (canonical core)
-    /// directly because recording only reads `.code` / `.constants`;
-    /// the production-blackhole path needs
-    /// `Arc<majit_metainterp::jitcode::JitCode>` because
-    /// `BlackholeInterpreter.jitcode` carries a per-jitcode descr pool
-    /// (`majit-metainterp/src/jitcode/mod.rs:394`).  Build-time
-    /// canonical arm jitcodes have no per-jitcode descrs (mod.rs:400-403
-    /// — they resolve through the global `ALL_DESCRS` table), so each
-    /// wrapper's `exec` field stays empty.
-    ///
-    /// `thread_local!` mirrors `ALL_JITCODES` above: `JitCode` payloads
-    /// transitively hold `!Sync` `Variable` cells.  Outer `OnceCell`
-    /// lazy-sizes the slot vector; per-slot `OnceCell` wraps the core
-    /// on first lookup, then hands out `Arc::clone`s.
-    static METAINTERP_JITCODE_CACHE: OnceCell<Vec<OnceCell<Arc<majit_metainterp::jitcode::JitCode>>>> =
-        const { OnceCell::new() };
-}
-
-/// Phase 5.B counterpart of `get_jitcode_by_index`: returns the
-/// metainterp-runtime `JitCode` wrapper for the canonical arm jitcode
-/// at `index`, suitable for installing on
-/// `BlackholeInterpreter.jitcode`.
-pub fn metainterp_jitcode_by_index(
-    index: usize,
-) -> Option<Arc<majit_metainterp::jitcode::JitCode>> {
-    METAINTERP_JITCODE_CACHE.with(|outer| {
-        let slots =
-            outer.get_or_init(|| (0..all_jitcodes().len()).map(|_| OnceCell::new()).collect());
-        let slot = slots.get(index)?;
-        Some(Arc::clone(slot.get_or_init(|| {
-            let canonical = all_jitcodes()
-                .get(index)
-                .expect("index validated by slot lookup");
-            Arc::new(majit_metainterp::jitcode::JitCode::from_canonical(
-                (**canonical).clone(),
-            ))
-        })))
-    })
-}
-
-/// Phase 5.B counterpart of `jitcode_for_arm`.
-pub fn metainterp_jitcode_for_arm(
-    arm_id: usize,
-) -> Option<Arc<majit_metainterp::jitcode::JitCode>> {
-    let arm = get_arm(arm_id)?;
-    let idx = arm.entry_jitcode_index?;
-    metainterp_jitcode_by_index(idx)
-}
-
-/// Phase 5.B counterpart of `jitcode_for_instruction`.  The
-/// BlackholeInterpreter-side entry for production dispatch
-/// (`dispatch_arm_via_blackhole`).
-pub fn metainterp_jitcode_for_instruction(
-    instruction: &Instruction,
-) -> Option<Arc<majit_metainterp::jitcode::JitCode>> {
-    metainterp_jitcode_for_arm(arm_id_for_instruction(instruction)?)
-}
-
 /// Deserialized `pipeline.insns` overlaid with `pyre_extension_insns()`
 /// — the build-observed `Assembler::write_insn` emit set plus the
 /// `_pyre/P` adapter keys that pyre's production blackhole builder

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -50,6 +50,15 @@ const _: () = assert!(
     "pyre's PyFrame virtualizable layout requires exactly one extra red (ec)",
 );
 
+/// `PYRE_PROBE_SUBSCR` env-var gate cached once on first read. The
+/// state.rs/jitcode_dispatch.rs probe sites are on hot paths; sampling
+/// `std::env::var_os` on every cache hit would dominate the cost when
+/// the probe is off.
+pub(crate) fn probe_subscr_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PROBE_SUBSCR").is_some())
+}
+
 /// Auto-generated trace functions from majit-translate.
 #[allow(dead_code, unsafe_op_in_unsafe_fn, unused_imports, unused_variables)]
 pub mod generated {

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -28,6 +28,7 @@ pub use trace_opcode::{production_blackhole_handles, production_walker_handles};
 pub mod trace;
 pub mod virtualizable_gen;
 pub mod virtualizable_spec;
+pub mod walker_frame_ops;
 
 // pyre-jit-trace local invariant: PyFrame's `_virtualizable_` declares
 // exactly one extra red (ec, see `virtualizable_gen.rs:29-31` and

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -31,7 +31,7 @@ pub mod state;
 pub mod super_inst_expand;
 mod trace_opcode;
 pub use pyjitcode::{PyJitCode, PyJitCodeMetadata};
-pub use trace_opcode::{production_blackhole_handles, production_walker_handles};
+pub use trace_opcode::production_walker_handles;
 pub mod trace;
 pub mod virtualizable_gen;
 pub mod virtualizable_spec;

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -5,6 +5,13 @@
 //! from pyre-jit's eval_loop_jit to prevent MIFrame's monomorphization
 //! of `execute_opcode_step<E>` from bloating the eval loop's codegen.
 
+// Self-alias so include!()'d codegen written for `majit-translate`'s
+// crate name keeps compiling when its source is also `include!`d into
+// this crate's `generated*` modules (jit_trace_gen.rs).  Allows generic
+// bounds like `F: pyre_jit_trace::walker_frame_ops::WalkerFrameOps` to
+// resolve from both sides.
+extern crate self as pyre_jit_trace;
+
 pub mod assembler;
 pub mod callbacks;
 pub mod canonical_bridge;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2255,38 +2255,41 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
 // the GC op without folding. The optimizer's `optimize_GETFIELD_GC_F`
 // (= `optimize_GETFIELD_GC_I` via RPython's alias) handles folding.
 
-/// Unbox int with proper GuardClass resume data via MIFrame::generate_guard.
-pub(crate) fn trace_unbox_int_with_resume(
-    frame: &mut MIFrame,
-    ctx: &mut TraceCtx,
+/// Unbox int with proper GuardClass resume data via the frame impl's
+/// `generate_guard`.  Generic over `WalkerFrameOps` so both `MIFrame`
+/// (trait dispatch) and `WalkContext` (walker dispatch) can invoke the
+/// same lowering.
+pub(crate) fn trace_unbox_int_with_resume<F: crate::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     obj: OpRef,
     int_type_addr: i64,
 ) -> OpRef {
     trace_unbox_int_with_resume_descr(
         frame,
-        ctx,
         obj,
         int_type_addr,
         crate::descr::int_intval_descr(),
     )
 }
 
-pub(crate) fn trace_unbox_int_with_resume_descr(
-    frame: &mut MIFrame,
-    ctx: &mut TraceCtx,
+pub(crate) fn trace_unbox_int_with_resume_descr<F: crate::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     obj: OpRef,
     type_addr: i64,
     intval_descr: majit_ir::DescrRef,
 ) -> OpRef {
     // pyjitpl.py GUARD_CLASS(box, cls): guard takes object box directly,
     // backend loads typeptr at offset 0.
-    if !ctx.heap_cache().is_class_known(obj) {
-        let type_const = ctx.const_int(type_addr);
-        frame.generate_guard(ctx, OpCode::GuardClass, &[obj, type_const]);
-        ctx.heap_cache_mut().class_now_known(obj, type_addr);
+    if !frame.ctx().heap_cache().is_class_known(obj) {
+        let type_const = frame.ctx_mut().const_int(type_addr);
+        frame.generate_guard(OpCode::GuardClass, &[obj, type_const]);
+        frame
+            .ctx_mut()
+            .heap_cache_mut()
+            .class_now_known(obj, type_addr);
     }
     crate::generated::trace_unbox_int(
-        ctx,
+        frame.ctx_mut(),
         obj,
         type_addr,
         crate::descr::ob_type_descr(),
@@ -2311,42 +2314,54 @@ pub(crate) fn trace_unbox_int_with_resume_descr(
 ///    `W_LongObject.toint()` (`longobject.py:138`) → `rbigint.toint()`
 ///    (`rbigint.py:465`, elidable). OverflowError is statically
 ///    unreachable post-fits-int GUARD_TRUE.
-pub(crate) fn trace_unbox_long_with_resume(
-    frame: &mut MIFrame,
-    ctx: &mut TraceCtx,
+pub(crate) fn trace_unbox_long_with_resume<F: crate::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     obj: OpRef,
     long_type_addr: i64,
 ) -> OpRef {
-    if !ctx.heap_cache().is_class_known(obj) {
-        let type_const = ctx.const_int(long_type_addr);
-        frame.generate_guard(ctx, OpCode::GuardClass, &[obj, type_const]);
-        ctx.heap_cache_mut().class_now_known(obj, long_type_addr);
+    if !frame.ctx().heap_cache().is_class_known(obj) {
+        let type_const = frame.ctx_mut().const_int(long_type_addr);
+        frame.generate_guard(OpCode::GuardClass, &[obj, type_const]);
+        frame
+            .ctx_mut()
+            .heap_cache_mut()
+            .class_now_known(obj, long_type_addr);
     }
-    let fits_fn =
-        ctx.const_int(pyre_object::longobject::jit_w_long_fits_int as *const () as usize as i64);
+    let fits_fn = frame
+        .ctx_mut()
+        .const_int(pyre_object::longobject::jit_w_long_fits_int as *const () as usize as i64);
     let fits_descr = crate::descr::make_jit_w_long_fits_int_calldescr();
-    let fits_result = ctx.record_op_with_descr(OpCode::CallI, &[fits_fn, obj], fits_descr);
-    frame.generate_guard(ctx, OpCode::GuardTrue, &[fits_result]);
-    let unbox_fn =
-        ctx.const_int(pyre_object::longobject::jit_w_long_toint as *const () as usize as i64);
+    let fits_result =
+        frame
+            .ctx_mut()
+            .record_op_with_descr(OpCode::CallI, &[fits_fn, obj], fits_descr);
+    frame.generate_guard(OpCode::GuardTrue, &[fits_result]);
+    let unbox_fn = frame
+        .ctx_mut()
+        .const_int(pyre_object::longobject::jit_w_long_toint as *const () as usize as i64);
     let unbox_descr = crate::descr::make_jit_w_long_toint_calldescr();
-    ctx.record_op_with_descr(OpCode::CallI, &[unbox_fn, obj], unbox_descr)
+    frame
+        .ctx_mut()
+        .record_op_with_descr(OpCode::CallI, &[unbox_fn, obj], unbox_descr)
 }
 
-/// Unbox float with proper GuardClass resume data via MIFrame::generate_guard.
-pub(crate) fn trace_unbox_float_with_resume(
-    frame: &mut MIFrame,
-    ctx: &mut TraceCtx,
+/// Unbox float with proper GuardClass resume data via the frame impl's
+/// `generate_guard`.  Generic over `WalkerFrameOps`.
+pub(crate) fn trace_unbox_float_with_resume<F: crate::walker_frame_ops::WalkerFrameOps>(
+    frame: &mut F,
     obj: OpRef,
     float_type_addr: i64,
 ) -> OpRef {
-    if !ctx.heap_cache().is_class_known(obj) {
-        let type_const = ctx.const_int(float_type_addr);
-        frame.generate_guard(ctx, OpCode::GuardClass, &[obj, type_const]);
-        ctx.heap_cache_mut().class_now_known(obj, float_type_addr);
+    if !frame.ctx().heap_cache().is_class_known(obj) {
+        let type_const = frame.ctx_mut().const_int(float_type_addr);
+        frame.generate_guard(OpCode::GuardClass, &[obj, type_const]);
+        frame
+            .ctx_mut()
+            .heap_cache_mut()
+            .class_now_known(obj, float_type_addr);
     }
     crate::generated::trace_unbox_float(
-        ctx,
+        frame.ctx_mut(),
         obj,
         float_type_addr,
         crate::descr::ob_type_descr(),
@@ -9160,7 +9175,6 @@ mod tests {
             };
             trace_unbox_int_with_resume(
                 &mut state,
-                &mut ctx,
                 int_obj,
                 &INT_TYPE as *const PyType as i64,
             )

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2264,12 +2264,7 @@ pub(crate) fn trace_unbox_int_with_resume<F: crate::walker_frame_ops::WalkerFram
     obj: OpRef,
     int_type_addr: i64,
 ) -> OpRef {
-    trace_unbox_int_with_resume_descr(
-        frame,
-        obj,
-        int_type_addr,
-        crate::descr::int_intval_descr(),
-    )
+    trace_unbox_int_with_resume_descr(frame, obj, int_type_addr, crate::descr::int_intval_descr())
 }
 
 pub(crate) fn trace_unbox_int_with_resume_descr<F: crate::walker_frame_ops::WalkerFrameOps>(
@@ -9173,11 +9168,7 @@ mod tests {
                 pre_opcode_registers_r: None,
                 pre_opcode_semantic_depth: None,
             };
-            trace_unbox_int_with_resume(
-                &mut state,
-                int_obj,
-                &INT_TYPE as *const PyType as i64,
-            )
+            trace_unbox_int_with_resume(&mut state, int_obj, &INT_TYPE as *const PyType as i64)
         };
 
         let recorder = ctx.into_recorder();

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2078,7 +2078,7 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
                     if let Some(majit_ir::Value::Int(loaded)) =
                         ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Int)
                     {
-                        if std::env::var_os("PYRE_PROBE_SUBSCR").is_some() && loaded != cached_int {
+                        if loaded != cached_int && crate::probe_subscr_enabled() {
                             eprintln!(
                                 "[PYRE_PROBE_SUBSCR] sanity-int-mismatch obj={:?} field_index={} struct_ptr={:#x} descr_pure={} cached={} loaded={}",
                                 obj,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2078,6 +2078,17 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
                     if let Some(majit_ir::Value::Int(loaded)) =
                         ctx.field_sanity_load(struct_ptr, &descr, majit_ir::Type::Int)
                     {
+                        if std::env::var_os("PYRE_PROBE_SUBSCR").is_some() && loaded != cached_int {
+                            eprintln!(
+                                "[PYRE_PROBE_SUBSCR] sanity-int-mismatch obj={:?} field_index={} struct_ptr={:#x} descr_pure={} cached={} loaded={}",
+                                obj,
+                                field_index,
+                                struct_ptr,
+                                descr.is_always_pure(),
+                                cached_int,
+                                loaded
+                            );
+                        }
                         assert_eq!(
                             loaded, cached_int,
                             "_opimpl_getfield_gc_any_pureornot sanity \

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6988,16 +6988,37 @@ impl MIFrame {
     /// on the trait path until walker snapshot capture can represent the
     /// full parent-frame chain.
     ///
-    /// `is_top_level=false` so the arm's `ref_return/r` terminator
-    /// surfaces as `DispatchOutcome::SubReturn` rather than emitting a
-    /// `Finish` (the outer Python frame's `Finish` is owned by the
-    /// trace_opcode dispatch's higher-level Return/Yield/CloseLoop
-    /// handling, not the per-opcode arm).
-    pub(crate) fn dispatch_via_walker_for_opcode(
+    /// PyPy `_opimpl_*` direct-record entry point for opcodes that emit
+    /// IR and produce concrete effects directly from the tracer, bypassing
+    /// the auto-gen arm-jitcode walk.  Mirrors `MetaInterp.interpret`'s
+    /// upstream dispatch shape where `pyjitpl.py:1346+ _opimpl_*` methods
+    /// invoke `metainterp.history.record*` and concrete-execute helpers
+    /// inline rather than walking an intermediate jitcode representation.
+    ///
+    /// Returns `Ok(Some(step_result))` when the opcode was handled here.
+    /// `Ok(None)` falls through to the arm-jitcode walker in
+    /// [`MIFrame::dispatch_via_walker_for_opcode`].  `Err(_)` propagates a
+    /// dispatch-time exception (e.g. `MIFrame::reraise` raising with
+    /// `reraise_lasti` populated).
+    ///
+    /// Each direct-dispatch handler must:
+    ///   1. Update the symbolic stack via `SharedOpcodeHandler::pop_value`
+    ///      / `peek_at` so subsequent walker opcodes see consistent vsd.
+    ///   2. Record any IR for the opcode (via a trait method like
+    ///      `MIFrame::store_subscr_value` or a `_opimpl_*`-style direct
+    ///      `record_op_*` call against `WalkContext`).
+    ///   3. Produce concrete heap effects when the upstream `_opimpl_*`
+    ///      counterpart does (e.g. `bh_execute_store_subscr`-style helper
+    ///      invocation).
+    ///
+    /// This entry point is the natural home for future `_opimpl_*` ports
+    /// — adding a new opcode here is the structural equivalent of writing
+    /// a new `pyjitpl.py:_opimpl_<name>` method.
+    fn try_walker_direct_opcode_dispatch(
         &mut self,
         instruction: &Instruction,
         op_arg: pyre_interpreter::OpArg,
-    ) -> Result<pyre_interpreter::StepResult<FrontendOp>, PyError> {
+    ) -> Result<Option<pyre_interpreter::StepResult<FrontendOp>>, PyError> {
         // Sub-slice 5c step 5.6b — STORE_SUBSCR walker activation via
         // trait-path delegation.
         //
@@ -7045,7 +7066,7 @@ impl MIFrame {
                 key.concrete.to_pyobj(),
                 value.concrete.to_pyobj(),
             )?;
-            return Ok(pyre_interpreter::StepResult::Continue);
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
         // `pyopcode.py:1348-1376 RERAISE` parity for the walker leg.
@@ -7063,7 +7084,31 @@ impl MIFrame {
         if let Instruction::Reraise { depth } = instruction {
             use pyre_interpreter::OpcodeStepExecutor;
             OpcodeStepExecutor::reraise(self, depth.get(op_arg))?;
-            return Ok(pyre_interpreter::StepResult::Continue);
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
+        Ok(None)
+    }
+
+    /// `is_top_level=false` so the arm's `ref_return/r` terminator
+    /// surfaces as `DispatchOutcome::SubReturn` rather than emitting a
+    /// `Finish` (the outer Python frame's `Finish` is owned by the
+    /// trace_opcode dispatch's higher-level Return/Yield/CloseLoop
+    /// handling, not the per-opcode arm).
+    pub(crate) fn dispatch_via_walker_for_opcode(
+        &mut self,
+        instruction: &Instruction,
+        op_arg: pyre_interpreter::OpArg,
+    ) -> Result<pyre_interpreter::StepResult<FrontendOp>, PyError> {
+        // PyPy `_opimpl_*` direct-record entry point — opcodes that bypass
+        // the auto-gen arm-jitcode walk and emit IR / produce concrete
+        // effects directly, matching `MetaInterp.interpret`'s upstream
+        // dispatch shape (`pyjitpl.py:1346+ _opimpl_*`).
+        //
+        // Returns `Some(step_result)` when the opcode was handled here.
+        // The arm-jitcode walker below runs only when this returns `None`.
+        if let Some(step_result) = self.try_walker_direct_opcode_dispatch(instruction, op_arg)? {
+            return Ok(step_result);
         }
 
         let jitcode = match crate::jitcode_runtime::jitcode_for_instruction(instruction) {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8003,14 +8003,13 @@ unsafe fn trace_check_exc_match_against(
 ///
 /// Subsequent batches grow this set until it covers every Python
 /// opcode.  The remaining wall is execution-side, not recording-side:
-/// `eval.rs:3111` skips `execute_opcode_step` for walker-handled
+/// `eval_loop_jit` skips `execute_opcode_step` for walker-handled
 /// opcodes, which is correct only when the arm body's heap effects ride
-/// `vable_setfield` / `setarrayitem_vable_r`.  Arms with non-elidable
-/// `residual_call`s (e.g. `store_subscr_fn`,
-/// `set_current_exception`) require the Phase 5.B dispatch-unification
-/// path (`production_blackhole_handles` + `dispatch_arm_via_blackhole`)
-/// before they can join this set.  The trait infra is deleted only
-/// after both predicates cover every opcode.
+/// `vable_setfield` / `setarrayitem_vable_r`, or when walker dispatch
+/// concrete-executes any non-elidable `residual_call` through
+/// `try_execute_residual_call_via_executor` (Task #390 sub-slice 3).
+/// The trait infra is deleted only after this predicate covers every
+/// opcode.
 ///
 pub fn production_walker_handles(instruction: &Instruction) -> bool {
     // The unit-variant fold rewrites `StepResult::Continue` &c. to
@@ -8168,26 +8167,6 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // the other pure pushes.
             | Instruction::PushNull
     )
-}
-
-/// Phase 5.B dispatch-unification predicate (companion to
-/// `production_walker_handles`).
-///
-/// Walker-handled opcodes whose arm body contains a non-elidable
-/// `residual_call` (e.g. `store_subscr_fn`, `set_current_exception`)
-/// cannot use the vable-only fast path at `eval.rs:3111`: walker
-/// recording skips concrete execution of impure residual_calls, and
-/// `eval_loop_jit` then skips `execute_opcode_step`, so the heap
-/// mutation never happens.  This predicate names the opcodes for which
-/// `eval_loop_jit` instead runs the arm jitcode through
-/// `BlackholeInterpreter` (`dispatch_arm_via_blackhole`), matching
-/// RPython `pyjitpl.py:_interpret`'s single-interpreter loop.
-///
-/// Returns `false` for every opcode today.  Slice 1 wires the
-/// predicate into `eval.rs` as a structural branch point; subsequent
-/// slices add opcodes once `dispatch_arm_via_blackhole` lands.
-pub fn production_blackhole_handles(_instruction: &Instruction) -> bool {
-    false
 }
 
 /// Apply the symbolic-tracker side effects of a walker-handled opcode.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5432,7 +5432,6 @@ impl MIFrame {
                     }
                     crate::generated_list_setslice_same_len_by_strategy(
                         this,
-                        ctx,
                         obj,
                         value,
                         raw_start,
@@ -5449,10 +5448,9 @@ impl MIFrame {
             }
         }
         // jtransform do_resizable_list_setitem dispatch.
-        let handled: bool = self.with_ctx(|this, ctx| {
+        let handled: bool = self.with_ctx(|this, _ctx| {
             Ok::<_, PyError>(crate::generated_store_subscr_value(
                 this,
-                ctx,
                 obj,
                 key,
                 value,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6996,6 +6996,7 @@ impl MIFrame {
     pub(crate) fn dispatch_via_walker_for_opcode(
         &mut self,
         instruction: &Instruction,
+        op_arg: pyre_interpreter::OpArg,
     ) -> Result<pyre_interpreter::StepResult<FrontendOp>, PyError> {
         // Sub-slice 5c step 5.6b — STORE_SUBSCR walker activation via
         // trait-path delegation.
@@ -7032,6 +7033,7 @@ impl MIFrame {
         // primitives.
         if matches!(instruction, Instruction::StoreSubscr) {
             use pyre_interpreter::SharedOpcodeHandler;
+            let _ = op_arg;
             let key = SharedOpcodeHandler::pop_value(self)?;
             let obj = SharedOpcodeHandler::pop_value(self)?;
             let value = SharedOpcodeHandler::pop_value(self)?;
@@ -7043,6 +7045,24 @@ impl MIFrame {
                 key.concrete.to_pyobj(),
                 value.concrete.to_pyobj(),
             )?;
+            return Ok(pyre_interpreter::StepResult::Continue);
+        }
+
+        // `pyopcode.py:1348-1376 RERAISE` parity for the walker leg.
+        //
+        // Production walker excluded `Reraise` because the trait path
+        // returns `Err(PyError)` with `reraise_lasti` populated for
+        // `oparg > 0`, while a walker hook returning `StepResult::Continue`
+        // (`Ok`) loses that channel and `trace_code_step` aborts on
+        // `oparg > 0 && reraise_lasti < 0`.  Delegate to the existing
+        // `MIFrame::reraise` impl (which mirrors `pyopcode.py:1357-1376`
+        // verbatim, reading the lasti from `concrete_stack[stack_idx]`
+        // and seeding `err.reraise_lasti`) and propagate its `Err` so
+        // `trace_code_step`'s `step_result.err().map(|e| e.reraise_lasti)`
+        // extraction works the same on either dispatch leg.
+        if let Instruction::Reraise { depth } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::reraise(self, depth.get(op_arg))?;
             return Ok(pyre_interpreter::StepResult::Continue);
         }
 
@@ -7288,7 +7308,7 @@ impl MIFrame {
                 // dispatch in inline frames.
                 let in_inline_frame = !self.parent_frames.is_empty();
                 if production_walker_handles(&instruction) && !in_inline_frame {
-                    self.dispatch_via_walker_for_opcode(&instruction)
+                    self.dispatch_via_walker_for_opcode(&instruction, op_arg)
                 } else {
                     let shadow_outcome =
                         crate::shadow_walker::shadow_validate_pre(self, &instruction, op_arg);
@@ -8113,13 +8133,7 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::CopyFreeVars { .. }
             | Instruction::MakeCell { .. }
             | Instruction::ConvertValue { .. }
-            // Instruction::Reraise excluded: `trace_code_step` reads
-            // `reraise_lasti` only from `step_result.err()`
-            // (trace_opcode.rs:6839-6843).  A walker-handled Reraise
-            // returns `StepResult::Continue` (Ok), so reraise_lasti is
-            // always -1 and `Reraise { depth > 0 }` aborts the trace.
-            // Keep on trait dispatch until the walker can propagate the
-            // saved lasti.
+            | Instruction::Reraise { .. } // walker hook in dispatch_via_walker_for_opcode delegates to MIFrame::reraise which returns Err(PyError) with reraise_lasti seeded — `step_result.err().map(|e| e.reraise_lasti)` extraction works the same on either leg
             | Instruction::PopJumpIfNone { .. }
             | Instruction::PopJumpIfNotNone { .. }
             | Instruction::ForIter { .. }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8082,7 +8082,7 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // Instruction::StoreFastStoreFast excluded: routed off the
             // walker JIT path (kept on trait dispatch) until the SFSF
             // walker re-enable is unblocked.
-            // | Instruction::StoreSubscr { .. } // sub-slice 5c: pending strategy-aware specialization port
+            // | Instruction::StoreSubscr // sub-slice 5c step 5.6 attempted 2026-06-08 + reverted: nbody+fannkuch regress (timeout / 31× slowdown); walker emits specialized IR but execution diverges from trait — investigation deferred (likely vable/heapcache + WalkerFrameOps::generate_guard snapshot delta vs trait `with_ctx + MIFrame.generate_guard`)
             // Instruction::PopExcept excluded: same bridge-tracing
             // rationale as PushExcInfo below — its arm manages the
             // exception-info stack via impure helper jitcodes the walker
@@ -8312,7 +8312,7 @@ fn apply_walker_stack_effect(state: &mut MIFrame, instruction: &Instruction) {
         | Instruction::CallFunctionEx
         | Instruction::LoadAttr { .. }
         | Instruction::StoreAttr { .. }
-        // | Instruction::StoreSubscr { .. } // sub-slice 5c: pending strategy-aware specialization port
+        // | Instruction::StoreSubscr // see production_walker_handles for revert note
         | Instruction::StoreFastStoreFast { .. }
         | Instruction::PushNull => {
             // Non-zero stack delta. The walker arm's

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8082,7 +8082,7 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // Instruction::StoreFastStoreFast excluded: routed off the
             // walker JIT path (kept on trait dispatch) until the SFSF
             // walker re-enable is unblocked.
-            // | Instruction::StoreSubscr // sub-slice 5c step 5.6 attempted 2026-06-08 + reverted: nbody+fannkuch regress (timeout / 31× slowdown); walker emits specialized IR but execution diverges from trait — investigation deferred (likely vable/heapcache + WalkerFrameOps::generate_guard snapshot delta vs trait `with_ctx + MIFrame.generate_guard`)
+            // | Instruction::StoreSubscr { .. } // sub-slice 5c step 5.6 attempted 2026-06-08 + reverted: nbody+fannkuch regress; 5.6b diagnosis 2026-06-08: arm jitcode `residual_call_r_r(bh_execute_store_subscr, frame)` requires concrete PyFrame stack to be populated by prior walker LOAD_FAST/CONST handlers, but walker handlers only populate MIFrame symbolic/concrete-shadow stacks — concrete frame pops null operands → SubRaise every trace
             // Instruction::PopExcept excluded: same bridge-tracing
             // rationale as PushExcInfo below — its arm manages the
             // exception-info stack via impure helper jitcodes the walker
@@ -8312,7 +8312,7 @@ fn apply_walker_stack_effect(state: &mut MIFrame, instruction: &Instruction) {
         | Instruction::CallFunctionEx
         | Instruction::LoadAttr { .. }
         | Instruction::StoreAttr { .. }
-        // | Instruction::StoreSubscr // see production_walker_handles for revert note
+        // | Instruction::StoreSubscr { .. } // see production_walker_handles for 5.6b root-cause note
         | Instruction::StoreFastStoreFast { .. }
         | Instruction::PushNull => {
             // Non-zero stack delta. The walker arm's

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -238,7 +238,6 @@ fn trace_plain_int_payload(
         if is_long(concrete_item) {
             return crate::state::trace_unbox_long_with_resume(
                 frame,
-                ctx,
                 item,
                 &LONG_TYPE as *const _ as i64,
             );
@@ -4959,7 +4958,6 @@ impl MIFrame {
                     } else {
                         crate::state::trace_unbox_float_with_resume(
                             this,
-                            ctx,
                             items[0],
                             &FLOAT_TYPE as *const _ as i64,
                         )
@@ -4969,7 +4967,6 @@ impl MIFrame {
                     } else {
                         crate::state::trace_unbox_float_with_resume(
                             this,
-                            ctx,
                             items[1],
                             &FLOAT_TYPE as *const _ as i64,
                         )

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6997,6 +6997,55 @@ impl MIFrame {
         &mut self,
         instruction: &Instruction,
     ) -> Result<pyre_interpreter::StepResult<FrontendOp>, PyError> {
+        // Sub-slice 5c step 5.6b — STORE_SUBSCR walker activation via
+        // trait-path delegation.
+        //
+        // The auto-gen arm jitcode for `StoreSubscr` is
+        // `int_copy, residual_call_r_r(bh_execute_store_subscr, frame),
+        // live, ref_return`.  `try_execute_residual_call_via_executor`
+        // matches the `CallR` shape and concrete-executes
+        // `bh_execute_store_subscr(frame)`, which casts the arg to
+        // `*mut PyFrame` and pops 3 values from
+        // `PyFrame.locals_cells_stack_w`.  Walker `LOAD_FAST` /
+        // `LOAD_CONST` / etc. populate only MIFrame's symbolic +
+        // concrete-shadow stacks — not the concrete `PyFrame`'s slots
+        // (`setfield_vable_i(vsd)` advances depth without writing the
+        // slot) — so the pop reads NULL and the helper raises every
+        // iteration, surfacing as `DispatchOutcome::SubRaise`.
+        //
+        // Trait dispatch documents `MIFrame::store_subscr` as
+        // "trace-only, no concrete mutation" (compiled trace handles
+        // real mutations later).  Mirror that here by short-circuiting
+        // the arm walk: pop 3 via `SharedOpcodeHandler::pop_value`
+        // (updates symbolic + concrete-shadow stacks + vsd shadow)
+        // and delegate to the existing `MIFrame::store_subscr_value`
+        // which records the same specialized IR shape
+        // (`guard_class + SETARRAYITEM_GC` family via
+        // `generated_store_subscr_value`, or `Call(jit_setitem, ...)`
+        // fallback via `trace_store_subscr`).  Bypasses the
+        // `apply_walker_stack_effect` post-walk step because
+        // `pop_value` already handles vsd.
+        //
+        // This delegation reuses the trait method intentionally; the
+        // 141 cutover can later replace it with a pure-walker variant
+        // once the walker grows symbolic-stack-aware specialization
+        // primitives.
+        if matches!(instruction, Instruction::StoreSubscr) {
+            use pyre_interpreter::SharedOpcodeHandler;
+            let key = SharedOpcodeHandler::pop_value(self)?;
+            let obj = SharedOpcodeHandler::pop_value(self)?;
+            let value = SharedOpcodeHandler::pop_value(self)?;
+            self.store_subscr_value(
+                obj.opref,
+                key.opref,
+                value.opref,
+                obj.concrete.to_pyobj(),
+                key.concrete.to_pyobj(),
+                value.concrete.to_pyobj(),
+            )?;
+            return Ok(pyre_interpreter::StepResult::Continue);
+        }
+
         let jitcode = match crate::jitcode_runtime::jitcode_for_instruction(instruction) {
             Some(jc) => jc,
             None => {
@@ -8082,7 +8131,7 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // Instruction::StoreFastStoreFast excluded: routed off the
             // walker JIT path (kept on trait dispatch) until the SFSF
             // walker re-enable is unblocked.
-            // | Instruction::StoreSubscr { .. } // sub-slice 5c step 5.6 attempted 2026-06-08 + reverted: nbody+fannkuch regress; 5.6b diagnosis 2026-06-08: arm jitcode `residual_call_r_r(bh_execute_store_subscr, frame)` requires concrete PyFrame stack to be populated by prior walker LOAD_FAST/CONST handlers, but walker handlers only populate MIFrame symbolic/concrete-shadow stacks — concrete frame pops null operands → SubRaise every trace
+            | Instruction::StoreSubscr // 5.6b: handled by dispatch_via_walker_for_opcode entry hook
             // Instruction::PopExcept excluded: same bridge-tracing
             // rationale as PushExcInfo below — its arm manages the
             // exception-info stack via impure helper jitcodes the walker

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8087,6 +8087,7 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // Instruction::StoreFastStoreFast excluded: routed off the
             // walker JIT path (kept on trait dispatch) until the SFSF
             // walker re-enable is unblocked.
+            // | Instruction::StoreSubscr { .. } // sub-slice 5c: pending strategy-aware specialization port
             // Instruction::PopExcept excluded: same bridge-tracing
             // rationale as PushExcInfo below — its arm manages the
             // exception-info stack via impure helper jitcodes the walker
@@ -8316,6 +8317,7 @@ fn apply_walker_stack_effect(state: &mut MIFrame, instruction: &Instruction) {
         | Instruction::CallFunctionEx
         | Instruction::LoadAttr { .. }
         | Instruction::StoreAttr { .. }
+        // | Instruction::StoreSubscr { .. } // sub-slice 5c: pending strategy-aware specialization port
         | Instruction::StoreFastStoreFast { .. }
         | Instruction::PushNull => {
             // Non-zero stack delta. The walker arm's

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -8,21 +8,36 @@
 //! emit the same `guard_class`+`SETARRAYITEM_GC`-family shape that
 //! today only the trait path produces.
 //!
+//! ## Trait shape — `self`-only signatures, `ctx` reached via accessor
+//!
+//! Earlier draft passed `ctx: &mut TraceCtx` as an explicit method
+//! argument alongside `&mut self`.  That shape forces the caller to
+//! split-borrow `self.trace_ctx` from `self`, which is illegal whenever
+//! the same `TraceCtx` is reached transitively through both `self` and
+//! the explicit arg (always true for `MIFrame`'s `self.ctx: *mut TraceCtx`
+//! and `WalkContext`'s `self.trace_ctx: &'frame mut TraceCtx`).
+//!
+//! The current shape — `&mut self` only, `ctx` reached through
+//! `self.ctx_mut()` / `self.ctx()` accessor methods — lets each impl
+//! choose how to materialise the borrow (`MIFrame` does `unsafe { &mut
+//! *self.ctx }`; `WalkContext` returns its `trace_ctx` field).  The
+//! accessor is scoped to a single statement at each callsite so the
+//! borrow ends before the next `self`-mut-call, satisfying the borrow
+//! checker without nested-borrow gymnastics.
+//!
 //! ## Why a trait (not free functions)
 //!
-//! Five of the six methods — `value_type`, `implement_guard_value`,
-//! `guard_class`, `guard_int_object_value`, `guard_list_strategy` — are
-//! pure compositions over `ctx` + `generate_guard`, so they live as
-//! default impls below.  The lone load-bearing method is
-//! `generate_guard`, which on `MIFrame` walks `parent_frames`,
-//! `flush_to_frame_for_guard`, `get_list_of_active_boxes`,
-//! `build_framestack_snapshot`, etc.  The walker has the same semantic
-//! responsibility (capture a multi-frame resume snapshot before
-//! recording the guard op) but reaches it through
-//! `walker_capture_snapshot_for_last_guard` and the dispatch-time
-//! `WalkContext` register banks instead of `MIFrame`'s state.  Two
-//! distinct implementations are unavoidable; a trait makes the two
-//! impls interchangeable at the `generated_*` call sites.
+//! Five of the six methods are pure compositions over `ctx_mut` +
+//! `generate_guard` and live as default impls below.  The lone
+//! load-bearing method is `generate_guard`, which on `MIFrame` walks
+//! `parent_frames`, `flush_to_frame_for_guard`,
+//! `get_list_of_active_boxes`, `build_framestack_snapshot`, etc.  The
+//! walker has the same semantic responsibility (capture a multi-frame
+//! resume snapshot before recording the guard op) but reaches it
+//! through `walker_capture_snapshot_for_last_guard` and the
+//! dispatch-time `WalkContext` register banks instead of `MIFrame`'s
+//! state.  Two distinct implementations are unavoidable; a trait makes
+//! the two impls interchangeable at the `generated_*` call sites.
 //!
 //! ## Trait scope
 //!
@@ -32,17 +47,16 @@
 //! this trait only when a future sub-slice needs them on the walker
 //! side.
 //!
-//! ## Step 4 plan
+//! ## Step 4 (this commit)
 //!
-//! Walker impl lives in `jitcode_dispatch.rs` as
-//! `impl<'a,'b> WalkerFrameOps for WalkContext<'a,'b>`.  Its
-//! `generate_guard` delegates to the existing
-//! `walker_capture_snapshot_for_last_guard` + `ctx.trace_ctx
-//! .record_guard(...)` pair, and `value_type` reads
-//! `ctx.trace_ctx.get_opref_type` directly.  After that lands,
-//! `generated_*` functions in `majit-translate/src/codegen.rs` swap
-//! `frame: &mut crate::state::MIFrame` for `frame: &mut impl
-//! WalkerFrameOps`, completing the lift.
+//! Adds `WalkContext` impl alongside the `MIFrame` impl.  Both delegate
+//! `generate_guard` to their existing infrastructure (`MIFrame`'s
+//! `generate_guard` method / walker's
+//! `walker_capture_snapshot_for_last_guard` pair).  The `generated_*`
+//! helpers in `majit-translate/src/codegen.rs` are not yet generic over
+//! `WalkerFrameOps` — that lift happens in step 5 together with the
+//! `dispatch_store_subscr_via_specialization` hook that wires the
+//! walker impl into the residual_call dispatcher.
 
 use majit_ir::{OpCode, OpRef, Type};
 use majit_metainterp::TraceCtx;
@@ -51,11 +65,26 @@ use pyre_object::PyType;
 /// Surface used by the strategy-aware STORE_SUBSCR specialization.  See
 /// module doc for the rationale.
 pub trait WalkerFrameOps {
+    /// Mut access to the embedded `TraceCtx`.  Each impl materialises
+    /// the borrow from its own internal storage (`MIFrame`'s
+    /// `self.ctx: *mut TraceCtx` raw pointer deref; `WalkContext`'s
+    /// `self.trace_ctx: &'frame mut TraceCtx` field).
+    fn ctx_mut(&mut self) -> &mut TraceCtx;
+
+    /// Immutable counterpart of [`ctx_mut`].  Used by `value_type`'s
+    /// `get_opref_type` lookup which doesn't need write access.
+    fn ctx(&self) -> &TraceCtx;
+
     /// `pyjitpl.py:177-220` `Box.type` parity — return the OpRef's
     /// intrinsic type (Const kind, recorded result_type, or PtrInfo
-    /// virtualized).  Defaults to `Type::Ref` when the OpRef has no
-    /// recorded type, mirroring `MIFrame::value_type`.
-    fn value_type(&self, ctx: &TraceCtx, value: OpRef) -> Type;
+    /// virtualized).  Default impl reads `ctx.get_opref_type`; impls
+    /// override only if they carry a faster cached lookup.
+    fn value_type(&self, value: OpRef) -> Type {
+        if value.is_none() {
+            return Type::Ref;
+        }
+        self.ctx().get_opref_type(value).unwrap_or(Type::Ref)
+    }
 
     /// `pyjitpl.py:2558-2602` `generate_guard` parity — flush a pending
     /// quasi-immut guard, capture multi-frame resume snapshot, then
@@ -63,20 +92,23 @@ pub trait WalkerFrameOps {
     /// method; impls diverge between `MIFrame` (trait dispatch frame
     /// state) and `WalkContext` (walker register banks + dispatch
     /// snapshot helper).
-    fn generate_guard(&mut self, ctx: &mut TraceCtx, opcode: OpCode, args: &[OpRef]);
+    fn generate_guard(&mut self, opcode: OpCode, args: &[OpRef]);
 
     /// `pyjitpl.py:3508-3514` `implement_guard_value` parity — pick the
     /// const factory (`const_ref` for Type::Ref, `const_int`
     /// otherwise), record `GUARD_VALUE`, then update the heapcache's
     /// box replacement so downstream reads see the proved constant.
-    fn implement_guard_value(&mut self, ctx: &mut TraceCtx, value: OpRef, expected: i64) {
-        let expected_ref = match self.value_type(ctx, value) {
-            Type::Ref => ctx.const_ref(expected),
-            _ => ctx.const_int(expected),
+    fn implement_guard_value(&mut self, value: OpRef, expected: i64) {
+        let ty = self.value_type(value);
+        let expected_ref = match ty {
+            Type::Ref => self.ctx_mut().const_ref(expected),
+            _ => self.ctx_mut().const_int(expected),
         };
-        self.generate_guard(ctx, OpCode::GuardValue, &[value, expected_ref]);
+        self.generate_guard(OpCode::GuardValue, &[value, expected_ref]);
         // pyjitpl.py:3512 `replace_box` parity.
-        ctx.heap_cache_mut().replace_box(value, expected_ref);
+        self.ctx_mut()
+            .heap_cache_mut()
+            .replace_box(value, expected_ref);
     }
 
     /// `pyjitpl.py:1518-1523` `opimpl_guard_class` parity.  Skips the
@@ -84,94 +116,119 @@ pub trait WalkerFrameOps {
     /// is constant (the runtime type is already pinned).  Otherwise
     /// records `GUARD_NONNULL_CLASS` with `expected_type_const` and
     /// updates the heapcache's class+nullity record.
-    fn guard_class(
-        &mut self,
-        ctx: &mut TraceCtx,
-        obj: OpRef,
-        expected_type: *const PyType,
-    ) {
-        if ctx.heap_cache().is_class_known(obj) {
+    fn guard_class(&mut self, obj: OpRef, expected_type: *const PyType) {
+        if self.ctx().heap_cache().is_class_known(obj) {
             return;
         }
         if obj.is_constant() {
-            // The trait-side body also flushes a pending
-            // GUARD_NOT_INVALIDATED here (trace_opcode.rs:4681).  The
-            // walker impl's `generate_guard` is responsible for the
-            // analogous flush; the const-skip path bypasses the guard
-            // record, so the flush must happen even on this branch.
-            // Walker impl: forward to `walker_flush_guard_not_invalidated`
-            // before `class_now_known`.  Default impl below stays
-            // flush-free since the constant short-circuit is the same
-            // upstream; impls override only if the flush sequencing
-            // differs.
-            ctx.heap_cache_mut()
+            // The const-arm `flush_guard_not_invalidated` in
+            // `MIFrame::guard_class` (trace_opcode.rs:4681) is skipped
+            // here.  It only fires when a prior quasi-immut field read
+            // set `pending_guard_not_invalidated_pc`; the
+            // `store_subscr_value` precondition (concrete obj/key/value
+            // are direct stack reads, not quasi-immut loads) excludes
+            // that path on the walker leg.
+            self.ctx_mut()
+                .heap_cache_mut()
                 .class_now_known(obj, expected_type as usize as i64);
             return;
         }
-        let expected_type_const = ctx.const_int(expected_type as usize as i64);
-        self.generate_guard(ctx, OpCode::GuardNonnullClass, &[obj, expected_type_const]);
+        let expected_type_const = self.ctx_mut().const_int(expected_type as usize as i64);
+        self.generate_guard(OpCode::GuardNonnullClass, &[obj, expected_type_const]);
         // heapcache.py:470-473 `class_now_known` parity.
-        ctx.heap_cache_mut()
+        self.ctx_mut()
+            .heap_cache_mut()
             .class_now_known(obj, expected_type as usize as i64);
     }
 
     /// `intobject.py` `int_intval`-pattern guard — class-guard the obj
     /// as `INT_TYPE`, read its `intval` field, then `implement_guard_value`
     /// the unboxed payload against `expected`.
-    fn guard_int_object_value(
-        &mut self,
-        ctx: &mut TraceCtx,
-        int_obj: OpRef,
-        expected: i64,
-    ) {
-        self.guard_class(
-            ctx,
+    fn guard_int_object_value(&mut self, int_obj: OpRef, expected: i64) {
+        self.guard_class(int_obj, &pyre_object::pyobject::INT_TYPE as *const PyType);
+        let actual_value = crate::state::opimpl_getfield_gc_i(
+            self.ctx_mut(),
             int_obj,
-            &pyre_object::pyobject::INT_TYPE as *const PyType,
+            crate::descr::int_intval_descr(),
         );
-        let actual_value =
-            crate::state::opimpl_getfield_gc_i(ctx, int_obj, crate::descr::int_intval_descr());
-        self.implement_guard_value(ctx, actual_value, expected);
+        self.implement_guard_value(actual_value, expected);
     }
 
     /// `listobject.py` strategy field guard — `getfield_gc_i(strategy)`
     /// then `implement_guard_value`.  Skips runtime W_ListObject layout
     /// reasoning by reading the strategy id directly from its descr.
-    fn guard_list_strategy(&mut self, ctx: &mut TraceCtx, obj: OpRef, expected: i64) {
-        let strategy =
-            crate::state::opimpl_getfield_gc_i(ctx, obj, crate::descr::list_strategy_descr());
-        self.implement_guard_value(ctx, strategy, expected);
+    fn guard_list_strategy(&mut self, obj: OpRef, expected: i64) {
+        let strategy = crate::state::opimpl_getfield_gc_i(
+            self.ctx_mut(),
+            obj,
+            crate::descr::list_strategy_descr(),
+        );
+        self.implement_guard_value(strategy, expected);
     }
 }
 
-// `MIFrame` impl — delegates to the existing `pub(crate)` methods in
-// `trace_opcode.rs` so the trait-dispatch leg keeps its current
-// `flush_guard_not_invalidated` / `parent_frames` / `orgpc` plumbing
-// untouched.  The trait + default impls above produce byte-identical
-// recorded IR to the inline `MIFrame::*` methods because the default
-// bodies are direct ports of the corresponding `MIFrame` bodies.
+// `MIFrame` impl — delegates `generate_guard` to the existing
+// `MIFrame::generate_guard` method so the trait-dispatch leg keeps its
+// current `flush_guard_not_invalidated` / `parent_frames` / `orgpc`
+// plumbing untouched.  The `ctx_mut` / `ctx` accessors materialise the
+// borrow from `self.ctx: *mut TraceCtx` via unsafe deref.  The deref is
+// sound because `MIFrame`'s lifetime invariant
+// (`pyjitpl.py:177 MIFrame.metainterp`) guarantees `self.ctx` always
+// points at the live `TraceCtx` owned by the enclosing dispatch frame.
 impl WalkerFrameOps for crate::state::MIFrame {
-    fn value_type(&self, _ctx: &TraceCtx, value: OpRef) -> Type {
-        crate::state::MIFrame::value_type(self, value)
+    fn ctx_mut(&mut self) -> &mut TraceCtx {
+        unsafe { &mut *self.ctx }
     }
 
-    fn generate_guard(&mut self, ctx: &mut TraceCtx, opcode: OpCode, args: &[OpRef]) {
-        crate::state::MIFrame::generate_guard(self, ctx, opcode, args)
+    fn ctx(&self) -> &TraceCtx {
+        unsafe { &*self.ctx }
     }
 
-    // `implement_guard_value` / `guard_class` / `guard_int_object_value`
-    // / `guard_list_strategy` use the default impls above.  Their
-    // bodies are direct ports of the `MIFrame` versions, so the
-    // recorded IR is byte-identical to the trait path's emit.
-    //
-    // The one observable behavior the default impls drop versus
-    // `MIFrame::guard_class` is the const-arm
-    // `flush_guard_not_invalidated` (trace_opcode.rs:4681): this only
-    // fires when a prior quasi-immut field read set
-    // `pending_guard_not_invalidated_pc`.  The trait path's
-    // `store_subscr_value` precondition is "no pending quasi-immut
-    // guard" (concrete obj/key/value are non-null direct stack reads,
-    // not quasi-immut field loads), so the const-skip never occurs in
-    // STORE_SUBSCR.  Walker impl in step 4 will assert the precondition
-    // before delegating, keeping behavior parity with the default impl.
+    fn generate_guard(&mut self, opcode: OpCode, args: &[OpRef]) {
+        // Re-borrow `ctx` from the raw pointer (rather than
+        // `self.ctx_mut()` which holds `&mut self`) so the
+        // `&mut MIFrame` borrow Rust's `MIFrame::generate_guard` needs
+        // is disjoint from the `&mut TraceCtx` arg it also needs.
+        // `self.ctx` is `*mut TraceCtx` so dereferencing it produces a
+        // borrow whose lifetime is independent of `self`'s.
+        let ctx_ptr: *mut TraceCtx = self.ctx;
+        let ctx_ref: &mut TraceCtx = unsafe { &mut *ctx_ptr };
+        crate::state::MIFrame::generate_guard(self, ctx_ref, opcode, args)
+    }
+}
+
+// `WalkContext` impl — `generate_guard` delegates to the existing
+// `walker_capture_snapshot_for_last_guard` snapshot helper after
+// recording the guard op via `ctx.record_guard`.  The walker has no
+// quasi-immut field reads in its STORE_SUBSCR path (concrete obj/key/value
+// are direct register reads, not field loads), so the
+// `flush_guard_not_invalidated` step that `MIFrame::generate_guard`
+// performs is intentionally omitted here.
+impl<'frame, 'static_a: 'frame> WalkerFrameOps
+    for crate::jitcode_dispatch::WalkContext<'frame, 'static_a>
+{
+    fn ctx_mut(&mut self) -> &mut TraceCtx {
+        self.trace_ctx
+    }
+
+    fn ctx(&self) -> &TraceCtx {
+        self.trace_ctx
+    }
+
+    fn generate_guard(&mut self, opcode: OpCode, args: &[OpRef]) {
+        // `pyjitpl.py:2558-2560 generate_guard` const-skip parity.
+        if let Some(&first) = args.first() {
+            if first.is_constant() {
+                return;
+            }
+        }
+        // Record the guard op first; then capture the snapshot via the
+        // walker-side helper that reads `outer_active_boxes`,
+        // `outer_jitcode_index`, `entry_py_pc` from `self` (the
+        // `WalkContext`).  Re-borrow `trace_ctx` from `self` in a scope
+        // narrow enough that `walker_capture_snapshot_for_last_guard`'s
+        // `&mut WalkContext` arg sees a fresh exclusive borrow.
+        self.trace_ctx.record_guard(opcode, args, 0);
+        crate::jitcode_dispatch::walker_capture_snapshot_for_last_guard(self, 0);
+    }
 }

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -1,0 +1,177 @@
+//! `WalkerFrameOps` trait — abstraction over the small surface of
+//! `MIFrame` methods that the strategy-aware STORE_SUBSCR specialization
+//! emits.  Sub-slice 5c lifts the trait-dispatch helpers
+//! (`generated_list_setitem_by_strategy`,
+//! `generated_list_setslice_same_len_by_strategy`,
+//! `generated_store_subscr_value`, and the `store_subscr_value` body in
+//! `trace_opcode.rs`) onto this trait so the walker dispatch path can
+//! emit the same `guard_class`+`SETARRAYITEM_GC`-family shape that
+//! today only the trait path produces.
+//!
+//! ## Why a trait (not free functions)
+//!
+//! Five of the six methods — `value_type`, `implement_guard_value`,
+//! `guard_class`, `guard_int_object_value`, `guard_list_strategy` — are
+//! pure compositions over `ctx` + `generate_guard`, so they live as
+//! default impls below.  The lone load-bearing method is
+//! `generate_guard`, which on `MIFrame` walks `parent_frames`,
+//! `flush_to_frame_for_guard`, `get_list_of_active_boxes`,
+//! `build_framestack_snapshot`, etc.  The walker has the same semantic
+//! responsibility (capture a multi-frame resume snapshot before
+//! recording the guard op) but reaches it through
+//! `walker_capture_snapshot_for_last_guard` and the dispatch-time
+//! `WalkContext` register banks instead of `MIFrame`'s state.  Two
+//! distinct implementations are unavoidable; a trait makes the two
+//! impls interchangeable at the `generated_*` call sites.
+//!
+//! ## Trait scope
+//!
+//! Only the methods reached by the STORE_SUBSCR specialization closure
+//! are members.  Other `MIFrame` methods (`guard_nonnull`,
+//! `trace_dynamic_list_index`, …) stay where they are; they'll join
+//! this trait only when a future sub-slice needs them on the walker
+//! side.
+//!
+//! ## Step 4 plan
+//!
+//! Walker impl lives in `jitcode_dispatch.rs` as
+//! `impl<'a,'b> WalkerFrameOps for WalkContext<'a,'b>`.  Its
+//! `generate_guard` delegates to the existing
+//! `walker_capture_snapshot_for_last_guard` + `ctx.trace_ctx
+//! .record_guard(...)` pair, and `value_type` reads
+//! `ctx.trace_ctx.get_opref_type` directly.  After that lands,
+//! `generated_*` functions in `majit-translate/src/codegen.rs` swap
+//! `frame: &mut crate::state::MIFrame` for `frame: &mut impl
+//! WalkerFrameOps`, completing the lift.
+
+use majit_ir::{OpCode, OpRef, Type};
+use majit_metainterp::TraceCtx;
+use pyre_object::PyType;
+
+/// Surface used by the strategy-aware STORE_SUBSCR specialization.  See
+/// module doc for the rationale.
+pub trait WalkerFrameOps {
+    /// `pyjitpl.py:177-220` `Box.type` parity — return the OpRef's
+    /// intrinsic type (Const kind, recorded result_type, or PtrInfo
+    /// virtualized).  Defaults to `Type::Ref` when the OpRef has no
+    /// recorded type, mirroring `MIFrame::value_type`.
+    fn value_type(&self, ctx: &TraceCtx, value: OpRef) -> Type;
+
+    /// `pyjitpl.py:2558-2602` `generate_guard` parity — flush a pending
+    /// quasi-immut guard, capture multi-frame resume snapshot, then
+    /// record the guard op with its snapshot.  The single load-bearing
+    /// method; impls diverge between `MIFrame` (trait dispatch frame
+    /// state) and `WalkContext` (walker register banks + dispatch
+    /// snapshot helper).
+    fn generate_guard(&mut self, ctx: &mut TraceCtx, opcode: OpCode, args: &[OpRef]);
+
+    /// `pyjitpl.py:3508-3514` `implement_guard_value` parity — pick the
+    /// const factory (`const_ref` for Type::Ref, `const_int`
+    /// otherwise), record `GUARD_VALUE`, then update the heapcache's
+    /// box replacement so downstream reads see the proved constant.
+    fn implement_guard_value(&mut self, ctx: &mut TraceCtx, value: OpRef, expected: i64) {
+        let expected_ref = match self.value_type(ctx, value) {
+            Type::Ref => ctx.const_ref(expected),
+            _ => ctx.const_int(expected),
+        };
+        self.generate_guard(ctx, OpCode::GuardValue, &[value, expected_ref]);
+        // pyjitpl.py:3512 `replace_box` parity.
+        ctx.heap_cache_mut().replace_box(value, expected_ref);
+    }
+
+    /// `pyjitpl.py:1518-1523` `opimpl_guard_class` parity.  Skips the
+    /// guard when the heapcache already knows the class or the OpRef
+    /// is constant (the runtime type is already pinned).  Otherwise
+    /// records `GUARD_NONNULL_CLASS` with `expected_type_const` and
+    /// updates the heapcache's class+nullity record.
+    fn guard_class(
+        &mut self,
+        ctx: &mut TraceCtx,
+        obj: OpRef,
+        expected_type: *const PyType,
+    ) {
+        if ctx.heap_cache().is_class_known(obj) {
+            return;
+        }
+        if obj.is_constant() {
+            // The trait-side body also flushes a pending
+            // GUARD_NOT_INVALIDATED here (trace_opcode.rs:4681).  The
+            // walker impl's `generate_guard` is responsible for the
+            // analogous flush; the const-skip path bypasses the guard
+            // record, so the flush must happen even on this branch.
+            // Walker impl: forward to `walker_flush_guard_not_invalidated`
+            // before `class_now_known`.  Default impl below stays
+            // flush-free since the constant short-circuit is the same
+            // upstream; impls override only if the flush sequencing
+            // differs.
+            ctx.heap_cache_mut()
+                .class_now_known(obj, expected_type as usize as i64);
+            return;
+        }
+        let expected_type_const = ctx.const_int(expected_type as usize as i64);
+        self.generate_guard(ctx, OpCode::GuardNonnullClass, &[obj, expected_type_const]);
+        // heapcache.py:470-473 `class_now_known` parity.
+        ctx.heap_cache_mut()
+            .class_now_known(obj, expected_type as usize as i64);
+    }
+
+    /// `intobject.py` `int_intval`-pattern guard — class-guard the obj
+    /// as `INT_TYPE`, read its `intval` field, then `implement_guard_value`
+    /// the unboxed payload against `expected`.
+    fn guard_int_object_value(
+        &mut self,
+        ctx: &mut TraceCtx,
+        int_obj: OpRef,
+        expected: i64,
+    ) {
+        self.guard_class(
+            ctx,
+            int_obj,
+            &pyre_object::pyobject::INT_TYPE as *const PyType,
+        );
+        let actual_value =
+            crate::state::opimpl_getfield_gc_i(ctx, int_obj, crate::descr::int_intval_descr());
+        self.implement_guard_value(ctx, actual_value, expected);
+    }
+
+    /// `listobject.py` strategy field guard — `getfield_gc_i(strategy)`
+    /// then `implement_guard_value`.  Skips runtime W_ListObject layout
+    /// reasoning by reading the strategy id directly from its descr.
+    fn guard_list_strategy(&mut self, ctx: &mut TraceCtx, obj: OpRef, expected: i64) {
+        let strategy =
+            crate::state::opimpl_getfield_gc_i(ctx, obj, crate::descr::list_strategy_descr());
+        self.implement_guard_value(ctx, strategy, expected);
+    }
+}
+
+// `MIFrame` impl — delegates to the existing `pub(crate)` methods in
+// `trace_opcode.rs` so the trait-dispatch leg keeps its current
+// `flush_guard_not_invalidated` / `parent_frames` / `orgpc` plumbing
+// untouched.  The trait + default impls above produce byte-identical
+// recorded IR to the inline `MIFrame::*` methods because the default
+// bodies are direct ports of the corresponding `MIFrame` bodies.
+impl WalkerFrameOps for crate::state::MIFrame {
+    fn value_type(&self, _ctx: &TraceCtx, value: OpRef) -> Type {
+        crate::state::MIFrame::value_type(self, value)
+    }
+
+    fn generate_guard(&mut self, ctx: &mut TraceCtx, opcode: OpCode, args: &[OpRef]) {
+        crate::state::MIFrame::generate_guard(self, ctx, opcode, args)
+    }
+
+    // `implement_guard_value` / `guard_class` / `guard_int_object_value`
+    // / `guard_list_strategy` use the default impls above.  Their
+    // bodies are direct ports of the `MIFrame` versions, so the
+    // recorded IR is byte-identical to the trait path's emit.
+    //
+    // The one observable behavior the default impls drop versus
+    // `MIFrame::guard_class` is the const-arm
+    // `flush_guard_not_invalidated` (trace_opcode.rs:4681): this only
+    // fires when a prior quasi-immut field read set
+    // `pending_guard_not_invalidated_pc`.  The trait path's
+    // `store_subscr_value` precondition is "no pending quasi-immut
+    // guard" (concrete obj/key/value are non-null direct stack reads,
+    // not quasi-immut field loads), so the const-skip never occurs in
+    // STORE_SUBSCR.  Walker impl in step 4 will assert the precondition
+    // before delegating, keeping behavior parity with the default impl.
+}

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3405,7 +3405,6 @@ pub extern "C" fn bh_unpack_item_fn(index: i64, seq: i64) -> i64 {
     }
 }
 
-
 /// Read the current (per-thread) exception saved in
 /// `pyre_interpreter::eval::CURRENT_EXCEPTION`. Matches the read at
 /// `pyopcode.py:786 PUSH_EXC_INFO` (implicit via `executioncontext.sys_exc_info`).

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3405,25 +3405,6 @@ pub extern "C" fn bh_unpack_item_fn(index: i64, seq: i64) -> i64 {
     }
 }
 
-pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {
-    let obj = obj as pyre_object::PyObjectRef;
-    let key = key as pyre_object::PyObjectRef;
-    let value = value as pyre_object::PyObjectRef;
-    if obj.is_null() || key.is_null() {
-        let err = pyre_interpreter::PyError::new(
-            pyre_interpreter::PyErrorKind::TypeError,
-            "store subscript on null operand".to_string(),
-        );
-        majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(err.to_exc_object() as i64));
-        return 0;
-    }
-    if let Err(err) = pyre_interpreter::baseobjspace::setitem(obj, key, value) {
-        let exc_obj = err.to_exc_object();
-        majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
-        return 0;
-    }
-    1 // success (non-zero)
-}
 
 /// Read the current (per-thread) exception saved in
 /// `pyre_interpreter::eval::CURRENT_EXCEPTION`. Matches the read at

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3174,9 +3174,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             });
             if bh_exc != 0 {
                 Err(unsafe {
-                    pyre_interpreter::PyError::from_exc_object(
-                        bh_exc as pyre_object::PyObjectRef,
-                    )
+                    pyre_interpreter::PyError::from_exc_object(bh_exc as pyre_object::PyObjectRef)
                 })
             } else {
                 Ok(StepResult::Continue)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3235,9 +3235,13 @@ pub(crate) fn eval_loop_jit_bridge(frame: &mut PyFrame) -> LoopResult {
         };
 
         // pyjitpl.py:1892-1914 run_one_step: trace + execute.
+        let mut walker_dispatched_this_opcode = false;
         if driver.is_tracing() {
             if let Some(loop_result) = jit_merge_point_hook(frame, code, pc, driver, info, &env) {
                 return loop_result;
+            }
+            if pyre_jit_trace::production_walker_handles(&instruction) {
+                walker_dispatched_this_opcode = true;
             }
         } else {
             // Tracing ended (bridge compiled or aborted).
@@ -3247,7 +3251,31 @@ pub(crate) fn eval_loop_jit_bridge(frame: &mut PyFrame) -> LoopResult {
         // handle_bytecode: execute the bytecode on the concrete frame.
         let next_instr = opcode_pc + 1;
         frame.set_last_instr_from_next_instr(next_instr);
-        match execute_opcode_step(frame, code, instruction, op_arg, next_instr) {
+        let step_result = if walker_dispatched_this_opcode {
+            // Mirror `eval_loop_jit`'s walker-dispatched bypass — the
+            // walker arm already mutated the live PyFrame via
+            // `vable_setfield` → `synchronize_virtualizable`, and the
+            // compiled trace owns the rest of the bytecode's heap
+            // effects on replay.  Running `execute_opcode_step` here
+            // would double-mutate `valuestackdepth` for the same opcode.
+            // Drain any pending raise from `BH_LAST_EXC_VALUE` so the
+            // exception handler runs against the bridge frame.
+            let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| {
+                let v = c.get();
+                c.set(0);
+                v
+            });
+            if bh_exc != 0 {
+                Err(unsafe {
+                    pyre_interpreter::PyError::from_exc_object(bh_exc as pyre_object::PyObjectRef)
+                })
+            } else {
+                Ok(StepResult::Continue)
+            }
+        } else {
+            execute_opcode_step(frame, code, instruction, op_arg, next_instr)
+        };
+        match step_result {
             Ok(StepResult::Continue) => {}
             Ok(StepResult::CloseLoop { .. }) => {}
             Ok(StepResult::Return(result)) => return LoopResult::Done(Ok(result)),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2981,221 +2981,6 @@ fn trace_jit_bytecode(_pc: usize, _instruction_name: &str) {
     // Debug logging disabled — per-bytecode eprintln causes O(n) slowdown.
 }
 
-/// JIT-enabled evaluation loop (PyPy interp_jit.py dispatch()).
-///
-/// Calls merge_point on EVERY iteration (PyPy line 85-87), not just
-/// when tracing. This matches PyPy's jit_merge_point placement.
-/// RPython interp_jit.py dispatch() parity.
-///
-/// The hot loop mirrors RPython's structure exactly:
-///   while True:
-///       jit_merge_point(...)      # thin inline check
-///       next_instr = handle_bytecode(...)
-///
-/// Phase 5.B dispatch-unification: run a single walker-handled
-/// opcode's arm jitcode through `BlackholeInterpreter` so its
-/// non-elidable `residual_call`s actually mutate heap, then return so
-/// `eval_loop_jit` advances to the next opcode.
-///
-/// RPython parity: `pyjitpl.py:_interpret` IS the execution loop —
-/// every opcode dispatches through the jitcode-bytecode path.  Pyre
-/// hosts the per-opcode loop in `eval_loop_jit` instead, so this
-/// helper bridges the two halves: walker-handled opcodes whose arms
-/// rely on impure residual_calls (e.g. `store_subscr_fn`,
-/// `set_current_exception`) route through here instead of the
-/// vable-only skip at `eval_loop_jit`'s walker-dispatched branch.
-///
-/// Selection gate: `pyre_jit_trace::production_blackhole_handles`
-/// (returns `false` everywhere today).  Subsequent Phase 5.B slices
-/// implement the body — arm jitcode lookup, BH builder
-/// acquire/release, PyFrame↔BH register marshalling, `interp.run()`
-/// — and grow the predicate per opcode.
-///
-/// ## Latent gaps before this path can be activated
-///
-/// The body below is reachable only when the predicate flips on for
-/// a given opcode, which is gated behind Task #390 sub-slice 6
-/// (retire Phase 5.B body wire once orthodox concrete-execute
-/// covers the same opcodes).  These items MUST close before any
-/// activation flip — they are tracked here so the predicate change
-/// surfaces them rather than crashing in production:
-///
-/// 1. **Non-void return-type push not implemented.** Below at the
-///    `todo!()` arm: `BhReturnType::Int|Ref|Float` panics.  Normal
-///    opcode arms typically end in `ref_return/r` →
-///    `DispatchOutcome::SubReturn { result: Some(opref) }` on the
-///    walker side; the blackhole equivalent surfaces via
-///    `bh.tmpreg_r`/`tmpreg_i`/`tmpreg_f` after
-///    `_final_result_anytype` / `_done_with_this_frame`
-///    (`rpython/jit/metainterp/blackhole.py:377, :1664`).  Slice
-///    3.8 ports the PyFrame stack push.
-///
-/// 2. **`bh.aborted` ignored.** Pyre's `BlackholeInterpreter` adds
-///    a pyre-only `aborted` flag for the `abort/` and
-///    `abort_permanent/` bhimpl opcodes
-///    (`majit/majit-metainterp/src/blackhole.rs:237`) which the
-///    resume path treats as failure
-///    (`pyre/pyre-jit/src/call_jit.rs:1478`).  This dispatcher
-///    currently reads only `mergepoint_args` / `got_exception` /
-///    `exception_value` / `return_type`, so an aborted arm would be
-///    misclassified as a normal completion.  Activation must check
-///    `bh.aborted` and raise — RPython has no "successful abort"
-///    path; bad/unwired blackhole bytecode fails loudly
-///    (`rpython/jit/metainterp/blackhole.py:97`).
-///
-/// 3. **`jitdrivers_sd` not seeded.** RPython blackhole recursive
-///    calls reach `builder.metainterp_sd.jitdrivers_sd[jdindex]`
-///    (`rpython/jit/metainterp/blackhole.py:1095`).  Pyre's
-///    existing resume path explicitly seeds `bh.jitdrivers_sd` at
-///    `pyre/pyre-jit/src/call_jit.rs:1424`; this helper only sets
-///    `virtualizable_ptr` and `virtualizable_info`.  Any future
-///    blackhole-handled opcode arm that reaches `recursive_call_*`
-///    would not match RPython.
-///
-/// 4. **`BH_LAST_EXC_VALUE` not drained.** The residual-call
-///    executor reports raised Python exceptions via
-///    `majit_metainterp::blackhole::BH_LAST_EXC_VALUE` (a
-///    thread-local seeded by `execute_residual_call`'s Err arm).
-///    This helper consults only `bh.got_exception` /
-///    `bh.exception_last_value`; a raised residual call could
-///    therefore fall through as `StepResult::Continue` and leave
-///    the TLS exception latched for a later opcode.  Activation
-///    must drain and clear `BH_LAST_EXC_VALUE` after `bh.run()`
-///    and map a non-zero value into `PyError`.
-///
-/// 5. **Hot-path lookup cost.** `metainterp_jitcode_for_instruction`
-///    (`pyre/pyre-jit-trace/src/jitcode_runtime.rs:337`) currently
-///    formats `Instruction` with `Debug` then linear-scans
-///    `ALL_OPCODE_ARMS`; before this path becomes default-on for
-///    any opcode, the arm/jitcode index needs threading through
-///    the dispatch site so the lookup is O(1).
-#[cold]
-fn dispatch_arm_via_blackhole(
-    frame: &mut pyre_interpreter::pyframe::PyFrame,
-    instruction: &pyre_interpreter::Instruction,
-) -> Result<StepResult<pyre_object::PyObjectRef>, pyre_interpreter::PyError> {
-    // Mirrors the walker-side fallback in
-    // `MIFrame::dispatch_via_walker_for_opcode`
-    // (pyre-jit-trace/src/trace_opcode.rs:6602) — an entry on
-    // `production_blackhole_handles` without a matching codewriter arm
-    // is a build-script wiring bug, not a user-visible error.  The
-    // metainterp-runtime wrapper is the form `BlackholeInterpreter.
-    // jitcode` consumes (descr pool stays empty for build-time canonical
-    // arms; `majit-metainterp/src/jitcode/mod.rs:400-403`).
-    let jitcode = pyre_jit_trace::jitcode_runtime::metainterp_jitcode_for_instruction(instruction)
-        .ok_or_else(|| {
-            pyre_interpreter::PyError::new(
-                pyre_interpreter::PyErrorKind::SystemError,
-                format!(
-                    "dispatch_arm_via_blackhole: production_blackhole_handles \
-                         admitted instruction without codewriter arm: {instruction:?}",
-                ),
-            )
-        })?;
-
-    // Thread-local BH pool — mirrors `call_jit.rs::blackhole_resume_via_
-    // rd_numb`'s `BH_BUILDER_RD` (call_jit.rs:1300-1315).  Separate
-    // builder from the resume-data path so the two cannot trip over each
-    // other's mutable borrow on re-entry; single-opcode arms don't go
-    // through `resume::blackhole_from_resumedata`.  Lazy-init on first
-    // dispatch; the predicate stays `false` everywhere today so the
-    // pool is never actually created in production.
-    thread_local! {
-        static BH_BUILDER_ARM: UnsafeCell<majit_metainterp::blackhole::BlackholeInterpBuilder> =
-            UnsafeCell::new(pyre_jit_trace::jitcode_runtime::build_pyre_production_bh_builder());
-    }
-    let sync_control_opcodes =
-        |builder: &mut majit_metainterp::blackhole::BlackholeInterpBuilder| {
-            let (op_live, op_catch_exception, op_rvmprof_code) =
-                pyre_jit_trace::state::blackhole_control_opcodes();
-            builder.setup_cached_control_opcodes(op_live, op_catch_exception, op_rvmprof_code);
-        };
-
-    let (mergepoint_args, got_exception, exception_value, return_type) =
-        BH_BUILDER_ARM.with(|cell| unsafe {
-            let builder = &mut *cell.get();
-            sync_control_opcodes(builder);
-            let mut bh = builder.acquire_interp();
-            // `setposition` (blackhole.py:312) initialises register
-            // banks + copies the constants pool into the upper portion
-            // of each bank.  Setting `jitcode` / `position` directly
-            // would leave the banks sized to the previous interp's
-            // jitcode (or empty on a fresh acquire), with no constants
-            // copied — wild reads at the first `bhimpl_*` that loads a
-            // constant.
-            bh.setposition(jitcode, 0);
-            // Virtualizable wiring — mirrors `call_jit.rs:1400-1423`.
-            // Single-arm dispatch has no caller chain so the
-            // `nextblackholeinterp` propagation loop reduces to no-op.
-            bh.virtualizable_ptr = frame as *mut pyre_interpreter::pyframe::PyFrame as i64;
-            bh.virtualizable_info = get_virtualizable_info();
-            // RPython MIFrame.setup parity: r0 = frame (per
-            // `trace_opcode.rs:6657-6660` walker-side seed).  Remaining
-            // working-bank slots stay zero/null; per-arm stack peeks
-            // are issued inside the arm body via `bhimpl_*` operand
-            // decoding (vable_get/setarrayitem_r against PyFrame's
-            // `locals_cells_stack_w`).
-            if !bh.registers_r.is_empty() {
-                bh.registers_r[0] = bh.virtualizable_ptr;
-            }
-            let mergepoint_args = bh.run();
-            let got_exception = bh.got_exception;
-            let exception_value = bh.exception_last_value;
-            let return_type = bh.return_type;
-            builder.release_interp(bh);
-            (mergepoint_args, got_exception, exception_value, return_type)
-        });
-
-    if got_exception {
-        // Mirrors `call_jit.rs:1486-1506` (BH chain-exit propagation):
-        // null `exception_value` means the arm raised without a
-        // payload (defensive RuntimeError); otherwise the value is a
-        // GC ref to a `W_BaseException` instance to re-wrap.
-        let err = if exception_value != 0 {
-            unsafe {
-                pyre_interpreter::PyError::from_exc_object(
-                    exception_value as pyre_object::PyObjectRef,
-                )
-            }
-        } else {
-            pyre_interpreter::PyError::new(
-                pyre_interpreter::PyErrorKind::RuntimeError,
-                "dispatch_arm_via_blackhole: arm raised exception with null exc_value",
-            )
-        };
-        return Err(err);
-    }
-    if mergepoint_args.is_some() {
-        // `ContinueRunningNormally` is the JIT-exit path: an arm
-        // discovered a jit_merge_point and wants the outer loop to
-        // re-warm.  Opcode arms don't issue merge points, so this is
-        // structurally unreachable for the per-opcode dispatch path.
-        unreachable!(
-            "dispatch_arm_via_blackhole: opcode arm raised \
-             ContinueRunningNormally — only portal arms should",
-        );
-    }
-    // LeaveFrame, no exception.  Dispatch on return_type per
-    // RPython `BlackholeInterpreter` (`blackhole.rs:696-701`):
-    //   Void  → arm already mutated heap via vable_setfield /
-    //           residual_call; stack push not needed.
-    //   Int/Ref/Float → result in `tmpreg_*` to push back onto
-    //           PyFrame stack; opcode-shape-specific marshalling
-    //           lands in slice 3.8.
-    match return_type {
-        majit_metainterp::blackhole::BhReturnType::Void => Ok(StepResult::Continue),
-        majit_metainterp::blackhole::BhReturnType::Int
-        | majit_metainterp::blackhole::BhReturnType::Ref
-        | majit_metainterp::blackhole::BhReturnType::Float => {
-            todo!(
-                "dispatch_arm_via_blackhole: non-void return-type \
-                 push lands in slice 3.8 (return_type={:?})",
-                return_type,
-            )
-        }
-    }
-}
-
 /// warmspot.py portal_runner parity: execute a frame through the JIT-enabled
 /// interpreter. Used by bhimpl_recursive_call (blackhole.py:1074-1093) for
 /// recursive portal depth. Returns PyObjectRef (NULL on void/exception).
@@ -3362,51 +3147,39 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         }
         let mut next_instr = frame.next_instr();
         let step_result = if walker_dispatched_this_opcode {
-            if pyre_jit_trace::production_blackhole_handles(&instruction) {
-                // Phase 5.B path: arm body contains a non-elidable
-                // `residual_call` (e.g. `store_subscr_fn`,
-                // `set_current_exception`) whose heap mutation walker
-                // recording skipped (`check_is_elidable` gate in
-                // `jitcode_dispatch::execute_residual_call`).  Run the
-                // arm jitcode through `BlackholeInterpreter` so the
-                // mutation actually happens, matching RPython
-                // `pyjitpl.py:_interpret`'s single-interpreter loop.
-                dispatch_arm_via_blackhole(frame, &instruction)
+            // Vable-only path: walker arm advanced PyFrame via
+            // `vable_setfield` / `setarrayitem_vable_r` →
+            // `synchronize_virtualizable` (trace_ctx.rs:1224-1265),
+            // which propagates the shadow back to the heap PyFrame.
+            // Running `execute_opcode_step` here would double-mutate.
+            // pc already advanced above via
+            // `set_last_instr_from_next_instr(opcode_pc + 1)`.
+            //
+            // Walker-side `try_execute_residual_call_via_executor`
+            // (Task #390 sub-slice 3, `jitcode_dispatch.rs`)
+            // concrete-executes non-elidable residual calls during
+            // walker dispatch and routes raised exceptions through
+            // `BH_LAST_EXC_VALUE` (matches RPython
+            // `pyjitpl.py:2156-2168 handle_possible_exception` →
+            // `metainterp.execute_raised`).  Surface a pending
+            // exception as `Err(PyError)` so the bytecode
+            // interpreter's exception handler runs — without this,
+            // the helper's exception would silently drop, leaving
+            // the interpreter at the post-call PC instead of the
+            // exception-handler PC.
+            let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| {
+                let v = c.get();
+                c.set(0);
+                v
+            });
+            if bh_exc != 0 {
+                Err(unsafe {
+                    pyre_interpreter::PyError::from_exc_object(
+                        bh_exc as pyre_object::PyObjectRef,
+                    )
+                })
             } else {
-                // Vable-only fast path: walker arm advanced PyFrame
-                // via `vable_setfield` / `setarrayitem_vable_r` →
-                // `synchronize_virtualizable` (trace_ctx.rs:1224-1265),
-                // which propagates the shadow back to the heap
-                // PyFrame.  Running `execute_opcode_step` here would
-                // double-mutate.  pc already advanced above via
-                // `set_last_instr_from_next_instr(opcode_pc + 1)`.
-                //
-                // Walker-side `try_execute_residual_call_via_executor`
-                // (Task #390 sub-slice 3, `jitcode_dispatch.rs`)
-                // concrete-executes non-elidable residual calls during
-                // walker dispatch and routes raised exceptions through
-                // `BH_LAST_EXC_VALUE` (matches RPython
-                // `pyjitpl.py:2156-2168 handle_possible_exception` →
-                // `metainterp.execute_raised`).  Surface a pending
-                // exception as `Err(PyError)` so the bytecode
-                // interpreter's exception handler runs — without this,
-                // the helper's exception would silently drop, leaving
-                // the interpreter at the post-call PC instead of the
-                // exception-handler PC.
-                let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| {
-                    let v = c.get();
-                    c.set(0);
-                    v
-                });
-                if bh_exc != 0 {
-                    Err(unsafe {
-                        pyre_interpreter::PyError::from_exc_object(
-                            bh_exc as pyre_object::PyObjectRef,
-                        )
-                    })
-                } else {
-                    Ok(StepResult::Continue)
-                }
+                Ok(StepResult::Continue)
             }
         } else {
             execute_opcode_step(frame, code, instruction, op_arg, next_instr)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3010,6 +3010,65 @@ fn trace_jit_bytecode(_pc: usize, _instruction_name: &str) {
 /// implement the body — arm jitcode lookup, BH builder
 /// acquire/release, PyFrame↔BH register marshalling, `interp.run()`
 /// — and grow the predicate per opcode.
+///
+/// ## Latent gaps before this path can be activated
+///
+/// The body below is reachable only when the predicate flips on for
+/// a given opcode, which is gated behind Task #390 sub-slice 6
+/// (retire Phase 5.B body wire once orthodox concrete-execute
+/// covers the same opcodes).  These items MUST close before any
+/// activation flip — they are tracked here so the predicate change
+/// surfaces them rather than crashing in production:
+///
+/// 1. **Non-void return-type push not implemented.** Below at the
+///    `todo!()` arm: `BhReturnType::Int|Ref|Float` panics.  Normal
+///    opcode arms typically end in `ref_return/r` →
+///    `DispatchOutcome::SubReturn { result: Some(opref) }` on the
+///    walker side; the blackhole equivalent surfaces via
+///    `bh.tmpreg_r`/`tmpreg_i`/`tmpreg_f` after
+///    `_final_result_anytype` / `_done_with_this_frame`
+///    (`rpython/jit/metainterp/blackhole.py:377, :1664`).  Slice
+///    3.8 ports the PyFrame stack push.
+///
+/// 2. **`bh.aborted` ignored.** Pyre's `BlackholeInterpreter` adds
+///    a pyre-only `aborted` flag for the `abort/` and
+///    `abort_permanent/` bhimpl opcodes
+///    (`majit/majit-metainterp/src/blackhole.rs:237`) which the
+///    resume path treats as failure
+///    (`pyre/pyre-jit/src/call_jit.rs:1478`).  This dispatcher
+///    currently reads only `mergepoint_args` / `got_exception` /
+///    `exception_value` / `return_type`, so an aborted arm would be
+///    misclassified as a normal completion.  Activation must check
+///    `bh.aborted` and raise — RPython has no "successful abort"
+///    path; bad/unwired blackhole bytecode fails loudly
+///    (`rpython/jit/metainterp/blackhole.py:97`).
+///
+/// 3. **`jitdrivers_sd` not seeded.** RPython blackhole recursive
+///    calls reach `builder.metainterp_sd.jitdrivers_sd[jdindex]`
+///    (`rpython/jit/metainterp/blackhole.py:1095`).  Pyre's
+///    existing resume path explicitly seeds `bh.jitdrivers_sd` at
+///    `pyre/pyre-jit/src/call_jit.rs:1424`; this helper only sets
+///    `virtualizable_ptr` and `virtualizable_info`.  Any future
+///    blackhole-handled opcode arm that reaches `recursive_call_*`
+///    would not match RPython.
+///
+/// 4. **`BH_LAST_EXC_VALUE` not drained.** The residual-call
+///    executor reports raised Python exceptions via
+///    `majit_metainterp::blackhole::BH_LAST_EXC_VALUE` (a
+///    thread-local seeded by `execute_residual_call`'s Err arm).
+///    This helper consults only `bh.got_exception` /
+///    `bh.exception_last_value`; a raised residual call could
+///    therefore fall through as `StepResult::Continue` and leave
+///    the TLS exception latched for a later opcode.  Activation
+///    must drain and clear `BH_LAST_EXC_VALUE` after `bh.run()`
+///    and map a non-zero value into `PyError`.
+///
+/// 5. **Hot-path lookup cost.** `metainterp_jitcode_for_instruction`
+///    (`pyre/pyre-jit-trace/src/jitcode_runtime.rs:337`) currently
+///    formats `Instruction` with `Debug` then linear-scans
+///    `ALL_OPCODE_ARMS`; before this path becomes default-on for
+///    any opcode, the arm/jitcode index needs threading through
+///    the dispatch site so the lookup is O(1).
 #[cold]
 fn dispatch_arm_via_blackhole(
     frame: &mut pyre_interpreter::pyframe::PyFrame,

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -154,7 +154,7 @@ impl Cpu {
             box_int_fn: crate::call_jit::bh_box_int_fn,
             truth_fn: crate::call_jit::bh_truth_fn,
             load_const_fn: crate::call_jit::bh_load_const_fn,
-            store_subscr_fn: crate::call_jit::bh_store_subscr_fn,
+            store_subscr_fn: pyre_interpreter::opcode_ops::bh_store_subscr_fn,
             build_list_fn: crate::call_jit::bh_build_list_fn,
             build_tuple_fn: crate::call_jit::bh_build_tuple_fn,
             unpack_sequence_fn: crate::call_jit::bh_unpack_sequence_fn,

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2225,10 +2225,8 @@ pub unsafe fn w_dict_is_regular_empty_no_proxy(obj: PyObjectRef) -> bool {
         return false;
     }
     let dict = &*(obj as *const W_DictObject);
-    std::ptr::eq(
-        dict.dstrategy as *const _ as *const u8,
-        &crate::dictstrategy::EMPTY_DICT_STRATEGY as *const _ as *const u8,
-    ) && dict.dict_storage_proxy.is_null()
+    dict.dstrategy.strategy_kind() == crate::dictstrategy::StrategyKind::Empty
+        && dict.dict_storage_proxy.is_null()
 }
 
 /// Adopt a freshly copied regular-dict storage into an empty regular
@@ -2352,29 +2350,23 @@ pub unsafe fn w_dict_setitem_str_no_proxy(obj: PyObjectRef, key: &str, value: Py
     // UnicodeDictStrategy stores `Vec<(PyObjectRef, PyObjectRef)>`
     // (same shape as ObjectDictStrategy), so the existing raw Vec
     // walk below is correct once the strategy slot points at it.
-    let s = dict.dstrategy as *const _ as *const u8;
-    let is_empty = std::ptr::eq(
-        s,
-        &crate::dictstrategy::EMPTY_DICT_STRATEGY as *const _ as *const u8,
-    );
-    let is_unicode = std::ptr::eq(
-        s,
-        &crate::dictstrategy::UNICODE_DICT_STRATEGY as *const _ as *const u8,
-    );
-    let is_object = std::ptr::eq(
-        s,
-        &crate::dictstrategy::OBJECT_DICT_STRATEGY as *const _ as *const u8,
-    );
-    if is_empty {
-        dict.dstrategy = &crate::dictstrategy::UNICODE_DICT_STRATEGY;
-    } else if !is_unicode && !is_object {
+    // Discriminate by `strategy_kind()`, never by `std::ptr::eq` on the
+    // strategy address: the strategy singletons are zero-sized statics
+    // whose addresses the compiler is free to coalesce, so pointer
+    // identity cannot tell `Empty`/`Unicode`/`Object` apart.
+    use crate::dictstrategy::StrategyKind;
+    match dict.dstrategy.strategy_kind() {
+        StrategyKind::Empty => {
+            dict.dstrategy = &crate::dictstrategy::UNICODE_DICT_STRATEGY;
+        }
+        StrategyKind::Unicode | StrategyKind::Object => {}
         // Int / Bytes / Identity / Kwargs typed storage: PyPy's
         // `AbstractTypedStrategy.setitem_str` (`dictmultiobject.py:1069`)
         // promotes to ObjectDictStrategy before the str-key insert.
         // Polymorphic dispatch through the trait converts the typed
         // backing to `Vec<(PyObjectRef, PyObjectRef)>` so the walk
         // below sees the correct layout.
-        dict.dstrategy.switch_to_object_strategy(obj);
+        _ => dict.dstrategy.switch_to_object_strategy(obj),
     }
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
     let w_key = crate::w_str_new(key);
@@ -2399,29 +2391,17 @@ pub unsafe fn w_dict_delitem_str_no_proxy(obj: PyObjectRef, key: &str) -> bool {
     // sees the right layout.  PyPy's typed `delitem` (`dictmultiobject.py:1081-1087`)
     // promotes on key-type mismatch; we promote on the str-keyed
     // back-mirror path for the same reason.
-    let s = dict.dstrategy as *const _ as *const u8;
-    let is_empty = std::ptr::eq(
-        s,
-        &crate::dictstrategy::EMPTY_DICT_STRATEGY as *const _ as *const u8,
-    );
-    let is_unicode = std::ptr::eq(
-        s,
-        &crate::dictstrategy::UNICODE_DICT_STRATEGY as *const _ as *const u8,
-    );
-    let is_object = std::ptr::eq(
-        s,
-        &crate::dictstrategy::OBJECT_DICT_STRATEGY as *const _ as *const u8,
-    );
-    if !is_empty && !is_unicode && !is_object {
-        dict.dstrategy.switch_to_object_strategy(obj);
+    // Discriminate by `strategy_kind()`; the strategy singletons are
+    // zero-sized statics whose addresses can coalesce, so `std::ptr::eq`
+    // on them is unreliable.
+    use crate::dictstrategy::StrategyKind;
+    match dict.dstrategy.strategy_kind() {
+        StrategyKind::Empty | StrategyKind::Unicode | StrategyKind::Object => {}
+        _ => dict.dstrategy.switch_to_object_strategy(obj),
     }
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
     let w_key = crate::w_str_new(key);
-    if entries.shift_remove(&object_key_for(w_key)).is_some() {
-        true
-    } else {
-        false
-    }
+    entries.shift_remove(&object_key_for(w_key)).is_some()
 }
 
 /// WTF-8 keyed sibling of `w_dict_setitem_str_no_proxy` — lets a
@@ -2443,12 +2423,10 @@ pub unsafe fn w_dict_setitem_wtf8_no_proxy(
         return;
     }
     let dict = &mut *(obj as *mut W_DictObject);
-    let s = dict.dstrategy as *const _ as *const u8;
-    let is_object = std::ptr::eq(
-        s,
-        &crate::dictstrategy::OBJECT_DICT_STRATEGY as *const _ as *const u8,
-    );
-    if !is_object {
+    // A lone-surrogate key can only live on `ObjectDictStrategy`; force
+    // the switch unless already there.  Detect via `strategy_kind()` —
+    // `std::ptr::eq` on the zero-sized strategy statics is unreliable.
+    if dict.dstrategy.strategy_kind() != crate::dictstrategy::StrategyKind::Object {
         dict.dstrategy.switch_to_object_strategy(obj);
     }
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
@@ -2466,20 +2444,15 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         return false;
     }
     let dict = &mut *(obj as *mut W_DictObject);
-    let s = dict.dstrategy as *const _ as *const u8;
-    let is_empty = std::ptr::eq(
-        s,
-        &crate::dictstrategy::EMPTY_DICT_STRATEGY as *const _ as *const u8,
-    );
-    if is_empty {
-        return false;
-    }
-    let is_object = std::ptr::eq(
-        s,
-        &crate::dictstrategy::OBJECT_DICT_STRATEGY as *const _ as *const u8,
-    );
-    if !is_object {
-        dict.dstrategy.switch_to_object_strategy(obj);
+    // Detect via `strategy_kind()`; the strategy singletons are
+    // zero-sized statics whose addresses can coalesce, so `std::ptr::eq`
+    // on them is unreliable (an `Object`-strategy dict could otherwise
+    // be misread as `Empty` and skip the removal entirely).
+    use crate::dictstrategy::StrategyKind;
+    match dict.dstrategy.strategy_kind() {
+        StrategyKind::Empty => return false,
+        StrategyKind::Object => {}
+        _ => dict.dstrategy.switch_to_object_strategy(obj),
     }
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
     let w_key = crate::w_str_from_wtf8(key.to_wtf8_buf());


### PR DESCRIPTION
Fix https://github.com/youknowone/pyre/issues/122

## Summary

- STORE_SUBSCR walker activation: entry hook in `dispatch_via_walker_for_opcode` pops 3 values and delegates to `MIFrame::store_subscr_value`, bypassing the arm-jitcode walk that pops from a concrete PyFrame stack the walker never populates.
- `try_execute_residual_call_via_executor` admits `CallMayForce*` when no active virtualizable (matches `do_residual_call`'s force-virtual branch with no vinfo).
- Reraise walker activation delegates to `MIFrame::reraise`, which seeds `err.reraise_lasti` from `concrete_stack` so the dispatcher's lasti extraction works the same on either leg. `dispatch_via_walker_for_opcode` gains an `op_arg` parameter.
- `dispatch_arm_via_blackhole` + `production_blackhole_handles` + `METAINTERP_JITCODE_CACHE` deleted; the walker executor is now the sole non-elidable residual_call mechanism. `build_pyre_production_bh_builder` + `blackhole_control_opcodes` retained for the resume path.
- `try_walker_direct_opcode_dispatch` extracted as the named entry point for opcodes that emit IR directly from the tracer.

Gate: dynasm 44/44 + cranelift 44/44 ×2 backends.

## Self-review

### Prompt & Model

Model:

Prompt:

### Answer

  1. Regressed Parity
  No behavior-level PyPy parity regressions found versus origin/main.

  The new early SubRaise returns in pyre/pyre-jit-trace/src/jitcode_dispatch.rs:4653 move Pyre closer to PyPy: handle_possible_exception() records GUARD_EXCEPTION
  and immediately calls finishframe_exception() in rpython/jit/metainterp/pyjitpl.py:3404-3417, so later arm bytecode should not be walked.

  2. Other Introduced Mismatches
  No new behavior mismatch found.

  Two new comments are misleading:

  - pyre/pyre-jit-trace/src/jitcode_dispatch.rs:3582 says residual-call success clears exception state at pyjitpl.py:1685-1690; upstream clears before execution in
    MIFrame.execute_varargs() at pyjitpl.py:1941-1943, and in the forces branch at pyjitpl.py:2010.

  - The release-GIL comment in the residual-call inventory overstates direct_call_release_gil: upstream concrete execution happens first via
    executor.execute_varargs(... CALL_MAY_FORCE_*) at pyjitpl.py:2023-2041; direct_call_release_gil() later records CALL_RELEASE_GIL_* at pyjitpl.py:3700-3705.

  3. Pre-existing Mismatches

  - pyre/pyre-jit-trace/src/jitcode_dispatch.rs:3493 still does not execute every residual call. It declines non-supported opcodes, non-const funcptrs, unpatched/
    high fnaddrs, over-arity calls, missing concrete args, and NULL refs. PyPy executes residual calls at trace-record time in pyjitpl.py:1995-2126.

  - If that helper returns None, Pyre still does not mirror upstream clear_exception() for that residual call. The patch only clears on Some(Ok(_)).
  - CallMayForce* and CallReleaseGil* concrete execution remain excluded from the walker executor path, while PyPy’s forces branch concretely executes first.
  - Existing documented gaps remain: OS_JIT_FORCE_VIRTUAL, direct_libffi_call, full virtualizable/vref after-call handling, direct assembler-call handling, and
    exact multi-frame guard snapshots.

  4. Structural Adaptations

  - pyre/pyre-interpreter/src/opcode_ops.rs:231 is a Rust ABI bridge, not a line-by-line PyPy shape. PyPy’s STORE_SUBSCR just performs space.setitem and returns
    through interpreter control flow; Pyre needs a C-ABI callable that publishes exceptions through BH_LAST_EXC_VALUE.

  - The bridge returns 1/0, while the opcode-arm JitCode has a Ref-shaped StepResult::Continue return. This is acceptable only because production opcode-entry
    dispatch treats any SubReturn as StepResult::Continue and ignores the returned Ref.

  - The BH_LAST_EXC_VALUE TLS, runtime fnaddr patching, and 47-bit fnaddr sanity gate are implementation-language/runtime adaptations, not RPython structures.
  - Single-frame walker snapshots are a deliberate Pyre adaptation because helper/sub-jitcodes are not blackhole-resumable Python frames.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster store-subscript (item assignment) paths and specialized residual-call dispatch to speed list/dict writes and JIT traces.

* **Bug Fixes**
  * More consistent exception propagation from residual helpers and JIT dispatch; fixed type-attribute deletion to actually remove keys instead of leaving tombstones.
  * Simplified walker-dispatched opcode handling to avoid double-mutating frames.

* **Debugging**
  * Optional environment-gated debug probes for store-subscript and certain heap-cache mismatches.

* **Other**
  * Fixed benchmark time formatting in reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->