### PR TITLE
Improve recursive JIT tracing for nbody

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -2166,17 +2166,19 @@ fn call_assembler_result_kind_name(kind: u64) -> &'static str {
     }
 }
 
-fn actual_call_assembler_target_result_kind(fail_descrs: &[DescrRef]) -> Result<u64, BackendError> {
-    let finish_descr = fail_descrs
-        .iter()
-        .find(|descr| as_fd(descr).is_finish())
-        .ok_or_else(|| {
-            unsupported_semantics(
-                OpCode::CallAssemblerN,
-                "call-assembler target must expose at least one finish exit",
-            )
-        })?;
-    actual_call_assembler_result_kind(as_fd(finish_descr))
+/// `None` when the target exposes no FINISH descr: a loop-greenkey target
+/// reached via do_recursive_call(assembler_call=True) at an inline-frame loop
+/// header (pyjitpl.py:1586) exits via guard-deopt, not FINISH, so it has no
+/// fixed result kind to compare against a caller's expectation. The result is
+/// reconstructed on the deopt/helper path. Callers skip the (cranelift-only)
+/// expectation check in that case.
+fn actual_call_assembler_target_result_kind(
+    fail_descrs: &[DescrRef],
+) -> Result<Option<u64>, BackendError> {
+    let Some(finish_descr) = fail_descrs.iter().find(|descr| as_fd(descr).is_finish()) else {
+        return Ok(None);
+    };
+    actual_call_assembler_result_kind(as_fd(finish_descr)).map(Some)
 }
 
 fn validate_call_assembler_target_result_kind(
@@ -2208,7 +2210,10 @@ fn validate_registered_target_against_call_assembler_expectations(
         return Ok(());
     }
 
-    let actual_result_kind = actual_call_assembler_target_result_kind(&target.fail_descrs)?;
+    let Some(actual_result_kind) = actual_call_assembler_target_result_kind(&target.fail_descrs)?
+    else {
+        return Ok(());
+    };
     for expected_result_kind in expected_result_kinds {
         validate_call_assembler_target_result_kind(
             target_token,
@@ -2305,13 +2310,16 @@ fn install_call_assembler_expectations(
 
     for (&target_token, &expected_result_kind) in &expectations {
         if let Some(target) = lookup_call_assembler_target(target_token) {
-            let actual_result_kind = actual_call_assembler_target_result_kind(&target.fail_descrs)?;
-            validate_call_assembler_target_result_kind(
-                target_token,
-                expected_result_kind,
-                actual_result_kind,
-                "callee finish result kind",
-            )?;
+            if let Some(actual_result_kind) =
+                actual_call_assembler_target_result_kind(&target.fail_descrs)?
+            {
+                validate_call_assembler_target_result_kind(
+                    target_token,
+                    expected_result_kind,
+                    actual_result_kind,
+                    "callee finish result kind",
+                )?;
+            }
         }
     }
 
@@ -4423,37 +4431,37 @@ fn resolve_call_assembler_target(
             ),
         ));
     }
-    let finish_descr = target
-        .fail_descrs
-        .iter()
-        .find(|descr| as_fd(descr).is_finish())
-        .ok_or_else(|| {
-            unsupported_semantics(
-                opcode,
-                "call-assembler target must expose at least one finish exit",
-            )
-        })?;
-    let finish_types = as_fd(finish_descr).fail_arg_types();
+    // A target reached via do_recursive_call(assembler_call=True) at an
+    // inline-frame loop header (opimpl_jit_merge_point pyjitpl.py:1586) is a
+    // loop greenkey, not a function-entry trace: it exits via guard-deopt and
+    // exposes no FINISH descr. RPython/x86 never require a target-local finish
+    // exit — _call_assembler_check_descr (x86/assembler.py:2274) compares the
+    // returned jf_descr against the CPU-global done_with_this_frame descr, and
+    // the helper path handles the deopt result. When the target DOES expose a
+    // finish exit (function-entry traces), keep validating its result type.
+    if let Some(finish_descr) = target.fail_descrs.iter().find(|d| as_fd(d).is_finish()) {
+        let finish_types = as_fd(finish_descr).fail_arg_types();
 
-    // Validate that the finish result type matches the call descriptor.
-    // When force_token_slots are present the finish output type is Ref
-    // (the raw force-token handle), so accept that as matching a Ref
-    // result descriptor even though the value isn't a real GC ref.
-    match call_descr.result_type() {
-        Type::Void => {
-            if !finish_types.is_empty() {
-                return Err(unsupported_semantics(
-                    opcode,
-                    "void call-assembler targets must finish without result values",
-                ));
+        // Validate that the finish result type matches the call descriptor.
+        // When force_token_slots are present the finish output type is Ref
+        // (the raw force-token handle), so accept that as matching a Ref
+        // result descriptor even though the value isn't a real GC ref.
+        match call_descr.result_type() {
+            Type::Void => {
+                if !finish_types.is_empty() {
+                    return Err(unsupported_semantics(
+                        opcode,
+                        "void call-assembler targets must finish without result values",
+                    ));
+                }
             }
-        }
-        result_type => {
-            if finish_types != [result_type] {
-                // Type mismatch between caller's expected result and target's
-                // actual finish type. Treat as unresolved — runtime will use
-                // the helper fallback path.
-                return Ok(None);
+            result_type => {
+                if finish_types != [result_type] {
+                    // Type mismatch between caller's expected result and target's
+                    // actual finish type. Treat as unresolved — runtime will use
+                    // the helper fallback path.
+                    return Ok(None);
+                }
             }
         }
     }
@@ -4473,16 +4481,14 @@ fn expected_call_assembler_result_kind(
             let Some(target) = target else {
                 return Ok(CALL_ASSEMBLER_RESULT_REF);
             };
-            let finish_descr = target
-                .fail_descrs
-                .iter()
-                .find(|descr| as_fd(descr).is_finish())
-                .ok_or_else(|| {
-                    unsupported_semantics(
-                        OpCode::CallAssemblerR,
-                        "call-assembler target must expose at least one finish exit",
-                    )
-                })?;
+            // Loop-token targets expose no FINISH descr (see
+            // resolve_call_assembler_target): default to a plain Ref result.
+            // The FORCE_TOKEN_REF refinement only applies to function-entry
+            // traces whose finish carries a force-token slot.
+            let Some(finish_descr) = target.fail_descrs.iter().find(|d| as_fd(d).is_finish())
+            else {
+                return Ok(CALL_ASSEMBLER_RESULT_REF);
+            };
             let finish_fd = as_fd(finish_descr);
             Ok(
                 if finish_fd.fail_arg_types() == [Type::Ref] && finish_fd.force_token_slots() == [0]

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1774,7 +1774,11 @@ impl<S: JitState> JitDriver<S> {
                 self.meta.leave_profiler_tracing();
                 self.meta.clear_trace_session();
             }
-            TraceAction::Abort => {
+            // Consumed inside the metainterp dispatch loop
+            // (PyreMetaInterp::step_inline_frame pops the inline frame and
+            // records the CALL_ASSEMBLER); it never reaches the jitdriver.
+            // Defensive: treat an escaped instance as a plain Abort.
+            TraceAction::RecursiveCallAssembler { .. } | TraceAction::Abort => {
                 if self.meta.bridge_info().is_some() {
                     crate::debug::log_one("jit-abort", "Abort during bridge tracing");
                 }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -183,6 +183,14 @@ pub enum TraceAction {
     Abort,
     /// Abort the current trace permanently (never trace this location again).
     AbortPermanent,
+    /// A loop back-edge was reached inside an inline callee frame whose
+    /// loop already has compiled code (opimpl_jit_merge_point
+    /// portal_call_depth>0, pyjitpl.py:1579-1602). The metainterp must
+    /// pop the inline frame (finishframe(None)) and record a
+    /// CALL_ASSEMBLER into the loop token from the parent frame
+    /// (do_recursive_call assembler_call=True), then continue tracing
+    /// the parent (ChangeFrame).
+    RecursiveCallAssembler { green_key: u64, target_pc: usize },
 }
 
 /// Marker macro for the tracing merge point.

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1077,48 +1077,39 @@ impl OptHeap {
     ///
     /// RPython heap.py: force_lazy_set → emit_extra(op, emit=False).
     ///
-    /// RPython parity: if the RHS value is virtual, do NOT emit the SetfieldGc.
-    /// Instead, add it to pendingfields for the guard's resume data
-    /// (heap.py:618-620). The virtual will be materialized at guard failure
-    /// time via rd_virtuals, and the pending setfield replayed after.
-    ///
-    /// `allow_force`: true for call-triggered force, false for JUMP/flush.
-    /// heap.py: cf.force_lazy_set(optheap, descr)
+    /// force_lazy_set (heap.py:122-145) emits unconditionally; the
+    /// virtual-rhs skip belongs only to force_lazy_sets_for_guard
+    /// (heap.py:610-639), which routes those ops to rd_pendingfields
+    /// before they ever reach this fn. A virtual rhs here is
+    /// materialized first, the way Optimizer._emit_operation forces
+    /// every emitted arg (optimizer.py:345-364 force_box).
     ///
     /// `get_rhs`: polymorphic RHS extractor matching
     /// `AbstractCachedEntry._get_rhs_from_set_op` (heap.py:169-170 /
     /// :300). `Self::field_get_rhs` → `op.arg(1)` for SETFIELD_GC;
     /// `Self::array_get_rhs` → `op.arg(2)` for SETARRAYITEM_GC.
-    ///
-    /// Emit a lazy SETFIELD_GC / SETARRAYITEM_GC. If the value is
-    /// virtual, return false (the caller should handle it via
-    /// pendingfields / rd_pendingfields).
-    fn emit_lazy_setfield(
-        op: &mut Op,
-        ctx: &mut OptContext,
-        _allow_force: bool,
-        get_rhs: fn(&Op) -> OpRef,
-    ) -> bool {
+    fn emit_lazy_setfield(op: &mut Op, ctx: &mut OptContext, get_rhs: fn(&Op) -> OpRef) {
         let rhs = get_rhs(op);
-        // heap.py:136: emit_extra(op, emit=False) re-processes through passes.
-        // Virtual values are skipped — handled by rd_pendingfields at guard
-        // time or dropped at JUMP.
-        let orig_is_virtual = ctx
-            .get_box_replacement_box(rhs)
-            .as_ref()
-            .map_or(false, |b| ctx.is_virtual(b));
-        if orig_is_virtual {
-            return false;
+        let resolved_box = ctx.get_box_replacement_box(rhs);
+        let rhs_is_virtual = resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b));
+        // Virtualizable exemption mirrors Optimizer::force_box: a
+        // virtualizable tracks an existing heap object, not a deferred
+        // allocation; forcing it would destroy the tracked field state.
+        if rhs_is_virtual
+            && !resolved_box
+                .as_ref()
+                .map_or(false, |b| ctx.is_virtualizable(b))
+        {
+            ctx.force_box_inline(rhs);
         }
 
-        // Non-virtual path: resolve forwarding and route after heap
+        // Resolve forwarding and route after heap
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..op.num_args() {
             op.setarg(i, ctx.resolve_box_box(&op.arg(i)));
         }
         // heap.py:136: emit_extra(op, emit=False) → next_optimization
         ctx.emit_extra(ctx.current_pass_idx, op.clone());
-        true
     }
 
     /// heap.py:122-145: force_lazy_set → emit_extra(op, emit=False)
@@ -1227,7 +1218,11 @@ impl OptHeap {
         let mut pendingfields = Vec::new();
 
         // heap.py:610-621: iterate cached fields
-        // Collect all lazy sets from CachedFields.
+        // Collect lazy sets WITHOUT consuming them: a virtual-valued
+        // lazy set stays cached (heap.py:618-620 `continue` does not
+        // clear `_lazy_set`), so every later guard re-collects it into
+        // pendingfields and a later call/flush boundary still emits it.
+        // Only force_lazy_set — the non-virtual arm — clears it.
         let mut ordered_entries: Vec<_> = self
             .cached_fields
             .iter_mut()
@@ -1238,7 +1233,7 @@ impl OptHeap {
             .into_iter()
             .filter_map(|(field_idx, descr, cf)| {
                 cf.lazy_set
-                    .take()
+                    .clone()
                     .map(|(obj, op)| (field_idx, descr, obj, op))
             })
             .collect();
@@ -1251,7 +1246,7 @@ impl OptHeap {
                 continue;
             }
             // heap.py:621: cf.force_lazy_set(self, descr) →
-            // invalidate first, then emit_extra(op, emit=False),
+            // _lazy_set = None, invalidate, emit_extra(op, emit=False),
             // then put_field_back_to_info restores the cache.
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
@@ -1261,6 +1256,7 @@ impl OptHeap {
             // heap.py:129,189-191: invalidate(descr) — purity self-gate
             // inside CachedField::invalidate (heap.py:189-194 parity).
             if let Some(cf) = self.get_cached_field_mut(&descr) {
+                cf.lazy_set = None;
                 cf.invalidate(&descr, ctx);
             }
             // heap.py:142-143 put_field_back_to_info needs the lazy_set Op
@@ -1289,7 +1285,7 @@ impl OptHeap {
                     .iter_mut()
                     .filter_map(move |(index, cai)| {
                         cai.lazy_set
-                            .take()
+                            .clone()
                             .map(|(obj, op)| (*descr_idx, *index, obj, op))
                     })
             })
@@ -1303,6 +1299,14 @@ impl OptHeap {
                 continue;
             }
 
+            // heap.py:635 cf.force_lazy_set(...): consume the lazy set
+            // (the non-virtual arm is what clears it).
+            if let Some(cai) = self
+                .get_cached_array_submap_mut(descr_idx)
+                .and_then(|s| s.const_get_mut(index))
+            {
+                cai.lazy_set = None;
+            }
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
                 op.setarg(i, ctx.resolve_box_box(&op.arg(i)));
@@ -1980,7 +1984,7 @@ impl OptHeap {
                         }
                     }
                 }
-                Self::emit_lazy_setfield(&mut lazy_op, ctx, true, Self::field_get_rhs);
+                Self::emit_lazy_setfield(&mut lazy_op, ctx, Self::field_get_rhs);
                 // can_cache=True: put_field_back_to_info
                 let final_value = lazy_op.arg(1);
                 let lazy_descr = lazy_op.getdescr().unwrap().clone();
@@ -2260,7 +2264,7 @@ impl OptHeap {
                 }
                 // heap.py:135 optheap.emit_extra(op, emit=False)
                 let put_back_op = lazy_op.clone();
-                Self::emit_lazy_setfield(&mut lazy_op, ctx, true, Self::array_get_rhs);
+                Self::emit_lazy_setfield(&mut lazy_op, ctx, Self::array_get_rhs);
                 // heap.py:136-137 if not can_cache: return
                 if !can_cache {
                     return;
@@ -2405,7 +2409,7 @@ impl OptHeap {
                 }
                 // heap.py:135 optheap.emit_extra(op, emit=False)
                 let put_back_op = lazy_op.clone();
-                Self::emit_lazy_setfield(&mut lazy_op, ctx, true, Self::field_get_rhs);
+                Self::emit_lazy_setfield(&mut lazy_op, ctx, Self::field_get_rhs);
                 // heap.py:136-137 if not can_cache: return
                 if !can_cache {
                     return;
@@ -2529,7 +2533,7 @@ impl OptHeap {
                             }
                         }
                     }
-                    Self::emit_lazy_setfield(&mut lazy_op, ctx, true, Self::array_get_rhs);
+                    Self::emit_lazy_setfield(&mut lazy_op, ctx, Self::array_get_rhs);
                     // can_cache=True: put_field_back_to_info
                     let final_value = lazy_op.arg(2);
                     let descr = lazy_op.getdescr();

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -5187,18 +5187,20 @@ mod tests {
     }
 
     #[test]
-    fn test_jump_drops_virtual_value_lazy_setfield() {
-        // RPython parity: at JUMP, lazy SetfieldGc with virtual value is
-        // DROPPED. heap.py emit_extra(op, emit=False) re-processes the op
-        // through passes → re-absorbed as lazy_set → lost. The virtual
-        // stays virtual and is carried across JUMP via imported heap cache.
+    fn test_jump_forces_virtual_value_lazy_setfield() {
+        // At the trace end, flush() forces all lazy sets (heap.py:392-398
+        // flush → force_all_lazy_sets). force_lazy_set (heap.py:122-145)
+        // re-sends the SetfieldGc with emit=False, which routes it past
+        // OptHeap through the rest of the chain — NOT back into the lazy
+        // cache — and the final emission forces boxes in its args
+        // (optimizer.py:345-364 _emit_operation force_box). A virtual
+        // stored into a non-virtual escapes: the New materializes and the
+        // store is emitted before the Jump.
         //
         // [p0]
         // p1 = new(descr=node)
         // setfield_gc(p0, p1, descr=next)
         // jump(p0)
-        //
-        // Result: only Jump (New is virtual, SetfieldGc is lazy → dropped).
         let node_sd = size_descr(1);
         let next_fd = ref_field_descr(11);
         let mut ops = vec![
@@ -5223,19 +5225,12 @@ mod tests {
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
 
-        // force_all_lazy_setfields re-sends the lazy SetfieldGc through the
-        // chain with emit=False (heap.py:136 force_lazy_set). SETFIELD_GC is
-        // in the earlyforce exempt set, so its virtual value is NOT forced —
-        // the New stays virtual and the store is re-absorbed (dropped). Only
-        // the Jump survives; the field relationship is carried across the JUMP
-        // via the imported heap cache.
-        let new_count = result.iter().filter(|op| op.opcode == OpCode::New).count();
-        assert_eq!(
-            new_count, 0,
-            "virtual New stored via lazy SetfieldGc stays virtual at Jump (SETFIELD_GC is earlyforce-exempt); got {result:?}"
-        );
         let opcodes: Vec<_> = result.iter().map(|op| op.opcode).collect();
-        assert_eq!(opcodes, vec![OpCode::Jump]);
+        assert_eq!(
+            opcodes,
+            vec![OpCode::New, OpCode::SetfieldGc, OpCode::Jump],
+            "virtual New stored into a non-virtual escapes at flush; got {result:?}"
+        );
     }
 
     // OptHeap's `force_from_effectinfo` path (heap.rs:2584) selectively

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -6785,7 +6785,7 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 {
                     let mut previous_tokens: Vec<std::sync::Weak<JitCellToken>> = Vec::new();
-                    let mut ft = self
+                    let ft = self
                         .compiled_loops
                         .get(&green_key)
                         .map(|c| c.front_target_tokens.clone())
@@ -6806,20 +6806,23 @@ impl<M: Clone> MetaInterp<M> {
                             self.retire_compiled_entry(green_key, old_entry, &mut traces);
                     }
                     token.set_retraced_count(rc);
-                    // `compile.py:245` `jitcell_token.target_tokens = [target_token]`
-                    // — every PyPy `compile_*` path emits at least one
-                    // TargetToken before publishing the JCT.  pyre's
-                    // FINISH-only `finish_and_compile` has no body LABEL
-                    // (the trace is `Phi → guard → ... → Finish`), so no
-                    // intrinsic TargetToken exists; synthesise one here so
-                    // `JitCellToken.target_tokens` is non-empty and the
-                    // `has_compiled_targets` (`pyjitpl.py:3898`) signal
-                    // matches PyPy's "any attached JCT is enterable".
-                    if ft.is_empty() {
-                        let synth = crate::optimizeopt::unroll::TargetToken::new_loop(token.number);
-                        synth.set_original_jitcell_token_number(token.number);
-                        ft.push(synth);
-                    }
+                    // `compile.py:1079-1083` — a FINISH trace
+                    // (`compile_done_with_this_frame` → `compile_trace` with
+                    // `info.final()`) sets `target_token =
+                    // new_trace.operations[-1].getdescr()` (the FINISH descr)
+                    // and attaches through `resumekey.compile_and_attach`.  It
+                    // never builds a `TargetToken`/LABEL and never adds to
+                    // `jitcell_token.target_tokens`.  So a FINISH-only trace
+                    // leaves `front_target_tokens` empty: `has_compiled_targets`
+                    // (`pyjitpl.py:3898` = `bool(token.target_tokens)`) is
+                    // false, while the trace stays enterable through
+                    // `has_compiled_loop`
+                    // (`get_procedure_token().has_compiled_code()`, mod.rs:8273
+                    // — `warmstate.py:482-511` gates entry on code presence,
+                    // not on target_tokens).  A jumpable target token must own
+                    // real `ll_loop_code`; synthesising a code-less one here let
+                    // a later guard-failure bridge close with a JUMP whose
+                    // backend target is `ll_loop_code == 0` (`br 0` → PC=0).
                     for target_token in &ft {
                         token.record_target_token(target_token.as_jump_target_descr());
                     }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -247,6 +247,15 @@ pub struct TraceCtx {
     /// Such a loop must not be unrolled as a root loop; the trace step
     /// reads and clears this to abort instead. See `request_inline_loop_abort`.
     pub(crate) inline_loop_abort_pending: bool,
+    /// Transient signal set when an inline-frame back-edge can take the
+    /// orthodox path instead of aborting: the callee loop's green key has
+    /// compiled code, so the metainterp pops the inline frame and records
+    /// a CALL_ASSEMBLER into the loop token from the parent
+    /// (opimpl_jit_merge_point portal_call_depth>0 → finishframe +
+    /// do_recursive_call(assembler_call=True), pyjitpl.py:1579-1602).
+    /// `(green_key, target_pc)` of the callee loop header. See
+    /// `request_recursive_call_assembler`.
+    pub(crate) recursive_call_assembler_pending: Option<(u64, usize)>,
     /// pyjitpl.py:3030 current_merge_points — loop headers visited during
     /// tracing with their trace positions. First visit records the key +
     /// position; second visit closes the loop.
@@ -1087,6 +1096,7 @@ impl TraceCtx {
             header_pc: 0,
             cut_inner_green_key: None,
             inline_loop_abort_pending: false,
+            recursive_call_assembler_pending: None,
             current_merge_points: vec![MergePoint {
                 green_key,
                 position: initial_position,
@@ -1154,6 +1164,7 @@ impl TraceCtx {
             header_pc: 0,
             cut_inner_green_key: None,
             inline_loop_abort_pending: false,
+            recursive_call_assembler_pending: None,
             current_merge_points: vec![MergePoint {
                 green_key,
                 position: initial_position,
@@ -1484,6 +1495,21 @@ impl TraceCtx {
     /// Read and clear the inline-loop abort signal.
     pub fn take_inline_loop_abort(&mut self) -> bool {
         std::mem::take(&mut self.inline_loop_abort_pending)
+    }
+
+    /// Mark that the current inline-frame back-edge targets a loop whose
+    /// green key already has compiled code, so the metainterp should pop
+    /// the inline frame and record a CALL_ASSEMBLER into the loop token
+    /// from the parent frame (opimpl_jit_merge_point
+    /// portal_call_depth>0, pyjitpl.py:1579-1602). Drained via
+    /// [`Self::take_recursive_call_assembler`].
+    pub fn request_recursive_call_assembler(&mut self, green_key: u64, target_pc: usize) {
+        self.recursive_call_assembler_pending = Some((green_key, target_pc));
+    }
+
+    /// Read and clear the recursive-call-assembler signal.
+    pub fn take_recursive_call_assembler(&mut self) -> Option<(u64, usize)> {
+        self.recursive_call_assembler_pending.take()
     }
 
     /// Number of input arguments to the current trace.

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -242,6 +242,11 @@ pub struct TraceCtx {
     /// the green key for the inner loop. Used to register an alias
     /// so can_enter_jit at the inner back-edge finds the outer key's entry.
     pub cut_inner_green_key: Option<u64>,
+    /// Transient signal set when a back-edge is reached while an inline
+    /// callee frame is active (opimpl_jit_merge_point portal_call_depth>0).
+    /// Such a loop must not be unrolled as a root loop; the trace step
+    /// reads and clears this to abort instead. See `request_inline_loop_abort`.
+    pub(crate) inline_loop_abort_pending: bool,
     /// pyjitpl.py:3030 current_merge_points — loop headers visited during
     /// tracing with their trace positions. First visit records the key +
     /// position; second visit closes the loop.
@@ -1081,6 +1086,7 @@ impl TraceCtx {
             virtualizable_heap_ptr: None,
             header_pc: 0,
             cut_inner_green_key: None,
+            inline_loop_abort_pending: false,
             current_merge_points: vec![MergePoint {
                 green_key,
                 position: initial_position,
@@ -1147,6 +1153,7 @@ impl TraceCtx {
             virtualizable_heap_ptr: None,
             header_pc: 0,
             cut_inner_green_key: None,
+            inline_loop_abort_pending: false,
             current_merge_points: vec![MergePoint {
                 green_key,
                 position: initial_position,
@@ -1464,6 +1471,19 @@ impl TraceCtx {
     /// to a reached loop header during tracing.
     pub fn root_green_key(&self) -> u64 {
         self.root_green_key
+    }
+
+    /// Mark that the current back-edge was reached inside an inline callee
+    /// frame and must not be unrolled (opimpl_jit_merge_point
+    /// portal_call_depth>0). The trace step drains this via
+    /// [`take_inline_loop_abort`] and aborts the trace.
+    pub fn request_inline_loop_abort(&mut self) {
+        self.inline_loop_abort_pending = true;
+    }
+
+    /// Read and clear the inline-loop abort signal.
+    pub fn take_inline_loop_abort(&mut self) -> bool {
+        std::mem::take(&mut self.inline_loop_abort_pending)
     }
 
     /// Number of input arguments to the current trace.

--- a/pyre/pyre-jit-trace/src/callbacks.rs
+++ b/pyre/pyre-jit-trace/src/callbacks.rs
@@ -17,6 +17,12 @@ pub struct CallJitCallbacks {
     pub callee_frame_helper: fn(usize) -> Option<*const ()>,
     pub recursive_force_cache_safe: fn(PyObjectRef) -> bool,
     pub jit_drop_callee_frame: *const (),
+    /// Inline back-edge CALL_ASSEMBLER writeback: store one
+    /// `locals_cells_stack_w` slot of the callee frame (Ref / raw-int /
+    /// raw-float variants; the raw variants box runtime-side).
+    pub jit_frame_set_slot_ref: *const (),
+    pub jit_frame_set_slot_int: *const (),
+    pub jit_frame_set_slot_float: *const (),
     pub jit_force_callee_frame: *const (),
     pub jit_force_recursive_call_1: *const (),
     pub jit_force_recursive_call_argraw_boxed_1: *const (),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4536,33 +4536,24 @@ fn try_execute_residual_call_via_executor(
             return Ok(None);
         }
     }
-    // Void-result calls (STORE_SUBSCR / list.append / dict.__setitem__ etc.)
-    // carry no value the walk specializes on — only their side effect.
-    //
     // `do_residual_call` (pyjitpl.py:2040/2104/2123 for CALL_MAY_FORCE_N /
-    // CALL_LOOPINVARIANT_N / CALL_N) still runs `executor.execute_varargs` for a
-    // void call, applying the side effect once during tracing, and then resumes
-    // the compiled loop at the *next* iteration (`raise_continue_running_normally`,
-    // pyjitpl.py:3072-3091, hands back the end-of-iteration-N state).  The
-    // full-body walk cannot mirror that eager step: it is a SYMBOLIC walk that
-    // does not advance the interpreter, so the compiled loop re-enters at the
-    // traced iteration N (entry = loop header) and re-runs the body.  Executing
-    // the helper here would land the heap mutation twice — once now, once when
-    // the compiled loop re-runs iteration N.  Record the call symbolically
-    // instead: falling through with `None` leaves the recorded residual op in
-    // the trace, so the compiled loop applies the side effect exactly once.
-    // That is the FBW-correct equivalent of the eager step, and the net
-    // once-per-iteration effect matches the trait path.  (Every `None`
-    // from this function marks `FBW_UNJOURNALED_EFFECT` at the dispatch
-    // sites, keeping the walk-end no-replay commit off for this trace.)
+    // CALL_LOOPINVARIANT_N / CALL_N) runs `executor.execute_varargs` for a void
+    // call exactly like the value-returning shapes, applying the side effect
+    // once during tracing and then resuming the compiled loop at the *next*
+    // iteration (`raise_continue_running_normally`, pyjitpl.py:3072-3091, hands
+    // back the end-of-iteration-N state so iteration N is never re-run).  Pyre
+    // mirrors the second half via the walk-end commit
+    // (`flush_walk_end_state_to_frame`, run_perfn_walk): a successful commit
+    // adopts the end-of-walk frame so the compiled loop enters at iteration
+    // N+1, leaving the eagerly-applied side effect counted once.  Executing
+    // void calls here (rather than recording-only) keeps that invariant whole —
+    // a deferred void store would be lost on commit (its symbolic op only fires
+    // for N+1+), which is why deferral previously forced the no-commit legacy
+    // replay.  The replay path that re-runs iteration N has the symmetric
+    // hazard for already-executed value calls (e.g. `list.insert` returns the
+    // None ref, so it is not a void call yet still mutates) — eager-everything +
+    // commit is the single consistent rule, matching `do_residual_call`.
     //
-    // The per-opcode arm walk has NO replay behind it (the interpreter
-    // advances opcode by opcode; the compiled loop enters at the next
-    // iteration), so a declined void effect would be lost, not deferred —
-    // it executes eagerly below, the direct `execute_varargs` analogue.
-    if ctx.is_full_body_walk && call_descr.result_type() == majit_ir::Type::Void {
-        return Ok(None);
-    }
     // pyjitpl.py:3329-3330 `vinfo.tracing_before_residual_call(virtualizable)`
     // heap half: every decline gate has passed, so the helper WILL execute —
     // set TOKEN_TRACING_RESCALL on the active virtualizable so a force

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1056,6 +1056,20 @@ pub enum DispatchError {
     /// own-portal callee frame is registered as the standard virtualizable
     /// (a perf follow-up).
     NonStandardVableFinishPortalUnsupported { pc: usize },
+    /// A residual call to a pure-Python callee that is inline-eligible
+    /// (plain, exact-positional, closure-free, not recursion-bound) but
+    /// whose body is NOT a straight-line leaf — it carries an internal loop
+    /// or branch (`goto_if_not` / `switch`) or a non-static `vable` op, so
+    /// the fast-path register-seeding inline (`try_walker_inline_user_call`)
+    /// declines.  Emitting the residual leaves the callee re-interpreted per
+    /// iteration (and its short inner loops compile + deopt-storm), strictly
+    /// slower than interpreting.  The trait tracer inlines such callees via
+    /// `push_inline_frame` + the `recursive-call-assembler` loop back-edge
+    /// (`metainterp.rs` opimpl_recursive_call_assembler).  Surface a typed
+    /// abort so the key routes to the trait leg (`FBW_DECLINED_KEYS`) until
+    /// the walker itself covers loop-callee inlining (task #62, the Phase-6
+    /// convergence).
+    LoopBearingCalleeInlineUnsupported { pc: usize },
 }
 
 /// Walk one opcode at `pc` and return the dispatch outcome plus the
@@ -7170,11 +7184,24 @@ fn try_walker_inline_user_call(
     // residual_call args).  A callee that materializes a frame — any
     // `*_vable_*` op, emitted when a local must survive a sub-call —
     // reads from the unseeded frame box; inlining it would abort the
-    // *whole* enclosing trace with `VableBoxNotSeeded`.  Decline such
-    // callees (and the zero-param case) so the call lowers to an ordinary
-    // residual call rather than aborting (orthodox non-inlinable path).
-    if nparams == 0 || !callee_fast_path_inlinable(body.code, callee_descr_refs, ctx) {
+    // *whole* enclosing trace with `VableBoxNotSeeded`.
+    //
+    // The zero-param case lowers to an ordinary residual call (orthodox
+    // non-inlinable path); a residual zero-arg call is cheap and the trait
+    // leg has no positional-arg inline win to recover.
+    if nparams == 0 {
         return Ok(None);
+    }
+    // A param-bearing Python callee that is otherwise inline-eligible but
+    // whose body is not a straight-line leaf (loop / branch / non-static
+    // vable) cannot be served by the fast-path register seeding.  Emitting
+    // the residual leaves it re-interpreted per iteration and lets its short
+    // inner loops compile + deopt-storm — strictly slower than interpreting.
+    // The trait leg inlines such callees via `push_inline_frame` +
+    // `recursive-call-assembler`, so route the enclosing key there
+    // (`FBW_DECLINED_KEYS`) instead of recording the slow residual.
+    if !callee_fast_path_inlinable(body.code, callee_descr_refs, ctx) {
+        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
     }
 
     // Path-1 (#68): the inlined callee's compile-time-constant frame fields,

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -708,6 +708,31 @@ impl PyreMetaInterp {
         cf.set_last_instr_from_next_instr(opcode_pc + 1);
         let next = cf.next_instr();
 
+        // issue #143 (inline-frame double-mutation): defer subscript/attribute
+        // stores instead of committing them to the shared heap here. This
+        // speculative concrete step runs inside an inline callee frame whose
+        // loop back-edge is aborted (close_loop_args inline gate); a store
+        // committed here persists past the abort and is re-applied when the
+        // interpreter re-runs the callee → wrong result. The root tracer
+        // already defers these stores (trace_store_subscr emits IR only,
+        // leaving its snapshot frame's concrete view stale until re-execution),
+        // so mirroring that here keeps the two paths consistent — only pop the
+        // operands to preserve the frame's stack.
+        match instruction {
+            Instruction::StoreSubscr => {
+                cf.pop();
+                cf.pop();
+                cf.pop();
+                return;
+            }
+            Instruction::StoreAttr { .. } => {
+                cf.pop();
+                cf.pop();
+                return;
+            }
+            _ => {}
+        }
+
         if let Instruction::Call { argc } = instruction {
             let nargs = argc.get(op_arg) as usize;
             let _ = super::state::execute_inline_residual_call(cf, nargs);

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -48,6 +48,13 @@ pub struct MetaInterpFrame {
     /// the still-at-CALL frame.  `None` when no inline call is in progress
     /// from this frame.
     pub call_site_pc: Option<usize>,
+    /// Symbolic callable + arg OpRefs of the CALL that pushed this
+    /// (inline) frame, carried from `PendingInlineFrame`. Consumed by
+    /// the inline back-edge CALL_ASSEMBLER path (`do_recursive_call`)
+    /// to shape the guard resume via `push_call_replay_stack`.
+    /// `OpRef::NONE` / empty on root frames.
+    pub replay_callable: OpRef,
+    pub replay_args: Vec<OpRef>,
 }
 
 impl MetaInterpFrame {
@@ -488,6 +495,10 @@ impl PyreMetaInterp {
                 ctx.truncate_inline_trace_positions(self.inline_trace_base);
                 LoopAction::Return(TraceAction::Abort)
             }
+            super::state::InlineTraceStepAction::Trace(TraceAction::RecursiveCallAssembler {
+                green_key,
+                target_pc,
+            }) => self.opimpl_recursive_call_assembler(ctx, green_key, target_pc),
             super::state::InlineTraceStepAction::Trace(action) => LoopAction::Return(action),
             super::state::InlineTraceStepAction::PushFrame(pending) => {
                 // trace_code_step_inline already took the pending frame
@@ -577,6 +588,8 @@ impl PyreMetaInterp {
             // their own; cleared when this frame becomes a caller via a
             // subsequent inline push.
             call_site_pc: None,
+            replay_callable: pending.replay_callable,
+            replay_args: pending.replay_args,
         };
 
         self.portal_call_depth += 1;
@@ -669,6 +682,162 @@ impl PyreMetaInterp {
         }
 
         // No pending_concrete_push needed — concrete_stack[result_idx] already updated above.
+    }
+
+    /// pyjitpl.py:1565-1602 opimpl_jit_merge_point portal_call_depth>0:
+    /// the inline callee reached its loop back-edge and the loop's green
+    /// key has compiled code. Pop the inline frame without a result
+    /// (finishframe(None, leave_portal_frame=False)), record a
+    /// CALL_ASSEMBLER into the loop token from the parent frame
+    /// (do_recursive_call assembler_call=True), bind the call result to
+    /// the parent's pending result slot (make_result_of_lastop,
+    /// pyjitpl.py:1586-1589), then resume dispatch on the parent
+    /// (ChangeFrame).
+    ///
+    /// RPython's do_residual_call executes the portal runner concretely
+    /// at this point (the callee's remaining iterations run during
+    /// tracing). Pyre traces on a snapshot and re-runs the closed loop's
+    /// iteration on restart, so the callee's remaining execution is
+    /// DEFERRED to the restart — the same contract as deferred
+    /// StoreSubscr/StoreAttr. The result's concrete half is therefore
+    /// Null; a downstream consumer that needs it fails the
+    /// missing-concrete checks and aborts the trace gracefully.
+    /// Convergence path: trace on the live frame (no re-run), then the
+    /// concrete continuation can run here as upstream does.
+    fn opimpl_recursive_call_assembler(
+        &mut self,
+        ctx: &mut TraceCtx,
+        green_key: u64,
+        target_pc: usize,
+    ) -> LoopAction {
+        let token_number = {
+            let (driver, _) = crate::driver::driver_pair();
+            driver.get_loop_token_number(green_key)
+        };
+        // Re-verify with framestack-level data the close_loop_args signal
+        // site cannot see: the callee must own a trace-visible frame
+        // object (CALL_ASSEMBLER red arg) and carry the CALL-site OpRefs
+        // for the guard-resume replay; the parent must be the root frame
+        // with a recorded CALL site.
+        let eligible = token_number.is_some()
+            && self.framestack.len() == 2
+            && {
+                let top = self.framestack.last().unwrap();
+                top.drop_frame_opref.is_some() && top.replay_callable != OpRef::NONE
+            }
+            && self.framestack[0].call_site_pc.is_some();
+        if !eligible {
+            // Fall back to the inline-loop-abort end state (the
+            // trace_step_result_to_action drain): stop tracing the root
+            // key so the callee loop compiles standalone.
+            let root_green_key = ctx.root_green_key();
+            let (driver, _) = crate::driver::driver_pair();
+            driver
+                .meta_interp_mut()
+                .warm_state_mut()
+                .disable_noninlinable_function(root_green_key);
+            if majit_metainterp::majit_log_enabled() {
+                eprintln!(
+                    "[jit][recursive-call-assembler] ineligible, abort: key={} target_pc={} depth={} root={}",
+                    green_key,
+                    target_pc,
+                    self.framestack.len(),
+                    root_green_key,
+                );
+            }
+            ctx.truncate_inline_trace_positions(self.inline_trace_base);
+            return LoopAction::Return(TraceAction::Abort);
+        }
+        let token_number = token_number.unwrap();
+
+        // Virtualizable write_boxes on the callee frame (pre-pop): the
+        // compiled loop reads locals_cells_stack_w / last_instr /
+        // valuestackdepth from the frame object at entry.
+        {
+            let top = self.framestack.last_mut().unwrap();
+            let frame_opref = top.drop_frame_opref.unwrap();
+            let sym = unsafe { &mut *top.sym };
+            let vsd = top
+                .owned_concrete_frame
+                .as_ref()
+                .map(|cf| cf.valuestackdepth)
+                .unwrap_or(sym.valuestackdepth)
+                .max(sym.nlocals);
+            super::trace_opcode::gen_writeback_inline_frame_to_heap(
+                ctx, sym, frame_opref, target_pc, vsd,
+            );
+        }
+
+        // pyjitpl.py:1581 finishframe(None, leave_portal_frame=False).
+        let popped = self.framestack.pop().unwrap();
+        self.portal_call_depth -= 1;
+        ctx.pop_inline_trace_position();
+        {
+            let (driver, _) = crate::driver::driver_pair();
+            driver.leave_inline_frame();
+        }
+        let frame_opref = popped.drop_frame_opref.unwrap();
+
+        // pyjitpl.py:1590 frame.do_recursive_call(assembler_call=True) on
+        // the parent frame.
+        let parent = self.framestack.last_mut().unwrap();
+        let call_pc = parent.call_site_pc.take().unwrap();
+        let code = unsafe {
+            &*(pyre_interpreter::w_code_get_ptr(parent.jitcode as pyre_object::PyObjectRef)
+                as *const pyre_interpreter::CodeObject)
+        };
+        let cf_addr = parent.concrete_frame_addr();
+        let parent_frames = parent.parent_frames.clone();
+        let parent_sym = unsafe { &mut *parent.sym };
+        let fallthrough_pc = semantic_fallthrough_pc(code, call_pc);
+        let ca_result = {
+            let mut fs = MIFrame::from_sym(ctx, parent_sym, cf_addr, fallthrough_pc, call_pc);
+            fs.parent_frames = parent_frames;
+            fs.do_recursive_call_assembler(
+                token_number,
+                frame_opref,
+                popped.replay_callable,
+                &popped.replay_args,
+                call_pc,
+            )
+        };
+
+        // pyjitpl.py:1592 leave_portal_frame — after the call, mirroring
+        // finishframe_inline's vref close + callee-frame drop.
+        let parent_sym = unsafe { &mut *self.framestack.last().unwrap().sym };
+        super::state::opimpl_virtual_ref_finish(ctx, parent_sym, frame_opref);
+        ctx.call_void(
+            crate::callbacks::get().jit_drop_callee_frame,
+            &[frame_opref],
+        );
+
+        match ca_result {
+            Ok(result) => {
+                if majit_metainterp::majit_log_enabled() {
+                    eprintln!(
+                        "[jit][recursive-call-assembler] emitted: key={} target_pc={} token={} call_pc={}",
+                        green_key, target_pc, token_number, call_pc,
+                    );
+                }
+                // make_result_of_lastop (pyjitpl.py:1586-1589). Concrete
+                // half stays Null — see the method doc.
+                if let Some(result_idx) = popped.caller_result_stack_idx {
+                    super::trace_opcode::write_stack_slot(
+                        parent_sym,
+                        ctx,
+                        result_idx,
+                        result,
+                        ConcreteValue::Null,
+                    );
+                }
+                // ChangeFrame: resume dispatch on the parent.
+                LoopAction::Continue
+            }
+            Err(_) => {
+                ctx.truncate_inline_trace_positions(self.inline_trace_base);
+                LoopAction::Return(TraceAction::Abort)
+            }
+        }
     }
 
     // ── Concrete execution helpers ───────────────────────────────

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -764,7 +764,11 @@ impl PyreMetaInterp {
                 .unwrap_or(sym.valuestackdepth)
                 .max(sym.nlocals);
             super::trace_opcode::gen_writeback_inline_frame_to_heap(
-                ctx, sym, frame_opref, target_pc, vsd,
+                ctx,
+                sym,
+                frame_opref,
+                target_pc,
+                vsd,
             );
         }
 

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
@@ -27,27 +27,45 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             // Its `close_loop_args_at` JUMP arg-set is built from the inline
             // callee's frame shape and diverges from the immutable root LABEL
             // (the 20-vs-17 arity crash). RPython resumes the parent via
-            // finishframe + do_recursive_call(assembler_call=True); pyre's
-            // safe subset aborts the trace and marks the callee non-inlinable
-            // so the next root trace makes it a residual call. The discriminator
-            // is a non-empty `parent_frames` (≡ metainterp `inline_depth()>0`),
-            // set here and drained in `trace_step_result_to_action` where the
-            // frame stack and warm-state bookkeeping are reachable.
+            // finishframe + do_recursive_call(assembler_call=True) into the
+            // loop token (pyjitpl.py:1579-1602). When the callee loop's
+            // green key already has compiled code and the parent is the
+            // root frame, take that path: signal the metainterp to pop the
+            // inline frame and record a CALL_ASSEMBLER from the parent.
+            // Otherwise fall back to aborting the trace and stopping the
+            // root key so the callee loop compiles standalone first
+            // (warmstate.py:714 get_assembler_token would synthesize a
+            // compile_tmp_callback token here; until that is wired through
+            // the walker, gate strictly on compiled presence). The
+            // discriminators are set here and drained in
+            // `trace_step_result_to_action` where the frame stack and
+            // warm-state bookkeeping are reachable.
             let is_inline = !this.parent_frames.is_empty();
             if is_inline {
+                let parent_is_root = this.parent_frames.len() == 1;
+                let token_compiled = {
+                    let (driver, _) = crate::driver::driver_pair();
+                    driver.get_loop_token_number(back_edge_key).is_some()
+                };
                 if majit_metainterp::majit_log_enabled() {
                     let (driver, _) = crate::driver::driver_pair();
                     let mi_inline_depth = driver.meta_interp().inline_depth();
                     eprintln!(
-                        "[jit][inline-loop-abort] back-edge in inline frame: parent_frames={} mi_inline_depth={} key={} target_pc={} sym_nlocals={}",
+                        "[jit][inline-loop-back-edge] parent_frames={} mi_inline_depth={} key={} target_pc={} sym_nlocals={} parent_is_root={} token_compiled={}",
                         this.parent_frames.len(),
                         mi_inline_depth,
                         back_edge_key,
                         target,
                         this.sym().nlocals,
+                        parent_is_root,
+                        token_compiled,
                     );
                 }
-                ctx.request_inline_loop_abort();
+                if parent_is_root && token_compiled {
+                    ctx.request_recursive_call_assembler(back_edge_key, target);
+                } else {
+                    ctx.request_inline_loop_abort();
+                }
                 return Ok(None);
             }
             // pyjitpl.py:2957-2965 build live_arg_boxes ONCE.

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
@@ -21,6 +21,35 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             let back_edge_key = crate::driver::make_green_key(code_ptr, target);
             // pyjitpl.py:2951 self.heapcache.reset()
             ctx.heap_cache_mut().reset();
+            // opimpl_jit_merge_point parity (pyjitpl.py:1551,1565-1602): a
+            // back-edge reached while an inline callee frame is active
+            // (portal_call_depth>0) must NOT be unrolled like a root loop.
+            // Its `close_loop_args_at` JUMP arg-set is built from the inline
+            // callee's frame shape and diverges from the immutable root LABEL
+            // (the 20-vs-17 arity crash). RPython resumes the parent via
+            // finishframe + do_recursive_call(assembler_call=True); pyre's
+            // safe subset aborts the trace and marks the callee non-inlinable
+            // so the next root trace makes it a residual call. The discriminator
+            // is a non-empty `parent_frames` (≡ metainterp `inline_depth()>0`),
+            // set here and drained in `trace_step_result_to_action` where the
+            // frame stack and warm-state bookkeeping are reachable.
+            let is_inline = !this.parent_frames.is_empty();
+            if is_inline {
+                if majit_metainterp::majit_log_enabled() {
+                    let (driver, _) = crate::driver::driver_pair();
+                    let mi_inline_depth = driver.meta_interp().inline_depth();
+                    eprintln!(
+                        "[jit][inline-loop-abort] back-edge in inline frame: parent_frames={} mi_inline_depth={} key={} target_pc={} sym_nlocals={}",
+                        this.parent_frames.len(),
+                        mi_inline_depth,
+                        back_edge_key,
+                        target,
+                        this.sym().nlocals,
+                    );
+                }
+                ctx.request_inline_loop_abort();
+                return Ok(None);
+            }
             // pyjitpl.py:2957-2965 build live_arg_boxes ONCE.
             let live_args =
                 crate::state::MIFrame::close_loop_args_at(this, ctx, Some(target));

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls_pre.template.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls_pre.template.rs
@@ -85,8 +85,19 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
         let concrete_callable = callable.concrete.to_pyobj();
         let concrete_args: Vec<pyre_object::PyObjectRef> =
             args.iter().map(|a| a.concrete.to_pyobj()).collect();
+        let args_available =
+            !concrete_callable.is_null() && concrete_args.iter().all(|v| !v.is_null());
         let mut result_concrete = crate::state::ConcreteValue::Null;
-        if !concrete_callable.is_null() && concrete_args.iter().all(|v| !v.is_null()) {
+        // Builtin callees cannot be inlined; compute their concrete result up
+        // front (no trace-through path exists for them).
+        let is_user_fn = args_available
+            && unsafe {
+                pyre_interpreter::is_function(concrete_callable)
+                    && !pyre_interpreter::is_builtin_code(
+                        pyre_interpreter::getcode(concrete_callable) as pyre_object::PyObjectRef,
+                    )
+            };
+        if args_available && !is_user_fn {
             unsafe {
                 if pyre_interpreter::is_function(concrete_callable)
                     && pyre_interpreter::is_builtin_code(
@@ -100,27 +111,6 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
                     );
                     let result = func(&concrete_args).unwrap_or(pyre_object::PY_NULL);
                     result_concrete = crate::state::ConcreteValue::from_pyobj(result);
-                } else if pyre_interpreter::is_function(concrete_callable) {
-                    // pyjitpl.py:2025 concrete execution only.
-                    use std::cell::Cell;
-                    thread_local! {
-                        static CONCRETE_CALL_DEPTH: Cell<u32> = Cell::new(0);
-                    }
-                    let depth = CONCRETE_CALL_DEPTH.with(|d| d.get());
-                    if depth < 32 {
-                        CONCRETE_CALL_DEPTH.with(|d| d.set(depth + 1));
-                        let exec_ctx = self.sym().concrete_execution_context;
-                        let result =
-                            pyre_interpreter::call::call_user_function_plain_with_ctx(
-                                exec_ctx,
-                                concrete_callable,
-                                &concrete_args,
-                            );
-                        CONCRETE_CALL_DEPTH.with(|d| d.set(depth));
-                        if let Ok(result) = result {
-                            result_concrete = crate::state::ConcreteValue::from_pyobj(result);
-                        }
-                    }
                 }
             }
         }
@@ -131,6 +121,40 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
             concrete_callable,
             &concrete_args,
         )?;
+        // pyjitpl.py:2025 concrete execution only — for residual calls.
+        //
+        // RPython decides perform_call (inline) vs do_residual_call BEFORE
+        // executing, and only residual calls run the callee as a whole; an
+        // inlined callee is traced through and its concrete values come from
+        // the inline framestack. Pyre's snapshot trace shares the heap with
+        // the interpreter that re-runs this iteration, so executing a callee
+        // here commits its heap side effects, and the re-run repeats them
+        // (issue #143). Mirror RPython: skip the whole-callee execution when
+        // `call_callable_value` chose to inline (pending_inline_frame set) —
+        // the inline frame's per-opcode concrete steps defer stores like the
+        // root tracer does.
+        if is_user_fn && self.pending_inline_frame.is_none() {
+            unsafe {
+                use std::cell::Cell;
+                thread_local! {
+                    static CONCRETE_CALL_DEPTH: Cell<u32> = Cell::new(0);
+                }
+                let depth = CONCRETE_CALL_DEPTH.with(|d| d.get());
+                if depth < 32 {
+                    CONCRETE_CALL_DEPTH.with(|d| d.set(depth + 1));
+                    let exec_ctx = self.sym().concrete_execution_context;
+                    let result = pyre_interpreter::call::call_user_function_plain_with_ctx(
+                        exec_ctx,
+                        concrete_callable,
+                        &concrete_args,
+                    );
+                    CONCRETE_CALL_DEPTH.with(|d| d.set(depth));
+                    if let Ok(result) = result {
+                        result_concrete = crate::state::ConcreteValue::from_pyobj(result);
+                    }
+                }
+            }
+        }
         Ok(crate::state::FrontendOp::new(opref, result_concrete))
     }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8511,6 +8511,9 @@ mod tests {
                 callee_frame_helper: |_| None,
                 recursive_force_cache_safe: |_| false,
                 jit_drop_callee_frame: std::ptr::null(),
+                jit_frame_set_slot_ref: std::ptr::null(),
+                jit_frame_set_slot_int: std::ptr::null(),
+                jit_frame_set_slot_float: std::ptr::null(),
                 jit_force_callee_frame: std::ptr::null(),
                 jit_force_recursive_call_1: std::ptr::null(),
                 jit_force_recursive_call_argraw_boxed_1: std::ptr::null(),
@@ -11164,6 +11167,15 @@ pub struct PendingInlineFrame {
     pub nargs: usize,
     pub caller_result_stack_idx: Option<usize>,
     pub caller_result_type: Option<Type>,
+    /// Symbolic callable + arg OpRefs of the CALL that pushed this frame.
+    /// Consumed by the inline back-edge CALL_ASSEMBLER path
+    /// (`do_recursive_call`) to shape the GuardNotForced /
+    /// GuardNoException resume via `push_call_replay_stack` — on guard
+    /// failure the parent re-executes the CALL, mirroring the residual
+    /// call capture. `OpRef::NONE` when the path is unavailable
+    /// (bridge-reconstructed frames).
+    pub replay_callable: OpRef,
+    pub replay_args: Vec<OpRef>,
 }
 
 /// Reify one Ref-bank recipe slot as the boxed `W_Root` pointer that
@@ -11302,6 +11314,11 @@ pub(crate) fn assemble_bridge_inline_pending(
         nargs: recipe.nargs,
         caller_result_stack_idx: None,
         caller_result_type: Some(Type::Ref),
+        // Reconstructed frames carry no CALL-site OpRefs; the inline
+        // back-edge CALL_ASSEMBLER path requires drop_frame_opref and
+        // is gated out for them anyway.
+        replay_callable: OpRef::NONE,
+        replay_args: Vec::new(),
     }
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1997,6 +1997,16 @@ pub struct PyreSym {
     /// Virtualizable object pointer (PyFrame).
     /// RPython MetaInterp stores the virtualizable separately from MIFrame.
     pub(crate) concrete_vable_ptr: *mut u8,
+    /// Live (interpreter-owned) virtualizable `PyFrame` behind the tracing
+    /// snapshot, or 0 when tracing runs without one (tests).
+    /// `concrete_vable_ptr` points at the `snapshot_for_tracing` copy whose
+    /// `debugdata` / `lastblock` are owned clones freed when the snapshot
+    /// drops; vable-statics capture (`flush_to_frame`) reads those
+    /// pointer-valued fields from this frame so the trace's resume data
+    /// never carries snapshot-owned pointers.  RPython has no snapshot —
+    /// `read_boxes` (virtualizable.py:86-93) always reads the live
+    /// virtualizable, which is what this field restores.
+    pub(crate) live_vable_frame_addr: usize,
     /// Function-entry traces use typed locals (RPython MIFrame parity).
     pub(crate) is_function_entry_trace: bool,
     /// RPython MetaInterp.last_exc_value (pyjitpl.py:2745): concrete
@@ -3583,6 +3593,7 @@ impl PyreSym {
             is_function_entry_trace: false,
             concrete_execution_context: std::ptr::null(),
             concrete_vable_ptr: std::ptr::null_mut(),
+            live_vable_frame_addr: 0,
             last_exc_value: std::ptr::null_mut(),
             class_of_last_exc_is_const: false,
             last_exc_box: OpRef::NONE,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -181,6 +181,8 @@ pub fn trace_bytecode(
         caller_result_type: None,
         arg_state: pyre_interpreter::bytecode::OpArgState::default(),
         call_site_pc: None,
+        replay_callable: majit_ir::OpRef::NONE,
+        replay_args: Vec::new(),
     };
 
     let mut metainterp = PyreMetaInterp::new(w_code, std::ptr::null_mut());

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -66,6 +66,7 @@ pub fn trace_bytecode(
     _code: &CodeObject,
     start_pc: usize,
     mut concrete_frame: pyre_interpreter::pyframe::FrameBox,
+    live_frame_addr: usize,
 ) -> (TraceAction, pyre_interpreter::pyframe::FrameBox) {
     // `llmodel.py:557` parity — install pyre's `Cpu` impl so the
     // optimizer's `protect_speculative_string` / `bh_strlen` /
@@ -123,6 +124,13 @@ pub fn trace_bytecode(
     // (trace_opcode.rs:3323-3424) and don't call init_symbolic; this path
     // handles the root frame push.
     sym.init_symbolic(ctx, cf_addr);
+    // The snapshot stands in for concrete stepping only; vable-statics
+    // capture must read pointer-valued fields (`debugdata` / `lastblock`)
+    // from the live frame the compiled loop will run on.  See the
+    // `live_vable_frame_addr` field doc (state.rs).  Set before the
+    // full-body-walk leg below so the walker path (the production tracer
+    // post-#73) sees it as well as the trait `interpret()` leg.
+    sym.live_vable_frame_addr = live_frame_addr;
     // Issue #73 walker-as-tracer foundation probe (slice #1, gated).
     // `PYRE_WALK_PERFN_JITCODE=1` attempts to walk the per-CodeObject
     // JitCode body via `dispatch_via_miframe` from the resume entry pc,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -973,6 +973,7 @@ fn full_body_walk_trace(
                 | DE::MayForceNullRefArgUnsupported { .. }
                 | DE::BranchGuardKeptStackUnsupported { .. }
                 | DE::NonStandardVableFinishPortalUnsupported { .. }
+                | DE::LoopBearingCalleeInlineUnsupported { .. }
                 | DE::ResidualCallArgUnbound { .. } => {
                     fbw_decline(crate::driver::make_green_key(w_code, start_pc));
                     TraceAction::Abort

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -702,6 +702,80 @@ pub(crate) fn write_stack_slot(
     }
 }
 
+/// Write an inline callee frame's live state back to its heap `PyFrame`
+/// before a loop-token CALL_ASSEMBLER (opimpl_jit_merge_point
+/// portal_call_depth>0 → do_recursive_call, pyjitpl.py:1579-1602).
+///
+/// The callee's compiled loop reads `locals_cells_stack_w` /
+/// `last_instr` / `valuestackdepth` from the frame object at entry
+/// (virtualizable.py:86-98 read_boxes), but the inlined prefix advanced
+/// those values only in the symbolic register banks; the runtime frame
+/// still holds its creation-time state (call args). Emit the
+/// virtualizable write_boxes shape (virtualizable.py:99-110):
+/// SETFIELD_GC for the per-call statics + one residual helper CALL per
+/// live array slot. Slots never touched symbolically (`OpRef::NONE`)
+/// keep their runtime creation value.
+///
+/// The other four statics (`pycode`, `debugdata`, `lastblock`,
+/// `w_globals`) are correct from frame creation and have no mutators
+/// under CPython 3.14 bytecode (see `flush_to_frame_for_guard`).
+pub(crate) fn gen_writeback_inline_frame_to_heap(
+    ctx: &mut TraceCtx,
+    sym: &mut PyreSym,
+    frame_opref: OpRef,
+    target_pc: usize,
+    valuestackdepth: usize,
+) {
+    let info = crate::frame_layout::build_pyframe_virtualizable_info();
+
+    // last_instr = target_pc - 1 so the compiled loop's next_instr()
+    // lands on the merge point (pyjitpl.py:2973 reached_loop_header pin).
+    let last_instr = ctx.const_int(target_pc as i64 - 1);
+    if let Some(idx) = info.static_field_index_by_name("last_instr") {
+        let descr = info.static_field_descr(idx);
+        ctx.vable_setfield_descr(frame_opref, last_instr, descr);
+    }
+    let vsd = ctx.const_int(valuestackdepth as i64);
+    if let Some(idx) = info.static_field_index_by_name("valuestackdepth") {
+        let descr = info.static_field_descr(idx);
+        ctx.vable_setfield_descr(frame_opref, vsd, descr);
+    }
+
+    // locals_cells_stack_w items, emitted as residual helper CALLs
+    // (jit_frame_set_slot_{ref,int,float}) rather than SetarrayitemGc.
+    // direct_assembler_call (pyjitpl.py:3613) passes the red boxes as
+    // CALL_ASSEMBLER args, so virtual values among them are forced at
+    // the call; pyre's uniform `[frame, ec]` loop ABI delivers the reds
+    // through the heap frame instead, and making each slot value a call
+    // argument keeps the same force-at-call property. The raw int/float
+    // helper variants box runtime-side (w_int_new / w_float_new), so no
+    // boxing ops enter the trace. GC visibility of the stored refs
+    // between these stores and the compiled loop's entry loads is
+    // covered by `walk_jit_callee_frame_roots` (pyre-jit::call_jit) —
+    // the heap frame sits on no `CURRENT_FRAME` chain while compiled
+    // code runs.
+    let cb = crate::callbacks::get();
+    for slot in 0..valuestackdepth {
+        let Some(&value) = sym.registers_r.get(slot) else {
+            break;
+        };
+        if value == OpRef::NONE {
+            continue;
+        }
+        let index = ctx.const_int(slot as i64);
+        let (helper, value_type) = match ctx.get_opref_type(value) {
+            Some(Type::Int) => (cb.jit_frame_set_slot_int, Type::Int),
+            Some(Type::Float) => (cb.jit_frame_set_slot_float, Type::Float),
+            _ => (cb.jit_frame_set_slot_ref, Type::Ref),
+        };
+        ctx.call_void_typed(
+            helper,
+            &[frame_opref, index, value],
+            &[Type::Ref, Type::Int, value_type],
+        );
+    }
+}
+
 /// Read the symbolic OpRef at depth offset `stack_idx`, with lazy
 /// heap-fill from `locals_cells_stack_w` when the slot is empty.
 /// Symmetric counterpart of `write_stack_slot`.
@@ -7341,6 +7415,57 @@ impl MIFrame {
             nargs: args.len(),
             caller_result_stack_idx: None,
             caller_result_type: Some(Type::Ref),
+            replay_callable: callable,
+            replay_args: args.to_vec(),
+        })
+    }
+
+    /// pyjitpl.py:1425-1432 do_recursive_call(assembler_call=True) +
+    /// pyjitpl.py:3613-3635 direct_assembler_call, invoked on the PARENT
+    /// frame after the inline callee was popped at its loop back-edge
+    /// (opimpl_jit_merge_point portal_call_depth>0, pyjitpl.py:1579-1602).
+    ///
+    /// Records CALL_ASSEMBLER into the callee loop's compiled token with
+    /// `[callee_frame, ec]` red args (interp_jit.py:67 reds), bracketed by
+    /// the same vable/vref + GuardNotForced / GuardNoException sequence as
+    /// the residual-call emission (do_residual_call, pyjitpl.py:1995-2083).
+    /// The guard resume is shaped by `push_call_replay_stack` with the
+    /// original CALL's callable/args so a failure re-executes the call in
+    /// the interpreter — the same capture the residual path uses.
+    ///
+    /// Returns the CALL_ASSEMBLER result OpRef (Ref-typed: the callee's
+    /// boxed return value).
+    pub(crate) fn do_recursive_call_assembler(
+        &mut self,
+        token_number: u64,
+        callee_frame: OpRef,
+        replay_callable: OpRef,
+        replay_args: &[OpRef],
+        call_pc: usize,
+    ) -> Result<OpRef, PyError> {
+        self.with_ctx(|this, ctx| {
+            // pyjitpl.py:2017: do_residual_call step 1
+            this.vable_and_vrefs_before_residual_call(ctx);
+            let ec = this.ensure_execution_context(ctx);
+            let ca_result = ctx.call_assembler_red_only_ref(
+                token_number,
+                &[callee_frame, ec],
+                &[Type::Ref, Type::Ref],
+            );
+            // pyjitpl.py:3625-3631 direct_assembler_call: keep the callee
+            // virtualizable alive past the CALL_ASSEMBLER.
+            ctx.record_op(OpCode::Keepalive, &[callee_frame]);
+            // pyjitpl.py:2049
+            this.vrefs_after_residual_call(ctx);
+            // pyjitpl.py:2078
+            this.vable_after_residual_call()?;
+            // pyjitpl.py:2079
+            this.push_call_replay_stack(ctx, replay_callable, replay_args, call_pc);
+            this.generate_guard(ctx, OpCode::GuardNotForced, &[]);
+            this.generate_guard(ctx, OpCode::GuardNoException, &[]);
+            ctx.heap_cache_mut().invalidate_caches_for_escaped();
+            this.pop_call_replay_stack(ctx, replay_args.len())?;
+            Ok(ca_result)
         })
     }
 
@@ -9164,6 +9289,17 @@ pub(crate) fn trace_step_result_to_action(
 ) -> TraceAction {
     match result {
         Ok(pyre_interpreter::StepResult::Continue) => {
+            // opimpl_jit_merge_point portal_call_depth>0 orthodox path
+            // (pyjitpl.py:1579-1602): the inline-frame back-edge targets a
+            // loop with compiled code; surface the signal so the metainterp
+            // pops the inline frame and records a CALL_ASSEMBLER from the
+            // parent (finishframe + do_recursive_call assembler_call=True).
+            if let Some((green_key, target_pc)) = state.ctx().take_recursive_call_assembler() {
+                return TraceAction::RecursiveCallAssembler {
+                    green_key,
+                    target_pc,
+                };
+            }
             // opimpl_jit_merge_point portal_call_depth>0 safe subset: a
             // back-edge reached inside an inline callee frame was flagged in
             // close_loop_args (it cannot be unrolled — its JUMP arg-set is

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9164,6 +9164,42 @@ pub(crate) fn trace_step_result_to_action(
 ) -> TraceAction {
     match result {
         Ok(pyre_interpreter::StepResult::Continue) => {
+            // opimpl_jit_merge_point portal_call_depth>0 safe subset: a
+            // back-edge reached inside an inline callee frame was flagged in
+            // close_loop_args (it cannot be unrolled — its JUMP arg-set is
+            // built from the callee frame shape, diverging from the root
+            // LABEL). Abort this trace and stop tracing the root loop so the
+            // callee compiles standalone instead of being re-inlined. Reuses
+            // the trace-too-long recovery primitive (disable_noninlinable_-
+            // function, below) but targets the root key, not the callee.
+            if state.ctx().take_inline_loop_abort() {
+                let root_green_key = state.with_ctx(|_, ctx| ctx.root_green_key());
+                let callee_key = biggest_inline_trace_key(state);
+                let (driver, _) = crate::driver::driver_pair();
+                let warm_state = driver.meta_interp_mut().warm_state_mut();
+                // Stop tracing the root loop that inlined this callee, so the
+                // callee compiles as its own LOOP and runs in JIT code while
+                // the (trivial) root loop stays interpreted.
+                //
+                // The orthodox endpoint is a residual CALL_ASSEMBLER from the
+                // root into the callee's compiled loop (do_recursive_call,
+                // assembler_call=True). This safe subset stops short of
+                // emitting that call. Marking the *callee* non-inlinable
+                // instead would route it through a function-entry PROCEDURE
+                // compile, which is broken for a callee first reached by an
+                // aborted inline trace (guard-failure storm → crash); marking
+                // the *root* lets the callee's hot loop compile exactly as it
+                // does when the driver lives at module scope and never inlines
+                // it (the working baseline).
+                warm_state.disable_noninlinable_function(root_green_key);
+                if majit_metainterp::majit_log_enabled() {
+                    eprintln!(
+                        "[jit][inline-loop-abort] disable root={} (callee={:?})",
+                        root_green_key, callee_key
+                    );
+                }
+                return majit_metainterp::TraceAction::Abort;
+            }
             let compile_trace_succeeded = {
                 let (driver, _) = crate::driver::driver_pair();
                 driver.compile_trace_success_pending()

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2528,12 +2528,32 @@ impl MIFrame {
     pub(crate) fn flush_to_frame(&mut self, ctx: &mut TraceCtx) {
         let resume_pc = self.orgpc;
         let frame_addr = self.concrete_frame_addr;
-        let (code_ptr, debugdata, lastblock) = if frame_addr != 0 {
+        // virtualizable.py:86-93 read_boxes reads statics from the LIVE
+        // virtualizable.  The root MIFrame's concrete frame is the
+        // trace-stepping snapshot (`snapshot_for_tracing`), whose
+        // `debugdata` / `lastblock` are owned clones freed when tracing
+        // ends — a const captured from the snapshot dangles in the
+        // compiled trace's resume data, and the guard-failure vable
+        // write (`write_from_resume_data_partial`) then stamps the
+        // dangling pointer into the live frame.  Read the pointer-valued
+        // statics from the live virtualizable instead; `pycode` is
+        // copied by the snapshot so either source gives the same value.
+        // `last_instr` / `valuestackdepth` are plain values that evolve
+        // with the trace, so they stay snapshot-sourced below.
+        let statics_addr = {
+            let live = self.sym().live_vable_frame_addr;
+            if live != 0 && self.sym().owns_virtualizable_shadow() {
+                live
+            } else {
+                frame_addr
+            }
+        };
+        let (code_ptr, debugdata, lastblock) = if statics_addr != 0 {
             unsafe {
                 (
-                    *((frame_addr + PYFRAME_PYCODE_OFFSET) as *const usize),
-                    *((frame_addr + PYFRAME_DEBUGDATA_OFFSET) as *const usize),
-                    *((frame_addr + PYFRAME_LASTBLOCK_OFFSET) as *const usize),
+                    *((statics_addr + PYFRAME_PYCODE_OFFSET) as *const usize),
+                    *((statics_addr + PYFRAME_DEBUGDATA_OFFSET) as *const usize),
+                    *((statics_addr + PYFRAME_LASTBLOCK_OFFSET) as *const usize),
                 )
             }
         } else {
@@ -3149,9 +3169,18 @@ impl MIFrame {
                 }
             }
         }
+        // An active virtualizable owner must have its array base seeded by
+        // `init_symbolic` / `become_active_vable_owner` before the JUMP-arg
+        // derivation below reads `nlocals`/`vable_array_base`.  `nlocals` is
+        // NOT a usable proxy for "init ran": module-scope (`<module>`) frames
+        // are vable owners (M1 portal gate) yet have `co_nlocals == 0`, the
+        // same value as the struct default — names go through globals, not
+        // fast locals.  `target_array_capacity` below handles `nlocals == 0`
+        // via the `valuestackdepth` saturating-sub, so the seeded base is the
+        // real precondition.
         debug_assert!(
-            self.sym().nlocals > 0 || !self.sym().is_active_vable_owner,
-            "nlocals must be set by init_symbolic before close_loop_args_at"
+            !self.sym().is_active_vable_owner || self.sym().vable_array_base.is_some(),
+            "an active vable owner must have a seeded vable_array_base before close_loop_args_at"
         );
         // RPython close_loop_args parity: JUMP args must match the target
         // label's types (inputarg_types). materialize_loop_carried_value
@@ -7872,6 +7901,41 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // PUSH_NULL walker activation via direct symbolic push.
+        //
+        // The auto-gen arm jitcode for `PushNull` is `int_copy,
+        // residual_call_r_r(opcode_push_null, frame), live, ref_return` —
+        // a residual wrapper whose helper is NOT in the runtime fnaddr
+        // registry, so `try_execute_residual_call_via_executor` rejects
+        // its placeholder funcptr (47-bit gate) and the arm walk records
+        // the call WITHOUT executing it.  The concrete `PyFrame.
+        // valuestackdepth` then never advances, and the post-walk
+        // `resync_sym_vsd_from_concrete_frame` clobbers
+        // `sym.valuestackdepth` with the stale frame value — losing every
+        // preceding trait-leg push and underflowing the next CALL
+        // (`LOAD_NAME f; PUSH_NULL; LOAD_NAME s; CALL` at module scope,
+        // `f = g; f(s)` local-callable calls in function scope).
+        //
+        // Short-circuit the arm walk with the symbolic effect directly:
+        // PUSH_NULL pushes a constant NULL stack slot (the `_null_or_self`
+        // operand `opcode_call` pops and discards), so no IR op is needed —
+        // a `const_ref(PY_NULL)` through the trait push machinery keeps
+        // `sym.valuestackdepth` / vable shadow / concrete mirror coherent.
+        // Same delegation pattern as the StoreSubscr hook above; bypasses
+        // `apply_walker_stack_effect` because `push_value` handles vsd.
+        if matches!(instruction, Instruction::PushNull) {
+            use pyre_interpreter::SharedOpcodeHandler;
+            let _ = op_arg;
+            let null_opref = self.with_ctx(|_this, ctx| {
+                Ok::<_, PyError>(ctx.const_ref(pyre_object::PY_NULL as i64))
+            })?;
+            SharedOpcodeHandler::push_value(
+                self,
+                FrontendOp::new(null_opref, ConcreteValue::Ref(pyre_object::PY_NULL)),
+            )?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // `pyopcode.py:1348-1376 RERAISE` parity for the walker leg.
         //
         // Production walker excluded `Reraise` because the trait path
@@ -8989,8 +9053,15 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::DictMerge { .. }
             | Instruction::SetFunctionAttribute { .. }
             | Instruction::UnpackEx { .. }
-            | Instruction::LoadName { .. }
-            | Instruction::StoreName { .. }
+            // Instruction::LoadName / StoreName excluded: the trait
+            // handlers (`load_name_value` / `store_name_value`) carry the
+            // celldict ModuleDictStrategy fast path (LOAD_GLOBAL_cached
+            // celldict.py:285-322: QUASIIMMUT_FIELD version dep + elidable
+            // cell fold; STORE_GLOBAL_cached celldict.py:328-333:
+            // layout-agnostic setitem_str). The walker's jitcode arm for
+            // these aborts with ResidualCallArgUnbound on the &str name
+            // argument — it was never exercised before module-level frames
+            // became portals.
             | Instruction::StoreGlobal { .. }
             | Instruction::DeleteAttr { .. }
             | Instruction::ImportName { .. }
@@ -9071,10 +9142,12 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // wrong arg count (bridge fails to compile) and a backend
             // regalloc panic.  Keep the whole handler region on one concrete
             // (trait) leg so the bridge's framestate matches the loop entry.
-            // PushNull is a bare stack push (delta +1) with no may-force
-            // receiver and no `vsd <= nlocals` underflow guard, so it
-            // routes through the non-zero stack-effect resync alongside
-            // the other pure pushes.
+            // PushNull is handled by the dispatch_via_walker_for_opcode
+            // entry hook (direct const-NULL symbolic push): its auto-gen
+            // arm is an inert residual wrapper (`opcode_push_null` is not
+            // in the runtime fnaddr registry), so the arm-walk +
+            // vsd-resync route loses the push and underflows the
+            // following CALL.
             | Instruction::PushNull
     )
 }
@@ -9251,8 +9324,8 @@ fn apply_walker_stack_effect(state: &mut MIFrame, instruction: &Instruction) {
         | Instruction::LoadAttr { .. }
         | Instruction::StoreAttr { .. }
         // | Instruction::StoreSubscr { .. } // see production_walker_handles for the walker hook rationale
-        | Instruction::StoreFastStoreFast { .. }
-        | Instruction::PushNull => {
+        // | Instruction::PushNull // handled by the dispatch_via_walker_for_opcode entry hook; push_value advances vsd
+        | Instruction::StoreFastStoreFast { .. } => {
             // Non-zero stack delta. The walker arm's
             // `setfield_vable_i(valuestackdepth)` emit routes through
             // `vable_setfield` (trace_ctx.rs:2608-2655) which calls

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -512,6 +512,35 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             let back_edge_key = crate::driver::make_green_key(code_ptr, target);
             // pyjitpl.py:2951 self.heapcache.reset()
             ctx.heap_cache_mut().reset();
+            // opimpl_jit_merge_point parity (pyjitpl.py:1551,1565-1602): a
+            // back-edge reached while an inline callee frame is active
+            // (portal_call_depth>0) must NOT be unrolled like a root loop.
+            // Its `close_loop_args_at` JUMP arg-set is built from the inline
+            // callee's frame shape and diverges from the immutable root LABEL
+            // (the 20-vs-17 arity crash). RPython resumes the parent via
+            // finishframe + do_recursive_call(assembler_call=True); pyre's
+            // safe subset aborts the trace and marks the callee non-inlinable
+            // so the next root trace makes it a residual call. The discriminator
+            // is a non-empty `parent_frames` (≡ metainterp `inline_depth()>0`),
+            // set here and drained in `trace_step_result_to_action` where the
+            // frame stack and warm-state bookkeeping are reachable.
+            let is_inline = !this.parent_frames.is_empty();
+            if is_inline {
+                if majit_metainterp::majit_log_enabled() {
+                    let (driver, _) = crate::driver::driver_pair();
+                    let mi_inline_depth = driver.meta_interp().inline_depth();
+                    eprintln!(
+                        "[jit][inline-loop-abort] back-edge in inline frame: parent_frames={} mi_inline_depth={} key={} target_pc={} sym_nlocals={}",
+                        this.parent_frames.len(),
+                        mi_inline_depth,
+                        back_edge_key,
+                        target,
+                        this.sym().nlocals,
+                    );
+                }
+                ctx.request_inline_loop_abort();
+                return Ok(None);
+            }
             // pyjitpl.py:2957-2965 build live_arg_boxes ONCE.
             let live_args =
                 crate::state::MIFrame::close_loop_args_at(this, ctx, Some(target));

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -90,8 +90,19 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
         let concrete_callable = callable.concrete.to_pyobj();
         let concrete_args: Vec<pyre_object::PyObjectRef> =
             args.iter().map(|a| a.concrete.to_pyobj()).collect();
+        let args_available =
+            !concrete_callable.is_null() && concrete_args.iter().all(|v| !v.is_null());
         let mut result_concrete = crate::state::ConcreteValue::Null;
-        if !concrete_callable.is_null() && concrete_args.iter().all(|v| !v.is_null()) {
+        // Builtin callees cannot be inlined; compute their concrete result up
+        // front (no trace-through path exists for them).
+        let is_user_fn = args_available
+            && unsafe {
+                pyre_interpreter::is_function(concrete_callable)
+                    && !pyre_interpreter::is_builtin_code(
+                        pyre_interpreter::getcode(concrete_callable) as pyre_object::PyObjectRef,
+                    )
+            };
+        if args_available && !is_user_fn {
             unsafe {
                 if pyre_interpreter::is_function(concrete_callable)
                     && pyre_interpreter::is_builtin_code(
@@ -105,27 +116,6 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
                     );
                     let result = func(&concrete_args).unwrap_or(pyre_object::PY_NULL);
                     result_concrete = crate::state::ConcreteValue::from_pyobj(result);
-                } else if pyre_interpreter::is_function(concrete_callable) {
-                    // pyjitpl.py:2025 concrete execution only.
-                    use std::cell::Cell;
-                    thread_local! {
-                        static CONCRETE_CALL_DEPTH: Cell<u32> = Cell::new(0);
-                    }
-                    let depth = CONCRETE_CALL_DEPTH.with(|d| d.get());
-                    if depth < 32 {
-                        CONCRETE_CALL_DEPTH.with(|d| d.set(depth + 1));
-                        let exec_ctx = self.sym().concrete_execution_context;
-                        let result =
-                            pyre_interpreter::call::call_user_function_plain_with_ctx(
-                                exec_ctx,
-                                concrete_callable,
-                                &concrete_args,
-                            );
-                        CONCRETE_CALL_DEPTH.with(|d| d.set(depth));
-                        if let Ok(result) = result {
-                            result_concrete = crate::state::ConcreteValue::from_pyobj(result);
-                        }
-                    }
                 }
             }
         }
@@ -136,6 +126,40 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
             concrete_callable,
             &concrete_args,
         )?;
+        // pyjitpl.py:2025 concrete execution only — for residual calls.
+        //
+        // RPython decides perform_call (inline) vs do_residual_call BEFORE
+        // executing, and only residual calls run the callee as a whole; an
+        // inlined callee is traced through and its concrete values come from
+        // the inline framestack. Pyre's snapshot trace shares the heap with
+        // the interpreter that re-runs this iteration, so executing a callee
+        // here commits its heap side effects, and the re-run repeats them
+        // (issue #143). Mirror RPython: skip the whole-callee execution when
+        // `call_callable_value` chose to inline (pending_inline_frame set) —
+        // the inline frame's per-opcode concrete steps defer stores like the
+        // root tracer does.
+        if is_user_fn && self.pending_inline_frame.is_none() {
+            unsafe {
+                use std::cell::Cell;
+                thread_local! {
+                    static CONCRETE_CALL_DEPTH: Cell<u32> = Cell::new(0);
+                }
+                let depth = CONCRETE_CALL_DEPTH.with(|d| d.get());
+                if depth < 32 {
+                    CONCRETE_CALL_DEPTH.with(|d| d.set(depth + 1));
+                    let exec_ctx = self.sym().concrete_execution_context;
+                    let result = pyre_interpreter::call::call_user_function_plain_with_ctx(
+                        exec_ctx,
+                        concrete_callable,
+                        &concrete_args,
+                    );
+                    CONCRETE_CALL_DEPTH.with(|d| d.set(depth));
+                    if let Ok(result) = result {
+                        result_concrete = crate::state::ConcreteValue::from_pyobj(result);
+                    }
+                }
+            }
+        }
         Ok(crate::state::FrontendOp::new(opref, result_concrete))
     }
 

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -1,6 +1,5 @@
 ---
 source: pyre/pyre-jit-trace/tests/trait_impls_snapshot.rs
-assertion_line: 48
 expression: assembled
 ---
 // `OpcodeHandler` trait impls for `MIFrame` — variant section, part 1.
@@ -542,27 +541,45 @@ impl pyre_interpreter::ControlFlowOpcodeHandler for crate::state::MIFrame {
             // Its `close_loop_args_at` JUMP arg-set is built from the inline
             // callee's frame shape and diverges from the immutable root LABEL
             // (the 20-vs-17 arity crash). RPython resumes the parent via
-            // finishframe + do_recursive_call(assembler_call=True); pyre's
-            // safe subset aborts the trace and marks the callee non-inlinable
-            // so the next root trace makes it a residual call. The discriminator
-            // is a non-empty `parent_frames` (≡ metainterp `inline_depth()>0`),
-            // set here and drained in `trace_step_result_to_action` where the
-            // frame stack and warm-state bookkeeping are reachable.
+            // finishframe + do_recursive_call(assembler_call=True) into the
+            // loop token (pyjitpl.py:1579-1602). When the callee loop's
+            // green key already has compiled code and the parent is the
+            // root frame, take that path: signal the metainterp to pop the
+            // inline frame and record a CALL_ASSEMBLER from the parent.
+            // Otherwise fall back to aborting the trace and stopping the
+            // root key so the callee loop compiles standalone first
+            // (warmstate.py:714 get_assembler_token would synthesize a
+            // compile_tmp_callback token here; until that is wired through
+            // the walker, gate strictly on compiled presence). The
+            // discriminators are set here and drained in
+            // `trace_step_result_to_action` where the frame stack and
+            // warm-state bookkeeping are reachable.
             let is_inline = !this.parent_frames.is_empty();
             if is_inline {
+                let parent_is_root = this.parent_frames.len() == 1;
+                let token_compiled = {
+                    let (driver, _) = crate::driver::driver_pair();
+                    driver.get_loop_token_number(back_edge_key).is_some()
+                };
                 if majit_metainterp::majit_log_enabled() {
                     let (driver, _) = crate::driver::driver_pair();
                     let mi_inline_depth = driver.meta_interp().inline_depth();
                     eprintln!(
-                        "[jit][inline-loop-abort] back-edge in inline frame: parent_frames={} mi_inline_depth={} key={} target_pc={} sym_nlocals={}",
+                        "[jit][inline-loop-back-edge] parent_frames={} mi_inline_depth={} key={} target_pc={} sym_nlocals={} parent_is_root={} token_compiled={}",
                         this.parent_frames.len(),
                         mi_inline_depth,
                         back_edge_key,
                         target,
                         this.sym().nlocals,
+                        parent_is_root,
+                        token_compiled,
                     );
                 }
-                ctx.request_inline_loop_abort();
+                if parent_is_root && token_compiled {
+                    ctx.request_recursive_call_assembler(back_edge_key, target);
+                } else {
+                    ctx.request_inline_loop_abort();
+                }
                 return Ok(None);
             }
             // pyjitpl.py:2957-2965 build live_arg_boxes ONCE.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -46,6 +46,7 @@ use pyre_object::intobject::w_int_new;
 use pyre_object::pyobject::is_int;
 use pyre_object::{PY_NULL, PyObjectRef};
 
+use majit_ir::GcRef;
 use pyre_interpreter::pyframe::PyFrame;
 use pyre_jit_trace::trace::trace_bytecode;
 
@@ -257,12 +258,26 @@ fn heap_alloc_frame(frame: PyFrame) -> *mut PyFrame {
         gc_header: majit_gc::header::GcHeader { tid_and_flags: 0 },
         frame,
     }));
-    unsafe { &mut (*gc_frame).frame as *mut PyFrame }
+    let ptr = unsafe { &mut (*gc_frame).frame as *mut PyFrame };
+    HEAP_CALLEE_FRAMES.with(|cell| unsafe { &mut *cell.get() }.push(ptr));
+    ptr
 }
 
 fn heap_free_frame(ptr: *mut PyFrame) {
+    HEAP_CALLEE_FRAMES.with(|cell| {
+        let frames = unsafe { &mut *cell.get() };
+        if let Some(pos) = frames.iter().position(|p| *p == ptr) {
+            frames.swap_remove(pos);
+        }
+    });
     let gc_frame = unsafe { (ptr as *mut u8).sub(GC_HEADER_SIZE) as *mut GcPyFrame };
     unsafe { drop(Box::from_raw(gc_frame)) };
+}
+
+thread_local! {
+    /// Live heap-fallback callee frames (arena overflow). Walked by
+    /// `walk_jit_callee_frame_roots` alongside armed arena slots.
+    static HEAP_CALLEE_FRAMES: UnsafeCell<Vec<*mut PyFrame>> = const { UnsafeCell::new(Vec::new()) };
 }
 
 struct FrameArena {
@@ -272,6 +287,13 @@ struct FrameArena {
     /// Frames below this index have been initialized at least once.
     /// Reuse only needs reinit of changed fields, not full new_for_call.
     initialized: usize,
+    /// Per-slot GC visibility: set once a slot's frame is fully
+    /// initialized for the current call, cleared on `put`. The extra
+    /// root walker (`walk_jit_callee_frame_roots`) visits only armed
+    /// slots — `top` alone cannot be used because a non-LIFO `put`
+    /// leaves dead slots below `top`, and a slot between `take` and
+    /// end-of-init holds an uninitialized or stale frame.
+    armed: [bool; ARENA_CAP],
 }
 
 impl FrameArena {
@@ -280,6 +302,7 @@ impl FrameArena {
             buf: Box::new([const { GcFrameSlot::zeroed() }; ARENA_CAP]),
             top: 0,
             initialized: 0,
+            armed: [false; ARENA_CAP],
         };
         // Publish stable pointers so Cranelift-generated code can
         // inline arena take/put without going through TLS.
@@ -312,6 +335,9 @@ impl FrameArena {
     /// Return a frame to the arena. Must be the most recently taken frame (LIFO).
     #[inline]
     fn put(&mut self, ptr: *mut PyFrame) -> bool {
+        if let Some(idx) = self.slot_index(ptr) {
+            self.armed[idx] = false;
+        }
         if self.top > 0 && ptr == self.buf[self.top - 1].frame.as_mut_ptr() {
             self.top -= 1;
             unsafe {
@@ -320,10 +346,30 @@ impl FrameArena {
             return true;
         }
         // Check if within arena range — don't free, but mark as non-LIFO.
-        let base = self.buf[0].frame.as_mut_ptr() as usize;
-        let end = unsafe { (self.buf.as_ptr() as *const GcFrameSlot).add(ARENA_CAP) as usize };
+        self.slot_index(ptr).is_some()
+    }
+
+    /// Slot index for a frame pointer inside the arena buffer, if any.
+    #[inline]
+    fn slot_index(&self, ptr: *mut PyFrame) -> Option<usize> {
+        let base = self.buf.as_ptr() as usize;
+        let end = unsafe { (self.buf.as_ptr()).add(ARENA_CAP) } as usize;
         let addr = ptr as usize;
-        addr >= base && addr < end
+        if addr >= base && addr < end {
+            Some((addr - base) / std::mem::size_of::<GcFrameSlot>())
+        } else {
+            None
+        }
+    }
+
+    /// Mark a fully-initialized in-use slot as visible to the GC root
+    /// walker. Call only after the frame body and its locals array are
+    /// completely written for the current call.
+    #[inline]
+    fn arm(&mut self, ptr: *mut PyFrame) {
+        if let Some(idx) = self.slot_index(ptr) {
+            self.armed[idx] = true;
+        }
     }
 
     /// Mark that frames up to `top` have been fully initialized.
@@ -345,6 +391,48 @@ thread_local! {
 #[inline]
 fn arena_ref() -> &'static mut FrameArena {
     FRAME_ARENA.with(|cell| unsafe { &mut *cell.get() })
+}
+
+/// Visit the GC-ref slots of one live callee frame: every
+/// `locals_cells_stack_w` item plus the ref-bearing statics — the same
+/// field set `walk_pyframe_roots` (pyre-interpreter::eval) visits for
+/// interpreter frames on the `CURRENT_FRAME` chain.
+///
+/// # Safety
+/// `frame` must point at a fully-initialized live `PyFrame`.
+unsafe fn visit_callee_frame_roots(frame: *mut PyFrame, visitor: &mut dyn FnMut(&mut GcRef)) {
+    let frame = unsafe { &mut *frame };
+    for slot in frame.locals_w_mut().as_mut_slice() {
+        visitor(unsafe { &mut *(slot as *mut PyObjectRef as *mut GcRef) });
+    }
+    visitor(unsafe { &mut *(&mut frame.f_generator_nowref as *mut PyObjectRef as *mut GcRef) });
+    visitor(unsafe { &mut *(&mut frame.w_yielding_from as *mut PyObjectRef as *mut GcRef) });
+    visitor(unsafe { &mut *(&mut frame.w_globals_obj as *mut PyObjectRef as *mut GcRef) });
+}
+
+/// Extra GC root walker for JIT-created callee frames (frame arena +
+/// heap fallbacks). These frames are host-allocated (zeroed GcHeader,
+/// outside the GC heap) and sit on no `CURRENT_FRAME`/`f_backref`
+/// chain while compiled code runs, so neither the standard tracer nor
+/// `walk_pyframe_roots` reaches their locals. Without this walk, a
+/// young object stored into a callee frame slot (argument boxing,
+/// back-edge CALL_ASSEMBLER writeback) is invisible to a minor
+/// collection and the slot is left pointing at evacuated nursery
+/// memory. Registered via `register_extra_root_walker`, mirroring the
+/// framework.py `root_walker.walk_roots` seam the collector already
+/// uses for the other host-side root sources.
+pub fn walk_jit_callee_frame_roots(visitor: &mut dyn FnMut(&mut GcRef)) {
+    let arena = arena_ref();
+    for idx in 0..ARENA_CAP {
+        if arena.armed[idx] {
+            unsafe { visit_callee_frame_roots(arena.buf[idx].frame.as_mut_ptr(), visitor) };
+        }
+    }
+    HEAP_CALLEE_FRAMES.with(|cell| {
+        for &ptr in unsafe { &*cell.get() }.iter() {
+            unsafe { visit_callee_frame_roots(ptr, visitor) };
+        }
+    });
 }
 
 // ── JIT call callbacks ───────────────────────────────────────────
@@ -2345,6 +2433,7 @@ fn create_callee_frame_impl_1_boxed(
             }
             arena.mark_initialized();
         }
+        arena.arm(ptr);
         return ptr as i64;
     }
 
@@ -2416,6 +2505,7 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
             }
             arena.mark_initialized();
         }
+        arena.arm(ptr);
         if majit_metainterp::majit_log_enabled() {
             let f = unsafe { &*ptr };
             eprintln!(
@@ -2499,6 +2589,7 @@ fn create_callee_frame_impl(caller_frame: i64, callable: i64, args: &[PyObjectRe
             }
             arena.mark_initialized();
         }
+        arena.arm(ptr);
         return ptr as i64;
     }
 
@@ -2599,6 +2690,7 @@ pub extern "C" fn jit_create_self_recursive_callee_frame_1_raw_int(
                 arena.mark_initialized();
             }
         }
+        arena.arm(ptr);
         if majit_metainterp::majit_log_enabled() {
             let f = unsafe { &*ptr };
             eprintln!(
@@ -2737,6 +2829,35 @@ pub extern "C" fn jit_drop_callee_frame(frame_ptr: i64) {
         // Not an arena frame (heap fallback) — free GcPyFrame allocation.
         heap_free_frame(ptr);
     }
+}
+
+/// Store a W_Root into a callee frame's `locals_cells_stack_w[idx]`.
+///
+/// Residual helper for the inline back-edge CALL_ASSEMBLER writeback
+/// (do_recursive_call, pyjitpl.py:1579-1602): the callee's compiled
+/// loop reads its locals from the frame object at entry, so the
+/// inlined prefix's register values are stored back through these
+/// helpers before the call. Plain store, same as `PyFrame::push`.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_frame_set_slot_ref(frame_ptr: i64, idx: i64, value: i64) {
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    frame.locals_w_mut()[idx as usize] = value as PyObjectRef;
+}
+
+/// `jit_frame_set_slot_ref` for a raw int value — boxes via `w_int_new`.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_frame_set_slot_int(frame_ptr: i64, idx: i64, raw: i64) {
+    let boxed = pyre_object::intobject::w_int_new(raw);
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    frame.locals_w_mut()[idx as usize] = boxed;
+}
+
+/// `jit_frame_set_slot_ref` for a raw float value — boxes via `w_float_new`.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_frame_set_slot_float(frame_ptr: i64, idx: i64, raw: f64) {
+    let boxed = pyre_object::floatobject::w_float_new(raw);
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    frame.locals_w_mut()[idx as usize] = boxed;
 }
 
 // ===========================================================================

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2066,6 +2066,7 @@ pub fn trace_and_compile_from_bridge(
     // value-stack underflow / off-by-one-iteration result otherwise).
     let resume_state = frame.snapshot_for_tracing();
     let trace_frame = frame.snapshot_for_tracing();
+    let live_frame_addr = frame as *const PyFrame as usize;
     let mut adopted_walk_end_state = false;
     let outcome = {
         let (driver, _) = crate::eval::driver_pair();
@@ -2076,7 +2077,8 @@ pub fn trace_and_compile_from_bridge(
             &env,
             || {},
             |meta, sym| {
-                let (action, executed) = trace_bytecode(meta, sym, code, resume_pc, trace_frame);
+                let (action, executed) =
+                    trace_bytecode(meta, sym, code, resume_pc, trace_frame, live_frame_addr);
                 // pyjitpl.py:3048-3091 raise_continue_running_normally:
                 // a bridge walk that closed at a merge point and committed
                 // its end-of-walk state into the trace snapshot
@@ -3386,6 +3388,72 @@ pub extern "C" fn bh_load_method_self_fn(
         attr as pyre_object::PyObjectRef,
         name,
     ) as i64
+}
+
+/// `LOAD_NAME` residual for the standalone (blackhole / deopt)
+/// per-CodeObject jitcode.  `pyopcode.py:945-955 LOAD_NAME` — when
+/// `getorcreatedebug().w_locals is not get_w_globals()` the lookup
+/// tries `finditem_str(w_locals, varname)` first, then falls through
+/// to the `LOAD_GLOBAL` globals → builtins chain.  Delegates to the
+/// interpreter trait impl (`eval.rs load_name_checked_value`) so the
+/// blackhole re-execution and the interpreter share one lookup order.
+/// `LOAD_NAME` is traced via the `NamespaceOpcodeHandler` trait leg
+/// (not the walker), so this helper runs ONLY on the blackhole
+/// resume / deopt path, like `bh_getattr_fn`.  `w_name` is the
+/// interned immortal str constant the flatten driver lowers the
+/// `load_name` HLOp's name operand to (`box_str_constant`); `namei`
+/// feeds the `pycode._globals_caches[nameindex]` global cache
+/// (`celldict.py:292`).  On error it sets `BH_LAST_EXC_VALUE` and
+/// returns 0, matching `bh_load_global_fn`'s NameError path.
+pub extern "C" fn bh_load_name_fn(frame_ptr: i64, w_name: i64, namei: i64) -> i64 {
+    use pyre_interpreter::pyopcode::NamespaceOpcodeHandler;
+    assert!(
+        frame_ptr != 0,
+        "bh_load_name_fn requires a non-null PyFrame; every LOAD_NAME emit \
+         site must thread portal_frame_reg as the leading ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let name =
+        unsafe { pyre_object::strobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
+    match frame.load_name_checked_value(name, namei as usize) {
+        Ok(w_value) => w_value as i64,
+        Err(err) => {
+            let exc_obj = err.to_exc_object();
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+            0
+        }
+    }
+}
+
+/// `STORE_NAME` residual for the standalone (blackhole / deopt)
+/// per-CodeObject jitcode.  `pyopcode.py:855-859 STORE_NAME` —
+/// `setitem_str(getorcreatedebug().w_locals, varname, w_newvalue)`.
+/// Delegates to the interpreter trait impl (`eval.rs
+/// store_name_value`), which routes non-dict mapping locals through
+/// `space.setitem` and module/class namespaces through the dict
+/// strategy.  Same blackhole-only execution contract and `w_name` ABI
+/// as `bh_load_name_fn`.  `STORE_NAME` carries no nameindex-keyed
+/// cache upstream, so the trait's `nameindex` argument is passed as 0.
+/// Returns 1 on success; on error it sets `BH_LAST_EXC_VALUE` and
+/// returns 0, matching `bh_store_subscr_fn`.
+pub extern "C" fn bh_store_name_fn(frame_ptr: i64, w_name: i64, value: i64) -> i64 {
+    use pyre_interpreter::pyopcode::NamespaceOpcodeHandler;
+    assert!(
+        frame_ptr != 0,
+        "bh_store_name_fn requires a non-null PyFrame; every STORE_NAME emit \
+         site must thread portal_frame_reg as the leading ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let name =
+        unsafe { pyre_object::strobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
+    match frame.store_name_value(name, 0, value as pyre_object::PyObjectRef) {
+        Ok(()) => 1,
+        Err(err) => {
+            let exc_obj = err.to_exc_object();
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+            0
+        }
+    }
 }
 
 /// Load a constant from the code object.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3110,21 +3110,22 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     //   - "has back-edge AND name != <module>": same problem —
     //     non-loop function frames are skipped.
     //
-    // interp_jit.py:81-99 applies pypyjitdriver to every frame including
-    // `<module>`, so `true` is the parity-correct value and is what lets
-    // the module-level driver loop (nbody_50k `while i < n: advance(...)`)
-    // trace at all.  But module-loop tracing is a NET perf regression
-    // today: the dynamic call to `advance` cannot be inlined by the
-    // full-body walker (#62 not yet landed), so the trace is pure overhead
-    // and advance's short inner loop deopt-storms (nbody_50k 0.20s
-    // interpreter-only -> 3.6s traced).  Gate module-frame portal status
-    // behind PYRE_MODULE_LOOP_TRACE until call-inlining (#62) makes the
-    // trace a win; the default keeps `<module>` non-portal.  Function
-    // frames are always portals (the alternatives in the note above that
-    // skip non-loop function frames regress; excluding only `<module>`
-    // does not).
-    let is_portal: bool = &*code.obj_name != "<module>"
-        || std::env::var_os("PYRE_MODULE_LOOP_TRACE").as_deref() == Some(std::ffi::OsStr::new("1"));
+    // interp_jit.py:81-99 `PyFrame.dispatch` applies `pypyjitdriver`
+    // (`jit_merge_point` :87, `can_enter_jit` :117) to EVERY frame
+    // uniformly — there is no `co_name == "<module>"` gate and no env
+    // switch, so `<module>` frames trace exactly like function frames.
+    // The parity-correct value is unconditional `true`.
+    //
+    // This was briefly gated (a `<module>` exclusion, then a
+    // PYRE_MODULE_LOOP_TRACE env switch) while module-loop tracing was a
+    // deopt-storm regression: a dynamic driver-loop call to a loop-bearing
+    // callee is not inlinable by the full-body walker yet (#62).  That is
+    // resolved — the walk now declines such a key to the trait leg
+    // (`DispatchError::LoopBearingCalleeInlineUnsupported` ->
+    // `FBW_DECLINED_KEYS`), which inlines the callee via
+    // `recursive-call-assembler` — so module-loop tracing is a win
+    // (nbody_50k 0.22s interpreter -> 0.09s traced) and the gate is gone.
+    let is_portal: bool = true;
     // interp_jit.py:66 — next_instr, pycode are greens (managed by jit_merge_point).
     // No explicit promote needed; the JitDriver green-key mechanism handles this.
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1723,6 +1723,14 @@ thread_local! {
         // normally traced by the translated GC. Walk its value slots
         // explicitly until the table is folded into the object layout.
         majit_gc::shadow_stack::register_extra_root_walker(pyre_interpreter_side_table_root_walker);
+        // JIT-created callee frames (frame arena + heap fallbacks) hold
+        // GC refs in their locals arrays but sit on no
+        // `CURRENT_FRAME`/`f_backref` chain while compiled code runs,
+        // so `walk_pyframe_roots` never reaches them. See
+        // `call_jit::walk_jit_callee_frame_roots`.
+        majit_gc::shadow_stack::register_extra_root_walker(
+            crate::call_jit::walk_jit_callee_frame_roots,
+        );
         // Route pyre-object host-side allocators through the backend's
         // nursery. `set_gc_allocator` populated
         // `majit_gc::ACTIVE_ALLOC_NURSERY_TYPED` with the active
@@ -2589,6 +2597,9 @@ fn init_callbacks() {
                 callee_frame_helper: crate::call_jit::callee_frame_helper,
                 recursive_force_cache_safe: crate::call_jit::recursive_force_cache_safe,
                 jit_drop_callee_frame: crate::call_jit::jit_drop_callee_frame as *const (),
+                jit_frame_set_slot_ref: crate::call_jit::jit_frame_set_slot_ref as *const (),
+                jit_frame_set_slot_int: crate::call_jit::jit_frame_set_slot_int as *const (),
+                jit_frame_set_slot_float: crate::call_jit::jit_frame_set_slot_float as *const (),
                 jit_force_callee_frame: crate::call_jit::jit_force_callee_frame as *const (),
                 jit_force_recursive_call_1: crate::call_jit::jit_force_recursive_call_1
                     as *const (),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3092,13 +3092,9 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // The codewriter-side portal check
     // (`CallControl::jitdriver_sd_from_portal_graph`, codewriter.py:37)
     // is the canonical "is this code a portal" answer once
-    // `setup_jitdriver` has registered it. The eval-side gate below
-    // is a different question — "should this **frame** go through the
-    // JIT machinery at all" — and stays a structural pyre-specific
-    // check because module-level `<module>` frames lack the
-    // function-scope PyFrame layout the JIT relies on.
+    // `setup_jitdriver` has registered it.
     //
-    // Note: pyre routes every function-scope
+    // Note: pyre routes every
     // CodeObject through `jit_merge_point_hook` and `can_enter_jit`
     // so that recursive calls into a previously-traced function reach
     // `maybe_compile_and_run` even before the function's own loop
@@ -3114,11 +3110,21 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     //   - "has back-edge AND name != <module>": same problem —
     //     non-loop function frames are skipped.
     //
-    // Until pyre's portal/interpreter split is ported, the eval-side
-    // gate stays pyre-specific: every non-module CodeObject reaches
-    // the JIT machinery; the codewriter-side decides portal-ness via
-    // the registry.
-    let is_portal: bool = &*code.obj_name != "<module>";
+    // interp_jit.py:81-99 applies pypyjitdriver to every frame including
+    // `<module>`, so `true` is the parity-correct value and is what lets
+    // the module-level driver loop (nbody_50k `while i < n: advance(...)`)
+    // trace at all.  But module-loop tracing is a NET perf regression
+    // today: the dynamic call to `advance` cannot be inlined by the
+    // full-body walker (#62 not yet landed), so the trace is pure overhead
+    // and advance's short inner loop deopt-storms (nbody_50k 0.20s
+    // interpreter-only -> 3.6s traced).  Gate module-frame portal status
+    // behind PYRE_MODULE_LOOP_TRACE until call-inlining (#62) makes the
+    // trace a win; the default keeps `<module>` non-portal.  Function
+    // frames are always portals (the alternatives in the note above that
+    // skip non-loop function frames regress; excluding only `<module>`
+    // does not).
+    let is_portal: bool = &*code.obj_name != "<module>"
+        || std::env::var_os("PYRE_MODULE_LOOP_TRACE").as_deref() == Some(std::ffi::OsStr::new("1"));
     // interp_jit.py:66 — next_instr, pycode are greens (managed by jit_merge_point).
     // No explicit promote needed; the JitDriver green-key mechanism handles this.
 
@@ -3546,7 +3552,9 @@ fn jit_merge_point_hook(
             crate::jit::codewriter::register_portal_jitdriver(code, frame.pycode, Some(pc));
             let snapshot = frame.snapshot_for_tracing();
             let _ = concrete_frame;
-            let (action, executed_frame) = trace_bytecode(meta, sym, code, pc, snapshot);
+            let live_frame_addr = &*frame as *const PyFrame as usize;
+            let (action, executed_frame) =
+                trace_bytecode(meta, sym, code, pc, snapshot, live_frame_addr);
             // pyjitpl.py:3048-3091 raise_continue_running_normally: tracing
             // IS execution — a walk that committed its end-of-walk state
             // into the snapshot (CloseLoop / CompileTracePending flush)
@@ -4235,8 +4243,15 @@ fn bound_reached(
                         Some(loop_header_pc),
                     );
                     let concrete_frame = frame.snapshot_for_tracing();
-                    let (action, executed_frame) =
-                        trace_bytecode(meta, sym, code, loop_header_pc, concrete_frame);
+                    let live_frame_addr = &*frame as *const PyFrame as usize;
+                    let (action, executed_frame) = trace_bytecode(
+                        meta,
+                        sym,
+                        code,
+                        loop_header_pc,
+                        concrete_frame,
+                        live_frame_addr,
+                    );
                     // raise_continue_running_normally seam — see the
                     // jit_merge_point_hook tracing site for the contract.
                     if pyre_jit_trace::trace::take_walk_end_flush_committed() {
@@ -8946,7 +8961,17 @@ while i < 40:
     s = s + outer(i)
     i = i + 1";
         let code = pyre_interpreter::compile_exec(source).expect("compile failed");
-        let mut frame = PyFrame::new(code);
+        // Production shape (see `test_nested_direct_helper_calls_stay_correct`):
+        // the module-level loop is a portal (interp_jit.py:81-99 applies the
+        // jitdriver to every frame), so the full-body walk concrete-executes
+        // the `outer(i)` residual during tracing — `bh_call_fn_impl` resolves
+        // the parent frame from `getexecutioncontext().gettopframe()`, which a
+        // bare `PyFrame::new` frame never seeds.
+        let execution_context = std::rc::Rc::new(pyre_interpreter::PyExecutionContext::default());
+        pyre_interpreter::call::set_last_exec_ctx(std::rc::Rc::as_ptr(&execution_context));
+        let mut frame =
+            pyre_interpreter::pyframe::PyFrame::new_with_context(code, execution_context)
+                .expect("frame construction failed");
         let _ = eval_with_jit(&mut frame);
         unsafe {
             let s = *(*frame_globals_storage(&frame)).get("s").unwrap();

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2609,6 +2609,54 @@ fn emit_frontend_load_method_self(
     )
 }
 
+fn emit_frontend_load_name(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    frame: super::flow::FlowValue,
+    name: super::flow::FlowValue,
+    namei: usize,
+    offset: i64,
+) -> super::flow::Variable {
+    // pyopcode.py:945-955 LOAD_NAME is a frame method (w_locals probe +
+    // LOAD_GLOBAL fallback); flow analysis never processes module-scope
+    // code upstream, so there is no flowspace HLOp to mirror.  Record
+    // the frame-receiver call shape directly; the canonical flatten
+    // driver lowers it to a `bh_load_name_fn(frame, w_name, namei)`
+    // residual call (`flatten::lower_load_name_hlop_to_insn`).
+    let v_namei: super::flow::FlowValue = super::flow::Constant::signed(namei as i64).into();
+    emit_graph_op_with_result(
+        graph,
+        block,
+        "load_name",
+        vec![frame.into(), name.into(), v_namei.into()],
+        Kind::Ref,
+        offset,
+    )
+}
+
+fn emit_frontend_store_name(
+    _graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    frame: super::flow::FlowValue,
+    name: super::flow::FlowValue,
+    value: super::flow::FlowValue,
+    offset: i64,
+) {
+    // pyopcode.py:855-859 STORE_NAME ->
+    // `setitem_str(getorcreatedebug().w_locals, varname, w_newvalue)`.
+    // Frame-receiver call shape like `emit_frontend_load_name`; lowers
+    // to `bh_store_name_fn(frame, w_name, value)`
+    // (`flatten::lower_store_name_hlop_to_insn`).  See
+    // `emit_frontend_setitem` for the void-result rationale.
+    record_graph_op(
+        block,
+        "store_name",
+        vec![frame.into(), name.into(), value.into()],
+        None,
+        offset,
+    );
+}
+
 fn emit_frontend_simple_call(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3069,6 +3117,8 @@ struct FnPtrIndices {
     load_const_fn: HelperHandle,
     store_subscr_fn: HelperHandle,
     getattr_fn: HelperHandle,
+    load_name_fn: HelperHandle,
+    store_name_fn: HelperHandle,
     build_list_fn: HelperHandle,
     newtuple_from_array_fn: HelperHandle,
     unpack_sequence_fn: HelperHandle,
@@ -3294,6 +3344,15 @@ fn register_helper_fn_pointers(
         cpu.load_method_self_fn as *const (),
         CallFlavor::PlainCannotRaise,
     );
+    // `bh_load_name_fn` / `bh_store_name_fn` delegate to the interpreter
+    // `NamespaceOpcodeHandler` impl (pyopcode.py:945 LOAD_NAME / :855
+    // STORE_NAME).  Both run only on the blackhole/deopt path —
+    // LOAD_NAME / STORE_NAME are traced via the trait leg, never the
+    // walker — so they share `bh_getattr_fn`'s classification:
+    // `CallFlavor::Plain` (can raise, no virtual-force while live).
+    // Bound after the existing fn_ptrs to preserve their indices.
+    let load_name_fn = bind(assembler, cpu.load_name_fn as *const (), CallFlavor::Plain);
+    let store_name_fn = bind(assembler, cpu.store_name_fn as *const (), CallFlavor::Plain);
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -3304,6 +3363,8 @@ fn register_helper_fn_pointers(
         load_const_fn,
         store_subscr_fn,
         getattr_fn,
+        load_name_fn,
+        store_name_fn,
         build_list_fn,
         newtuple_from_array_fn,
         unpack_sequence_fn,
@@ -4127,6 +4188,16 @@ impl CodeWriter {
                     idx: getattr_fn_idx,
                     flavor: _getattr_fn_flavor,
                 },
+            load_name_fn:
+                HelperHandle {
+                    idx: load_name_fn_idx,
+                    flavor: _load_name_fn_flavor,
+                },
+            store_name_fn:
+                HelperHandle {
+                    idx: store_name_fn_idx,
+                    flavor: _store_name_fn_flavor,
+                },
             build_list_fn:
                 HelperHandle {
                     idx: build_list_fn_idx,
@@ -4258,6 +4329,8 @@ impl CodeWriter {
                 truth_fn_idx,
                 store_subscr_fn_idx,
                 getattr_fn_idx,
+                load_name_fn_idx,
+                store_name_fn_idx,
                 build_list_fn_idx,
                 newtuple_from_array_fn_idx,
                 // `[u16; 9]` indexed by nargs (0..=8).  `call_fn_idx` (nargs=1)
@@ -7183,32 +7256,65 @@ impl CodeWriter {
                         // Stack-effect-aware abort_permanent for unsupported ops.
                         // current_depth must track interpreter parity so that
                         // subsequent CALL handlers don't underflow.
-                        Instruction::LoadName { .. } => {
-                            // flowcontext.py:859 LOAD_NAME = LOAD_GLOBAL.
-                            // RPython resolves the name to a Constant during flow
-                            // analysis; pyre cannot fold module namespace lookups at
-                            // codewriter time, so do not invent a graph op here.
-                            // The abort_permanent above means the loaded value is
-                            // never observed at runtime, but downstream ops in the
-                            // same block (e.g. the bool() arg of POP_JUMP_IF_FALSE)
-                            // pop from current_state.stack and would otherwise
-                            // hit `fresh_ref_value` — producing an orphan Variable
-                            // with no graph SpaceOp producer that breaks canonical
-                            // SSARepr build's make_dependencies (regalloc.py:26-77
-                            // adds depgraph nodes only for op.result + inputargs).
-                            // Push `Constant::none()` so downstream pops resolve
-                            // to a constant, not a fresh Variable.
-                            current_state
-                                .stack
-                                .push(super::flow::Constant::none().into());
-                            emit_abort_permanent!();
-                            current_depth += 1;
-                            emit_vsd!(current_depth, py_pc);
+                        Instruction::LoadName { namei } => {
+                            // pyopcode.py:945-955 LOAD_NAME — w_locals probe +
+                            // LOAD_GLOBAL fallback, a runtime namespace lookup
+                            // that cannot fold at codewriter time (module-loop
+                            // names mutate every iteration).  Record the
+                            // `load_name` HLOp with the portal frame as
+                            // receiver; the canonical splice lowers it to a
+                            // `bh_load_name_fn(frame, w_name, namei)` residual
+                            // call.  LOAD_NAME is traced via the trait leg
+                            // (`NamespaceOpcodeHandler::load_name_value`), so
+                            // the residual runs only on blackhole/deopt —
+                            // same contract as the LoadAttr arm.
+                            let name_idx = namei.get(op_arg) as usize;
+                            let attr_name =
+                                super::flow::Constant::string(code.names[name_idx].as_str());
+                            let loaded_dst_reg = stack_base + current_depth;
+                            let result_value = emit_frontend_load_name(
+                                &mut graph,
+                                &current_block.block(),
+                                frame_var.into(),
+                                attr_name.into(),
+                                name_idx,
+                                py_pc as i64,
+                            );
+                            pin!(Some(result_value), loaded_dst_reg);
+                            let result_fv: super::flow::FlowValue = result_value.into();
+                            current_state.stack.push(result_fv.clone());
+                            emit_pushvalue_ref!(current_depth, loaded_dst_reg, result_fv, py_pc);
                         }
-                        Instruction::StoreName { .. } | Instruction::StoreGlobal { .. } => {
-                            // flowcontext.py marks STORE_NAME unsupported, but the
-                            // stack effect still consumes one value. STORE_GLOBAL
-                            // follows the same shape in flowcontext.py:884-890.
+                        Instruction::StoreName { namei } => {
+                            // pyopcode.py:855-859 STORE_NAME — pops the value
+                            // and writes it into `w_locals` via the
+                            // `store_name` HLOp → `bh_store_name_fn(frame,
+                            // w_name, value)` residual call.  Traced via the
+                            // trait leg (`store_name_value`); the residual
+                            // runs only on blackhole/deopt.
+                            let name_idx = namei.get(op_arg) as usize;
+                            let attr_name =
+                                super::flow::Constant::string(code.names[name_idx].as_str());
+                            let value_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let stored_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            if let super::flow::FlowValue::Variable(v) = &stored_value {
+                                pin!(Some(*v), value_reg);
+                            }
+                            emit_frontend_store_name(
+                                &mut graph,
+                                &current_block.block(),
+                                frame_var.into(),
+                                attr_name.into(),
+                                stored_value,
+                                py_pc as i64,
+                            );
+                        }
+                        Instruction::StoreGlobal { .. } => {
+                            // flowcontext.py:884-890 STORE_GLOBAL is
+                            // unsupported; the stack effect still consumes one
+                            // value.  Unlike STORE_NAME it bypasses w_locals
+                            // (`pyopcode.py:940`), and no hot path needs it
+                            // yet — keep the abort until a helper lands.
                             emit_abort_permanent!();
                             pop_and_decr_depth(&mut current_state, &mut current_depth);
                             emit_vsd!(current_depth, py_pc);

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -68,6 +68,14 @@ pub struct Cpu {
     /// constant.  Blackhole/deopt lowering of `LOAD_ATTR`
     /// (`rclass.py:838 rtype_getattr`).
     pub getattr_fn: extern "C" fn(i64, i64) -> i64,
+    /// `bhimpl_load_name` — `(frame: Ref, w_name: Ref, namei: Int) → Ref`
+    /// with `w_name` an interned str constant.  Blackhole/deopt lowering
+    /// of `LOAD_NAME` (`pyopcode.py:945`).
+    pub load_name_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bhimpl_store_name` — `(frame: Ref, w_name: Ref, value: Ref) → Void`
+    /// with `w_name` an interned str constant.  Blackhole/deopt lowering
+    /// of `STORE_NAME` (`pyopcode.py:855`).
+    pub store_name_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// `bhimpl_build_list` — (argc, item0, item1, item2) → new list.
     pub build_list_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// `newtuple(list_w)` (`objspace.py:332`) — (ref array) → new tuple.
@@ -174,6 +182,8 @@ impl Cpu {
             load_const_fn: crate::call_jit::bh_load_const_fn,
             store_subscr_fn: pyre_interpreter::opcode_ops::bh_store_subscr_fn,
             getattr_fn: crate::call_jit::bh_getattr_fn,
+            load_name_fn: crate::call_jit::bh_load_name_fn,
+            store_name_fn: crate::call_jit::bh_store_name_fn,
             build_list_fn: crate::call_jit::bh_build_list_fn,
             newtuple_from_array_fn: crate::call_jit::bh_newtuple_from_array,
             unpack_sequence_fn: crate::call_jit::bh_unpack_sequence_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -9483,6 +9483,8 @@ mod tests {
             getattr_fn_idx: 0,
             load_attr_fn_idx: 91,
             load_method_self_fn_idx: 92,
+            load_name_fn_idx: 93,
+            store_name_fn_idx: 94,
         };
         let code_const = Constant::new(
             super::super::flow::ConstantValue::Signed(0x2000),

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3066,6 +3066,18 @@ pub struct LoweringContext {
     /// via [`lower_getattr_hlop_to_insn`] to `load_attr_fn` instead,
     /// and bare 2-arg `getattr` HLOps pass through.
     pub getattr_fn_idx: u16,
+    /// `load_name_fn` descrs-pool index.  LOAD_NAME family (single
+    /// HLOp opname `load_name`, the `pyopcode.py:945` frame-receiver
+    /// shape) lowers to `residual_call_ir_r` (`ListI([namei])` +
+    /// `ListR([frame, w_name])`, Ref result) via
+    /// [`lower_load_name_hlop_to_insn`].
+    pub load_name_fn_idx: u16,
+    /// `store_name_fn` descrs-pool index.  STORE_NAME family (single
+    /// HLOp opname `store_name`, the `pyopcode.py:855` frame-receiver
+    /// shape) lowers to `residual_call_r_v` (three Ref inputs `[frame,
+    /// w_name, value]`, void result) via
+    /// [`lower_store_name_hlop_to_insn`].
+    pub store_name_fn_idx: u16,
     /// `build_list_fn` descrs-pool index — see codewriter.rs:2401
     /// (`bind(assembler, cpu.build_list_fn as *const (),
     /// CallFlavor::Plain)`) for the production source.  BUILD_LIST
@@ -3617,6 +3629,93 @@ pub fn build_load_method_self_fn_residual_call_ir_r_insn(
         ],
         Register::new(Kind::Ref, dst_reg),
     )
+}
+
+/// Lower a `LOAD_NAME` pre-rtype HLOp `load_name(frame, w_name, namei)`
+/// → `result: Ref` (the `pyopcode.py:945-955 LOAD_NAME` frame-receiver
+/// shape recorded by `emit_frontend_load_name`) to the post-rtype
+/// `residual_call_ir_r(ConstInt(load_name_fn_idx), ListI([namei]),
+/// ListR([frame, w_name]), Descr) → reg` Insn.  `bh_load_name_fn(frame:
+/// Ref, w_name: Ref, namei: Int) → Ref` delegates to the interpreter
+/// `load_name_checked_value`; the name Constant lowers to the interned
+/// immortal str pointer via `lower_constant` and `namei` to a plain
+/// `ConstInt`.  `LOAD_NAME` is traced via the trait leg (the walker
+/// never records this residual), so the frame lowers as a plain
+/// register operand.  `CallFlavor::Plain` (can-raise `NameError`, no
+/// virtual-force) — same classification as `getattr_fn`.
+pub fn lower_load_name_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "load_name" {
+        return None;
+    }
+    if op.args.len() != 3 {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    let namei = match flatten_arg_with_lowering(&op.args[2], get_register, lower_constant) {
+        Operand::ConstInt(v) => v,
+        _ => return None,
+    };
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    Some(build_residual_call_ir_r_insn_from_operands(
+        ctx.load_name_fn_idx,
+        namei,
+        frame_operand,
+        name_operand,
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+        dst_reg,
+    ))
+}
+
+/// Lower a `STORE_NAME` pre-rtype HLOp `store_name(frame, w_name,
+/// value)` → void (the `pyopcode.py:855-859 STORE_NAME` frame-receiver
+/// shape recorded by `emit_frontend_store_name`) to the post-rtype
+/// `residual_call_r_v(ConstInt(store_name_fn_idx), ListR([frame,
+/// w_name, value]), Descr)` Insn — the same void 3-Ref shape as
+/// SETITEM.  `bh_store_name_fn(frame: Ref, w_name: Ref, value: Ref)`
+/// delegates to the interpreter `store_name_value`.
+/// `CallFlavor::Plain` like [`lower_load_name_hlop_to_insn`].
+pub fn lower_store_name_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "store_name" {
+        return None;
+    }
+    if op.args.len() != 3 {
+        return None;
+    }
+    if op.result.is_some() {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    let value_operand = flatten_arg_with_lowering(&op.args[2], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.store_name_fn_idx,
+        vec![frame_operand, name_operand, value_operand],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+    ))
 }
 
 /// Construct the CALL-family `residual_call_r_r` Insn from raw
@@ -4406,6 +4505,12 @@ where
         return Some(insn);
     }
     if let Some(insn) = lower_setitem_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_load_name_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_store_name_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
     if let Some(insn) = lower_new_sequence_hlop_to_insn(op, ctx, get_register, lower_constant) {
@@ -5915,6 +6020,8 @@ mod tests {
             truth_fn_idx: 17,
             store_subscr_fn_idx: 19,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6049,6 +6156,8 @@ mod tests {
             truth_fn_idx: 17,
             store_subscr_fn_idx: 19,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6170,6 +6279,8 @@ mod tests {
             truth_fn_idx: 17,
             store_subscr_fn_idx: 19,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6254,6 +6365,8 @@ mod tests {
             truth_fn_idx: 17,
             store_subscr_fn_idx: 19,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6382,6 +6495,8 @@ mod tests {
             truth_fn_idx: 17,
             store_subscr_fn_idx: 19,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6555,6 +6670,8 @@ mod tests {
             truth_fn_idx: 17,
             store_subscr_fn_idx: 19,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6777,6 +6894,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6865,6 +6984,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -6897,6 +7018,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7002,6 +7125,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7066,6 +7191,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7096,6 +7223,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7133,6 +7262,8 @@ mod tests {
             truth_fn_idx: 23,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7197,6 +7328,8 @@ mod tests {
             truth_fn_idx: 23,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7224,6 +7357,8 @@ mod tests {
             truth_fn_idx: 31,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7265,6 +7400,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 41,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7322,6 +7459,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 41,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7364,6 +7503,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 53,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7421,6 +7562,8 @@ mod tests {
             truth_fn_idx: 31,
             store_subscr_fn_idx: 53,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7454,6 +7597,8 @@ mod tests {
             truth_fn_idx: 31,
             store_subscr_fn_idx: 53,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7487,6 +7632,8 @@ mod tests {
             truth_fn_idx: 31,
             store_subscr_fn_idx: 53,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7525,6 +7672,8 @@ mod tests {
             truth_fn_idx: 31,
             store_subscr_fn_idx: 53,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -7577,6 +7726,8 @@ mod tests {
             truth_fn_idx: 31,
             store_subscr_fn_idx: 53,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -8952,6 +9103,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 9],
@@ -9226,6 +9379,8 @@ mod tests {
             truth_fn_idx: 0,
             store_subscr_fn_idx: 0,
             getattr_fn_idx: 0,
+            load_name_fn_idx: 0,
+            store_name_fn_idx: 0,
             build_list_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs,


### PR DESCRIPTION
second target #128 

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

- Improve recursive and inlined JIT call handling for the nbody path, including recursive CALL_ASSEMBLER signalling and safer inline-loop aborts.
- Add LOAD_NAME/STORE_NAME lowering and trace support needed by the walker path.
- Keep JIT-created callee frames visible to GC and tighten optimizer heap-store forcing/pendingfield behavior around virtual values.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline-backedge handling to avoid committing speculative stores and unnecessary retraces/compilation.

* **New Features**
  * Recursive-assembler inline calls and safer inline-abort/resume control for inlined callees.
  * Runtime/JIT support for LOAD_NAME/STORE_NAME and expanded callee-frame GC rooting and slot writeback callbacks.
  * Tracing now tracks the live frame address for correct virtualizable/frame resolution.

* **Tests**
  * Updated virtualizable lazy-set test to expect forced materialization on flush.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
