### PR TITLE
JIT: trace-specialize builtin list.append/pop and lower LOAD_ATTR through the canonical splice (#143)

### DIFF
--- a/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
@@ -93,7 +93,7 @@ so `callable = NULL` is structurally impossible.
 
 ## Pyre after #121: "RPython" is Rust
 
-#121 replaced the JIT front-end with a **Charon-extracted MIR front-end**. The
+`#121` replaced the JIT front-end with a **Charon-extracted MIR front-end**. The
 build requires `build/llbc/{pyre-object,pyre-interpreter}.ullbc`, i.e. the
 majit-translate pipeline turns **Rust** (via Charon LLBC) into jitcodes. So
 pyre's "RPython" is Rust, and the metainterp inlines Rust helper calls by
@@ -111,6 +111,7 @@ Critically, the Rust list code is favorably structured:
   **not** `dyn`-trait dispatch (avoids the documented "no common base"
   trait-dispatch wall).
 - `object_push` has the exact hot/cold split PyPy traces:
+
   ```rust
   unsafe fn object_push(&mut self, value: PyObjectRef) {
       if self.length == self.object_items_capacity() {   // → resize GUARD
@@ -121,6 +122,7 @@ Critically, the Rust list code is favorably structured:
       self.length += 1;                                   // setfield len+1
   }
   ```
+
 - The IR `generated_list_append_by_strategy` hand-emits today is **byte-for-byte
   the IR real tracing into `w_list_append` would produce** — so the compiled
   fast-path trace is unchanged by going orthodox; only its *provenance* and the

--- a/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
@@ -394,15 +394,43 @@ verdict's "index registration UNIMPLEMENTED" was overstated.)
   (indirectcalltargets_tests) proves production `pyjitcode_for_jitcode_index(idx)`
   resolves the helper and `resume_jitcode_pc_for(off)==off`. PASSES under
   `cargo test -p pyre-jit-trace --no-default-features --features dynasm`.
-- **M-core2 — synthesize callee SnapshotFrame.** A `build_framestack_snapshot`
-  variant that prepends a top `SnapshotFrame{jitcode_index=helper, pc=guard_offset,
-  boxes=[list,value]}` (NO `NUM_SCALAR_INPUTARGS` header-skip — a helper has no
-  scalar-inputarg header; verify this), then demotes the current `self`
-  (outer Python frame) to the first parent at `resume_pc=fallthrough_pc` via
-  `materialize_parent_snapshot_state` (trace_opcode.rs:3925), then
-  `self.parent_frames`. MIFrame holds `&mut PyreSym`, so demoting self needs a
-  `ResumeFrameState{sym: self.sym as *mut …}` re-borrow (same raw-ptr pattern
-  the parent path already uses).
+- **M-core2 — LANDED (uncommitted, tested; 2026-06-06, verdict-revised).**
+  Three methods on `impl MIFrame` (trace_opcode.rs), all dead-code until M-core3:
+  (1) `build_framestack_frames(ctx, lead) -> Vec<SnapshotFrame>` extracted from
+  `build_framestack_snapshot` (append `self.parent_frames` to an innermost-first
+  `lead`, then `reverse()` to the outermost-first `recorder.rs:56` contract); the
+  existing `build_framestack_snapshot` now delegates to it (`lead=[top]`). (2)
+  `build_synthetic_callee_frames(ctx, helper_jitcode_index, helper_pc, boxes,
+  result_stack_idx, result_type)` — helper top frame with boxes built UNSLICED
+  (no `NUM_SCALAR_INPUTARGS` header; types via `value_type` per box → list=Ref,
+  unboxed int value=Int), self demoted to first parent at `resume_pc=
+  fallthrough_pc` through `materialize_parent_snapshot_state` (borrow-safe: it
+  reads nothing from `self`, rebuilds an MIFrame from the raw `sym` ptr → ≤1
+  `&mut PyreSym` live), then `self.parent_frames`; returns outermost-first
+  `[...parents, self, helper]`. (3) `build_framestack_snapshot_with_synthetic_callee`
+  wraps (2) + one-shot vable/vref from the REAL Python `sym`. Test
+  `build_synthetic_callee_frames_synthesizes_self_caller_and_helper_top` asserts
+  `frames==[self@fallthrough(empty boxes), helper@guard([Box(list,Ref),
+  Box(value,Int)])]`. Full `pyre-jit-trace` suite green (239 passed).
+  **3-lens adversarial verify resolved into the code:** (a) the demoted self's
+  pending result slot is a SIGNATURE PARAMETER (`result_stack_idx`/`result_type`)
+  — it MUST be `Some` in production so `get_list_of_active_boxes`'s `in_a_call`
+  null-out (trace_opcode.rs:1538) clears the undefined call result instead of
+  capturing a stale box; the unit test passes `None` (valid empty-liveness case).
+  (b) the unit test uses an IDENTITY pc_map `(0..6)` so `resume_jitcode_pc_for(
+  fallthrough_pc=3)` resolves (a partial pc_map would `.expect`-panic at
+  trace_opcode.rs:1231 — the bug all 3 verifiers caught in the draft). (c)
+  frame order is OUTERMOST-FIRST (`frames[0]=self`, `frames[1]=helper`), refuting
+  two finders that claimed `frames[0]=helper`.
+  **Deferred to M-core3 (documented in method (3)'s doc comment):** the
+  `orgpc` swap + vable scalar save/restore that `capture_resumedata`
+  (trace_opcode.rs:3742-3771) performs around the snapshot must wrap the M-core3
+  call site (`list_of_boxes_virtualizable` derives the vable last_instr/vsd from
+  `self.orgpc`); the value box's SnapshotTagged kind must match the kind the
+  M-core1 helper jitcode declares at `guard_pc` (Ref vs Int mismatch mis-numbers
+  the box on resume); and method (3)'s vable/vref tail is unit-untested (it would
+  SEGV on a skeleton helper's null code — needs a real PyFrame or seeded
+  `virtualizable_array_lengths`).
 - **M-core3 — wire + real helper body.** Call the M-core2 builder from
   `guard_append_without_resize` (codegen.rs:1646). The helper jitcode BODY must
   contain the generic append incl. realloc so post-guard resume does the right

--- a/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
@@ -1,0 +1,415 @@
+# Issue #143 — Make `list.append`/`list.pop` genuinely inlinable (PyPy-orthodox)
+
+Date: 2026-06-06
+Branch: `pyre-7`
+Issue: https://github.com/youknowone/pyre/issues/143
+
+> **SUPERSEDED IN PART — see "VERIFIED INVESTIGATION (2026-06-06)" at the bottom.**
+> A multi-agent investigation (with adversarial verification + direct re-reads)
+> corrected this doc's central premise. Summary of corrections:
+> 1. The production forward tracer is the hand-written **Python-bytecode walker**;
+>    it does NOT trace into Rust jitcodes. "Remove `dont_look_inside` → the walker
+>    inlines the fast path" is FALSE.
+> 2. `guess_call_kind` classifies `jit_list_append` as `CallKind::Builtin`
+>    (residual) because it is in `LIST_APPEND_TARGETS` — the builtin check
+>    PRECEDES the candidate-graph check (`call.rs:3086`). Removing
+>    `dont_look_inside` alone keeps it residual; it must ALSO be removed from the
+>    oopspec/builtin targets to become a `Regular` candidate.
+> 3. The orthodox resume ("resize guard inside a real callee frame") requires
+>    NEW infrastructure pyre lacks: **the blackhole cannot resume into a helper
+>    (Rust) jitcode** — it only resumes at outer Python opcode boundaries
+>    (`jitcode_dispatch.rs:3740-3756`); the multi-frame snapshot
+>    (`capture_snapshot_for_last_guard_multi_frame_with_vable_vref`) is a named
+>    placeholder. This is the load-bearing cost and the real #73 resume story.
+>    The "resume is free from the pipeline" claim below is WRONG.
+> 4. `Skip` ≠ untranslated: the dual-gate `Skip` arm types a graph via the
+>    LEGACY rtyper (still produces a jitcode). The Match=0 / 926-skip cascade is
+>    the #73 canonical-flip / legacy-retirement concern — ORTHOGONAL to whether
+>    list.append translates. So translation is likely NOT the blocker.
+> 5. The user chose the FULL #73 convergence path (walker → translated-interpreter
+>    jitcode tracing) so the fast path also comes from real tracing.
+
+## Problem
+
+When `list.append(x)` / `list.pop()` are folded into inline IR in a compiled
+trace (strategy guard + `getfield(len)` + resize-guard + `setarrayitem` +
+`setfield(len+1)`), a growing list eventually fails the resize-guard at runtime.
+On that guard failure the blackhole interpreter re-executes the Python `CALL`
+bytecode of the method call and reconstructs the callable as `NULL`, raising
+`TypeError: call on null callable`.
+
+Reproduction:
+
+```python
+def main():
+    xs = []
+    i = 0
+    while i < 5000:
+        xs.append(i)
+        i = i + 1
+    print(len(xs), xs[0], xs[4999])
+main()
+```
+
+## Root cause
+
+The fold is hand-emitted (`generated_list_append_by_strategy`) directly in the
+**outer Python frame** while tracing the `CALL` opcode. So the resize-guard's
+resume PC is the `CALL` PC, and the metainterp framestack at guard-capture is
+just `[python_frame]`. On guard failure the blackhole resumes at the `CALL` and
+re-executes the method-shape call — but the codewriter's static blackhole call
+convention cannot reconstruct a method-shape callable from the deep/shallow
+stack slots, so the callable reads `NULL`.
+
+CPython-shaped workarounds (replaying the `CALL` operands into the guard
+snapshot, materializing the bound method as a constant, reordering the
+codewriter `Call`/`LoadAttr` arms) all bottom out at this wall — they all still
+require the blackhole to re-execute a method-shape `CALL`.
+
+The current branch WIP (`004ca99cf4`) is exactly this workaround
+(`push_call_replay_stack*` + a `load_method` arm that materializes the unbound
+function as a `Const`). It is the path the issue rejects.
+
+## How PyPy does it (the orthodox target)
+
+PyPy traces **into** RPython. `list.append` is RPython (`W_ListObject.append`
+→ strategy → `_ll_list_resize_ge` → store), and the codewriter generates a
+jitcode for it at translation time. When the Python `CALL` is traced, the
+metainterp **inlines** the call: `MIFrame.perform_call` pushes a real `MIFrame`
+for the callee jitcode and traces into it, recording `getfield(len)`, the
+resize check (→ `int_lt` + `guard_true`), `setarrayitem`, `setfield(len+1)`.
+
+At the resize guard, `capture_resumedata` walks the **live framestack**
+`[…, python_frame, …, w_list_append_frame, _ll_list_resize_ge_frame]` and
+snapshots each frame's `(jitcode, pc, live regs)`. The frame chain in the
+resume descriptor falls out automatically because the frames are real.
+
+On guard failure the blackhole rebuilds the chain, runs the innermost callee
+from the guard's realloc branch (`_ll_list_resize_hint_really`, which is
+`@jit.dont_look_inside` → a residual call), does the store, returns up through
+`ll_append`, and finally lands the Python frame at the instruction **after**
+the `CALL` with the result already pending. The `CALL` is never re-executed,
+so `callable = NULL` is structurally impossible.
+
+## Pyre after #121: "RPython" is Rust
+
+#121 replaced the JIT front-end with a **Charon-extracted MIR front-end**. The
+build requires `build/llbc/{pyre-object,pyre-interpreter}.ullbc`, i.e. the
+majit-translate pipeline turns **Rust** (via Charon LLBC) into jitcodes. So
+pyre's "RPython" is Rust, and the metainterp inlines Rust helper calls by
+default (`policy.look_inside_graph` / `guess_call_kind`, faithful ports of
+RPython `JitPolicy`). `#[majit_macros::dont_look_inside]` is the faithful port
+of `@jit.dont_look_inside` and opts a call **out** of inlining (residual).
+
+`jit_list_append` was marked `#[dont_look_inside]` in commit `f6e042f3ab`
+("helper annotations — rlib/jit.py decorator parity"), a blanket annotation
+sweep — **not** because inlining was attempted and failed.
+
+Critically, the Rust list code is favorably structured:
+
+- `ListStrategy` is a `#[repr(u8)]` enum, so strategy dispatch is a `match`,
+  **not** `dyn`-trait dispatch (avoids the documented "no common base"
+  trait-dispatch wall).
+- `object_push` has the exact hot/cold split PyPy traces:
+  ```rust
+  unsafe fn object_push(&mut self, value: PyObjectRef) {
+      if self.length == self.object_items_capacity() {   // → resize GUARD
+          self.object_grow(self.length + 1);              // cold realloc → residual
+      }
+      let base = items_block_items_base(self.items);     // getfield items
+      *base.add(self.length) = value;                     // setarrayitem
+      self.length += 1;                                   // setfield len+1
+  }
+  ```
+- The IR `generated_list_append_by_strategy` hand-emits today is **byte-for-byte
+  the IR real tracing into `w_list_append` would produce** — so the compiled
+  fast-path trace is unchanged by going orthodox; only its *provenance* and the
+  *resume descriptor* change.
+
+## Chosen approach: make `list.append`/`list.pop` genuinely inlinable
+
+Remove `#[dont_look_inside]` from the `jit_list_append`/`jit_list_pop` boundary
+helpers and let the metainterp inline the call, tracing
+`jit_list_append → w_list_append → object_push / IntArray::push / FloatArray::push`.
+Keep the cold paths (`object_grow`/`grow_list_items_block`/realloc,
+`switch_to_*_strategy`) as `#[dont_look_inside]` residual calls — exactly like
+PyPy's `_ll_list_resize_hint_really`.
+
+Result:
+- The resize check becomes a real guard inside the `w_list_append`/`object_push`
+  callee jitcode frame. `capture_resumedata` snapshots
+  `[python_frame @ CALL-fallthrough, w_list_append_callee @ resize-guard]`.
+- On guard failure the blackhole runs the callee from the realloc branch
+  (residual `object_grow`), does the store + length++, returns, and the Python
+  frame continues at the `CALL` fallthrough. No `CALL` re-execution; no null
+  callable.
+- Resume liveness / `pc_map` / per-frame live-value counts come **free** from
+  the normal codewriter pipeline (no hand-built jitcode metadata).
+
+### Why orthodox
+
+- Single source of truth: `w_list_append` — no hand-emitted IR that can diverge
+  from the interpreter's real semantics.
+- Generalizes: pop / insert / extend / other builtins get the same treatment by
+  removing their `dont_look_inside` boundary, not by writing per-op folds.
+- Resume correctness is structural (a real jitcode frame), not bolted on.
+
+### Removed at the end
+
+- `generated_list_append_by_strategy` / `generated_list_pop_by_strategy` and the
+  `guard_append_without_resize` / `guard_pop_without_resize_le` helpers
+  (`majit/majit-translate/src/codegen.rs`).
+- The list-method arms in `call_callable_value` and the list arm in
+  `load_method` (`pyre/pyre-jit-trace/src/trace_opcode.rs`).
+- The WIP workaround: `push_call_replay_stack` /
+  `push_call_replay_stack_self_in_args` / `pop_call_replay_stack*` and the
+  `load_method` Const-materialization arm.
+
+## Gating risk → Phase 0 spike
+
+The only unknown is whether the Charon → majit-translate pipeline ingests
+`w_list_append`'s hot-path subtree as inlinable graphs (raw-pointer ops
+`items_block_items_base` / `base.add`, `IntArray`/`FloatArray` push, capacity
+header read, `is_plain_int1` / `plain_int_w`) and whether the metainterp
+produces a clean trace. The translator frontier can hit walls (untranslatable
+ops needing IR lowerings or `dont_look_inside` boundaries pushed inward).
+
+**Phase 0** is a throwaway spike:
+1. Remove `dont_look_inside` from `jit_list_append`.
+2. Mark `object_grow` / `grow_list_items_block` / `switch_to_*_strategy` as
+   `dont_look_inside`.
+3. Remove the `list_append` fold dispatch so the call stays a plain inlinable
+   call (no hand-emitted fold).
+4. Build, run the reproduction + `bench/list_pop_append.py` on dynasm, observe
+   where the translator or tracer breaks.
+
+Outcomes:
+- (a) Traces clean → proceed to full implementation; the spike is the skeleton.
+- (b) Specific untranslatable ops → add IR lowerings or push `dont_look_inside`
+  boundaries inward (still orthodox), iterate.
+- (c) Deep cascade wall → report honestly; choose between investing in the
+  translator frontier vs. landing the A1 fallback as interim.
+
+## A1 fallback (documented safety net)
+
+If Phase 0 hits a (c) wall, A1 produces the **identical compiled output**:
+hand-emit the fold (keep `generated_list_append_by_strategy`) + synthesize a
+build-time slow-path callee jitcode (`residual_call(jit_list_append, list,
+value); return None`) and inject a synthetic top `SnapshotFrame` so the resize
+guard snapshots `[outer @ fallthrough, synthetic-callee @ slow-path]`. Cost:
+hand-built `JitCodeBody` + a skeleton `PyJitCode` metadata (`pc_map`,
+`stack_base`, liveness offsets) registered by `jitcode_index` — the
+machinery exists (`JitCode::new` + `set_body`, `get_jitcode_by_index`) and a
+working `dispatch_loop` test template exists, but resume needs the metadata
+wired manually. Kept as fallback only; the tracked goal stays the orthodox path.
+
+## Phasing
+
+- **Phase 0** — feasibility spike (de-risk). Throwaway.
+- **Phase 1** — `append` inlinable end-to-end: reproduction + `list_pop_append`
+  append side green on dynasm and cranelift.
+- **Phase 2** — `pop` inlinable: add a `jit_list_pop` boundary helper (none
+  exists today), pop shrink guard via real tracing.
+- **Phase 3** — remove the hand-emitted fold, all list-method special-casing,
+  and the WIP workaround. Verify `check.py` 41/41 both backends + perf gate
+  (`list_pop_append`, `synth/list_append_pop`).
+
+## Acceptance criteria (from the issue)
+
+- `bench/list_pop_append.py` and `bench/synth/list_append_pop.py` pass on both
+  dynasm and cranelift with the append/pop fold enabled (not interpreter
+  fallback).
+- A program growing a list across ≥1 reallocation in a hot loop runs correctly
+  on both backends.
+- The resize-guard failure resumes through the blackhole frame chain without
+  re-executing the `CALL`; no `call on null callable`.
+- No regression in the test suite or benchmark perf gate.
+
+## Key code references
+
+- `pyre/pyre-object/src/listobject.rs` — `jit_list_append` (`dont_look_inside`),
+  `w_list_append`, `object_push`/`object_grow`, `ListStrategy` enum.
+- `pyre/pyre-object/src/{int_array,float_array,object_array}.rs` — typed array
+  push / spare_capacity / grow.
+- `majit/majit-translate/src/jit_codewriter/call.rs` — `CALL_DESCRIPTOR_TABLE`
+  (`LIST_APPEND_TARGETS`), `guess_call_kind`, `policy.look_inside_graph`.
+- `majit/majit-translate/src/codegen.rs` — `generated_list_append_by_strategy`,
+  `generated_list_pop_by_strategy`, `guard_append_without_resize`.
+- `pyre/pyre-jit-trace/src/trace_opcode.rs` — `call_callable_value` list arms,
+  `load_method` list arm, `list_append_value`/`list_pop_value`, the WIP
+  `push_call_replay_stack*`.
+- `pyre/pyre-jit/src/call_jit.rs` — `bh_call_fn_impl_with_frame`, the
+  `resolve_jitcode` closure, `blackhole_from_resumedata`.
+- Build: `scripts/install-charon.sh`, `scripts/extract-llbc.sh`,
+  `pyre/check.py`.
+
+---
+
+# VERIFIED INVESTIGATION (2026-06-06)
+
+A multi-agent workflow (4 parallel readers + synthesis + 3 adversarial
+verifiers) plus direct re-reads established the following. Empirical anchors:
+the bug reproduces (`while i<5000: xs.append(i)` → `TypeError: call on null
+callable` on baseline dynasm); `bench/list_pop_append.py` passes only because
+append↔pop keeps len≈5 (no realloc). (One verifier wrongly claimed the bug was
+"already fixed" by the WIP replay-stack — refuted by the live crash.)
+
+## Architecture (verified)
+
+- **Production forward tracer = hand-written Python-bytecode walker**
+  (`trace_opcode.rs` / `metainterp.rs` / `jitcode_dispatch.rs`). The top driver
+  dispatches each Python opcode via the trait interpreter and diverts only
+  allow-listed opcodes into the codewriter walker
+  (`trace_opcode.rs:6931 production_walker_handles(&instruction) && !in_inline_frame`).
+  The walker DOES record real IR and DOES recurse into sub-jitcodes via
+  `inline_call_*` (`jitcode_dispatch.rs:4526+`) — but only for the opcodes it
+  handles. **`Call{argc}` is NOT walker-handled** (only `CallKw`/`CallFunctionEx`
+  are, `trace_opcode.rs:7752`); `xs.append(i)` is handled by hand-wired
+  trait-dispatch arms in `call_callable_value` (`trace_opcode.rs:5356/5457`) →
+  `list_append_value` (`:5103`) → `generated_list_append_by_strategy`
+  (`codegen.rs:2127`) hand-fold emitted in the OUTER Python frame.
+
+- **Blackhole resume wall (load-bearing)** — `jitcode_dispatch.rs:3740-3756`,
+  verbatim: pyre's blackhole "only knows how to run *pyjitcode* bytecode (Python
+  bytecode), not helper jitcodes … any walker-emitted guard … must resume to the
+  *outer* Python opcode boundary — that is the only resume point pyre's blackhole
+  can re-enter." The multi-frame successor
+  `capture_snapshot_for_last_guard_multi_frame_with_vable_vref` is named as
+  future work ("WalkContext must grow a parent-Python-frame chain"). **Building
+  this — multi-frame snapshot + blackhole resume INTO a helper/Rust jitcode — is
+  the campaign's core deliverable and is exactly the #73 resume convergence.**
+
+- **`guess_call_kind` builtin precedence** — `call.rs:3071-3098`: the
+  `builtin_targets` check (`:3086`) precedes `graphs_from(op).is_none()`
+  (`:3093`). So an oopspec/`*_TARGETS` member is `CallKind::Builtin` (residual)
+  even when it is also a candidate graph. To inline `jit_list_append` it must be
+  removed from `LIST_APPEND_TARGETS` AND lose `dont_look_inside`.
+
+- **`Skip` ≠ untranslated** — `codewriter.rs:324-399`: the dual-gate `Skip` arm
+  falls back to `legacy_annotator::annotate` + `legacy_resolve::resolve_types`
+  (still commits a jitcode). `Match` = the canonical real-rtyper path. The
+  Match=0 / ~926-skip cascade is the #73 canonical-flip / legacy-retirement
+  metric — orthogonal to whether the list subtree translates. The only true
+  panic is `Err` ("PYRE_RTYPER real-path failure", `codewriter.rs:400`): a new
+  unported shape on the canonical path that is not whitelisted as known-unported.
+
+## Goal-directed campaign (full #73 path, chosen)
+
+The smallest slice that puts the resize guard inside a REAL `jit_list_append`
+callee frame with correct resume:
+
+- **REUSE**: walker IR recorder + `inline_call_*` recursion; the hand-wired
+  list devirtualization (receiver=list + method=append behind a strategy guard);
+  `LIST_APPEND_TARGETS` registration (as the recognition hook).
+- **MUST-BUILD (core)**: blackhole multi-frame resume into a Rust callee jitcode
+  + the multi-frame snapshot. This is the #73 resume story; multi-week.
+- **MUST-BUILD (routing)**: make `jit_list_append` a `Regular` candidate (drop
+  it from `LIST_APPEND_TARGETS` + drop `dont_look_inside`) AND drive inline
+  tracing of its jitcode from the trait-dispatch list arm (or add `Call{argc}`
+  to the walker), replacing the hand-fold.
+- **PROBE (one spike-only unknown)**: does the `jit_list_append → w_list_append
+  → object_push / IntArray::push` subtree translate (via Match or legacy Skip)
+  without an `Err` real-path panic? (In progress.)
+
+## Scope verdict (honest)
+
+Genuinely a multi-week campaign. Even the narrow list-only slice is gated on
+building the blackhole resume-into-callee infrastructure (NOT free). Sequence:
+PROBE (resolve translation) → build resume infra (the bulk) → rewire routing →
+verify both backends + perf. The full "move the entire forward driver onto
+translated-interpreter jitcode tracing" is the larger umbrella.
+
+## Milestones
+
+- **M0 PROBE**: confirm the list subtree translates (no `Err` panic); observe
+  Skip(legacy)/Match per graph via `PYRE_RTYPER_VERBOSE=1`. Throwaway edits.
+- **M1 forward trace-into-callee**: `jit_list_append` Regular candidate + trait
+  arm drives inline tracing; observe (MAJIT_LOG) the fold + resize guard emitted
+  inside the `jit_list_append` callee frame. (Resume still broken here.)
+- **M2 resume infra**: multi-frame snapshot + blackhole resume into the callee
+  jitcode; `repro143.py` runs correctly, dynasm.
+- **M3 cranelift parity + pop**: same on cranelift; add `jit_list_pop` path;
+  `list_pop_append` / `synth/list_append_pop` green both backends.
+- **M4 cleanup**: remove the hand-fold + list special-casing + WIP workaround;
+  `check.py` 41/41 both backends + perf gate.
+
+## CORE BUILD STATUS (2026-06-06, verdict-corrected)
+
+A 3-agent adversarial build-plan workflow + direct re-reads refined the model
+above. The user chose to build the **core resume infra first**.
+
+### Corrected resume model (supersedes the "Blackhole resume wall" item)
+
+- The blackhole resume **engine** `blackhole_from_resumedata` (resume.rs:6775)
+  is ALREADY jitcode-agnostic. Proof: the passing test
+  `blackhole_from_resumedata_accepts_runtime_jitcode_without_canonical_pair`
+  (resume.rs:4935) drives it with a CodeObject-less hand-built jitcode. The
+  chain loop (resume.rs:6824-6845) resolves every frame uniformly via the
+  caller `resolve_jitcode` closure + `consume_one_section`; it does NOT branch
+  on Python-vs-helper.
+- The "NAMED PLACEHOLDER" wall is the **walker's** multi-frame helper. But
+  `list.append` does NOT use the walker — its resize `GuardTrue` is emitted by
+  `MIFrame::generate_guard` (trace_opcode.rs:3567) on the **metainterp** path
+  (codegen.rs:1669). So CORE extends `generate_guard` →
+  `build_framestack_snapshot` (trace_opcode.rs:3817) → `blackhole_from_resumedata`,
+  NOT a walker placeholder.
+- **interpret() can't trace a Rust callee.** `PyreMetaInterp::interpret`
+  (metainterp.rs:88-99) decodes `top.jitcode` as a `W_CodeObject` (Python
+  bytecode) via `cf.next_instr()`. So we CANNOT push a real Rust-callee MIFrame
+  and let interpret() trace it. The fast path stays the hand-fold
+  (`generated_list_append_by_strategy`); CORE only needs to **synthesize the
+  callee SnapshotFrame at the resize guard** so RESUME enters the helper.
+
+### Verdict-converged load-bearing gaps
+
+1. Top-level `xs.append(i)` has EMPTY `self.parent_frames` → `generate_guard`
+   takes the single-frame fallback (trace_opcode.rs:3660-3675) with
+   `resume_pc = orgpc` (the CALL) → re-exec CALL = the null-callable bug. #143
+   MUST make the snapshot `[callee=helper@guard-pc, parent=outer-Python@post-CALL-fallthrough, …self.parent_frames]`.
+   (The HEAD `push_call_replay_stack` WIP does NOT push/synthesize a frame — it
+   only re-stages operands → still re-execs the CALL → wrong.)
+2. The callee frame needs a valid `jitcode_index` (`build_framestack_snapshot`
+   reads `(*self.sym().jitcode).index`, trace_opcode.rs:3826).
+3. cranelift x86_64 GC-root crash: the callee's extra `[list,value]` refs land
+   in blackhole `registers_r` and become GC roots → recurring typeid OOB at
+   trace.rs:820 (see memory `cranelift-linux-gc-typeid-crash`). OPEN — only
+   ubuntu cranelift CI can validate; gate cranelift to baseline until cleared.
+
+### KEY INSIGHT — identity pc_map closes gap 2 with NO production resolve change
+
+`resolve_jitcode` (call_jit.rs:1318) maps `resume_jitcode_pc_for(pc)` =
+`pc_map.get(pc)`. Register the helper with an **identity pc_map** (`pc_map[i]==i`)
+so a jitcode byte-offset resumes to itself. And `jitcode_for` /
+`portal_bridge_jitcode_for` (state.rs:360/332) already assign
+`index = jitcodes.len()` at RUNTIME (not just startup) — so runtime index
+registration is one new method, not an architecture change. (feasibility
+verdict's "index registration UNIMPLEMENTED" was overstated.)
+
+### M-core milestones (refines M1–M4 above)
+
+- **M-core1 — LANDED (uncommitted, tested).** `MetaInterpStaticData::
+  register_runtime_helper_jitcode` (state.rs, after :394; null `w_code`, identity
+  pc_map, `#[allow(dead_code)]` until M-core2 wires it). Test
+  `register_runtime_helper_jitcode_resolves_by_index_with_identity_pc`
+  (indirectcalltargets_tests) proves production `pyjitcode_for_jitcode_index(idx)`
+  resolves the helper and `resume_jitcode_pc_for(off)==off`. PASSES under
+  `cargo test -p pyre-jit-trace --no-default-features --features dynasm`.
+- **M-core2 — synthesize callee SnapshotFrame.** A `build_framestack_snapshot`
+  variant that prepends a top `SnapshotFrame{jitcode_index=helper, pc=guard_offset,
+  boxes=[list,value]}` (NO `NUM_SCALAR_INPUTARGS` header-skip — a helper has no
+  scalar-inputarg header; verify this), then demotes the current `self`
+  (outer Python frame) to the first parent at `resume_pc=fallthrough_pc` via
+  `materialize_parent_snapshot_state` (trace_opcode.rs:3925), then
+  `self.parent_frames`. MIFrame holds `&mut PyreSym`, so demoting self needs a
+  `ResumeFrameState{sym: self.sym as *mut …}` re-borrow (same raw-ptr pattern
+  the parent path already uses).
+- **M-core3 — wire + real helper body.** Call the M-core2 builder from
+  `guard_append_without_resize` (codegen.rs:1646). The helper jitcode BODY must
+  contain the generic append incl. realloc so post-guard resume does the right
+  work, and `guard_offset` must land at the resize branch. Option B (CORE seam,
+  hand-built body — what M-core1 registers today, empty) proves the wiring;
+  Option A (codewriter discovery so `make_jitcodes` builds the real body) is the
+  orthodox follow-up. End-to-end gate: `repro143.py`
+  (`while i<5000: xs.append(i)`) stops crashing on dynasm.
+- **M-core4 — cranelift gate** (gap 3). Validate on ubuntu cranelift CI; keep
+  cranelift on baseline (re-exec-CALL) until the GC-root path is proven safe.

--- a/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
@@ -431,13 +431,82 @@ verdict's "index registration UNIMPLEMENTED" was overstated.)
   the box on resume); and method (3)'s vable/vref tail is unit-untested (it would
   SEGV on a skeleton helper's null code — needs a real PyFrame or seeded
   `virtualizable_array_lengths`).
-- **M-core3 — wire + real helper body.** Call the M-core2 builder from
-  `guard_append_without_resize` (codegen.rs:1646). The helper jitcode BODY must
-  contain the generic append incl. realloc so post-guard resume does the right
-  work, and `guard_offset` must land at the resize branch. Option B (CORE seam,
-  hand-built body — what M-core1 registers today, empty) proves the wiring;
-  Option A (codewriter discovery so `make_jitcodes` builds the real body) is the
-  orthodox follow-up. End-to-end gate: `repro143.py`
-  (`while i<5000: xs.append(i)`) stops crashing on dynasm.
+- **M-core3 — wire + real helper body. VERIFIED PLAN (2026-06-06, workflow
+  `wzunyzc9c`: 6 findings + synth `feasible-with-changes` + 3 adversarial
+  verdicts, all source-grounded).** The whole stack exists; no architecture
+  change. Implement in committable increments:
+  - **Helper body (the resumable callee).** The blackhole CAN execute a
+    hand-built runtime-helper jitcode that does a residual call: wired handlers
+    `residual_call_r_v/iRd` … `residual_call_irf_*` (blackhole.rs:6819-6828);
+    `read_descr` reads `bh.jitcode.exec.descrs[idx]` (blackhole.rs:5066, fallback
+    `bh.descrs`); `setup_return_value_r` threads a returning callee's result into
+    `caller.registers_r[caller.code[caller.position-1]]` (blackhole.rs:677-688)
+    and `resume_mainloop`/`run_forever` (blackhole.rs:727,2180) drive the chain.
+    Build the body with the **high-level `JitCodeBuilder`** (majit-metainterp
+    jitcode/assembler.rs), NOT raw bytes: `b.live(...)` (resume-entry liveness
+    marker, live_r=[0,1] = list,value) → `b.residual_call_void_canonical_typed_args(
+    jit_list_append as i64, &[JitCallArg{reg:0,Ref}, JitCallArg{reg:1,Ref}],
+    BhCallDescr::from_arg_classes("rr".into(), 'v', default_effect_info()))`
+    (:2072) → `b.ref_return_const(w_none() as i64)` (:1690) → `b.finish()`.
+    **CORRECTNESS FIX (found vs the draft):** `jit_list_append` returns `0`
+    always (listobject.rs:1107, side-effect-only via `w_list_append`); the
+    existing emit treats it VOID (helpers.rs:524). `None` in pyre is `w_none()`
+    (a real pointer), **NOT** `0`/null — so the helper must do a VOID append then
+    `ref_return_const(w_none())`, never reinterpret the `0` as `GcRef(0)`. Wrap
+    `finish()` in `PyJitCode::from_parts` with IDENTITY pc_map `(0..len)` + null
+    `w_code`, register via M-core1 `register_runtime_helper_jitcode`.
+  - **Increment 1 — LANDED (tested, both backends).** `build_list_append_resize_helper_payload()`
+    (state.rs, after `register_runtime_helper_jitcode`) + a unit test
+    `list_append_resize_helper_appends_and_returns_none_through_blackhole` that
+    drives it through the REAL `build_pyre_production_bh_builder()`
+    (jitcode_runtime.rs:503) blackhole as a single bottommost frame — builds a
+    `W_ListObject` filled to the `IntArray` inline boundary (`INT_ARRAY_INLINE_CAP`=8,
+    spare 0 → next append MUST realloc, asserted via `w_list_can_append_without_realloc`),
+    `setposition(payload,0)`, `setarg_r(0,list)`/`setarg_r(1,value)`,
+    `run_forever(&mut builder, bh, 0)`, asserts `DoneWithThisFrameRef(w_none())` +
+    `w_list_len` grew by 1. Proves the residual call EXECUTES end-to-end (the one
+    gap the resume.rs:4935 test leaves — it proves the chain BUILDS, not that
+    opcodes RUN). check.py-suite unaffected; 233/233 lib tests both backends.
+    **Plan deviations discovered + resolved while grounding:**
+    (a) `default_effect_info()` → used `EffectInfo::MOST_GENERAL` (what
+    `BhCallDescr::default()` carries; conservative, and `bh_call_v` ignores
+    extra_info anyway — only `arg_classes` drives dispatch). (b) The "builder
+    needs the global insns table" note was WRONG: `write_insn` resolves via the
+    STATIC `wellknown_bh_insns()` table (insns.rs), so building needs NO prior
+    init; the production-bh-builder init is only for the blackhole's `op_*` cache
+    + cpu wiring at EXECUTE time. (c) `live(&mut asm,…)` needs an `Assembler` —
+    used a throwaway local `Assembler::new()`; safe because `handler_live` only
+    SKIPS the 2-byte offset (never derefs it) and `run` roots all of `registers_r`
+    via `push_bh_regs`, so the local intern is inert at resume + GC-covered.
+    (d) Test gated `#[cfg(any(feature="dynasm",feature="cranelift"))]`: without a
+    backend `builder.cpu` is `None` and the residual handler's `cpu()` panics.
+  - **Increment 2 (committable):** 2-frame chain test (stub-caller + helper) via
+    `run_forever`, proving `setup_return_value_r` threads `w_none()` into the
+    caller's `code[position-1]` register. Isolates the return convention WITHOUT
+    pyre's real Python CALL layout.
+  - **Increment 3-5 (tracer wiring):** memoized `ensure_list_append_resize_helper_index()`
+    (thread_local Cell, build payload BEFORE the METAINTERP_SD borrow — `intern_liveness`
+    re-borrows it → nested-borrow panic otherwise); `capture_resumedata_with_synthetic_callee`
+    on MIFrame (saves/restores orgpc+vable_last_instr+vable_valuestackdepth like
+    capture_resumedata trace_opcode.rs:3742-3771, sets orgpc=fallthrough before the
+    build); `generate_guard_with_synthetic_callee` (record_guard_typed BEFORE
+    set_last_guard_resume_position; fail_arg_types in snapshot box order
+    [helper,self,parents]); then codegen.rs:1646 — add `value: OpRef` to
+    `guard_append_without_resize`, pass `value` from generated_list_append_by_strategy
+    (:2143), and route to the synthetic guard ONLY when `value_type(value)==Ref`
+    (else single-frame fallback). `result_stack_idx` = COMPUTE from
+    `sym().valuestackdepth`/`nlocals` (do NOT hardcode `Some(0)`); `result_type=Ref`.
+  - **Increment 6 (gate):** `repro143.py` (`while i<5000: xs.append(i)`) stops
+    crashing on dynasm; check.py green both backends.
+  - **LOAD-BEARING UNPROVEN (all 3 verifiers):** the `setup_return_value_r`
+    `code[position-1]` result-register convention is verified for normal inline
+    calls but UNPROVEN for a folded-method-CALL fallthrough in pyre's real Python
+    jitcode. Increment 2 tests the mechanism in isolation; Increment 6 is the real
+    proof. If wrong, set the self-frame resume pc to the exact post-call
+    result-register offset instead of generic `fallthrough_pc`.
+  - **cranelift = M-core4:** if the extra `[list,value]` callee refs regress
+    cranelift x86_64 GC roots, gate the synthetic path to dynasm
+    (`cfg!(feature="cranelift") -> single-frame fallback`, nbody-entry-bridge
+    style) and defer.
 - **M-core4 — cranelift gate** (gap 3). Validate on ubuntu cranelift CI; keep
   cranelift on baseline (re-exec-CALL) until the GC-root path is proven safe.

--- a/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
@@ -494,9 +494,22 @@ verdict's "index registration UNIMPLEMENTED" was overstated.)
     (already used by every inline call) — the genuinely unproven part (that the
     real Python jitcode's fallthrough `code[position-1]` IS the append's result
     slot) is still increment 6's job; see LOAD-BEARING UNPROVEN below.
-  - **Increment 3-5 (tracer wiring):** memoized `ensure_list_append_resize_helper_index()`
-    (thread_local Cell, build payload BEFORE the METAINTERP_SD borrow — `intern_liveness`
-    re-borrows it → nested-borrow panic otherwise); `capture_resumedata_with_synthetic_callee`
+  - **Increment 3 — memoized helper index — LANDED (tested, both backends).**
+    `ensure_list_append_resize_helper_index()` (state.rs free fn) →
+    `MetaInterpStaticData::ensure_list_append_resize_helper_jitcode` registers the
+    payload once and caches the index in a NEW SD field
+    `list_append_resize_helper_index: Option<i32>` (NOT a thread_local Cell — the
+    field is reset-safe: it lives/dies with the `jitcodes` table, and the index
+    stays valid because `set_jitcodes_from_make_result` only updates
+    W_CodeObject-keyed entries [helper carries null `w_code`] and appends, never
+    shifting an existing index). The "build BEFORE the METAINTERP_SD borrow /
+    intern_liveness nested-borrow" caveat is MOOT — the inc.1 builder uses a
+    throwaway local `Assembler`, touching no thread-local, so the build is safe
+    even inside `borrow_mut`. Test
+    `ensure_list_append_resize_helper_index_is_stable_and_resolves`: second call
+    returns same index; resolves to a populated non-skeleton null-`w_code` payload
+    with identity pc_map. 235/235 lib tests both backends.
+  - **Increment 4-5 (tracer wiring) — REMAINING:** `capture_resumedata_with_synthetic_callee`
     on MIFrame (saves/restores orgpc+vable_last_instr+vable_valuestackdepth like
     capture_resumedata trace_opcode.rs:3742-3771, sets orgpc=fallthrough before the
     build); `generate_guard_with_synthetic_callee` (record_guard_typed BEFORE

--- a/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue143-list-append-pop-inlinable-jitcode-design.md
@@ -480,10 +480,20 @@ verdict's "index registration UNIMPLEMENTED" was overstated.)
     via `push_bh_regs`, so the local intern is inert at resume + GC-covered.
     (d) Test gated `#[cfg(any(feature="dynasm",feature="cranelift"))]`: without a
     backend `builder.cpu` is `None` and the residual handler's `cpu()` panics.
-  - **Increment 2 (committable):** 2-frame chain test (stub-caller + helper) via
-    `run_forever`, proving `setup_return_value_r` threads `w_none()` into the
-    caller's `code[position-1]` register. Isolates the return convention WITHOUT
-    pyre's real Python CALL layout.
+  - **Increment 2 — LANDED (tested, both backends).** 2-frame chain test
+    `list_append_resize_helper_threads_none_into_caller_result_register`
+    (stub-caller + real helper) via `run_forever`, proving `setup_return_value_r`
+    threads `w_none()` into the caller's `code[position-1]` register. Stub caller
+    jitcode = `[dest_reg=0, BC_REF_RETURN, r0]` resumed at position 1
+    (`code[0]`=the post-CALL result-register byte); chain linked
+    `helper.nextblackholeinterp = Some(caller)`, helper runs first, threads None
+    into caller r0, caller `ref_return r0` → `DoneWithThisFrameRef(w_none())`.
+    Isolates the return convention WITHOUT pyre's real Python CALL layout (the
+    real fallthrough layout is the increment-6 proof). 234/234 lib tests both
+    backends. NOTE: only re-confirms the GENERIC `setup_return_value_r` mechanism
+    (already used by every inline call) — the genuinely unproven part (that the
+    real Python jitcode's fallthrough `code[position-1]` IS the append's result
+    slot) is still increment 6's job; see LOAD-BEARING UNPROVEN below.
   - **Increment 3-5 (tracer wiring):** memoized `ensure_list_append_resize_helper_index()`
     (thread_local Cell, build payload BEFORE the METAINTERP_SD borrow — `intern_liveness`
     re-borrows it → nested-borrow panic otherwise); `capture_resumedata_with_synthetic_callee`

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -1647,6 +1647,7 @@ fn guard_append_without_resize(
     frame: &mut crate::state::MIFrame,
     ctx: &mut majit_metainterp::TraceCtx,
     list: majit_ir::OpRef,
+    value: majit_ir::OpRef,
     strategy_id: i64,
     len: majit_ir::OpRef,
     is_inline: bool,
@@ -1666,7 +1667,25 @@ fn guard_append_without_resize(
     {
         ctx.set_opref_concrete(has_room, majit_ir::Value::Int((l < c) as i64));
     }
-    frame.generate_guard(ctx, OpCode::GuardTrue, &[has_room]);
+    // Issue #143: when the appended `value` is a real `PyObjectRef` (Ref),
+    // route the resize guard through a synthetic-callee snapshot so a
+    // realloc-driven guard failure resumes into the `jit_list_append`
+    // helper jitcode (re-doing the append generically) and the Python
+    // frame continues after the method-shape CALL — instead of
+    // re-executing the CALL and rebuilding a NULL callable. An unboxed
+    // (Int/Float) value cannot feed the Ref-typed helper, so fall back to
+    // the single-frame guard.
+    if frame.value_type(value) == majit_ir::Type::Ref {
+        frame.generate_guard_with_synthetic_callee(
+            ctx,
+            OpCode::GuardTrue,
+            &[has_room],
+            list,
+            value,
+        );
+    } else {
+        frame.generate_guard(ctx, OpCode::GuardTrue, &[has_room]);
+    }
 }
 
 #[inline]
@@ -2190,7 +2209,7 @@ pub fn generated_list_append_by_strategy(
 
     let len_descr = list_len_descr_for_strategy(strategy_id);
     let len = crate::state::opimpl_getfield_gc_i(ctx, list, len_descr.clone());
-    guard_append_without_resize(frame, ctx, list, strategy_id, len, is_inline);
+    guard_append_without_resize(frame, ctx, list, value, strategy_id, len, is_inline);
 
     // Write value: object strategy stores directly, int/float unbox first.
     match strategy_id {

--- a/pyre/bench/synth/list_bound_method_mutation.py
+++ b/pyre/bench/synth/list_bound_method_mutation.py
@@ -1,0 +1,34 @@
+# Bound list methods flowing as values (`m = xs.append; m(i)`) dispatch the
+# JIT's W_MethodObject method-form arms, which get NO concrete execution
+# during tracing — their heap effect must stay deferred (no dm143 advance),
+# unlike the builtin-form `xs.append(i)` shape which mutates concretely
+# during trace and is advanced past the traced iteration.
+N = 200000
+
+
+def main():
+    xs = []
+    m_append = xs.append
+    i = 0
+    while i < N:
+        m_append(i)
+        i = i + 1
+
+    acc = 0
+    m_pop = xs.pop
+    j = 0
+    while j < N // 4:
+        acc = acc + m_pop()
+        j = j + 1
+
+    k = 0
+    while k < N // 16:
+        acc = acc + m_pop(0)
+        k = k + 1
+
+    m_rev = xs.reverse
+    m_rev()
+    print(len(xs), acc, xs[0], xs[len(xs) - 1])
+
+
+main()

--- a/pyre/bench/synth/load_attr_blackhole_resume.py
+++ b/pyre/bench/synth/load_attr_blackhole_resume.py
@@ -1,0 +1,25 @@
+# Guard-failure blackhole resume across a LOAD_ATTR (issue #143 guard-12
+# class).  The rare branch fails its guard until the bridge threshold, and
+# each failure resumes the rest of the iteration through `c.v` — the
+# jitcode position that used to carry `abort_permanent` (which crashed the
+# blackhole with an out-of-bounds register read) and is now lowered to the
+# `load_attr_fn` residual call by the canonical splice.
+class C:
+    def __init__(self):
+        self.v = 3
+
+
+def run(c, n):
+    total = 0
+    i = 0
+    while i < n:
+        if i % 37 == 36:
+            k = 2
+        else:
+            k = 1
+        total += c.v * k
+        i += 1
+    return total
+
+
+print(run(C(), 300000))

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2068,6 +2068,117 @@ impl ConstantOpcodeHandler for PyFrame {
     }
 }
 
+/// Compute the `null_or_self` value LOAD_METHOD pushes alongside the
+/// resolved attribute `attr` (the result of `getattr(obj, name)`).
+///
+/// Pure MRO inspection (`lookup_in_type` + descriptor-kind predicates) —
+/// it never invokes a descriptor `__get__` or `__getattribute__`, so the
+/// side effects already paid by the `getattr` that produced `attr` are not
+/// repeated.  Shared by [`PyFrame::load_method`] and the blackhole residual
+/// helper `bh_load_method_self_fn` so both bind self identically.
+///
+///  - regular method → bind instance (self)
+///  - classmethod → bind class (w_type)
+///  - staticmethod / property / member / type / getset → no binding (NULL)
+///  - builtin type method (list.append etc.) → bind instance
+pub fn compute_load_method_bound(
+    obj: PyObjectRef,
+    attr: PyObjectRef,
+    name: &str,
+) -> PyObjectRef {
+    unsafe {
+        if pyre_object::is_method(attr) {
+            return PY_NULL;
+        }
+        if pyre_object::is_instance(obj) {
+            // callmethod.py:66-67 `w_value = w_obj.getdictvalue(space, name)`:
+            // a shadowing instance attribute is what getattr returned for
+            // every non-data descriptor — never bind self for it.  (Data
+            // descriptors that win over the instance dict — property /
+            // member — resolve to PY_NULL either way.)
+            let shadowed =
+                crate::objspace::std::mapdict::instance_node_getdictvalue(obj, name).is_some();
+            let w_type = pyre_object::w_instance_get_type(obj);
+            let raw = crate::baseobjspace::lookup_in_type(w_type, name);
+            match raw {
+                _ if shadowed => PY_NULL,
+                Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
+                // ClassMethod.__get__ → Method(func, klass)
+                Some(d) if pyre_object::is_classmethod(d) => w_type,
+                // Type / property / member descriptors stored as class
+                // attributes are NOT methods — invoking them must not
+                // prepend self.  e.g. `class L: inner = list; L().inner(x)`
+                // calls list(x), not list(L(), x).
+                Some(d) if pyre_object::is_type(d) => PY_NULL,
+                Some(d) if pyre_object::is_property(d) => PY_NULL,
+                Some(d) if pyre_object::is_member(d) => PY_NULL,
+                Some(d) if crate::is_function(d) => {
+                    let ob_type = (*d).ob_type;
+                    if std::ptr::eq(ob_type, &crate::BUILTIN_FUNCTION_TYPE as *const _) {
+                        // BuiltinFunction has no __get__.
+                        PY_NULL
+                    } else if std::ptr::eq(ob_type, &crate::FUNCTION_TYPE as *const _)
+                        && crate::is_builtin_code(
+                            crate::function_get_code(d) as pyre_object::PyObjectRef
+                        )
+                    {
+                        // FunctionWithFixedCode (interp2app) on a builtin
+                        // type — `dict.get` etc. — binds like a method.
+                        obj
+                    } else {
+                        obj
+                    }
+                }
+                Some(_) => obj, // found in type MRO → bind self (method)
+                None => {
+                    // Not found in type MRO → found in instance __dict__.
+                    // Instance __dict__ attrs bypass descriptor protocol.
+                    PY_NULL
+                }
+            }
+        } else if pyre_object::is_type(obj) {
+            // Type object: check for classmethod in type's MRO
+            let raw = crate::baseobjspace::lookup_in_type(obj, name);
+            match raw {
+                Some(d) if pyre_object::is_classmethod(d) => obj,
+                Some(_) => PY_NULL, // found in own MRO → no binding
+                None => {
+                    // Not found in type's own MRO → check metaclass MRO.
+                    // If found there, bind obj (the type) as self.
+                    obj
+                }
+            }
+        } else if let Some(w_type) =
+            crate::typedef::r#type(obj).filter(|_| !pyre_object::is_module(obj))
+        {
+            // Builtin type method (list.append, etc.) found via TypeDef.
+            // LOOKUP_METHOD binds self for builtin type methods, except
+            // staticmethods (str.maketrans) and classmethods (dict.fromkeys),
+            // which getattr already unwrapped above.
+            //
+            // A builtin-storage subclass instance (`class MyInt(int)`, enum
+            // members) is not is_instance-shaped, so it reaches this branch
+            // too; its `w_type` is the subclass with a full MRO.  Non-method
+            // descriptors (type / property / member / getset such as
+            // `__class__`) do not prepend self, and an attribute not in the
+            // type MRO (a special attribute resolved directly in getattr, or
+            // an instance-dict entry) binds none.
+            match crate::baseobjspace::lookup_in_type(w_type, name) {
+                Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
+                Some(d) if pyre_object::is_classmethod(d) => w_type,
+                Some(d) if pyre_object::is_type(d) => PY_NULL,
+                Some(d) if pyre_object::is_property(d) => PY_NULL,
+                Some(d) if pyre_object::is_member(d) => PY_NULL,
+                Some(d) if pyre_object::getsetproperty::is_getset_property(d) => PY_NULL,
+                Some(_) => obj,
+                None => PY_NULL,
+            }
+        } else {
+            PY_NULL
+        }
+    }
+}
+
 impl OpcodeStepExecutor for PyFrame {
     /// SETUP_ANNOTATIONS — ensure `__annotations__` exists in the
     /// current locals namespace. PyPy: pyopcode.py SETUP_ANNOTATIONS
@@ -3024,114 +3135,11 @@ impl OpcodeStepExecutor for PyFrame {
             return Ok(());
         }
         let attr = crate::baseobjspace::getattr_str(obj, name)?;
-        if unsafe { pyre_object::is_method(attr) } {
-            self.push(attr);
-            self.push(PY_NULL);
-            return Ok(());
-        }
+        // LOOKUP_METHOD pushes (attr, null_or_self): the resolved attribute
+        // first, then the bound receiver computed by the shared, side-effect
+        // free binding decision (NULL when no self should be prepended).
+        let bound = compute_load_method_bound(obj, attr, name);
         self.push(attr);
-        // Bind self only for regular instance method calls.
-        // staticmethod/classmethod descriptors already unwrap to the raw
-        // function via getattr → get; self must NOT
-        // be prepended for those.
-        // PyPy: LOOKUP_METHOD checks whether the attr came from a
-        // non-data descriptor that is a plain function (not staticmethod).
-        // Determine what to bind as null_or_self.
-        // PyPy: LOOKUP_METHOD resolves descriptors and decides binding.
-        //  - regular method → bind instance (self)
-        //  - classmethod → bind class (w_type)
-        //  - staticmethod → no binding (NULL)
-        //  - builtin type method (list.append etc.) → bind instance
-        let bound = unsafe {
-            if pyre_object::is_instance(obj) {
-                // callmethod.py:66-67 `w_value = w_obj.getdictvalue(space, name)`:
-                // a shadowing instance attribute is what getattr returned for
-                // every non-data descriptor — never bind self for it.  (Data
-                // descriptors that win over the instance dict — property /
-                // member — resolve to PY_NULL either way.)
-                let shadowed =
-                    crate::objspace::std::mapdict::instance_node_getdictvalue(obj, name).is_some();
-                let w_type = pyre_object::w_instance_get_type(obj);
-                let raw = crate::baseobjspace::lookup_in_type(w_type, name);
-                match raw {
-                    _ if shadowed => PY_NULL,
-                    Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
-                    // PyPy: ClassMethod.__get__ → Method(func, klass)
-                    Some(d) if pyre_object::is_classmethod(d) => w_type,
-                    // Type / property / member descriptors stored as class
-                    // attributes are NOT methods — invoking them must not
-                    // prepend self.  e.g. `class L: inner = list; L().inner(x)`
-                    // calls list(x), not list(L(), x).
-                    Some(d) if pyre_object::is_type(d) => PY_NULL,
-                    Some(d) if pyre_object::is_property(d) => PY_NULL,
-                    Some(d) if pyre_object::is_member(d) => PY_NULL,
-                    Some(d) if crate::is_function(d) => {
-                        let ob_type = (*d).ob_type;
-                        if std::ptr::eq(ob_type, &crate::BUILTIN_FUNCTION_TYPE as *const _) {
-                            // BuiltinFunction has no __get__ in PyPy.
-                            PY_NULL
-                        } else if std::ptr::eq(ob_type, &crate::FUNCTION_TYPE as *const _)
-                            && crate::is_builtin_code(
-                                crate::function_get_code(d) as pyre_object::PyObjectRef
-                            )
-                        {
-                            // FunctionWithFixedCode (interp2app) on a builtin
-                            // type — `dict.get` etc. — binds like a method.
-                            obj
-                        } else {
-                            obj
-                        }
-                    }
-                    Some(_) => obj, // found in type MRO → bind self (method)
-                    None => {
-                        // Not found in type MRO → found in instance __dict__.
-                        // Instance __dict__ attrs bypass descriptor protocol.
-                        PY_NULL
-                    }
-                }
-            } else if pyre_object::is_type(obj) {
-                // Type object: check for classmethod in type's MRO
-                let raw = crate::baseobjspace::lookup_in_type(obj, name);
-                match raw {
-                    Some(d) if pyre_object::is_classmethod(d) => obj,
-                    Some(_) => PY_NULL, // found in own MRO → no binding
-                    None => {
-                        // Not found in type's own MRO → check metaclass MRO.
-                        // If found there, bind obj (the type) as self.
-                        // PyPy: type.__getattribute__ metatype descriptor binding.
-                        obj
-                    }
-                }
-            } else if let Some(w_type) =
-                crate::typedef::r#type(obj).filter(|_| !pyre_object::is_module(obj))
-            {
-                // Builtin type method (list.append, etc.) found via TypeDef.
-                // PyPy: LOOKUP_METHOD binds self for builtin type methods,
-                // except staticmethods (str.maketrans) and classmethods
-                // (dict.fromkeys), which getattr already unwrapped above.
-                //
-                // A builtin-storage subclass instance (`class MyInt(int)`,
-                // enum members) is not is_instance-shaped, so it reaches this
-                // branch too; its `w_type` is the subclass with a full MRO.
-                // Mirror the is_instance branch: non-method descriptors
-                // (type / property / member / getset such as `__class__`) do
-                // not prepend self, and an attribute not in the type MRO (a
-                // special attribute like `__class__`/`__dict__`, resolved
-                // directly in getattr, or an instance-dict entry) binds none.
-                match crate::baseobjspace::lookup_in_type(w_type, name) {
-                    Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
-                    Some(d) if pyre_object::is_classmethod(d) => w_type,
-                    Some(d) if pyre_object::is_type(d) => PY_NULL,
-                    Some(d) if pyre_object::is_property(d) => PY_NULL,
-                    Some(d) if pyre_object::is_member(d) => PY_NULL,
-                    Some(d) if pyre_object::getsetproperty::is_getset_property(d) => PY_NULL,
-                    Some(_) => obj,
-                    None => PY_NULL,
-                }
-            } else {
-                PY_NULL
-            }
-        };
         self.push(bound);
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2108,6 +2108,10 @@ pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str
                 Some(d) if pyre_object::is_type(d) => PY_NULL,
                 Some(d) if pyre_object::is_property(d) => PY_NULL,
                 Some(d) if pyre_object::is_member(d) => PY_NULL,
+                // Getset descriptors (`__class__`, `__dict__`, ...) are data
+                // descriptors: getattr already ran `__get__`, so the loaded
+                // value must not prepend self.
+                Some(d) if pyre_object::getsetproperty::is_getset_property(d) => PY_NULL,
                 Some(d) if crate::is_function(d) => {
                     let ob_type = (*d).ob_type;
                     if std::ptr::eq(ob_type, &crate::BUILTIN_FUNCTION_TYPE as *const _) {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2068,6 +2068,35 @@ impl ConstantOpcodeHandler for PyFrame {
     }
 }
 
+/// `callmethod.py:66-78` fast-path discriminator: bind the receiver only
+/// when the MRO descriptor `d` is a method-descriptor-typed function
+/// (`flag_method_descriptor` — set on `function` alone, typedef.py:807)
+/// that `getattr` surfaced unchanged.  The `d == attr` identity check is
+/// the moral equivalent of `w_obj.getdictvalue(space, name) is None` plus
+/// `has_object_getattribute()` (callmethod.py:46/67): an instance-dict
+/// shadow, a descriptor `__get__` result, or a `__getattribute__` override
+/// all hand `getattr` a different object than the raw descriptor.
+/// Everything else takes the slow path (callmethod.py:79-82): the getattr
+/// result is called as-is, with no self binding.
+unsafe fn method_descriptor_bound(
+    d: PyObjectRef,
+    attr: PyObjectRef,
+    obj: PyObjectRef,
+) -> PyObjectRef {
+    unsafe {
+        if d != attr || !crate::is_function(d) {
+            return PY_NULL;
+        }
+        // BuiltinFunction has no `__get__` (its typedef carries no
+        // `method_descriptor` flag, function.py:783).
+        if std::ptr::eq((*d).ob_type, &crate::BUILTIN_FUNCTION_TYPE as *const _) {
+            PY_NULL
+        } else {
+            obj
+        }
+    }
+}
+
 /// Compute the `null_or_self` value LOAD_METHOD pushes alongside the
 /// resolved attribute `attr` (the result of `getattr(obj, name)`).
 ///
@@ -2077,10 +2106,11 @@ impl ConstantOpcodeHandler for PyFrame {
 /// repeated.  Shared by [`PyFrame::load_method`] and the blackhole residual
 /// helper `bh_load_method_self_fn` so both bind self identically.
 ///
-///  - regular method → bind instance (self)
+///  - method-descriptor function surfaced unchanged by getattr → bind
+///    instance (self); see [`method_descriptor_bound`]
 ///  - classmethod → bind class (w_type)
-///  - staticmethod / property / member / type / getset → no binding (NULL)
-///  - builtin type method (list.append etc.) → bind instance
+///  - everything else (staticmethod / non-method descriptors / shadowed
+///    or arbitrary class attrs) → no binding (NULL)
 pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str) -> PyObjectRef {
     unsafe {
         if pyre_object::is_method(attr) {
@@ -2098,38 +2128,12 @@ pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str
             let raw = crate::baseobjspace::lookup_in_type(w_type, name);
             match raw {
                 _ if shadowed => PY_NULL,
+                // staticmethod / classmethod wrappers: getattr already
+                // unwrapped them, so the identity fast path below can never
+                // match; classmethod keeps its explicit cls binding.
                 Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
-                // ClassMethod.__get__ → Method(func, klass)
                 Some(d) if pyre_object::is_classmethod(d) => w_type,
-                // Type / property / member descriptors stored as class
-                // attributes are NOT methods — invoking them must not
-                // prepend self.  e.g. `class L: inner = list; L().inner(x)`
-                // calls list(x), not list(L(), x).
-                Some(d) if pyre_object::is_type(d) => PY_NULL,
-                Some(d) if pyre_object::is_property(d) => PY_NULL,
-                Some(d) if pyre_object::is_member(d) => PY_NULL,
-                // Getset descriptors (`__class__`, `__dict__`, ...) are data
-                // descriptors: getattr already ran `__get__`, so the loaded
-                // value must not prepend self.
-                Some(d) if pyre_object::getsetproperty::is_getset_property(d) => PY_NULL,
-                Some(d) if crate::is_function(d) => {
-                    let ob_type = (*d).ob_type;
-                    if std::ptr::eq(ob_type, &crate::BUILTIN_FUNCTION_TYPE as *const _) {
-                        // BuiltinFunction has no __get__.
-                        PY_NULL
-                    } else if std::ptr::eq(ob_type, &crate::FUNCTION_TYPE as *const _)
-                        && crate::is_builtin_code(
-                            crate::function_get_code(d) as pyre_object::PyObjectRef
-                        )
-                    {
-                        // FunctionWithFixedCode (interp2app) on a builtin
-                        // type — `dict.get` etc. — binds like a method.
-                        obj
-                    } else {
-                        obj
-                    }
-                }
-                Some(_) => obj, // found in type MRO → bind self (method)
+                Some(d) => method_descriptor_bound(d, attr, obj),
                 None => {
                     // Not found in type MRO → found in instance __dict__.
                     // Instance __dict__ attrs bypass descriptor protocol.
@@ -2137,40 +2141,39 @@ pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str
                 }
             }
         } else if pyre_object::is_type(obj) {
-            // Type object: check for classmethod in type's MRO
+            // Type receiver: PyPy resolves LOAD_METHOD through the
+            // METAclass MRO (`space.type(w_obj)`), so a name found in the
+            // type's own MRO reaches the call as a plain getattr value
+            // with no binding.
             let raw = crate::baseobjspace::lookup_in_type(obj, name);
             match raw {
                 Some(d) if pyre_object::is_classmethod(d) => obj,
                 Some(_) => PY_NULL, // found in own MRO → no binding
                 None => {
-                    // Not found in type's own MRO → check metaclass MRO.
-                    // If found there, bind obj (the type) as self.
-                    obj
+                    // Not in the type's own MRO → resolved via the
+                    // metaclass MRO; bind the type for a method-descriptor
+                    // function getattr surfaced unchanged.
+                    match crate::typedef::r#type(obj)
+                        .and_then(|meta| crate::baseobjspace::lookup_in_type(meta, name))
+                    {
+                        Some(d) => method_descriptor_bound(d, attr, obj),
+                        None => PY_NULL,
+                    }
                 }
             }
         } else if let Some(w_type) =
             crate::typedef::r#type(obj).filter(|_| !pyre_object::is_module(obj))
         {
-            // Builtin type method (list.append, etc.) found via TypeDef.
-            // LOOKUP_METHOD binds self for builtin type methods, except
-            // staticmethods (str.maketrans) and classmethods (dict.fromkeys),
-            // which getattr already unwrapped above.
-            //
-            // A builtin-storage subclass instance (`class MyInt(int)`, enum
-            // members) is not is_instance-shaped, so it reaches this branch
-            // too; its `w_type` is the subclass with a full MRO.  Non-method
-            // descriptors (type / property / member / getset such as
-            // `__class__`) do not prepend self, and an attribute not in the
-            // type MRO (a special attribute resolved directly in getattr, or
-            // an instance-dict entry) binds none.
+            // Builtin-storage receiver (list, str, ... and their
+            // subclasses such as enum members) found via TypeDef; the
+            // same fast-path discriminator applies — `dict.get` etc. are
+            // FunctionWithFixedCode (interp2app) attrs that getattr
+            // returns unchanged, while staticmethods (str.maketrans) and
+            // classmethods (dict.fromkeys) were already unwrapped.
             match crate::baseobjspace::lookup_in_type(w_type, name) {
                 Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
                 Some(d) if pyre_object::is_classmethod(d) => w_type,
-                Some(d) if pyre_object::is_type(d) => PY_NULL,
-                Some(d) if pyre_object::is_property(d) => PY_NULL,
-                Some(d) if pyre_object::is_member(d) => PY_NULL,
-                Some(d) if pyre_object::getsetproperty::is_getset_property(d) => PY_NULL,
-                Some(_) => obj,
+                Some(d) => method_descriptor_bound(d, attr, obj),
                 None => PY_NULL,
             }
         } else {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2081,11 +2081,7 @@ impl ConstantOpcodeHandler for PyFrame {
 ///  - classmethod → bind class (w_type)
 ///  - staticmethod / property / member / type / getset → no binding (NULL)
 ///  - builtin type method (list.append etc.) → bind instance
-pub fn compute_load_method_bound(
-    obj: PyObjectRef,
-    attr: PyObjectRef,
-    name: &str,
-) -> PyObjectRef {
+pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str) -> PyObjectRef {
     unsafe {
         if pyre_object::is_method(attr) {
             return PY_NULL;

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls_pre.template.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls_pre.template.rs
@@ -208,7 +208,11 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
         list: Self::Value,
         value: Self::Value,
     ) -> Result<(), pyre_interpreter::PyError> {
-        // MIFrame parity: trace-only, no concrete mutation.
+        // MIFrame parity: the hook itself is trace-only — the concrete
+        // LIST_APPEND mutation is performed by the eval loop
+        // (`execute_opcode_step` / inline-frame `concrete_execute_step`),
+        // which is why this path marks the heap mutation.
+        self.dm143_mark_heap_mutated();
         self.list_append_value(
             list.opref,
             value.opref,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11520,10 +11520,12 @@ mod indirectcalltargets_tests {
         // Identity pc_map: the resume pc IS the jitcode byte offset.
         let metadata = crate::PyJitCodeMetadata {
             pc_map: (0..code_len).collect(),
+            first_jit_pc_by_py_pc: (0..code_len).collect(),
             depth_at_py_pc: vec![0; code_len],
             after_residual_call_resume_pc: vec![None; code_len],
             portal_frame_reg: u16::MAX,
             portal_ec_reg: u16::MAX,
+            built_as_portal: false,
             stack_base: 0,
             stack_slot_color_map: Vec::new(),
             pyre_color_for_semantic_local: Vec::new(),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -486,6 +486,87 @@ impl MetaInterpStaticData {
     }
 }
 
+/// Build the runtime-helper `PyJitCode` for issue #143's folded
+/// `list.append` resize fallback.
+///
+/// A JIT-folded `list.append` checks capacity inline and stores the new
+/// element directly; the resize guard fails when the backing store is
+/// full. The blackhole then resumes into this helper jitcode, whose body
+/// re-runs the full append (allocating realloc included) as a residual
+/// call and returns `None` — exactly the value a Python `list.append`
+/// call leaves on the caller's stack.
+///
+/// The helper takes two ref registers — `r0` = the list, `r1` = the
+/// value being appended — matching the snapshot boxes
+/// `build_synthetic_callee_frames` records for the callee frame
+/// (M-core2). Body (identity `pc_map`; a helper frame resumes on a
+/// jitcode byte offset, not a Python PC):
+///
+/// ```text
+///   live              live_r=[r0, r1]
+///   residual_call_r_v jit_list_append(r0, r1)   ; arg_classes "rr", void
+///   ref_return        None
+/// ```
+///
+/// The `residual_call` is void, mirroring the trace-side emission in
+/// `helpers.rs::trace_list_append`: [`jit_list_append`] performs the
+/// append purely for its side effect and returns a sentinel `0`, so the
+/// helper must NOT thread that raw `0` as a ref result. It returns
+/// [`w_none`] (a real boxed `None` pointer) instead.
+#[allow(dead_code)]
+fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode> {
+    use majit_metainterp::jitcode::{JitCallArg, JitCodeBuilder};
+    use majit_translate::jitcode::BhCallDescr;
+
+    // `live` interns its liveness triple into this throwaway `Assembler`.
+    // The blackhole's `live/` handler only skips the 2-byte offset operand
+    // (it never dereferences it), and `BlackholeInterpreter::run` roots the
+    // whole `registers_r` file via `push_bh_regs` for the duration of the
+    // residual call, so a process-local intern is sufficient: GC roots are
+    // already covered and the offset value is inert at resume time.
+    let mut asm = majit_translate::jit_codewriter::assembler::Assembler::new();
+    let mut builder = JitCodeBuilder::new();
+
+    // live live_r=[r0, r1]
+    builder.live(&mut asm, &[], &[0, 1], &[]);
+    // residual_call_r_v jit_list_append(r0=list, r1=value) -> void
+    builder.residual_call_void_canonical_typed_args(
+        pyre_object::listobject::jit_list_append as *const () as i64,
+        &[JitCallArg::reference(0), JitCallArg::reference(1)],
+        BhCallDescr::from_arg_classes(
+            "rr".to_string(),
+            'v',
+            majit_ir::descr::EffectInfo::MOST_GENERAL,
+        ),
+    );
+    // ref_return None
+    builder.ref_return_const(pyre_object::noneobject::w_none() as i64);
+
+    let runtime = std::sync::Arc::new(builder.finish());
+    let code_len = runtime.body().code.len();
+
+    // Identity pc_map: a helper frame's resume pc IS its jitcode byte
+    // offset, so `resume_jitcode_pc_for(offset)` must map it to itself
+    // (see `register_runtime_helper_jitcode`).
+    let metadata = crate::PyJitCodeMetadata {
+        pc_map: (0..code_len).collect(),
+        depth_at_py_pc: vec![0; code_len],
+        portal_frame_reg: u16::MAX,
+        portal_ec_reg: u16::MAX,
+        stack_base: 0,
+        stack_slot_color_map: Vec::new(),
+        pyre_color_for_semantic_local: Vec::new(),
+    };
+    std::sync::Arc::new(crate::PyJitCode::from_parts(
+        runtime,
+        metadata,
+        std::ptr::null(),
+        std::ptr::null(),
+        false,
+        None,
+    ))
+}
+
 /// RPython assembler.py:234-248 `Assembler._encode_liveness` parity:
 /// intern one `[live_i, live_r, live_f]` triple in the assembler's
 /// `all_liveness` buffer and return its 2-byte offset.
@@ -11342,6 +11423,78 @@ mod indirectcalltargets_tests {
         let resolved = pyjitcode_for_jitcode_index(index)
             .expect("registered runtime helper must resolve by index");
         assert!(Arc::ptr_eq(&resolved, &payload));
+    }
+
+    /// Issue #143 M-core3 increment 1: the folded `list.append` resize
+    /// helper jitcode, driven through the production blackhole, must
+    /// actually perform the append (including the heap realloc that the
+    /// inline guard could not) and return `None` as a
+    /// `DoneWithThisFrameRef`.
+    ///
+    /// This proves the residual-call body executes end-to-end — not just
+    /// that a frame chain can be built (the resume-side seam test only
+    /// covers chain construction). The list starts at the inline-array
+    /// capacity boundary so the helper's append must reallocate, exactly
+    /// the path the runtime guard fails into.
+    ///
+    /// Requires a backend feature: the residual call dispatches through
+    /// `cpu.bh_call_v`, which only performs the real C call when a
+    /// concrete backend is wired (`build_pyre_production_bh_builder` sets
+    /// `builder.cpu` under `dynasm`/`cranelift`). Without one the cpu is
+    /// `None` and the residual handler's `cpu()` would panic.
+    #[cfg(any(feature = "dynasm", feature = "cranelift"))]
+    #[test]
+    fn list_append_resize_helper_appends_and_returns_none_through_blackhole() {
+        use majit_metainterp::blackhole::run_forever;
+        use majit_metainterp::jitexc::JitException;
+        use pyre_object::{
+            w_int_new, w_list_can_append_without_realloc, w_list_len, w_list_new, w_none,
+        };
+
+        let payload = super::build_list_append_resize_helper_payload();
+
+        // Pin the heap objects: `run` roots `registers_r` for the residual
+        // call itself, but the list/value must survive any collection
+        // between construction here and the blackhole entry below.
+        let _roots = pyre_object::gc_roots::push_roots();
+        // listobject `IntArray` inlines up to `INT_ARRAY_INLINE_CAP` (8)
+        // ints; a list filled to exactly that boundary has zero spare
+        // capacity, so the next append must reallocate.
+        let list = w_list_new((0..8).map(w_int_new).collect());
+        let item = w_int_new(99);
+        pyre_object::gc_roots::pin_root(list);
+        pyre_object::gc_roots::pin_root(item);
+
+        let len_before = unsafe { w_list_len(list) };
+        assert_eq!(len_before, 8, "list must start at the inline boundary");
+        assert!(
+            !unsafe { w_list_can_append_without_realloc(list) },
+            "the next append must require a realloc (the guard-failure path)",
+        );
+
+        let mut builder = crate::jitcode_runtime::build_pyre_production_bh_builder();
+        let mut bh = builder.acquire_interp();
+        bh.setposition(payload.jitcode.clone(), 0);
+        // r0 = list, r1 = appended value (the callee-frame snapshot boxes).
+        bh.setarg_r(0, list as i64);
+        bh.setarg_r(1, item as i64);
+
+        let exc = run_forever(&mut builder, bh, 0);
+        match exc {
+            JitException::DoneWithThisFrameRef(r) => assert_eq!(
+                r.0,
+                w_none() as usize,
+                "helper must return None (a real boxed pointer), not the \
+                 raw 0 sentinel jit_list_append returns",
+            ),
+            other => panic!("expected DoneWithThisFrameRef(None), got {other:?}"),
+        }
+
+        assert_eq!(
+            unsafe { w_list_len(list) },
+            len_before + 1,
+            "the residual call must have appended exactly one element",
+        );
     }
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -177,13 +177,18 @@ impl MetaInterpStaticData {
     /// [`Self::register_runtime_helper_jitcode`] with an identity
     /// `pc_map`. The resulting index is cached on the SD and reused, so the
     /// helper is registered exactly once per `jitcodes` table.
-    fn ensure_list_append_resize_helper_jitcode(&mut self) -> i32 {
+    /// Register a pre-built `list.append` resize helper payload and cache
+    /// its index. The payload is built by the caller OUTSIDE the
+    /// `METAINTERP_SD` borrow because `build_list_append_resize_helper_payload`
+    /// interns the helper's liveness via `intern_liveness`, which itself
+    /// borrows `METAINTERP_SD` (a nested borrow would panic).
+    fn register_list_append_resize_helper(
+        &mut self,
+        payload: std::sync::Arc<crate::PyJitCode>,
+    ) -> i32 {
         if let Some(index) = self.list_append_resize_helper_index {
             return index;
         }
-        // Built before registration; the builder touches no thread-local
-        // state, so this is safe even while `METAINTERP_SD` is borrowed.
-        let payload = build_list_append_resize_helper_payload();
         let index = self.register_runtime_helper_jitcode(payload);
         self.list_append_resize_helper_index = Some(index);
         index
@@ -548,17 +553,18 @@ fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode>
     use majit_metainterp::jitcode::{JitCallArg, JitCodeBuilder};
     use majit_translate::jitcode::BhCallDescr;
 
-    // `live` interns its liveness triple into this throwaway `Assembler`.
-    // The blackhole's `live/` handler only skips the 2-byte offset operand
-    // (it never dereferences it), and `BlackholeInterpreter::run` roots the
-    // whole `registers_r` file via `push_bh_regs` for the duration of the
-    // residual call, so a process-local intern is sufficient: GC roots are
-    // already covered and the offset value is inert at resume time.
-    let mut asm = majit_translate::jit_codewriter::assembler::Assembler::new();
     let mut builder = JitCodeBuilder::new();
 
-    // live live_r=[r0, r1]
-    builder.live(&mut asm, &[], &[0, 1], &[]);
+    // live live_r=[r0, r1] — emit `live/` + a placeholder 2-byte offset,
+    // patched below to the GLOBAL `all_liveness` position. The resume path
+    // (`consume_one_section` → `get_live_vars_info`) decodes this offset
+    // against `liveness_info_snapshot()` (the global table), so the helper's
+    // liveness MUST be interned there via `intern_liveness`. Interning into a
+    // throwaway local `Assembler` (as `builder.live(asm, ..)` would) leaves
+    // the offset pointing into a table the resume reader never sees, so the
+    // helper frame mis-decodes its live register set and writes the snapshot
+    // boxes to the wrong registers.
+    let live_patch = builder.live_placeholder_with_triple(&[], &[0, 1], &[]);
     // residual_call_r_v jit_list_append(r0=list, r1=value) -> void
     builder.residual_call_void_canonical_typed_args(
         pyre_object::listobject::jit_list_append as *const () as i64,
@@ -571,6 +577,11 @@ fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode>
     );
     // ref_return None
     builder.ref_return_const(pyre_object::noneobject::w_none() as i64);
+
+    // Patch the `live/` offset to the global `all_liveness` position.
+    let live_off = intern_liveness(&[], &[0, 1], &[])
+        .expect("list.append resize helper liveness offset fits in u16");
+    builder.patch_live_offset(live_patch, live_off);
 
     let runtime = std::sync::Arc::new(builder.finish());
     let code_len = runtime.body().code.len();
@@ -937,7 +948,18 @@ pub fn raw_code_for_jitcode_index(jitcode_index: i32) -> Option<*const CodeObjec
 #[allow(dead_code)]
 pub(crate) fn ensure_list_append_resize_helper_index() -> i32 {
     ensure_finish_setup();
-    METAINTERP_SD.with(|r| r.borrow_mut().ensure_list_append_resize_helper_jitcode())
+    // Fast path: already registered. The borrow is released before any
+    // build so the slow path below can intern liveness (which re-borrows
+    // METAINTERP_SD).
+    if let Some(index) = METAINTERP_SD.with(|r| r.borrow().list_append_resize_helper_index) {
+        return index;
+    }
+    // Build OUTSIDE the SD borrow: `build_list_append_resize_helper_payload`
+    // interns the helper's liveness triple into the global `all_liveness`
+    // via `intern_liveness`, which borrows METAINTERP_SD — building inside
+    // a held borrow would panic with a nested borrow_mut.
+    let payload = build_list_append_resize_helper_payload();
+    METAINTERP_SD.with(|r| r.borrow_mut().register_list_append_resize_helper(payload))
 }
 
 /// Resolve `MetaInterpStaticData.jitcodes[jitcode_index]` to the same

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11485,6 +11485,7 @@ mod indirectcalltargets_tests {
         let metadata = crate::PyJitCodeMetadata {
             pc_map: (0..code_len).collect(),
             depth_at_py_pc: vec![0; code_len],
+            after_residual_call_resume_pc: vec![None; code_len],
             portal_frame_reg: u16::MAX,
             portal_ec_reg: u16::MAX,
             stack_base: 0,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -421,6 +421,57 @@ impl MetaInterpStaticData {
         ptr
     }
 
+    /// Register a Rust runtime-helper `PyJitCode` (no backing
+    /// `W_CodeObject`) into the runtime `jitcodes` table and return its
+    /// index.
+    ///
+    /// This is the resume-side counterpart of [`Self::jitcode_for`] /
+    /// [`Self::portal_bridge_jitcode_for`] for jitcodes that are NOT
+    /// lifted from a Python `CodeObject` — e.g. a folded `list.append`
+    /// callee body that owns the resize guard. `build_framestack_snapshot`
+    /// stores this index in resume data; the resume-side
+    /// `resolve_jitcode` resolves it back through
+    /// [`pyjitcode_for_jitcode_index`].
+    ///
+    /// The caller is responsible for building the payload with an
+    /// *identity* `metadata.pc_map` (`pc_map[i] == i`): a helper frame's
+    /// resume pc is a jitcode byte offset, not a Python bytecode PC, so
+    /// `resume_jitcode_pc_for(offset)` must map the offset to itself
+    /// rather than translate through a per-Python-PC map. With an
+    /// identity map the existing `resolve_jitcode` path needs no change.
+    ///
+    /// `code` is `null` because a helper has no `W_CodeObject`; this also
+    /// means `raw_code()` returns `null` for the entry, so the
+    /// `raw_code`-keyed `compiled_jitcode_lookup` / `jitcode_for` paths
+    /// never alias it with a real Python code (whose `raw_code()` is
+    /// non-null). Resolution of a helper is by index only.
+    ///
+    /// Currently exercised only by the index/resolve seam test; the
+    /// production `list.append` callee-frame wiring (M-core2/M-core3) is
+    /// the first runtime caller.
+    #[allow(dead_code)]
+    fn register_runtime_helper_jitcode(
+        &mut self,
+        payload: std::sync::Arc<crate::PyJitCode>,
+    ) -> i32 {
+        assert!(
+            payload.w_code.is_null(),
+            "runtime-helper jitcode must not carry a W_CodeObject"
+        );
+        assert!(
+            !payload.is_skeleton(),
+            "runtime-helper jitcode must be populated (identity pc_map) before registration"
+        );
+        let index = self.jitcodes.len() as i32;
+        Self::stamp_payload_index(index, &payload);
+        self.jitcodes.push(Box::new(JitCode {
+            code: std::ptr::null(),
+            index,
+            payload,
+        }));
+        index
+    }
+
     /// Return the installed SD entry for a `W_CodeObject`.
     /// RPython's runtime lookup never compiles and never creates a
     /// skeleton here: every entry must already have arrived through
@@ -11079,7 +11130,10 @@ mod indirectcalltargets_tests {
     //! `MetaInterpStaticData` methods directly — independent of the
     //! thread-local `METAINTERP_SD` singleton so concurrent callers
     //! (and unrelated tests that use the thread-local) do not alias.
-    use super::{METAINTERP_SD, MetaInterpStaticData, raw_code_for_jitcode_index};
+    use super::{
+        METAINTERP_SD, MetaInterpStaticData, pyjitcode_for_jitcode_index,
+        raw_code_for_jitcode_index,
+    };
     use majit_metainterp::jitcode::{JitCode, JitCodeBuilder};
     use pyre_interpreter::bytecode::CodeObject;
     use std::sync::Arc;
@@ -11212,6 +11266,82 @@ mod indirectcalltargets_tests {
 
         let hit = raw_code_for_jitcode_index(0).expect("jitcode index 0 must resolve");
         assert_eq!(hit, expected_raw);
+    }
+
+    /// Issue #143 core seam: a Rust runtime-helper jitcode (no backing
+    /// `W_CodeObject`) registered via `register_runtime_helper_jitcode`
+    /// must acquire a valid index that the production resume lookup
+    /// `pyjitcode_for_jitcode_index` resolves, and its identity `pc_map`
+    /// must pass a jitcode byte offset through `resume_jitcode_pc_for`
+    /// unchanged. Helper frames store byte offsets, not Python PCs, so an
+    /// identity map lets the existing `resolve_jitcode` (call_jit.rs)
+    /// resume into the helper with no production change. This is the
+    /// load-bearing index/resolve gap for resuming a guard inside a
+    /// folded `list.append` callee through the blackhole.
+    #[test]
+    fn register_runtime_helper_jitcode_resolves_by_index_with_identity_pc() {
+        use majit_metainterp::jitcode::insns::BC_LIVE;
+
+        // Hand-build a tiny populated helper body. Content is irrelevant
+        // here (it never runs); it only has to be non-skeleton so the
+        // resume-side discriminators classify it as a normal populated
+        // jitcode. The guard/resume offset lives at byte 3.
+        const GUARD_OFFSET: usize = 3;
+        let mut runtime = JitCodeBuilder::default().finish();
+        runtime.body_mut().code = vec![BC_LIVE, 0, 0, BC_LIVE, 0, 0];
+        runtime.body_mut().c_num_regs_i = 1;
+        runtime.body_mut().startpoints = Some([0_usize, GUARD_OFFSET].into_iter().collect());
+        let code_len = runtime.body().code.len();
+        let runtime = Arc::new(runtime);
+
+        // Identity pc_map: the resume pc IS the jitcode byte offset.
+        let metadata = crate::PyJitCodeMetadata {
+            pc_map: (0..code_len).collect(),
+            depth_at_py_pc: vec![0; code_len],
+            portal_frame_reg: u16::MAX,
+            portal_ec_reg: u16::MAX,
+            stack_base: 0,
+            stack_slot_color_map: Vec::new(),
+            pyre_color_for_semantic_local: Vec::new(),
+        };
+        let payload = Arc::new(crate::PyJitCode::from_parts(
+            runtime,
+            metadata,
+            std::ptr::null(),
+            std::ptr::null(),
+            false,
+            None,
+        ));
+
+        let mut sd = MetaInterpStaticData::new();
+        let index = sd.register_runtime_helper_jitcode(payload.clone());
+        assert_eq!(index, 0, "first registration takes slot 0");
+        // The inner runtime JitCode index must be stamped so
+        // `build_framestack_snapshot`'s `(*sym().jitcode).index` read is
+        // valid for the helper callee frame.
+        assert_eq!(payload.jitcode.index(), index as usize);
+
+        // Resume-side discriminators: a populated, non-portal,
+        // non-skeleton jitcode with no abort opcode, so `resolve_jitcode`
+        // does not bail.
+        assert!(payload.is_populated());
+        assert!(!payload.is_portal_bridge());
+        assert!(!payload.is_skeleton());
+        assert!(!payload.has_abort_opcode());
+
+        // Identity pc_map passes a byte offset through unchanged.
+        assert_eq!(
+            payload.resume_jitcode_pc_for(GUARD_OFFSET),
+            Some(GUARD_OFFSET)
+        );
+
+        // The production resume lookup resolves the helper by index.
+        METAINTERP_SD.with(|slot| {
+            *slot.borrow_mut() = sd;
+        });
+        let resolved = pyjitcode_for_jitcode_index(index)
+            .expect("registered runtime helper must resolve by index");
+        assert!(Arc::ptr_eq(&resolved, &payload));
     }
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -595,6 +595,8 @@ fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode>
         // its own containing-opcode coordinate for a helper frame.
         first_jit_pc_by_py_pc: (0..code_len).collect(),
         depth_at_py_pc: vec![0; code_len],
+        // The helper's residual_call (jit_list_append) sits outside any
+        // try-block, so no pc lands on an after-residual-call catch.
         after_residual_call_resume_pc: vec![None; code_len],
         portal_frame_reg: u16::MAX,
         portal_ec_reg: u16::MAX,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -138,6 +138,15 @@ struct MetaInterpStaticData {
     /// `state::bytecode_for_address`) and from future callers that
     /// hold a `&mut MetaInterpStaticData` directly.
     canonical: majit_metainterp::MetaInterpStaticData,
+    /// Issue #143: memoized index of the folded `list.append` resize
+    /// helper jitcode (`build_list_append_resize_helper_payload`) inside
+    /// `jitcodes`. Registered lazily on the first guard that needs it and
+    /// reused thereafter. Stored ON the SD (not a process-global) so it is
+    /// reset-safe: it lives and dies with this `jitcodes` table. The index
+    /// stays valid because `set_jitcodes_from_make_result` only updates
+    /// W_CodeObject-keyed entries (the helper carries a null `w_code`) and
+    /// appends new ones, never shifting an existing index.
+    list_append_resize_helper_index: Option<i32>,
 }
 
 #[allow(dead_code)]
@@ -156,7 +165,28 @@ impl MetaInterpStaticData {
             op_float_return: u8::MAX,
             op_void_return: u8::MAX,
             canonical: majit_metainterp::MetaInterpStaticData::new(),
+            list_append_resize_helper_index: None,
         }
+    }
+
+    /// Issue #143: return the `jitcodes` index of the folded `list.append`
+    /// resize helper, registering it on first use.
+    ///
+    /// The helper has no backing `W_CodeObject`; it is built by
+    /// [`build_list_append_resize_helper_payload`] and registered through
+    /// [`Self::register_runtime_helper_jitcode`] with an identity
+    /// `pc_map`. The resulting index is cached on the SD and reused, so the
+    /// helper is registered exactly once per `jitcodes` table.
+    fn ensure_list_append_resize_helper_jitcode(&mut self) -> i32 {
+        if let Some(index) = self.list_append_resize_helper_index {
+            return index;
+        }
+        // Built before registration; the builder touches no thread-local
+        // state, so this is safe even while `METAINTERP_SD` is borrowed.
+        let payload = build_list_append_resize_helper_payload();
+        let index = self.register_runtime_helper_jitcode(payload);
+        self.list_append_resize_helper_index = Some(index);
+        index
     }
 
     /// pyjitpl.py:2248-2249 `setup_indirectcalltargets(indirectcalltargets)`.
@@ -897,6 +927,17 @@ pub fn raw_code_for_jitcode_index(jitcode_index: i32) -> Option<*const CodeObjec
         let idx = jitcode_index as usize;
         sd.jitcodes.get(idx).map(|jc| unsafe { jc.raw_code() })
     })
+}
+
+/// Issue #143: register (once) the folded `list.append` resize helper
+/// jitcode in the thread-local `METAINTERP_SD` and return its stable
+/// `jitcodes` index. The synthetic callee-frame snapshot a failing resize
+/// guard records (`build_synthetic_callee_frames`) stores this index so
+/// the blackhole can resume into the helper.
+#[allow(dead_code)]
+pub(crate) fn ensure_list_append_resize_helper_index() -> i32 {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| r.borrow_mut().ensure_list_append_resize_helper_jitcode())
 }
 
 /// Resolve `MetaInterpStaticData.jitcodes[jitcode_index]` to the same
@@ -11513,8 +11554,8 @@ mod indirectcalltargets_tests {
     #[test]
     fn list_append_resize_helper_threads_none_into_caller_result_register() {
         use majit_metainterp::blackhole::run_forever;
-        use majit_metainterp::jitcode::insns::BC_REF_RETURN;
         use majit_metainterp::jitcode::JitCodeBuilder;
+        use majit_metainterp::jitcode::insns::BC_REF_RETURN;
         use majit_metainterp::jitexc::JitException;
         use pyre_object::{w_int_new, w_list_len, w_list_new, w_none};
 
@@ -11566,6 +11607,42 @@ mod indirectcalltargets_tests {
             len_before + 1,
             "the callee frame must still have performed the append",
         );
+    }
+
+    /// Issue #143 M-core3 increment 3: the resize helper is registered in
+    /// the production `METAINTERP_SD` exactly once and resolves back by its
+    /// memoized index. A second `ensure` returns the same index (no
+    /// duplicate registration), and the index resolves to a populated,
+    /// non-skeleton runtime-helper payload (null `w_code`) whose identity
+    /// `pc_map` passes a byte offset through unchanged.
+    #[test]
+    fn ensure_list_append_resize_helper_index_is_stable_and_resolves() {
+        use super::{
+            METAINTERP_SD, MetaInterpStaticData, ensure_list_append_resize_helper_index,
+            pyjitcode_for_jitcode_index,
+        };
+
+        // Isolate from any helper a prior test on this thread registered.
+        METAINTERP_SD.with(|slot| *slot.borrow_mut() = MetaInterpStaticData::new());
+
+        let idx = ensure_list_append_resize_helper_index();
+        assert_eq!(
+            ensure_list_append_resize_helper_index(),
+            idx,
+            "ensure must memoize — a second call registers nothing new",
+        );
+
+        let payload =
+            pyjitcode_for_jitcode_index(idx).expect("helper index must resolve to a payload");
+        assert!(
+            payload.w_code.is_null(),
+            "runtime-helper payload carries no W_CodeObject",
+        );
+        assert!(payload.is_populated());
+        assert!(!payload.is_skeleton());
+        assert!(!payload.has_abort_opcode());
+        // Identity pc_map: a helper byte offset maps to itself.
+        assert_eq!(payload.resume_jitcode_pc_for(0), Some(0));
     }
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -497,6 +497,18 @@ impl MetaInterpStaticData {
             !payload.is_skeleton(),
             "runtime-helper jitcode must be populated (identity pc_map) before registration"
         );
+        // Helper frames store jitcode byte offsets, not Python PCs, so
+        // `resume_jitcode_pc_for` must pass every offset through unchanged.
+        assert!(
+            payload.metadata.pc_map.len() == payload.jitcode.body().code.len()
+                && payload
+                    .metadata
+                    .pc_map
+                    .iter()
+                    .enumerate()
+                    .all(|(i, &pc)| pc == i),
+            "runtime-helper jitcode must carry an identity pc_map"
+        );
         let index = self.jitcodes.len() as i32;
         Self::stamp_payload_index(index, &payload);
         self.jitcodes.push(Box::new(JitCode {
@@ -11310,6 +11322,32 @@ pub unsafe fn int_strategy_preserves_identity(value: pyre_object::PyObjectRef) -
     unsafe { pyre_object::is_plain_int1(value) }
 }
 
+/// Test-only RAII guard: swap a `MetaInterpStaticData` into the
+/// thread-local `METAINTERP_SD` and restore the previous value on drop,
+/// so tests sharing a thread (`--test-threads=1`) do not observe each
+/// other's registrations.
+#[cfg(test)]
+pub(crate) struct MetainterpSdGuard {
+    prev: Option<MetaInterpStaticData>,
+}
+
+#[cfg(test)]
+impl MetainterpSdGuard {
+    pub(crate) fn swap(sd: MetaInterpStaticData) -> Self {
+        let prev = METAINTERP_SD.with(|slot| std::mem::replace(&mut *slot.borrow_mut(), sd));
+        Self { prev: Some(prev) }
+    }
+}
+
+#[cfg(test)]
+impl Drop for MetainterpSdGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = self.prev.take() {
+            METAINTERP_SD.with(|slot| *slot.borrow_mut() = prev);
+        }
+    }
+}
+
 #[cfg(test)]
 mod indirectcalltargets_tests {
     //! Line-by-line parity tests for `pyjitpl.py:2248-2249` and
@@ -11318,7 +11356,7 @@ mod indirectcalltargets_tests {
     //! thread-local `METAINTERP_SD` singleton so concurrent callers
     //! (and unrelated tests that use the thread-local) do not alias.
     use super::{
-        METAINTERP_SD, MetaInterpStaticData, pyjitcode_for_jitcode_index,
+        MetaInterpStaticData, MetainterpSdGuard, pyjitcode_for_jitcode_index,
         raw_code_for_jitcode_index,
     };
     use majit_metainterp::jitcode::{JitCode, JitCodeBuilder};
@@ -11447,9 +11485,7 @@ mod indirectcalltargets_tests {
         let mut sd = MetaInterpStaticData::new();
         let (code, expected_raw) = make_code("x = 1\n");
         sd.set_jitcodes_from_make_result(vec![populated_pyjit(expected_raw, code)]);
-        METAINTERP_SD.with(|slot| {
-            *slot.borrow_mut() = sd;
-        });
+        let _sd_guard = MetainterpSdGuard::swap(sd);
 
         let hit = raw_code_for_jitcode_index(0).expect("jitcode index 0 must resolve");
         assert_eq!(hit, expected_raw);
@@ -11524,9 +11560,7 @@ mod indirectcalltargets_tests {
         );
 
         // The production resume lookup resolves the helper by index.
-        METAINTERP_SD.with(|slot| {
-            *slot.borrow_mut() = sd;
-        });
+        let _sd_guard = MetainterpSdGuard::swap(sd);
         let resolved = pyjitcode_for_jitcode_index(index)
             .expect("registered runtime helper must resolve by index");
         assert!(Arc::ptr_eq(&resolved, &payload));
@@ -11684,12 +11718,12 @@ mod indirectcalltargets_tests {
     #[test]
     fn ensure_list_append_resize_helper_index_is_stable_and_resolves() {
         use super::{
-            METAINTERP_SD, MetaInterpStaticData, ensure_list_append_resize_helper_index,
+            MetaInterpStaticData, MetainterpSdGuard, ensure_list_append_resize_helper_index,
             pyjitcode_for_jitcode_index,
         };
 
         // Isolate from any helper a prior test on this thread registered.
-        METAINTERP_SD.with(|slot| *slot.borrow_mut() = MetaInterpStaticData::new());
+        let _sd_guard = MetainterpSdGuard::swap(MetaInterpStaticData::new());
 
         let idx = ensure_list_append_resize_helper_index();
         assert_eq!(
@@ -11727,7 +11761,7 @@ pub struct ResumeFrameState {
 
 #[cfg(test)]
 mod finish_setup_tests {
-    use super::{METAINTERP_SD, MetaInterpStaticData, blackhole_control_opcodes};
+    use super::{MetaInterpStaticData, MetainterpSdGuard, blackhole_control_opcodes};
     use crate::assembler::publish_state;
 
     #[test]
@@ -11769,9 +11803,7 @@ mod finish_setup_tests {
         insns.insert("catch_exception/L".to_string(), 89u8);
         insns.insert("rvmprof_code/ii".to_string(), 91u8);
         sd.finish_setup_if_needed(&insns, Vec::new());
-        METAINTERP_SD.with(|slot| {
-            *slot.borrow_mut() = sd;
-        });
+        let _sd_guard = MetainterpSdGuard::swap(sd);
 
         assert_eq!(blackhole_control_opcodes(), (88, 89, 91));
     }
@@ -11781,9 +11813,7 @@ mod finish_setup_tests {
         let mut sd = MetaInterpStaticData::new();
         let empty: majit_ir::VecAssoc<String, u8> = majit_ir::VecAssoc::new();
         sd.finish_setup_if_needed(&empty, Vec::new());
-        METAINTERP_SD.with(|slot| {
-            *slot.borrow_mut() = sd;
-        });
+        let _sd_guard = MetainterpSdGuard::swap(sd);
 
         let mut insns = majit_ir::VecAssoc::new();
         insns.insert("live/".to_string(), 88u8);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11496,6 +11496,77 @@ mod indirectcalltargets_tests {
             "the residual call must have appended exactly one element",
         );
     }
+
+    /// Issue #143 M-core3 increment 2: the load-bearing return-threading
+    /// convention. When the folded `list.append` callee frame returns
+    /// through the blackhole, `setup_return_value_r` must write the
+    /// callee's `None` into the CALLER frame's
+    /// `registers_r[code[position-1]]` — the post-CALL result register.
+    ///
+    /// This isolates that convention with a 2-frame chain (a hand-built
+    /// stub caller + the real resize helper) WITHOUT pyre's full Python
+    /// CALL bytecode layout: the caller's `code[position-1]` byte names the
+    /// result register, and resuming the caller at `position` runs
+    /// `ref_return` on it, surfacing the threaded value. The real Python
+    /// fallthrough layout is exercised end-to-end by increment 6.
+    #[cfg(any(feature = "dynasm", feature = "cranelift"))]
+    #[test]
+    fn list_append_resize_helper_threads_none_into_caller_result_register() {
+        use majit_metainterp::blackhole::run_forever;
+        use majit_metainterp::jitcode::insns::BC_REF_RETURN;
+        use majit_metainterp::jitcode::JitCodeBuilder;
+        use majit_metainterp::jitexc::JitException;
+        use pyre_object::{w_int_new, w_list_len, w_list_new, w_none};
+
+        let helper = super::build_list_append_resize_helper_payload();
+
+        let _roots = pyre_object::gc_roots::push_roots();
+        let list = w_list_new((0..8).map(w_int_new).collect());
+        let item = w_int_new(99);
+        pyre_object::gc_roots::pin_root(list);
+        pyre_object::gc_roots::pin_root(item);
+        let len_before = unsafe { w_list_len(list) };
+
+        // Stub caller jitcode. `code[0]` is the post-CALL result-register
+        // index (r0) that `setup_return_value_r` reads from
+        // `code[position-1]`; resuming at position 1 runs `ref_return r0`,
+        // surfacing whatever the callee threaded into r0.
+        let mut caller = JitCodeBuilder::default().finish();
+        caller.body_mut().code = vec![0x00, BC_REF_RETURN, 0x00];
+        caller.body_mut().c_num_regs_r = 1;
+        caller.body_mut().startpoints = Some([1_usize].into_iter().collect());
+        let caller = std::sync::Arc::new(caller);
+
+        let mut builder = crate::jitcode_runtime::build_pyre_production_bh_builder();
+
+        // Chain: helper (callee, runs first) → caller (its
+        // `nextblackholeinterp`, resumed with the threaded return).
+        let mut caller_bh = builder.acquire_interp();
+        caller_bh.setposition(caller, 1);
+
+        let mut helper_bh = builder.acquire_interp();
+        helper_bh.setposition(helper.jitcode.clone(), 0);
+        helper_bh.setarg_r(0, list as i64);
+        helper_bh.setarg_r(1, item as i64);
+        helper_bh.nextblackholeinterp = Some(Box::new(caller_bh));
+
+        let exc = run_forever(&mut builder, helper_bh, 0);
+        match exc {
+            JitException::DoneWithThisFrameRef(r) => assert_eq!(
+                r.0,
+                w_none() as usize,
+                "the caller must surface the None the callee returned, \
+                 threaded via setup_return_value_r into code[position-1]'s \
+                 register",
+            ),
+            other => panic!("expected DoneWithThisFrameRef(None), got {other:?}"),
+        }
+        assert_eq!(
+            unsafe { w_list_len(list) },
+            len_before + 1,
+            "the callee frame must still have performed the append",
+        );
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -591,9 +591,15 @@ fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode>
     // (see `register_runtime_helper_jitcode`).
     let metadata = crate::PyJitCodeMetadata {
         pc_map: (0..code_len).collect(),
+        // Identity pc_map ⇒ identity inverse: each jitcode byte offset is
+        // its own containing-opcode coordinate for a helper frame.
+        first_jit_pc_by_py_pc: (0..code_len).collect(),
         depth_at_py_pc: vec![0; code_len],
+        after_residual_call_resume_pc: vec![None; code_len],
         portal_frame_reg: u16::MAX,
         portal_ec_reg: u16::MAX,
+        // Runtime helper, not a portal body.
+        built_as_portal: false,
         stack_base: 0,
         stack_slot_color_map: Vec::new(),
         pyre_color_for_semantic_local: Vec::new(),
@@ -1945,6 +1951,13 @@ pub struct PyreSym {
     // instead of reading from an external PyFrame snapshot.
     pub(crate) concrete_locals: Vec<ConcreteValue>,
     pub concrete_stack: Vec<ConcreteValue>,
+    /// #143 frame-advance gate: set true when a concrete heap mutation
+    /// (a concrete STORE_SUBSCR store or any concrete CALL) runs during this
+    /// trace. `dm143_advance_live_locals` advances the live frame only when
+    /// this is set — a mutation-free loop never needs the advance (re-running
+    /// its traced iteration has no heap side effect), and advancing it would
+    /// desync the guard-failure resume path (`set_membership`).
+    pub(crate) dm143_heap_mutated: bool,
     /// pyjitpl.py:74: frame.jitcode — JitCode reference.
     /// Provides both .code (CodeObject*) and .index (snapshot encoding).
     pub(crate) jitcode: *const JitCode,
@@ -3534,6 +3547,7 @@ impl PyreSym {
             is_active_vable_owner: false,
             concrete_locals: Vec::new(),
             concrete_stack: Vec::new(),
+            dm143_heap_mutated: false,
             // jitcode and concrete_namespace initialized below
             jitcode: null_jitcode() as *const JitCode,
             concrete_namespace: std::ptr::null_mut(),
@@ -3728,6 +3742,8 @@ impl PyreSym {
     /// frames set symbolic state manually in perform_call
     /// (trace_opcode.rs:3323-3424) and do NOT call this.
     pub(crate) fn init_symbolic(&mut self, ctx: &mut TraceCtx, concrete_frame: usize) {
+        // #143: reset the per-trace heap-mutation gate at root-frame setup.
+        self.dm143_heap_mutated = false;
         self.is_function_entry_trace = ctx.header_pc == 0;
         let nlocals = concrete_nlocals(concrete_frame).unwrap_or(0);
         if majit_metainterp::majit_log_enabled() {
@@ -3997,6 +4013,31 @@ impl PyreSym {
     pub(crate) fn concrete_value_at(&self, abs_idx: usize) -> ConcreteValue {
         self.concrete_value_at_opt(abs_idx)
             .unwrap_or(ConcreteValue::Null)
+    }
+
+    /// #143 frame-advance: number of local slots whose post-trace concrete
+    /// state is tracked (`min(concrete_locals.len(), nlocals)`).
+    pub fn tracked_local_count(&self) -> usize {
+        self.concrete_locals.len().min(self.nlocals)
+    }
+
+    /// #143 frame-advance: materialize local slot `i`'s post-trace concrete
+    /// value as a boxed `PyObjectRef` (lazy `Int`/`Float` allocated via
+    /// `w_int_new`/`w_float_new`; `Ref` returned as-is). `None` for a `Null`
+    /// (dead/uninitialized) slot. The caller must root the returned box
+    /// before the next allocation.
+    pub fn materialize_local(&self, i: usize) -> Option<PyObjectRef> {
+        let cv = *self.concrete_locals.get(i)?;
+        if cv.is_null() {
+            None
+        } else {
+            Some(cv.to_pyobj())
+        }
+    }
+
+    /// #143 frame-advance gate predicate — see the `dm143_heap_mutated` field.
+    pub fn dm143_heap_mutated(&self) -> bool {
+        self.dm143_heap_mutated
     }
 }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4175,6 +4175,123 @@ impl MIFrame {
         }
     }
 
+    /// Issue #143 M-core3: emit the `list.append`/`list.pop` resize
+    /// `GuardTrue` whose resume captures a synthetic-callee framestack —
+    /// the runtime-helper jitcode (folded `jit_list_append`) as the
+    /// innermost/top frame, the current Python frame demoted to its
+    /// immediate caller resuming at the post-CALL `fallthrough_pc`.
+    ///
+    /// On guard failure the blackhole runs the helper (a residual
+    /// `jit_list_append(list, value)` that performs the generic
+    /// append+realloc and returns `w_none()`), threads the result into the
+    /// caller's pending slot via `setup_return_value_r`, and the Python
+    /// frame continues *after* the method-shape `CALL` — never
+    /// re-executing it and rebuilding a NULL callable (the issue #143 bug).
+    ///
+    /// Mirrors `generate_guard` / `generate_guard_core` (const-skip →
+    /// flush_guard_not_invalidated → record_guard_typed → capture) but
+    /// swaps the snapshot builder for
+    /// `build_framestack_snapshot_with_synthetic_callee` and the resume pc
+    /// for `fallthrough_pc`.  The orgpc swap + vable scalar save/restore
+    /// around the build mirrors `capture_resumedata` (trace_opcode.rs:
+    /// 3742-3771): `list_of_boxes_virtualizable` re-derives
+    /// `last_instr`/`valuestackdepth` from `self.orgpc`
+    /// (trace_opcode.rs:4256-4264), so it must read `fallthrough_pc` to
+    /// encode the demoted caller's post-CALL state.
+    ///
+    /// `list` / `value` are the helper boxes (`[list, value]`).  The gate
+    /// at the call site (`guard_append_without_resize`) routes here only
+    /// when `value` is a `Ref` (a real `PyObjectRef`), matching the
+    /// helper's `live live_r=[0,1]` declaration — an unboxed `Int` value
+    /// would mis-number on resume.
+    pub(crate) fn generate_guard_with_synthetic_callee(
+        &mut self,
+        ctx: &mut TraceCtx,
+        opcode: OpCode,
+        args: &[OpRef],
+        list: OpRef,
+        value: OpRef,
+    ) {
+        // pyjitpl.py:2558-2560: a const guard operand needs no guard.
+        if let Some(&first) = args.first() {
+            if first.is_constant() {
+                return;
+            }
+        }
+        // pyjitpl.py:1087: flush a pending guard_not_invalidated first.
+        if opcode != OpCode::GuardNotInvalidated {
+            self.flush_guard_not_invalidated(ctx);
+        }
+
+        let helper_index = crate::state::ensure_list_append_resize_helper_index() as u32;
+        // helper resumes at byte 0: `live` → `residual_call jit_list_append`
+        // → `ref_return w_none()` (identity pc_map, M-core1).
+        let helper_pc = 0usize;
+        let boxes = [list, value];
+        let result_type = Type::Ref;
+
+        // The CALL handler already popped the callable + args, so the
+        // append result (None) lands at the current top of self's value
+        // stack: `result_stack_idx` is that slot relative to nlocals. The
+        // demoted-caller snapshot nulls it (get_list_of_active_boxes
+        // in_a_call, trace_opcode.rs:1538) so no stale box is captured
+        // where `setup_return_value_r` will write the helper's return.
+        let result_stack_idx = {
+            let s = self.sym();
+            s.valuestackdepth.saturating_sub(s.nlocals)
+        };
+
+        // fail_arg_types in snapshot box order [helper(1:1, no header),
+        // self(sliced), ...parents(sliced)] — mirrors generate_guard's
+        // extend_types_with_parents.  These are an overwritten fallback:
+        // store_final_boxes_in_guard (optimizeopt/mod.rs:3200) repopulates
+        // op.fail_args from the snapshot below.
+        let n = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;
+        let helper_types: Vec<Type> = boxes.iter().map(|&op| self.value_type(op)).collect();
+        let mut types = helper_types;
+        let self_as_parent = crate::state::ResumeFrameState {
+            sym: self.sym,
+            concrete_frame_addr: self.concrete_frame_addr,
+            resume_pc: self.fallthrough_pc,
+            pending_result_stack_idx: Some(result_stack_idx),
+            pending_result_type: Some(result_type),
+        };
+        let (self_types_full, _) = self.materialize_parent_frame_state(ctx, self_as_parent);
+        if self_types_full.len() > n {
+            types.extend_from_slice(&self_types_full[n..]);
+        }
+        let types = self.extend_types_with_parents(ctx, types);
+        ctx.record_guard_typed(opcode, args, types);
+
+        // capture_resumedata parity (trace_opcode.rs:3742-3771): swap orgpc
+        // to the post-CALL fallthrough so the demoted caller's vable
+        // scalars encode the resume state, then restore.
+        let saved_orgpc = self.orgpc;
+        let saved_ni = self.sym().vable_last_instr;
+        let saved_vsd = self.sym().vable_valuestackdepth;
+        self.orgpc = self.fallthrough_pc;
+
+        let snapshot = self.build_framestack_snapshot_with_synthetic_callee(
+            ctx,
+            helper_index,
+            helper_pc,
+            &boxes,
+            Some(result_stack_idx),
+            Some(result_type),
+        );
+        let snapshot_id = ctx.capture_resumedata(snapshot);
+        ctx.set_last_guard_resume_position(snapshot_id);
+
+        self.orgpc = saved_orgpc;
+        let s = self.sym_mut();
+        s.vable_last_instr = saved_ni;
+        s.vable_valuestackdepth = saved_vsd;
+
+        // pyjitpl.py:2581 profiler.count_ops parity.
+        ctx.profiler()
+            .count_ops(opcode, majit_metainterp::counters::GUARDS);
+    }
+
     fn materialize_parent_frame_state(
         &mut self,
         ctx: &mut TraceCtx,
@@ -5976,21 +6093,16 @@ impl MIFrame {
                     })
                 };
                 if args.len() == 1 && canonical_list_method("append") == Some(inner_func) {
-                    // The folded fast path emits guards (resize-guard,
-                    // strategy guard, ...) that resume at the CALL pc. Replay
-                    // the `[callable, null, value]` operand stack the CALL
-                    // handler already popped so those guards capture the real
-                    // operands; otherwise blackhole re-execution of CALL on a
-                    // resize-guard failure reads a null callable.
-                    let call_pc = self.fallthrough_pc.saturating_sub(1);
-                    self.with_ctx(|this, ctx| {
-                        this.push_call_replay_stack(ctx, callable, args, call_pc)
-                    });
+                    // Issue #143: the folded fast path's resize guard routes
+                    // through a synthetic-callee snapshot
+                    // (`generate_guard_with_synthetic_callee`) so a
+                    // realloc-driven failure resumes into the `jit_list_append`
+                    // helper jitcode and the Python frame continues *after* the
+                    // CALL. No CALL re-execution, so the prior
+                    // `push_call_replay_stack` workaround (which reconstructed a
+                    // NULL method callable on resume) is removed.
                     let self_ref = recover_self(self);
-                    let res =
-                        self.list_append_value(self_ref, args[0], inner_self, concrete_args[0]);
-                    self.with_ctx(|this, ctx| this.pop_call_replay_stack(ctx, args.len()))?;
-                    res?;
+                    self.list_append_value(self_ref, args[0], inner_self, concrete_args[0])?;
                     let none_ref =
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
                     return Ok(none_ref);
@@ -6047,31 +6159,22 @@ impl MIFrame {
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
-                    // The folded fast path emits guards (resize-guard,
-                    // strategy guard, ...) that resume at the CALL pc. Replay
-                    // the `[callable, self, value]` operand stack the CALL
-                    // handler already popped so those guards capture the real
-                    // operands for blackhole re-execution on guard failure.
-                    let call_pc = self.fallthrough_pc.saturating_sub(1);
-                    self.with_ctx(|this, ctx| {
-                        this.push_call_replay_stack_self_in_args(
-                            ctx,
-                            callable,
-                            ConcreteValue::Ref(concrete_callable),
-                            args,
-                            call_pc,
-                        )
-                    });
-                    let res = self.list_append_value(
+                    // Issue #143: the folded fast path's resize guard routes
+                    // through a synthetic-callee snapshot
+                    // (`generate_guard_with_synthetic_callee`), so a
+                    // realloc-driven failure resumes into the `jit_list_append`
+                    // helper jitcode and the Python frame continues *after* the
+                    // CALL. No CALL re-execution, so the prior
+                    // `push_call_replay_stack` workaround — which reconstructed a
+                    // NULL callable on resume and inflated `valuestackdepth`,
+                    // skewing the synthetic guard's `result_stack_idx` — is
+                    // removed.
+                    self.list_append_value(
                         args[0],
                         args[1],
                         concrete_args[0],
                         concrete_args[1],
-                    );
-                    self.with_ctx(|this, ctx| {
-                        this.pop_call_replay_stack_self_in_args(ctx, args.len())
-                    })?;
-                    res?;
+                    )?;
                     let none_ref =
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
                     return Ok(none_ref);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1067,31 +1067,23 @@ impl MIFrame {
     }
 
     /// #143 frame-advance gate: mark this trace as having performed a concrete
-    /// heap mutation during tracing. Called only from the precise list mutation
-    /// recorders (`list_append_value`/`list_pop_value`/`list_pop_at_value`/
-    /// `list_reverse_value`). Non-mutating method calls (`x in s`, `len(xs)`)
-    /// and deferred stores (`STORE_SUBSCR`) never reach this, so their loops
-    /// stay unmarked and `dm143_advance_live_locals` skips their advance.
+    /// heap mutation during tracing. Called exactly where the concrete
+    /// mutation is a certainty: the BUILTIN-form list dispatch arms
+    /// (append/pop/pop-at/reverse — the trait impl's `call_callable` executed
+    /// the builtin concretely before dispatch) and the LIST_APPEND opcode hook
+    /// (the eval loop's `execute_opcode_step` / inline-frame
+    /// `concrete_execute_step` performs the write).
     ///
-    /// Precision caveat: for the dominant callers — the builtin-form dispatch
-    /// arms and the LIST_APPEND opcode hook — the concrete mutation is
-    /// guaranteed (the trait impl's `call_callable` executes builtin/user
-    /// functions concretely before dispatch; non-walker opcodes run
-    /// `execute_opcode_step`). The rare method-form arms (a `W_MethodObject`
-    /// flowing as a value, e.g. `m = xs.pop; m(0)`) get NO concrete execution
-    /// (the trait impl only executes `is_function` callables), so they
-    /// over-mark; such traces also carry a Null concrete result and degrade
-    /// before a clean CloseLoop. The precise fix is a `W_MethodObject` unwrap
-    /// in the trait impl's concrete-execution block (executor parity), not a
-    /// recorder-side gate.
+    /// Deliberately NOT marked: deferred stores (`STORE_SUBSCR` — the compiled
+    /// loop performs the write exactly once, nbody/fannkuch), non-mutating
+    /// calls, and the W_MethodObject method-form arms (`m = xs.pop; m(0)`) —
+    /// the trait impl only executes `is_function` callables concretely, so no
+    /// during-trace mutation happens on that path and marking it would
+    /// wrongly advance past an iteration whose mutation only exists as
+    /// deferred IR. (Those traces currently always abort before CloseLoop;
+    /// unmarked-deferred stays correct if they ever close.)
     #[inline]
     pub(crate) fn dm143_mark_heap_mutated(&mut self) {
-        // Set by the concrete-during-trace mutation recorders only
-        // (list append / pop / pop-at / reverse — method-call mutations that
-        // run at `call_callable` line ~101 during tracing). STORE_SUBSCR is
-        // deferred (no concrete write during trace) so it deliberately does
-        // NOT mark: a pure-STORE_SUBSCR loop (nbody / fannkuch) must keep its
-        // deferred write, which the compiled loop performs exactly once.
         self.sym_mut().dm143_heap_mutated = true;
     }
 
@@ -5806,7 +5798,6 @@ impl MIFrame {
         concrete_list: PyObjectRef,
         concrete_value: PyObjectRef,
     ) -> Result<(), PyError> {
-        self.dm143_mark_heap_mutated();
         if concrete_list.is_null() {
             return self.trace_list_append(list, value);
         }
@@ -5872,7 +5863,6 @@ impl MIFrame {
         concrete_list: PyObjectRef,
         concrete_len: usize,
     ) -> Result<OpRef, PyError> {
-        self.dm143_mark_heap_mutated();
         if concrete_list.is_null() || concrete_len == 0 {
             // Caller's guard ensures concrete_len > 0; defensive fallback.
             return self.trace_call_callable(callable, &[]);
@@ -5911,7 +5901,6 @@ impl MIFrame {
         list: OpRef,
         concrete_list: PyObjectRef,
     ) -> Result<OpRef, PyError> {
-        self.dm143_mark_heap_mutated();
         if concrete_list.is_null() || unsafe { !is_list(concrete_list) } {
             return self.trace_call_callable(callable, &[]);
         }
@@ -5950,7 +5939,6 @@ impl MIFrame {
         index: OpRef,
         concrete_list: PyObjectRef,
     ) -> Result<OpRef, PyError> {
-        self.dm143_mark_heap_mutated();
         // Pick the strategy-specific length field so the inline length update
         // mirrors `generated_list_pop_by_strategy`. A null / non-list / mixed
         // receiver has no known length field, so fall back to the generic
@@ -6311,6 +6299,13 @@ impl MIFrame {
                     // NULL callable on resume and inflated `valuestackdepth`,
                     // skewing the synthetic guard's `result_stack_idx` — is
                     // removed.
+                    //
+                    // Builtin-form arms mark the heap mutation here: the trait
+                    // impl's `call_callable` already executed the builtin
+                    // concretely before dispatch, so the mutation is a
+                    // certainty. The W_Method method-form arms above do NOT
+                    // mark — no concrete execution happens on that path.
+                    self.dm143_mark_heap_mutated();
                     self.list_append_value(args[0], args[1], concrete_args[0], concrete_args[1])?;
                     let none_ref =
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
@@ -6325,6 +6320,7 @@ impl MIFrame {
                     // inline by `list_pop_at_value` (residual shift +
                     // reconstructible length overlay), called directly like the
                     // append arm — no replay scaffolding.
+                    self.dm143_mark_heap_mutated();
                     return self.list_pop_at_value(callable, args[0], args[1], concrete_args[0]);
                 }
                 if args.len() == 1
@@ -6332,6 +6328,7 @@ impl MIFrame {
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
+                    self.dm143_mark_heap_mutated();
                     let call_pc = self.fallthrough_pc.saturating_sub(1);
                     self.with_ctx(|this, ctx| {
                         this.push_call_replay_stack_self_in_args(
@@ -6355,6 +6352,7 @@ impl MIFrame {
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
+                    self.dm143_mark_heap_mutated();
                     let call_pc = self.fallthrough_pc.saturating_sub(1);
                     self.with_ctx(|this, ctx| {
                         this.implement_guard_value(ctx, callable, concrete_callable as i64);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5804,24 +5804,16 @@ impl MIFrame {
                     })
                 };
                 if args.len() == 1 && canonical_list_method("append") == Some(inner_func) {
-                    // Do not replace this with `list_append_value` until
-                    // guard-failure blackhole resume is complete.  A direct
-                    // trace-visible append/pop port looks closer to PyPy, but
-                    // currently corrupts semantics: `python3 pyre/check.py
-                    // --synthetic-only --synthetic-pattern list_append_pop.py`
-                    // reports wrong output on both dynasm and cranelift when
-                    // these aborts are removed.
-                    return Err(trace_abort_error(
-                        "abort tracing builtin list.append until guard-failure blackhole resume is complete",
-                    ));
+                    let self_ref = recover_self(self);
+                    self.list_append_value(self_ref, args[0], inner_self, concrete_args[0])?;
+                    let none_ref =
+                        self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
+                    return Ok(none_ref);
                 }
                 if args.len() == 0 && canonical_list_method("pop") == Some(inner_func) {
-                    // Keep in sync with the append guard above. Removing this
-                    // abort caused `synth/list_append_pop` correctness
-                    // failures during the PyPy-parity audit.
-                    return Err(trace_abort_error(
-                        "abort tracing builtin list.pop until guard-failure blackhole resume is complete",
-                    ));
+                    let self_ref = recover_self(self);
+                    let concrete_len = unsafe { w_list_len(inner_self) };
+                    return self.list_pop_value(callable, self_ref, inner_self, concrete_len);
                 }
                 if args.len() == 0 && canonical_list_method("reverse") == Some(inner_func) {
                     let self_ref = recover_self(self);
@@ -5864,28 +5856,18 @@ impl MIFrame {
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
-                    // Do not replace this with `list_append_value` until
-                    // guard-failure blackhole resume is complete.  A direct
-                    // trace-visible append/pop port looks closer to PyPy, but
-                    // currently corrupts semantics: `python3 pyre/check.py
-                    // --synthetic-only --synthetic-pattern list_append_pop.py`
-                    // reports wrong output on both dynasm and cranelift when
-                    // these aborts are removed.
-                    return Err(trace_abort_error(
-                        "abort tracing builtin list.append until guard-failure blackhole resume is complete",
-                    ));
+                    self.list_append_value(args[0], args[1], concrete_args[0], concrete_args[1])?;
+                    let none_ref =
+                        self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
+                    return Ok(none_ref);
                 }
                 if args.len() == 1
                     && canonical_list_method("pop") == Some(concrete_callable)
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
-                    // Keep in sync with the append guard above. Removing this
-                    // abort caused `synth/list_append_pop` correctness
-                    // failures during the PyPy-parity audit.
-                    return Err(trace_abort_error(
-                        "abort tracing builtin list.pop until guard-failure blackhole resume is complete",
-                    ));
+                    let concrete_len = unsafe { w_list_len(concrete_args[0]) };
+                    return self.list_pop_value(callable, args[0], concrete_args[0], concrete_len);
                 }
                 if args.len() == 1
                     && canonical_list_method("reverse") == Some(concrete_callable)

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1072,6 +1072,18 @@ impl MIFrame {
     /// `list_reverse_value`). Non-mutating method calls (`x in s`, `len(xs)`)
     /// and deferred stores (`STORE_SUBSCR`) never reach this, so their loops
     /// stay unmarked and `dm143_advance_live_locals` skips their advance.
+    ///
+    /// Precision caveat: for the dominant callers — the builtin-form dispatch
+    /// arms and the LIST_APPEND opcode hook — the concrete mutation is
+    /// guaranteed (the trait impl's `call_callable` executes builtin/user
+    /// functions concretely before dispatch; non-walker opcodes run
+    /// `execute_opcode_step`). The rare method-form arms (a `W_MethodObject`
+    /// flowing as a value, e.g. `m = xs.pop; m(0)`) get NO concrete execution
+    /// (the trait impl only executes `is_function` callables), so they
+    /// over-mark; such traces also carry a Null concrete result and degrade
+    /// before a clean CloseLoop. The precise fix is a `W_MethodObject` unwrap
+    /// in the trait impl's concrete-execution block (executor parity), not a
+    /// recorder-side gate.
     #[inline]
     pub(crate) fn dm143_mark_heap_mutated(&mut self) {
         // Set by the concrete-during-trace mutation recorders only

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2071,6 +2071,42 @@ impl MIFrame {
         Ok(())
     }
 
+    /// Variant of `push_call_replay_stack` for the resolved-builtin call
+    /// shape where the receiver already occupies `args[0]` (the
+    /// `null_or_self` slot was non-null and the CALL handler folded it into
+    /// the arg list). Replays the exact CALL operand stack
+    /// `[callable, args...]` with no synthesised null sentinel.
+    fn push_call_replay_stack_self_in_args(
+        &mut self,
+        ctx: &mut TraceCtx,
+        callable: OpRef,
+        callable_concrete: ConcreteValue,
+        args: &[OpRef],
+        call_pc: usize,
+    ) {
+        // The callable carries its real concrete (a Const unbound function
+        // for resolved-builtin calls). A Const operand is numbered as
+        // TAGCONST from its concrete value at guard-failure resume, so a
+        // `ConcreteValue::Null` here would reconstruct a null callable.
+        self.push_value(ctx, callable, callable_concrete);
+        for &arg in args {
+            self.push_value(ctx, arg, ConcreteValue::Null);
+        }
+        self.sym_mut().pending_next_instr = Some(call_pc);
+    }
+
+    fn pop_call_replay_stack_self_in_args(
+        &mut self,
+        ctx: &mut TraceCtx,
+        args_len: usize,
+    ) -> Result<(), PyError> {
+        for _ in 0..(1 + args_len) {
+            let _ = self.pop_value(ctx)?;
+        }
+        self.sym_mut().pending_next_instr = None;
+        Ok(())
+    }
+
     pub(crate) fn swap_values(&mut self, ctx: &mut TraceCtx, depth: usize) -> Result<(), PyError> {
         // Read the stack depth from the
         // concrete `PyFrame` at `concrete_frame_addr` rather than the
@@ -5804,16 +5840,35 @@ impl MIFrame {
                     })
                 };
                 if args.len() == 1 && canonical_list_method("append") == Some(inner_func) {
+                    // The folded fast path emits guards (resize-guard,
+                    // strategy guard, ...) that resume at the CALL pc. Replay
+                    // the `[callable, null, value]` operand stack the CALL
+                    // handler already popped so those guards capture the real
+                    // operands; otherwise blackhole re-execution of CALL on a
+                    // resize-guard failure reads a null callable.
+                    let call_pc = self.fallthrough_pc.saturating_sub(1);
+                    self.with_ctx(|this, ctx| {
+                        this.push_call_replay_stack(ctx, callable, args, call_pc)
+                    });
                     let self_ref = recover_self(self);
-                    self.list_append_value(self_ref, args[0], inner_self, concrete_args[0])?;
+                    let res =
+                        self.list_append_value(self_ref, args[0], inner_self, concrete_args[0]);
+                    self.with_ctx(|this, ctx| this.pop_call_replay_stack(ctx, args.len()))?;
+                    res?;
                     let none_ref =
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
                     return Ok(none_ref);
                 }
                 if args.len() == 0 && canonical_list_method("pop") == Some(inner_func) {
+                    let call_pc = self.fallthrough_pc.saturating_sub(1);
+                    self.with_ctx(|this, ctx| {
+                        this.push_call_replay_stack(ctx, callable, args, call_pc)
+                    });
                     let self_ref = recover_self(self);
                     let concrete_len = unsafe { w_list_len(inner_self) };
-                    return self.list_pop_value(callable, self_ref, inner_self, concrete_len);
+                    let res = self.list_pop_value(callable, self_ref, inner_self, concrete_len);
+                    self.with_ctx(|this, ctx| this.pop_call_replay_stack(ctx, args.len()))?;
+                    return res;
                 }
                 if args.len() == 0 && canonical_list_method("reverse") == Some(inner_func) {
                     let self_ref = recover_self(self);
@@ -5856,7 +5911,31 @@ impl MIFrame {
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
-                    self.list_append_value(args[0], args[1], concrete_args[0], concrete_args[1])?;
+                    // The folded fast path emits guards (resize-guard,
+                    // strategy guard, ...) that resume at the CALL pc. Replay
+                    // the `[callable, self, value]` operand stack the CALL
+                    // handler already popped so those guards capture the real
+                    // operands for blackhole re-execution on guard failure.
+                    let call_pc = self.fallthrough_pc.saturating_sub(1);
+                    self.with_ctx(|this, ctx| {
+                        this.push_call_replay_stack_self_in_args(
+                            ctx,
+                            callable,
+                            ConcreteValue::Ref(concrete_callable),
+                            args,
+                            call_pc,
+                        )
+                    });
+                    let res = self.list_append_value(
+                        args[0],
+                        args[1],
+                        concrete_args[0],
+                        concrete_args[1],
+                    );
+                    self.with_ctx(|this, ctx| {
+                        this.pop_call_replay_stack_self_in_args(ctx, args.len())
+                    })?;
+                    res?;
                     let none_ref =
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
                     return Ok(none_ref);
@@ -5866,18 +5945,45 @@ impl MIFrame {
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
-                    let concrete_len = unsafe { w_list_len(concrete_args[0]) };
-                    return self.list_pop_value(callable, args[0], concrete_args[0], concrete_len);
+                    let call_pc = self.fallthrough_pc.saturating_sub(1);
+                    self.with_ctx(|this, ctx| {
+                        this.push_call_replay_stack_self_in_args(
+                            ctx,
+                            callable,
+                            ConcreteValue::Ref(concrete_callable),
+                            args,
+                            call_pc,
+                        )
+                    });
+                    let concrete_len = w_list_len(concrete_args[0]);
+                    let res =
+                        self.list_pop_value(callable, args[0], concrete_args[0], concrete_len);
+                    self.with_ctx(|this, ctx| {
+                        this.pop_call_replay_stack_self_in_args(ctx, args.len())
+                    })?;
+                    return res;
                 }
                 if args.len() == 1
                     && canonical_list_method("reverse") == Some(concrete_callable)
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
+                    let call_pc = self.fallthrough_pc.saturating_sub(1);
                     self.with_ctx(|this, ctx| {
-                        this.implement_guard_value(ctx, callable, concrete_callable as i64)
+                        this.implement_guard_value(ctx, callable, concrete_callable as i64);
+                        this.push_call_replay_stack_self_in_args(
+                            ctx,
+                            callable,
+                            ConcreteValue::Ref(concrete_callable),
+                            args,
+                            call_pc,
+                        );
                     });
-                    return self.list_reverse_value(callable, args[0], concrete_args[0]);
+                    let res = self.list_reverse_value(callable, args[0], concrete_args[0]);
+                    self.with_ctx(|this, ctx| {
+                        this.pop_call_replay_stack_self_in_args(ctx, args.len())
+                    })?;
+                    return res;
                 }
                 if args.len() == 1 {
                     let c_arg0 = concrete_args.first().copied().unwrap_or(PY_NULL);
@@ -8274,7 +8380,6 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::ForIter { .. }
             | Instruction::CallKw { .. }
             | Instruction::CallFunctionEx
-            | Instruction::LoadAttr { .. }
             | Instruction::StoreAttr { .. }
             // Instruction::StoreFastStoreFast excluded: routed off the
             // walker JIT path (kept on trait dispatch) until the SFSF
@@ -8958,6 +9063,40 @@ impl OpcodeStepExecutor for MIFrame {
         // below for every other receiver / descriptor shape.
         if self.try_load_method_fast_path(obj, concrete_obj, name)? {
             return Ok(());
+        }
+
+        // Resolve the foldable builtin list methods (append/pop/reverse) to
+        // a Const unbound function guarded by class, with self in the
+        // receiver slot, instead of a residual `jit_getattr` that
+        // materialises a fresh bound `W_MethodObject` every iteration. A
+        // Const callable is trivially reconstructed at guard-failure resume
+        // (a residual bound method is not — it resolves to a null callable
+        // on the blackhole CALL re-execution) and routes the following CALL
+        // through the resolved-builtin folding shape (`call_callable_value`).
+        if !concrete_obj.is_null()
+            && matches!(name, "append" | "pop" | "reverse")
+            && unsafe { is_list(concrete_obj) }
+        {
+            let list_type = pyre_interpreter::typedef::gettypeobject(&LIST_TYPE);
+            if let Some(unbound) = unsafe { pyre_interpreter::lookup_in_type(list_type, name) } {
+                if unsafe { is_function(unbound) }
+                    && unsafe {
+                        is_builtin_code(
+                            pyre_interpreter::getcode(unbound) as pyre_object::PyObjectRef
+                        )
+                    }
+                {
+                    let method_op = self.with_ctx(|this, ctx| {
+                        this.guard_class(ctx, obj.opref, &LIST_TYPE as *const PyType);
+                        ctx.const_ref(unbound as i64)
+                    });
+                    <Self as SharedOpcodeHandler>::push_value(
+                        self,
+                        FrontendOp::new(method_op, ConcreteValue::Ref(unbound)),
+                    )?;
+                    return <Self as SharedOpcodeHandler>::push_value(self, obj);
+                }
+            }
         }
 
         let attr = <Self as SharedOpcodeHandler>::load_attr(self, obj, name)?;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7882,6 +7882,43 @@ impl MIFrame {
         }
     }
 
+    /// True for the method-form `LOAD_ATTR` of a foldable builtin list
+    /// method (`append` / `pop` / `reverse`) on a concrete list receiver
+    /// at TOS.  The dispatch gate routes exactly this shape OFF the
+    /// walker leg so `MIFrame::load_method` can resolve it to a
+    /// class-guarded Const unbound function instead of the walker arm's
+    /// residual getattr (which materialises a fresh bound method every
+    /// iteration and resolves to a null callable on blackhole CALL
+    /// re-execution).
+    fn is_foldable_list_method_load_attr(
+        &self,
+        instruction: &Instruction,
+        op_arg: pyre_interpreter::OpArg,
+        code: &CodeObject,
+    ) -> bool {
+        let Instruction::LoadAttr { namei } = instruction else {
+            return false;
+        };
+        let attr = namei.get(op_arg);
+        if !attr.is_method() {
+            return false;
+        }
+        let Some(name) = code.names.get(attr.name_idx() as usize) else {
+            return false;
+        };
+        if !matches!(name.as_ref(), "append" | "pop" | "reverse") {
+            return false;
+        }
+        let s = self.sym();
+        let Some(stack_idx) = s.valuestackdepth.checked_sub(s.nlocals + 1) else {
+            return false;
+        };
+        matches!(
+            s.concrete_stack.get(stack_idx),
+            Some(ConcreteValue::Ref(obj)) if !obj.is_null() && unsafe { is_list(*obj) }
+        )
+    }
+
     pub fn trace_code_step(&mut self, code: &CodeObject, pc: usize) -> TraceAction {
         if pc >= code.instructions.len() {
             if majit_metainterp::majit_log_enabled() {
@@ -7996,7 +8033,12 @@ impl MIFrame {
                 // multi_frame_with_vable_vref`), fall back to trait
                 // dispatch in inline frames.
                 let in_inline_frame = !self.parent_frames.is_empty();
-                if production_walker_handles(&instruction) && !in_inline_frame {
+                let foldable_list_load_attr =
+                    self.is_foldable_list_method_load_attr(&instruction, op_arg, code);
+                if production_walker_handles(&instruction)
+                    && !in_inline_frame
+                    && !foldable_list_load_attr
+                {
                     self.dispatch_via_walker_for_opcode(&instruction, op_arg)
                 } else {
                     let shadow_outcome =
@@ -8828,6 +8870,13 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::ForIter { .. }
             | Instruction::CallKw { .. }
             | Instruction::CallFunctionEx
+            // Instruction::LoadAttr is walker-routed EXCEPT the foldable
+            // builtin list-method form (append/pop/reverse on a list
+            // receiver), which the dispatch gate carves out to the trait
+            // leg so MIFrame::load_method can resolve it to a
+            // class-guarded Const unbound function (the list
+            // specialization); see is_foldable_list_method_load_attr.
+            | Instruction::LoadAttr { .. }
             | Instruction::StoreAttr { .. }
             // Instruction::StoreFastStoreFast excluded: routed off the
             // walker JIT path (kept on trait dispatch) until the SFSF

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -10265,7 +10265,10 @@ mod tests {
         // fallthrough_pc=3 with no live boxes.
         let all_liveness = vec![0u8, 0, 0];
         let mut insns: VecAssoc<String, u8> = VecAssoc::new();
-        insns.insert("live/".to_string(), majit_metainterp::jitcode::insns::BC_LIVE);
+        insns.insert(
+            "live/".to_string(),
+            majit_metainterp::jitcode::insns::BC_LIVE,
+        );
         crate::assembler::publish_state(&insns, &all_liveness, all_liveness.len(), 1);
 
         // Outer (caller) jitcode: BC_LIVE at byte 0 and byte 3.  Identity

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5938,6 +5938,7 @@ impl MIFrame {
         list: OpRef,
         index: OpRef,
         concrete_list: PyObjectRef,
+        concrete_index: PyObjectRef,
     ) -> Result<OpRef, PyError> {
         // Pick the strategy-specific length field so the inline length update
         // mirrors `generated_list_pop_by_strategy`. A null / non-list / mixed
@@ -5960,6 +5961,31 @@ impl MIFrame {
             // The method-form generic call shape is `callable(index)`.
             return self.trace_call_callable(callable, &[index]);
         };
+        // The `jit_list_pop_at` residual panics on an out-of-range index
+        // instead of raising IndexError, so the fast path may only be taken
+        // with a trace-time in-range proof plus matching runtime guards
+        // (emitted by `trace_dynamic_list_index` below). A non-W_IntObject
+        // index or an out-of-range concrete index (IndexError at runtime)
+        // falls back to the generic call.
+        let concrete_key = unsafe {
+            if pyre_object::pyobject::py_type_check(concrete_index, &INT_TYPE) {
+                Some(pyre_object::w_int_get_value(concrete_index))
+            } else {
+                None
+            }
+        };
+        let Some(concrete_key) = concrete_key else {
+            return self.trace_call_callable(callable, &[index]);
+        };
+        let concrete_len = unsafe { w_list_len(concrete_list) } as i64;
+        let normalized_key = if concrete_key < 0 {
+            concrete_key + concrete_len
+        } else {
+            concrete_key
+        };
+        if normalized_key < 0 || normalized_key >= concrete_len {
+            return self.trace_call_callable(callable, &[index]);
+        }
         let len_descr_idx = len_descr.index();
         let result = self.with_ctx(|this, ctx| {
             this.guard_class(ctx, list, &LIST_TYPE as *const PyType);
@@ -5967,7 +5993,10 @@ impl MIFrame {
             // Pre-pop length (cached); `new_len = len - 1` is the
             // reconstructible post-pop length.
             let len = opimpl_getfield_gc_i(ctx, list, len_descr.clone());
-            let idx_int = this.trace_guarded_int_payload(ctx, index);
+            // `descr_pop` shape: unbox the index, normalize a negative one
+            // against `len`, and guard `0 <= idx < len`, so the residual's
+            // out-of-range panic is unreachable from compiled code.
+            let idx_int = this.trace_dynamic_list_index(ctx, index, len, concrete_key);
             // The residual does the real heap mutation (read + O(n) shift +
             // length decrement + tail clear) in compiled code.
             let res = crate::helpers::emit_trace_call_ref_typed(
@@ -6194,11 +6223,13 @@ impl MIFrame {
                     unsafe { pyre_interpreter::lookup_in_type(list_type, name) }
                 };
                 let recover_self = |this: &mut Self| {
-                    if let Some(existing) =
-                        this.with_ctx(|this, ctx| this.existing_ref_for_concrete(ctx, inner_self))
-                    {
-                        return existing;
-                    }
+                    // Pin the callable identity before any specialization:
+                    // the receiver opref alone does not tie the trace to the
+                    // builtin method — the bound method (or the local it was
+                    // stored in) can be rebound between loop entries while
+                    // the receiver still passes its class/strategy guards.
+                    // The method object is freshly allocated per iteration
+                    // but its `w_function` slot is stable, so guard on that.
                     this.with_ctx(|this, ctx| {
                         this.guard_class(ctx, callable, &METHOD_TYPE as *const PyType);
                         let func_ref = ctx.record_op_with_descr(
@@ -6207,6 +6238,13 @@ impl MIFrame {
                             crate::descr::method_w_function_descr(),
                         );
                         this.implement_guard_value(ctx, func_ref, inner_func as i64);
+                    });
+                    if let Some(existing) =
+                        this.with_ctx(|this, ctx| this.existing_ref_for_concrete(ctx, inner_self))
+                    {
+                        return existing;
+                    }
+                    this.with_ctx(|this, ctx| {
                         ctx.record_op_with_descr(
                             majit_ir::OpCode::GetfieldGcR,
                             &[callable],
@@ -6235,7 +6273,13 @@ impl MIFrame {
                     // length overlay). Called directly like the append arm — no
                     // replay scaffolding.
                     let self_ref = recover_self(self);
-                    return self.list_pop_at_value(callable, self_ref, args[0], inner_self);
+                    return self.list_pop_at_value(
+                        callable,
+                        self_ref,
+                        args[0],
+                        inner_self,
+                        concrete_args[0],
+                    );
                 }
                 if args.len() == 0 && canonical_list_method("pop") == Some(inner_func) {
                     let call_pc = self.fallthrough_pc.saturating_sub(1);
@@ -6306,6 +6350,13 @@ impl MIFrame {
                     // certainty. The W_Method method-form arms above do NOT
                     // mark — no concrete execution happens on that path.
                     self.dm143_mark_heap_mutated();
+                    // Pin the callable identity (as the reverse arm below):
+                    // the receiver's class/strategy guards alone do not keep
+                    // the trace from running the builtin append after the
+                    // callable has been rebound.
+                    self.with_ctx(|this, ctx| {
+                        this.implement_guard_value(ctx, callable, concrete_callable as i64)
+                    });
                     self.list_append_value(args[0], args[1], concrete_args[0], concrete_args[1])?;
                     let none_ref =
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
@@ -6321,7 +6372,16 @@ impl MIFrame {
                     // reconstructible length overlay), called directly like the
                     // append arm — no replay scaffolding.
                     self.dm143_mark_heap_mutated();
-                    return self.list_pop_at_value(callable, args[0], args[1], concrete_args[0]);
+                    self.with_ctx(|this, ctx| {
+                        this.implement_guard_value(ctx, callable, concrete_callable as i64)
+                    });
+                    return self.list_pop_at_value(
+                        callable,
+                        args[0],
+                        args[1],
+                        concrete_args[0],
+                        concrete_args[1],
+                    );
                 }
                 if args.len() == 1
                     && canonical_list_method("pop") == Some(concrete_callable)
@@ -6329,6 +6389,9 @@ impl MIFrame {
                     && is_list(concrete_args[0])
                 {
                     self.dm143_mark_heap_mutated();
+                    self.with_ctx(|this, ctx| {
+                        this.implement_guard_value(ctx, callable, concrete_callable as i64)
+                    });
                     let call_pc = self.fallthrough_pc.saturating_sub(1);
                     self.with_ctx(|this, ctx| {
                         this.push_call_replay_stack_self_in_args(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -3919,6 +3919,55 @@ impl MIFrame {
         types
     }
 
+    /// Append `self.parent_frames` onto an innermost-first `lead` frame
+    /// list and reverse the whole vector to the outermost-first order
+    /// required by `recorder.rs:54` ("Frames in the snapshot, outermost
+    /// first") and `resume.rs:252`.  Extracted so both the ordinary
+    /// `build_framestack_snapshot` (lead = `[top]`) and the issue #143
+    /// synthetic-callee path (lead = `[helper, self-as-parent]`) share one
+    /// parent-collection + reverse seam.
+    fn build_framestack_frames(
+        &mut self,
+        ctx: &mut TraceCtx,
+        mut lead: Vec<majit_metainterp::recorder::SnapshotFrame>,
+    ) -> Vec<majit_metainterp::recorder::SnapshotFrame> {
+        let n = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;
+        // opencoder.py:806: parent frames keep their original pc.
+        // Snapshot boxes = active boxes only (skip scalar inputarg header).
+        for parent in self.parent_frames.clone() {
+            let (parent_types_full, parent_jitcode_index, parent_active) =
+                self.materialize_parent_snapshot_state(ctx, parent);
+            let parent_types: &[Type] = if parent_types_full.len() > n {
+                &parent_types_full[n..]
+            } else {
+                &[]
+            };
+            // Parent frames never carry the after-residual-call marker, so
+            // their raw resume pc must leave bit 14 free or decode would
+            // mis-read it as marked (resumedata.rs:48-62).
+            assert!(
+                (parent.resume_pc as usize)
+                    < majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG as usize,
+                "parent resume pc {} >= AFTER_RESIDUAL_CALL_PC_FLAG; \
+                 function too large for bit-14 resume encoding",
+                parent.resume_pc
+            );
+            lead.push(majit_metainterp::recorder::SnapshotFrame {
+                jitcode_index: parent_jitcode_index,
+                pc: parent.resume_pc as u32,
+                boxes: Self::fail_args_to_snapshot_boxes_typed(&parent_active, parent_types, ctx),
+            });
+        }
+        // opencoder.py:217 `SnapshotIterator.__init__` calls
+        // `self.framestack.reverse()` so the numbering loop at
+        // `resume.py:249-253` iterates outermost-first.  pyre builds the
+        // frame list innermost-first (`[top, immediate_caller, ...,
+        // outermost]`); reverse so `Snapshot.frames[0]` is outermost,
+        // matching `recorder.rs:54` / `resume.rs:252`.
+        lead.reverse();
+        lead
+    }
+
     /// Build the full framestack `Snapshot` — top (callee) frame
     /// followed by every parent frame in `self.parent_frames` — plus
     /// virtualizable and virtualref boxes.  Mirrors opencoder.py:819-832
@@ -3941,7 +3990,7 @@ impl MIFrame {
         let n = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;
         let top_snapshot_types = &top_snapshot_types_full[n..];
         let top_jitcode_index = unsafe { (*self.sym().jitcode).index } as u32;
-        let mut frames = vec![majit_metainterp::recorder::SnapshotFrame {
+        let top_frame = majit_metainterp::recorder::SnapshotFrame {
             jitcode_index: top_jitcode_index,
             pc: top_pc as u32,
             boxes: Self::fail_args_to_snapshot_boxes_typed(
@@ -3949,44 +3998,8 @@ impl MIFrame {
                 top_snapshot_types,
                 ctx,
             ),
-        }];
-        // opencoder.py:806: parent frames keep their original pc.
-        // Snapshot boxes = active boxes only (skip scalar inputarg header).
-        for parent in self.parent_frames.clone() {
-            let (parent_types_full, parent_jitcode_index, parent_active) =
-                self.materialize_parent_snapshot_state(ctx, parent);
-            let parent_types: &[Type] = if parent_types_full.len() > n {
-                &parent_types_full[n..]
-            } else {
-                &[]
-            };
-            // Parent frames never carry the after-residual-call marker, so
-            // their raw resume pc must leave bit 14 free or decode would
-            // mis-read it as marked (resumedata.rs:48-62).
-            assert!(
-                (parent.resume_pc as usize)
-                    < majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG as usize,
-                "parent resume pc {} >= AFTER_RESIDUAL_CALL_PC_FLAG; \
-                 function too large for bit-14 resume encoding",
-                parent.resume_pc
-            );
-            frames.push(majit_metainterp::recorder::SnapshotFrame {
-                jitcode_index: parent_jitcode_index,
-                pc: parent.resume_pc as u32,
-                boxes: Self::fail_args_to_snapshot_boxes_typed(&parent_active, parent_types, ctx),
-            });
-        }
-        // opencoder.py:217 `SnapshotIterator.__init__` calls
-        // `self.framestack.reverse()` so the numbering loop at
-        // `resume.py:249-253` iterates outermost-first.  Pyre's
-        // encoder builds `frames` innermost-first
-        // (`[top, immediate_caller, ..., outermost]`); reverse here
-        // so `Snapshot.frames[0]` is outermost-first, matching the
-        // documented contract on `recorder.rs:54` "Frames in the
-        // snapshot, outermost first" and `resume.rs:252`
-        // "Input tuples for this factory follow the same caller-first
-        // order".
-        frames.reverse();
+        };
+        let frames = self.build_framestack_frames(ctx, vec![top_frame]);
         let vable_boxes = self.list_of_boxes_virtualizable(ctx);
         let vref_boxes = Self::build_virtualref_boxes(self.sym(), ctx);
         // PHASE 1.4 candidate D probe: detect snapshot-time divergence
@@ -4032,6 +4045,129 @@ impl MIFrame {
                 diverge
             );
         }
+        majit_metainterp::recorder::Snapshot {
+            frames,
+            vable_boxes,
+            vref_boxes,
+        }
+    }
+
+    /// Issue #143 core: synthesize a framestack whose innermost frame is a
+    /// Rust runtime-helper jitcode (the folded `list.append`/`pop` body),
+    /// not a Python frame.  Because `PyreMetaInterp::interpret`
+    /// (metainterp.rs:88) can only decode a `W_CodeObject` jitcode, the
+    /// helper callee can never be *traced*; instead the resize `GuardTrue`
+    /// captures a snapshot in which the helper is the top/callee frame and
+    /// the current Python frame is demoted to its immediate caller.  On
+    /// guard failure the blackhole resumes into the helper at `helper_pc`
+    /// (an identity-`pc_map` byte offset registered by
+    /// `register_runtime_helper_jitcode`, M-core1), runs the generic
+    /// append+realloc, returns its result into the caller's pending slot,
+    /// and the caller resumes at the post-CALL `fallthrough_pc` — instead
+    /// of re-executing the method-shape `CALL` and rebuilding a NULL
+    /// callable.
+    ///
+    /// `boxes` is the hand-built `[list, value]` carried into the helper.
+    /// It has NO scalar-inputarg header (the helper has no virtualizable
+    /// Python frame), so its types are computed 1:1 and passed UNSLICED.
+    /// `result_stack_idx` / `result_type` are the caller's pending call
+    /// result slot (relative to `nlocals`) and kind; they MUST be `Some`
+    /// in production so the demoted caller's `get_list_of_active_boxes`
+    /// (`in_a_call`, trace_opcode.rs:1538) nulls the undefined result slot
+    /// rather than capturing a stale box.  Returns frames outermost-first
+    /// (`[...outer parents, self, helper]`).
+    #[allow(dead_code)]
+    fn build_synthetic_callee_frames(
+        &mut self,
+        ctx: &mut TraceCtx,
+        helper_jitcode_index: u32,
+        helper_pc: usize,
+        boxes: &[OpRef],
+        result_stack_idx: Option<usize>,
+        result_type: Option<Type>,
+    ) -> Vec<majit_metainterp::recorder::SnapshotFrame> {
+        let n = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;
+
+        // Synthetic Rust-helper callee (new innermost/top frame). Its boxes
+        // are hand-built with NO 8-entry scalar-inputarg header, so
+        // `helper_types` matches `boxes` 1:1 and is passed UNSLICED. Each
+        // box keeps its intrinsic kind via `value_type` (list -> Ref, an
+        // unboxed int value -> Int) so resume `_number_boxes` tags it
+        // correctly.
+        let helper_types: Vec<Type> = boxes.iter().map(|&op| self.value_type(op)).collect();
+        let helper_frame = majit_metainterp::recorder::SnapshotFrame {
+            jitcode_index: helper_jitcode_index,
+            pc: helper_pc as u32,
+            boxes: Self::fail_args_to_snapshot_boxes_typed(boxes, &helper_types, ctx),
+        };
+
+        // Demote `self` (the Python frame doing the append) to the helper's
+        // immediate caller, resuming at the post-CALL fallthrough. Routing
+        // self through the SAME parent path as real parents is borrow-safe:
+        // `materialize_parent_snapshot_state` reads nothing from `self`
+        // (trace_opcode.rs:3925) — it rebuilds a fresh MIFrame from the raw
+        // `sym` pointer — so at most one `&mut PyreSym` is ever live, even
+        // when `parent.sym == self.sym`. `self.sym` / `concrete_frame_addr`
+        // / `fallthrough_pc` are Copy and read into the struct literal
+        // before the `&mut self` call. The pending result slot is carried
+        // so the caller's undefined call result is nulled at snapshot time.
+        let self_as_parent = ResumeFrameState {
+            sym: self.sym,
+            concrete_frame_addr: self.concrete_frame_addr,
+            resume_pc: self.fallthrough_pc,
+            pending_result_stack_idx: result_stack_idx,
+            pending_result_type: result_type,
+        };
+        let (self_types_full, self_jitcode_index, self_active) =
+            self.materialize_parent_snapshot_state(ctx, self_as_parent);
+        let self_types: &[Type] = if self_types_full.len() > n {
+            &self_types_full[n..]
+        } else {
+            &[]
+        };
+        let self_frame = majit_metainterp::recorder::SnapshotFrame {
+            jitcode_index: self_jitcode_index,
+            pc: self.fallthrough_pc as u32,
+            boxes: Self::fail_args_to_snapshot_boxes_typed(&self_active, self_types, ctx),
+        };
+
+        // Innermost-first lead = [helper(top), self(first parent)]; append
+        // self.parent_frames and reverse -> outermost-first
+        // [...outer parents, self, helper] (synthetic callee = frames[len-1]).
+        self.build_framestack_frames(ctx, vec![helper_frame, self_frame])
+    }
+
+    /// Full M-core2 `Snapshot` for the issue #143 resize guard: the
+    /// synthetic-callee framestack from `build_synthetic_callee_frames`
+    /// plus the one-shot virtualizable + virtualref boxes, both sourced
+    /// from the REAL Python frame's `sym` (the helper has none) exactly as
+    /// `build_framestack_snapshot` does.
+    ///
+    /// Like `build_framestack_snapshot`, this does NOT swap `self.orgpc`
+    /// or save/restore the vable scalars; the M-core3 caller must do that
+    /// around this call (mirroring `capture_resumedata`,
+    /// trace_opcode.rs:3742-3771) since `list_of_boxes_virtualizable`
+    /// derives the vable `last_instr`/`valuestackdepth` from `self.orgpc`.
+    #[allow(dead_code)]
+    fn build_framestack_snapshot_with_synthetic_callee(
+        &mut self,
+        ctx: &mut TraceCtx,
+        helper_jitcode_index: u32,
+        helper_pc: usize,
+        boxes: &[OpRef],
+        result_stack_idx: Option<usize>,
+        result_type: Option<Type>,
+    ) -> majit_metainterp::recorder::Snapshot {
+        let frames = self.build_synthetic_callee_frames(
+            ctx,
+            helper_jitcode_index,
+            helper_pc,
+            boxes,
+            result_stack_idx,
+            result_type,
+        );
+        let vable_boxes = self.list_of_boxes_virtualizable(ctx);
+        let vref_boxes = Self::build_virtualref_boxes(self.sym(), ctx);
         majit_metainterp::recorder::Snapshot {
             frames,
             vable_boxes,
@@ -10105,6 +10241,119 @@ mod tests {
 
         let active = frame.get_list_of_active_boxes(&mut ctx, false, false);
         assert_eq!(active, vec![stack0]);
+
+        unsafe {
+            let _ = Box::from_raw(inner_jc_ptr as *mut crate::state::JitCode);
+        }
+    }
+
+    /// Issue #143 M-core2: the resize guard synthesizes a 2-frame snapshot
+    /// whose innermost frame is the Rust runtime-helper callee (top) and
+    /// whose outer frame is the demoted Python caller resuming at its
+    /// post-CALL fallthrough.  Frames come back outermost-first
+    /// (`recorder.rs:56`), so `frames[0]` is the caller and `frames[1]` the
+    /// synthetic helper.  Exercises `build_synthetic_callee_frames` (the
+    /// frame-chain novelty) — NOT the full `_with_synthetic_callee` wrapper,
+    /// whose vable/vref tail would deref a skeleton helper's null code.
+    #[test]
+    fn build_synthetic_callee_frames_synthesizes_self_caller_and_helper_top() {
+        use majit_ir::VecAssoc;
+        use majit_metainterp::recorder::SnapshotTagged;
+        use std::sync::Arc;
+
+        // Empty liveness banks at offset 0: the demoted caller resumes at
+        // fallthrough_pc=3 with no live boxes.
+        let all_liveness = vec![0u8, 0, 0];
+        let mut insns: VecAssoc<String, u8> = VecAssoc::new();
+        insns.insert("live/".to_string(), majit_metainterp::jitcode::insns::BC_LIVE);
+        crate::assembler::publish_state(&insns, &all_liveness, all_liveness.len(), 1);
+
+        // Outer (caller) jitcode: BC_LIVE at byte 0 and byte 3.  Identity
+        // pc_map so resume_jitcode_pc_for(fallthrough_pc=3) == Some(3)
+        // (the M-core1 sibling-test pattern); the operand bytes [4],[5]=0,0
+        // select liveness offset 0 -> empty banks.
+        let runtime_jc = {
+            let inner = majit_metainterp::jitcode::JitCode::new("synth_callee_outer");
+            inner.set_body(majit_translate::jitcode::JitCodeBody {
+                code: vec![
+                    majit_metainterp::jitcode::insns::BC_LIVE,
+                    0,
+                    0,
+                    majit_metainterp::jitcode::insns::BC_LIVE,
+                    0,
+                    0,
+                ],
+                c_num_regs_r: 1,
+                startpoints: Some([0_usize, 3_usize].into_iter().collect()),
+                ..Default::default()
+            });
+            inner
+        };
+        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null(), None);
+        pyjit.jitcode = Arc::new(runtime_jc);
+        pyjit.metadata.pc_map = (0..6).collect();
+        const OUTER_INDEX: i32 = 4;
+        let inner_jc = crate::state::JitCode {
+            code: std::ptr::null(),
+            index: OUTER_INDEX,
+            payload: Arc::new(pyjit),
+        };
+        let inner_jc_ptr = Box::into_raw(Box::new(inner_jc));
+
+        let mut sym = PyreSym::new_uninit(OpRef::NONE);
+        sym.jitcode = inner_jc_ptr;
+        sym.nlocals = 0;
+        sym.valuestackdepth = 0;
+        // registers_r left empty: no live boxes for the caller frame.
+
+        let mut ctx = TraceCtx::for_test(1);
+        let mut frame = MIFrame {
+            ctx: &mut ctx,
+            sym: &mut sym,
+            fallthrough_pc: 3,
+            parent_frames: Vec::new(), // empty -> exactly 2 frames out
+            pending_result_stack_idx: None,
+            pending_result_type: None,
+            pending_inline_frame: None,
+            orgpc: 3,
+            concrete_frame_addr: 0,
+            pre_opcode_registers_r: None,
+            pre_opcode_semantic_depth: None,
+        };
+
+        // Synthetic helper boxes: list = Ref op, value = unboxed Int op.
+        let list = OpRef::ref_op(20);
+        let value = OpRef::int_op(21);
+        const HELPER_INDEX: u32 = 7;
+        const GUARD_PC: usize = 99; // guard byte offset (identity pc_map)
+
+        let frames = frame.build_synthetic_callee_frames(
+            &mut ctx,
+            HELPER_INDEX,
+            GUARD_PC,
+            &[list, value],
+            None,
+            None,
+        );
+
+        // Outermost-first: [caller (demoted self), helper (innermost/top)].
+        assert_eq!(frames.len(), 2);
+
+        // frames[0] = self demoted to caller, resuming at fallthrough_pc.
+        assert_eq!(frames[0].jitcode_index, OUTER_INDEX as u32);
+        assert_eq!(frames[0].pc, 3); // self.fallthrough_pc
+        assert!(frames[0].boxes.is_empty()); // empty liveness, header sliced
+
+        // frames[1] = synthetic Rust-helper callee (new innermost/top frame).
+        assert_eq!(frames[1].jitcode_index, HELPER_INDEX);
+        assert_eq!(frames[1].pc, GUARD_PC as u32); // guard byte offset, raw
+        assert_eq!(
+            frames[1].boxes,
+            vec![
+                SnapshotTagged::Box(list, majit_ir::Type::Ref), // list -> Ref
+                SnapshotTagged::Box(value, majit_ir::Type::Int), // value -> Int (no header)
+            ]
+        );
 
         unsafe {
             let _ = Box::from_raw(inner_jc_ptr as *mut crate::state::JitCode);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1067,16 +1067,20 @@ impl MIFrame {
     }
 
     /// #143 frame-advance gate: mark this trace as having performed a concrete
-    /// heap mutation. Called from the precise list/dict mutation recorders
-    /// (`list_append_value`/`list_pop_value`/`list_reverse_value` and the
-    /// concrete `store_subscr_value` store). Non-mutating method calls
-    /// (`x in s`, `len(xs)`) never reach these, so a mutation-free loop's root
-    /// sym stays unmarked and `dm143_advance_live_locals` skips its advance.
+    /// heap mutation during tracing. Called only from the precise list mutation
+    /// recorders (`list_append_value`/`list_pop_value`/`list_pop_at_value`/
+    /// `list_reverse_value`). Non-mutating method calls (`x in s`, `len(xs)`)
+    /// and deferred stores (`STORE_SUBSCR`) never reach this, so their loops
+    /// stay unmarked and `dm143_advance_live_locals` skips their advance.
     #[inline]
     pub(crate) fn dm143_mark_heap_mutated(&mut self) {
-        if dm143_concrete_stores_enabled() {
-            self.sym_mut().dm143_heap_mutated = true;
-        }
+        // Set by the concrete-during-trace mutation recorders only
+        // (list append / pop / pop-at / reverse — method-call mutations that
+        // run at `call_callable` line ~101 during tracing). STORE_SUBSCR is
+        // deferred (no concrete write during trace) so it deliberately does
+        // NOT mark: a pure-STORE_SUBSCR loop (nbody / fannkuch) must keep its
+        // deferred write, which the compiled loop performs exactly once.
+        self.sym_mut().dm143_heap_mutated = true;
     }
 
     pub(crate) fn frame(&self) -> OpRef {
@@ -5685,21 +5689,13 @@ impl MIFrame {
         concrete_key: PyObjectRef,
         concrete_value: PyObjectRef,
     ) -> Result<(), PyError> {
-        // Emit the (deferred) STORE_SUBSCR IR first; its strategy guards read
-        // the PRE-mutation concrete object, matching the state the compiled
-        // loop guards check at entry.
+        // STORE_SUBSCR is deferred: the emitted IR performs the heap write in
+        // the compiled loop (exactly once), and no concrete write happens
+        // during trace. So it must NOT mark the loop as heap-mutated — a
+        // pure-STORE_SUBSCR loop (nbody / fannkuch) is not advanced, keeping
+        // its single deferred write. Only the concrete-during-trace method
+        // mutations (append / pop / reverse) drive `dm143_advance_live_locals`.
         self.store_subscr_value_emit(obj, key, value, concrete_obj, concrete_key, concrete_value)?;
-        if dm143_concrete_stores_enabled() {
-            // #143 Part 2: the IR above performs NO heap write during trace.
-            // Paired with dm143_advance_live_locals (which advances the live
-            // frame past this iteration so the compiled loop does not re-run
-            // it), the deferred write would be LOST. Execute it concretely now
-            // — the same concrete-during-trace behavior method-call mutations
-            // (xs.append()) already have. Covers every STORE_SUBSCR strategy
-            // (list int/float/object, dict, slice) through one objspace call.
-            pyre_interpreter::setitem(concrete_obj, concrete_key, concrete_value)?;
-            self.dm143_mark_heap_mutated();
-        }
         Ok(())
     }
 
@@ -5916,6 +5912,89 @@ impl MIFrame {
                 &[Type::Ref],
             );
             ctx.const_ref(pyre_object::w_none() as i64)
+        });
+        self.trace_record_no_exception_guard();
+        Ok(result)
+    }
+
+    /// Direct trace path for `list.pop(index)` (front / indexed pop).
+    ///
+    /// `ll_pop_zero` (`oopspec = 'list.pop(l, 0)'`) / `ll_pop_nonneg`
+    /// (`'list.pop(l, index)'`). The O(n) element shift is performed by the
+    /// `jit_list_pop_at` residual (an escaped, non-virtual list lowers the
+    /// oopspec to a residual call upstream too), but the residual is opaque:
+    /// `default_effect_info` only invalidates the list's cached length, so
+    /// the compiled loop would track a stale length and a later `append`
+    /// would write past the live elements (issue #143, the dominant len
+    /// error). Mirror the already-correct end-pop
+    /// (`generated_list_pop_by_strategy`): overlay an inline
+    /// `SetfieldGc(new_len)` so the post-pop length is a known,
+    /// resume-reconstructible value. The inline write is idempotent with the
+    /// residual's own decrement (both leave `length == len - 1`).
+    pub(crate) fn list_pop_at_value(
+        &mut self,
+        callable: OpRef,
+        list: OpRef,
+        index: OpRef,
+        concrete_list: PyObjectRef,
+    ) -> Result<OpRef, PyError> {
+        self.dm143_mark_heap_mutated();
+        // Pick the strategy-specific length field so the inline length update
+        // mirrors `generated_list_pop_by_strategy`. A null / non-list / mixed
+        // receiver has no known length field, so fall back to the generic
+        // residual on the method object.
+        let strategy = unsafe {
+            if concrete_list.is_null() || !is_list(concrete_list) {
+                None
+            } else if w_list_uses_object_storage(concrete_list) {
+                Some((0i64, crate::descr::list_length_descr()))
+            } else if w_list_uses_int_storage(concrete_list) {
+                Some((1i64, crate::descr::list_int_items_len_descr()))
+            } else if w_list_uses_float_storage(concrete_list) {
+                Some((2i64, crate::descr::list_float_items_len_descr()))
+            } else {
+                None
+            }
+        };
+        let Some((strategy_id, len_descr)) = strategy else {
+            // The method-form generic call shape is `callable(index)`.
+            return self.trace_call_callable(callable, &[index]);
+        };
+        let len_descr_idx = len_descr.index();
+        let result = self.with_ctx(|this, ctx| {
+            this.guard_class(ctx, list, &LIST_TYPE as *const PyType);
+            this.guard_list_strategy(ctx, list, strategy_id);
+            // Pre-pop length (cached); `new_len = len - 1` is the
+            // reconstructible post-pop length.
+            let len = opimpl_getfield_gc_i(ctx, list, len_descr.clone());
+            let idx_int = this.trace_guarded_int_payload(ctx, index);
+            // The residual does the real heap mutation (read + O(n) shift +
+            // length decrement + tail clear) in compiled code.
+            let res = crate::helpers::emit_trace_call_ref_typed(
+                ctx,
+                pyre_object::listobject::jit_list_pop_at as *const (),
+                &[list, idx_int],
+                &[Type::Ref, Type::Int],
+            );
+            // Load-bearing #143 fix: publish the post-pop length as a known
+            // value the optimizer/heapcache can carry forward and resume can
+            // replay (SetfieldGc lands in pending_fields).
+            let one = ctx.const_int(1);
+            let new_len = ctx.record_op(OpCode::IntSub, &[len, one]);
+            let new_len_value = ctx
+                .heapcache_getfield_cached(list, len_descr_idx)
+                .and_then(|b| match ctx.box_value(b)? {
+                    Value::Int(n) => Some(n),
+                    _ => None,
+                })
+                .map(|n| Value::Int(n.wrapping_sub(1)))
+                .unwrap_or(Value::Void);
+            if !matches!(new_len_value, Value::Void) {
+                ctx.set_opref_concrete(new_len, new_len_value);
+            }
+            ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr.clone());
+            ctx.heapcache_setfield_cached(list, len_descr_idx, new_len);
+            res
         });
         self.trace_record_no_exception_guard();
         Ok(result)
@@ -6150,6 +6229,14 @@ impl MIFrame {
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
                     return Ok(none_ref);
                 }
+                if args.len() == 1 && canonical_list_method("pop") == Some(inner_func) {
+                    // Indexed pop `xs.pop(i)`: recorded inline by
+                    // `list_pop_at_value` (residual shift + reconstructible
+                    // length overlay). Called directly like the append arm — no
+                    // replay scaffolding.
+                    let self_ref = recover_self(self);
+                    return self.list_pop_at_value(callable, self_ref, args[0], inner_self);
+                }
                 if args.len() == 0 && canonical_list_method("pop") == Some(inner_func) {
                     let call_pc = self.fallthrough_pc.saturating_sub(1);
                     self.with_ctx(|this, ctx| {
@@ -6212,15 +6299,21 @@ impl MIFrame {
                     // NULL callable on resume and inflated `valuestackdepth`,
                     // skewing the synthetic guard's `result_stack_idx` — is
                     // removed.
-                    self.list_append_value(
-                        args[0],
-                        args[1],
-                        concrete_args[0],
-                        concrete_args[1],
-                    )?;
+                    self.list_append_value(args[0], args[1], concrete_args[0], concrete_args[1])?;
                     let none_ref =
                         self.with_ctx(|_this, ctx| ctx.const_ref(pyre_object::w_none() as i64));
                     return Ok(none_ref);
+                }
+                if args.len() == 2
+                    && canonical_list_method("pop") == Some(concrete_callable)
+                    && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
+                    && is_list(concrete_args[0])
+                {
+                    // Builtin-form indexed pop `list.pop(xs, i)`: recorded
+                    // inline by `list_pop_at_value` (residual shift +
+                    // reconstructible length overlay), called directly like the
+                    // append arm — no replay scaffolding.
+                    return self.list_pop_at_value(callable, args[0], args[1], concrete_args[0]);
                 }
                 if args.len() == 1
                     && canonical_list_method("pop") == Some(concrete_callable)
@@ -8519,17 +8612,6 @@ unsafe fn trace_check_exc_match_against(
         return false;
     };
     pyre_interpreter::baseobjspace::exception_match(w_exc_class, exc_type)
-}
-
-/// #143 frame-advance gate (mirrors `dm143_advance_enabled` in pyre-jit
-/// eval.rs). The live-frame locals advance and the concrete-during-trace
-/// execution of otherwise-DEFERRED heap mutations (STORE_SUBSCR) are two
-/// halves of one fix and MUST be enabled together: advance without concrete
-/// stores loses the deferred write; concrete stores without advance applies
-/// it twice (trace + compiled re-run). Both read the same `PYRE_DM_ADVANCE`.
-pub(crate) fn dm143_concrete_stores_enabled() -> bool {
-    static EN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *EN.get_or_init(|| std::env::var_os("PYRE_DM_ADVANCE").is_some())
 }
 
 /// Production-walker allow-list for the walker cutover.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1066,6 +1066,19 @@ impl MIFrame {
         unsafe { &mut *self.sym }
     }
 
+    /// #143 frame-advance gate: mark this trace as having performed a concrete
+    /// heap mutation. Called from the precise list/dict mutation recorders
+    /// (`list_append_value`/`list_pop_value`/`list_reverse_value` and the
+    /// concrete `store_subscr_value` store). Non-mutating method calls
+    /// (`x in s`, `len(xs)`) never reach these, so a mutation-free loop's root
+    /// sym stays unmarked and `dm143_advance_live_locals` skips its advance.
+    #[inline]
+    pub(crate) fn dm143_mark_heap_mutated(&mut self) {
+        if dm143_concrete_stores_enabled() {
+            self.sym_mut().dm143_heap_mutated = true;
+        }
+    }
+
     pub(crate) fn frame(&self) -> OpRef {
         self.sym().frame
     }
@@ -5672,6 +5685,33 @@ impl MIFrame {
         concrete_key: PyObjectRef,
         concrete_value: PyObjectRef,
     ) -> Result<(), PyError> {
+        // Emit the (deferred) STORE_SUBSCR IR first; its strategy guards read
+        // the PRE-mutation concrete object, matching the state the compiled
+        // loop guards check at entry.
+        self.store_subscr_value_emit(obj, key, value, concrete_obj, concrete_key, concrete_value)?;
+        if dm143_concrete_stores_enabled() {
+            // #143 Part 2: the IR above performs NO heap write during trace.
+            // Paired with dm143_advance_live_locals (which advances the live
+            // frame past this iteration so the compiled loop does not re-run
+            // it), the deferred write would be LOST. Execute it concretely now
+            // — the same concrete-during-trace behavior method-call mutations
+            // (xs.append()) already have. Covers every STORE_SUBSCR strategy
+            // (list int/float/object, dict, slice) through one objspace call.
+            pyre_interpreter::setitem(concrete_obj, concrete_key, concrete_value)?;
+            self.dm143_mark_heap_mutated();
+        }
+        Ok(())
+    }
+
+    fn store_subscr_value_emit(
+        &mut self,
+        obj: OpRef,
+        key: OpRef,
+        value: OpRef,
+        concrete_obj: PyObjectRef,
+        concrete_key: PyObjectRef,
+        concrete_value: PyObjectRef,
+    ) -> Result<(), PyError> {
         if let Some((raw_start, raw_stop, start, stop, step_is_none)) =
             const_step_one_slice_bounds(concrete_obj, concrete_key, concrete_value)
         {
@@ -5758,6 +5798,7 @@ impl MIFrame {
         concrete_list: PyObjectRef,
         concrete_value: PyObjectRef,
     ) -> Result<(), PyError> {
+        self.dm143_mark_heap_mutated();
         if concrete_list.is_null() {
             return self.trace_list_append(list, value);
         }
@@ -5823,6 +5864,7 @@ impl MIFrame {
         concrete_list: PyObjectRef,
         concrete_len: usize,
     ) -> Result<OpRef, PyError> {
+        self.dm143_mark_heap_mutated();
         if concrete_list.is_null() || concrete_len == 0 {
             // Caller's guard ensures concrete_len > 0; defensive fallback.
             return self.trace_call_callable(callable, &[]);
@@ -5861,6 +5903,7 @@ impl MIFrame {
         list: OpRef,
         concrete_list: PyObjectRef,
     ) -> Result<OpRef, PyError> {
+        self.dm143_mark_heap_mutated();
         if concrete_list.is_null() || unsafe { !is_list(concrete_list) } {
             return self.trace_call_callable(callable, &[]);
         }
@@ -8476,6 +8519,17 @@ unsafe fn trace_check_exc_match_against(
         return false;
     };
     pyre_interpreter::baseobjspace::exception_match(w_exc_class, exc_type)
+}
+
+/// #143 frame-advance gate (mirrors `dm143_advance_enabled` in pyre-jit
+/// eval.rs). The live-frame locals advance and the concrete-during-trace
+/// execution of otherwise-DEFERRED heap mutations (STORE_SUBSCR) are two
+/// halves of one fix and MUST be enabled together: advance without concrete
+/// stores loses the deferred write; concrete stores without advance applies
+/// it twice (trace + compiled re-run). Both read the same `PYRE_DM_ADVANCE`.
+pub(crate) fn dm143_concrete_stores_enabled() -> bool {
+    static EN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *EN.get_or_init(|| std::env::var_os("PYRE_DM_ADVANCE").is_some())
 }
 
 /// Production-walker allow-list for the walker cutover.

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -1,5 +1,6 @@
 ---
 source: pyre/pyre-jit-trace/tests/trait_impls_snapshot.rs
+assertion_line: 48
 expression: assembled
 ---
 // `OpcodeHandler` trait impls for `MIFrame` — variant section, part 1.
@@ -212,7 +213,11 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
         list: Self::Value,
         value: Self::Value,
     ) -> Result<(), pyre_interpreter::PyError> {
-        // MIFrame parity: trace-only, no concrete mutation.
+        // MIFrame parity: the hook itself is trace-only — the concrete
+        // LIST_APPEND mutation is performed by the eval loop
+        // (`execute_opcode_step` / inline-frame `concrete_execute_step`),
+        // which is why this path marks the heap mutation.
+        self.dm143_mark_heap_mutated();
         self.list_append_value(
             list.opref,
             value.opref,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3193,6 +3193,61 @@ pub extern "C" fn bh_getattr_fn(obj: i64, w_name: i64) -> i64 {
     }
 }
 
+/// Resolve `getattr(obj, code.names[name_idx])` for blackhole LOAD_ATTR
+/// resume — the attribute / unbound-method half of LOOKUP_METHOD.  Mirrors
+/// `PyFrame::load_method`'s `getattr` call so the blackhole reproduces the
+/// interpreter's attribute lookup exactly (descriptor `__get__`, super
+/// proxies, weakref forcing).  On error stashes the exception in
+/// `BH_LAST_EXC_VALUE` and returns 0 (the trailing `-live-` lets the
+/// blackhole route it through the except handler), matching
+/// [`bh_load_global_fn`].
+pub extern "C" fn bh_load_attr_fn(obj: i64, w_code_ptr: i64, name_idx: i64) -> i64 {
+    let code = unsafe {
+        &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
+            as *const pyre_interpreter::CodeObject)
+    };
+    let idx = name_idx as usize;
+    if idx >= code.names.len() {
+        return 0;
+    }
+    let name = code.names[idx].as_ref();
+    match pyre_interpreter::baseobjspace::getattr(obj as pyre_object::PyObjectRef, name) {
+        Ok(attr) => attr as i64,
+        Err(err) => {
+            let exc_obj = err.to_exc_object();
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+            0
+        }
+    }
+}
+
+/// Compute the LOOKUP_METHOD `null_or_self` for blackhole LOAD_ATTR resume,
+/// given the already-resolved `attr` from [`bh_load_attr_fn`].  Delegates to
+/// the shared `compute_load_method_bound`, a pure MRO inspection that never
+/// re-invokes a descriptor, so it cannot raise (returns `PY_NULL` when no
+/// receiver should be prepended).
+pub extern "C" fn bh_load_method_self_fn(
+    obj: i64,
+    attr: i64,
+    w_code_ptr: i64,
+    name_idx: i64,
+) -> i64 {
+    let code = unsafe {
+        &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
+            as *const pyre_interpreter::CodeObject)
+    };
+    let idx = name_idx as usize;
+    if idx >= code.names.len() {
+        return pyre_object::PY_NULL as i64;
+    }
+    let name = code.names[idx].as_ref();
+    pyre_interpreter::eval::compute_load_method_bound(
+        obj as pyre_object::PyObjectRef,
+        attr as pyre_object::PyObjectRef,
+        name,
+    ) as i64
+}
+
 /// Load a constant from the code object.
 /// jtransform.py parity: code comes from getfield_vable_r(frame, pycode).
 pub extern "C" fn bh_load_const_fn(w_code_ptr: i64, consti: i64) -> i64 {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3211,7 +3211,7 @@ pub extern "C" fn bh_load_attr_fn(obj: i64, w_code_ptr: i64, name_idx: i64) -> i
         return 0;
     }
     let name = code.names[idx].as_ref();
-    match pyre_interpreter::baseobjspace::getattr(obj as pyre_object::PyObjectRef, name) {
+    match pyre_interpreter::baseobjspace::getattr_str(obj as pyre_object::PyObjectRef, name) {
         Ok(attr) => attr as i64,
         Err(err) => {
             let exc_obj = err.to_exc_object();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3361,13 +3361,15 @@ pub(crate) fn eval_loop_jit_bridge(frame: &mut PyFrame) -> LoopResult {
     }
 }
 
-/// #143 frame-advance spike gate. While the deferred-store asymmetry
-/// (`STORE_SUBSCR`/`STORE_ATTR` defer their heap write; `list.append`
-/// mutates during trace) is being characterized, the live-frame advance
-/// is opt-in via `PYRE_DM_ADVANCE` so check.py can A/B it.
+/// #143 live-frame advance master switch. The precise gate is the
+/// per-loop `dm143_heap_mutated` marker (set only by concrete-during-trace
+/// mutation recorders: `list.append`/`pop`/`pop(i)`/`reverse`).
+/// `STORE_SUBSCR`/`STORE_ATTR` defer their heap write and never set the
+/// marker, so their loops are not advanced. `PYRE_DM_NO_ADVANCE` forces
+/// the advance off for A/B debugging.
 fn dm143_advance_enabled() -> bool {
     static EN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *EN.get_or_init(|| std::env::var_os("PYRE_DM_ADVANCE").is_some())
+    *EN.get_or_init(|| std::env::var_os("PYRE_DM_NO_ADVANCE").is_none())
 }
 
 /// #143: at a successful loop close, advance the LIVE frame's locals to the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3361,6 +3361,51 @@ pub(crate) fn eval_loop_jit_bridge(frame: &mut PyFrame) -> LoopResult {
     }
 }
 
+/// #143 frame-advance spike gate. While the deferred-store asymmetry
+/// (`STORE_SUBSCR`/`STORE_ATTR` defer their heap write; `list.append`
+/// mutates during trace) is being characterized, the live-frame advance
+/// is opt-in via `PYRE_DM_ADVANCE` so check.py can A/B it.
+fn dm143_advance_enabled() -> bool {
+    static EN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *EN.get_or_init(|| std::env::var_os("PYRE_DM_ADVANCE").is_some())
+}
+
+/// #143: at a successful loop close, advance the LIVE frame's locals to the
+/// post-traced-iteration concrete state captured during tracing
+/// (`PyreSym.concrete_locals`). Without this the live frame's locals stay at
+/// the pre-trace iteration, so the compiled loop RE-RUNS the traced iteration
+/// — re-applying any during-trace heap mutation (`list.append`) and producing
+/// an off-by-one result (#143).
+pub(crate) fn dm143_advance_live_locals(
+    frame: &mut PyFrame,
+    sym: &pyre_jit_trace::state::PyreSym,
+    action: &majit_metainterp::TraceAction,
+) {
+    if !dm143_advance_enabled()
+        || !matches!(
+            action,
+            majit_metainterp::TraceAction::CloseLoop
+                | majit_metainterp::TraceAction::CloseLoopWithArgs { .. }
+        )
+        // Only advance loops whose traced iteration concretely mutated the heap.
+        // A mutation-free loop's compiled re-run of the traced iteration has no
+        // heap side effect, so the advance is unnecessary; advancing it would
+        // also desync the guard-failure resume (`set_membership`).
+        || !sym.dm143_heap_mutated()
+    {
+        return;
+    }
+    let n = sym.tracked_local_count().min(frame.locals_w().len());
+    for i in 0..n {
+        // Materialize + root one box at a time: w_int_new/w_float_new
+        // allocate, so each box must reach the frame (a GC root) before the
+        // next materialize_local call can trigger a nursery collection.
+        if let Some(obj) = sym.materialize_local(i) {
+            frame.locals_w_mut()[i] = obj;
+        }
+    }
+}
+
 /// RPython jit_merge_point slow path — only called when tracing is active.
 #[cold]
 #[inline(never)]
@@ -3478,6 +3523,13 @@ fn jit_merge_point_hook(
             if pyre_jit_trace::trace::take_walk_end_flush_committed() {
                 frame.restore_resume_state_from(&executed_frame);
             }
+            // Heap-mutation fallback (issue #143): when the trace took the
+            // trait leg and committed no walk-end flush, advance the live
+            // locals to the traced iteration's end so the post-abort
+            // interpreter re-run does not replay an append/pop that already
+            // mutated the heap concretely.  Idempotent with the flush above
+            // (both are absolute writes to the same iteration-end locals).
+            dm143_advance_live_locals(frame, sym, &action);
             action
         },
     ) {
@@ -4155,6 +4207,9 @@ fn bound_reached(
                     if pyre_jit_trace::trace::take_walk_end_flush_committed() {
                         frame.restore_resume_state_from(&executed_frame);
                     }
+                    // issue #143 heap-mutation fallback — see the
+                    // jit_merge_point_hook tracing site for the contract.
+                    dm143_advance_live_locals(frame, sym, &action);
                     action
                 },
             );

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3046,6 +3046,8 @@ struct FnPtrIndices {
     call_fn_8: HelperHandle,
     get_current_exception_fn: HelperHandle,
     set_current_exception_fn: HelperHandle,
+    load_attr_fn: HelperHandle,
+    load_method_self_fn: HelperHandle,
 }
 
 /// Register every blackhole helper fn pointer with the assembler in
@@ -3238,6 +3240,17 @@ fn register_helper_fn_pointers(
     // `load_global_fn`.  Bound after the existing fn_ptrs to preserve
     // their indices.
     let getattr_fn = bind(assembler, cpu.getattr_fn as *const (), CallFlavor::Plain);
+    // LOOKUP_METHOD lowering (appended last to preserve fn_ptr indices).
+    // `bh_load_attr_fn` calls `baseobjspace::getattr`, which can run user
+    // `__getattribute__` (forces virtualizables) and raise `AttributeError`
+    // → `MayForce`.  `bh_load_method_self_fn` is the pure binding decision —
+    // reads the type MRO (touches heap) but never raises → `PlainCannotRaise`.
+    let load_attr_fn = bind(assembler, cpu.load_attr_fn as *const (), CallFlavor::MayForce);
+    let load_method_self_fn = bind(
+        assembler,
+        cpu.load_method_self_fn as *const (),
+        CallFlavor::PlainCannotRaise,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -3264,6 +3277,8 @@ fn register_helper_fn_pointers(
         call_fn_8,
         get_current_exception_fn,
         set_current_exception_fn,
+        load_attr_fn,
+        load_method_self_fn,
     }
 }
 
@@ -4148,6 +4163,16 @@ impl CodeWriter {
                 HelperHandle {
                     idx: set_current_exception_fn_idx,
                     flavor: _set_current_exception_fn_flavor,
+                },
+            load_attr_fn:
+                HelperHandle {
+                    idx: load_attr_fn_idx,
+                    flavor: _load_attr_fn_flavor,
+                },
+            load_method_self_fn:
+                HelperHandle {
+                    idx: load_method_self_fn_idx,
+                    flavor: _load_method_self_fn_flavor,
                 },
         } = register_helper_fn_pointers(&mut assembler, self.cpu());
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3245,7 +3245,11 @@ fn register_helper_fn_pointers(
     // `__getattribute__` (forces virtualizables) and raise `AttributeError`
     // → `MayForce`.  `bh_load_method_self_fn` is the pure binding decision —
     // reads the type MRO (touches heap) but never raises → `PlainCannotRaise`.
-    let load_attr_fn = bind(assembler, cpu.load_attr_fn as *const (), CallFlavor::MayForce);
+    let load_attr_fn = bind(
+        assembler,
+        cpu.load_attr_fn as *const (),
+        CallFlavor::MayForce,
+    );
     let load_method_self_fn = bind(
         assembler,
         cpu.load_method_self_fn as *const (),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2571,15 +2571,58 @@ fn emit_frontend_getattr(
     block: &super::flow::BlockRef,
     obj: super::flow::FlowValue,
     attr_name: super::flow::FlowValue,
+    code_const: super::flow::FlowValue,
+    name_idx_const: super::flow::FlowValue,
     offset: i64,
 ) -> super::flow::Variable {
     // flowcontext.py:862-867 LOAD_ATTR ->
-    // `op.getattr(w_obj, w_attributename).eval(self)`.
+    // `op.getattr(w_obj, w_attributename).eval(self)`, extended with
+    // two rtyper-surrogate operands (the code object as a post-rtype
+    // `Signed(ptr) + Kind::Ref` constant and the `co_names` index)
+    // that `flatten.rs::lower_getattr_hlop_to_insn` threads into the
+    // `bh_load_attr_fn(obj, code, name_idx)` residual — pyre runs no
+    // `rclass.py:838 rtype_getattr` to rewrite the HLOp post-record.
     emit_graph_op_with_result(
         graph,
         block,
         "getattr",
-        vec![obj.into(), attr_name.into()],
+        vec![
+            obj.into(),
+            attr_name.into(),
+            code_const.into(),
+            name_idx_const.into(),
+        ],
+        Kind::Ref,
+        offset,
+    )
+}
+
+/// LOOKUP_METHOD `null_or_self` half — pyre-specific HLOp (upstream
+/// PyPy's `callmethod.py` two-value LOAD_METHOD is an objspace-level
+/// rewrite with no flow-graph counterpart; pyre's CPython-3.13 method
+/// form materializes the bound receiver as a second stack value).
+/// `attr` is the paired `getattr` HLOp's result.  Lowered by
+/// `flatten.rs::lower_load_method_self_hlop_to_insn` to the
+/// `bh_load_method_self_fn(obj, attr, code, name_idx)` residual.
+fn emit_frontend_load_method_self(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    obj: super::flow::FlowValue,
+    attr: super::flow::FlowValue,
+    code_const: super::flow::FlowValue,
+    name_idx_const: super::flow::FlowValue,
+    offset: i64,
+) -> super::flow::Variable {
+    emit_graph_op_with_result(
+        graph,
+        block,
+        "load_method_self",
+        vec![
+            obj.into(),
+            attr.into(),
+            code_const.into(),
+            name_idx_const.into(),
+        ],
         Kind::Ref,
         offset,
     )
@@ -4235,6 +4278,8 @@ impl CodeWriter {
                     call_fn_7_idx,
                     call_fn_8_idx,
                 ],
+                load_attr_fn_idx,
+                load_method_self_fn_idx,
             });
         }
 
@@ -7198,60 +7243,72 @@ impl CodeWriter {
                             emit_abort_permanent!();
                         }
                         Instruction::LoadAttr { namei } => {
-                            // PyPy assemble.py gives LOAD_ATTR a net-0 stack effect.
-                            // pyre's CPython-3.13 method form pushes an extra
-                            // null/self sentinel, so keep current_depth in sync.
+                            // LOAD_ATTR net-0 (plain form); the CPython-3.13
+                            // method form pushes an extra null_or_self for a
+                            // net +1.  Recorded as graph HLOps the canonical
+                            // splice lowers to residual calls
+                            // (`flatten.rs::lower_getattr_hlop_to_insn` /
+                            // `lower_load_method_self_hlop_to_insn`):
+                            //   * `load_attr_fn(obj, code, name_idx)` →
+                            //     getattr(obj, name)
+                            //   * (method only) `load_method_self_fn(obj,
+                            //     attr, code, name_idx)` → bound receiver.
+                            // Stack order is the interpreter convention: attr
+                            // at the lower slot, null_or_self above it
+                            // (`load_method` pushes attr then bound; the CALL
+                            // arm pops null_or_self first).
                             let attr = namei.get(op_arg);
                             let name_idx = attr.name_idx() as usize;
                             let attr_name =
                                 super::flow::Constant::string(code.names[name_idx].as_str());
-                            // Pop the receiver; the graph-side `getattr` HLOp
-                            // carries `obj_value`, so the vacated slot index is
-                            // not consumed here.
+                            // rtyper-surrogate operands for the splice
+                            // lowering: the jitcode's own W_CodeObject as a
+                            // post-rtype `Signed(ptr) + Kind::Ref` constant
+                            // (per-code jitcode ⇒ fixed pointer) and the
+                            // co_names index `bh_load_attr_fn` resolves the
+                            // name with.
+                            let code_const: super::flow::FlowValue = super::flow::Constant::new(
+                                super::flow::ConstantValue::Signed(w_code as i64),
+                                Some(Kind::Ref),
+                            )
+                            .into();
+                            let name_idx_const: super::flow::FlowValue =
+                                super::flow::Constant::signed(name_idx as i64).into();
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let obj_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             let result_value = emit_frontend_getattr(
                                 &mut graph,
                                 &current_block.block(),
-                                obj_value,
+                                obj_value.clone(),
                                 attr_name.into(),
+                                code_const.clone(),
+                                name_idx_const.clone(),
                                 py_pc as i64,
                             );
-                            // The call shape is `[callable (lower), self_or_null
-                            // (top)]` (eval.rs load_method, shared_opcode.rs
-                            // opcode_call).  The method form lands the (bound)
-                            // attribute at the deeper slot and a `PY_NULL`
-                            // self-slot on top of it, mirroring the `LoadGlobal`
-                            // push-null variant; the bound attribute already
-                            // carries `self`, so the top slot is a bare null.
-                            let loaded_dst_reg = stack_base + current_depth;
-                            pin!(Some(result_value), loaded_dst_reg);
-                            // Runnable residual lowering for the blackhole/deopt
-                            // path: `rclass.py:838 rtype_getattr` rewrites
-                            // `getattr` → `getfield_gc` after rtyping; pyre has
-                            // no rtyper, so the `getattr` HLOp recorded by
-                            // `emit_frontend_getattr` above lowers to a
-                            // `bh_getattr_fn(obj, w_name)` residual call in the
-                            // canonical flatten driver
-                            // (`flatten::lower_getattr_hlop_to_insn`); the name
-                            // Constant lowers to its interned immortal str
-                            // pointer (`box_str_constant`).  LOAD_ATTR is
-                            // walker-skipped during recording
-                            // (`trace_opcode.rs walker_skip_opcodes`), so this
-                            // call never runs while a virtualizable is live; the
-                            // optimized trace records `jit_getattr` via the
-                            // trait leg.
-                            let result_fv: super::flow::FlowValue = result_value.into();
-                            current_state.stack.push(result_fv.clone());
-                            emit_pushvalue_ref!(current_depth, loaded_dst_reg, result_fv, py_pc);
-                            // Method form: push the `PY_NULL` self-slot on top
-                            // of the attribute (callable), matching the
-                            // interpreter `load_method` push order.
+                            pin!(Some(result_value), stack_base + current_depth);
+                            current_state.stack.push(result_value.into());
+                            emit_pushvalue_ref!(
+                                current_depth,
+                                stack_base + current_depth,
+                                result_value.into(),
+                                py_pc
+                            );
                             if attr.is_method() {
-                                current_state.stack.push(null_stack_sentinel());
-                                emit_pushvalue_ref_const!(
+                                let bound_value = emit_frontend_load_method_self(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    obj_value,
+                                    result_value.into(),
+                                    code_const,
+                                    name_idx_const,
+                                    py_pc as i64,
+                                );
+                                pin!(Some(bound_value), stack_base + current_depth);
+                                current_state.stack.push(bound_value.into());
+                                emit_pushvalue_ref!(
                                     current_depth,
-                                    pyre_object::PY_NULL as i64,
+                                    stack_base + current_depth,
+                                    bound_value.into(),
                                     py_pc
                                 );
                             }
@@ -9859,8 +9916,23 @@ mod tests {
         let mut graph = FunctionGraph::new("getattr", start.clone(), None);
         let obj = Variable::new(VariableId(34), Kind::Ref);
         let name = Constant::string("field");
+        // rtyper-surrogate operands (post-rtype code-object ConstRef + the
+        // co_names index) trail the upstream 2-arg flowspace shape.
+        let code_const = Constant::new(
+            super::super::flow::ConstantValue::Signed(0x1000),
+            Some(Kind::Ref),
+        );
+        let name_idx_const = Constant::signed(3);
 
-        let result = emit_frontend_getattr(&mut graph, &start, obj.into(), name.clone().into(), 57);
+        let result = emit_frontend_getattr(
+            &mut graph,
+            &start,
+            obj.into(),
+            name.clone().into(),
+            code_const.clone().into(),
+            name_idx_const.clone().into(),
+            57,
+        );
 
         let block = start.borrow();
         let op = block
@@ -9869,7 +9941,15 @@ mod tests {
             .expect("getattr op should be recorded");
         assert_eq!(op.opname, "getattr");
         assert_eq!(op.offset, 57);
-        assert_eq!(op.args, vec![obj.into(), name.into()]);
+        assert_eq!(
+            op.args,
+            vec![
+                obj.into(),
+                name.into(),
+                code_const.into(),
+                name_idx_const.into(),
+            ]
+        );
         assert_eq!(op.result, Some(result.into()));
     }
 

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -45,6 +45,12 @@ pub struct Cpu {
     pub call_fn_8: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
     /// `bhimpl_load_global` — namespace/code from getfield_vable_r plus live frame.
     pub load_global_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
+    /// LOOKUP_METHOD attribute half — `(obj, code, name_idx) → attr`.
+    /// Reproduces `PyFrame::load_method`'s `getattr` for blackhole resume.
+    pub load_attr_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// LOOKUP_METHOD `null_or_self` half — `(obj, attr, code, name_idx) →
+    /// bound`. Pure binding decision shared with the interpreter.
+    pub load_method_self_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// `bhimpl_compare_op` — RPython compare_op opcodes.
     pub compare_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// `bhimpl_binary_op` — RPython binary_op opcodes.
@@ -157,6 +163,8 @@ impl Cpu {
             call_fn_7: crate::call_jit::bh_call_fn_7,
             call_fn_8: crate::call_jit::bh_call_fn_8,
             load_global_fn: crate::call_jit::bh_load_global_fn,
+            load_attr_fn: crate::call_jit::bh_load_attr_fn,
+            load_method_self_fn: crate::call_jit::bh_load_method_self_fn,
             compare_fn: crate::call_jit::bh_compare_fn,
             binary_op_fn: crate::call_jit::bh_binary_op_fn,
             box_int_fn: crate::call_jit::bh_box_int_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -677,12 +677,11 @@ pub fn slot_for_call_flavor(flavor: CallFlavor) -> majit_metainterp::EffectInfoS
 /// `W_TypeObject`, so the
 /// `getfield_gc_r` shape is not required.
 ///
-/// `getattr` is NOT elided (no longer in this list): the LoadAttr arm
-/// production-flipped from `emit_abort_permanent!` to a runnable
-/// residual lowering, so the `getattr` HLOp recorded by
-/// `emit_frontend_getattr` now routes through
-/// [`lower_getattr_hlop_to_insn`] (the `residual_call_r_r` →
-/// `bh_getattr_fn` shape) in the retired-family dispatcher.
+/// `getattr` is NOT in this set: the LoadAttr arm records the 4-arg
+/// rtyper-surrogate shape that [`lower_getattr_hlop_to_insn`] lowers
+/// to the `load_attr_fn` residual call (upstream `rclass.py:838
+/// rtype_getattr` would rewrite the HLOp post-rtyping; pyre's lowering
+/// arm is the surrogate for that pass).
 ///
 /// `setattr` — emitted by `codewriter.rs::emit_frontend_setattr`
 /// mirroring `flowcontext.py:1031-1036 op.setattr(w_obj,
@@ -3060,11 +3059,12 @@ pub struct LoweringContext {
     /// so the residual_call Insn has no result Register and no
     /// `ListI` (no scalar Int args).
     pub store_subscr_fn_idx: u16,
-    /// `getattr_fn` descrs-pool index.  LOAD_ATTR family (single HLOp
-    /// opname `getattr`, the `flowcontext.py:862-867 op.getattr` shape)
-    /// lowers to `residual_call_r_r` (two Ref inputs `[obj, w_name]`,
-    /// Ref result) via [`lower_getattr_hlop_to_insn`] — the no-rtyper
-    /// stand-in for `rclass.py:838 rtype_getattr → getfield_gc`.
+    /// `getattr_fn` descrs-pool index — `bh_getattr_fn(obj: Ref,
+    /// w_name: Ref) → Ref`, the interned-name residual for the bare
+    /// 2-arg `flowcontext.py:862-867 op.getattr` shape.  Dormant: the
+    /// LoadAttr arm records the 4-arg rtyper-surrogate shape lowered
+    /// via [`lower_getattr_hlop_to_insn`] to `load_attr_fn` instead,
+    /// and bare 2-arg `getattr` HLOps pass through.
     pub getattr_fn_idx: u16,
     /// `build_list_fn` descrs-pool index — see codewriter.rs:2401
     /// (`bind(assembler, cpu.build_list_fn as *const (),
@@ -3100,6 +3100,26 @@ pub struct LoweringContext {
     /// HLOp record), so the lowering arm returns `None`
     /// (passthrough) on nargs > 8.
     pub call_fn_idx_by_nargs: [u16; 9],
+    /// `load_attr_fn` descrs-pool index — see codewriter.rs
+    /// `register_helper_fn_pointers` for the production source
+    /// (`bind(assembler, cpu.load_attr_fn, CallFlavor::MayForce)`).
+    /// LOAD_ATTR family (HLOp opname `getattr`) lowers to
+    /// `residual_call_ir_r(ConstInt(fn_idx), ListI([name_idx]),
+    /// ListR([obj, code]), Descr) → reg` via
+    /// [`lower_getattr_hlop_to_insn`]; `bh_load_attr_fn(obj, code,
+    /// name_idx)` resolves the name through the code object and runs
+    /// `getattr` (may invoke user `__getattribute__` → `MayForce`).
+    pub load_attr_fn_idx: u16,
+    /// `load_method_self_fn` descrs-pool index — see codewriter.rs
+    /// `register_helper_fn_pointers` for the production source.
+    /// The LOOKUP_METHOD `null_or_self` half (pyre HLOp opname
+    /// `load_method_self`) lowers to `residual_call_ir_r(
+    /// ConstInt(fn_idx), ListI([name_idx]), ListR([obj, attr, code]),
+    /// Descr) → reg` via [`lower_load_method_self_hlop_to_insn`];
+    /// `bh_load_method_self_fn` is the pure
+    /// `compute_load_method_bound` binding decision (reads the type
+    /// MRO, never raises → `PlainCannotRaise`).
+    pub load_method_self_fn_idx: u16,
 }
 
 /// Map a BINARY_OP HLOp opname (`add`/.../`xor`/`getitem` plus the
@@ -3512,51 +3532,6 @@ fn build_load_global_fn_insn_from_operands(
         ],
         Register::new(Kind::Ref, dst_reg),
     )
-}
-
-/// Lower a `LOAD_ATTR` pre-rtype HLOp `getattr(w_obj, w_attributename)`
-/// → `result: Ref` (the `flowcontext.py:862-867 op.getattr` shape
-/// recorded by `emit_frontend_getattr`) to the post-rtype
-/// `residual_call_r_r(ConstInt(getattr_fn_idx), ListR([obj, w_name]),
-/// Descr) → reg` Insn — the no-rtyper stand-in for `rclass.py:838
-/// rtype_getattr → getfield_gc`.  `bh_getattr_fn(obj: Ref, w_name: Ref)
-/// → Ref` runs `getattr_str(obj, name)`; the name Constant lowers to
-/// the interned immortal str pointer via `lower_constant`
-/// ([`flatten_constant_operand`]'s `Str` arm → `box_str_constant`).
-/// `LOAD_ATTR` is walker-skipped during recording (the optimizer
-/// matches the `jit_getattr` trait-leg op, not this), so there is no
-/// known-result-cache constraint and the receiver lowers as a plain
-/// register operand.  `CallFlavor::Plain` (can-raise `AttributeError`,
-/// no virtual-force).
-pub fn lower_getattr_hlop_to_insn<F, LC>(
-    op: &super::flow::SpaceOperation,
-    ctx: &LoweringContext,
-    get_register: &mut F,
-    lower_constant: &mut LC,
-) -> Option<Insn>
-where
-    F: FnMut(super::flow::Variable) -> Register,
-    LC: FnMut(&Constant) -> Operand,
-{
-    if op.opname != "getattr" {
-        return None;
-    }
-    if op.args.len() != 2 {
-        return None;
-    }
-    let obj_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
-    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
-    let dst_reg = match &op.result {
-        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
-        _ => return None,
-    };
-    Some(build_residual_call_r_r_insn_from_operands(
-        ctx.getattr_fn_idx,
-        vec![obj_operand, name_operand],
-        CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
-        dst_reg,
-    ))
 }
 
 /// LOOKUP_METHOD attribute half — `bh_load_attr_fn(obj, code, name_idx)
@@ -4316,16 +4291,169 @@ where
     if let Some(insn) = lower_setitem_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
-    if let Some(insn) = lower_getattr_hlop_to_insn(op, ctx, get_register, lower_constant) {
-        return Some(insn);
-    }
     if let Some(insn) = lower_new_sequence_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
     if let Some(insn) = lower_simple_call_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_getattr_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_load_method_self_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
     None
+}
+
+/// Resolve one `SpaceOperationArg` to a flat `Operand` (Variable →
+/// colored Register, Constant → `lower_constant`).  Returns `None`
+/// for the non-value arg variants so lowering arms can decline
+/// malformed shapes by passthrough, mirroring
+/// [`lower_simple_call_hlop_to_insn`]'s inline match.
+fn operand_for_value_arg<F, LC>(
+    arg: &super::flow::SpaceOperationArg,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Operand>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    match arg {
+        super::flow::SpaceOperationArg::Value(super::flow::FlowValue::Variable(var)) => {
+            Some(Operand::Register(get_register(*var)))
+        }
+        super::flow::SpaceOperationArg::Value(super::flow::FlowValue::Constant(c)) => {
+            Some(lower_constant(c))
+        }
+        _ => None,
+    }
+}
+
+/// Read a `Constant::signed` arg as a plain `i64` (the rtyper-surrogate
+/// scalar operands the LOAD_ATTR family threads through the HLOp).
+fn const_int_for_value_arg(arg: &super::flow::SpaceOperationArg) -> Option<i64> {
+    match arg {
+        super::flow::SpaceOperationArg::Value(super::flow::FlowValue::Constant(Constant {
+            value: super::flow::ConstantValue::Signed(value),
+            ..
+        })) => Some(*value),
+        _ => None,
+    }
+}
+
+/// Lower a LOAD_ATTR pre-rtype HLOp `getattr(obj, w_attributename,
+/// code, name_idx)` → `result: Ref` to the post-rtype
+/// `residual_call_ir_r(ConstInt(load_attr_fn_idx), ListI([name_idx]),
+/// ListR([obj, code]), Descr) → reg` Insn — the
+/// [`build_load_attr_fn_residual_call_ir_r_insn`] shape.
+///
+/// Walker contract: pyre's LOAD_ATTR arm records upstream's 2-arg
+/// `op.getattr(w_obj, w_attributename)` (`flowcontext.py:862-867`)
+/// extended with two rtyper-surrogate operands — the code object as a
+/// post-rtype `Signed(ptr) + Kind::Ref` constant and the `co_names`
+/// index — because pyre runs no `rclass.py:838 rtype_getattr` to
+/// rewrite the HLOp and `bh_load_attr_fn(obj, code, name_idx)`
+/// resolves the name through the code object.  The shadow
+/// `w_attributename` string (args[1]) is not a lowerable operand
+/// (`flatten_constant_operand` has no string interning) and is
+/// carried for graph readability only.  A `getattr` with any other
+/// arity (legacy/test graphs) passes through.
+pub fn lower_getattr_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "getattr" || op.args.len() != 4 {
+        return None;
+    }
+    let obj = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let code = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
+    let name_idx = const_int_for_value_arg(&op.args[3])?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.load_attr_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(name_idx)],
+            )),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![obj, code])),
+            descr_operand,
+        ],
+        dst_reg,
+    ))
+}
+
+/// Lower the LOOKUP_METHOD `null_or_self` half — pyre HLOp
+/// `load_method_self(obj, attr, code, name_idx)` → `result: Ref` — to
+/// `residual_call_ir_r(ConstInt(load_method_self_fn_idx),
+/// ListI([name_idx]), ListR([obj, attr, code]), Descr) → reg`, the
+/// [`build_load_method_self_fn_residual_call_ir_r_insn`] shape.
+///
+/// The HLOp is pyre-specific: upstream PyPy has no two-value
+/// LOAD_METHOD at the flow-graph level (`callmethod.py` is an
+/// objspace-level bytecode rewrite), while pyre's CPython-3.13 method
+/// form must materialize the bound receiver as a second stack value.
+/// `attr` is the paired `getattr` HLOp's result; the binding decision
+/// (`compute_load_method_bound`) is a pure MRO inspection → the
+/// `PlainCannotRaise` flavor carries no trailing `-live-`.
+pub fn lower_load_method_self_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "load_method_self" || op.args.len() != 4 {
+        return None;
+    }
+    let obj = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let attr = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let code = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
+    let name_idx = const_int_for_value_arg(&op.args[3])?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.load_method_self_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(name_idx)],
+            )),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![obj, attr, code])),
+            descr_operand,
+        ],
+        dst_reg,
+    ))
 }
 
 /// Lower a CALL-family pre-rtype HLOp `simple_call(callable, arg0,
@@ -5672,6 +5800,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut on = SSARepr::new("setattr_on");
         let mut on_regallocs = make_regallocs();
@@ -5804,6 +5934,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("retired_families");
@@ -5923,6 +6055,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("trailing_live");
@@ -6005,6 +6139,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("multi_block_lowering");
@@ -6131,6 +6267,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("pyre_walker_2exit");
@@ -6302,6 +6440,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         });
 
         let mut regallocs = perform_register_allocation_all_kinds(&graph);
@@ -6522,6 +6662,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -6608,6 +6750,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -6638,6 +6782,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
 
         let hlop = SpaceOperation::new("sub", vec![lhs.into(), rhs.into()], Some(result.into()), 0);
@@ -6741,6 +6887,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -6803,6 +6951,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -6831,6 +6981,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let hlop = SpaceOperation::new("eq", vec![lhs.into(), rhs.into()], Some(result.into()), 0);
         let mut get_register = identity_register_mapper();
@@ -6866,6 +7018,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -6928,6 +7082,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -6953,6 +7109,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let hlop = SpaceOperation::new("bool", vec![cond.into()], Some(result.into()), 0);
         let mut get_register = identity_register_mapper();
@@ -6992,6 +7150,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -7047,6 +7207,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -7087,6 +7249,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let hlop = SpaceOperation::new(
             "setitem",
@@ -7142,6 +7306,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -7173,6 +7339,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -7204,6 +7372,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -7240,6 +7410,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -7290,6 +7462,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -8663,6 +8837,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         flatten_graph_for_test_with_lowering(&graph, &mut ssarepr, ctx, Some(cpu));
         ssarepr
@@ -8935,6 +9111,8 @@ mod tests {
             build_list_fn_idx: 0,
             build_tuple_fn_idx: 0,
             call_fn_idx_by_nargs,
+            load_attr_fn_idx: 0,
+            load_method_self_fn_idx: 0,
         };
         let null_or_self_var = Variable::new(VariableId(10), Kind::Ref);
         let op = super::super::flow::SpaceOperation::new(
@@ -9010,6 +9188,229 @@ mod tests {
                         index: 102
                     }),
                     "result register must come from the op's result Variable"
+                );
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+    }
+
+    /// Shared fixture for the LOAD_ATTR-family lowering tests: a
+    /// `LoweringContext` with distinct fn indices plus the rtyper-
+    /// surrogate constants (code-object `Signed(ptr) + Kind::Ref`,
+    /// `co_names` index) the 4-arg HLOp shape threads through.
+    fn load_attr_lowering_fixture() -> (LoweringContext, Constant, Constant) {
+        let ctx = LoweringContext {
+            binary_op_fn_idx: 0,
+            compare_op_fn_idx: 0,
+            truth_fn_idx: 0,
+            store_subscr_fn_idx: 0,
+            build_list_fn_idx: 0,
+            build_tuple_fn_idx: 0,
+            call_fn_idx_by_nargs: [0; 9],
+            getattr_fn_idx: 0,
+            load_attr_fn_idx: 91,
+            load_method_self_fn_idx: 92,
+        };
+        let code_const = Constant::new(
+            super::super::flow::ConstantValue::Signed(0x2000),
+            Some(Kind::Ref),
+        );
+        let name_idx_const = Constant::signed(5);
+        (ctx, code_const, name_idx_const)
+    }
+
+    #[test]
+    fn lower_getattr_hlop_emits_load_attr_fn_residual() {
+        // `getattr(obj, w_attributename, code, name_idx)` →
+        // `residual_call_ir_r(ConstInt(load_attr_fn_idx),
+        // ListI([name_idx]), ListR([obj, code]), Descr) → reg`, the
+        // `build_load_attr_fn_residual_call_ir_r_insn` shape.  The shadow
+        // string operand (args[1]) is carried for graph readability and
+        // must NOT reach the lowered operand list.
+        let obj_var = Variable::new(VariableId(8), Kind::Ref);
+        let result_var = Variable::new(VariableId(9), Kind::Ref);
+        let (ctx, code_const, name_idx_const) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "getattr",
+            vec![
+                obj_var.into(),
+                Constant::string("field").into(),
+                code_const.into(),
+                name_idx_const.into(),
+            ],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |var: Variable| match var.id {
+            VariableId(8) => Register {
+                kind: Kind::Ref,
+                index: 101,
+            },
+            VariableId(9) => Register {
+                kind: Kind::Ref,
+                index: 102,
+            },
+            _ => panic!("unexpected var id {:?}", var.id),
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        let insn =
+            super::lower_getattr_hlop_to_insn(&op, &ctx, &mut get_register, &mut lower_constant)
+                .expect("4-arg getattr lowering must succeed");
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_ir_r");
+                assert!(
+                    matches!(args[0], Operand::ConstInt(91)),
+                    "load_attr_fn pool index, got {:?}",
+                    args[0]
+                );
+                match &args[1] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Int);
+                        assert!(
+                            matches!(&list.content[..], [Operand::ConstInt(5)]),
+                            "ListI = [name_idx], got {:?}",
+                            list.content
+                        );
+                    }
+                    other => panic!("expected ListI, got {other:?}"),
+                }
+                match &args[2] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        match &list.content[..] {
+                            [Operand::Register(r), Operand::ConstRef(0x2000)] => {
+                                assert_eq!(r.kind, Kind::Ref);
+                                assert_eq!(r.index, 101, "leading Ref operand must be obj");
+                            }
+                            other => panic!(
+                                "ListR must be [obj, code]; the shadow string must \
+                                 not appear, got {other:?}"
+                            ),
+                        }
+                    }
+                    other => panic!("expected ListR, got {other:?}"),
+                }
+                assert_eq!(
+                    result,
+                    Some(Register {
+                        kind: Kind::Ref,
+                        index: 102
+                    }),
+                );
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+    }
+
+    #[test]
+    fn lower_getattr_hlop_declines_two_arg_legacy_shape() {
+        // Upstream's bare 2-arg `op.getattr(w_obj, w_attributename)`
+        // (legacy/test graphs without the rtyper-surrogate operands) must
+        // pass through, not lower with garbage operands.
+        let obj_var = Variable::new(VariableId(8), Kind::Ref);
+        let result_var = Variable::new(VariableId(9), Kind::Ref);
+        let (ctx, _, _) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "getattr",
+            vec![obj_var.into(), Constant::string("field").into()],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |_var: Variable| Register {
+            kind: Kind::Ref,
+            index: 101,
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        assert!(
+            super::lower_getattr_hlop_to_insn(&op, &ctx, &mut get_register, &mut lower_constant)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn lower_load_method_self_hlop_emits_load_method_self_fn_residual() {
+        // `load_method_self(obj, attr, code, name_idx)` →
+        // `residual_call_ir_r(ConstInt(load_method_self_fn_idx),
+        // ListI([name_idx]), ListR([obj, attr, code]), Descr) → reg`, the
+        // `build_load_method_self_fn_residual_call_ir_r_insn` shape.
+        let obj_var = Variable::new(VariableId(8), Kind::Ref);
+        let attr_var = Variable::new(VariableId(9), Kind::Ref);
+        let result_var = Variable::new(VariableId(10), Kind::Ref);
+        let (ctx, code_const, name_idx_const) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "load_method_self",
+            vec![
+                obj_var.into(),
+                attr_var.into(),
+                code_const.into(),
+                name_idx_const.into(),
+            ],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |var: Variable| match var.id {
+            VariableId(8) => Register {
+                kind: Kind::Ref,
+                index: 101,
+            },
+            VariableId(9) => Register {
+                kind: Kind::Ref,
+                index: 102,
+            },
+            VariableId(10) => Register {
+                kind: Kind::Ref,
+                index: 103,
+            },
+            _ => panic!("unexpected var id {:?}", var.id),
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        let insn = super::lower_load_method_self_hlop_to_insn(
+            &op,
+            &ctx,
+            &mut get_register,
+            &mut lower_constant,
+        )
+        .expect("load_method_self lowering must succeed");
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_ir_r");
+                assert!(
+                    matches!(args[0], Operand::ConstInt(92)),
+                    "load_method_self_fn pool index, got {:?}",
+                    args[0]
+                );
+                match &args[2] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        match &list.content[..] {
+                            [
+                                Operand::Register(obj),
+                                Operand::Register(attr),
+                                Operand::ConstRef(0x2000),
+                            ] => {
+                                assert_eq!(obj.index, 101);
+                                assert_eq!(attr.index, 102);
+                            }
+                            other => panic!("ListR must be [obj, attr, code], got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected ListR, got {other:?}"),
+                }
+                assert_eq!(
+                    result,
+                    Some(Register {
+                        kind: Kind::Ref,
+                        index: 103
+                    }),
                 );
             }
             _ => panic!("expected Insn::Op, got {insn:?}"),

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3582,7 +3582,10 @@ pub fn build_load_attr_fn_residual_call_ir_r_insn(
         "residual_call_ir_r",
         vec![
             Operand::ConstInt(load_attr_fn_idx as i64),
-            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(name_idx)])),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(name_idx)],
+            )),
             Operand::ListOfKind(ListOfKind::new(
                 Kind::Ref,
                 vec![
@@ -3619,7 +3622,10 @@ pub fn build_load_method_self_fn_residual_call_ir_r_insn(
         "residual_call_ir_r",
         vec![
             Operand::ConstInt(load_method_self_fn_idx as i64),
-            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(name_idx)])),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(name_idx)],
+            )),
             Operand::ListOfKind(ListOfKind::new(
                 Kind::Ref,
                 vec![

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3559,6 +3559,81 @@ where
     ))
 }
 
+/// LOOKUP_METHOD attribute half — `bh_load_attr_fn(obj, code, name_idx)
+/// → attr` (`(obj: Ref, code: Ref, name_idx: Int) → Ref`,
+/// `CallFlavor::MayForce`).  Reproduces `PyFrame::load_method`'s `getattr`
+/// for blackhole LOAD_ATTR resume; the getattr can run user
+/// `__getattribute__` and raise `AttributeError`, so the trailing `-live-`
+/// lets the blackhole route the exception through the except handler.
+pub fn build_load_attr_fn_residual_call_ir_r_insn(
+    load_attr_fn_idx: u16,
+    name_idx: i64,
+    obj_reg: u16,
+    code_operand: Operand,
+    dst_reg: u16,
+) -> Insn {
+    let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(load_attr_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(name_idx)])),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Ref,
+                vec![
+                    Operand::Register(Register::new(Kind::Ref, obj_reg)),
+                    code_operand,
+                ],
+            )),
+            descr_operand,
+        ],
+        Register::new(Kind::Ref, dst_reg),
+    )
+}
+
+/// LOOKUP_METHOD `null_or_self` half — `bh_load_method_self_fn(obj, attr,
+/// code, name_idx) → bound` (`(obj: Ref, attr: Ref, code: Ref, name_idx:
+/// Int) → Ref`, `CallFlavor::PlainCannotRaise`).  `attr` is the
+/// [`build_load_attr_fn_residual_call_ir_r_insn`] result; the binding
+/// decision is a pure MRO inspection (reads heap, never raises).
+pub fn build_load_method_self_fn_residual_call_ir_r_insn(
+    load_method_self_fn_idx: u16,
+    name_idx: i64,
+    obj_reg: u16,
+    attr_reg: u16,
+    code_operand: Operand,
+    dst_reg: u16,
+) -> Insn {
+    let effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(load_method_self_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(name_idx)])),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Ref,
+                vec![
+                    Operand::Register(Register::new(Kind::Ref, obj_reg)),
+                    Operand::Register(Register::new(Kind::Ref, attr_reg)),
+                    code_operand,
+                ],
+            )),
+            descr_operand,
+        ],
+        Register::new(Kind::Ref, dst_reg),
+    )
+}
+
 /// Construct the CALL-family `residual_call_r_r` Insn from raw
 /// register indices.  Production codewriter callsite replaces the prior `emit_residual_call(
 /// call_fn_N_idx, ...)` SSARepr emit at codewriter.rs:5747-5754

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1152,6 +1152,16 @@ pub extern "C" fn jit_list_reverse(list: i64) -> i64 {
     0
 }
 
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_list_pop_at(list: i64, index: i64) -> i64 {
+    unsafe {
+        match w_list_pop(list as PyObjectRef, index) {
+            Some(value) => value as i64,
+            None => panic!("pop index out of range in JIT"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Fix #143
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JIT handling so list methods (append/pop/reverse) can be inlined more reliably and method-form attribute binding is supported during resume.
* **Bug Fixes**
  * Addressed rare resume-time crashes and ensured correct behavior across list growth/realloc and pop cases.
* **Refactor**
  * Simplified method-load binding and live-frame local advancement to stabilize traced-to-concrete state transitions.
* **Documentation**
  * Added a design/spec describing the approach, rollout phases, and acceptance criteria.
* **Tests & Benchmarks**
  * Added unit tests and micro-benchmarks for list-method mutation and attribute-resume scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
