### PR TITLE
rtyper cutover: drain dual-gate census walls (781 → 776)

### DIFF
--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -289,6 +289,40 @@ impl<'a> Drop for PolicyGuard<'a> {
     }
 }
 
+/// Revert an evicted block to a pristine "never annotated" state by
+/// clearing the annotation on every Variable it DEFINES (inputargs +
+/// operation results).  Both dual-gate eviction paths
+/// ([`AddedBlocksGuard::drop`] and
+/// [`RPythonAnnotator::raise_if_subject_blocked`]) must pair every
+/// `annotated.shift_remove` with this reset: dropping a block from
+/// `annotated` while its Variables retain annotations leaves a
+/// half-state where a later subject reaching the same (session-shared)
+/// block sees `seen_before == false` in `addpendingblock`, takes the
+/// `bindinputargs` initial-seed path, and calls `setbinding` with the
+/// caller's (possibly narrower) cell over the retained annotation —
+/// tripping the monotonicity assert `setbinding: new value does not
+/// contain old` (e.g. two callers of one helper passing different
+/// constant static addresses).
+///
+/// Best-effort under `try_borrow`: a panic that unwinds while a cell
+/// is borrowed degrades to a leak rather than an abort-during-unwind
+/// double-borrow.
+fn clear_block_bindings(block: &BlockRef) {
+    if let Ok(blk) = block.try_borrow() {
+        let vars = blk
+            .inputargs
+            .iter()
+            .chain(blk.operations.iter().map(|op| &op.result));
+        for v in vars {
+            if let Hlvalue::Variable(var) = v {
+                if let Ok(mut slot) = var.annotation.try_borrow_mut() {
+                    *slot = None;
+                }
+            }
+        }
+    }
+}
+
 /// RAII guard for `self.added_blocks = {}; ...; finally:
 /// self.added_blocks = saved` in `complete_helpers()`.
 ///
@@ -340,13 +374,37 @@ impl<'a> Drop for AddedBlocksGuard<'a> {
                     .filter(|k| !self.annotated_at_entry.contains(*k))
                     .cloned()
                     .collect();
+                let fixed_graphs = self.ann.fixed_graphs.try_borrow();
                 for k in &new_keys {
-                    evict_block_and_clear_annotations(
-                        &mut annotated,
-                        &mut all_blocks,
-                        &mut blocked_blocks,
-                        k,
-                    );
+                    // Blocks of fixed (already-rtyped) graphs are
+                    // frozen — see `raise_if_subject_blocked`.  A
+                    // subject can rtype a callee during its own drive
+                    // and still fail afterwards (e.g. a dual-gate
+                    // divergence skip); the callee's annotations must
+                    // survive for later callers' fixed-graph
+                    // validation.
+                    if let Ok(fixed) = fixed_graphs.as_deref() {
+                        let graph = annotated.get(k).cloned().flatten().or_else(|| {
+                            blocked_blocks
+                                .get(k)
+                                .map(|(_, g, _)| std::rc::Rc::clone(g))
+                        });
+                        if let Some(g) = &graph {
+                            if fixed.contains_key(&GraphKey::of(g)) {
+                                continue;
+                            }
+                        }
+                    }
+                    annotated.shift_remove(k);
+                    blocked_blocks.shift_remove(k);
+                    // See `clear_block_bindings` — every eviction from
+                    // `annotated` must also reset the block's defined
+                    // Variables.  Mirrors the dual-gate Skip arm's
+                    // graph-wide `var.annotation = None` reset
+                    // (codewriter.rs::dual_gate_type_state).
+                    if let Some(block) = all_blocks.shift_remove(k) {
+                        clear_block_bindings(&block);
+                    }
                 }
                 if !new_keys.is_empty() {
                     if let Ok(mut pending) = self.ann.genpendingblocks.try_borrow_mut() {
@@ -359,49 +417,6 @@ impl<'a> Drop for AddedBlocksGuard<'a> {
         }
         if let Some(saved) = self.saved.take() {
             *self.ann.added_blocks.borrow_mut() = saved;
-        }
-    }
-}
-
-/// Evict one block from the session-shared tracking maps AND revert it
-/// to a pristine "never annotated" state by clearing the annotation on
-/// every Variable it DEFINES (inputargs + operation results).
-///
-/// Dropping the block from `annotated` without the clearing leaves a
-/// half-state: a later subject reaching the same (session-shared) block
-/// sees `seen_before == false` in `addpendingblock`, takes the
-/// `bindinputargs` initial-seed path, and calls `setbinding` with the
-/// caller's (possibly narrower) cell over the Variable's retained
-/// annotation — tripping the monotonicity assert `setbinding: new value
-/// does not contain old`.  Mirrors the dual-gate Skip arm's graph-wide
-/// `var.annotation = None` reset (codewriter.rs::dual_gate_type_state).
-/// Used by both eviction paths: the uncommitted [`AddedBlocksGuard`]
-/// drop and [`RPythonAnnotator::raise_if_subject_blocked`].
-///
-/// Lenient `try_borrow` on the block / annotation slots: the guard path
-/// can run during panic-unwind where a slot may still be borrowed —
-/// degrade to a leak rather than an abort-during-unwind double-borrow.
-fn evict_block_and_clear_annotations(
-    annotated: &mut IndexMap<BlockKey, Option<GraphRef>>,
-    all_blocks: &mut IndexMap<BlockKey, BlockRef>,
-    blocked_blocks: &mut IndexMap<BlockKey, (BlockRef, GraphRef, Option<usize>)>,
-    k: &BlockKey,
-) {
-    annotated.shift_remove(k);
-    blocked_blocks.shift_remove(k);
-    if let Some(block) = all_blocks.shift_remove(k) {
-        if let Ok(blk) = block.try_borrow() {
-            let vars = blk
-                .inputargs
-                .iter()
-                .chain(blk.operations.iter().map(|op| &op.result));
-            for v in vars {
-                if let Hlvalue::Variable(var) = v {
-                    if let Ok(mut slot) = var.annotation.try_borrow_mut() {
-                        *slot = None;
-                    }
-                }
-            }
         }
     }
 }
@@ -1402,30 +1417,39 @@ impl RPythonAnnotator {
         let mut annotated = self.annotated.borrow_mut();
         let mut all_blocks = self.all_blocks.borrow_mut();
         let mut blocked_blocks = self.blocked_blocks.borrow_mut();
-        // `evict_block_and_clear_annotations` (not bare `shift_remove`):
-        // this eviction runs BEFORE the subject's `AddedBlocksGuard`
-        // drops, so the guard's `new_keys` sweep no longer sees these
-        // blocks — the Variable annotations must be cleared here or
-        // they leak into the next subject's `bindinputargs`.
+        let fixed_graphs = self.fixed_graphs.borrow();
         for bkey in &added_keys {
-            evict_block_and_clear_annotations(
-                &mut annotated,
-                &mut all_blocks,
-                &mut blocked_blocks,
-                bkey,
-            );
-        }
-        // Prune the evicted blocks' pending rows too (the guard's Drop
-        // sweep can no longer see these keys in its `annotated` diff).
-        // The drain preceding this call normally leaves the queue
-        // empty, so this only matters when a blocked subject re-queued
-        // a block after its generation was processed.
-        {
-            let evicted: std::collections::HashSet<&BlockKey> = added_keys.iter().collect();
-            let mut pending = self.genpendingblocks.borrow_mut();
-            for g in pending.iter_mut() {
-                g.retain(|k, _| !evicted.contains(k));
+            // A block belonging to a fixed (already-rtyped) graph is
+            // frozen: its annotations must survive forever so the
+            // `addpendingblock` fixed-graph safety check can validate
+            // later callers against them.  Such a block can land in a
+            // failing subject's `added_blocks` via a notify reflow;
+            // evicting (and resetting) it here would strand every
+            // later caller on "fixed graph's inputarg lacks
+            // annotation".
+            let graph = annotated.get(bkey).cloned().flatten().or_else(|| {
+                blocked_blocks
+                    .get(bkey)
+                    .map(|(_, g, _)| std::rc::Rc::clone(g))
+            });
+            if let Some(g) = &graph {
+                if fixed_graphs.contains_key(&GraphKey::of(g)) {
+                    continue;
+                }
             }
+            annotated.shift_remove(bkey);
+            // See `clear_block_bindings` — evicting from `annotated`
+            // without resetting the block's defined Variables leaves a
+            // half-state that trips the `setbinding` monotonicity
+            // assert when the next subject re-seeds the same
+            // session-shared callee block (the `AddedBlocksGuard` drop
+            // cannot compensate: by then these keys are already gone
+            // from `annotated`, so its `new_keys` sweep never sees
+            // them).
+            if let Some(block) = all_blocks.shift_remove(bkey) {
+                clear_block_bindings(&block);
+            }
+            blocked_blocks.shift_remove(bkey);
         }
         Err(err)
     }

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -376,34 +376,42 @@ impl<'a> Drop for AddedBlocksGuard<'a> {
                     .collect();
                 let fixed_graphs = self.ann.fixed_graphs.try_borrow();
                 for k in &new_keys {
-                    // Blocks of fixed (already-rtyped) graphs are
-                    // frozen — see `raise_if_subject_blocked`.  A
-                    // subject can rtype a callee during its own drive
-                    // and still fail afterwards (e.g. a dual-gate
-                    // divergence skip); the callee's annotations must
-                    // survive for later callers' fixed-graph
-                    // validation.
-                    if let Ok(fixed) = fixed_graphs.as_deref() {
-                        let graph = annotated.get(k).cloned().flatten().or_else(|| {
-                            blocked_blocks
-                                .get(k)
-                                .map(|(_, g, _)| std::rc::Rc::clone(g))
-                        });
-                        if let Some(g) = &graph {
-                            if fixed.contains_key(&GraphKey::of(g)) {
-                                continue;
-                            }
-                        }
-                    }
+                    // A block of a fixed (already-rtyped) graph is
+                    // evicted from the maps like any other — leaving it
+                    // in `annotated` would re-feed the session-global
+                    // specialize walk with a block whose rtyping
+                    // already failed, echoing one failure into every
+                    // later subject.  Only its Variable BINDINGS are
+                    // kept: the `addpendingblock` fixed-graph arm
+                    // validates later callers against them and returns
+                    // before the `bindinputargs` re-seed, so the
+                    // bindings-without-`annotated`-entry state is
+                    // harmless for fixed graphs.
+                    let is_fixed = match fixed_graphs.as_deref() {
+                        Ok(fixed) => annotated
+                            .get(k)
+                            .cloned()
+                            .flatten()
+                            .or_else(|| {
+                                blocked_blocks
+                                    .get(k)
+                                    .map(|(_, g, _)| std::rc::Rc::clone(g))
+                            })
+                            .is_some_and(|g| fixed.contains_key(&GraphKey::of(&g))),
+                        Err(_) => false,
+                    };
                     annotated.shift_remove(k);
                     blocked_blocks.shift_remove(k);
                     // See `clear_block_bindings` — every eviction from
                     // `annotated` must also reset the block's defined
-                    // Variables.  Mirrors the dual-gate Skip arm's
-                    // graph-wide `var.annotation = None` reset
+                    // Variables (unless the graph is fixed).  Mirrors
+                    // the dual-gate Skip arm's graph-wide
+                    // `var.annotation = None` reset
                     // (codewriter.rs::dual_gate_type_state).
                     if let Some(block) = all_blocks.shift_remove(k) {
-                        clear_block_bindings(&block);
+                        if !is_fixed {
+                            clear_block_bindings(&block);
+                        }
                     }
                 }
                 if !new_keys.is_empty() {
@@ -1419,24 +1427,26 @@ impl RPythonAnnotator {
         let mut blocked_blocks = self.blocked_blocks.borrow_mut();
         let fixed_graphs = self.fixed_graphs.borrow();
         for bkey in &added_keys {
-            // A block belonging to a fixed (already-rtyped) graph is
-            // frozen: its annotations must survive forever so the
-            // `addpendingblock` fixed-graph safety check can validate
-            // later callers against them.  Such a block can land in a
-            // failing subject's `added_blocks` via a notify reflow;
-            // evicting (and resetting) it here would strand every
-            // later caller on "fixed graph's inputarg lacks
-            // annotation".
-            let graph = annotated.get(bkey).cloned().flatten().or_else(|| {
-                blocked_blocks
-                    .get(bkey)
-                    .map(|(_, g, _)| std::rc::Rc::clone(g))
-            });
-            if let Some(g) = &graph {
-                if fixed_graphs.contains_key(&GraphKey::of(g)) {
-                    continue;
-                }
-            }
+            // Evict from the maps unconditionally — a leftover entry
+            // would re-feed the session-global specialize walk with a
+            // block whose processing already failed.  A block of a
+            // fixed (already-rtyped) graph keeps its Variable BINDINGS
+            // though: the `addpendingblock` fixed-graph arm validates
+            // later callers against them and returns before the
+            // `bindinputargs` re-seed, so the
+            // bindings-without-`annotated`-entry state is harmless for
+            // fixed graphs (and clearing them would strand every later
+            // caller on "fixed graph's inputarg lacks annotation").
+            let is_fixed = annotated
+                .get(bkey)
+                .cloned()
+                .flatten()
+                .or_else(|| {
+                    blocked_blocks
+                        .get(bkey)
+                        .map(|(_, g, _)| std::rc::Rc::clone(g))
+                })
+                .is_some_and(|g| fixed_graphs.contains_key(&GraphKey::of(&g)));
             annotated.shift_remove(bkey);
             // See `clear_block_bindings` — evicting from `annotated`
             // without resetting the block's defined Variables leaves a
@@ -1447,7 +1457,9 @@ impl RPythonAnnotator {
             // from `annotated`, so its `new_keys` sweep never sees
             // them).
             if let Some(block) = all_blocks.shift_remove(bkey) {
-                clear_block_bindings(&block);
+                if !is_fixed {
+                    clear_block_bindings(&block);
+                }
             }
             blocked_blocks.shift_remove(bkey);
         }

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -393,9 +393,7 @@ impl<'a> Drop for AddedBlocksGuard<'a> {
                             .cloned()
                             .flatten()
                             .or_else(|| {
-                                blocked_blocks
-                                    .get(k)
-                                    .map(|(_, g, _)| std::rc::Rc::clone(g))
+                                blocked_blocks.get(k).map(|(_, g, _)| std::rc::Rc::clone(g))
                             })
                             .is_some_and(|g| fixed.contains_key(&GraphKey::of(&g))),
                         Err(_) => false,

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1814,7 +1814,15 @@ impl Bookkeeper {
             seen.insert(cur.rsplit("::").next().unwrap_or(&cur).to_string());
             chain.push(cur.clone());
             let next = self.pyre_struct_fields.borrow().as_ref().and_then(|reg| {
-                let (_, first_ty) = reg.fields.get(&cur)?.first()?;
+                let (first_name, first_ty) = reg.fields.get(&cur)?.first()?;
+                // Only header-conventional first fields mark subclassing
+                // (`ob_header: PyObject` / `base: FrameBlock`).  A
+                // by-value first field of another registered type is
+                // otherwise plain composition (`PyError { kind:
+                // PyErrorKind, … }`), not a class hierarchy.
+                if first_name != "ob_header" && first_name != "base" {
+                    return None;
+                }
                 let leaf = first_ty.rsplit("::").next().unwrap_or(first_ty);
                 (reg.fields.contains_key(leaf) && !seen.contains(leaf)).then(|| leaf.to_string())
             });
@@ -1910,7 +1918,13 @@ impl Bookkeeper {
             "f32" => return SomeValue::SingleFloat(super::model::SomeSingleFloat::new()),
             "f64" => return SomeValue::Float(super::model::SomeFloat::new()),
             "bool" => return super::model::s_bool(),
-            "String" | "str" => return super::model::s_str0(),
+            // Rust strings are UTF-8 text; literals lower through
+            // `__str_const` into `UniStr` constants (UnicodeString
+            // annotation, `UnicodeRepr::convert_const`), so the field
+            // projection must be the unicode string type or attr-cell
+            // unions degrade to the byte `StringRepr` ("not a str:
+            // UniStr(..)" at convert_const).
+            "String" | "str" => return super::model::s_unicode0(),
             "char" => return SomeValue::Char(super::model::SomeChar::new(false)),
             "()" => return super::model::s_none(),
             _ => {}

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1779,6 +1779,33 @@ impl Bookkeeper {
         host
     }
 
+    /// True when `name` is a type-root key in the snapshot
+    /// struct-field registry ([`Self::pyre_struct_fields`]).  Enums and
+    /// structs both register under their qualified path AND bare leaf
+    /// (`front/mir.rs` `TypeDeclKind::Enum` / `Struct` arms), so a
+    /// ctor's `owner_path` last segment answers true exactly when the
+    /// owner is itself an ADT (an enum-variant ctor) rather than a
+    /// module (a struct ctor).
+    pub fn is_pyre_struct_root(&self, name: &str) -> bool {
+        self.pyre_struct_fields
+            .borrow()
+            .as_ref()
+            .is_some_and(|reg| reg.fields.contains_key(name))
+    }
+
+    /// True when type-root `root`'s registry rows include a field named
+    /// `name`.  The cutover's class-dict method population consults this
+    /// so a method member never shadows a same-named instance field — a
+    /// function source for a field attribute would union-conflict in
+    /// `generalize_attr`.
+    pub fn pyre_struct_root_has_field(&self, root: &str, name: &str) -> bool {
+        self.pyre_struct_fields.borrow().as_ref().is_some_and(|reg| {
+            reg.fields
+                .get(root)
+                .is_some_and(|rows| rows.iter().any(|(field, _)| field == name))
+        })
+    }
+
     /// TODO: no upstream equivalent.  Project a Rust type
     /// string (`"Vec<i32>"`, `"Option<PyFrame>"`, `"HashMap<String,
     /// Box<W_Obj>>"`, …) into a `SomeValue` matching what RPython

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1538,7 +1538,22 @@ impl Bookkeeper {
             // `ClassDef` on every call — the identity cache is the memo, no
             // name-keyed side table needed.
             let host = self.intern_class_by_qualname(&n);
-            self.getuniqueclassdef(&host)?;
+            // Materialise the classdef lineage base-most first:
+            // `getdesc` and `ClassDef::new` each recurse into their
+            // base (classdesc.py:559 / :672) and both memoise, so
+            // pre-seeding every base keeps the native recursion depth
+            // at one frame even when the embedded-header chain is
+            // registry-deep (same worklist discipline as `graph`).
+            let mut lineage: Vec<HostObject> = vec![host];
+            while let Some(base) = lineage
+                .last()
+                .and_then(|h| h.class_bases().and_then(|b| b.first().cloned()))
+            {
+                lineage.push(base);
+            }
+            for h in lineage.iter().rev() {
+                self.getuniqueclassdef(h)?;
+            }
             let referenced: Vec<String> = {
                 let guard = self.pyre_struct_fields.borrow();
                 if let Some(reg) = guard.as_ref() {
@@ -1741,20 +1756,84 @@ impl Bookkeeper {
     /// lookups of one type-root — the pyre analog of resolving a type
     /// name to one class object before `getuniqueclassdef(cls)`.
     ///
-    /// A bare leaf is first resolved to its canonical `module::Leaf`
-    /// spelling through `canonical_struct_name`, so the bare and
-    /// qualified spellings of one struct intern to one `HostObject` —
-    /// name strings are a resolution input, never the identity itself
-    /// (`getuniqueclassdef(cls)` keys by class object, bookkeeper.py:339).
-    /// A duplicate leaf whose origin was tombstoned by
-    /// `harden_duplicate_leaf_metadata` passes through unresolved; its
-    /// classdef stays attrs-empty because the field registry withdrew
-    /// the bare alias, so no struct's fields can be misattributed.
-    /// Dotted qualnames (transparent-ctor classes) pass through
-    /// `canonical_struct_name` unchanged, so qualname callers intern
-    /// by their full spelling.
+    /// Embedded-header subclassing: a struct whose FIRST field embeds
+    /// another registered type root BY VALUE (`W_IntObject { ob_header:
+    /// PyObject, intval: i64 }`, `LoopBlock { base: FrameBlock }`) is
+    /// the Rust spelling of upstream's class hierarchy
+    /// (`W_IntObject(W_Root)`, `LoopBlock(FrameBlock)`) — base the
+    /// minted class on the header root's class, the same shared-Arc
+    /// shape [`Self::intern_class_by_qualname_with_bases`] uses for
+    /// enum variants, so `ClassDef::commonbase` unions siblings to the
+    /// header root and `cast_pointer`-style refinement connects the
+    /// `InstanceRepr`s.  The base is interned under its BARE LEAF —
+    /// the spelling `tyref_class_root` seeds params with — so the
+    /// subclass points at the same class Arc the rest of the session
+    /// uses.
+    ///
+    /// Each chain node's cache key is resolved through
+    /// `canonical_struct_name`, so the bare and qualified spellings of
+    /// one struct intern to one `HostObject` — name strings are a
+    /// resolution input, never the identity itself
+    /// (`getuniqueclassdef(cls)` keys by class object,
+    /// bookkeeper.py:339).  Dotted qualnames pass through unchanged; a
+    /// bare leaf whose origin was tombstoned by
+    /// `harden_duplicate_leaf_metadata` stays unresolved and keeps an
+    /// attrs-empty classdef because the field registry withdrew the
+    /// bare alias.
+    ///
+    /// The header chain is collected iteratively with a revisit guard:
+    /// registry field-type strings strip references
+    /// (`tyref_to_ast_string` renders `&T` as `T`), so a reference
+    /// cycle (`A.next: &B`, `B.prev: &A`) is indistinguishable from
+    /// by-value embedding here — a revisited leaf ends the chain (a
+    /// reference loop is linkage, not a header hierarchy), and a
+    /// pathological registry chain must not exhaust the native stack
+    /// (same O(reachable)-heap discipline as
+    /// [`Self::getuniqueclassdef_for_struct_root`]'s worklist).
     pub fn intern_class_by_qualname(self: &Rc<Self>, name: &str) -> HostObject {
-        self.intern_class_by_qualname_with_bases(name, Vec::new())
+        // Collect `name`'s embedded-header chain, outermost first,
+        // stopping at an already-interned class (its Arc becomes the
+        // deepest base) or at a chain end (scalar / unregistered /
+        // revisited first field).  The class-cache key is the canonical
+        // `module::Leaf` (`canonical_struct_name`); the field-registry
+        // lookup uses the raw spelling (the registry carries both
+        // qualified and bare keys).
+        let mut chain: Vec<String> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut base_host: Option<HostObject> = None;
+        let mut cur = name.to_string();
+        loop {
+            let key = majit_ir::descr::canonical_struct_name(&cur);
+            if let Some(existing) = self.pyre_struct_root_classes.borrow().get(&key) {
+                if chain.is_empty() {
+                    return existing.clone();
+                }
+                base_host = Some(existing.clone());
+                break;
+            }
+            seen.insert(cur.rsplit("::").next().unwrap_or(&cur).to_string());
+            chain.push(cur.clone());
+            let next = self.pyre_struct_fields.borrow().as_ref().and_then(|reg| {
+                let (_, first_ty) = reg.fields.get(&cur)?.first()?;
+                let leaf = first_ty.rsplit("::").next().unwrap_or(first_ty);
+                (reg.fields.contains_key(leaf) && !seen.contains(leaf)).then(|| leaf.to_string())
+            });
+            match next {
+                Some(n) => cur = n,
+                None => break,
+            }
+        }
+        // Mint base-most first so each class links its base's Arc.
+        for node in chain.iter().rev() {
+            let key = majit_ir::descr::canonical_struct_name(node);
+            let bases = base_host.iter().cloned().collect();
+            let host = crate::flowspace::model::HostObject::new_class(key.clone(), bases);
+            self.pyre_struct_root_classes
+                .borrow_mut()
+                .insert(key, host.clone());
+            base_host = Some(host);
+        }
+        base_host.expect("chain holds at least `name` itself")
     }
 
     /// [`Self::intern_class_by_qualname`] with explicit `__bases__` for

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1886,11 +1886,14 @@ impl Bookkeeper {
     /// function source for a field attribute would union-conflict in
     /// `generalize_attr`.
     pub fn pyre_struct_root_has_field(&self, root: &str, name: &str) -> bool {
-        self.pyre_struct_fields.borrow().as_ref().is_some_and(|reg| {
-            reg.fields
-                .get(root)
-                .is_some_and(|rows| rows.iter().any(|(field, _)| field == name))
-        })
+        self.pyre_struct_fields
+            .borrow()
+            .as_ref()
+            .is_some_and(|reg| {
+                reg.fields
+                    .get(root)
+                    .is_some_and(|rows| rows.iter().any(|(field, _)| field == name))
+            })
     }
 
     /// TODO: no upstream equivalent.  Project a Rust type

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -1316,8 +1316,30 @@ pub fn std_mem_align_of(
 pub fn pyre_cast_instance(
     bk: &Rc<Bookkeeper>,
     args_s: &[Option<SomeValue>],
-    _kwds: &HashMap<String, Option<SomeValue>>,
+    kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
+    // The marker is `Call(["__pyre_cast_instance", <root>], [operand])`:
+    // exactly the pointer operand plus the constant-root string, no
+    // keywords.  A different shape is a producer bug, surfaced here
+    // rather than silently swallowed.
+    if !kwds.is_empty() || args_s.len() != 2 {
+        return Err(AnnotatorError::new(
+            "__pyre_cast_instance expects (operand, constant_root) positional arguments",
+        ));
+    }
+    // Carry the operand's nullability onto the downcast result instead
+    // of unconditionally narrowing to non-None: a downcast of a nullable
+    // pointer is itself nullable.
+    let can_be_none = match arg_at(args_s, 0, "__pyre_cast_instance") {
+        SomeValue::Instance(inst) => inst.can_be_none,
+        SomeValue::None_(_) => true,
+        SomeValue::Ptr(_) | SomeValue::Address(_) => false,
+        other => {
+            return Err(AnnotatorError::new(format!(
+                "__pyre_cast_instance: non-pointer operand: {other:?}"
+            )));
+        }
+    };
     let root = match args_s
         .get(1)
         .and_then(|o| o.as_ref())
@@ -1334,7 +1356,7 @@ pub fn pyre_cast_instance(
     let classdef = bk.getuniqueclassdef_for_struct_root(&root)?;
     Ok(SomeValue::Instance(super::model::SomeInstance::new(
         Some(classdef),
-        false,
+        can_be_none,
         std::collections::BTreeMap::new(),
     )))
 }

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -333,6 +333,13 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // `usize` lattice as `size_of`; called by `object_array.rs` /
     // `pyframe.rs`.
     analyzer_for(&mut reg, "std.mem.align_of", std_mem_align_of);
+    // `__pyre_cast_instance` — front-end pointer-downcast narrow (#298).
+    // `obj as *const RegisteredStruct` lowers to a simple_call against
+    // this stub so the classdef-less pointer narrows to
+    // `SomeInstance(root)` and a field read on the pointee resolves.
+    // Keyed by the qualname `flowspace/model.rs`'s HOST_ENV bootstrap
+    // assigns (which also keys the `BUILTIN_TYPER` entry on the same Arc).
+    analyzer_for(&mut reg, "__pyre_cast_instance", pyre_cast_instance);
     // Rust `String::new()` / `String::with_capacity(n)` construct an empty
     // owned UTF-8 buffer; both annotate as a mutable `SomeString` so the
     // `String.new` / `String.with_capacity` HOST_ENV stubs do not reach the
@@ -1289,6 +1296,47 @@ pub fn std_mem_align_of(
     kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
     std_mem_size_of(bk, args_s, kwds)
+}
+
+/// Analyzer for `__pyre_cast_instance` — the front-end pointer-downcast
+/// narrow (#298).  `front::mir` aliases the classdef-less pointer for a
+/// same-bank `obj as *const RegisteredStruct` cast, so a field read on
+/// the pointee blocks on a classdef-less `SomeInstance` (unaryop.rs
+/// getattr arm).  The frontend instead lowers such a cast to
+/// `simple_call(__pyre_cast_instance, operand)`, stashing the target
+/// struct root in the `FunctionPath`; `flowspace_adapter` reconstructs
+/// the root as a trailing `ByteStr` constant arg (the `Vec<Variable>`
+/// arg carrier cannot hold a `Constant`).  The result is
+/// `SomeInstance(classdef)` for that root so the field read resolves;
+/// the rtyper lowers the call to a `cast_pointer` (rclass
+/// `pairtype(InstanceRepr, InstanceRepr).convert_from_to`,
+/// rclass.py:1035 — its `r_ins1.classdef is None` arm already emits the
+/// root→concrete cast).  `args[0]` is the pointer operand; `args[1]` is
+/// the constant root name.
+pub fn pyre_cast_instance(
+    bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    let root = match args_s
+        .get(1)
+        .and_then(|o| o.as_ref())
+        .and_then(|sv| sv.const_())
+        .and_then(|c| c.as_pystr())
+    {
+        Some(s) => s.to_string(),
+        None => {
+            return Err(AnnotatorError::new(
+                "__pyre_cast_instance: target struct root must be a constant string",
+            ));
+        }
+    };
+    let classdef = bk.getuniqueclassdef_for_struct_root(&root)?;
+    Ok(SomeValue::Instance(super::model::SomeInstance::new(
+        Some(classdef),
+        false,
+        std::collections::BTreeMap::new(),
+    )))
 }
 
 /// Analyzer for `String::new()` / `String::with_capacity(n)`.  Both

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2093,6 +2093,63 @@ impl HostEnv {
         // `copy_nonoverlapping` members before the `mods.insert` below.
         std_ptr.module_set("null", HostObject::new_builtin_callable("std.ptr.null"));
 
+        // `std::mem::size_of` / `align_of` re-export `core::mem::*`;
+        // monomorphised LLBC spells the canonical `["core", "mem", _]`
+        // form (same std→core normalisation as `core.ptr` above).  Bind
+        // `core.mem` to the SAME `std.mem` callables so the size_of /
+        // align_of analyzers (keyed by `HostObject` Arc identity) apply.
+        let core_mem = HostObject::new_module("core.mem");
+        core_mem.module_set(
+            "size_of",
+            std_mem.module_get("size_of").expect("std.mem.size_of bound above"),
+        );
+        core_mem.module_set(
+            "align_of",
+            std_mem.module_get("align_of").expect("std.mem.align_of bound above"),
+        );
+
+        // Container / bigint ctors reach the adapter spelled with their
+        // DEFINING crate's canonical module path (`vec::Vec`,
+        // `bigint::BigInt`, `boxed::Box`, and IndexMap's internal `map`
+        // module), not the type-name / re-export shape registered above
+        // (`Vec`, `BigInt`, `Box`, `indexmap.IndexMap`).  Branch 3b joins
+        // `segments[..len-1]` with `.`, so the crate-qualified module key
+        // must exist for resolution.  Reuse the existing analyzer-less
+        // callables where present; mint fresh ones for the methods not
+        // yet surfaced (`with_capacity` / `zero` / `new_uninit`).
+        let vec_crate = HostObject::new_module("vec.Vec");
+        vec_crate.module_set("new", vec_ty.module_get("new").expect("Vec.new bound above"));
+        vec_crate.module_set(
+            "with_capacity",
+            HostObject::new_builtin_callable("vec.Vec.with_capacity"),
+        );
+        let bigint_crate = HostObject::new_module("bigint.BigInt");
+        bigint_crate.module_set(
+            "from",
+            bigint.module_get("from").expect("BigInt.from bound above"),
+        );
+        bigint_crate.module_set(
+            "zero",
+            HostObject::new_builtin_callable("bigint.BigInt.zero"),
+        );
+        let boxed_crate = HostObject::new_module("boxed.Box");
+        boxed_crate.module_set("new", box_ty.module_get("new").expect("Box.new bound above"));
+        boxed_crate.module_set(
+            "into_raw",
+            box_ty.module_get("into_raw").expect("Box.into_raw bound above"),
+        );
+        boxed_crate.module_set(
+            "new_uninit",
+            HostObject::new_builtin_callable("boxed.Box.new_uninit"),
+        );
+        let map_indexmap = HostObject::new_module("map.IndexMap");
+        map_indexmap.module_set(
+            "new",
+            indexmap_indexmap
+                .module_get("new")
+                .expect("indexmap.IndexMap.new bound above"),
+        );
+
         // `pub const PY_NULL: PyObjectRef = std::ptr::null_mut()`
         // (`pyre_object::pyobject::PY_NULL`).  Charon emits the const
         // read as a Global place; `front::mir` lowers an unknown global
@@ -2125,6 +2182,11 @@ impl HostEnv {
         mods.insert("rpython.rtyper.lltypesystem.llmemory".into(), llmemory);
         mods.insert("weakref".into(), weakref_mod);
         mods.insert("core.ptr".into(), core_ptr);
+        mods.insert("core.mem".into(), core_mem);
+        mods.insert("vec.Vec".into(), vec_crate);
+        mods.insert("bigint.BigInt".into(), bigint_crate);
+        mods.insert("boxed.Box".into(), boxed_crate);
+        mods.insert("map.IndexMap".into(), map_indexmap);
         mods.insert("std.ptr".into(), std_ptr);
         mods.insert("std.mem".into(), std_mem);
         mods.insert("std.alloc".into(), std_alloc);

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -1628,6 +1628,17 @@ impl HostEnv {
         for name in ["object.__init__"] {
             self.insert_builtin(name, HostObject::new_builtin_callable(name));
         }
+        // Pyre-internal front-end pointer-downcast narrow (#298): the
+        // frontend lowers `obj as *const RegisteredStruct` to a
+        // `simple_call` against this stub so the classdef-less pointer
+        // narrows to `SomeInstance(root)` and a field read on the pointee
+        // resolves.  Its analyzer (annotator/builtin.rs) keys on this
+        // qualname and its typer (rtyper/rbuiltin.rs) keys on this same
+        // singleton Arc, so the binding must live in HOST_ENV.
+        self.insert_builtin(
+            "__pyre_cast_instance",
+            HostObject::new_builtin_callable("__pyre_cast_instance"),
+        );
     }
 
     fn bootstrap_std_modules(&mut self) {

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2101,11 +2101,15 @@ impl HostEnv {
         let core_mem = HostObject::new_module("core.mem");
         core_mem.module_set(
             "size_of",
-            std_mem.module_get("size_of").expect("std.mem.size_of bound above"),
+            std_mem
+                .module_get("size_of")
+                .expect("std.mem.size_of bound above"),
         );
         core_mem.module_set(
             "align_of",
-            std_mem.module_get("align_of").expect("std.mem.align_of bound above"),
+            std_mem
+                .module_get("align_of")
+                .expect("std.mem.align_of bound above"),
         );
 
         // Container / bigint ctors reach the adapter spelled with their
@@ -2118,7 +2122,10 @@ impl HostEnv {
         // callables where present; mint fresh ones for the methods not
         // yet surfaced (`with_capacity` / `zero` / `new_uninit`).
         let vec_crate = HostObject::new_module("vec.Vec");
-        vec_crate.module_set("new", vec_ty.module_get("new").expect("Vec.new bound above"));
+        vec_crate.module_set(
+            "new",
+            vec_ty.module_get("new").expect("Vec.new bound above"),
+        );
         vec_crate.module_set(
             "with_capacity",
             HostObject::new_builtin_callable("vec.Vec.with_capacity"),
@@ -2133,10 +2140,15 @@ impl HostEnv {
             HostObject::new_builtin_callable("bigint.BigInt.zero"),
         );
         let boxed_crate = HostObject::new_module("boxed.Box");
-        boxed_crate.module_set("new", box_ty.module_get("new").expect("Box.new bound above"));
+        boxed_crate.module_set(
+            "new",
+            box_ty.module_get("new").expect("Box.new bound above"),
+        );
         boxed_crate.module_set(
             "into_raw",
-            box_ty.module_get("into_raw").expect("Box.into_raw bound above"),
+            box_ty
+                .module_get("into_raw")
+                .expect("Box.into_raw bound above"),
         );
         boxed_crate.module_set(
             "new_uninit",

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -980,6 +980,20 @@ impl std::error::Error for LowerError {}
 // Lowering state
 // ---------------------------------------------------------------------------
 
+/// The `(base, index)` operands of a devirtualized workspace index call,
+/// recorded for the paired `*p = v` write.  Each operand keeps the
+/// resolving-block Variable plus its source MIR local (`None` for a
+/// constant operand) so the write site can re-resolve through
+/// `local_var` after the operand is rebound across the call's block
+/// split.  See [`Lowering::index_elem_alias`].
+#[derive(Clone)]
+struct IndexElemAlias {
+    base_local: Option<usize>,
+    base_var: Variable,
+    index_local: Option<usize>,
+    index_var: Variable,
+}
+
 struct Lowering<'a> {
     graph: FunctionGraph,
     llbc: &'a Llbc,
@@ -1045,8 +1059,14 @@ struct Lowering<'a> {
     /// getarrayitem instead and the paired `*p = v` write
     /// ([`Lowering::emit_projection_write`] `Deref` arm) consults
     /// this map to emit `ArrayWrite` rather than the opaque
-    /// `__deref_write` marker.
-    index_elem_alias: std::collections::HashMap<usize, (Variable, Variable)>,
+    /// `__deref_write` marker.  The base/index are kept as both the
+    /// resolving-block Variable and their source MIR local: the write
+    /// usually lands in a later block (the index call terminates its
+    /// own block), where the operands have been rebound to fresh
+    /// inputarg Variables, so the consumer re-resolves through
+    /// `local_var` by local and only falls back to the recorded
+    /// Variable for a base/index without a backing local (a constant).
+    index_elem_alias: std::collections::HashMap<usize, IndexElemAlias>,
     /// MIR locals bound by a devirtualized infallible widening
     /// `usize::try_from(u8|u16|u32)` call.  The value is the source
     /// integer itself (the conversion cannot fail on 64-bit targets),
@@ -1147,7 +1167,8 @@ impl<'a> Lowering<'a> {
         for _ in 1..body.body.len() {
             block_id.push(graph.create_block());
         }
-        let block_live_in = compute_mir_liveness(body);
+        let index_write_extra_live = compute_index_write_extra_live(body, llbc);
+        let block_live_in = compute_mir_liveness(body, &index_write_extra_live);
         let mut block_entry_local_var = vec![vec![None; n_locals]; body.body.len()];
         let block_entry_positional_aggregate_locals =
             vec![std::collections::HashMap::new(); body.body.len()];
@@ -1885,6 +1906,18 @@ impl<'a> Lowering<'a> {
         }
     }
 
+    /// Re-resolve a recorded [`IndexElemAlias`] operand to the Variable
+    /// live in the current block: prefer the current `local_var` binding
+    /// of its source MIR local (rebound to a fresh inputarg if the
+    /// operand was threaded across the index call's block split), and
+    /// fall back to the Variable captured at the index call for a
+    /// constant operand with no backing local.
+    fn realias_operand(&self, local: Option<usize>, recorded: Variable) -> Variable {
+        local
+            .and_then(|l| self.local_var.get(l).cloned().flatten())
+            .unwrap_or(recorded)
+    }
+
     /// Emit the side-effectful write op for an `Assign` whose dest is
     /// a `Projection(inner, elem)`. `value` is the freshly computed
     /// rvalue.  `dest_ty` is the projected place's own `TyRef` — the
@@ -1908,14 +1941,21 @@ impl<'a> Lowering<'a> {
         let bb_id = self.block_id[mir_bb];
         let op = match &elem {
             ProjectionElem::Atom(s) if s == "Deref" => {
-                if let Some((arr, idx)) = inner_local
+                if let Some(alias) = inner_local
                     .and_then(|i| self.index_elem_alias.get(&i))
                     .cloned()
                 {
                     // `*p = val` where `p` was bound by a
                     // devirtualized workspace `index_mut` call is the
                     // write half of `arr[i] = val` — emit the array
-                    // write directly (setarrayitem).
+                    // write directly (setarrayitem).  The index call
+                    // terminates its own block, so the base/index
+                    // operands are typically rebound to fresh inputarg
+                    // Variables here; re-resolve them through
+                    // `local_var` by their source local and fall back
+                    // to the recorded Variable for a constant operand.
+                    let arr = self.realias_operand(alias.base_local, alias.base_var);
+                    let idx = self.realias_operand(alias.index_local, alias.index_var);
                     OpKind::ArrayWrite {
                         base: arr,
                         index: idx,
@@ -3416,8 +3456,15 @@ impl<'a> Lowering<'a> {
                             nolength: false,
                         },
                     });
-                    self.index_elem_alias
-                        .insert(dest_local, (args[0].clone(), args[1].clone()));
+                    self.index_elem_alias.insert(
+                        dest_local,
+                        IndexElemAlias {
+                            base_local: arg_locals.first().copied().flatten(),
+                            base_var: args[0].clone(),
+                            index_local: arg_locals.get(1).copied().flatten(),
+                            index_var: args[1].clone(),
+                        },
+                    );
                     self.local_var[dest_local] = Some(res);
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -3892,15 +3939,7 @@ impl<'a> Lowering<'a> {
     /// getarrayitem/setarrayitem on the receiver and is devirtualized
     /// to `ArrayRead`/`ArrayWrite` by the caller.
     fn is_workspace_index_call(&self, reg: &RegularCall) -> bool {
-        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
-            return false;
-        };
-        let Some(fd) = self.llbc.fn_by_id(*id) else {
-            return false;
-        };
-        let path = fd.item_meta.name_path();
-        let leaf = path.rsplit("::").next().unwrap_or("");
-        (leaf == "index" || leaf == "index_mut") && path.starts_with("pyre_")
+        is_workspace_index_regular(reg, self.llbc)
     }
 
     /// `usize::try_from` (`ptr_try_from_impls`, Opaque core code)
@@ -4925,7 +4964,111 @@ fn compute_binop_result_locals(body: &Unstructured) -> std::collections::HashSet
     set
 }
 
-fn compute_mir_liveness(body: &Unstructured) -> Vec<Vec<bool>> {
+/// Whether a statically-resolved [`RegularCall`] is a workspace
+/// `Index::index` / `IndexMut::index_mut` impl (the `FixedObjectArray`
+/// family) — those bottom out at raw-slice construction and are lowered
+/// as RPython's getarrayitem rather than a residual call.  Shared by the
+/// call-lowering intercept and the liveness pre-pass.
+fn is_workspace_index_regular(reg: &RegularCall, llbc: &Llbc) -> bool {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return false;
+    };
+    let Some(fd) = llbc.fn_by_id(*id) else {
+        return false;
+    };
+    let path = fd.item_meta.name_path();
+    let leaf = path.rsplit("::").next().unwrap_or("");
+    (leaf == "index" || leaf == "index_mut") && path.starts_with("pyre_")
+}
+
+/// The MIR local behind a plain-local [`Operand`], or `None` for a
+/// constant or a projected place.
+fn operand_local(op: Option<&Operand>) -> Option<usize> {
+    match op? {
+        Operand::Copy(p) | Operand::Move(p) => match p.kind {
+            PlaceKind::Local(i) => Some(i as usize),
+            _ => None,
+        },
+        Operand::Const(_) => None,
+    }
+}
+
+/// The base MIR local of a `*p = v` deref write (`Projection(Local(p),
+/// Deref)`), or `None` for any other place shape — the same destination
+/// shape [`Lowering::emit_projection_write`] re-expresses as an
+/// `ArrayWrite` when `p` was bound by a workspace index call.
+fn deref_write_base_local(place: &Place) -> Option<usize> {
+    let PlaceKind::Projection(inner, elem) = &place.kind else {
+        return None;
+    };
+    let ProjectionElem::Atom(s) = elem else {
+        return None;
+    };
+    if s != "Deref" {
+        return None;
+    }
+    match inner.kind {
+        PlaceKind::Local(i) => Some(i as usize),
+        _ => None,
+    }
+}
+
+/// Per-block extra-live MIR locals for the deferred array-write base /
+/// index of a workspace `index` / `index_mut` call.
+///
+/// `arr[i] = v` lowers to `_p = index_mut(_s, _i)` (recorded as an
+/// `index_elem_alias`, [`Lowering::lower_call`]) followed — across the
+/// call's own block split — by `*_p = v`, which
+/// [`Lowering::emit_projection_write`] re-expresses as `ArrayWrite {
+/// base: _s, index: _i, .. }`.  That `ArrayWrite` is a synthetic use of
+/// `_s` / `_i` the MIR never spells, so plain liveness drops them before
+/// the write block and the base reaches the rtyper as an undefined
+/// operand.  Return, per block, the base/index locals of every such
+/// `_p` deref-written in it, for [`compute_mir_liveness`] to mark live;
+/// the backward fixpoint then threads them from their definition (which
+/// dominates the `_p` use).
+fn compute_index_write_extra_live(body: &Unstructured, llbc: &Llbc) -> Vec<Vec<usize>> {
+    let mut index_call: std::collections::HashMap<usize, (Option<usize>, Option<usize>)> =
+        std::collections::HashMap::new();
+    for bb in &body.body {
+        let Ok(TermKind::Call { call, .. }) = bb.term() else {
+            continue;
+        };
+        let CallFunc::Regular(reg) = &call.func else {
+            continue;
+        };
+        if !is_workspace_index_regular(reg, llbc) {
+            continue;
+        }
+        let PlaceKind::Local(p) = call.dest.kind else {
+            continue;
+        };
+        index_call.insert(
+            p as usize,
+            (operand_local(call.args.first()), operand_local(call.args.get(1))),
+        );
+    }
+    let mut extra = vec![Vec::new(); body.body.len()];
+    if index_call.is_empty() {
+        return extra;
+    }
+    for (bb_idx, bb) in body.body.iter().enumerate() {
+        for stmt in &bb.statements {
+            let Ok(StmtKind::Assign(place, _)) = stmt.stmt_kind() else {
+                continue;
+            };
+            if let Some(p) = deref_write_base_local(&place)
+                && let Some((base, idx)) = index_call.get(&p)
+            {
+                extra[bb_idx].extend(base.iter().copied());
+                extra[bb_idx].extend(idx.iter().copied());
+            }
+        }
+    }
+    extra
+}
+
+fn compute_mir_liveness(body: &Unstructured, extra_live: &[Vec<usize>]) -> Vec<Vec<bool>> {
     let n_blocks = body.body.len();
     let n_locals = body.locals.locals.len();
     let mut uses = vec![vec![false; n_locals]; n_blocks];
@@ -4983,6 +5126,20 @@ fn compute_mir_liveness(body: &Unstructured) -> Vec<Vec<bool>> {
             }
             TermKind::Drop { target, .. } => push_successor(&mut succs[bb_idx], target, n_blocks),
             TermKind::UnwindResume | TermKind::Abort(_) | TermKind::Unknown => {}
+        }
+    }
+
+    // Synthetic deferred-array-write uses: the base/index of a
+    // workspace index call feed an `ArrayWrite` the MIR never spells
+    // (see `compute_index_write_extra_live`).  Mark them live-used in
+    // the block that holds the `*p = v` write — unless that block also
+    // defines them — so the backward fixpoint threads them in from
+    // their definition, which dominates the `_p` use.
+    for (bb_idx, locals) in extra_live.iter().enumerate().take(n_blocks) {
+        for &local_idx in locals {
+            if local_idx < n_locals && !defs[bb_idx][local_idx] {
+                uses[bb_idx][local_idx] = true;
+            }
         }
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3616,7 +3616,37 @@ impl<'a> Lowering<'a> {
                 // the method name never reaches the rtyper as a
                 // `ptr.getattr`.
                 if args.len() == 1 && self.is_ptr_identity_cast(&reg) {
-                    self.local_var[dest_local] = Some(args[0].clone());
+                    // When the cast target names a registered struct root
+                    // (`ptr.cast::<W_SRE_Pattern>()` then a field read),
+                    // narrow the result to `SomeInstance(root)` exactly
+                    // like the `Rvalue::Cast` arm: a bare alias leaves the
+                    // pointer classdef-less and the downstream `getattr`
+                    // blocks at the annotator.  The receiver is already a
+                    // raw pointer (`is_ptr_identity_cast`), so this is a
+                    // genuine `cast_pointer` (ptr→ptr).
+                    if let ValueType::Ref(_) = tyref_to_value_type(&call.dest.ty, self.llbc)
+                        && let Some(root) = tyref_class_root(&call.dest.ty, self.llbc)
+                    {
+                        let res = self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                            result: Some(res.clone()),
+                            kind: OpKind::Call {
+                                target: CallTarget::FunctionPath {
+                                    segments: vec![
+                                        "__pyre_cast_instance".to_string(),
+                                        root.clone(),
+                                    ],
+                                },
+                                args: vec![args[0].clone()],
+                                result_ty: ValueType::Ref(Some(root)),
+                            },
+                        });
+                        self.local_var[dest_local] = Some(res);
+                    } else {
+                        self.local_var[dest_local] = Some(args[0].clone());
+                    }
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -6504,8 +6534,6 @@ fn typevar_bounded_by_into_string(
         let subject_is_var = types
             .first()
             .and_then(|s| strip(llbc, s))
-            .and_then(|s| s.as_object())
-            .and_then(|o| o.get("TypeVar"))
             .and_then(typevar_bound_index)
             == Some(var_index);
         if !subject_is_var {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3664,25 +3664,22 @@ impl<'a> Lowering<'a> {
                 )? {
                     return Ok(());
                 }
-                let alias = if let Some(payload) =
-                    self.expect_on_const_ok(&segments, &args, &arg_locals)
-                {
-                    // Identity unwrap: the receiver variable was bound
-                    // directly to the `Ok` payload, so the result is
-                    // that variable — bind and close the block with no
-                    // op emitted.
-                    Some(payload)
-                } else {
-                    self.reflexive_into_alias(
-                        &segments,
-                        &args,
-                        first_arg_ty.as_ref(),
-                        &call.dest.ty,
-                    )
-                    .or_else(|| {
-                        self.trait_into_string_alias(&segments, &args, &call.dest.ty)
-                    })
-                };
+                let alias =
+                    if let Some(payload) = self.expect_on_const_ok(&segments, &args, &arg_locals) {
+                        // Identity unwrap: the receiver variable was bound
+                        // directly to the `Ok` payload, so the result is
+                        // that variable — bind and close the block with no
+                        // op emitted.
+                        Some(payload)
+                    } else {
+                        self.reflexive_into_alias(
+                            &segments,
+                            &args,
+                            first_arg_ty.as_ref(),
+                            &call.dest.ty,
+                        )
+                        .or_else(|| self.trait_into_string_alias(&segments, &args, &call.dest.ty))
+                    };
                 if let Some(value) = alias {
                     self.local_var[dest_local] = Some(value);
                     let bb_id = self.block_id[mir_bb];
@@ -6394,10 +6391,7 @@ fn typevar_bounded_by_into_string(
     else {
         return false;
     };
-    fn strip<'a>(
-        llbc: &'a Llbc,
-        mut v: &'a serde_json::Value,
-    ) -> Option<&'a serde_json::Value> {
+    fn strip<'a>(llbc: &'a Llbc, mut v: &'a serde_json::Value) -> Option<&'a serde_json::Value> {
         loop {
             let obj = v.as_object()?;
             if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3428,6 +3428,9 @@ impl<'a> Lowering<'a> {
                         first_arg_ty.as_ref(),
                         &call.dest.ty,
                     )
+                    .or_else(|| {
+                        self.trait_into_string_alias(&segments, &args, &call.dest.ty)
+                    })
                 };
                 if let Some(value) = alias {
                     self.local_var[dest_local] = Some(value);
@@ -4388,6 +4391,61 @@ impl<'a> Lowering<'a> {
         let src = self.tyref_body(first_arg_ty?)?;
         let dst = self.tyref_body(dest_ty)?;
         (src == dst).then(|| arg.clone())
+    }
+
+    /// Resolve the trait-spelled `Into::into` (`["Into", "into"]` — a
+    /// generic-parameter receiver, so Charon cannot select the impl at
+    /// the call site) to its operand when the destination type is
+    /// `alloc::string::String`.  `impl Into<String>` message parameters
+    /// (the `PyError` constructor family) reach `msg.into()` inside the
+    /// generic body; the annotation model maps `String` and `str` to
+    /// the same string value (`project_pyre_field_type` — `s_unicode0`),
+    /// matching upstream's single string type (`rstr.py`), so the
+    /// conversion is an identity at the annotation level.  Other
+    /// destination types keep the generic `Call` form.
+    fn trait_into_string_alias(
+        &self,
+        segments: &[String],
+        args: &[Variable],
+        dest_ty: &TyRef,
+    ) -> Option<Variable> {
+        let [trait_seg, leaf] = segments else {
+            return None;
+        };
+        if trait_seg.as_str() != "Into" || leaf.as_str() != "into" {
+            return None;
+        }
+        let [arg] = args else {
+            return None;
+        };
+        let dest_path = self.tyref_adt_name_path(dest_ty)?;
+        (dest_path == "alloc::string::String").then(|| arg.clone())
+    }
+
+    /// The fully-qualified `name_path()` of the ADT a [`TyRef`]
+    /// resolves to, following `Deduplicated` / `HashConsedValue`
+    /// wrapper layers.  `None` for non-ADT shapes.
+    fn tyref_adt_name_path(&self, ty: &TyRef) -> Option<String> {
+        let mut v = self.tyref_body(ty)?;
+        loop {
+            let obj = v.as_object()?;
+            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+                v = self.llbc.dedup_body(id)?;
+                continue;
+            }
+            if let Some(arr) = obj
+                .get("HashConsedValue")
+                .and_then(serde_json::Value::as_array)
+                && arr.len() == 2
+            {
+                v = &arr[1];
+                continue;
+            }
+            break;
+        }
+        let def_id = inline_adt_def_id(v)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        Some(td.item_meta.name_path())
     }
 
     /// The resolved JSON body of a [`TyRef`], following the dedup
@@ -5790,6 +5848,93 @@ fn typevar_bound_index(node: &serde_json::Value) -> Option<u64> {
         .as_u64()
 }
 
+/// True when fn-level type variable `var_index` carries an
+/// `Into<String>` trait clause.  The clause's trait generics spell
+/// `[<subject>, <target>]`; the subject must be our variable and the
+/// target must resolve to the `alloc::string::String` ADT, with the
+/// trait decl's leaf name `Into` (a `From<String>` bound has the same
+/// generics shape but means the *opposite* conversion).
+fn typevar_bounded_by_into_string(
+    var_index: u64,
+    fn_generics: &serde_json::Value,
+    llbc: &Llbc,
+) -> bool {
+    let Some(clauses) = fn_generics
+        .as_object()
+        .and_then(|g| g.get("trait_clauses"))
+        .and_then(|c| c.as_array())
+    else {
+        return false;
+    };
+    fn strip<'a>(
+        llbc: &'a Llbc,
+        mut v: &'a serde_json::Value,
+    ) -> Option<&'a serde_json::Value> {
+        loop {
+            let obj = v.as_object()?;
+            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+                v = llbc.dedup_body(id)?;
+                continue;
+            }
+            if let Some(arr) = obj
+                .get("HashConsedValue")
+                .and_then(serde_json::Value::as_array)
+                && arr.len() == 2
+            {
+                v = &arr[1];
+                continue;
+            }
+            return Some(v);
+        }
+    }
+    for clause in clauses {
+        let Some(sb) = clause
+            .as_object()
+            .and_then(|c| c.get("trait_"))
+            .and_then(|t| t.as_object())
+            .and_then(|t| t.get("skip_binder"))
+            .and_then(|s| s.as_object())
+        else {
+            continue;
+        };
+        let is_into = sb
+            .get("id")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|id| llbc.trait_by_id(id))
+            .map(|td| td.item_meta.name_path())
+            .is_some_and(|n| n.rsplit("::").next() == Some("Into"));
+        if !is_into {
+            continue;
+        }
+        let Some(types) = sb
+            .get("generics")
+            .and_then(|g| g.get("types"))
+            .and_then(|t| t.as_array())
+        else {
+            continue;
+        };
+        let subject_is_var = types
+            .first()
+            .and_then(|s| strip(llbc, s))
+            .and_then(|s| s.as_object())
+            .and_then(|o| o.get("TypeVar"))
+            .and_then(typevar_bound_index)
+            == Some(var_index);
+        if !subject_is_var {
+            continue;
+        }
+        let target_is_string = types
+            .get(1)
+            .and_then(|t| resolve_tyexpr_to_adt_def_id_free(llbc, t))
+            .and_then(|id| llbc.type_by_id(id))
+            .is_some_and(|td| td.item_meta.name_path() == "alloc::string::String");
+        if target_is_string {
+            return true;
+        }
+    }
+    false
+}
+
 /// Resolve a generic parameter type (`&T` where `T: Trait`, including a
 /// trait default body's `&Self`) to the bound trait's qualified
 /// `name_path()`.
@@ -5822,6 +5967,16 @@ fn tyref_generic_trait_bound_root(
         TyRef::Dedup { id } => llbc.dedup_body(*id)?,
     };
     let param_index = typevar_bound_index(strip_ty_wrappers(node, llbc)?)?;
+    // `T: Into<String>` — the conventional message-parameter bound
+    // (`PyError::type_error(msg: impl Into<String>)`).  Such a variable
+    // is a string at the annotation level (the model maps `String` and
+    // `str` to one string type), so it resolves to the `"String"` root
+    // and the input-cell derivation seeds `s_unicode0` instead of a
+    // classdef-less instance shell whose field writes would poison
+    // classdef attr cells.
+    if typevar_bounded_by_into_string(param_index, generics, llbc) {
+        return Some("String".to_string());
+    }
     for clause in generics.get("trait_clauses")?.as_array()? {
         let Some(pred) = clause.get("trait_").and_then(|t| t.get("skip_binder")) else {
             continue;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3545,7 +3545,9 @@ impl<'a> Lowering<'a> {
 
     /// Resolve a Charon `CallKind` to a flattened path segment list the
     /// codewriter consumes as `CallTarget::FunctionPath`, plus an
-    /// optional `(owner_root_leaf, method_leaf)` pair for impl methods.
+    /// optional `(owner_root_leaf, method_leaf)` pair for impl methods,
+    /// plus the `[Owner, leaf]` registration spelling when the callee is
+    /// an inherent-impl *associated function* (no receiver).
     ///
     /// The method hint is `Some` when the FunDecl's raw name segments
     /// encode an `Impl` block immediately before the leaf `Ident` —
@@ -3555,6 +3557,14 @@ impl<'a> Lowering<'a> {
     /// `CallTarget::FunctionPath` so the annotator can prepend a
     /// classdef-bound `SomeInstance` for `self`; see the comment at
     /// the use site in [`Self::lower_call`].
+    ///
+    /// The associated-function spelling is computed only when the
+    /// method hint is `None` (a receiver-shaped callee never consumes
+    /// it), and only the `CallTarget::FunctionPath` construction in
+    /// `lower_call` applies it — the raw `name_path()` segments stay
+    /// untouched for the std special-case matchers (`checked_neg` /
+    /// `try_from` / `into` / `expect`) that key on the
+    /// `[.., "<Impl>", leaf]` shape.
     fn call_target_segments(
         &self,
         mir_bb: usize,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3466,6 +3466,18 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<Atomic*>::load(&self, ordering)` — a relaxed read of a
+                // layout-transparent atomic.  `&self` already aliases the
+                // inner field read, so alias the destination to it (the
+                // `ordering` arg is discarded); the `load` name never
+                // reaches the rtyper as a `ptr.getattr`.
+                if args.len() == 2 && self.is_atomic_load(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // Resolve the target function's fully-qualified path
                 // through the FunId → FunDecl table. `Trait` here is
                 // Charon's "trait-bound generic resolved at extraction
@@ -3956,6 +3968,37 @@ impl<'a> Lowering<'a> {
                 .and_then(|n| strip_ty_wrappers(n, self.llbc))
                 .and_then(serde_json::Value::as_object)
                 .is_some_and(|o| o.contains_key("RawPtr"))
+        })
+    }
+
+    /// `<core::sync::atomic::Atomic*>::load(&self, ordering)` — a relaxed
+    /// read of a std atomic.  The atomic types are layout-transparent
+    /// over their inner scalar/pointer (asserted for the `PyType`
+    /// `subclassrange_*` / `instantiate` vtable fields), so the JIT
+    /// models the load as that inner value: [`tyref_atomic_inner_value_type`]
+    /// types the `Atomic*` field as its inner [`ValueType`], the `&self`
+    /// `Ref` rvalue aliases to that field read, and this aliases the load
+    /// destination to the receiver.  Gating on an atomic receiver
+    /// excludes unrelated inherent `load` methods, and the method name
+    /// never reaches the rtyper as a `ptr.getattr`.
+    fn is_atomic_load(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        let name = fd.item_meta.name_path();
+        if name.rsplit("::").next() != Some("load") {
+            return false;
+        }
+        fd.signature.inputs.first().is_some_and(|t| {
+            adt_path_of_tyref(t, self.llbc).is_some_and(|p| {
+                p.contains("::sync::atomic::")
+                    && p.rsplit("::")
+                        .next()
+                        .is_some_and(|leaf| leaf.starts_with("Atomic"))
+            })
         })
     }
 
@@ -5665,6 +5708,14 @@ fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
 }
 
 fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
+    // Atomic wrappers type as their inner value; integer widths collapse
+    // to `Int` here, matching the literal-int handling below.
+    if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
+        return match inner {
+            ValueType::Unsigned => ValueType::Int,
+            other => other,
+        };
+    }
     // The HashConsedValue arm carries the body inline; primitives
     // typically land here.  The Deduplicated arm carries only an
     // ID; consult the dedup-body index to recover the inline shape
@@ -5738,6 +5789,12 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
 /// slice, array, `Box`/`Rc`/`Arc` wrapper) folds to `Ref(None)` whose
 /// someshell ignores the payload.
 fn tyref_to_attr_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
+    // Atomic wrappers register as their inner value, keeping the
+    // signed/unsigned split so `AtomicUsize` shells to `SomeInteger {
+    // unsigned: true }` like a bare `usize` field.
+    if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
+        return inner;
+    }
     let value = match ty {
         TyRef::Inline { value: (_, v) } => v,
         TyRef::Other(v) => v,
@@ -5830,6 +5887,29 @@ fn adt_path_of_tyref(ty: &TyRef, llbc: &Llbc) -> Option<String> {
     let node = strip_ty_wrappers(node, llbc)?;
     let id = adt_node_def_id(node)?;
     Some(llbc.type_by_id(id)?.item_meta.name_path())
+}
+
+/// The inner [`ValueType`] of a `core::sync::atomic` atomic type
+/// (`AtomicI64` → `Int`, `AtomicUsize` → `Unsigned`, `AtomicBool` →
+/// `Bool`, `AtomicPtr<T>` → `Ref(None)`), or `None` when `ty` is not a
+/// std atomic.  The atomic wrappers are layout-transparent over their
+/// inner scalar/pointer (asserted at pyobject.rs for the `PyType` vtable
+/// `subclassrange_*` / `instantiate` fields), and the upstream typeptr
+/// ranges are plain int fields, so a field of one types as that inner
+/// value and its `load`/`store` fold to it (`is_atomic_load`).
+fn tyref_atomic_inner_value_type(ty: &TyRef, llbc: &Llbc) -> Option<ValueType> {
+    let path = adt_path_of_tyref(ty, llbc)?;
+    if !path.contains("::sync::atomic::") {
+        return None;
+    }
+    let leaf = path.rsplit("::").next().unwrap_or(&path);
+    match leaf {
+        "AtomicPtr" => Some(ValueType::Ref(None)),
+        "AtomicBool" => Some(ValueType::Bool),
+        l if l.starts_with("AtomicI") => Some(ValueType::Int),
+        l if l.starts_with("AtomicU") => Some(ValueType::Unsigned),
+        _ => None,
+    }
 }
 
 /// `Arg<T>` from `rustpython_compiler_core::bytecode::instruction` —

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4091,6 +4091,191 @@ impl<'a> Lowering<'a> {
                 result_ty: ValueType::Int,
             },
         );
+        self.emit_tagged_pair_aggregate(mir_bb, &owner, disc, payload, dest_local, target)?;
+        Ok(true)
+    }
+
+    /// Lower the infallible `usize::try_from(<u8|u16|u32>)`
+    /// (`core::convert::num::ptr_try_from_impls::<Impl>::try_from`,
+    /// Opaque in the LLBC like every core fn) to its decomposed
+    /// always-`Ok` shape: `__discriminant = 0` (`Result`'s `Ok` tag)
+    /// and `__pos_0 = arg` (the widening is an identity on the i64
+    /// carrier).  Upstream `rarithmetic.py:140-145 widen` performs
+    /// the same smaller-than-word unsigned → Signed widening as a
+    /// no-op; pyre spells it `usize::try_from(x).expect(..)`
+    /// (`pyopcode.rs` `u32_as_usize` / `raise_kind_as_usize`), whose
+    /// `Err` arm is statically dead on the 64-bit-only targets pyre
+    /// supports.  Impls with word-sized-or-wider inputs — the
+    /// genuinely fallible directions of the same impl group — keep
+    /// the `Call` form.
+    fn try_lower_usize_try_from(
+        &mut self,
+        mir_bb: usize,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return Ok(false);
+        };
+        if first.as_str() != "core"
+            || module.as_str() != "ptr_try_from_impls"
+            || impl_seg.as_str() != "<Impl>"
+            || leaf.as_str() != "try_from"
+        {
+            return Ok(false);
+        }
+        let [arg] = args else {
+            return Ok(false);
+        };
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return Ok(false);
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return Ok(false);
+        };
+        let Some(src) = fd.signature.inputs.first() else {
+            return Ok(false);
+        };
+        if !matches!(
+            self.tyref_literal_uint_atom(src),
+            Some("U8" | "U16" | "U32")
+        ) {
+            return Ok(false);
+        }
+        let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
+            return Ok(false);
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return Ok(false);
+        };
+        let owner = td.item_meta.name_path();
+        let arg = arg.clone();
+        if self.multi_assigned_locals.contains(&dest_local) {
+            // A re-bindable local may later carry a runtime `Result`,
+            // so the constant tag can't be recorded and consumers
+            // can't be folded — materialize the aggregate so field
+            // reads on the local stay type-consistent.
+            let bb_id = self.block_id[mir_bb];
+            let disc = self
+                .graph
+                .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(disc.clone()),
+                kind: OpKind::ConstInt(0),
+            });
+            self.emit_tagged_pair_aggregate(mir_bb, &owner, disc, arg, dest_local, target)?;
+            return Ok(true);
+        }
+        // Identity widening: bind the destination local directly to
+        // the operand — no `Result` object is materialized at all,
+        // exactly as upstream `widen` leaves no op in the graph.
+        // The discriminant switch always sits in a successor block
+        // (a MIR call terminates its own block), so record the
+        // constant tag per-local: `Rvalue::Discriminant` folds to
+        // `ConstInt(0)` and `expect`/`unwrap` aliases the payload
+        // (`expect_on_const_ok`) without touching the variable.
+        self.const_discriminant_locals.insert(dest_local, 0);
+        self.local_var[dest_local] = Some(arg);
+        let bb_id = self.block_id[mir_bb];
+        let target_bb = self.block_id[target];
+        let link_args = self.edge_args(mir_bb, target)?;
+        self.graph.set_goto(bb_id, target_bb, link_args);
+        Ok(true)
+    }
+
+    /// Resolve `Result::expect` / `Result::unwrap` on a receiver local
+    /// recorded always-`Ok` (`const_discriminant_locals`, tag 0) to
+    /// the receiver variable itself.  Such locals are bound directly
+    /// to the `Ok` payload by [`Lowering::try_lower_usize_try_from`]
+    /// (no `Result` object is materialized), so the unwrap is an
+    /// alias, not an op.  The match these methods perform lives
+    /// inside the Opaque core body, so without the intercept the call
+    /// keeps its panic-message `&str` argument and the graph walls on
+    /// the `__str_const` lowering even though the `Err` arm is
+    /// statically dead.  Upstream has no such call: `ovfcheck`-free
+    /// widening is a plain identity (`rarithmetic.py:140-145 widen`),
+    /// so the operand *is* the whole operation.  Returns `None` for
+    /// any other callee or a receiver without the always-`Ok` record,
+    /// keeping the generic `Call` form.
+    fn expect_on_const_ok(
+        &self,
+        segments: &[String],
+        args: &[Variable],
+        arg_locals: &[Option<usize>],
+    ) -> Option<Variable> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return None;
+        };
+        if first.as_str() != "core"
+            || module.as_str() != "result"
+            || impl_seg.as_str() != "<Impl>"
+            || !matches!(leaf.as_str(), "expect" | "unwrap")
+        {
+            return None;
+        }
+        let recv = args.first()?;
+        let recv_local = (*arg_locals.first()?)?;
+        if *self.const_discriminant_locals.get(&recv_local)? != 0 {
+            return None;
+        }
+        Some(recv.clone())
+    }
+
+    /// The `UInt` width atom (`"U8"` / `"U32"` / `"Usize"` …) of a
+    /// scalar-typed [`TyRef`], `None` for any non-`UInt` shape.
+    fn tyref_literal_uint_atom<'t>(&self, ty: &'t TyRef) -> Option<&'t str>
+    where
+        'a: 't,
+    {
+        let value = match ty {
+            TyRef::Inline { value: (_, v) } => v,
+            TyRef::Other(v) => v,
+            TyRef::Dedup { id } => self.llbc.dedup_body(*id)?,
+        };
+        value
+            .as_object()?
+            .get("Literal")?
+            .as_object()?
+            .get("UInt")?
+            .as_str()
+    }
+
+    /// Shared tail for the decomposed checked-arithmetic /
+    /// infallible-conversion call lowerings: write `disc` and
+    /// `payload` into the destination `Option`/`Result` local as a
+    /// synthetic aggregate — the same transparent-ctor + `FieldWrite`
+    /// chain [`Rvalue::Aggregate`] emits — then bind the destination
+    /// local and close the block toward the call's success target.
+    ///
+    /// Unlike `resolve_aggregate_adt`'s enum arm, which constructs
+    /// the VARIANT identity (`Option::Some`), this constructs the
+    /// enum TYPE root (`Option`) and writes `__discriminant`
+    /// explicitly.  That is deliberate: `disc` may be a runtime value
+    /// (`checked_neg`'s `ne(v, MIN)`), so no single variant identity
+    /// is correct, and the enum root is exactly the flat class every
+    /// downstream enum attr read keys (`Rvalue::Discriminant` reads
+    /// `__discriminant` with no owner, payload projections key the
+    /// enum leaf — `resolve_adt_field` — and `extract_struct_fields`
+    /// registers `__discriminant` + the payload-field union on the
+    /// root).  Constructing a variant identity here instead breaks
+    /// the real-path annotation of multi-assigned destination locals
+    /// (`<other> ∪ int` UnionError in `mergeinputargs`).
+    fn emit_tagged_pair_aggregate(
+        &mut self,
+        mir_bb: usize,
+        owner: &str,
+        disc: Variable,
+        payload: Variable,
+        dest_local: usize,
+        target: usize,
+    ) -> Result<(), LowerError> {
+        let bb_id = self.block_id[mir_bb];
+        let mut owner_path: Vec<String> = owner.split("::").map(str::to_string).collect();
+        let ctor_name = owner_path.pop().unwrap_or_default();
         let ctor_target = if owner_path.is_empty() {
             CallTarget::synthetic_transparent_ctor(ctor_name.clone())
         } else {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3370,6 +3370,16 @@ impl<'a> Lowering<'a> {
                 // `unaryop.rs:3587` (lib test
                 // `generic_handler_graphs_keep_symbolic_fnaddr_surface`).
                 let (segments, method_hint) = self.call_target_segments(mir_bb, &reg)?;
+                if self.try_lower_checked_neg(
+                    mir_bb,
+                    &segments,
+                    &args,
+                    dest_local,
+                    &call.dest.ty,
+                    target,
+                )? {
+                    return Ok(());
+                }
                 if let Some(field_read) = self.oparg_from_field_read(&reg.kind, &segments, &args) {
                     field_read
                 } else {
@@ -3993,6 +4003,126 @@ impl<'a> Lowering<'a> {
             TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
             TyRef::Dedup { id } => self.llbc.dedup_to_adt_def_id(*id),
         }
+    }
+
+    /// Lower `i64::checked_neg()` (`core::num::<Impl>::checked_neg` —
+    /// core fn bodies are Opaque in the LLBC, so the `Call` form is
+    /// permanently unliftable) to a decomposed ovfcheck shape.
+    /// Upstream `translator/simplify.py:70-108 transform_ovfcheck`
+    /// rewrites `ovfcheck(-x)` into the op's `_ovf` variant
+    /// (`flowspace/operation.py:195-200 ovfchecked`, registered by
+    /// `operation.py:466 add_operator('neg', ..., ovf=True)`), whose
+    /// OverflowError edge the caller branches on.  Rust spells that
+    /// ovfcheck as `checked_neg()` + a `Some`/`None` match, so the
+    /// equivalent decomposition writes the destination `Option<i64>`
+    /// as a synthetic aggregate (the same transparent-ctor +
+    /// `FieldWrite` chain `Rvalue::Aggregate` emits):
+    /// `__discriminant = ne(v, i64::MIN)` — negation overflows only
+    /// at `i64::MIN`, and `Option`'s `None`/`Some` tags are 0/1 — and
+    /// payload `__pos_0 = neg(v)` (wrapping; the `None` arm never
+    /// reads it).  The downstream discriminant switch and payload
+    /// downcast then lower through the ordinary enum FieldRead paths.
+    /// Returns `Ok(false)` when the call is not `checked_neg` (or the
+    /// destination's `Option` decl cannot be resolved) so the generic
+    /// `Call` lowering proceeds.
+    fn try_lower_checked_neg(
+        &mut self,
+        mir_bb: usize,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return Ok(false);
+        };
+        if first.as_str() != "core"
+            || module.as_str() != "num"
+            || impl_seg.as_str() != "<Impl>"
+            || leaf.as_str() != "checked_neg"
+        {
+            return Ok(false);
+        }
+        let [arg] = args else {
+            return Ok(false);
+        };
+        // Resolve the destination `Option` decl so the FieldWrite owner
+        // matches what `resolve_aggregate_adt` would record for a real
+        // `Some(..)` construction site of the same type.
+        let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
+            return Ok(false);
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return Ok(false);
+        };
+        // Same owner-path / ctor-leaf split `resolve_aggregate_adt`
+        // performs, so the ctor target and FieldWrite owner carry the
+        // spellings the rest of the aggregate machinery expects.
+        let owner = td.item_meta.name_path();
+        let mut owner_path: Vec<String> = owner.split("::").map(str::to_string).collect();
+        let ctor_name = owner_path.pop().unwrap_or_default();
+        let arg = arg.clone();
+        let bb_id = self.block_id[mir_bb];
+
+        let mut push_op = |graph: &mut FunctionGraph, kind: OpKind| {
+            let res = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(res.clone()),
+                kind,
+            });
+            res
+        };
+        let payload = push_op(
+            &mut self.graph,
+            OpKind::UnaryOp {
+                op: "neg".to_string(),
+                operand: arg.clone(),
+                result_ty: ValueType::Int,
+            },
+        );
+        let min = push_op(&mut self.graph, OpKind::ConstInt(i64::MIN));
+        let disc = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "ne".to_string(),
+                lhs: arg,
+                rhs: min,
+                result_ty: ValueType::Int,
+            },
+        );
+        let ctor_target = if owner_path.is_empty() {
+            CallTarget::synthetic_transparent_ctor(ctor_name.clone())
+        } else {
+            CallTarget::synthetic_transparent_ctor_with_owner(owner_path, ctor_name)
+        };
+        let res = push_op(
+            &mut self.graph,
+            OpKind::Call {
+                target: ctor_target,
+                args: Vec::new(),
+                result_ty: ValueType::Ref(Some(owner.to_string())),
+            },
+        );
+        for (name, value) in [("__discriminant", disc), ("__pos_0", payload)] {
+            self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: res.clone(),
+                    field: crate::model::FieldDescriptor {
+                        name: name.to_string(),
+                        owner_root: Some(owner.to_string()),
+                    },
+                    value,
+                    ty: ValueType::Ref(None),
+                },
+            });
+        }
+        self.local_var[dest_local] = Some(res);
+        let target_bb = self.block_id[target];
+        let link_args = self.edge_args(mir_bb, target)?;
+        self.graph.set_goto(bb_id, target_bb, link_args);
+        Ok(true)
     }
 
     fn lower_switch(

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3365,27 +3365,31 @@ impl<'a> Lowering<'a> {
                 // `unaryop.rs:3587` (lib test
                 // `generic_handler_graphs_keep_symbolic_fnaddr_surface`).
                 let (segments, method_hint) = self.call_target_segments(mir_bb, &reg)?;
-                // `CallTarget::Method` requires a receiver in `args[0]`
-                // (the flowspace adapter lowers it to `getattr(recv,
-                // method_leaf) → simple_call(bound_method, …)`).
-                // Charon's `impl_method_owner` matches both inherent
-                // methods (which carry `&self`) *and* associated
-                // functions (e.g. `RootScope::new()` — no `self` arg).
-                // Only the former actually has a receiver in `args[0]`;
-                // routing a 0-arg associated function through `Method`
-                // panics at `flowspace_adapter.rs:1045` ("Call::Method
-                // has empty args").  Fall back to the `FunctionPath`
-                // segments when there is no receiver to thread.
-                let target = match method_hint {
-                    Some((owner_root, leaf)) if !args.is_empty() => {
-                        CallTarget::method(leaf, Some(owner_root))
+                if let Some(field_read) = self.oparg_from_field_read(&reg.kind, &segments, &args) {
+                    field_read
+                } else {
+                    // `CallTarget::Method` requires a receiver in `args[0]`
+                    // (the flowspace adapter lowers it to `getattr(recv,
+                    // method_leaf) → simple_call(bound_method, …)`).
+                    // Charon's `impl_method_owner` matches both inherent
+                    // methods (which carry `&self`) *and* associated
+                    // functions (e.g. `RootScope::new()` — no `self` arg).
+                    // Only the former actually has a receiver in `args[0]`;
+                    // routing a 0-arg associated function through `Method`
+                    // panics at `flowspace_adapter.rs:1045` ("Call::Method
+                    // has empty args").  Fall back to the `FunctionPath`
+                    // segments when there is no receiver to thread.
+                    let target = match method_hint {
+                        Some((owner_root, leaf)) if !args.is_empty() => {
+                            CallTarget::method(leaf, Some(owner_root))
+                        }
+                        _ => CallTarget::FunctionPath { segments },
+                    };
+                    OpKind::Call {
+                        target,
+                        args,
+                        result_ty: result_ty.clone(),
                     }
-                    _ => CallTarget::FunctionPath { segments },
-                };
-                OpKind::Call {
-                    target,
-                    args,
-                    result_ty: result_ty.clone(),
                 }
             }
             (CallClass::Dynamic, CallFunc::Dynamic(dyn_operand)) => {
@@ -3913,6 +3917,77 @@ impl<'a> Lowering<'a> {
             return self.llbc.dedup_to_adt_def_id(id);
         }
         None
+    }
+
+    /// Lower `u32::from(<oparg value>)` — the `From<OpArg> for u32`
+    /// (`rustpython-compiler-core` `bytecode/oparg.rs:95`) and
+    /// `oparg_enum!`-synthesized `From<$Enum> for u32` impls — to the
+    /// extraction their bodies perform.  The dependency crate's bodies
+    /// are never in the local LLBC, so the `Call` form is permanently
+    /// unliftable.  Each impl is a single extraction: `self.0` for the
+    /// transparent newtype, a discriminant cast for the fieldless
+    /// enums — the same reads local code expresses as `FieldRead
+    /// __pos_0` / `FieldRead __discriminant` (the
+    /// `Rvalue::Discriminant` lowering).  Returns `None` for any other
+    /// path or shape so unrelated `from` impls keep the `Call` form.
+    fn oparg_from_field_read(
+        &self,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+    ) -> Option<OpKind> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return None;
+        };
+        if first.as_str() != "rustpython_compiler_core"
+            || module.as_str() != "oparg"
+            || impl_seg.as_str() != "<Impl>"
+            || leaf.as_str() != "from"
+        {
+            return None;
+        }
+        let [arg] = args else {
+            return None;
+        };
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return None;
+        };
+        let fd = self.llbc.fn_by_id(*id)?;
+        let src_ty = fd.signature.inputs.first()?;
+        let def_id = self.tyref_adt_def_id(src_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let owner_root = td
+            .item_meta
+            .name_path()
+            .rsplit("::")
+            .next()
+            .unwrap_or("")
+            .to_string();
+        let field = match &td.kind {
+            TypeDeclKind::Struct(fields) if fields.len() == 1 => fields[0]
+                .name
+                .clone()
+                .unwrap_or_else(|| "__pos_0".to_string()),
+            TypeDeclKind::Enum(variants) if variants.iter().all(|v| v.fields.is_empty()) => {
+                "__discriminant".to_string()
+            }
+            _ => return None,
+        };
+        Some(OpKind::FieldRead {
+            base: arg.clone(),
+            field: FieldDescriptor::new(field, Some(owner_root)),
+            ty: ValueType::Int,
+            pure: false,
+        })
+    }
+
+    /// The ADT `def_id` behind a signature [`TyRef`], whether inline
+    /// or routed through the dedup table.  `None` for non-ADT shapes.
+    fn tyref_adt_def_id(&self, ty: &TyRef) -> Option<u64> {
+        match ty {
+            TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
+            TyRef::Dedup { id } => self.llbc.dedup_to_adt_def_id(*id),
+        }
     }
 
     fn lower_switch(

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2172,9 +2172,50 @@ impl<'a> Lowering<'a> {
                 // encodes the conversion.  Genuine `Neg` / `Not` arithmetic
                 // keeps a real scalar `OpKind::UnaryOp`.
                 if unary_op_is_cast(&op_json) {
+                    // Signedness-aware source classification — `operand_value_kind`
+                    // (`tyref_to_value_type`) collapses `uN` and `iN` both to
+                    // `Int`, hiding a `usize as i64` flip; `tyref_to_attr_value_type`
+                    // keeps the signed/unsigned split.
+                    let src_attr = match &operand {
+                        Operand::Copy(p) | Operand::Move(p) => {
+                            Some(tyref_to_attr_value_type(&p.ty, self.llbc))
+                        }
+                        Operand::Const(_) => None,
+                    };
                     let src_kind = self.operand_value_kind(&operand);
                     let arg = self.resolve_operand(mir_bb, operand)?;
                     let dst_kind = tyref_to_value_type(dest_ty, self.llbc);
+                    // Signedness-flipping int cast (`w_tuple_len(obj) as i64`)
+                    // — aliasing keeps the source `r_uint` annotation on the
+                    // signed destination, tripping the SomeInteger signedness
+                    // `UnionError` (`binaryop.py:178-202`) when the length
+                    // meets a signed index.  Route the unsigned→signed flip
+                    // through `rarithmetic.intmask` (the RPython spelling of
+                    // this re-type): `rtype_intmask` coerces to `lltype.Signed`
+                    // — identity on the i64 carrier — so the value is unchanged
+                    // and the result re-types Signed.  Resolves via the Layer-3
+                    // `HOST_ENV.import_module(rpython.rlib.rarithmetic)
+                    // .module_get(intmask)` path (`flowspace_adapter.rs`).
+                    if matches!(src_attr, Some(ValueType::Unsigned))
+                        && matches!(tyref_to_attr_value_type(dest_ty, self.llbc), ValueType::Int)
+                    {
+                        let res = self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                        return Ok((
+                            Some(OpKind::Call {
+                                target: CallTarget::FunctionPath {
+                                    segments: ["rpython", "rlib", "rarithmetic", "intmask"]
+                                        .into_iter()
+                                        .map(str::to_string)
+                                        .collect(),
+                                },
+                                args: vec![arg],
+                                result_ty: ValueType::Int,
+                            }),
+                            res,
+                        ));
+                    }
                     return Ok(
                         match src_kind
                             .as_ref()

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2131,22 +2131,32 @@ impl<'a> Lowering<'a> {
                             }
                             // Same bank (or a bank pair with no host cast
                             // callable): alias the operand — except a
-                            // ptr→ptr cast onto a monomorphic-ADT
-                            // pointee, which is the upstream instance
-                            // downcast `cast_pointer(PTRTYPE, p)`;
-                            // surface it for the annotator (jtransform
-                            // re-aliases, see
-                            // [`cast_pointer_marker_op`]).
+                            // ptr→ptr cast to a registered struct root,
+                            // which narrows to `SomeInstance(root)` so a
+                            // field read on the pointee resolves (#298;
+                            // see the `Rvalue::Cast` arm for the full
+                            // rationale).
                             None => {
-                                if matches!(dst_kind, ValueType::Ref(_))
-                                    && matches!(src_kind, Some(ValueType::Ref(_)))
+                                if let ValueType::Ref(_) = dst_kind
                                     && let Some(root) =
-                                        cast_ptr_target_class_root(dest_ty, self.llbc)
+                                        tyref_class_root(dest_ty, self.llbc)
                                 {
                                     let res = self.graph.alloc_value_var_with_type(
                                         crate::model::ConcreteType::Unknown,
                                     );
-                                    (Some(cast_pointer_marker_op(root, arg)), res)
+                                    (
+                                        Some(OpKind::Call {
+                                            target: CallTarget::FunctionPath {
+                                                segments: vec![
+                                                    "__pyre_cast_instance".to_string(),
+                                                    root.clone(),
+                                                ],
+                                            },
+                                            args: vec![arg],
+                                            result_ty: ValueType::Ref(Some(root)),
+                                        }),
+                                        res,
+                                    )
                                 } else {
                                     (None, arg)
                                 }
@@ -2236,21 +2246,36 @@ impl<'a> Lowering<'a> {
             // so reuse the alias path: the cast result Variable is the
             // same as the operand Variable. `as` casts that do not
             // change the JIT-visible kind collapse this way.
-            // Exception: a `RawPtr` cast onto a monomorphic-ADT
-            // pointee (`obj as *const W_Foo`) is the upstream instance
-            // downcast `cast_pointer(PTRTYPE, p)` — surface it as the
-            // `__cast_pointer/<Root>` marker so the annotator types
-            // the result; jtransform re-aliases it (see
-            // [`cast_pointer_marker_op`]).
-            Rvalue::Cast(kind, operand, ty) => {
+            Rvalue::Cast(_kind, operand, ty) => {
                 let v = self.resolve_operand(mir_bb, operand)?;
-                if cast_kind_is_raw_ptr(&kind)
-                    && let Some(root) = cast_ptr_target_class_root(&ty, self.llbc)
+                // #298: a same-bank ptr→ptr cast to a registered struct
+                // root (`obj as *const W_CodeObject`) keeps the i64
+                // pointer carrier in place, so it would alias like above
+                // — but the result is then read like an instance of that
+                // struct (`(*p).code_ptr`), and aliasing leaves the
+                // pointer classdef-less so the field read blocks at the
+                // annotator getattr arm.  `tyref_class_root` returns
+                // `Some` only for a named-ADT pointee (None for
+                // primitives / builtin containers / generics / multi-impl
+                // type-vars), so emit a `__pyre_cast_instance` narrow
+                // whose annotator types the result `SomeInstance(root)`
+                // and whose typer folds to a `cast_pointer`.
+                if let ValueType::Ref(_) = tyref_to_value_type(&ty, self.llbc)
+                    && let Some(root) = tyref_class_root(&ty, self.llbc)
                 {
                     let res = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
-                    return Ok((Some(cast_pointer_marker_op(root, v)), res));
+                    return Ok((
+                        Some(OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                            },
+                            args: vec![v],
+                            result_ty: ValueType::Ref(Some(root)),
+                        }),
+                        res,
+                    ));
                 }
                 Ok((None, v))
             }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2199,9 +2199,14 @@ impl<'a> Lowering<'a> {
                             // which narrows to `SomeInstance(root)` so a
                             // field read on the pointee resolves (#298;
                             // see the `Rvalue::Cast` arm for the full
-                            // rationale).
+                            // rationale).  The SOURCE must already be a Ref
+                            // for this to be a genuine `cast_pointer`
+                            // (ptr→ptr); an int→ptr or unknown-source cast
+                            // is `cast_int_to_ptr` territory and aliases
+                            // instead of narrowing to an instance.
                             None => {
-                                if let ValueType::Ref(_) = dst_kind
+                                if matches!(src_kind, Some(ValueType::Ref(_)))
+                                    && let ValueType::Ref(_) = dst_kind
                                     && let Some(root) = tyref_class_root(dest_ty, self.llbc)
                                 {
                                     let res = self.graph.alloc_value_var_with_type(
@@ -2309,7 +2314,7 @@ impl<'a> Lowering<'a> {
             // so reuse the alias path: the cast result Variable is the
             // same as the operand Variable. `as` casts that do not
             // change the JIT-visible kind collapse this way.
-            Rvalue::Cast(_kind, operand, ty) => {
+            Rvalue::Cast(kind, operand, ty) => {
                 let v = self.resolve_operand(mir_bb, operand)?;
                 // #298: a same-bank ptr→ptr cast to a registered struct
                 // root (`obj as *const W_CodeObject`) keeps the i64
@@ -2322,8 +2327,14 @@ impl<'a> Lowering<'a> {
                 // primitives / builtin containers / generics / multi-impl
                 // type-vars), so emit a `__pyre_cast_instance` narrow
                 // whose annotator types the result `SomeInstance(root)`
-                // and whose typer folds to a `cast_pointer`.
-                if let ValueType::Ref(_) = tyref_to_value_type(&ty, self.llbc)
+                // and whose typer folds to a `cast_pointer`.  Gate on the
+                // raw-pointer cast kind: `lltype.cast_pointer`
+                // (`lltype.py:964-975`) is pointer-to-pointer only, and
+                // int-to-pointer is the separate `cast_int_to_ptr`
+                // analyzer, so an `addr_usize as *const Struct` reinterpret
+                // must NOT be narrowed to an instance downcast.
+                if cast_kind_is_raw_ptr(&kind)
+                    && let ValueType::Ref(_) = tyref_to_value_type(&ty, self.llbc)
                     && let Some(root) = tyref_class_root(&ty, self.llbc)
                 {
                     let res = self

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3400,6 +3400,20 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `*const T::cast_mut()` / `*mut T::cast_const()` /
+                // `<ptr>::cast()` — address-preserving pointer
+                // reinterprets the JIT models as identity (the
+                // receiver-method twin of the `CastKind::RawPtr` Rvalue
+                // → `same_as`).  Alias the destination to the receiver so
+                // the method name never reaches the rtyper as a
+                // `ptr.getattr`.
+                if args.len() == 1 && self.is_ptr_identity_cast(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // Resolve the target function's fully-qualified path
                 // through the FunId → FunDecl table. `Trait` here is
                 // Charon's "trait-bound generic resolved at extraction
@@ -3859,6 +3873,38 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::result::<Impl>::expect")
+    }
+
+    /// Pointer reinterprets `*const T::cast_mut` / `*mut T::cast_const`
+    /// / `<ptr>::cast` — address-preserving const↔mut flips and pointee
+    /// retypes.  The same i64 machine repr as the receiver, so the JIT
+    /// models them as identity, the receiver-method twin of the
+    /// `CastKind::RawPtr` Rvalue (`same_as`, [`cast_label_from_payload`]).
+    /// Gating on a `RawPtr` self excludes unrelated inherent `cast`
+    /// methods on non-pointer owners.
+    fn is_ptr_identity_cast(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        let leaf = fd
+            .item_meta
+            .name_path()
+            .rsplit("::")
+            .next()
+            .unwrap_or("")
+            .to_string();
+        if !matches!(leaf.as_str(), "cast" | "cast_mut" | "cast_const") {
+            return false;
+        }
+        fd.signature.inputs.first().is_some_and(|t| {
+            tyref_node(t, self.llbc)
+                .and_then(|n| strip_ty_wrappers(n, self.llbc))
+                .and_then(serde_json::Value::as_object)
+                .is_some_and(|o| o.contains_key("RawPtr"))
+        })
     }
 
     /// Devirtualize a callsite of the blanket

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3646,6 +3646,10 @@ impl<'a> Lowering<'a> {
                 }
                 if let Some(field_read) = self.oparg_from_field_read(&reg.kind, &segments, &args) {
                     field_read
+                } else if let Some(field_read) =
+                    self.oparg_arg_get_field_read(&reg.kind, &segments, &args)
+                {
+                    field_read
                 } else {
                     // `CallTarget::Method` requires a receiver in `args[0]`
                     // (the flowspace adapter lowers it to `getattr(recv,
@@ -4362,6 +4366,66 @@ impl<'a> Lowering<'a> {
         };
         Some(OpKind::FieldRead {
             base: arg.clone(),
+            field: FieldDescriptor::new(field, Some(owner_root)),
+            ty: ValueType::Int,
+            pure: false,
+        })
+    }
+
+    /// Lower `Arg::<T>::get(self, arg: OpArg) -> T`
+    /// (`rustpython_compiler_core::bytecode::instruction`, instruction.rs:1286)
+    /// to a direct `OpArg` payload read.  `Arg<T>` is the zero-sized
+    /// oparg marker ([`tyref_is_bytecode_arg_marker`]); the lifted
+    /// model carries it as a plain integer, so the method call's `self`
+    /// receiver surfaces as `getattr(Integer, "get")` — an attribute
+    /// the annotator cannot type (the dominant `Cannot find attribute
+    /// "get" on Integer` wall behind `complete_pending_blocks` for the
+    /// `execute_unpack_sequence` / `build_list` / `build_tuple` /
+    /// `build_map` count-argument family).  The body is
+    /// `T::try_from(u32::from(arg)).unwrap()`, and every `OpArgType`
+    /// (`VarNum` / `VarNums` / `u32`) is a transparent newtype over
+    /// `u32`, so the value's bits equal `u32::from(arg)` — the raw
+    /// operand.  That is exactly the `FieldRead __pos_0` the inverse
+    /// [`Self::oparg_from_field_read`] (`u32::from(oparg)`) emits.
+    ///
+    /// Identified by the second input being the single-field `OpArg`
+    /// struct: no other `.get` (slice / `Vec` / map) takes an `OpArg`,
+    /// and the concrete `OpArg` resolves robustly where the generic
+    /// `self: Arg<T>` marker would not.  Returns `None` for any other
+    /// `.get` so those keep the `Call` form.
+    fn oparg_arg_get_field_read(
+        &self,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+    ) -> Option<OpKind> {
+        if segments.last().map(String::as_str) != Some("get") {
+            return None;
+        }
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return None;
+        };
+        let fd = self.llbc.fn_by_id(*id)?;
+        // The `OpArg` argument (`inputs[1]` — `args[1]`, after the
+        // `self` receiver) is the payload source.
+        let oparg_ty = fd.signature.inputs.get(1)?;
+        let def_id = self.tyref_adt_def_id(oparg_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let name_path = td.item_meta.name_path();
+        if !name_path.ends_with("oparg::OpArg") {
+            return None;
+        }
+        let owner_root = name_path.rsplit("::").next().unwrap_or("").to_string();
+        let field = match &td.kind {
+            TypeDeclKind::Struct(fields) if fields.len() == 1 => fields[0]
+                .name
+                .clone()
+                .unwrap_or_else(|| "__pos_0".to_string()),
+            _ => return None,
+        };
+        let oparg_arg = args.get(1)?;
+        Some(OpKind::FieldRead {
+            base: oparg_arg.clone(),
             field: FieldDescriptor::new(field, Some(owner_root)),
             ty: ValueType::Int,
             pure: false,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1081,12 +1081,6 @@ struct Lowering<'a> {
     /// `local_var` by local and only falls back to the recorded
     /// Variable for a base/index without a backing local (a constant).
     index_elem_alias: std::collections::HashMap<usize, IndexElemAlias>,
-    /// MIR locals bound by a devirtualized infallible widening
-    /// `usize::try_from(u8|u16|u32)` call.  The value is the source
-    /// integer itself (the conversion cannot fail on 64-bit targets),
-    /// so the paired `Result::expect` on such a local also aliases it
-    /// — see [`Lowering::is_infallible_widening_try_from`].
-    infallible_result_locals: std::collections::HashSet<usize>,
     /// MIR locals whose enum discriminant is a translation-time
     /// constant: single-assignment locals bound by an always-`Ok`
     /// decomposed conversion ([`Lowering::try_lower_usize_try_from`]).
@@ -1236,7 +1230,6 @@ impl<'a> Lowering<'a> {
             positional_aggregate_locals: std::collections::HashMap::new(),
             binop_result_locals: compute_binop_result_locals(body),
             index_elem_alias: std::collections::HashMap::new(),
-            infallible_result_locals: std::collections::HashSet::new(),
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
@@ -3397,16 +3390,6 @@ impl<'a> Lowering<'a> {
 
         // Resolve arguments before deciding the call shape so receiver
         // resolution and `dyn` operand handling share the same path.
-        // The first operand's MIR local (if it is one) feeds the
-        // paired `try_from`/`expect` devirtualization below, which
-        // keys on `infallible_result_locals`.
-        let first_arg_local = call.args.first().and_then(|op| match op {
-            Operand::Move(p) | Operand::Copy(p) => match &p.kind {
-                PlaceKind::Local(i) => Some(*i as usize),
-                _ => None,
-            },
-            Operand::Const(_) => None,
-        });
         let mut args: Vec<Variable> = Vec::with_capacity(call.args.len());
         // MIR local index behind each plain-local argument, kept
         // alongside the resolved Variables so call intercepts can
@@ -3568,33 +3551,6 @@ impl<'a> Lowering<'a> {
                         self.graph
                             .alloc_value_var_with_type(crate::model::ConcreteType::Void),
                     );
-                    let target_bb = self.block_id[target];
-                    let link_args = self.edge_args(mir_bb, target)?;
-                    self.graph.set_goto(bb_id, target_bb, link_args);
-                    return Ok(());
-                }
-                // `usize::try_from(x).expect(…)` where `x` is u8/u16/
-                // u32 — a widening conversion that cannot fail on the
-                // 64-bit targets pyre supports, routed through the
-                // Opaque `ptr_try_from_impls` core impls.  `try_from`
-                // aliases its argument and records the destination
-                // local; the paired `expect` on that local unwraps by
-                // aliasing the same value.  A fallible source width
-                // never matches, so genuine error paths keep their
-                // ordinary call lowering.
-                if args.len() == 1 && self.is_infallible_widening_try_from(&reg) {
-                    self.infallible_result_locals.insert(dest_local);
-                    self.local_var[dest_local] = Some(args[0].clone());
-                    let target_bb = self.block_id[target];
-                    let link_args = self.edge_args(mir_bb, target)?;
-                    self.graph.set_goto(bb_id, target_bb, link_args);
-                    return Ok(());
-                }
-                if args.len() == 2
-                    && first_arg_local.is_some_and(|l| self.infallible_result_locals.contains(&l))
-                    && self.is_result_expect(&reg)
-                {
-                    self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -4053,41 +4009,6 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::slice::<Impl>::swap")
-    }
-
-    /// `usize::try_from` (`ptr_try_from_impls`, Opaque core code)
-    /// applied to a u8/u16/u32 source — always `Ok` when the target
-    /// is pointer-width on 64-bit, so the call aliases its argument
-    /// (see the paired `expect` handling in [`Self::lower_call`]).
-    fn is_infallible_widening_try_from(&self, reg: &RegularCall) -> bool {
-        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
-            return false;
-        };
-        let Some(fd) = self.llbc.fn_by_id(*id) else {
-            return false;
-        };
-        if fd.item_meta.name_path() != "core::convert::num::ptr_try_from_impls::<Impl>::try_from" {
-            return false;
-        }
-        fd.signature.inputs.first().is_some_and(|t| {
-            tyref_node(t, self.llbc)
-                .and_then(|n| strip_ty_wrappers(n, self.llbc))
-                .and_then(|n| n.get("Literal"))
-                .and_then(|l| l.get("UInt"))
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|w| matches!(w, "U8" | "U16" | "U32"))
-        })
-    }
-
-    /// `Result::expect` (Opaque core code) — only devirtualized when
-    /// the receiver local was bound by an infallible `try_from` above.
-    fn is_result_expect(&self, reg: &RegularCall) -> bool {
-        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
-            return false;
-        };
-        self.llbc
-            .fn_by_id(*id)
-            .is_some_and(|fd| fd.item_meta.name_path() == "core::result::<Impl>::expect")
     }
 
     /// Pointer reinterprets `*const T::cast_mut` / `*mut T::cast_const`
@@ -4845,6 +4766,12 @@ impl<'a> Lowering<'a> {
                 result_ty: ValueType::Ref(Some(owner.to_string())),
             },
         });
+        // Both decomposed fields carry integers: the `__discriminant`
+        // tag is an `i64` (matching the `Rvalue::Discriminant`
+        // `FieldRead` and the `i64` field registration) and the
+        // `__pos_0` payload is the negated / widened integer the
+        // `checked_neg` / `usize::try_from` callers materialize.  A
+        // `Ref` field type here would disagree with that registration.
         for (name, value) in [("__discriminant", disc), ("__pos_0", payload)] {
             self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                 result: None,
@@ -4855,7 +4782,7 @@ impl<'a> Lowering<'a> {
                         owner_root: Some(owner.to_string()),
                     },
                     value,
-                    ty: ValueType::Ref(None),
+                    ty: ValueType::Int,
                 },
             });
         }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3636,6 +3636,7 @@ impl<'a> Lowering<'a> {
                         )
                         .or_else(|| self.trait_into_string_alias(&segments, &args, &call.dest.ty))
                         .or_else(|| self.oparg_arg_get_alias(&reg.kind, &segments, &args))
+                        .or_else(|| self.oparg_value_alias(&segments, &args))
                     };
                 if let Some(value) = alias {
                     self.local_var[dest_local] = Some(value);
@@ -3645,9 +3646,7 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                if let Some(field_read) = self.oparg_from_field_read(&reg.kind, &segments, &args) {
-                    field_read
-                } else {
+                {
                     // `CallTarget::Method` requires a receiver in `args[0]`
                     // (the flowspace adapter lowers it to `getattr(recv,
                     // method_leaf) → simple_call(bound_method, …)`).
@@ -4307,68 +4306,6 @@ impl<'a> Lowering<'a> {
         None
     }
 
-    /// Lower `u32::from(<oparg value>)` — the `From<OpArg> for u32`
-    /// (`rustpython-compiler-core` `bytecode/oparg.rs:95`) and
-    /// `oparg_enum!`-synthesized `From<$Enum> for u32` impls — to the
-    /// extraction their bodies perform.  The dependency crate's bodies
-    /// are never in the local LLBC, so the `Call` form is permanently
-    /// unliftable.  Each impl is a single extraction: `self.0` for the
-    /// transparent newtype, a discriminant cast for the fieldless
-    /// enums — the same reads local code expresses as `FieldRead
-    /// __pos_0` / `FieldRead __discriminant` (the
-    /// `Rvalue::Discriminant` lowering).  Returns `None` for any other
-    /// path or shape so unrelated `from` impls keep the `Call` form.
-    fn oparg_from_field_read(
-        &self,
-        kind: &CallKind,
-        segments: &[String],
-        args: &[Variable],
-    ) -> Option<OpKind> {
-        let [first, .., module, impl_seg, leaf] = segments else {
-            return None;
-        };
-        if first.as_str() != "rustpython_compiler_core"
-            || module.as_str() != "oparg"
-            || impl_seg.as_str() != "<Impl>"
-            || leaf.as_str() != "from"
-        {
-            return None;
-        }
-        let [arg] = args else {
-            return None;
-        };
-        let CallKind::Fun(FunId::Regular { id }) = kind else {
-            return None;
-        };
-        let fd = self.llbc.fn_by_id(*id)?;
-        let src_ty = fd.signature.inputs.first()?;
-        let def_id = self.tyref_adt_def_id(src_ty)?;
-        let td = self.llbc.type_by_id(def_id)?;
-        let owner_root = td
-            .item_meta
-            .name_path()
-            .rsplit("::")
-            .next()
-            .unwrap_or("")
-            .to_string();
-        let field = match &td.kind {
-            TypeDeclKind::Struct(fields) if fields.len() == 1 => fields[0]
-                .name
-                .clone()
-                .unwrap_or_else(|| "__pos_0".to_string()),
-            TypeDeclKind::Enum(variants) if variants.iter().all(|v| v.fields.is_empty()) => {
-                "__discriminant".to_string()
-            }
-            _ => return None,
-        };
-        Some(OpKind::FieldRead {
-            base: arg.clone(),
-            field: FieldDescriptor::new(field, Some(owner_root)),
-            ty: ValueType::Int,
-            pure: false,
-        })
-    }
-
     /// Alias `Arg::<T>::get(self, arg: OpArg) -> T`
     /// (`rustpython_compiler_core::bytecode::instruction`, instruction.rs:1286)
     /// to its `OpArg` argument.  `Arg<T>` is the zero-sized oparg marker
@@ -4410,12 +4347,40 @@ impl<'a> Lowering<'a> {
         let oparg_ty = fd.signature.inputs.get(1)?;
         // `OpArg` is `Opaque` in the LLBC (external crate), so resolve it
         // by qualified name rather than structural shape.
-        if !adt_path_of_tyref(oparg_ty, self.llbc)
-            .is_some_and(|p| p.ends_with("oparg::OpArg"))
-        {
+        if !adt_path_of_tyref(oparg_ty, self.llbc).is_some_and(|p| p.ends_with("oparg::OpArg")) {
             return None;
         }
         args.get(1).cloned()
+    }
+
+    /// Alias the transparent `OpArgType` conversions to their single
+    /// argument.  Each oparg newtype is `#[repr(transparent)]` over
+    /// `u32` and the fieldless oparg enums carry their operand as the
+    /// discriminant, so — once the operand is modeled as an integer
+    /// ([`tyref_is_oparg`], [`oparg_arg_get_alias`]) — every conversion
+    /// below is the identity on that integer:
+    ///   * the inherent `as_u32` / `as_usize` extractors and the
+    ///     `from_u32` constructor (`newtype_oparg!`), and
+    ///   * the `From` conversions (`u32::from(oparg)` for a newtype, the
+    ///     `__discriminant` read for a fieldless enum).
+    /// Gated on the defining impl living in `bytecode::oparg` so the
+    /// generic `from` / `as_u32` / `as_usize` names cannot match
+    /// unrelated types.
+    fn oparg_value_alias(&self, segments: &[String], args: &[Variable]) -> Option<Variable> {
+        let [arg] = args else {
+            return None;
+        };
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return None;
+        };
+        if first.as_str() != "rustpython_compiler_core"
+            || module.as_str() != "oparg"
+            || impl_seg.as_str() != "<Impl>"
+            || !matches!(leaf.as_str(), "as_u32" | "as_usize" | "from_u32" | "from")
+        {
+            return None;
+        }
+        Some(arg.clone())
     }
 
     /// The ADT `def_id` behind a signature [`TyRef`], whether inline

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3261,6 +3261,28 @@ impl<'a> Lowering<'a> {
             Operand::Const(_) => None,
         });
         let mut args: Vec<Variable> = Vec::with_capacity(call.args.len());
+        // MIR local index behind each plain-local argument, kept
+        // alongside the resolved Variables so call intercepts can
+        // consult per-local lowering state
+        // (`const_discriminant_locals`).
+        let arg_locals: Vec<Option<usize>> = call
+            .args
+            .iter()
+            .map(|op| match op {
+                Operand::Copy(p) | Operand::Move(p) => match p.kind {
+                    PlaceKind::Local(i) => Some(i as usize),
+                    _ => None,
+                },
+                Operand::Const(_) => None,
+            })
+            .collect();
+        // First argument's MIR-declared type, captured before the
+        // operands are consumed — `reflexive_into_alias` compares it
+        // against the destination type.
+        let first_arg_ty: Option<TyRef> = call.args.first().and_then(|op| match op {
+            Operand::Copy(p) | Operand::Move(p) => Some(clone_tyref(&p.ty)),
+            Operand::Const(_) => None,
+        });
         for op in call.args {
             args.push(self.resolve_operand(mir_bb, op)?);
         }
@@ -3378,6 +3400,41 @@ impl<'a> Lowering<'a> {
                     &call.dest.ty,
                     target,
                 )? {
+                    return Ok(());
+                }
+                if self.try_lower_usize_try_from(
+                    mir_bb,
+                    &reg.kind,
+                    &segments,
+                    &args,
+                    dest_local,
+                    &call.dest.ty,
+                    target,
+                )? {
+                    return Ok(());
+                }
+                let alias = if let Some(payload) =
+                    self.expect_on_const_ok(&segments, &args, &arg_locals)
+                {
+                    // Identity unwrap: the receiver variable was bound
+                    // directly to the `Ok` payload, so the result is
+                    // that variable — bind and close the block with no
+                    // op emitted.
+                    Some(payload)
+                } else {
+                    self.reflexive_into_alias(
+                        &segments,
+                        &args,
+                        first_arg_ty.as_ref(),
+                        &call.dest.ty,
+                    )
+                };
+                if let Some(value) = alias {
+                    self.local_var[dest_local] = Some(value);
+                    let bb_id = self.block_id[mir_bb];
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
                 if let Some(field_read) = self.oparg_from_field_read(&reg.kind, &segments, &args) {
@@ -3639,6 +3696,15 @@ impl<'a> Lowering<'a> {
         };
         let owner_leaf = match self.resolve_impl_owner_adt_def_id(impl_payload) {
             Some(adt_def_id) => {
+                // The hint is only valid when the fn actually receives
+                // the impl owner as `self` (`Owner` / `&Owner` /
+                // `*mut Owner` first input).  Associated functions —
+                // `PyError::type_error(msg)` — have no receiver;
+                // routing them as `Method` makes the adapter getattr
+                // the method name off `args[0]` (the message string).
+                if !self.first_input_is_adt(fd, adt_def_id) {
+                    return None;
+                }
                 let td = self.llbc.type_by_id(adt_def_id)?;
                 let owner = td
                     .item_meta
@@ -3873,6 +3939,61 @@ impl<'a> Lowering<'a> {
             .trait_by_id(trait_id)
             .is_some_and(|td| td.item_meta.name_path() == "core::convert::Into");
         is_into && tyref_is_string_adt(dest_ty, self.llbc)
+    }
+
+    /// Whether the FunDecl's first signature input is the given ADT,
+    /// possibly behind reference / raw-pointer layers (`self: Owner`,
+    /// `&Owner`, `&mut Owner`, `*const/mut Owner`).  Distinguishes a
+    /// real method from an associated function of the same impl block.
+    fn first_input_is_adt(&self, fd: &FunDecl, adt_def_id: u64) -> bool {
+        let Some(first) = fd.signature.inputs.first() else {
+            return false;
+        };
+        let Some(mut v) = self.tyref_body(first) else {
+            return false;
+        };
+        loop {
+            let Some(obj) = v.as_object() else {
+                return false;
+            };
+            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+                match self.llbc.dedup_body(id) {
+                    Some(b) => {
+                        v = b;
+                        continue;
+                    }
+                    None => return false,
+                }
+            }
+            if let Some(arr) = obj
+                .get("HashConsedValue")
+                .and_then(serde_json::Value::as_array)
+                && arr.len() == 2
+            {
+                v = &arr[1];
+                continue;
+            }
+            // `{"Ref": [region, ty, kind]}` / `{"RawPtr": [ty, kind]}`.
+            if let Some(arr) = obj.get("Ref").and_then(serde_json::Value::as_array) {
+                match arr.get(1) {
+                    Some(inner) => {
+                        v = inner;
+                        continue;
+                    }
+                    None => return false,
+                }
+            }
+            if let Some(arr) = obj.get("RawPtr").and_then(serde_json::Value::as_array) {
+                match arr.first() {
+                    Some(inner) => {
+                        v = inner;
+                        continue;
+                    }
+                    None => return false,
+                }
+            }
+            return inline_adt_def_id(v) == Some(adt_def_id);
+        }
     }
 
     /// Decode the receiver type's ADT `def_id` from an `Impl` NameSeg
@@ -4223,6 +4344,55 @@ impl<'a> Lowering<'a> {
             return None;
         }
         Some(recv.clone())
+    }
+
+    /// Resolve the reflexive blanket `Into::into`
+    /// (`core::convert::<Impl>::into` where the argument's declared
+    /// type equals the destination's) to its operand.  `impl<T>
+    /// From<T> for T` makes `x.into()` an identity, but the blanket
+    /// fn's body is Opaque in the LLBC so the `Call` form is
+    /// permanently unliftable.  Upstream has no counterpart: an
+    /// identity conversion never appears as an op in RPython graphs.
+    /// Non-reflexive `into` calls (source ≠ destination type) keep
+    /// the generic `Call` form.
+    fn reflexive_into_alias(
+        &self,
+        segments: &[String],
+        args: &[Variable],
+        first_arg_ty: Option<&TyRef>,
+        dest_ty: &TyRef,
+    ) -> Option<Variable> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return None;
+        };
+        if first.as_str() != "core"
+            || module.as_str() != "convert"
+            || impl_seg.as_str() != "<Impl>"
+            || leaf.as_str() != "into"
+        {
+            return None;
+        }
+        let [arg] = args else {
+            return None;
+        };
+        let src = self.tyref_body(first_arg_ty?)?;
+        let dst = self.tyref_body(dest_ty)?;
+        (src == dst).then(|| arg.clone())
+    }
+
+    /// The resolved JSON body of a [`TyRef`], following the dedup
+    /// table.  Two `TyRef`s denote the same type iff their bodies are
+    /// structurally equal (the dedup table only dedupes identical
+    /// bodies, so mixed inline/dedup spellings still compare equal).
+    fn tyref_body<'t>(&self, ty: &'t TyRef) -> Option<&'t serde_json::Value>
+    where
+        'a: 't,
+    {
+        match ty {
+            TyRef::Inline { value: (_, v) } => Some(v),
+            TyRef::Other(v) => Some(v),
+            TyRef::Dedup { id } => self.llbc.dedup_body(*id),
+        }
     }
 
     /// The `UInt` width atom (`"U8"` / `"U32"` / `"Usize"` …) of a

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3635,6 +3635,7 @@ impl<'a> Lowering<'a> {
                             &call.dest.ty,
                         )
                         .or_else(|| self.trait_into_string_alias(&segments, &args, &call.dest.ty))
+                        .or_else(|| self.oparg_arg_get_alias(&reg.kind, &segments, &args))
                     };
                 if let Some(value) = alias {
                     self.local_var[dest_local] = Some(value);
@@ -3645,10 +3646,6 @@ impl<'a> Lowering<'a> {
                     return Ok(());
                 }
                 if let Some(field_read) = self.oparg_from_field_read(&reg.kind, &segments, &args) {
-                    field_read
-                } else if let Some(field_read) =
-                    self.oparg_arg_get_field_read(&reg.kind, &segments, &args)
-                {
                     field_read
                 } else {
                     // `CallTarget::Method` requires a receiver in `args[0]`
@@ -4372,33 +4369,35 @@ impl<'a> Lowering<'a> {
         })
     }
 
-    /// Lower `Arg::<T>::get(self, arg: OpArg) -> T`
+    /// Alias `Arg::<T>::get(self, arg: OpArg) -> T`
     /// (`rustpython_compiler_core::bytecode::instruction`, instruction.rs:1286)
-    /// to a direct `OpArg` payload read.  `Arg<T>` is the zero-sized
-    /// oparg marker ([`tyref_is_bytecode_arg_marker`]); the lifted
-    /// model carries it as a plain integer, so the method call's `self`
-    /// receiver surfaces as `getattr(Integer, "get")` — an attribute
-    /// the annotator cannot type (the dominant `Cannot find attribute
-    /// "get" on Integer` wall behind `complete_pending_blocks` for the
-    /// `execute_unpack_sequence` / `build_list` / `build_tuple` /
-    /// `build_map` count-argument family).  The body is
-    /// `T::try_from(u32::from(arg)).unwrap()`, and every `OpArgType`
-    /// (`VarNum` / `VarNums` / `u32`) is a transparent newtype over
-    /// `u32`, so the value's bits equal `u32::from(arg)` — the raw
-    /// operand.  That is exactly the `FieldRead __pos_0` the inverse
-    /// [`Self::oparg_from_field_read`] (`u32::from(oparg)`) emits.
+    /// to its `OpArg` argument.  `Arg<T>` is the zero-sized oparg marker
+    /// ([`tyref_is_bytecode_arg_marker`]) and `OpArg` is the transparent
+    /// `struct OpArg(u32)` newtype, both modeled as a plain integer (the
+    /// raw operand) — see [`tyref_is_oparg`].
+    /// The body is `T::try_from(u32::from(arg)).unwrap()`, and every
+    /// `OpArgType` (`VarNum` / `VarNums` / `u32`) is a transparent newtype
+    /// over `u32`, so the result's bits equal `u32::from(arg)` — the
+    /// argument's own integer value.  Returning `arg` (`args[1]`) directly
+    /// is the identity the marker `self` is dropped around.
     ///
-    /// Identified by the second input being the single-field `OpArg`
-    /// struct: no other `.get` (slice / `Vec` / map) takes an `OpArg`,
-    /// and the concrete `OpArg` resolves robustly where the generic
-    /// `self: Arg<T>` marker would not.  Returns `None` for any other
-    /// `.get` so those keep the `Call` form.
-    fn oparg_arg_get_field_read(
+    /// Without this the `.get` method call lowers to `getattr(Integer,
+    /// "get")` on the integer `self` marker — an attribute the annotator
+    /// cannot type (the dominant `Cannot find attribute "get" on Integer`
+    /// wall behind `complete_pending_blocks` for the opcode-dispatch
+    /// handler family, which all read their operand via `<field>.get(op_arg)`).
+    ///
+    /// Identified by the second input being the `oparg::OpArg` type: no
+    /// other `.get` (slice / `Vec` / map) takes an `OpArg`, and the
+    /// concrete `OpArg` resolves robustly where the generic `self: Arg<T>`
+    /// marker would not.  Returns `None` for any other `.get` so those
+    /// keep the `Call` form.
+    fn oparg_arg_get_alias(
         &self,
         kind: &CallKind,
         segments: &[String],
         args: &[Variable],
-    ) -> Option<OpKind> {
+    ) -> Option<Variable> {
         if segments.last().map(String::as_str) != Some("get") {
             return None;
         }
@@ -4407,29 +4406,16 @@ impl<'a> Lowering<'a> {
         };
         let fd = self.llbc.fn_by_id(*id)?;
         // The `OpArg` argument (`inputs[1]` — `args[1]`, after the
-        // `self` receiver) is the payload source.
+        // `self` receiver) is the operand value.
         let oparg_ty = fd.signature.inputs.get(1)?;
-        let def_id = self.tyref_adt_def_id(oparg_ty)?;
-        let td = self.llbc.type_by_id(def_id)?;
-        let name_path = td.item_meta.name_path();
-        if !name_path.ends_with("oparg::OpArg") {
+        // `OpArg` is `Opaque` in the LLBC (external crate), so resolve it
+        // by qualified name rather than structural shape.
+        if !adt_path_of_tyref(oparg_ty, self.llbc)
+            .is_some_and(|p| p.ends_with("oparg::OpArg"))
+        {
             return None;
         }
-        let owner_root = name_path.rsplit("::").next().unwrap_or("").to_string();
-        let field = match &td.kind {
-            TypeDeclKind::Struct(fields) if fields.len() == 1 => fields[0]
-                .name
-                .clone()
-                .unwrap_or_else(|| "__pos_0".to_string()),
-            _ => return None,
-        };
-        let oparg_arg = args.get(1)?;
-        Some(OpKind::FieldRead {
-            base: oparg_arg.clone(),
-            field: FieldDescriptor::new(field, Some(owner_root)),
-            ty: ValueType::Int,
-            pure: false,
-        })
+        args.get(1).cloned()
     }
 
     /// The ADT `def_id` behind a signature [`TyRef`], whether inline
@@ -6066,6 +6052,13 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
             other => other,
         };
     }
+    // `OpArg` is the transparent `struct OpArg(u32)` raw-operand wrapper;
+    // its external decl is `Opaque`, so it would otherwise fall to
+    // `Ref(None)` and shell to a classdef-less instance.  Model it as the
+    // bare integer operand it carries (`tyref_is_oparg`).
+    if tyref_is_oparg(ty, llbc) {
+        return ValueType::Int;
+    }
     ValueType::Ref(None)
 }
 
@@ -6236,6 +6229,34 @@ fn tyref_atomic_inner_value_type(ty: &TyRef, llbc: &Llbc) -> Option<ValueType> {
 fn tyref_is_bytecode_arg_marker(ty: &TyRef, llbc: &Llbc) -> bool {
     adt_path_of_tyref(ty, llbc)
         .is_some_and(|p| p == "rustpython_compiler_core::bytecode::instruction::Arg")
+}
+
+/// Whether a `TyRef` resolves (behind reference wrappers) to the
+/// `rustpython_compiler_core::bytecode::oparg::OpArg` newtype.  `OpArg`
+/// is the transparent `struct OpArg(u32)` raw-operand wrapper; its
+/// external decl is `Opaque` in the LLBC, so a payload row spelled
+/// through it would project to an attr the annotator cannot type.  The
+/// value is only ever the raw u32 operand (constructed from a `u32`,
+/// consumed by `Arg::get` / `u32::from`), so the lifted model carries it
+/// as a plain integer wherever it appears — matching upstream, where the
+/// bytecode operand is a bare int with no wrapper type.
+fn tyref_is_oparg(ty: &TyRef, llbc: &Llbc) -> bool {
+    let Some(node) = tyref_node(ty, llbc).and_then(|n| strip_ty_wrappers(n, llbc)) else {
+        return false;
+    };
+    let Some(id) = adt_node_def_id(node) else {
+        return false;
+    };
+    let Some(td) = llbc.type_by_id(id) else {
+        return false;
+    };
+    // Cheap leaf check before the full path-string comparison: bail
+    // unless the type's last segment is the `OpArg` ident.
+    let leaf_is_oparg = matches!(
+        td.item_meta.name.last(),
+        Some(NameSeg::Ident { ident: (s, _) }) if s == "OpArg"
+    );
+    leaf_is_oparg && td.item_meta.name_path().ends_with("oparg::OpArg")
 }
 
 /// The ADT def_id of an (already wrapper-stripped) type node, or

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3635,7 +3635,9 @@ impl<'a> Lowering<'a> {
                             &call.dest.ty,
                         )
                         .or_else(|| self.trait_into_string_alias(&segments, &args, &call.dest.ty))
-                        .or_else(|| self.oparg_arg_get_alias(&reg.kind, &segments, &args))
+                        .or_else(|| {
+                            self.oparg_arg_get_alias(&reg.kind, &segments, &args, &call.dest.ty)
+                        })
                         .or_else(|| self.oparg_value_alias(&segments, &args))
                     };
                 if let Some(value) = alias {
@@ -4334,6 +4336,7 @@ impl<'a> Lowering<'a> {
         kind: &CallKind,
         segments: &[String],
         args: &[Variable],
+        dest_ty: &TyRef,
     ) -> Option<Variable> {
         if segments.last().map(String::as_str) != Some("get") {
             return None;
@@ -4348,6 +4351,18 @@ impl<'a> Lowering<'a> {
         // `OpArg` is `Opaque` in the LLBC (external crate), so resolve it
         // by qualified name rather than structural shape.
         if !adt_path_of_tyref(oparg_ty, self.llbc).is_some_and(|p| p.ends_with("oparg::OpArg")) {
+            return None;
+        }
+        // A fieldless-enum result (`Arg::<SpecialMethod>::get`) must keep
+        // its `Ref` enum shape.  Aliasing to the bare integer operand
+        // would make the downstream `match`'s `Rvalue::Discriminant` read
+        // a `__discriminant` field off an integer base — a
+        // `getfield_gc_i_pure/id>i` opname no blackhole handler covers.
+        // The generic `fd.signature.output` is the type parameter `T`, so
+        // key off the call's concrete destination type instead.  Only the
+        // int-newtype results (`VarNum` / `u32`, whose bits *are* the
+        // operand) alias; the enum keeps the canonical `…/rd>i` read.
+        if self.tyref_is_fieldless_enum(dest_ty) {
             return None;
         }
         args.get(1).cloned()
@@ -4389,6 +4404,28 @@ impl<'a> Lowering<'a> {
         match ty {
             TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
             TyRef::Dedup { id } => self.llbc.dedup_to_adt_def_id(*id),
+        }
+    }
+
+    /// `true` when `ty` resolves to a fieldless (C-like) enum — at least
+    /// one variant and every variant carrying zero payload fields.  Such
+    /// an enum is represented by-value as its discriminant integer, so
+    /// `Rvalue::Discriminant` on it is the identity on that value (see the
+    /// `Discriminant` lowering).  Payload-carrying enums return `false`
+    /// and keep the `__discriminant` field read against their aggregate
+    /// `Ref` base.
+    fn tyref_is_fieldless_enum(&self, ty: &TyRef) -> bool {
+        let Some(def_id) = self.tyref_adt_def_id(ty) else {
+            return false;
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return false;
+        };
+        match &td.kind {
+            TypeDeclKind::Enum(variants) => {
+                !variants.is_empty() && variants.iter().all(|v| v.fields.is_empty())
+            }
+            _ => false,
         }
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3471,6 +3471,77 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<[T]>::swap(s, a, b)` over a `&mut [T]` whose base is
+                // the same `FixedObjectArray` shape the workspace index
+                // path reads.  Lower to the getarrayitem/setarrayitem
+                // decomposition: read both elements, then write each
+                // back to the other's index.  The base operand feeds the
+                // synthetic `ArrayWrite`s the MIR never spells, but every
+                // arg here is live in the call block (no cross-block
+                // rebind like the deferred `index_mut` write), so no
+                // extra liveness threading is needed.  The call returns
+                // `()`; its dead destination binds to a fresh Void var.
+                if args.len() == 3 && self.is_slice_swap_call(&reg) {
+                    let base = args[0].clone();
+                    let idx_a = args[1].clone();
+                    let idx_b = args[2].clone();
+                    let elem_a = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    let elem_b = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(elem_a.clone()),
+                        kind: OpKind::ArrayRead {
+                            base: base.clone(),
+                            index: idx_a.clone(),
+                            item_ty: ValueType::Ref(None),
+                            array_type_id: None,
+                            nolength: false,
+                        },
+                    });
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(elem_b.clone()),
+                        kind: OpKind::ArrayRead {
+                            base: base.clone(),
+                            index: idx_b.clone(),
+                            item_ty: ValueType::Ref(None),
+                            array_type_id: None,
+                            nolength: false,
+                        },
+                    });
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: None,
+                        kind: OpKind::ArrayWrite {
+                            base: base.clone(),
+                            index: idx_a,
+                            value: elem_b,
+                            item_ty: ValueType::Ref(None),
+                            array_type_id: None,
+                            nolength: false,
+                        },
+                    });
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: None,
+                        kind: OpKind::ArrayWrite {
+                            base,
+                            index: idx_b,
+                            value: elem_a,
+                            item_ty: ValueType::Ref(None),
+                            array_type_id: None,
+                            nolength: false,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(
+                        self.graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Void),
+                    );
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `usize::try_from(x).expect(…)` where `x` is u8/u16/
                 // u32 — a widening conversion that cannot fail on the
                 // 64-bit targets pyre supports, routed through the
@@ -3940,6 +4011,20 @@ impl<'a> Lowering<'a> {
     /// to `ArrayRead`/`ArrayWrite` by the caller.
     fn is_workspace_index_call(&self, reg: &RegularCall) -> bool {
         is_workspace_index_regular(reg, self.llbc)
+    }
+
+    /// `<[T]>::swap(s, a, b)` (`core::slice::<Impl>::swap`) — an
+    /// in-place element exchange through a `&mut [T]`.  The slice base
+    /// is the same `FixedObjectArray` shape `is_workspace_index_call`
+    /// reads, so the callsite lowers to the getarrayitem/setarrayitem
+    /// decomposition rather than residualizing the Opaque core body.
+    fn is_slice_swap_call(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::slice::<Impl>::swap")
     }
 
     /// `usize::try_from` (`ptr_try_from_impls`, Opaque core code)

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3925,6 +3925,36 @@ impl<'a> Lowering<'a> {
         let discr_var = self.resolve_operand(mir_bb, discr)?;
         match targets {
             SwitchTargets::If(then_bb, else_bb) => {
+                // Constant-bool discriminant: take the known arm
+                // unconditionally.  `flowcontext.py:364-367
+                // FlowContext.guessbool` returns a Constant condition's
+                // value directly instead of forking the recorder, so a
+                // translation-time `const` gate like
+                // `if WITHPREBUILTINT { ... }` leaves no branch in the
+                // upstream graph.  The discriminant here is a fresh var
+                // whose defining op sits in this same block when the
+                // read folded to a constant (`static_addr_op` /
+                // `global_literal_init_op` chain); the untaken target
+                // stays in `block_id` but drops out via the adapter's
+                // reachability prune.
+                let const_cond = self
+                    .graph
+                    .block(bb_id)
+                    .operations
+                    .iter()
+                    .rev()
+                    .find(|op| op.result.as_ref() == Some(&discr_var))
+                    .and_then(|op| match op.kind {
+                        OpKind::ConstBool(b) => Some(b),
+                        _ => None,
+                    });
+                if let Some(cond) = const_cond {
+                    let taken = if cond { then_bb } else { else_bb };
+                    let args = self.edge_args(mir_bb, taken as usize)?;
+                    self.graph
+                        .set_goto(bb_id, self.block_id[taken as usize], args);
+                    return Ok(());
+                }
                 // Route through `set_branch` so the cond gets the
                 // upstream `bool` UnaryOp wrap before becoming the
                 // exitswitch (flowcontext.py:756

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -258,7 +258,21 @@ fn is_known_lowering_gap(msg: &str) -> bool {
     // it classifies the residual failure as a tracked degradation (the
     // function becomes a residual call) rather than a build-failing
     // regression.
-    msg.contains("uninitialised local")
+    if msg.contains("uninitialised local") {
+        return true;
+    }
+    // A scoped (`execute_*` family) Result-of-PyError wrapper whose body
+    // is a pure tail-forward of an *unscoped* Result-of-PyError callee
+    // (`let step = executor.method()?; Ok(step)` where `method` is not in
+    // `RESULT_EXC_LOWERING_SCOPE`).  The forward collapses to a direct
+    // returnblock link with no `Ok`/`Err` shell, so the callee rule finds
+    // nothing to rewrite and the caller rule never saw a scoped call —
+    // `result_exc::lower_result_exc_returns` reports "no rewritable
+    // returns".  The exception-link lowering cannot model this shape, so
+    // the wrapper degrades to a residual call (the trivial forward runs
+    // unchanged at the interpreter level); the inner method still JITs
+    // through its own scoped callees.
+    msg.contains("no rewritable returns")
 }
 
 pub fn build_semantic_program_from_llbc(
@@ -1073,6 +1087,21 @@ struct Lowering<'a> {
     /// so the paired `Result::expect` on such a local also aliases it
     /// — see [`Lowering::is_infallible_widening_try_from`].
     infallible_result_locals: std::collections::HashSet<usize>,
+    /// MIR locals whose enum discriminant is a translation-time
+    /// constant: single-assignment locals bound by an always-`Ok`
+    /// decomposed conversion ([`Lowering::try_lower_usize_try_from`]).
+    /// `Rvalue::Discriminant` on such a local emits `ConstInt(tag)`
+    /// instead of the synthetic FieldRead, which lets the
+    /// `lower_switch` Constant fold drop the statically dead
+    /// `Err`/panic arm even though MIR calls terminate their block
+    /// (the switch always sits in a successor block).  Only locals
+    /// outside [`Lowering::multi_assigned_locals`] enter this map, so
+    /// a re-bound local can never carry a stale tag.
+    const_discriminant_locals: std::collections::HashMap<usize, i64>,
+    /// MIR locals assigned more than once anywhere in the body
+    /// (statement assigns + call destinations).  Guard set for
+    /// [`Lowering::const_discriminant_locals`].
+    multi_assigned_locals: std::collections::HashSet<usize>,
     /// Result `Variable`s of calls to `RESULT_EXC_LOWERING_SCOPE`
     /// callees whose declared result is `Result<T, PyError>`.  Each
     /// heads a `Try::branch` diamond that
@@ -1208,6 +1237,8 @@ impl<'a> Lowering<'a> {
             binop_result_locals: compute_binop_result_locals(body),
             index_elem_alias: std::collections::HashMap::new(),
             infallible_result_locals: std::collections::HashSet::new(),
+            const_discriminant_locals: std::collections::HashMap::new(),
+            multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
         })
     }
@@ -4483,12 +4514,10 @@ impl<'a> Lowering<'a> {
         // performs, so the ctor target and FieldWrite owner carry the
         // spellings the rest of the aggregate machinery expects.
         let owner = td.item_meta.name_path();
-        let mut owner_path: Vec<String> = owner.split("::").map(str::to_string).collect();
-        let ctor_name = owner_path.pop().unwrap_or_default();
         let arg = arg.clone();
         let bb_id = self.block_id[mir_bb];
 
-        let mut push_op = |graph: &mut FunctionGraph, kind: OpKind| {
+        let push_op = |graph: &mut FunctionGraph, kind: OpKind| {
             let res = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
             graph.block_mut(bb_id).operations.push(SpaceOperation {
                 result: Some(res.clone()),
@@ -4808,14 +4837,17 @@ impl<'a> Lowering<'a> {
         } else {
             CallTarget::synthetic_transparent_ctor_with_owner(owner_path, ctor_name)
         };
-        let res = push_op(
-            &mut self.graph,
-            OpKind::Call {
+        let res = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+            result: Some(res.clone()),
+            kind: OpKind::Call {
                 target: ctor_target,
                 args: Vec::new(),
                 result_ty: ValueType::Ref(Some(owner.to_string())),
             },
-        );
+        });
         for (name, value) in [("__discriminant", disc), ("__pos_0", payload)] {
             self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                 result: None,
@@ -4834,7 +4866,7 @@ impl<'a> Lowering<'a> {
         let target_bb = self.block_id[target];
         let link_args = self.edge_args(mir_bb, target)?;
         self.graph.set_goto(bb_id, target_bb, link_args);
-        Ok(true)
+        Ok(())
     }
 
     fn lower_switch(
@@ -5047,6 +5079,33 @@ fn compute_binop_result_locals(body: &Unstructured) -> std::collections::HashSet
         }
     }
     set
+}
+
+/// MIR locals assigned more than once anywhere in `body` — statement
+/// assigns plus call destinations.  See
+/// [`Lowering::multi_assigned_locals`].
+fn compute_multi_assigned_locals(body: &Unstructured) -> std::collections::HashSet<usize> {
+    let mut counts: std::collections::HashMap<usize, u32> = std::collections::HashMap::new();
+    let mut bump = |place: &Place| {
+        if let PlaceKind::Local(i) = place.kind {
+            *counts.entry(i as usize).or_insert(0) += 1;
+        }
+    };
+    for bb in &body.body {
+        for stmt in &bb.statements {
+            if let Ok(StmtKind::Assign(place, _)) = stmt.stmt_kind() {
+                bump(&place);
+            }
+        }
+        if let Ok(TermKind::Call { call, .. }) = bb.term() {
+            bump(&call.dest);
+        }
+    }
+    counts
+        .into_iter()
+        .filter(|(_, c)| *c > 1)
+        .map(|(i, _)| i)
+        .collect()
 }
 
 /// Whether a statically-resolved [`RegularCall`] is a workspace

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2680,7 +2680,12 @@ impl<'a> Lowering<'a> {
                                 base,
                                 field: FieldDescriptor::new(
                                     format!("__pos_{idx}"),
-                                    Some("Adt".to_string()),
+                                    // Same spelling the construction-side
+                                    // FieldWrite chain records for builtin
+                                    // tuple aggregates (`aggregate_ctor_name`
+                                    // id atom), so read and write attrs key
+                                    // under one owner.
+                                    Some("Tuple".to_string()),
                                 ),
                                 ty,
                                 pure: false,
@@ -4850,6 +4855,32 @@ fn aggregate_ctor_name(kind: &serde_json::Value) -> String {
         return s.to_string();
     }
     if let Some(obj) = kind.as_object() {
+        // `{"Adt": [{"id": "Tuple" | {"Builtin": "Array"}}, ...]}` — an
+        // aggregate whose type id is a builtin container atom rather
+        // than a resolvable ADT def_id.  Name the placeholder after the
+        // id atom so every tuple/array site shares one spelling; the
+        // wrapper key "Adt" would mint a fresh same-named class per
+        // site (the adapter's bare-leaf arm does not intern), and two
+        // `()` values meeting at a join then fail to union ("RPython
+        // cannot unify instances with no common base class").
+        if let Some(id) = obj
+            .get("Adt")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|arr| arr.first())
+            .and_then(serde_json::Value::as_object)
+            .and_then(|m| m.get("id"))
+        {
+            if let Some(atom) = id.as_str() {
+                return atom.to_string();
+            }
+            if let Some(builtin) = id
+                .as_object()
+                .and_then(|m| m.get("Builtin"))
+                .and_then(serde_json::Value::as_str)
+            {
+                return builtin.to_string();
+            }
+        }
         if let Some(k) = obj.keys().next() {
             return k.clone();
         }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2138,8 +2138,7 @@ impl<'a> Lowering<'a> {
                             // rationale).
                             None => {
                                 if let ValueType::Ref(_) = dst_kind
-                                    && let Some(root) =
-                                        tyref_class_root(dest_ty, self.llbc)
+                                    && let Some(root) = tyref_class_root(dest_ty, self.llbc)
                                 {
                                     let res = self.graph.alloc_value_var_with_type(
                                         crate::model::ConcreteType::Unknown,
@@ -5708,14 +5707,6 @@ fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
 }
 
 fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
-    // Atomic wrappers type as their inner value; integer widths collapse
-    // to `Int` here, matching the literal-int handling below.
-    if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
-        return match inner {
-            ValueType::Unsigned => ValueType::Int,
-            other => other,
-        };
-    }
     // The HashConsedValue arm carries the body inline; primitives
     // typically land here.  The Deduplicated arm carries only an
     // ID; consult the dedup-body index to recover the inline shape
@@ -5773,6 +5764,16 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
             }
         }
     }
+    // Non-`Literal` (ADT / pointer / tuple) shapes only.  Atomic wrappers
+    // type as their inner value; integer widths collapse to `Int` here,
+    // matching the literal-int handling above.  Checked after the cheap
+    // `Literal` fast-path so primitive operands never pay the lookup.
+    if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
+        return match inner {
+            ValueType::Unsigned => ValueType::Int,
+            other => other,
+        };
+    }
     ValueType::Ref(None)
 }
 
@@ -5789,12 +5790,6 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
 /// slice, array, `Box`/`Rc`/`Arc` wrapper) folds to `Ref(None)` whose
 /// someshell ignores the payload.
 fn tyref_to_attr_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
-    // Atomic wrappers register as their inner value, keeping the
-    // signed/unsigned split so `AtomicUsize` shells to `SomeInteger {
-    // unsigned: true }` like a bare `usize` field.
-    if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
-        return inner;
-    }
     let value = match ty {
         TyRef::Inline { value: (_, v) } => v,
         TyRef::Other(v) => v,
@@ -5830,6 +5825,14 @@ fn tyref_to_attr_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
                 return ValueType::Float;
             }
         }
+    }
+    // Non-`Literal` (ADT / pointer / tuple) shapes only.  Atomic wrappers
+    // type as their inner value; unlike [`tyref_to_value_type`] the
+    // signed/unsigned split is kept here (`AtomicUsize` → `Unsigned`) so
+    // the per-field someshell matches the inner scalar.  Checked after
+    // the cheap `Literal` fast-path so primitive fields never pay it.
+    if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
+        return inner;
     }
     ValueType::Ref(None)
 }
@@ -5898,11 +5901,29 @@ fn adt_path_of_tyref(ty: &TyRef, llbc: &Llbc) -> Option<String> {
 /// ranges are plain int fields, so a field of one types as that inner
 /// value and its `load`/`store` fold to it (`is_atomic_load`).
 fn tyref_atomic_inner_value_type(ty: &TyRef, llbc: &Llbc) -> Option<ValueType> {
-    let path = adt_path_of_tyref(ty, llbc)?;
-    if !path.contains("::sync::atomic::") {
+    let node = strip_ty_wrappers(tyref_node(ty, llbc)?, llbc)?;
+    let id = adt_node_def_id(node)?;
+    let name = &llbc.type_by_id(id)?.item_meta.name;
+    // Cheap leaf check first — no path-string allocation (unlike
+    // `name_path` / `adt_path_of_tyref`).  This runs on the hot
+    // `tyref_to_value_type` fallback path, so it must stay
+    // allocation-free: bail before the module scan unless the type's
+    // last segment is an `Atomic*` ident.
+    let leaf = match name.last()? {
+        NameSeg::Ident { ident: (s, _) } => s.as_str(),
+        NameSeg::Other(_) => return None,
+    };
+    if !leaf.starts_with("Atomic") {
         return None;
     }
-    let leaf = path.rsplit("::").next().unwrap_or(&path);
+    // Confirm std's `core::sync::atomic` module so a user type
+    // coincidentally named `Atomic*` does not match.
+    let in_atomic_mod = name
+        .iter()
+        .any(|s| matches!(s, NameSeg::Ident { ident: (id, _) } if id == "atomic"));
+    if !in_atomic_mod {
+        return None;
+    }
     match leaf {
         "AtomicPtr" => Some(ValueType::Ref(None)),
         "AtomicBool" => Some(ValueType::Bool),

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5130,7 +5130,10 @@ fn compute_index_write_extra_live(body: &Unstructured, llbc: &Llbc) -> Vec<Vec<u
         };
         index_call.insert(
             p as usize,
-            (operand_local(call.args.first()), operand_local(call.args.get(1))),
+            (
+                operand_local(call.args.first()),
+                operand_local(call.args.get(1)),
+            ),
         );
     }
     let mut extra = vec![Vec::new(); body.body.len()];

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2749,6 +2749,42 @@ impl<'a> Lowering<'a> {
                     return Ok(res);
                 }
                 let segments = self.global_segments(mir_bb, id)?;
+                // A `PyType` singleton static (`&SLICE_TYPE`): narrow the
+                // raw address through `__pyre_cast_instance["PyType"]` so
+                // the read types `SomeInstance("PyType")`, matching the
+                // `(*obj).ob_type` field-read.  The bare `ConstInt` address
+                // would pair `IntegerRepr` against that field's
+                // `InstanceRepr` and block `rtype_is_` on the
+                // `ob_type == &TYPE` pointer-identity chain — the same
+                // narrow `obj as *const RegisteredStruct` already uses
+                // (#298).
+                if let Some(addr) = self.pytype_static_addr(&segments) {
+                    let bb_id = self.block_id[mir_bb];
+                    let raw = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(raw.clone()),
+                        kind: OpKind::ConstRefAddr(addr),
+                    });
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec![
+                                    "__pyre_cast_instance".to_string(),
+                                    "PyType".to_string(),
+                                ],
+                            },
+                            args: vec![raw],
+                            result_ty: ValueType::Ref(Some("PyType".to_string())),
+                        },
+                    });
+                    return Ok(res);
+                }
                 let op = self
                     .static_addr_op(&segments)
                     .or_else(|| self.const_eval_global(id))
@@ -3043,17 +3079,33 @@ impl<'a> Lowering<'a> {
     fn static_addr_op(&self, segments: &[String]) -> Option<OpKind> {
         let full = segments.join("::");
         let stripped = strip_crate_prefix(&full);
-        for (key, addr) in self.static_addrs.pytypes {
-            if static_key_matches(&full, &stripped, key) {
-                return Some(OpKind::ConstInt(*addr));
-            }
-        }
         for (key, addr) in self.static_addrs.refs {
             if static_key_matches(&full, &stripped, key) {
                 return Some(OpKind::ConstRefAddr(*addr));
             }
         }
         None
+    }
+
+    /// Address of a `pytypes`-bucket host static — a `PyType` singleton
+    /// (`&SLICE_TYPE`, `&INT_TYPE`, …).  The `Global` reader lowers these
+    /// to a `__pyre_cast_instance["PyType"]` narrow of the raw address
+    /// (a typed instance pointer) rather than the bare `ConstInt` the
+    /// `refs` siblings avoid: a `PyType` static is the same kind of value
+    /// as the `(*obj).ob_type` field-read it is compared against, so it
+    /// must type `SomeInstance("PyType")` for `rtype_is_` (pointer
+    /// identity) to lower the `ob_type == &TYPE` chain
+    /// (`is_slice` / `is_cell` / `is_range`).  `jit_static_pytype_addrs`
+    /// puts only `PyType` statics in this bucket, so the root is always
+    /// `"PyType"`.
+    fn pytype_static_addr(&self, segments: &[String]) -> Option<i64> {
+        let full = segments.join("::");
+        let stripped = strip_crate_prefix(&full);
+        self.static_addrs
+            .pytypes
+            .iter()
+            .find(|(key, _)| static_key_matches(&full, &stripped, key))
+            .map(|(_, addr)| *addr)
     }
 
     /// Evaluate a global's initializer to its literal when the body is

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2180,6 +2180,10 @@ pub fn clear_unreachable_blocks(graph: &mut FunctionGraph) {
             block.exits.clear();
             block.inputargs.clear();
             block.exitswitch = None;
+            // Drop the locals snapshot too: a retained framestate keeps
+            // variable references alive into later analysis passes, which
+            // defeats the unreachable-block drain.
+            block.framestate = None;
         }
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1193,6 +1193,46 @@ pub(crate) fn populate_call_registry_from_call_graphs(
             }
         }
     }
+    // Pass 3 — make impl methods visible in their owner's class dict.
+    // RPython's ClassDesc reads methods straight off the class object
+    // (`classdesc.py:808-817 find_source_for` → `cls.__dict__[name]`):
+    // a Python class object already carries its functions as members
+    // when annotation starts.  Pyre's struct-root class objects are
+    // minted with no members (`Bookkeeper::intern_class_by_qualname`),
+    // so a receiver method call — `CallTarget::Method` lowers to
+    // `getattr(recv, name)` + `simple_call`
+    // (`flowspace_adapter.rs:1357`) — found no attribute source and
+    // blocked.  Registering each `[owner, method]` registry entry's
+    // user-function HostObject as a class member completes the
+    // analogue: `find_source_for` imports it into the classdict as a
+    // Constant, and `s_get_value` binds it under the classdef
+    // (`bind_callables_under` → MethodDesc) whose `cachedgraph` hits
+    // the pass-2 prefill.  Owner names are gated on the struct-field
+    // registry (module and trait leaves are never type roots), and a
+    // same-named instance field wins — a function source for a field
+    // attribute would union-conflict in `generalize_attr`.
+    let bk = registry.bookkeeper();
+    for (key, _graph, entry) in &pending {
+        // `CallPath::for_impl_method` splits the module-qualified owner
+        // ("pyframe::PyFrame" → [pyframe, PyFrame, method]), so the
+        // owner is the second-to-last segment.  Free-function paths
+        // ([module, foo]) put a module there, and modules are never
+        // type roots — the struct-field-registry gate filters them.
+        let segs = key.segments();
+        let [.., owner, method] = segs else {
+            continue;
+        };
+        if !bk.is_pyre_struct_root(owner) || bk.pyre_struct_root_has_field(owner, method) {
+            continue;
+        }
+        let class_host = bk.intern_class_by_qualname(owner);
+        if class_host.class_get(method).is_none() {
+            class_host.class_set(
+                method.clone(),
+                crate::flowspace::model::ConstValue::HostObject(entry.host_object.clone()),
+            );
+        }
+    }
     Ok(())
 }
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -850,24 +850,6 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // a divergence.  Skip to the legacy walker until the pair is
         // ported.
         || msg.contains("no upstream pair(s1, s2).union() handler in current subset")
-        // Integer-signedness `UnionError` (`binaryop.py:178-202`
-        // `pairtype(SomeInteger, SomeInteger).union`): a signed and an
-        // unsigned `SomeInteger` meet and the signed side is not
-        // provably `nonneg`, which upstream raises uncaught.  The
-        // production hitter is a length-vs-index mix —
-        // `w_tuple_getitem`'s `w_tuple_len(obj) as i64` then `index +
-        // len`: `w_tuple_len` returns `usize` (annotated `r_uint`), and
-        // `front::mir` lowers the same-bank `usize as i64` cast as a
-        // pure operand alias (every int-width cast keeps the i64
-        // carrier in place), so the length keeps its `r_uint`
-        // annotation instead of converting to a `nonneg` Signed the way
-        // RPython's `intmask(r_uint(...))` would.  Adding it to a signed
-        // `index` (`nonneg=False`) then trips the signedness union.
-        // Skip to the legacy walker until the front-end models the
-        // unsigned↔signed cast as an `intmask`/`r_uint` re-typing op
-        // rather than a bare alias.
-        || msg.contains("of the same signedness")
-        || msg.contains("cannot unify these integer types")
         // `InstanceRepr.getfield` walking the `rbase` chain before the
         // repr's deferred `setup()` ran (upstream drains pending
         // setups via `call_all_setups`, rtyper.py:198, after every

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1132,14 +1132,15 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // (the `ExtRegistryEntry.compute_result_annotation` shape) so
         // callers annotate the declared unit/bool result and the
         // codewriter emits the residual call via the fn's registered
-        // C ABI address (`pyre/jit_fnaddr.rs`).  Non-unit/bool returns
+        // C ABI address (`pyre/jit_fnaddr.rs`).  Non-scalar returns
         // fall through to the normal lift — no current marker needs
-        // them, and the stub builder's scalar coverage is unaudited
-        // for that case.
+        // them, and the stub builder's coverage is unaudited for that
+        // case.
         if graph.hints.iter().any(|h| h == "dont_look_inside") {
             let return_lltype = match graph.return_type.as_deref() {
                 None | Some("()") => Some(LowLevelType::Void),
                 Some("bool") => Some(LowLevelType::Bool),
+                Some("i64") => Some(LowLevelType::Signed),
                 _ => None,
             };
             if let Some(return_lltype) = return_lltype

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -924,6 +924,17 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // DictRepr, rrange.py iterator reprs, …) are not ported yet;
         // the legacy walker handles such graphs until each repr lands.
         || msg.contains("rtyper_makerepr — port rpython/rtyper/")
+        // `ClassRepr` / `InstanceRepr` accessors that require a
+        // completed `_setup_repr` (`rbase` populated, rclass.py:273-274)
+        // reached through a path that never ran `Repr::setup()` on the
+        // repr.  Upstream's `rtyper.getrepr` always queues `setup()`
+        // before handing the repr out; pyre's host-struct-seeded
+        // receivers (`*mut PyObject` params with a registry classdef)
+        // can reach class-field reads through reprs minted outside
+        // that queue.  Setup-ordering port gap — fall back to the
+        // legacy walker until the getrepr/setup chain covers these
+        // roots.
+        || msg.contains("rbase missing — call setup() first")
         // `BrokenReprTyperError` (`rmodel.py:42-44`, ported at
         // `rmodel.rs:449-456`): a Repr whose `setup()` failed earlier
         // is re-requested and refuses to half-initialize.  In the

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -901,6 +901,26 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // threading misses a name in the predecessor link; the
         // annotator cannot merge `None` annotations.
         || msg.contains("inputarg lacks annotation")
+        // Unported `rtyper_makerepr` arms (`rmodel.rs:2895-2965`
+        // SomeList / SomeDict / SomeIterator / SomeByteArray /
+        // SomeObject) surface bare `MissingRTypeOperation` messages of
+        // the form "<Some*>.rtyper_makerepr — port rpython/rtyper/…"
+        // WITHOUT the trait helper's "unimplemented operation:" prefix
+        // (`rmodel.rs:817-822`), so the substring above does not
+        // absorb them.  Container reprs (rlist.py ListRepr, rdict.py
+        // DictRepr, rrange.py iterator reprs, …) are not ported yet;
+        // the legacy walker handles such graphs until each repr lands.
+        || msg.contains("rtyper_makerepr — port rpython/rtyper/")
+        // `BrokenReprTyperError` (`rmodel.py:42-44`, ported at
+        // `rmodel.rs:449-456`): a Repr whose `setup()` failed earlier
+        // is re-requested and refuses to half-initialize.  In the
+        // per-graph census a Skipped subject can leave a shared
+        // session `ClassRepr` in the BROKEN state; the next graph
+        // touching the same repr then surfaces this message.  It is a
+        // secondary echo of the root failure (itself Skip-classified
+        // above), not an independent cause — absorb it so one broken
+        // repr does not fatal every later graph in the session.
+        || msg.contains("cannot setup already failed Repr")
         // `AnnotatorError: immutablevalue(HostObject` is not
         // Skip-classified for `SyntheticTransparentCtor` (Ok/Err/Some/
         // None).  The adapter emits `HostObject::new_class(name, [])`

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -901,6 +901,19 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // threading misses a name in the predecessor link; the
         // annotator cannot merge `None` annotations.
         || msg.contains("inputarg lacks annotation")
+        // `rtyper.py:815 convertvar` TyperError — no pairtype
+        // convert_from_to edge between the two reprs.  The live hitter
+        // is generic-enum payload conflation: the front registers ONE
+        // flat class per enum (`Result.Ok`) with first-writer-wins
+        // field rows, so two monomorphic instantiations (`Result<Tuple,
+        // _>` vs `Result<Option<_>, _>`) share one `__pos_0` attr and
+        // the second write needs an unrelated-classdef conversion
+        // (`Option.None` → `Tuple`) that
+        // `pair_instance_instance_convert_from_to` correctly answers
+        // NotImplemented for (rclass.py:1054-1055).  Skip until
+        // per-instantiation variant classes (generic payload
+        // monomorphization) land.
+        || msg.contains("don't know how to convert from")
         // Unported `rtyper_makerepr` arms (`rmodel.rs:2895-2965`
         // SomeList / SomeDict / SomeIterator / SomeByteArray /
         // SomeObject) surface bare `MissingRTypeOperation` messages of

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -850,6 +850,24 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // a divergence.  Skip to the legacy walker until the pair is
         // ported.
         || msg.contains("no upstream pair(s1, s2).union() handler in current subset")
+        // Integer-signedness `UnionError` (`binaryop.py:178-202`
+        // `pairtype(SomeInteger, SomeInteger).union`): a signed and an
+        // unsigned `SomeInteger` meet and the signed side is not
+        // provably `nonneg`, which upstream raises uncaught.  The
+        // production hitter is a length-vs-index mix —
+        // `w_tuple_getitem`'s `w_tuple_len(obj) as i64` then `index +
+        // len`: `w_tuple_len` returns `usize` (annotated `r_uint`), and
+        // `front::mir` lowers the same-bank `usize as i64` cast as a
+        // pure operand alias (every int-width cast keeps the i64
+        // carrier in place), so the length keeps its `r_uint`
+        // annotation instead of converting to a `nonneg` Signed the way
+        // RPython's `intmask(r_uint(...))` would.  Adding it to a signed
+        // `index` (`nonneg=False`) then trips the signedness union.
+        // Skip to the legacy walker until the front-end models the
+        // unsigned↔signed cast as an `intmask`/`r_uint` re-typing op
+        // rather than a bare alias.
+        || msg.contains("of the same signedness")
+        || msg.contains("cannot unify these integer types")
         // `InstanceRepr.getfield` walking the `rbase` chain before the
         // repr's deferred `setup()` ran (upstream drains pending
         // setups via `call_all_setups`, rtyper.py:198, after every

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1246,6 +1246,12 @@ pub fn translate_op(
                     // the `__pyre_cast_instance` HOST_ENV singleton so its
                     // Arc identity matches the `BUILTIN_TYPER` key.
                     if segments.len() == 2 && segments[0] == "__pyre_cast_instance" {
+                        if arg_hls.len() != 1 {
+                            return Err(TyperError::message(format!(
+                                "__pyre_cast_instance requires exactly one operand, got {}",
+                                arg_hls.len()
+                            )));
+                        }
                         let callable_host = HOST_ENV
                             .lookup_builtin("__pyre_cast_instance")
                             .ok_or_else(|| {
@@ -1282,6 +1288,12 @@ pub fn translate_op(
                         && segments[2] == "<Impl>"
                         && segments[3] == "len"
                     {
+                        if arg_hls.len() != 1 {
+                            return Err(TyperError::message(format!(
+                                "core::slice::<Impl>::len requires exactly one receiver arg, got {}",
+                                arg_hls.len()
+                            )));
+                        }
                         let mut iter = arg_hls.into_iter();
                         let arg = iter.next().ok_or_else(|| {
                             TyperError::message(

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1230,6 +1230,32 @@ pub fn translate_op(
                         call_args.extend(arg_hls);
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
+                    // `<[T]>::len(slice)` — the slice-receiver `.len()`
+                    // method call.  Rust lowers `slice.len()` to a MIR
+                    // call to `core::slice::<impl [T]>::len`, not to the
+                    // `Rvalue::Len` that `front/mir.rs` lowers to a
+                    // `__len` synthetic.  There is no source body for the
+                    // intrinsic to register, so route it to the rtyper's
+                    // `len` operation (`rtyper.rs:2016 "len" arm` →
+                    // `Repr.rtype_len`), the same dispatch upstream
+                    // `op.len(v)` reaches via `unaryop.py:867-870`.  The
+                    // receiver annotates as `SomeList` (slices map to
+                    // `SomeList` in `bookkeeper`), so `rtype_len` lands on
+                    // the list repr's `ll_length` lowering.
+                    if segments.len() == 4
+                        && segments[0] == "core"
+                        && segments[1] == "slice"
+                        && segments[2] == "<Impl>"
+                        && segments[3] == "len"
+                    {
+                        let mut iter = arg_hls.into_iter();
+                        let arg = iter.next().ok_or_else(|| {
+                            TyperError::message(
+                                "core::slice::<Impl>::len requires a receiver arg".to_string(),
+                            )
+                        })?;
+                        return Ok(vec![FlowspaceOp::new("len", vec![arg], result)]);
+                    }
                     let key =
                         crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments(
                             segments.iter().cloned(),

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1410,22 +1410,23 @@ pub fn translate_op(
                     // interned: a bare variant name like `Ok` is ambiguous
                     // across enums, so interning it would conflate distinct
                     // classes onto one `ClassDesc`.  Exception: the fixed
-                    // aggregate-kind placeholder tags (`Adt` for tuples /
-                    // unresolved ADTs, `Array`, `Closure` — see
-                    // `front::mir::aggregate_ctor_name`) are not variant
-                    // names, and the construction-side FieldWrite chain
-                    // shares the same tag as `owner_root` with the
-                    // field-projection side (which resolves it through
-                    // `getuniqueclassdef_for_struct_root` →
-                    // `intern_class_by_qualname`).  Minting a fresh Arc
-                    // per site here splits the placeholder into one
-                    // `ClassDef` per occurrence, so the value's classdef
-                    // can never match the field repr's interned classdef
-                    // (rtyper convert_from_to has no common base → typer
-                    // error).
+                    // aggregate-kind placeholder tags named by id atom
+                    // (`Tuple` for tuples / unresolved ADTs, `Array`,
+                    // `Closure` — see `front::mir::aggregate_ctor_name`) are
+                    // not variant names; they name ONE universal placeholder
+                    // each (no enum ambiguity), and the construction-side
+                    // FieldWrite chain shares the same tag as `owner_root`
+                    // with the field-projection side (which resolves it
+                    // through `getuniqueclassdef_for_struct_root` →
+                    // `intern_class_by_qualname`).  Minting a fresh Arc per
+                    // site here splits the placeholder into one `ClassDef`
+                    // per occurrence, so the value's classdef can never match
+                    // the field repr's interned classdef (rtyper
+                    // convert_from_to has no common base → typer error), and
+                    // two `()` values meeting at a join can never union.
                     let host = if owner_path.is_empty() {
-                        if matches!(name.as_str(), "Adt" | "Array" | "Closure") {
-                            call_registry.bookkeeper().intern_class_by_qualname(name)
+                        if matches!(name.as_str(), "Tuple" | "Array" | "Closure") {
+                            call_registry.bookkeeper().intern_class_by_qualname(&name)
                         } else {
                             HostObject::new_class(name.clone(), Vec::new())
                         }

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1230,6 +1230,40 @@ pub fn translate_op(
                         call_args.extend(arg_hls);
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
+                    // `__pyre_cast_instance` — front-end pointer-downcast
+                    // narrow (#298).  `front::mir` emits a synthetic
+                    // `Call(["__pyre_cast_instance", <root>], [operand])`
+                    // for `obj as *const RegisteredStruct`, stashing the
+                    // target struct root in `segments[1]` because the
+                    // `Vec<Variable>` arg carrier cannot hold a `Constant`
+                    // (same carrier limitation as the Branch-3c
+                    // `simple_call(<exc class>)` reconstruction below).
+                    // Reconstruct it here as `simple_call(callable,
+                    // operand, Constant(root))`: the analyzer reads the
+                    // trailing `ByteStr` root to type the result
+                    // `SomeInstance(root)`, and the typer lowers the call
+                    // to a `cast_pointer`.  The callable resolves through
+                    // the `__pyre_cast_instance` HOST_ENV singleton so its
+                    // Arc identity matches the `BUILTIN_TYPER` key.
+                    if segments.len() == 2 && segments[0] == "__pyre_cast_instance" {
+                        let callable_host =
+                            HOST_ENV.lookup_builtin("__pyre_cast_instance").ok_or_else(|| {
+                                TyperError::message(
+                                    "__pyre_cast_instance missing from HOST_ENV bootstrap"
+                                        .to_string(),
+                                )
+                            })?;
+                        let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                            callable_host,
+                        )));
+                        let mut call_args = Vec::with_capacity(arg_hls.len() + 2);
+                        call_args.push(callable);
+                        call_args.extend(arg_hls);
+                        call_args.push(Hlvalue::Constant(Constant::new(ConstValue::byte_str(
+                            &segments[1],
+                        ))));
+                        return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
+                    }
                     // `<[T]>::len(slice)` — the slice-receiver `.len()`
                     // method call.  Rust lowers `slice.len()` to a MIR
                     // call to `core::slice::<impl [T]>::len`, not to the

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2061,6 +2061,21 @@ pub(crate) fn derive_subject_inputcells(
             // classdef-less shell, narrowed by call-propagation as before
             // (`description.py:283-305 FunctionDesc.pycall`).
             if matches!(ty, crate::model::ValueType::Ref(_)) {
+                // String-typed params are string values, not class
+                // instances: `String` and `str` both map to the single
+                // unicode string type (`project_pyre_field_type` —
+                // `s_unicode0`; string literals lower to `UniStr`
+                // constants).  The foreign
+                // `alloc::string::String` TypeDecl also registers
+                // struct-field rows, so the registry path below would
+                // otherwise seed a `SomeInstance(String)` shell whose
+                // field writes poison classdef attr cells with
+                // instance-annotated strings.
+                if class_root.as_deref() == Some("String") || class_root.as_deref() == Some("str")
+                {
+                    cells.push(crate::annotator::model::s_unicode0());
+                    continue;
+                }
                 if let (Some(root), Some(bk)) = (class_root.as_ref(), bookkeeper) {
                     // A generic param (`&T` where `T: Trait`, incl. a
                     // trait default body's `&Self`) carries the bound

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2131,8 +2131,7 @@ pub(crate) fn derive_subject_inputcells(
                 // otherwise seed a `SomeInstance(String)` shell whose
                 // field writes poison classdef attr cells with
                 // instance-annotated strings.
-                if class_root.as_deref() == Some("String") || class_root.as_deref() == Some("str")
-                {
+                if class_root.as_deref() == Some("String") || class_root.as_deref() == Some("str") {
                     cells.push(crate::annotator::model::s_unicode0());
                     continue;
                 }

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1246,16 +1246,16 @@ pub fn translate_op(
                     // the `__pyre_cast_instance` HOST_ENV singleton so its
                     // Arc identity matches the `BUILTIN_TYPER` key.
                     if segments.len() == 2 && segments[0] == "__pyre_cast_instance" {
-                        let callable_host =
-                            HOST_ENV.lookup_builtin("__pyre_cast_instance").ok_or_else(|| {
+                        let callable_host = HOST_ENV
+                            .lookup_builtin("__pyre_cast_instance")
+                            .ok_or_else(|| {
                                 TyperError::message(
                                     "__pyre_cast_instance missing from HOST_ENV bootstrap"
                                         .to_string(),
                                 )
                             })?;
-                        let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(
-                            callable_host,
-                        )));
+                        let callable =
+                            Hlvalue::Constant(Constant::new(ConstValue::HostObject(callable_host)));
                         let mut call_args = Vec::with_capacity(arg_hls.len() + 2);
                         call_args.push(callable);
                         call_args.extend(arg_hls);

--- a/majit/majit-translate/src/translator/rtyper/mod.rs
+++ b/majit/majit-translate/src/translator/rtyper/mod.rs
@@ -29,6 +29,7 @@ pub mod rbuiltin;
 pub mod rclass;
 pub mod rfloat;
 pub mod rint;
+pub mod rlist;
 pub mod rmodel;
 pub mod rnone;
 pub mod rpbc;

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -120,6 +120,12 @@ pub enum ReprClassId {
     InstanceRepr,
     /// `rtuple.py:129 TupleRepr`.
     TupleRepr,
+    /// `lltypesystem/rlist.py:173 FixedSizeListRepr(
+    /// AbstractFixedSizeListRepr, BaseListRepr)` — the non-resized list
+    /// whose `LIST` lowers to a bare `Ptr(GcArray(ITEM))`. Slices
+    /// (`&[T]`) annotate as a non-resized `SomeList`, so this is the
+    /// repr the `len` lowering lands on.
+    FixedSizeListRepr,
     /// `rstr.py:483 AbstractCharRepr` (`CharRepr` lltypesystem
     /// realisation, `lowleveltype = Char`).
     CharRepr,
@@ -182,6 +188,7 @@ impl ReprClassId {
             MethodsPBCRepr => &[MethodsPBCRepr, Repr],
             ClassesPBCRepr => &[ClassesPBCRepr, Repr],
             InstanceRepr => &[InstanceRepr, Repr],
+            FixedSizeListRepr => &[FixedSizeListRepr, Repr],
             TupleRepr => &[TupleRepr, Repr],
             CharRepr => &[CharRepr, Repr],
             UniCharRepr => &[UniCharRepr, Repr],

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -581,6 +581,17 @@ fn dispatch_rtype_op(
         (Repr, PtrRepr, "eq") => committed(r2.rtype_eq(hop)),
         (Repr, PtrRepr, "ne") => committed(r2.rtype_ne(hop)),
 
+        // rclass.py:1070 — `pairtype(InstanceRepr, InstanceRepr).rtype_eq
+        // = rtype_is_`: both sides upcast to the common-base instance
+        // repr, then pointer identity (`ptr_eq`).  rtype_ne (1072-1074)
+        // negates it.
+        (InstanceRepr, InstanceRepr, "eq") => {
+            committed(super::rclass::pair_instance_instance_rtype_is_(r1, r2, hop))
+        }
+        (InstanceRepr, InstanceRepr, "ne") => {
+            committed(super::rclass::pair_instance_instance_rtype_ne(r1, r2, hop))
+        }
+
         // rint.py:217-310 — IntegerRepr/IntegerRepr pair arithmetic and
         // comparisons. `truediv` is intentionally absent here: upstream
         // delegates it to FloatRepr through the MRO.

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -552,6 +552,20 @@ impl PyreCallRegistry {
                     {
                         return false;
                     }
+                } else {
+                    // Impl-method-shaped query (`[Owner, leaf]`, pre-leaf
+                    // PascalCase): the candidate must carry the query as
+                    // a suffix.  Method resolution never crosses the
+                    // owner-type boundary — upstream resolves through the
+                    // receiver's `ClassDesc`, so a same-leaf method of a
+                    // different type is a different desc.  Without this
+                    // gate, an unregistered `[OwnerA, leaf]` query would
+                    // capture the sole `[OwnerB, leaf]` registration.
+                    if cand_segs.len() < segments.len()
+                        || cand_segs[cand_segs.len() - segments.len()..] != *segments
+                    {
+                        return false;
+                    }
                 }
                 true
             })

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -3199,7 +3199,11 @@ pub fn rtype_pyre_cast_instance(
     let result_lltype = r_result.lowleveltype().clone();
     let v_ptr = hop.args_v.borrow()[0].clone();
     hop.exception_cannot_occur()?;
-    Ok(hop.genop("cast_pointer", vec![v_ptr], GenopResult::LLType(result_lltype)))
+    Ok(hop.genop(
+        "cast_pointer",
+        vec![v_ptr],
+        GenopResult::LLType(result_lltype),
+    ))
 }
 
 #[cfg(test)]

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -217,6 +217,11 @@ fn install_default_typers(map: &mut HashMap<HostObject, BuiltinTyperFn>) {
         ("hasattr", rtype_builtin_hasattr),
         // rbuiltin.py:264-267
         ("object.__init__", rtype_object__init__),
+        // Pyre-internal front-end pointer-downcast narrow (#298).  Keyed
+        // by the `__pyre_cast_instance` HOST_ENV singleton (same Arc the
+        // adapter resolves the call's callable to), lowers to a
+        // `cast_pointer` into the narrowed `InstanceRepr`.
+        ("__pyre_cast_instance", rtype_pyre_cast_instance),
     ];
     for (name, typer) in entries {
         if let Some(host) = HOST_ENV.lookup_builtin(name) {
@@ -3167,6 +3172,34 @@ pub fn rtype_cast_int_to_ptr(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>
     let vlist = hop.inputargs(vec![ConvertedTo::LowLevelType(&LowLevelType::Signed)])?;
     hop.exception_cannot_occur()?;
     Ok(hop.genop("cast_int_to_ptr", vlist, GenopResult::LLType(result_lltype)))
+}
+
+/// `__pyre_cast_instance` typer — front-end pointer-downcast narrow
+/// (#298).  The annotator typed the result as `SomeInstance(root)`, so
+/// `hop.r_result` is the target `InstanceRepr`; lower the call to a
+/// `cast_pointer` of the pointer operand to that lowleveltype.  This
+/// mirrors `pairtype(InstanceRepr, InstanceRepr).convert_from_to`
+/// (rclass.py:1035) — the same `genop('cast_pointer', [v],
+/// resulttype=r_ins2.lowleveltype)` it emits for the `r_ins1.classdef is
+/// None` (classdef-less → concrete) arm.  `args[0]` is the pointer
+/// operand; `args[1]` is the constant root name (read by the annotator,
+/// unused here — it carries no runtime value).
+pub fn rtype_pyre_cast_instance(
+    hop: &HighLevelOp,
+    _kwds_i: &HashMap<String, usize>,
+) -> RTypeResult {
+    use crate::translator::rtyper::rtyper::GenopResult;
+
+    let r_result = hop
+        .r_result
+        .borrow()
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| TyperError::message("rtype_pyre_cast_instance: missing r_result"))?;
+    let result_lltype = r_result.lowleveltype().clone();
+    let v_ptr = hop.args_v.borrow()[0].clone();
+    hop.exception_cannot_occur()?;
+    Ok(hop.genop("cast_pointer", vec![v_ptr], GenopResult::LLType(result_lltype)))
 }
 
 #[cfg(test)]

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -3197,7 +3197,11 @@ pub fn rtype_pyre_cast_instance(
         .cloned()
         .ok_or_else(|| TyperError::message("rtype_pyre_cast_instance: missing r_result"))?;
     let result_lltype = r_result.lowleveltype().clone();
-    let v_ptr = hop.args_v.borrow()[0].clone();
+    // Validated operand extraction: a malformed call (wrong arity)
+    // surfaces a `TyperError` here instead of panicking on a raw
+    // `args_v[0]` index, matching the other typers in this module.
+    let r_arg0 = arg_repr(hop, 0)?;
+    let v_ptr = hop.inputarg(&r_arg0, 0)?;
     hop.exception_cannot_occur()?;
     Ok(hop.genop(
         "cast_pointer",

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -4045,6 +4045,23 @@ pub(super) fn pair_instance_instance_rtype_is_(
     .map(Some)
 }
 
+/// RPython `pairtype(InstanceRepr, InstanceRepr).rtype_ne`
+/// (rclass.py:1072-1074): negate `rtype_eq` (which aliases `rtype_is_`).
+pub(super) fn pair_instance_instance_rtype_ne(
+    r1: &dyn Repr,
+    r2: &dyn Repr,
+    hop: &HighLevelOp,
+) -> Result<Option<Hlvalue>, TyperError> {
+    let Some(v_eq) = pair_instance_instance_rtype_is_(r1, r2, hop)? else {
+        return Ok(None);
+    };
+    Ok(hop.genop(
+        "bool_not",
+        vec![v_eq],
+        GenopResult::LLType(LowLevelType::Bool),
+    ))
+}
+
 /// RPython `buildinstancerepr(rtyper, classdef, gcflavor='gc')`
 /// (`rclass.py:91-119`).
 ///

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -2175,6 +2175,69 @@ impl InstanceRepr {
         // upstream: `pass`.
     }
 
+    /// RPython `InstanceRepr.hook_setfield(self, vinst, fieldname,
+    /// llops)` (rclass.py:715-718):
+    ///
+    /// ```python
+    /// def hook_setfield(self, vinst, fieldname, llops):
+    ///     if self.is_quasi_immutable(fieldname):
+    ///         c_fieldname = inputconst(Void, 'mutate_' + fieldname)
+    ///         llops.genop('jit_force_quasi_immutable', [vinst, c_fieldname])
+    /// ```
+    pub fn hook_setfield(
+        self: &Arc<Self>,
+        vinst: &Hlvalue,
+        fieldname: &str,
+        llops: &mut LowLevelOpList,
+    ) {
+        if self.is_quasi_immutable(fieldname) {
+            let c_fieldname = Hlvalue::Constant(Constant::with_concretetype(
+                ConstValue::byte_str(format!("mutate_{fieldname}")),
+                LowLevelType::Void,
+            ));
+            llops.genop(
+                "jit_force_quasi_immutable",
+                vec![vinst.clone(), c_fieldname],
+                GenopResult::Void,
+            );
+        }
+    }
+
+    /// RPython `InstanceRepr.is_quasi_immutable(self, fieldname)`
+    /// (rclass.py:720-729):
+    ///
+    /// ```python
+    /// def is_quasi_immutable(self, fieldname):
+    ///     search1 = fieldname + '?'
+    ///     search2 = fieldname + '?[*]'
+    ///     rbase = self
+    ///     while rbase.classdef is not None:
+    ///         if (search1 in rbase.immutable_field_set or
+    ///                 search2 in rbase.immutable_field_set):
+    ///             return True
+    ///         rbase = rbase.rbase
+    ///     return False
+    /// ```
+    pub fn is_quasi_immutable(self: &Arc<Self>, fieldname: &str) -> bool {
+        let search1 = format!("{fieldname}?");
+        let search2 = format!("{fieldname}?[*]");
+        let mut rbase = self.clone();
+        while rbase.classdef.is_some() {
+            {
+                let set = rbase.immutable_field_set.borrow();
+                if set.contains(&search1) || set.contains(&search2) {
+                    return true;
+                }
+            }
+            let next = rbase.rbase.borrow().clone();
+            match next {
+                Some(n) => rbase = n,
+                None => break,
+            }
+        }
+        false
+    }
+
     /// RPython `InstanceRepr.getfield(self, vinst, attr, llops,
     /// force_cast=False, flags={})` (rclass.py:987-1000):
     ///
@@ -2302,6 +2365,8 @@ impl InstanceRepr {
             };
             // upstream: `self.hook_access_field(vinst, cname, llops, flags)`.
             self.hook_access_field(&vinst, &cname, llops, flags);
+            // upstream: `self.hook_setfield(vinst, attr, llops)`.
+            self.hook_setfield(&vinst, attr, llops);
             // upstream: `llops.genop('setfield', [vinst, cname, vvalue])`.
             llops.genop("setfield", vec![vinst, cname, vvalue], GenopResult::Void);
             return Ok(());
@@ -2328,26 +2393,32 @@ impl InstanceRepr {
     ///     """Build a new instance, without calling __init__."""
     ///     flavor = self.gcflavor
     ///     flags = {'flavor': flavor}
+    ///     if nonmovable:
+    ///         flags['nonmovable'] = True
     ///     ctype = inputconst(Void, self.object_type)
     ///     cflags = inputconst(Void, flags)
     ///     vlist = [ctype, cflags]
     ///     vptr = llops.genop('malloc', vlist, resulttype=Ptr(self.object_type))
     ///     ctypeptr = inputconst(CLASSTYPE, self.rclass.getvtable())
     ///     self.setfield(vptr, '__class__', ctypeptr, llops)
+    ///     if self.has_special_memory_pressure(self.object_type):
+    ///         self.setfield(vptr, 'special_memory_pressure',
+    ///             inputconst(lltype.Signed, 0), llops)
     ///     ...                # initialize instance attributes from defaults
     ///     return vptr
     /// ```
     ///
     /// Emits the runtime `malloc` op (vs the host-side immortal
     /// allocation [`Self::create_instance`] used for prebuilt data) plus
-    /// the `__class__` `setfield`. The class-level defaults loop
-    /// (rclass.py:752-769) is a no-op for fieldless classes — every
-    /// `allinstancefields` entry but `__class__` is skipped; a field
-    /// that survives the skips needs default-value conversion that is
-    /// deferred to a follow-up and surfaces here as an explicit error.
+    /// the `__class__` `setfield` and the class-level defaults loop.
+    /// `classcallhop` is unused in this base body, exactly as upstream —
+    /// its only consumer is the `TaggedInstanceRepr` override
+    /// (`lltypesystem/rtagged.py:30-38`), unported.
     pub fn new_instance(
         self: &Arc<Self>,
         llops: &mut LowLevelOpList,
+        _classcallhop: Option<&crate::translator::rtyper::rtyper::HighLevelOp>,
+        nonmovable: bool,
     ) -> Result<Hlvalue, TyperError> {
         // upstream: `ctype = inputconst(Void, self.object_type)` — the
         // Void-typed type tag carrying the resolved object Struct lltype,
@@ -2362,15 +2433,18 @@ impl InstanceRepr {
             other => other,
         };
         let ctype = Constant::with_concretetype(
-            ConstValue::LowLevelType(Box::new(object_lltype)),
+            ConstValue::LowLevelType(Box::new(object_lltype.clone())),
             LowLevelType::Void,
         );
-        // upstream: `cflags = inputconst(Void, {'flavor': flavor})`. The
-        // flavor sentinel matches the `newtuple` emitter's encoding; the
+        // upstream: `cflags = inputconst(Void, {'flavor': flavor})` plus
+        // `flags['nonmovable'] = True` when requested. The flavor
+        // sentinel matches the `newtuple` emitter's encoding; the
         // lowering pass reads the type from `ctype` and the flavor here.
-        let flavor_sentinel = match self.gcflavor {
-            Flavor::Gc => "flavor=gc",
-            Flavor::Raw => "flavor=raw",
+        let flavor_sentinel = match (self.gcflavor, nonmovable) {
+            (Flavor::Gc, false) => "flavor=gc",
+            (Flavor::Gc, true) => "flavor=gc;nonmovable",
+            (Flavor::Raw, false) => "flavor=raw",
+            (Flavor::Raw, true) => "flavor=raw;nonmovable",
         };
         let cflags =
             Constant::with_concretetype(ConstValue::byte_str(flavor_sentinel), LowLevelType::Void);
@@ -2414,6 +2488,24 @@ impl InstanceRepr {
             false,
             &Flags::default(),
         )?;
+        // upstream rclass.py:745-748 — zero the
+        // `special_memory_pressure` counter slot when the object struct
+        // carries one.  The slot is minted by the
+        // `_special_memory_pressure_` class hint (rclass.py:541-544,
+        // unported), so this arm stays dormant until that hint lands.
+        if has_special_memory_pressure(&object_lltype) {
+            self.setfield(
+                vptr.clone(),
+                "special_memory_pressure",
+                Hlvalue::Constant(Constant::with_concretetype(
+                    ConstValue::Int(0),
+                    LowLevelType::Signed,
+                )),
+                llops,
+                false,
+                &Flags::default(),
+            )?;
+        }
         // upstream rclass.py:752-769 — initialize instance attributes
         // from their class-level defaults:
         //
@@ -3770,10 +3862,36 @@ pub fn rtype_new_instance(
     rtyper: &Rc<RPythonTyper>,
     classdef: Option<&Rc<RefCell<ClassDef>>>,
     llops: &mut LowLevelOpList,
+    classcallhop: Option<&crate::translator::rtyper::rtyper::HighLevelOp>,
+    nonmovable: bool,
 ) -> Result<Hlvalue, TyperError> {
     let rinstance = getinstancerepr(rtyper, classdef, Flavor::Gc)?;
     Repr::setup(rinstance.as_ref() as &dyn Repr)?;
-    rinstance.new_instance(llops)
+    rinstance.new_instance(llops, classcallhop, nonmovable)
+}
+
+/// RPython `InstanceRepr.has_special_memory_pressure(self, tp)`
+/// (rclass.py:480-485):
+///
+/// ```python
+/// def has_special_memory_pressure(self, tp):
+///     if 'special_memory_pressure' in tp._flds:
+///         return True
+///     if 'super' in tp._flds:
+///         return self.has_special_memory_pressure(tp._flds['super'])
+///     return False
+/// ```
+fn has_special_memory_pressure(tp: &LowLevelType) -> bool {
+    let LowLevelType::Struct(s) = tp else {
+        return false;
+    };
+    if s._flds.get("special_memory_pressure").is_some() {
+        return true;
+    }
+    match s._flds.get("super") {
+        Some(sup) => has_special_memory_pressure(sup),
+        None => false,
+    }
 }
 
 /// RPython `pairtype(InstanceRepr, InstanceRepr).convert_from_to((r_ins1,

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -1121,7 +1121,11 @@ impl ClassRepr {
         // upstream: `if self.classdef is None: raise MissingRTypeAttribute(attr)`.
         // ClassRepr always has classdef != None, so route to rbase.
         let rbase = self.rbase.borrow().clone().ok_or_else(|| {
-            TyperError::message("ClassRepr.getclsfield: rbase missing — call setup() first")
+            TyperError::message(format!(
+                "ClassRepr.getclsfield({attr:?}) on class {:?}: \
+                 rbase missing — call setup() first",
+                self.classdef.borrow().name
+            ))
         })?;
         match rbase {
             ClassReprArc::Inst(inst) => inst.getclsfield(vcls, attr, llops),

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -3500,9 +3500,14 @@ impl Repr for InstanceRepr {
         let host_obj = match value {
             ConstValue::HostObject(h) => h.clone(),
             other => {
+                let class = self
+                    .classdef
+                    .as_ref()
+                    .map(|cd| cd.borrow().name.clone())
+                    .unwrap_or_else(|| "<no classdef>".to_string());
                 return Err(TyperError::message(format!(
                     "InstanceRepr.convert_const: expected HostObject or None, \
-                     got {other:?}"
+                     got {other:?} (repr class: {class})"
                 )));
             }
         };

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -1,0 +1,181 @@
+//! RPython `rpython/rtyper/rlist.py` + `lltypesystem/rlist.py` —
+//! minimal `FixedSizeListRepr` slice covering the `len(list)` lowering.
+//!
+//! Rust slices (`&[T]`) and fixed arrays annotate as a non-resized
+//! `SomeList` (`bookkeeper`), so `slice.len()` — routed to the rtyper's
+//! `len` operation by `flowspace_adapter` — lands on this repr's
+//! `rtype_len`.
+//!
+//! The full list repr surface (`ListRepr` resized `GcStruct("list",
+//! length, items)`, the `ADTIList` / `ADTIFixedList` adtmeth tables,
+//! `rtype_method_append` / `getitem` / `setitem` / iterators, and the
+//! `pairtype(BaseListRepr, BaseListRepr)` operations) is deferred to
+//! follow-on slices. Today only the data shape `Ptr(GcArray(ITEM))`
+//! and the `ll_fixed_length` lowering land.
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::flowspace::model::{
+    Block, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
+    SpaceOperation,
+};
+use crate::flowspace::pygraph::PyGraph;
+use crate::translator::rtyper::error::TyperError;
+use crate::translator::rtyper::lltypesystem::lltype::{ArrayType, LowLevelType, Ptr, PtrTarget};
+use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
+use crate::translator::rtyper::rtyper::{
+    ConvertedTo, HighLevelOp, RPythonTyper, helper_pygraph_from_graph, variable_with_lltype,
+};
+
+/// RPython `class FixedSizeListRepr(AbstractFixedSizeListRepr,
+/// BaseListRepr)` (`lltypesystem/rlist.py:173-187`):
+///
+/// ```python
+/// def _setup_repr(self):
+///     if 'item_repr' not in self.__dict__:
+///         self.external_item_repr, self.item_repr = externalvsinternal(
+///             self.rtyper, self._item_repr_computer(), gcref=True)
+///     if isinstance(self.LIST, GcForwardReference):
+///         ITEMARRAY = self.get_itemarray_lowleveltype()
+///         self.LIST.become(ITEMARRAY)
+/// ```
+///
+/// `LIST` becomes a bare `GcArray(ITEM)` (no `length`/`items` wrapper —
+/// that is the resized `ListRepr`), so the low-level type is
+/// `Ptr(GcArray(ITEM))`.
+#[derive(Debug)]
+pub struct FixedSizeListRepr {
+    state: ReprState,
+    lltype: LowLevelType,
+    /// `self.item_repr` (`lltypesystem/rlist.py:177`) — the internal
+    /// (gcref-wrapped) element repr.
+    #[allow(dead_code)]
+    item_repr: Arc<dyn Repr>,
+}
+
+impl FixedSizeListRepr {
+    pub fn new(rtyper: &Rc<RPythonTyper>, item_repr: Arc<dyn Repr>) -> Result<Self, TyperError> {
+        // `externalvsinternal(rtyper, item_repr, gcref=True)` —
+        // gc `InstanceRepr` items become the generic `Ptr(OBJECT)`
+        // gcref so the array element type is never a gc container
+        // (which `ArrayType::gc` rejects); non-instance reprs pass
+        // through unchanged.
+        let (_external, internal) =
+            crate::translator::rtyper::rclass::externalvsinternal(rtyper, item_repr)?;
+        let item_lltype = internal.lowleveltype().clone();
+        let arr = ArrayType::gc(item_lltype);
+        let lltype = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Array(arr),
+        }));
+        Ok(FixedSizeListRepr {
+            state: ReprState::new(),
+            lltype,
+            item_repr: internal,
+        })
+    }
+}
+
+impl Repr for FixedSizeListRepr {
+    fn lowleveltype(&self) -> &LowLevelType {
+        &self.lltype
+    }
+
+    fn state(&self) -> &ReprState {
+        &self.state
+    }
+
+    fn class_name(&self) -> &'static str {
+        "FixedSizeListRepr"
+    }
+
+    fn repr_class_id(&self) -> super::pairtype::ReprClassId {
+        super::pairtype::ReprClassId::FixedSizeListRepr
+    }
+
+    /// RPython `AbstractBaseListRepr.rtype_len(self, hop)`
+    /// (`rlist.py:124-130`):
+    ///
+    /// ```python
+    /// def rtype_len(self, hop):
+    ///     v_lst, = hop.inputargs(self)
+    ///     if hop.args_s[0].listdef.listitem.resized:
+    ///         ll_func = ll_len
+    ///     else:
+    ///         ll_func = ll_len_foldable
+    ///     return hop.gendirectcall(ll_func, v_lst)
+    /// ```
+    ///
+    /// `FixedSizeListRepr` is only minted for the non-resized case, so
+    /// the lowering is the `ll_len_foldable` path: `l.ll_length()` →
+    /// `ll_fixed_length` (`lltypesystem/rlist.py:395-396`) = `len(l)` =
+    /// the `getarraysize` op on the `Ptr(GcArray)` receiver. The
+    /// `len_foldable` oopspec is a tracing-time JIT hint; the lowered
+    /// op is the bare `getarraysize`.
+    fn rtype_len(&self, hop: &HighLevelOp) -> RTypeResult {
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_fixed_length".to_string(),
+            vec![ptr_lltype],
+            LowLevelType::Signed,
+            move |_rtyper, _args, _result| {
+                build_ll_fixed_length_helper_graph("ll_fixed_length", ptr_for_builder.clone())
+            },
+        )?;
+        hop.gendirectcall(&helper, vlist)
+    }
+}
+
+/// Synthesise `LLHelpers`-style `ll_fixed_length`
+/// (`lltypesystem/rlist.py:395-396`):
+///
+/// ```python
+/// def ll_fixed_length(l):
+///     return len(l)
+/// ```
+///
+/// Single-block graph: `getarraysize(l) -> Signed`. Unlike
+/// `ll_strlen` (which `getsubstruct`s the nested `chars` array first),
+/// the `FixedSizeListRepr` receiver IS the `Ptr(GcArray)`, so the
+/// length is one op.
+pub(crate) fn build_ll_fixed_length_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let arg = variable_with_lltype("l", ptr_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(arg.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let v_len = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarraysize",
+        vec![Hlvalue::Variable(arg)],
+        Hlvalue::Variable(v_len.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_len)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string()],
+        func,
+    ))
+}

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2930,11 +2930,29 @@ pub fn rtyper_makerepr(
             )
         }
         SomeValue::List(s_list) => {
-            // rlist.py:43-50 — `BaseListRepr.__new__` returns
-            // `FixedSizeListRepr` for a non-resized listdef and
-            // `ListRepr` for a resized one. Pyre lands the non-resized
-            // (slice / fixed-array) repr today; the resized
-            // `GcStruct("list", length, items)` variant is deferred.
+            // rlist.py:40-58 `SomeList.rtyper_makerepr`. Three upstream
+            // branches; pyre lands only the non-resized one today:
+            //
+            //   1. `range_step is not None and not mutated and
+            //      not SomeImpossibleValue` → `RangeRepr(range_step)`
+            //      (lltypesystem/rrange.py). Not ported — `RangeRepr`
+            //      has no Rust counterpart yet (the whole `rrange.py`
+            //      surface is deferred, see `SomeIterator` below); a
+            //      range-list therefore falls through to the
+            //      fixed-size repr instead.
+            //   2. resized listdef → `ListRepr` (`GcStruct("list",
+            //      length, items)`) — deferred (the `Err` arm below).
+            //   3. non-resized → `FixedSizeListRepr`.
+            //
+            // Upstream also passes a LAZY `item_repr = lambda:
+            // rtyper.getrepr(listitem.s_value)` for recursive list
+            // structures; pyre computes it EAGERLY below. Sound for the
+            // current usage (list items are `PyObjectRef`, i.e. the root
+            // `InstanceRepr`, never the list type itself), so no eager
+            // recursion occurs; the lazy form is a parity follow-up.
+            // (`externalvsinternal`'s `gcref=True` arm is likewise
+            // deferred — `rclass.rs` — and unreached for `PyObjectRef`
+            // items.)
             let resized = s_list.listdef.listitem_rc().borrow().resized;
             if resized {
                 Err(TyperError::missing_rtype_operation(format!(

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2929,10 +2929,30 @@ pub fn rtyper_makerepr(
                 )?) as std::sync::Arc<dyn Repr>,
             )
         }
-        SomeValue::List(l) => Err(TyperError::missing_rtype_operation(format!(
-            "SomeList.rtyper_makerepr — port rpython/rtyper/rlist.py ListRepr (listdef: {:?})",
-            l.listdef
-        ))),
+        SomeValue::List(s_list) => {
+            // rlist.py:43-50 — `BaseListRepr.__new__` returns
+            // `FixedSizeListRepr` for a non-resized listdef and
+            // `ListRepr` for a resized one. Pyre lands the non-resized
+            // (slice / fixed-array) repr today; the resized
+            // `GcStruct("list", length, items)` variant is deferred.
+            let resized = s_list.listdef.listitem_rc().borrow().resized;
+            if resized {
+                Err(TyperError::missing_rtype_operation(format!(
+                    "SomeList(resized).rtyper_makerepr — port \
+                     rpython/rtyper/lltypesystem/rlist.py ListRepr (GcStruct length+items) \
+                     (listdef: {:?})",
+                    s_list.listdef
+                )))
+            } else {
+                let item_r = rtyper.getrepr(&s_list.listdef.s_value())?;
+                let rtyper_rc = rtyper.self_rc()?;
+                Ok(
+                    std::sync::Arc::new(crate::translator::rtyper::rlist::FixedSizeListRepr::new(
+                        &rtyper_rc, item_r,
+                    )?) as std::sync::Arc<dyn Repr>,
+                )
+            }
+        }
         SomeValue::Dict(_) => Err(TyperError::missing_rtype_operation(
             "SomeDict.rtyper_makerepr — port rpython/rtyper/rdict.py DictRepr",
         )),

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -5657,7 +5657,8 @@ impl ClassesPBCRepr {
         hop: &crate::translator::rtyper::rtyper::HighLevelOp,
         _call_args: bool,
     ) -> crate::translator::rtyper::rmodel::RTypeResult {
-        use crate::annotator::classdesc::{ClassDef, ClassDesc};
+        use crate::annotator::classdesc::ClassDef;
+        use crate::annotator::classdesc::ClassDesc;
         use crate::annotator::model::SomeValue;
 
         // Shapes outside the ported single-class / Void / no-`__init__` /
@@ -5714,6 +5715,10 @@ impl ClassesPBCRepr {
         //    adapter AFTER that pass, so they reach here unnumbered.  Since
         //    `assign_inheritance_ids` is now append-stable (skip-if-numbered
         //    + append-only), number such a class on demand below.
+        // Field-bearing classes route through `new_instance`'s
+        // class-default initialisation loop (rclass.py:752-769) like
+        // any other; a field without a class-level default keeps the
+        // malloc zero-init.
         if !init_is_impossible {
             return Err(unported("class has __init__ (rpbc.py:1060-1067)"));
         }
@@ -5771,6 +5776,8 @@ impl ClassesPBCRepr {
                 &rtyper,
                 Some(&classdef),
                 &mut llops,
+                Some(hop),
+                false,
             )?
         };
         // upstream rpbc.py:1058-1059 — no `__init__` ⇒ the malloc cannot

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -192,8 +192,8 @@ fn lowers_tuple_roundtrip_with_symmetric_positional_field_reads() {
     assert_eq!(
         field_writes,
         vec![
-            ("__pos_0".to_string(), Some("Adt".to_string())),
-            ("__pos_1".to_string(), Some("Adt".to_string())),
+            ("__pos_0".to_string(), Some("Tuple".to_string())),
+            ("__pos_1".to_string(), Some("Tuple".to_string())),
         ],
         "tuple construction must emit a __pos_0 / __pos_1 FieldWrite chain"
     );
@@ -205,8 +205,8 @@ fn lowers_tuple_roundtrip_with_symmetric_positional_field_reads() {
     assert_eq!(
         field_reads,
         vec![
-            ("__pos_0".to_string(), Some("Adt".to_string())),
-            ("__pos_1".to_string(), Some("Adt".to_string())),
+            ("__pos_0".to_string(), Some("Tuple".to_string())),
+            ("__pos_1".to_string(), Some("Tuple".to_string())),
         ],
         "tuple reads must emit __pos_0 / __pos_1 FieldReads (owner_root \
          matching the FieldWrite chain) and *Checked .0 reads must collapse"

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -25,6 +25,33 @@ PYPY3 = os.environ.get("PYRE_CHECK_PYPY3") or (
     "pypy3" if shutil.which("pypy3") else "pypy"
 )
 
+
+def _detect_cpython_stdlib():
+    """Stdlib directory of the CPython baseline (`PYTHON3`).
+
+    pyre's native modules (`_sre`, ...) are coupled to one CPython version,
+    and pyre's own `detect_stdlib_path` falls back to a bare `python3` on
+    PATH. When several interpreters are on PATH (e.g. CI sets up CPython
+    then PyPy, whose `python3` then shadows it) that fallback can resolve
+    to a foreign stdlib; only the regex bench — the one pure-Python stdlib
+    import in the suite — then crashes. Resolve the baseline's own stdlib
+    so `pyre_env` can pin pyre to it.
+    """
+    try:
+        proc = subprocess.run(
+            [PYTHON3, "-c", "import sysconfig; print(sysconfig.get_paths()['stdlib'])"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    path = (proc.stdout or "").strip()
+    return path if path and os.path.isdir(path) else None
+
+
+PYRE_STDLIB = _detect_cpython_stdlib()
+
 BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
 SNAP_DIR = "pyre/check.snap"
@@ -186,6 +213,11 @@ def pyre_env():
     env = dict(os.environ)
     env["MAJIT_STRICT"] = "1"
     env["MAJIT_STATS"] = "1"
+    # Pin the stdlib to the CPython baseline so pyre never auto-detects a
+    # foreign `python3` (e.g. a PyPy that shadows CPython on the CI PATH).
+    # An explicit PYRE_STDLIB in the environment wins.
+    if PYRE_STDLIB and "PYRE_STDLIB" not in env:
+        env["PYRE_STDLIB"] = PYRE_STDLIB
     return env
 
 
@@ -452,6 +484,7 @@ class Check:
                         [self._pyre(backend), script],
                         stdout=subprocess.DEVNULL,
                         timeout=30,
+                        env=pyre_env(),
                     )
                 except Exception:
                     pass

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2148,13 +2148,32 @@ pub fn getattr_str(obj: PyObjectRef, name: &str) -> PyResult {
             || pyre_object::itertoolsmodule::is_filterfalse(obj)
             || pyre_object::itertoolsmodule::is_pairwise(obj)
         {
-            let entry: Option<(fn(&[PyObjectRef]) -> PyResult, &str)> = match name {
-                "__next__" => Some((iter_next_method, "__next__")),
-                "__iter__" => Some((iter_self_method, "__iter__")),
+            let entry: Option<(fn(&[PyObjectRef]) -> PyResult, &str, u16)> = match name {
+                "__next__" => Some((iter_next_method, "__next__", 1)),
+                "__iter__" => Some((iter_self_method, "__iter__", 1)),
+                // takewhile/dropwhile expose `__reduce__` + `__setstate__`,
+                // filterfalse `__reduce__` only (interp_itertools.py
+                // W_TakeWhile/W_DropWhile/W_FilterFalse typedefs); pairwise
+                // exposes neither.
+                "__reduce__" if pyre_object::itertoolsmodule::is_takewhile(obj) => {
+                    Some((takewhile_reduce_method, "__reduce__", 1))
+                }
+                "__setstate__" if pyre_object::itertoolsmodule::is_takewhile(obj) => {
+                    Some((takewhile_setstate_method, "__setstate__", 2))
+                }
+                "__reduce__" if pyre_object::itertoolsmodule::is_dropwhile(obj) => {
+                    Some((dropwhile_reduce_method, "__reduce__", 1))
+                }
+                "__setstate__" if pyre_object::itertoolsmodule::is_dropwhile(obj) => {
+                    Some((dropwhile_setstate_method, "__setstate__", 2))
+                }
+                "__reduce__" if pyre_object::itertoolsmodule::is_filterfalse(obj) => {
+                    Some((filterfalse_reduce_method, "__reduce__", 1))
+                }
                 _ => None,
             };
-            if let Some((func, sname)) = entry {
-                let func_obj = crate::make_builtin_function_with_arity(sname, func, 1);
+            if let Some((func, sname, arity)) = entry {
+                let func_obj = crate::make_builtin_function_with_arity(sname, func, arity);
                 return Ok(pyre_object::w_method_new(
                     func_obj,
                     obj,
@@ -8068,6 +8087,57 @@ fn iter_next_method(args: &[PyObjectRef]) -> PyResult {
 /// `__iter__` for an iterator — returns the iterator itself.
 fn iter_self_method(args: &[PyObjectRef]) -> PyResult {
     Ok(args.first().copied().unwrap_or(pyre_object::PY_NULL))
+}
+
+/// `takewhile.__reduce__` — `interp_itertools.py W_TakeWhile.descr_reduce`:
+/// `(type(self), (predicate, iterable), stopped)`.
+fn takewhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let it = unsafe { &*(args[0] as *const pyre_object::itertoolsmodule::W_TakeWhile) };
+    let w_type = crate::typedef::gettypefor(&pyre_object::itertoolsmodule::TAKEWHILE_TYPE)
+        .unwrap_or(PY_NULL);
+    let state = w_tuple_new(vec![it.w_predicate, it.w_iterable]);
+    Ok(w_tuple_new(vec![w_type, state, w_bool_from(it.stopped)]))
+}
+
+/// `takewhile.__setstate__` — `interp_itertools.py W_TakeWhile.descr_setstate`:
+/// `self.stopped = space.bool_w(w_state)`.
+fn takewhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
+    let it = unsafe { &mut *(args[0] as *mut pyre_object::itertoolsmodule::W_TakeWhile) };
+    it.stopped = is_true(args.get(1).copied().unwrap_or(w_none()));
+    Ok(w_none())
+}
+
+/// `dropwhile.__reduce__` — `interp_itertools.py W_DropWhile.descr_reduce`:
+/// `(type(self), (predicate, iterable), started)`.
+fn dropwhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let it = unsafe { &*(args[0] as *const pyre_object::itertoolsmodule::W_DropWhile) };
+    let w_type = crate::typedef::gettypefor(&pyre_object::itertoolsmodule::DROPWHILE_TYPE)
+        .unwrap_or(PY_NULL);
+    let state = w_tuple_new(vec![it.w_predicate, it.w_iterable]);
+    Ok(w_tuple_new(vec![w_type, state, w_bool_from(it.started)]))
+}
+
+/// `dropwhile.__setstate__` — `interp_itertools.py W_DropWhile.descr_setstate`:
+/// `self.started = space.bool_w(w_state)`.
+fn dropwhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
+    let it = unsafe { &mut *(args[0] as *mut pyre_object::itertoolsmodule::W_DropWhile) };
+    it.started = is_true(args.get(1).copied().unwrap_or(w_none()));
+    Ok(w_none())
+}
+
+/// `filterfalse.__reduce__` — `interp_itertools.py W_FilterFalse.descr_reduce`:
+/// `(type(self), (None-or-predicate, iterable))` — no state element.
+fn filterfalse_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    let it = unsafe { &*(args[0] as *const pyre_object::itertoolsmodule::W_FilterFalse) };
+    let w_type = crate::typedef::gettypefor(&pyre_object::itertoolsmodule::FILTERFALSE_TYPE)
+        .unwrap_or(PY_NULL);
+    let w_pred = if it.w_predicate.is_null() {
+        w_none()
+    } else {
+        it.w_predicate
+    };
+    let state = w_tuple_new(vec![w_pred, it.w_iterable]);
+    Ok(w_tuple_new(vec![w_type, state]))
 }
 
 /// PyPy: GeneratorIterator.descr_send(w_arg)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8093,8 +8093,7 @@ fn iter_self_method(args: &[PyObjectRef]) -> PyResult {
 /// `(type(self), (predicate, iterable), stopped)`.
 fn takewhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &*(args[0] as *const pyre_object::itertoolsmodule::W_TakeWhile) };
-    let w_type = crate::typedef::gettypefor(&pyre_object::itertoolsmodule::TAKEWHILE_TYPE)
-        .unwrap_or(PY_NULL);
+    let w_type = crate::typedef::r#type(args[0]).unwrap_or(PY_NULL);
     let state = w_tuple_new(vec![it.w_predicate, it.w_iterable]);
     Ok(w_tuple_new(vec![w_type, state, w_bool_from(it.stopped)]))
 }
@@ -8103,7 +8102,7 @@ fn takewhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// `self.stopped = space.bool_w(w_state)`.
 fn takewhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &mut *(args[0] as *mut pyre_object::itertoolsmodule::W_TakeWhile) };
-    it.stopped = is_true(args.get(1).copied().unwrap_or(w_none()));
+    it.stopped = int_w(args.get(1).copied().unwrap_or(w_none()))? != 0;
     Ok(w_none())
 }
 
@@ -8111,8 +8110,7 @@ fn takewhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
 /// `(type(self), (predicate, iterable), started)`.
 fn dropwhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &*(args[0] as *const pyre_object::itertoolsmodule::W_DropWhile) };
-    let w_type = crate::typedef::gettypefor(&pyre_object::itertoolsmodule::DROPWHILE_TYPE)
-        .unwrap_or(PY_NULL);
+    let w_type = crate::typedef::r#type(args[0]).unwrap_or(PY_NULL);
     let state = w_tuple_new(vec![it.w_predicate, it.w_iterable]);
     Ok(w_tuple_new(vec![w_type, state, w_bool_from(it.started)]))
 }
@@ -8121,7 +8119,7 @@ fn dropwhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// `self.started = space.bool_w(w_state)`.
 fn dropwhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &mut *(args[0] as *mut pyre_object::itertoolsmodule::W_DropWhile) };
-    it.started = is_true(args.get(1).copied().unwrap_or(w_none()));
+    it.started = int_w(args.get(1).copied().unwrap_or(w_none()))? != 0;
     Ok(w_none())
 }
 
@@ -8129,8 +8127,7 @@ fn dropwhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
 /// `(type(self), (None-or-predicate, iterable))` — no state element.
 fn filterfalse_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &*(args[0] as *const pyre_object::itertoolsmodule::W_FilterFalse) };
-    let w_type = crate::typedef::gettypefor(&pyre_object::itertoolsmodule::FILTERFALSE_TYPE)
-        .unwrap_or(PY_NULL);
+    let w_type = crate::typedef::r#type(args[0]).unwrap_or(PY_NULL);
     let w_pred = if it.w_predicate.is_null() {
         w_none()
     } else {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2597,17 +2597,16 @@ fn build_class_inner(
     }
 
     // When `__prepare__` returned a custom mapping (a dict subclass such as
-    // enum._EnumDict), the class body must execute against it directly so its
-    // `__setitem__`/`__getitem__` fire mid-body — e.g. `WHITE = RED | GREEN`
-    // reads the values `_EnumDict.__setitem__` resolved on assignment, not the
-    // stale `auto()` sentinels.  Route the frame's name binding through it via
-    // setdictscope_object; an absent or plain-dict namespace keeps the
-    // DictStorage fast path.  Restricted to a dict-subclass instance with a
-    // resolvable backing so the post-execution mirror below can recover its
-    // entries — an exotic non-dict mapping keeps the legacy path unchanged.
-    let mapping_namespace = w_namespace.filter(|&w| unsafe {
-        pyre_object::is_instance(w) && !crate::type_methods::resolve_dict_backing(w).is_null()
-    });
+    // enum._EnumDict, or any non-dict mapping), the class body must execute
+    // against it directly so its `__setitem__`/`__getitem__` fire mid-body —
+    // e.g. `WHITE = RED | GREEN` reads the values `_EnumDict.__setitem__`
+    // resolved on assignment, not the stale `auto()` sentinels.  Upstream
+    // `compiling.py:207-209` runs `frame.setdictscope(w_namespace)`
+    // unconditionally; route the frame's name binding through the mapping
+    // via setdictscope_object.  An absent or plain-dict namespace keeps the
+    // DictStorage fast path (plain-dict stores have no observable side
+    // effects, and the metaclass replay below restores its final contents).
+    let mapping_namespace = w_namespace.filter(|&w| unsafe { !pyre_object::is_dict(w) });
 
     let mut frame =
         crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
@@ -2630,12 +2629,13 @@ fn build_class_inner(
     // into class_ns for the downstream type construction (classcell capture,
     // create_all_slots, __set_name__), which read class_ns.
     if let Some(w_ns) = mapping_namespace {
+        let class_ns = unsafe { &mut *class_ns_ptr };
+        // Rebuild from the final contents so names `del`eted from the
+        // mapping during body execution don't survive in class_ns.
+        class_ns.clear();
         let backing = crate::type_methods::resolve_dict_backing(w_ns);
         if !backing.is_null() && unsafe { pyre_object::is_dict(backing) } {
-            let class_ns = unsafe { &mut *class_ns_ptr };
-            // Rebuild from the final backing so names `del`eted from the
-            // mapping during body execution don't survive in class_ns.
-            class_ns.clear();
+            // Dict subclass: read final entries off the backing dict.
             for (key, value) in unsafe { pyre_object::w_dict_items(backing) } {
                 if !value.is_null() && unsafe { pyre_object::is_str(key) } {
                     crate::dict_storage_store(
@@ -2645,8 +2645,31 @@ fn build_class_inner(
                     );
                 }
             }
-            unsafe { (*class_ns_ptr).fix_ptr() };
+        } else {
+            // Arbitrary non-dict mapping: walk its keys through the
+            // iteration protocol and read each value back via
+            // `space.getitem` so `__getitem__` overrides apply.
+            let w_iter = crate::baseobjspace::iter(w_ns)?;
+            loop {
+                let key = match crate::baseobjspace::next(w_iter) {
+                    Ok(k) => k,
+                    Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+                    Err(e) => return Err(e),
+                };
+                if !unsafe { pyre_object::is_str(key) } {
+                    continue;
+                }
+                let value = crate::baseobjspace::getitem(w_ns, key)?;
+                if !value.is_null() {
+                    crate::dict_storage_store(
+                        class_ns,
+                        unsafe { pyre_object::w_str_get_value(key) },
+                        value,
+                    );
+                }
+            }
         }
+        unsafe { (*class_ns_ptr).fix_ptr() };
     }
 
     // compiling.py:211-212 — when __mro_entries__ rewrote the bases, expose

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2645,15 +2645,30 @@ fn build_class_inner(
                     );
                 }
             }
+        } else if w_metaclass.is_some() {
+            // A custom metaclass receives the raw mapping unchanged (passed
+            // below) and owns its enumeration — `type.__new__` runs
+            // `PyMapping_Keys` itself.  The mapping must therefore not be
+            // walked here; only `__classcell__` is consumed locally, for the
+            // post-metaclass cell validation below, so lift just that one key
+            // via `space.getitem` rather than calling the mapping's `keys()`.
+            let w_cellkey = pyre_object::w_str_new("__classcell__");
+            match crate::baseobjspace::getitem(w_ns, w_cellkey) {
+                Ok(value) if !value.is_null() => {
+                    crate::dict_storage_store(class_ns, "__classcell__", value);
+                }
+                Ok(_) => {}
+                Err(e) if e.kind == crate::PyErrorKind::KeyError => {}
+                Err(e) => return Err(e),
+            }
         } else {
-            // Arbitrary non-dict mapping: enumerate via the mapping
-            // protocol's `keys()` (the `PyMapping_Keys` path `type.__new__`
-            // takes for a non-dict namespace) and read each value back via
-            // `space.getitem` so `__getitem__` overrides apply.  Using
-            // `keys()` rather than `iter()` keeps a mapping that implements
-            // the mapping protocol without `__iter__` working, matching
-            // `compiling.py:207` passing the namespace to the metaclass
-            // unchanged.
+            // Arbitrary non-dict mapping with the default metaclass: this path
+            // builds the type directly from `class_ns`, so materialize the
+            // whole namespace via the mapping protocol's `keys()` (the
+            // `PyMapping_Keys` path `type.__new__` takes for a non-dict
+            // namespace) and read each value back via `space.getitem` so
+            // `__getitem__` overrides apply.  `keys()` rather than `iter()`
+            // keeps a mapping without `__iter__` working.
             let keys_method = crate::baseobjspace::getattr_str(w_ns, "keys")?;
             let keys_obj = crate::call::call_function_impl_result(keys_method, &[])?;
             let keys = crate::builtins::collect_iterable(keys_obj)?;

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2646,16 +2646,18 @@ fn build_class_inner(
                 }
             }
         } else {
-            // Arbitrary non-dict mapping: walk its keys through the
-            // iteration protocol and read each value back via
-            // `space.getitem` so `__getitem__` overrides apply.
-            let w_iter = crate::baseobjspace::iter(w_ns)?;
-            loop {
-                let key = match crate::baseobjspace::next(w_iter) {
-                    Ok(k) => k,
-                    Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-                    Err(e) => return Err(e),
-                };
+            // Arbitrary non-dict mapping: enumerate via the mapping
+            // protocol's `keys()` (the `PyMapping_Keys` path `type.__new__`
+            // takes for a non-dict namespace) and read each value back via
+            // `space.getitem` so `__getitem__` overrides apply.  Using
+            // `keys()` rather than `iter()` keeps a mapping that implements
+            // the mapping protocol without `__iter__` working, matching
+            // `compiling.py:207` passing the namespace to the metaclass
+            // unchanged.
+            let keys_method = crate::baseobjspace::getattr_str(w_ns, "keys")?;
+            let keys_obj = crate::call::call_function_impl_result(keys_method, &[])?;
+            let keys = crate::builtins::collect_iterable(keys_obj)?;
+            for key in keys {
                 if !unsafe { pyre_object::is_str(key) } {
                     continue;
                 }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1084,12 +1084,18 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
         ),
         pytype_addr!("weakref::GC_WEAKREF_TYPE", weakref::GC_WEAKREF_TYPE),
         // CELL_TYPE / SLICE_TYPE / RANGE_TYPE / RANGE_ITER_TYPE /
-        // SEQ_ITER_TYPE are deliberately absent: folding them lets
-        // previously-Skipped object-space graphs lift, and
-        // ArithmeticOpcodeHandler::compare_value then hits a fatal
-        // "UnionError in mergeinputargs: <other> ∪ <other>" (CELL_TYPE
-        // alone reproduces it).  Add them back once that union is
-        // resolved.
+        // SEQ_ITER_TYPE are deliberately absent.  The earlier
+        // `IntegerRepr`-vs-`InstanceRepr` comparison wall is resolved
+        // (a `&PYTYPE_STATIC` read now types `SomeInstance("PyType")`),
+        // but registering these still lifts previously-Skipped
+        // object-space graphs (`is_slice` / `is_cell` / `is_range` and
+        // their callers, which pull in the `pyre_jit::eval` driver) onto
+        // the real rtyper path, where they hit a fatal classdef-less
+        // `getattr("load")` cascade (an atomic load on a `*const`/`*mut`
+        // field whose pointee host struct is unregistered, projecting to
+        // `SomeInstance(classdef=None)` — unaryop.rs:3742) plus sibling
+        // walls not yet in the dual-gate `is_known_unported` allowlist.
+        // Add them back once that classdef-less getattr cascade drains.
         pytype_addr!("methodobject::METHOD_TYPE", methodobject::METHOD_TYPE),
         pytype_addr!("memberobject::MEMBER_TYPE", memberobject::MEMBER_TYPE),
         pytype_addr!(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1083,19 +1083,14 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE
         ),
         pytype_addr!("weakref::GC_WEAKREF_TYPE", weakref::GC_WEAKREF_TYPE),
-        // CELL_TYPE / SLICE_TYPE / RANGE_TYPE / RANGE_ITER_TYPE /
-        // SEQ_ITER_TYPE are deliberately absent.  The earlier
-        // `IntegerRepr`-vs-`InstanceRepr` comparison wall is resolved
-        // (a `&PYTYPE_STATIC` read now types `SomeInstance("PyType")`),
-        // but registering these still lifts previously-Skipped
-        // object-space graphs (`is_slice` / `is_cell` / `is_range` and
-        // their callers, which pull in the `pyre_jit::eval` driver) onto
-        // the real rtyper path, where they hit a fatal classdef-less
-        // `getattr("load")` cascade (an atomic load on a `*const`/`*mut`
-        // field whose pointee host struct is unregistered, projecting to
-        // `SomeInstance(classdef=None)` — unaryop.rs:3742) plus sibling
-        // walls not yet in the dual-gate `is_known_unported` allowlist.
-        // Add them back once that classdef-less getattr cascade drains.
+        pytype_addr!("cellobject::CELL_TYPE", cellobject::CELL_TYPE),
+        pytype_addr!("sliceobject::SLICE_TYPE", sliceobject::SLICE_TYPE),
+        pytype_addr!("rangeobject::RANGE_TYPE", rangeobject::RANGE_TYPE),
+        pytype_addr!(
+            "rangeobject::RANGE_ITER_TYPE",
+            rangeobject::RANGE_ITER_TYPE
+        ),
+        pytype_addr!("rangeobject::SEQ_ITER_TYPE", rangeobject::SEQ_ITER_TYPE),
         pytype_addr!("methodobject::METHOD_TYPE", methodobject::METHOD_TYPE),
         pytype_addr!("memberobject::MEMBER_TYPE", memberobject::MEMBER_TYPE),
         pytype_addr!(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -490,6 +490,30 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::dict_eq_hook::has_hash_w_hook",
+        "pyre_object::has_hash_w_hook",
+        pyre_object::dict_eq_hook::has_hash_w_hook as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dict_eq_hook::hash_w_hooked",
+        "pyre_object::hash_w_hooked",
+        pyre_object::dict_eq_hook::hash_w_hooked as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dict_eq_hook::has_compares_by_identity_hook",
+        "pyre_object::has_compares_by_identity_hook",
+        pyre_object::dict_eq_hook::has_compares_by_identity_hook as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dict_eq_hook::compares_by_identity_hooked",
+        "pyre_object::compares_by_identity_hooked",
+        pyre_object::dict_eq_hook::compares_by_identity_hooked as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::stack_check::stack_almost_full",
         "pyre_interpreter::stack_almost_full",
         crate::stack_check::stack_almost_full as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1086,10 +1086,7 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
         pytype_addr!("cellobject::CELL_TYPE", cellobject::CELL_TYPE),
         pytype_addr!("sliceobject::SLICE_TYPE", sliceobject::SLICE_TYPE),
         pytype_addr!("rangeobject::RANGE_TYPE", rangeobject::RANGE_TYPE),
-        pytype_addr!(
-            "rangeobject::RANGE_ITER_TYPE",
-            rangeobject::RANGE_ITER_TYPE
-        ),
+        pytype_addr!("rangeobject::RANGE_ITER_TYPE", rangeobject::RANGE_ITER_TYPE),
         pytype_addr!("rangeobject::SEQ_ITER_TYPE", rangeobject::SEQ_ITER_TYPE),
         pytype_addr!("methodobject::METHOD_TYPE", methodobject::METHOD_TYPE),
         pytype_addr!("memberobject::MEMBER_TYPE", memberobject::MEMBER_TYPE),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -514,6 +514,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::dict_eq_hook::signal_hash_error",
+        "pyre_object::signal_hash_error",
+        pyre_object::dict_eq_hook::signal_hash_error as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dict_eq_hook::take_hash_error",
+        "pyre_object::take_hash_error",
+        pyre_object::dict_eq_hook::take_hash_error as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::stack_check::stack_almost_full",
         "pyre_interpreter::stack_almost_full",
         crate::stack_check::stack_almost_full as *const (),

--- a/pyre/pyre-object/src/dict_eq_hook.rs
+++ b/pyre/pyre-object/src/dict_eq_hook.rs
@@ -46,32 +46,37 @@ thread_local! {
     static HASH_W_HOOK: Cell<Option<HashWHookFn>> = const { Cell::new(None) };
     static COMPARES_BY_IDENTITY_HOOK: Cell<Option<ComparesByIdentityHookFn>> = const { Cell::new(None) };
     /// Error flag set by the hash hook when `space.hash_w` encounters
-    /// an unhashable type or a user `__hash__` raises.  The object
-    /// reference is stored so the caller can reconstruct the error
-    /// message.  Null means no error.
+    /// an unhashable type or a user `__hash__` raises.  Only presence
+    /// is observed (the error payload itself travels through the
+    /// interpreter-side pending-error slot the trampoline fills before
+    /// signalling).  Null means no error.
     static HASH_W_ERROR: Cell<PyObjectRef> = const { Cell::new(std::ptr::null_mut()) };
 }
 
 /// Signal that the most recent `hash_w` call failed.  Called by the
 /// hash hook trampoline when `try_hash_value` returns `Err`.  The
-/// caller retrieves the error via [`take_hash_error`].
-#[inline]
-pub fn signal_hash_error(obj: PyObjectRef) {
+/// caller observes the flag via [`take_hash_error`].
+/// `dont_look_inside`: thread-local write, residualizes via the
+/// registered fnaddr.  `obj` must be a valid PyObjectRef.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn signal_hash_error(obj: PyObjectRef) {
     HASH_W_ERROR.with(|cell| cell.set(obj));
 }
 
-/// Consume the pending hash error flag, returning the unhashable
-/// object if an error was signalled since the last `take`.  Returns
-/// `None` when no error is pending.
-#[inline]
-pub fn take_hash_error() -> Option<PyObjectRef> {
+/// Consume the pending hash error flag, returning `true` if an error
+/// was signalled since the last `take`.  Callers only branch on
+/// presence; the error payload is retrieved from the interpreter-side
+/// pending-error slot.  `dont_look_inside`: thread-local read,
+/// residualizes via the registered fnaddr.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn take_hash_error() -> bool {
     HASH_W_ERROR.with(|cell| {
         let obj = cell.get();
         if obj.is_null() {
-            None
+            false
         } else {
             cell.set(std::ptr::null_mut());
-            Some(obj)
+            true
         }
     })
 }

--- a/pyre/pyre-object/src/dict_eq_hook.rs
+++ b/pyre/pyre-object/src/dict_eq_hook.rs
@@ -127,7 +127,30 @@ pub unsafe fn try_eq_w(a: PyObjectRef, b: PyObjectRef) -> Option<bool> {
 /// `obj` must be a valid PyObjectRef (null tolerated).
 #[inline]
 pub unsafe fn try_hash_w(obj: PyObjectRef) -> Option<i64> {
-    HASH_W_HOOK.with(|cell| cell.get().map(|f| unsafe { f(obj) }))
+    if has_hash_w_hook() {
+        Some(hash_w_hooked(obj))
+    } else {
+        None
+    }
+}
+
+/// True when a `hash_w` hook is installed on this thread.
+/// `dont_look_inside`: the thread-local read has no liftable RPython
+/// shape; calls residualize via the registered fnaddr (same pattern
+/// as `gc_hook::try_gc_write_barrier`).
+#[majit_macros::dont_look_inside]
+pub extern "C" fn has_hash_w_hook() -> bool {
+    HASH_W_HOOK.with(|cell| cell.get().is_some())
+}
+
+/// Invoke the installed `hash_w` hook; returns 0 when no hook is
+/// installed — gate with [`has_hash_w_hook`] (the [`try_hash_w`]
+/// wrapper does).  Not `unsafe` for ABI-surface reasons (residual
+/// calls dispatch through a plain fnaddr); `obj` must nonetheless be
+/// a valid PyObjectRef (null tolerated).
+#[majit_macros::dont_look_inside]
+pub extern "C" fn hash_w_hooked(obj: PyObjectRef) -> i64 {
+    HASH_W_HOOK.with(|cell| cell.get().map(|f| unsafe { f(obj) }).unwrap_or(0))
 }
 
 /// Diagnostic panic for the single-hash contract.  Every dict key is
@@ -170,5 +193,27 @@ pub fn clear_compares_by_identity_hook() {
 /// (null tolerated).
 #[inline]
 pub unsafe fn try_compares_by_identity(w_type: PyObjectRef) -> Option<bool> {
-    COMPARES_BY_IDENTITY_HOOK.with(|cell| cell.get().map(|f| unsafe { f(w_type) }))
+    if has_compares_by_identity_hook() {
+        Some(compares_by_identity_hooked(w_type))
+    } else {
+        None
+    }
+}
+
+/// True when a `compares_by_identity` hook is installed on this
+/// thread.  `dont_look_inside`: thread-local read, residualizes via
+/// the registered fnaddr.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn has_compares_by_identity_hook() -> bool {
+    COMPARES_BY_IDENTITY_HOOK.with(|cell| cell.get().is_some())
+}
+
+/// Invoke the installed `compares_by_identity` hook; returns `false`
+/// when no hook is installed — gate with
+/// [`has_compares_by_identity_hook`] (the
+/// [`try_compares_by_identity`] wrapper does).  `w_type` must be a
+/// valid PyObjectRef pointing at a `W_TypeObject` (null tolerated).
+#[majit_macros::dont_look_inside]
+pub extern "C" fn compares_by_identity_hooked(w_type: PyObjectRef) -> bool {
+    COMPARES_BY_IDENTITY_HOOK.with(|cell| cell.get().map(|f| unsafe { f(w_type) }).unwrap_or(false))
 }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -115,7 +115,7 @@ unsafe fn key_as_utf8(key: PyObjectRef) -> Option<&'static str> {
 pub unsafe fn object_key_for(obj: PyObjectRef) -> ObjectKey {
     let hash = crate::dict_eq_hook::try_hash_w(obj)
         .unwrap_or_else(|| crate::dict_eq_hook::missing_hash_hook());
-    if crate::dict_eq_hook::take_hash_error().is_some() {
+    if crate::dict_eq_hook::take_hash_error() {
         // Infallible path: swallow the error and use structural hash.
         // Checked callers should use `object_key_for_checked` instead.
     }
@@ -130,7 +130,7 @@ pub unsafe fn object_key_for(obj: PyObjectRef) -> ObjectKey {
 pub unsafe fn object_key_for_checked(obj: PyObjectRef) -> Result<ObjectKey, DictKeyError> {
     let hash = crate::dict_eq_hook::try_hash_w(obj)
         .unwrap_or_else(|| crate::dict_eq_hook::missing_hash_hook());
-    if crate::dict_eq_hook::take_hash_error().is_some() {
+    if crate::dict_eq_hook::take_hash_error() {
         return Err(DictKeyError);
     }
     Ok(ObjectKey { hash, obj })
@@ -139,7 +139,7 @@ pub unsafe fn object_key_for_checked(obj: PyObjectRef) -> Result<ObjectKey, Dict
 #[inline]
 pub unsafe fn hash_key_checked(obj: PyObjectRef) -> Result<(), DictKeyError> {
     let _ = crate::dict_eq_hook::try_hash_w(obj);
-    if crate::dict_eq_hook::take_hash_error().is_some() {
+    if crate::dict_eq_hook::take_hash_error() {
         return Err(DictKeyError);
     }
     Ok(())
@@ -1615,7 +1615,7 @@ pub unsafe fn w_dict_lookup_checked(
         return w_dict_lookup_object_strategy_checked(obj, key);
     }
     let result = strategy.getitem(obj, key);
-    if crate::dict_eq_hook::take_hash_error().is_some() {
+    if crate::dict_eq_hook::take_hash_error() {
         return Err(DictKeyError);
     }
     Ok(result)
@@ -1838,7 +1838,7 @@ pub unsafe fn w_dict_store_checked(
         return w_dict_store_object_strategy_checked(obj, key, value);
     }
     strategy.setitem(obj, key, value);
-    if crate::dict_eq_hook::take_hash_error().is_some() {
+    if crate::dict_eq_hook::take_hash_error() {
         return Err(DictKeyError);
     }
     Ok(())
@@ -1891,7 +1891,7 @@ pub unsafe fn w_dict_setdefault_checked(
     // empty-dict setitem rejecting unhashable).  Route through
     // `w_dict_store_checked` and propagate its `Result` directly:
     // `object_key_for_checked` consumes the hook error slot, so a
-    // post-hoc `take_hash_error()` would observe `None`.
+    // post-hoc `take_hash_error()` would observe no pending error.
     if strategy_is(strategy, &crate::dictstrategy::EMPTY_DICT_STRATEGY) {
         crate::dictstrategy::EMPTY_DICT_STRATEGY.switch_to_correct_strategy(obj, key);
         w_dict_store_checked(obj, key, value)?;
@@ -1903,7 +1903,7 @@ pub unsafe fn w_dict_setdefault_checked(
         return Ok(value);
     }
     let result = strategy.setdefault(obj, key, value);
-    if crate::dict_eq_hook::take_hash_error().is_some() {
+    if crate::dict_eq_hook::take_hash_error() {
         return Err(DictKeyError);
     }
     Ok(result)
@@ -1941,13 +1941,13 @@ pub unsafe fn w_dict_pop_checked(
         let strategy = (*(obj as *const W_DictObject)).dstrategy;
         match strategy.pop(obj, key, None) {
             Ok(val) => {
-                if crate::dict_eq_hook::take_hash_error().is_some() {
+                if crate::dict_eq_hook::take_hash_error() {
                     return Err(DictKeyError);
                 }
                 Ok(Some(val))
             }
             Err(()) => {
-                if crate::dict_eq_hook::take_hash_error().is_some() {
+                if crate::dict_eq_hook::take_hash_error() {
                     return Err(DictKeyError);
                 }
                 Ok(None)
@@ -2603,7 +2603,7 @@ pub unsafe fn w_dict_delitem_checked(
         return w_dict_delitem_object_strategy_checked(obj, key);
     }
     let removed = strategy.delitem(obj, key);
-    if crate::dict_eq_hook::take_hash_error().is_some() {
+    if crate::dict_eq_hook::take_hash_error() {
         return Err(DictKeyError);
     }
     Ok(removed)


### PR DESCRIPTION
Fix https://github.com/youknowone/pyre/issues/122

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Z2.5 cutover progress: drain per-graph dual-gate skip causes so more graphs type through the real annotator/rtyper path instead of the legacy walker. Census (graphs still on the legacy fallback) goes 781 → 776 across the series; each commit moves a wall and keeps the full gate green (`cargo test --features dynasm --all` 0-fail + `check.py` all-pass on both backends).

**rtyper (PyPy ports)**

- `InstanceRepr::new_instance` class-default initialisation loop (rclass.py:752-769): fields with class-level defaults are written via `convert_desc_or_const` + `setfield`; NULL GC-pointer defaults keep malloc zero-init. Ports `hook_setfield` (rclass.py:715-718) + `is_quasi_immutable` (rclass.py:720-729) so quasi-immutable field writes emit `jit_force_quasi_immutable`. Drains the 17 "field-bearing class default init" gated subjects.
- Enum-variant ctor classes now subclass their enum root (shared `intern_class_by_qualname` base), so sibling-variant instances union at joins instead of dying with "no common base class".
- Dual-gate `is_known_unported` classifies two escaping failure texts (unported `rtyper_makerepr` arms, `BrokenReprTyperError` secondary echoes) as Skips rather than fatal build errors.

**front (MIR lowering folds — shapes rustc/Charon leave as unliftable opaque calls, which RPython flowspace sees as Constants)**

- Literal-initialized global reads and f64/f32 assoc consts (`INFINITY`/`NAN`) fold to constants; constant-bool `If` discriminants fold to a Goto (flowcontext.py:364-367 `guessbool`).
- `usize::try_from(u8|u16|u32)` lowers to an identity bind (rarithmetic.py:140-145 widen); `checked_neg` lowers to the inline `ovfcheck` decomposition (simplify.py:70-108 `transform_ovfcheck`); oparg `From`-to-u32 calls lower to field reads; builtin aggregates are named by their id atom so container placeholder classes stop colliding.
- `prune_dead_phis` + `clear_unreachable_blocks` run at front-lowering finalization (the simplify.py:1061 `transform_dead_op_vars` port, matching translator.py:56 `simplify_graph`), sweeping orphaned landing pads that produced spurious dual-gate divergences.

**dict_eq_hook / jit_fnaddr**

- `hash_w` / `compares_by_identity` / `take_hash_error` hook reads become `#[dont_look_inside]` extern "C" readers (gc_hook trampoline pattern), registered in `jit_fnaddr`; `take_hash_error` returns `bool` (every caller only tested `.is_some()`).
- Re-add `CELL_TYPE` / `SLICE_TYPE` / `RANGE_TYPE` / `RANGE_ITER_TYPE` / `SEQ_ITER_TYPE` `pytype_addr` statics, unblocked by the enum-root subclassing fix above.

## Self-review

This patch is AI-assisted (Claude, per-commit `Assisted-by:` trailers). Per-commit gates: `cargo test --features dynasm --all` 0-fail and `pyre/check.py` all-pass on dynasm + cranelift, plus a `PYRE_RTYPER_VERBOSE` census run verifying each drained wall. The cross-session parity review will be attached separately.

### Prompt & Model

Model: claude (Fable 5)

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `__pyre_cast_instance` support to improve type-aware casting and related lowering.
  * Added fixed-size list handling for `len(list)` lowering and equality for instance reprs.
  * Extended iterator pickle support for `itertools` (`takewhile`, `dropwhile`, `filterfalse`).

* **Improvements**
  * Enhanced class body execution to support non-dict `__prepare__` mappings.
  * Improved type narrowing/constant folding and impl-method dispatch correctness.

* **Bug Fixes**
  * Improved rollback annotation eviction behavior during annotation resets.
  * Updated checked dict hashing to treat hash-hook failures as `DictKeyError`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->