### PR TITLE
Exception virtualization: #155 review fixes + exit-code/re-raise bugs

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8623,6 +8623,10 @@ impl CraneliftBackend {
             }
             label_blocks.push((label_idx, block));
         }
+        // One block per LABEL, unconditionally — the entry-sync deferral
+        // above keyed `has_labels` on `label_indices`, which therefore
+        // agrees with the `label_blocks`-driven dispatch below.
+        debug_assert_eq!(label_blocks.len(), label_indices.len());
 
         // RPython backend: Label ops define loop blocks.
         // Linear traces (no Label, no Jump) stay in the entry block.

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -5040,4 +5040,49 @@ mod tests {
         assert_eq!(result[7].arg(2).to_opref(), result[2].pos.get()); // src
         assert_eq!(result[7].arg(3).to_opref(), result[6].pos.get());
     }
+
+    /// GUARD_EXCEPTION carries a Ref result (the caught exception).  The
+    /// guard arm emits through `emit_rewritten_from`, which must keep the
+    /// guard's original position and register a forwarding entry; a plain
+    /// `emit` renumbers the result after a preceding NEW expands into
+    /// multiple ops, dangling any downstream consumer of the caught
+    /// exception.
+    #[test]
+    fn test_guard_exception_result_keeps_pos_and_forwards_to_consumer() {
+        let rw = make_rewriter();
+        let exc_box = OpRef::ref_op(1);
+        let ops = vec![
+            // Expands to CallMallocNursery + GcStore(tid), shifting the
+            // rewriter's position counter past the guard's original pos.
+            mk_op_with_descr(OpCode::New, &[], 0, size_descr(16, 7)),
+            mk_op(OpCode::GuardException, &[OpRef::int_op(99)], 1),
+            // Downstream consumer of the caught exception.
+            mk_op_with_descr(
+                OpCode::SetfieldGc,
+                &[OpRef::ref_op(0), exc_box],
+                2,
+                ref_field_descr(),
+            ),
+        ];
+
+        let result = rw.rewrite_for_gc(&ops);
+
+        let guard = result
+            .iter()
+            .find(|o| o.opcode == OpCode::GuardException)
+            .expect("GUARD_EXCEPTION must survive the rewrite");
+        assert_eq!(
+            guard.pos.get(),
+            OpRef::op_typed(1, Type::Ref),
+            "non-void guard result must keep its original position"
+        );
+        // SETFIELD_GC lowers to GcStore(ptr, ofs, value, size); the value
+        // must still reference the guard's result, not a renumbered slot.
+        let store = result
+            .iter()
+            .filter(|o| o.opcode == OpCode::GcStore)
+            .find(|o| o.arg(2).to_opref() == guard.pos.get())
+            .expect("consumer GcStore must reference the guard's result");
+        assert_eq!(store.arg(0).to_opref(), result[0].pos.get());
+    }
 }

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -6608,7 +6608,13 @@ impl<'a> ResumeDataDirectReader<'a> {
         if num >= 0 {
             num as usize
         } else {
-            let len = self.rd_virtuals.map_or(0, |v| v.len()) as i32;
+            // On the GUARD_NOT_FORCED path (resume.py:1373-1374) the
+            // virtuals arrive preloaded in `virtuals_cache` while
+            // `rd_virtuals` stays None; the cache has one slot per
+            // virtual, so its length is the same wrap base.
+            let len =
+                self.rd_virtuals
+                    .map_or_else(|| self.virtuals_cache.len(), |v| v.len()) as i32;
             (len + num) as usize
         }
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3203,6 +3203,29 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str) -> PyResult {
                     return Ok(w_none());
                 }
             }
+            "code" => {
+                // `interp_exceptions.py:986-1006 W_SystemExit`: `code` is a
+                // `readwrite_attrproperty_w('w_code')` set by `descr_init`
+                // to `args_w[0]` for a single argument, `newtuple(args_w)`
+                // for several, and the `__init__` default `None` when the
+                // instance carries no arguments.  Derived from `args_w`
+                // here, the same way `value` is above; supporting a later
+                // `e.code = x` write-back would need a dedicated `w_code`
+                // slot like OSError's `w_errno`.
+                let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
+                if kind == pyre_object::excobject::ExcKind::SystemExit {
+                    let args = unsafe { pyre_object::excobject::w_exception_get_args(obj) };
+                    let len = unsafe { pyre_object::w_tuple_len(args) };
+                    if len == 1 {
+                        if let Some(v) = unsafe { pyre_object::w_tuple_getitem(args, 0) } {
+                            return Ok(v);
+                        }
+                    } else if len > 1 {
+                        return Ok(args);
+                    }
+                    return Ok(w_none());
+                }
+            }
             // `interp_exceptions.py:739-742 W_OSError` exposes
             // `errno` / `strerror` / `filename` / `filename2` as
             // `readwrite_attrproperty_w('w_errno', ...)` slots, populated

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3205,15 +3205,20 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str) -> PyResult {
             }
             "code" => {
                 // `interp_exceptions.py:986-1006 W_SystemExit`: `code` is a
-                // `readwrite_attrproperty_w('w_code')` set by `descr_init`
-                // to `args_w[0]` for a single argument, `newtuple(args_w)`
-                // for several, and the `__init__` default `None` when the
-                // instance carries no arguments.  Derived from `args_w`
-                // here, the same way `value` is above; supporting a later
-                // `e.code = x` write-back would need a dedicated `w_code`
-                // slot like OSError's `w_errno`.
+                // writable `readwrite_attrproperty_w('w_code')` slot
+                // (`:1006`) set by `descr_init` to `args_w[0]` for a single
+                // argument, `newtuple(args_w)` for several, and the
+                // `__init__` default `None` when the instance carries no
+                // arguments.  Read the slot first so an explicit
+                // `e.code = x` write persists, then derive from `args_w`
+                // (the internal-constructor path that bypasses the public
+                // setter), mirroring the OSError `errno` arm.
                 let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
                 if kind == pyre_object::excobject::ExcKind::SystemExit {
+                    let stored = unsafe { pyre_object::excobject::w_exception_get_code(obj) };
+                    if !stored.is_null() {
+                        return Ok(stored);
+                    }
                     let args = unsafe { pyre_object::excobject::w_exception_get_args(obj) };
                     let len = unsafe { pyre_object::w_tuple_len(args) };
                     if len == 1 {
@@ -5258,6 +5263,19 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                             _ => pyre_object::excobject::w_exception_set_filename2(obj, value),
                         }
                     };
+                    return Ok(w_none());
+                }
+            }
+            // `interp_exceptions.py:1006
+            // readwrite_attrproperty_w('w_code', W_SystemExit)` — the
+            // writer stores the raw `w_value` into the slot; the matching
+            // getattr arm reads it back ahead of the `args_w`-derived
+            // fallback.  Gated on SystemExit because PyPy installs the
+            // descriptor only on `W_SystemExit.typedef`.
+            "code" => {
+                let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
+                if kind == pyre_object::excobject::ExcKind::SystemExit {
+                    unsafe { pyre_object::excobject::w_exception_set_code(obj, value) };
                     return Ok(w_none());
                 }
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2543,7 +2543,7 @@ pub(crate) fn call_and_check(
 }
 
 /// intobject.py:989-1050 _new_baseint
-pub(crate) fn builtin_int(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn builtin_int(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.is_empty() {
         return Ok(w_int_new(0));
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -704,7 +704,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     crate::dict_storage_store(
         namespace,
         "RecursionError",
-        make_exc_type("RecursionError", exc_runtime_error_new, runtime_error),
+        make_exc_type("RecursionError", exc_recursion_error_new, runtime_error),
     );
 
     crate::dict_storage_store(
@@ -720,12 +720,12 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     crate::dict_storage_store(
         namespace,
         "GeneratorExit",
-        make_exc_type("GeneratorExit", exc_base_exception_new, base_exc),
+        make_exc_type("GeneratorExit", exc_generator_exit_new, base_exc),
     );
     crate::dict_storage_store(
         namespace,
         "SystemExit",
-        make_exc_type("SystemExit", exc_base_exception_new, base_exc),
+        make_exc_type("SystemExit", exc_system_exit_new, base_exc),
     );
     crate::dict_storage_store(
         namespace,
@@ -838,17 +838,17 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     crate::dict_storage_store(
         namespace,
         "MemoryError",
-        make_exc_type("MemoryError", exc_exception_new, exception),
+        make_exc_type("MemoryError", exc_memory_error_new, exception),
     );
     crate::dict_storage_store(
         namespace,
         "ReferenceError",
-        make_exc_type("ReferenceError", exc_exception_new, exception),
+        make_exc_type("ReferenceError", exc_reference_error_new, exception),
     );
     crate::dict_storage_store(
         namespace,
         "SystemError",
-        make_exc_type("SystemError", exc_exception_new, exception),
+        make_exc_type("SystemError", exc_system_error_new, exception),
     );
     crate::dict_storage_store(
         namespace,
@@ -1864,6 +1864,27 @@ exc_constructor!(
     exc_unicode_error,
     pyre_object::excobject::ExcKind::UnicodeError
 );
+exc_constructor!(
+    exc_generator_exit,
+    pyre_object::excobject::ExcKind::GeneratorExit
+);
+exc_constructor!(exc_system_exit, pyre_object::excobject::ExcKind::SystemExit);
+exc_constructor!(
+    exc_recursion_error,
+    pyre_object::excobject::ExcKind::RecursionError
+);
+exc_constructor!(
+    exc_memory_error,
+    pyre_object::excobject::ExcKind::MemoryError
+);
+exc_constructor!(
+    exc_reference_error,
+    pyre_object::excobject::ExcKind::ReferenceError
+);
+exc_constructor!(
+    exc_system_error,
+    pyre_object::excobject::ExcKind::SystemError
+);
 
 /// `interp_exceptions.py:551-652 W_OSError._parse_init_args` + `_init_error`.
 /// A 2..=5 positional-argument call fills the `errno` / `strerror` /
@@ -2222,6 +2243,12 @@ exc_new_wrapper!(exc_unicode_error_new, exc_unicode_error);
 exc_new_wrapper!(exc_unicode_decode_error_new, exc_unicode_decode_error);
 exc_new_wrapper!(exc_unicode_encode_error_new, exc_unicode_encode_error);
 exc_new_wrapper!(exc_unicode_translate_error_new, exc_unicode_translate_error);
+exc_new_wrapper!(exc_generator_exit_new, exc_generator_exit);
+exc_new_wrapper!(exc_system_exit_new, exc_system_exit);
+exc_new_wrapper!(exc_recursion_error_new, exc_recursion_error);
+exc_new_wrapper!(exc_memory_error_new, exc_memory_error);
+exc_new_wrapper!(exc_reference_error_new, exc_reference_error);
+exc_new_wrapper!(exc_system_error_new, exc_system_error);
 
 /// Build a builtin exception type with the given name, base, and __new__ wrapper.
 pub(crate) fn make_exc_type(

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -733,14 +733,14 @@ impl PyError {
     pub unsafe fn from_exc_object(obj: PyObjectRef) -> Self {
         unsafe {
             let kind = pyre_object::excobject::w_exception_get_kind(obj);
-            // `W_BaseException.descr_str` derives the string from
-            // `args_w`; `exc_object` keeps the exact value for
-            // `str(e)` / `repr(e)`, while this Rust-side string is the
-            // lossy-UTF-8 rendering used by `PyError`'s `Display`.
-            let message = crate::display::py_str(obj);
+            // The display string is derived lazily from `exc_object`
+            // (`message_text`), never here: conversion runs on every
+            // raise propagation, and stringifying the args eagerly would
+            // execute their `__str__` at raise time instead of at
+            // display time.
             PyError {
                 kind: Self::kind_from_exc(kind),
-                message,
+                message: String::new(),
                 exc_object: obj,
                 attach_tb: true,
                 reraise_lasti: -1,
@@ -791,13 +791,26 @@ impl PyError {
         }
     }
 
+    /// The exception text without the class name.  Rust-constructed
+    /// errors carry it in `message`; object-backed errors
+    /// (`from_exc_object`) derive it from `exc_object` on demand —
+    /// `W_BaseException.descr_str` formats `args_w`, so the args'
+    /// `__str__` runs at display time, not at raise time.
+    pub fn message_text(&self) -> String {
+        if !self.message.is_empty() || self.exc_object.is_null() {
+            return self.message.clone();
+        }
+        unsafe { crate::display::py_str(self.exc_object) }
+    }
+
     pub fn render_exception(&self) -> String {
         let name = exc_object_class_name(self.exc_object)
             .unwrap_or_else(|| exc_kind_name(self.to_exc_kind()).to_string());
-        if self.message.is_empty() {
+        let message = self.message_text();
+        if message.is_empty() {
             name
         } else {
-            format!("{name}: {}", self.message)
+            format!("{name}: {message}")
         }
     }
 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -344,18 +344,37 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
         // and are forwarded by the GC's root walker; no extra visit here.
 
         let mut frame = cf.get();
-        if !frame.is_null() {
-            let ec = unsafe { (*frame).execution_context as *mut PyExecutionContext };
-            if !ec.is_null() {
-                let top_slot = unsafe { &mut (*ec).topframeref as *mut *mut PyFrame };
-                visitor(unsafe { &mut *(top_slot as *mut majit_ir::GcRef) });
-                // `sys_exc_value` holds the active handler exception, which
-                // is nursery-allocated and may move; forward it so the EC
-                // slot is updated on a minor collection (the value-stack
-                // copy alone is not authoritative for later EC reads).
-                let exc_slot = unsafe { &mut (*ec).sys_exc_value as *mut PyObjectRef };
-                visitor(unsafe { &mut *(exc_slot as *mut majit_ir::GcRef) });
+        let frame_ec = if frame.is_null() {
+            std::ptr::null_mut()
+        } else {
+            unsafe { (*frame).execution_context as *mut PyExecutionContext }
+        };
+        // Root the EC slots from the current frame's EC AND the ambient
+        // TLS EC (`getexecutioncontext`).  The ambient visit covers the
+        // spans where no frame is installed in `CURRENT_FRAME` yet the EC
+        // is live — between `ExecutionContext::enter` and `eval_loop`'s
+        // frame install, and around `return_trace`/`leave` after the
+        // frame guard drops — where `sys_exc_value` may already hold a
+        // nursery exception.  PyPy reaches the ExecutionContext
+        // unconditionally through `space.threadlocals`, independent of
+        // any frame.
+        let ambient_ec = crate::call::take_last_exec_ctx() as *mut PyExecutionContext;
+        let mut visit_ec_slots = |ec: *mut PyExecutionContext| {
+            if ec.is_null() {
+                return;
             }
+            let top_slot = unsafe { &mut (*ec).topframeref as *mut *mut PyFrame };
+            visitor(unsafe { &mut *(top_slot as *mut majit_ir::GcRef) });
+            // `sys_exc_value` holds the active handler exception, which
+            // is nursery-allocated and may move; forward it so the EC
+            // slot is updated on a minor collection (the value-stack
+            // copy alone is not authoritative for later EC reads).
+            let exc_slot = unsafe { &mut (*ec).sys_exc_value as *mut PyObjectRef };
+            visitor(unsafe { &mut *(exc_slot as *mut majit_ir::GcRef) });
+        };
+        visit_ec_slots(frame_ec);
+        if ambient_ec != frame_ec {
+            visit_ec_slots(ambient_ec);
         }
         while !frame.is_null() {
             // SAFETY: PyFrame pointers on the f_backref chain are valid

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -5342,12 +5342,14 @@ except 42:
                     matches!(e.kind, crate::PyErrorKind::TypeError),
                     "expected TypeError, got {:?}: {}",
                     e.kind,
-                    e.message,
+                    e.message_text(),
                 );
+                // The error round-trips through the raised exception
+                // object, so the text lives behind `message_text()`.
                 assert!(
-                    e.message.contains("BaseException"),
+                    e.message_text().contains("BaseException"),
                     "expected CANNOT_CATCH_MSG, got: {}",
-                    e.message,
+                    e.message_text(),
                 );
             }
             Ok(_) => panic!("expected TypeError for `except 42:`"),

--- a/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
+++ b/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
@@ -554,32 +554,19 @@ pub fn register_module(ns: &mut DictStorage) {
     // sys.platlibdir — typically "lib" on POSIX; used by sysconfig to
     // construct install paths.
     dict_storage_store(ns, "platlibdir", w_str_new("lib"));
-    // sys.exit(code=0) — raise SystemExit
+    // `sys/app.py:114-127 exit(exitcode=None)` — `raise SystemExit(exitcode)`.
+    // Raise a real SystemExit instance so `e.code` / `e.args` carry the
+    // original object; code interpretation (None → 0, int() coercion,
+    // print-non-integral-and-exit-1) is the launcher's job
+    // (`app_main.py:114-129 handle_sys_exit`).
     dict_storage_store(
         ns,
         "exit",
         crate::make_builtin_function("exit", |args| {
-            let code = if args.is_empty() {
-                0i64
-            } else {
-                unsafe {
-                    if pyre_object::is_none(args[0]) {
-                        0
-                    } else if pyre_object::is_int(args[0]) || pyre_object::is_bool(args[0]) {
-                        pyre_object::w_int_get_value(args[0])
-                    } else {
-                        // Non-integer arg: print it to stderr and exit 1
-                        0
-                    }
-                }
-            };
-            Err(crate::PyError {
-                kind: crate::PyErrorKind::SystemExit,
-                message: code.to_string(),
-                exc_object: std::ptr::null_mut(),
-                attach_tb: true,
-                reraise_lasti: -1,
-            })
+            let cls = crate::builtins::lookup_exc_class("SystemExit")
+                .ok_or_else(|| crate::PyError::runtime_error("SystemExit class missing"))?;
+            let exc = crate::call::call_function_impl_result(cls, args)?;
+            Err(unsafe { crate::PyError::from_exc_object(exc) })
         }),
     );
     // sys.abiflags

--- a/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
+++ b/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
@@ -554,18 +554,30 @@ pub fn register_module(ns: &mut DictStorage) {
     // sys.platlibdir — typically "lib" on POSIX; used by sysconfig to
     // construct install paths.
     dict_storage_store(ns, "platlibdir", w_str_new("lib"));
-    // `sys/app.py:114-127 exit(exitcode=None)` — `raise SystemExit(exitcode)`.
-    // Raise a real SystemExit instance so `e.code` / `e.args` carry the
-    // original object; code interpretation (None → 0, int() coercion,
+    // `sys/app.py:114-126 exit(exitcode=None)` — raise SystemExit(exitcode),
+    // de-tupelizing a tuple argument so `exit((a, b))` becomes
+    // `SystemExit(a, b)` (the extra de-tupelizing normalize_exception does
+    // for `raise SystemExit, exitcode`).  A bare `exit()` defaults exitcode
+    // to None, so the instance carries `code = None` / `args = (None,)`.
+    // Interpreting the code (None → 0, int() coercion,
     // print-non-integral-and-exit-1) is the launcher's job
     // (`app_main.py:114-129 handle_sys_exit`).
     dict_storage_store(
         ns,
         "exit",
         crate::make_builtin_function("exit", |args| {
+            if args.len() > 1 {
+                return Err(crate::PyError::type_error("exit() takes at most 1 argument"));
+            }
             let cls = crate::builtins::lookup_exc_class("SystemExit")
                 .ok_or_else(|| crate::PyError::runtime_error("SystemExit class missing"))?;
-            let exc = crate::call::call_function_impl_result(cls, args)?;
+            let exitcode = args.first().copied().unwrap_or_else(w_none);
+            let ctor_args = if unsafe { is_tuple(exitcode) } {
+                unsafe { w_tuple_items_copy_as_vec(exitcode) }
+            } else {
+                vec![exitcode]
+            };
+            let exc = crate::call::call_function_impl_result(cls, &ctor_args)?;
             Err(unsafe { crate::PyError::from_exc_object(exc) })
         }),
     );

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8872,9 +8872,16 @@ mod tests {
         // get/set_current_exception read/write `(*ec).sys_exc_value` on the
         // thread's current EC; production establishes it via
         // `set_last_exec_ctx(frame.execution_context)` (eval.rs:841). Mirror
-        // that here so the save/restore round-trips like a real frame, and
-        // restore the prior ctx at the end to avoid leaking into sibling tests.
-        let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();
+        // that here so the save/restore round-trips like a real frame.  The
+        // prior ctx is restored on Drop so an assert failure mid-test still
+        // unwinds without leaking the frame's EC into sibling tests.
+        struct ExecCtxRestore(*const pyre_interpreter::PyExecutionContext);
+        impl Drop for ExecCtxRestore {
+            fn drop(&mut self) {
+                pyre_interpreter::call::set_last_exec_ctx(self.0);
+            }
+        }
+        let _saved_ctx = ExecCtxRestore(pyre_interpreter::call::take_last_exec_ctx());
         pyre_interpreter::call::set_last_exec_ctx(frame.execution_context);
 
         let mut ctx = TraceCtx::for_test(1);
@@ -8929,7 +8936,6 @@ mod tests {
         assert_eq!(state.sym().current_exc_box, restored_prev.opref);
         assert_eq!(pyre_interpreter::eval::get_current_exception(), prev_exc);
         pyre_interpreter::eval::set_current_exception(PY_NULL);
-        pyre_interpreter::call::set_last_exec_ctx(saved_ctx);
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1657,6 +1657,12 @@ pub struct PyreSym {
     /// unconditional `__context__ = ec.sys_exc_value` chaining that is
     /// valid only for a freshly constructed exception (w_context still
     /// null, self-cycle impossible).
+    ///
+    /// The entry is dropped as soon as freshness can no longer be proven:
+    /// `RAISE_VARARGS` consumes it (a re-raise of the same object must
+    /// take the residual path — its `w_context` is set by then), and
+    /// `box_value_for_python_helper` removes any value escaping into a
+    /// python-helper residual call (which may mutate the exception).
     pub(crate) trace_built_exc: majit_ir::VecAssoc<OpRef, pyre_object::PyObjectRef>,
     /// Symbolic mirror of executioncontext.current_exception/sys_exc_info.
     /// Used by PUSH_EXC_INFO / POP_EXCEPT to preserve nested handler state.
@@ -1979,7 +1985,15 @@ pub(crate) fn box_value_for_python_helper(
     match state.value_type(value) {
         Type::Int => wrapint(ctx, value),
         Type::Float => wrapfloat(ctx, value),
-        Type::Ref | Type::Void => value,
+        Type::Ref | Type::Void => {
+            // A trace-built exception escaping into a python-helper
+            // residual is no longer provably fresh (the callee may set
+            // `__context__` or other state); drop it so a later
+            // RAISE_VARARGS takes the residual path, whose runtime
+            // `attach_raise_cause` chaining is conditional.
+            state.sym_mut().trace_built_exc.remove(&value);
+            value
+        }
     }
 }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9830,7 +9830,7 @@ mod tests {
         assert_eq!(result, pending_jit_exception_raw());
         let err = unsafe { pyre_interpreter::PyError::from_exc_object(result as PyObjectRef) };
         assert_eq!(err.kind, pyre_interpreter::PyErrorKind::RuntimeError);
-        assert_eq!(err.message, "raise helper missing current frame");
+        assert_eq!(err.message_text(), "raise helper missing current frame");
         clear_pending_jit_exception();
     }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9556,7 +9556,12 @@ impl OpcodeStepExecutor for MIFrame {
         // E1: a trace-built exception (`try_trace_exception_new`) leaves the
         // type-call result with concrete=Null; recover the fresh instance
         // recorded at construction so the raise takes the instance fast path.
-        let trace_built = self.sym().trace_built_exc.get(&exc_val.opref).copied();
+        // Consumed (not just read): after this raise the instance is no
+        // longer fresh — its `w_context` is stamped below — so a second
+        // raise of the same object must take the residual path, whose
+        // runtime `attach_raise_cause` keeps an existing `__context__`
+        // and avoids the self-cycle.
+        let trace_built = self.sym_mut().trace_built_exc.remove(&exc_val.opref);
         let exc = if exc.is_null() {
             trace_built.unwrap_or(exc)
         } else {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3677,6 +3677,9 @@ mod tests_bh_normalize_raise {
         );
         let err = unsafe { pyre_interpreter::PyError::from_exc_object(result as PyObjectRef) };
         assert_eq!(err.kind, PyErrorKind::TypeError);
-        assert_eq!(err.message, "exceptions must derive from BaseException");
+        assert_eq!(
+            err.message_text(),
+            "exceptions must derive from BaseException"
+        );
     }
 }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6615,6 +6615,19 @@ impl CodeWriter {
                             // previous sys_exc_info so `POP_EXCEPT` can restore it).
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let exc_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            // A bare handler entry (no recorded catch-site
+                            // FrameState, codewriter.rs:5427-5443) fills the
+                            // symbolic stack with null sentinels, so the popped
+                            // slot can be a `Constant` — illegal as an op result
+                            // and unpinnable.  Bind a fresh Variable instead:
+                            // the `last_exc_value` re-read below becomes its
+                            // sole producer, which IS the caught exception this
+                            // slot holds at runtime.
+                            let exc_value = if exc_value.as_variable().is_some() {
+                                exc_value
+                            } else {
+                                fresh_ref_value(&mut graph)
+                            };
                             // PUSH_EXC_INFO is pyre-specific (rustpython 3.11+;
                             // no PyPy counterpart).  In the canonical splice the
                             // popped exc `Variable` has no graph producer: the

--- a/pyre/pyre-object/src/excobject.rs
+++ b/pyre/pyre-object/src/excobject.rs
@@ -300,6 +300,13 @@ pub struct W_ExceptionObject {
     /// `interp_exceptions.py:527 W_OSError.w_filename2` /
     /// `:742 readwrite_attrproperty_w('w_filename2', W_OSError)`.
     pub w_filename2: PyObjectRef,
+    /// `interp_exceptions.py:990 W_SystemExit.w_code` /
+    /// `:1006 readwrite_attrproperty_w('w_code', W_SystemExit)`.
+    /// `PY_NULL` is the class default `None`; the `code` getattr arm
+    /// derives the value from `args_w` (descr_init: `args_w[0]` for one
+    /// argument, the args tuple for several) when the slot is unset, and
+    /// a later `e.code = x` write persists here ahead of that fallback.
+    pub w_code: PyObjectRef,
 }
 
 pub const EXC_KIND_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, kind);
@@ -316,6 +323,7 @@ pub const EXC_W_ERRNO_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, w_
 pub const EXC_W_STRERROR_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, w_strerror);
 pub const EXC_W_FILENAME_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, w_filename);
 pub const EXC_W_FILENAME2_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, w_filename2);
+pub const EXC_W_CODE_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject, w_code);
 
 /// GC trace offsets for `W_ExceptionObject` — `args_w` plus the three
 /// `PyObjectRef`-shaped chained-exception slots per
@@ -324,10 +332,11 @@ pub const EXC_W_FILENAME2_OFFSET: usize = std::mem::offset_of!(W_ExceptionObject
 /// w_end / w_reason / w_encoding) that PyPy distributes across the
 /// W_UnicodeTranslateError / W_UnicodeDecodeError / W_UnicodeEncodeError
 /// subclasses, plus the four W_OSError per-class slots (w_errno /
-/// w_strerror / w_filename / w_filename2).  `kind` is a `u8` tag,
-/// `message` is a `*mut String` (raw heap), and `suppress_context` is
-/// a bool — none of those are GC-traced.
-pub const W_EXCEPTION_GC_PTR_OFFSETS: [usize; 13] = [
+/// w_strerror / w_filename / w_filename2), plus the W_SystemExit
+/// `w_code` slot.  `kind` is a `u8` tag, `message` is a `*mut String`
+/// (raw heap), and `suppress_context` is a bool — none of those are
+/// GC-traced.
+pub const W_EXCEPTION_GC_PTR_OFFSETS: [usize; 14] = [
     EXC_ARGS_W_OFFSET,
     EXC_W_CAUSE_OFFSET,
     EXC_W_CONTEXT_OFFSET,
@@ -341,6 +350,7 @@ pub const W_EXCEPTION_GC_PTR_OFFSETS: [usize; 13] = [
     EXC_W_STRERROR_OFFSET,
     EXC_W_FILENAME_OFFSET,
     EXC_W_FILENAME2_OFFSET,
+    EXC_W_CODE_OFFSET,
 ];
 
 /// GC type id assigned to `W_ExceptionObject` at JitDriver init time.
@@ -433,6 +443,9 @@ pub fn w_exception_new_empty(kind: ExcKind) -> PyObjectRef {
         w_strerror: PY_NULL,
         w_filename: PY_NULL,
         w_filename2: PY_NULL,
+        // `interp_exceptions.py:990` W_SystemExit class default
+        // `w_code = None`.
+        w_code: PY_NULL,
     }) as PyObjectRef
 }
 
@@ -880,6 +893,29 @@ pub unsafe fn w_exception_get_filename2(obj: PyObjectRef) -> PyObjectRef {
 pub unsafe fn w_exception_set_filename2(obj: PyObjectRef, value: PyObjectRef) {
     unsafe {
         (*(obj as *mut W_ExceptionObject)).w_filename2 = value;
+    }
+}
+
+/// `interp_exceptions.py:1006 readwrite_attrproperty_w('w_code', ...)`
+/// — `e.code` reader.  `PY_NULL` means the slot was never written (the
+/// `code` getattr arm then derives the value from `args_w`).
+///
+/// # Safety
+/// `obj` must point to a valid `W_ExceptionObject`.
+#[inline]
+pub unsafe fn w_exception_get_code(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_ExceptionObject)).w_code }
+}
+
+/// `interp_exceptions.py:1006 readwrite_attrproperty_w('w_code', ...)`
+/// — `e.code = ...` writer.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ExceptionObject`.
+#[inline]
+pub unsafe fn w_exception_set_code(obj: PyObjectRef, value: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut W_ExceptionObject)).w_code = value;
     }
 }
 

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -262,9 +262,8 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
         }
         Err(e) => {
             if e.kind == PyErrorKind::SystemExit {
-                let code: i32 = e.message_text().parse().unwrap_or(0);
                 maybe_print_jit_stats();
-                std::process::exit(code);
+                std::process::exit(system_exit_code(&e));
             }
             maybe_print_jit_stats();
             pyre_interpreter::eprint_exception(&e, true);
@@ -272,4 +271,41 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
         }
     }
     maybe_print_jit_stats();
+}
+
+/// app_main.py:114-129 `handle_sys_exit` — `SystemExit.code` is None for
+/// a bare exit (exit 0), coerced with `int()` when possible, and anything
+/// non-integral is printed to stderr with exit code 1.  `code` itself is
+/// `args[0]` for a 1-arg raise and the whole args tuple otherwise
+/// (interp_exceptions.py:993-998 `W_SystemExit.descr_init`).
+fn system_exit_code(e: &pyre_interpreter::PyError) -> i32 {
+    let exc = e.exc_object;
+    if exc.is_null() {
+        // Rust-raised SystemExit (sys.exit fast path) carries the code in
+        // the message string.
+        return e.message_text().parse().unwrap_or(0);
+    }
+    unsafe {
+        let args = pyre_object::excobject::w_exception_get_args(exc);
+        let items = pyre_object::w_tuple_items_copy_as_vec(args);
+        let code = match items.len() {
+            0 => return 0,
+            1 => items[0],
+            _ => args,
+        };
+        if code.is_null() || pyre_object::is_none(code) {
+            return 0;
+        }
+        if pyre_object::is_int(code) {
+            return pyre_object::w_int_get_value(code) as i32;
+        }
+        let text = pyre_interpreter::display::py_str(code);
+        match text.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                eprintln!("{text}");
+                1
+            }
+        }
+    }
 }

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -262,7 +262,7 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
         }
         Err(e) => {
             if e.kind == PyErrorKind::SystemExit {
-                let code: i32 = e.message.parse().unwrap_or(0);
+                let code: i32 = e.message_text().parse().unwrap_or(0);
                 maybe_print_jit_stats();
                 std::process::exit(code);
             }

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -273,39 +273,31 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
     maybe_print_jit_stats();
 }
 
-/// app_main.py:114-129 `handle_sys_exit` — `SystemExit.code` is None for
-/// a bare exit (exit 0), coerced with `int()` when possible, and anything
-/// non-integral is printed to stderr with exit code 1.  `code` itself is
-/// `args[0]` for a 1-arg raise and the whole args tuple otherwise
+/// app_main.py:114-129 `handle_sys_exit` — `exitcode = e.code`; None
+/// exits 0; otherwise `int(exitcode)` and a value `int()` rejects is
+/// printed to stderr with exit status 1.  `e.code` itself is `args[0]`
+/// for a 1-arg raise and the whole args tuple otherwise
 /// (interp_exceptions.py:993-998 `W_SystemExit.descr_init`).
 fn system_exit_code(e: &pyre_interpreter::PyError) -> i32 {
     let exc = e.exc_object;
     if exc.is_null() {
-        // Rust-raised SystemExit (sys.exit fast path) carries the code in
-        // the message string.
-        return e.message_text().parse().unwrap_or(0);
+        // No object-backed SystemExit means no `code` attribute (the
+        // class default None), i.e. a success exit.
+        return 0;
     }
-    unsafe {
-        let args = pyre_object::excobject::w_exception_get_args(exc);
-        let items = pyre_object::w_tuple_items_copy_as_vec(args);
-        let code = match items.len() {
-            0 => return 0,
-            1 => items[0],
-            _ => args,
-        };
-        if code.is_null() || pyre_object::is_none(code) {
-            return 0;
-        }
-        if pyre_object::is_int(code) {
-            return pyre_object::w_int_get_value(code) as i32;
-        }
-        let text = pyre_interpreter::display::py_str(code);
-        match text.parse() {
-            Ok(n) => n,
-            Err(_) => {
-                eprintln!("{text}");
-                1
-            }
+    let code = match pyre_interpreter::getattr(exc, pyre_object::w_str_new("code")) {
+        Ok(c) => c,
+        Err(_) => return 1,
+    };
+    if unsafe { pyre_object::is_none(code) } {
+        return 0;
+    }
+    match pyre_interpreter::builtins::builtin_int(&[code]) {
+        Ok(w_int) => unsafe { pyre_object::w_int_get_value(w_int) as i32 },
+        Err(_) => {
+            // app_main.py:124-125 `print(exitcode, file=sys.stderr)`.
+            eprintln!("{}", unsafe { pyre_interpreter::display::py_str(code) });
+            1
         }
     }
 }


### PR DESCRIPTION
Follow-up #129

## Summary

Follow-up to #155 (which squash-merged the exception-virtualization body). This branch carries the post-merge review-fix round plus two pre-existing bugs uncovered while adjudicating the reviews.

### #155 review findings
- **gc: root EC `sys_exc_value` independently of `CURRENT_FRAME`** — `walk_pyframe_roots` reached the execution context's pending exception only through a non-null `CURRENT_FRAME`, leaving a live nursery exception unrooted in the gaps around frame install/leave (the E2 EC-field move's regression surface). Also visit the ambient TLS EC, frame-independently (threadlocals parity).
- **exc: drop `trace_built_exc` entries on raise and helper escape** — the trace-built-exception map is now consumed on use (`RAISE_VARARGS` removes the entry) and invalidated when a value escapes through `box_value_for_python_helper`, making the freshness invariant structural rather than de-facto.
- **error: derive object-backed `PyError` text lazily** — `from_exc_object` no longer runs the args' `__str__` (`py_str`) eagerly on every conversion; text is derived on demand via `message_text()`, used by `render_exception` and the launcher's SystemExit code parse.
- **resume: wrap negative virtual index against `virtuals_cache` len** (unreachable-today hardening).
- **cranelift: assert `label_blocks` / `label_indices` agreement** (`debug_assert`).
- **majit-gc: regression test** that `GUARD_EXCEPTION` rewrite keeps pos and forwards to the consumer.
- **tests: restore ambient exec ctx with a Drop guard.**

### Pre-existing bugs fixed
- **`raise SystemExit(3)` printed a traceback and exited 1** (expected: silent exit 3). SystemExit, GeneratorExit, RecursionError, MemoryError, ReferenceError and SystemError were registered with `exc_base_exception_new`, so the instance kind fell back to RuntimeError and the launcher's SystemExit branch never matched. Each now gets a dedicated `exc_constructor!`/`exc_new_wrapper!` pair stamping its own `ExcKind`. `sys.exit` raises a real SystemExit instance (`sys/app.py:114-127`) so `e.code`/`e.args` carry the original object, and the launcher interprets the code per `app_main.py:114-129 handle_sys_exit` (None → 0, ints pass through, non-integral → stderr + exit 1; `code` is `args[0]` for a 1-arg raise, the whole tuple otherwise).
- **`GraphFlattener` panic at flatten.rs:2315** (`op last_exc_value has Constant result`) on a nested re-raise of the same exception in its own handler. A bare handler entry with no recorded catch-site `FrameState` fills the symbolic stack with null `Constant` sentinels; `PUSH_EXC_INFO` popped one and used it as the `last_exc_value` op result, which the flattener rejects. Substitute a fresh `Variable` when the popped slot is not one — the `last_exc_value` re-read becomes its sole producer.

## Verification
- `MAJIT_STRICT=1 check.py` 46/46 on both dynasm and cranelift backends.
- Unit tests green: pyre-interpreter 343, pyre-jit 262 (dynasm) / 261 (cranelift), majit-gc.
- SystemExit 8-case matrix and the nested re-raise repro match CPython on both backends.

## Self-review

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed several exception construction/handling paths so exceptions use correct kinds and preserve payloads.
  * Made exception message rendering lazy to avoid premature or incorrect message text.
  * Improved system-exit handling and exit-code derivation.
  * Strengthened runtime/JIT invariants and indexing checks to prevent incorrect reuse/retention of values across helpers and GC.

* **Tests**
  * Added and updated tests verifying GC rewriting, exception propagation, and internal consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->