### PR TITLE
Result-of-PyError exception lowering, walker parity batch, and FieldWrite descriptor resolution

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1643,11 +1643,25 @@ impl Bookkeeper {
     /// `canonical_struct_name` unchanged, so qualname callers intern
     /// by their full spelling.
     pub fn intern_class_by_qualname(self: &Rc<Self>, name: &str) -> HostObject {
+        self.intern_class_by_qualname_with_bases(name, Vec::new())
+    }
+
+    /// [`Self::intern_class_by_qualname`] with explicit `__bases__` for
+    /// the first mint.  First-mint wins: a cache hit returns the
+    /// existing class regardless of `bases`, so every site minting a
+    /// given qualname must derive the same bases (the variant-ctor arm
+    /// in `flowspace_adapter::translate_op` derives them from the
+    /// ctor's own `owner_path`, which is identical at every site).
+    pub fn intern_class_by_qualname_with_bases(
+        self: &Rc<Self>,
+        name: &str,
+        bases: Vec<HostObject>,
+    ) -> HostObject {
         let key = majit_ir::descr::canonical_struct_name(name);
         if let Some(existing) = self.pyre_struct_root_classes.borrow().get(&key) {
             return existing.clone();
         }
-        let host = crate::flowspace::model::HostObject::new_class(key.clone(), Vec::new());
+        let host = crate::flowspace::model::HostObject::new_class(key.clone(), bases);
         self.pyre_struct_root_classes
             .borrow_mut()
             .insert(key, host.clone());

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2993,6 +2993,31 @@ impl<'a> Lowering<'a> {
     /// calls, aggregates) return `None` and keep the Call fallback.
     fn const_eval_global(&self, def_id: u64) -> Option<OpKind> {
         let g = self.llbc.global_by_id(def_id)?;
+        // Only an immutable, non-thread-local global folds to its init
+        // literal.  A `static mut` is written at runtime and a
+        // thread-local holds a per-thread value, so a post-init read of
+        // either must reach the live accessor, not the initialiser.  (A
+        // by-value read carries no address identity, so an immutable
+        // `static`'s literal is safe to inline here even when its address
+        // is taken elsewhere.)  `global_kind` does not distinguish
+        // `static mut` from `static`, so the mutability comes from the
+        // `static mut` keyword in Charon's recorded `source_text`.
+        if g.rest
+            .get("global_kind")
+            .and_then(serde_json::Value::as_str)
+            == Some("ThreadLocal")
+        {
+            return None;
+        }
+        let is_static_mut = g
+            .rest
+            .get("item_meta")
+            .and_then(|m| m.get("source_text"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|s| s.contains("static mut"));
+        if is_static_mut {
+            return None;
+        }
         let init_id = g.rest.get("init")?.as_u64()?;
         let fd = self.llbc.fn_by_id(init_id)?;
         let u = fd.unstructured()?;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1751,12 +1751,21 @@ impl<'a> Lowering<'a> {
                     // fits.  Emit a synthetic 2-arg Call so the write
                     // remains visible to the downstream side-effect
                     // tracking.
+                    //
+                    // The write produces no value (`result` below is `None`),
+                    // so the declared result kind must be Void: jtransform's
+                    // `resolve_call_result` reads `result_ty` when the op has
+                    // no result Variable, and a non-void kind there assembles
+                    // a `residual_call_r_<kind>` key with no `>` result tail
+                    // — a malformed opname nothing wires (`getkind(Void)`
+                    // keeps result-less calls on the `residual_call_*_v`
+                    // row).
                     OpKind::Call {
                         target: CallTarget::FunctionPath {
                             segments: vec!["__deref_write".to_string()],
                         },
                         args: vec![base, value],
-                        result_ty: ValueType::Int,
+                        result_ty: ValueType::Void,
                     }
                 }
             }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -750,16 +750,22 @@ pub fn lower_fun_decl_with_static_addrs(
             // end-of-lowering simplify, byte-identical.
             simplify_lowered_graph(&mut lo.graph);
         }
+        let mut tail_forwarded_returns = 0usize;
         if !lo.result_exc_call_results.is_empty() {
-            crate::front::result_exc::rewire_result_exc_call_sites(
+            let outcome = crate::front::result_exc::rewire_result_exc_call_sites(
                 &mut lo.graph,
                 &lo.result_exc_call_results,
+                result_exc_callee,
             )
             .map_err(LowerError::Unsupported)?;
+            tail_forwarded_returns = outcome.tail_forwards;
         }
         if result_exc_callee {
-            crate::front::result_exc::lower_result_exc_returns(&mut lo.graph)
-                .map_err(LowerError::Unsupported)?;
+            crate::front::result_exc::lower_result_exc_returns(
+                &mut lo.graph,
+                tail_forwarded_returns,
+            )
+            .map_err(LowerError::Unsupported)?;
         }
         simplify_lowered_graph(&mut lo.graph);
         Ok(())

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2629,6 +2629,7 @@ impl<'a> Lowering<'a> {
                 let segments = self.global_segments(mir_bb, id)?;
                 let op = self
                     .static_addr_op(&segments)
+                    .or_else(|| self.const_eval_global(id))
                     .unwrap_or_else(|| OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
                         args: vec![],
@@ -2931,6 +2932,48 @@ impl<'a> Lowering<'a> {
             }
         }
         None
+    }
+
+    /// Evaluate a global's initializer to its literal when the body is
+    /// the trivial `_0 = <literal>; return` shape.  The read then
+    /// lowers to the same `Const*` op an inline literal produces —
+    /// flow graphs carry module-level constants as `Constant(value)`,
+    /// so config bools like `WITHPREBUILTINT` constant-fold their
+    /// guarded branches instead of minting a synthetic 0-arg call no
+    /// registry can resolve.  Non-trivial initializers (multi-block,
+    /// calls, aggregates) return `None` and keep the Call fallback.
+    fn const_eval_global(&self, def_id: u64) -> Option<OpKind> {
+        let g = self.llbc.global_by_id(def_id)?;
+        let init_id = g.rest.get("init")?.as_u64()?;
+        let fd = self.llbc.fn_by_id(init_id)?;
+        let u = fd.unstructured()?;
+        let [block] = u.body.as_slice() else {
+            return None;
+        };
+        if !matches!(block.term(), Ok(TermKind::Return)) {
+            return None;
+        }
+        let mut assigned: Option<serde_json::Value> = None;
+        for stmt in &block.statements {
+            match stmt.stmt_kind() {
+                Ok(StmtKind::StorageLive(_)) | Ok(StmtKind::StorageDead(_)) => {}
+                Ok(StmtKind::Assign(place, Rvalue::Use(Operand::Const(value))))
+                    if matches!(place.kind, PlaceKind::Local(0)) && assigned.is_none() =>
+                {
+                    assigned = Some(value);
+                }
+                _ => return None,
+            }
+        }
+        match decode_constant(self.llbc, &assigned?).ok()? {
+            DecodedConst::Int(n) => Some(OpKind::ConstInt(n)),
+            DecodedConst::Bool(b) => Some(OpKind::ConstBool(b)),
+            DecodedConst::Float(bits) => Some(OpKind::ConstFloat(bits)),
+            // Strings / fn pointers keep the existing Call shapes the
+            // operand-constant lowering uses; folding them here would
+            // diverge from the `Rvalue::Use(Const)` treatment.
+            DecodedConst::Str(_) | DecodedConst::FnPath(_) => None,
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -752,7 +752,10 @@ pub fn lower_fun_decl_with_static_addrs(
     }
     let mut lo = Lowering::new(llbc, name.clone(), &u, static_addrs, fd.generics.as_ref())?;
     match lo.lower(BlockOrder::Linear) {
-        Ok(()) => Ok(lo.graph),
+        Ok(()) => {
+            simplify_lowered_graph(&mut lo.graph);
+            Ok(lo.graph)
+        }
         // A forward-referenced definition — typically a `TermKind::Call`
         // dest at a higher MIR index than the block that reads it — reads
         // as an uninitialised local under MIR-index order.  Re-lower the
@@ -765,9 +768,37 @@ pub fn lower_fun_decl_with_static_addrs(
         Err(LowerError::Unsupported(msg)) if is_known_lowering_gap(&msg) => {
             let mut lo = Lowering::new(llbc, name, &u, static_addrs, fd.generics.as_ref())?;
             lo.lower(BlockOrder::ReversePostorder)?;
+            simplify_lowered_graph(&mut lo.graph);
             Ok(lo.graph)
         }
         Err(e) => Err(e),
+    }
+}
+
+/// Per-graph simplification after lowering — the model-layer slice of
+/// RPython `simplify_graph(graph)` (`simplify.py:1075-1081`), which
+/// upstream runs on every freshly built flow graph.  Only the passes
+/// the Abort → `RaiseImplicit` fold needs are wired:
+///
+/// - `eliminate_empty_blocks` (simplify.py:52-69) collapses the empty
+///   raise block between a discriminant switch's `else
+///   unreachable!()` exit and `exceptblock`, exposing the
+///   `[Constant(AssertionError), …]` link to the next pass.
+/// - `remove_assertion_errors` (simplify.py:321-346) prunes the
+///   shouldn't-occur branch and promotes the surviving exit to an
+///   unconditional link.
+/// - `prune_dead_phis` (`transform_dead_op_vars`, simplify.py:422-524)
+///   melts the now-dead condition ops — the `__discriminant`
+///   FieldRead feeding the dropped exitswitch
+///   (`removeassert.py:35-37` "now melt away the (hopefully) dead
+///   operation that compute the condition").  Upstream leaves this to
+///   the later backendopt sweep (`backendopt/all.py`); the model
+///   layer has no later sweep, so it runs here, gated on an actual
+///   removal to keep untouched graphs byte-identical.
+fn simplify_lowered_graph(graph: &mut FunctionGraph) {
+    crate::model::eliminate_empty_blocks(graph);
+    if crate::model::remove_assertion_errors(graph) > 0 {
+        crate::model::prune_dead_phis(graph);
     }
 }
 
@@ -2865,6 +2896,25 @@ impl<'a> Lowering<'a> {
                 self.graph.set_return(bb_id, Some(ret));
                 Ok(())
             }
+            TermKind::Abort(_) => {
+                // A Rust panic-abort (`unreachable!()`, `panic!`,
+                // failed `unwrap`).  Python-level exceptions never
+                // reach here — they ride the `Result<_, PyError>`
+                // Switch/Return edges as ordinary control flow — so
+                // an Abort marks a "shouldn't occur at run-time"
+                // path, exactly the implicit-exception raise of
+                // `RaiseImplicit.nomoreblocks`
+                // (`flowcontext.py:1271-1284`).  Closing the block
+                // with `[Constant(AssertionError),
+                // Constant(AssertionError(msg))]` lets
+                // `remove_assertion_errors` (simplify.py:321-346)
+                // prune the branch — e.g. the `else unreachable!()`
+                // arm of a per-variant `let Instruction::X {..} =`
+                // re-match folds away together with its discriminant
+                // switch.
+                self.graph.set_raise_implicit(bb_id, "AssertionError");
+                Ok(())
+            }
             TermKind::UnwindResume => {
                 // Unwind-table cleanup resume.  Its only inbound edges
                 // are `on_unwind` edges, all of which this lowering
@@ -2875,28 +2925,6 @@ impl<'a> Lowering<'a> {
                 // ride the `Result<_, PyError>` Switch/Return edges as
                 // ordinary control flow.
                 self.graph.set_raise(bb_id, "mir-unwind");
-                Ok(())
-            }
-            TermKind::Abort(_) => {
-                // A panic site reached by ordinary control flow
-                // (explicit `panic!` / `unreachable!` / a diverging
-                // match arm), not unwind cleanup.  The RPython
-                // analogue of a host-level invariant failure is an
-                // `assert` raise, so lower the canonical
-                // `exc_from_raise` op sequence
-                // (`op.simple_call(const(AssertionError))` +
-                // `op.type(evalue)`) and close the block with the
-                // `(etype, evalue)` exception Link.  Message operands
-                // are not threaded through: the MIR panic payload is a
-                // host-formatting call chain with no Python-level
-                // meaning, matching the bare-`panic!()` shape of
-                // `lower_exc_from_raise`.
-                crate::front::raise::lower_exc_from_raise(
-                    &mut self.graph,
-                    bb_id,
-                    "AssertionError",
-                    vec![],
-                );
                 Ok(())
             }
             TermKind::Goto { target } => {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2683,18 +2683,21 @@ impl<'a> Lowering<'a> {
         kind: &serde_json::Value,
     ) -> Option<(Vec<String>, String, Vec<String>)> {
         let adt = kind.as_object()?.get("Adt")?.as_array()?;
-        // The first element is a Charon type body
-        // `{"id": {"Adt": <def_id>} | "Tuple" | {"Builtin": …}, "generics": …}`.
-        // The ADT `def_id` is nested at `[0]["id"]["Adt"]`; a `"Tuple"`
-        // / builtin atom `id` has no user-defined class and falls
-        // through to `None` (the Tuple/Array placeholder).
-        let type_id = adt
-            .first()?
-            .as_object()?
-            .get("id")?
-            .as_object()?
-            .get("Adt")?
-            .as_u64()?;
+        // `AggregateKind::Adt` head: either a bare `type_id` u64 or a
+        // full `TypeDeclRef` object `{"generics": …, "id": {"Adt":
+        // <type_id>} | "Tuple" | {"Builtin": …}}` (the object shape is
+        // what Charon emits for generic-instantiated types such as
+        // `Result<T, E>`).  The bare-u64 read alone made every generic
+        // aggregate fall through to the `"Adt"` ctor-name fallback,
+        // collapsing all such constructors onto one identity (variant +
+        // owner lost).  A `"Tuple"` / builtin atom `id` has no
+        // user-defined class and falls through to `None` (the
+        // Tuple/Array placeholder).
+        let head = adt.first()?;
+        let type_id = match head.as_u64() {
+            Some(id) => id,
+            None => head.get("id")?.get("Adt")?.as_u64()?,
+        };
         let variant_idx = adt.get(1).and_then(serde_json::Value::as_u64);
         let td = self.llbc.type_by_id(type_id)?;
         let name_path = td.item_meta.name_path();

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -813,17 +813,18 @@ pub fn lower_fun_decl_with_static_addrs(
         if lo.mir_model_is_acyclic() {
             match lo.lower_framestate() {
                 Ok(()) => {
-                    // The exception-link ABI (raise-through vs Result
-                    // return) must be uniform across lowering
-                    // strategies — a framestate-lowered scoped callee
-                    // that kept its Result returns would break a
-                    // monotonic-lowered caller whose call site was
-                    // rewired to LastException exits.  Bodies the
-                    // transforms don't touch skip this, keeping the
-                    // framestate output unchanged.
-                    if !lo.result_exc_call_results.is_empty() || result_exc_callee {
-                        finish(&mut lo)?;
-                    }
+                    // Run the shared post-lowering stage uniformly, same
+                    // as the linear / RPO paths below.  `finish` folds
+                    // constant exitswitches, drops `Abort` arms and runs
+                    // `simplify_lowered_graph`; gating it on result-exc
+                    // activity would let the framestate path keep dead
+                    // arms the other strategies prune, diverging the
+                    // graph for the same body.  The result-exc-specific
+                    // `clear_unreachable_blocks` stays gated inside
+                    // `finish`, and the exception-link ABI (raise-through
+                    // vs Result return) the transforms install runs here
+                    // too — uniform across lowering strategies.
+                    finish(&mut lo)?;
                     return Ok(lo.graph);
                 }
                 Err(e) => {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -738,6 +738,11 @@ pub fn lower_fun_decl_with_static_addrs(
     // dead-op sweep the Abort → RaiseImplicit fold uses.
     let result_exc_callee = crate::front::result_exc::in_result_exc_scope(&name)
         && crate::front::result_exc::tyref_is_result_of_pyerror(&fd.signature.output, llbc);
+    // A `Result<(), PyError>` scoped callee returns void after the
+    // exception-link lowering; widen its returnblock so the call
+    // descriptor's `FUNC.RESULT` is `v`, not the `Ref`-typed unit shell.
+    let result_exc_ok_is_unit = result_exc_callee
+        && crate::front::result_exc::tyref_result_ok_is_unit(&fd.signature.output, llbc);
     let finish = |lo: &mut Lowering<'_>| -> Result<(), LowerError> {
         if !lo.result_exc_call_results.is_empty() || result_exc_callee {
             // The exception-link transforms run on a simplified graph,
@@ -766,6 +771,32 @@ pub fn lower_fun_decl_with_static_addrs(
                 tail_forwarded_returns,
             )
             .map_err(LowerError::Unsupported)?;
+            if result_exc_ok_is_unit {
+                // Stamp `FUNC.RESULT = void`.  The exception-link lowering
+                // already returns the unit `()` (the callee no longer
+                // builds a `Result` shell), but `front::mir` types every
+                // aggregate — including `()` — as `Ref`, so the CFG return
+                // kind is still `r`.  The codewriter reconciles this by
+                // collapsing the returnblock to a genuine void return
+                // post-annotation (the `declared==v && cfg==r` gate),
+                // mirroring `exceptiontransform.py` running after rtyping;
+                // doing the structural collapse here, before the
+                // whole-program annotation fixpoint, destabilises it.
+                lo.graph.return_type = Some("()".to_string());
+            }
+        }
+        // The `?`-diamond rewrite (`rewire_result_exc_call_sites`) detaches
+        // the pre-rewrite branch / discriminant / break blocks: the call
+        // block now exits straight to the continue arm and `exceptblock`,
+        // so those blocks lose their only predecessor.  RPython graph
+        // consumers only iterate blocks reachable from `startblock`
+        // (`flowspace/model.py:66 iterblocks`), so drop the now-unreachable
+        // blocks here — before `prune_dead_phis`, which would otherwise
+        // treat a no-predecessor block as an extra root
+        // (`transform_dead_op_vars`'s start set), and before the
+        // `jit_codewriter` consumers that scan `graph.blocks` directly.
+        if !lo.result_exc_call_results.is_empty() || result_exc_callee {
+            crate::model::clear_unreachable_blocks(&mut lo.graph);
         }
         simplify_lowered_graph(&mut lo.graph);
         Ok(())
@@ -5277,7 +5308,11 @@ fn tyref_to_ast_string(ty: &TyRef, llbc: &Llbc) -> String {
 /// Recursive worker for [`tyref_to_ast_string`] operating on a raw
 /// Charon type-expression `Value` (a TyRef body or a nested
 /// generic-argument type).  `depth` guards against pathological cycles.
-fn charon_type_value_to_ast_string(v: &serde_json::Value, llbc: &Llbc, depth: usize) -> String {
+pub(crate) fn charon_type_value_to_ast_string(
+    v: &serde_json::Value,
+    llbc: &Llbc,
+    depth: usize,
+) -> String {
     if depth > 24 {
         return "??deep".to_string();
     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2341,18 +2341,24 @@ impl<'a> Lowering<'a> {
                 // typed analogue today.
                 if let ProjectionElem::Tagged(v) = &elem
                     && let Some(field_payload) = v.as_object().and_then(|m| m.get("Field"))
-                    && let Some((owner_root, field_name, _field_ty)) =
+                    && let Some((owner_root, field_name, field_ty)) =
                         self.resolve_adt_field(field_payload)
                 {
                     let base = self.resolve_place(mir_bb, *inner)?;
                     let bb_id = self.block_id[mir_bb];
-                    // The projected place's own `ty` is the field type
-                    // AFTER generic substitution; the TypeDecl's field ty
-                    // (`_field_ty`) is the declaration-side generic param
-                    // for generic ADTs (`Result<i64, E>`'s Ok payload
-                    // declares `T`), which `tyref_to_value_type` can only
-                    // degrade to `Ref(None)` — mistyping scalar payloads.
-                    let ty = tyref_to_value_type(&place_ty, self.llbc);
+                    // The field's DECLARED ty is the polymorphic decl's
+                    // (monomorphize=false): for a generic container
+                    // (`ControlFlow<B, C>`, `Result<T, E>`) it is a bare
+                    // type variable, which projects to the `Ref`
+                    // fallback even when the instantiated payload is an
+                    // `i64`.  The place's post-projection type carries
+                    // the substituted use-site type, so prefer it; keep
+                    // the decl ty for the rare place shapes whose
+                    // post-projection type the reader cannot resolve.
+                    let ty = match tyref_to_value_type(&place_ty, self.llbc) {
+                        ValueType::Ref(None) => tyref_to_value_type(&field_ty, self.llbc),
+                        resolved => resolved,
+                    };
                     let res = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -730,6 +730,40 @@ pub fn lower_fun_decl_with_static_addrs(
         ))
     })?;
     let name = fd.item_meta.name_path();
+    // The Result-of-PyError exception-link lowering's callee rule
+    // applies when this body is a scoped callee (see
+    // `front::result_exc`); the caller rule applies to the diamond
+    // sites the body lowering captured.  Both run before
+    // `simplify_lowered_graph` so the freed shell ops feed the same
+    // dead-op sweep the Abort → RaiseImplicit fold uses.
+    let result_exc_callee = crate::front::result_exc::in_result_exc_scope(&name)
+        && crate::front::result_exc::tyref_is_result_of_pyerror(&fd.signature.output, llbc);
+    let finish = |lo: &mut Lowering<'_>| -> Result<(), LowerError> {
+        if !lo.result_exc_call_results.is_empty() || result_exc_callee {
+            // The exception-link transforms run on a simplified graph,
+            // as exceptiontransform.py does (graphs reach it after
+            // `simplify_graph`, simplify.py:1075): the discriminant
+            // switch's `default → Abort` else-unreachable arm must be
+            // pruned by `remove_assertion_errors` before the diamond
+            // matcher sees the switch, leaving the plain 0/1 pair.
+            // Untouched graphs skip this and keep their single
+            // end-of-lowering simplify, byte-identical.
+            simplify_lowered_graph(&mut lo.graph);
+        }
+        if !lo.result_exc_call_results.is_empty() {
+            crate::front::result_exc::rewire_result_exc_call_sites(
+                &mut lo.graph,
+                &lo.result_exc_call_results,
+            )
+            .map_err(LowerError::Unsupported)?;
+        }
+        if result_exc_callee {
+            crate::front::result_exc::lower_result_exc_returns(&mut lo.graph)
+                .map_err(LowerError::Unsupported)?;
+        }
+        simplify_lowered_graph(&mut lo.graph);
+        Ok(())
+    };
     // Opt-in framestate-threaded lowering for acyclic bodies (the GAP-B
     // path that threads locals as block inputargs / phis).  Default
     // (flag unset) keeps the monotonic lowering so the gate stays green
@@ -741,7 +775,20 @@ pub fn lower_fun_decl_with_static_addrs(
         let mut lo = Lowering::new(llbc, name.clone(), &u, static_addrs, fd.generics.as_ref())?;
         if lo.mir_model_is_acyclic() {
             match lo.lower_framestate() {
-                Ok(()) => return Ok(lo.graph),
+                Ok(()) => {
+                    // The exception-link ABI (raise-through vs Result
+                    // return) must be uniform across lowering
+                    // strategies — a framestate-lowered scoped callee
+                    // that kept its Result returns would break a
+                    // monotonic-lowered caller whose call site was
+                    // rewired to LastException exits.  Bodies the
+                    // transforms don't touch skip this, keeping the
+                    // framestate output unchanged.
+                    if !lo.result_exc_call_results.is_empty() || result_exc_callee {
+                        finish(&mut lo)?;
+                    }
+                    return Ok(lo.graph);
+                }
                 Err(e) => {
                     if std::env::var_os("PYRE_MIR_FRAMESTATE_STRICT").is_some() {
                         return Err(e);
@@ -753,7 +800,7 @@ pub fn lower_fun_decl_with_static_addrs(
     let mut lo = Lowering::new(llbc, name.clone(), &u, static_addrs, fd.generics.as_ref())?;
     match lo.lower(BlockOrder::Linear) {
         Ok(()) => {
-            simplify_lowered_graph(&mut lo.graph);
+            finish(&mut lo)?;
             Ok(lo.graph)
         }
         // A forward-referenced definition — typically a `TermKind::Call`
@@ -768,7 +815,7 @@ pub fn lower_fun_decl_with_static_addrs(
         Err(LowerError::Unsupported(msg)) if is_known_lowering_gap(&msg) => {
             let mut lo = Lowering::new(llbc, name, &u, static_addrs, fd.generics.as_ref())?;
             lo.lower(BlockOrder::ReversePostorder)?;
-            simplify_lowered_graph(&mut lo.graph);
+            finish(&mut lo)?;
             Ok(lo.graph)
         }
         Err(e) => Err(e),
@@ -914,6 +961,13 @@ struct Lowering<'a> {
     /// so the paired `Result::expect` on such a local also aliases it
     /// — see [`Lowering::is_infallible_widening_try_from`].
     infallible_result_locals: std::collections::HashSet<usize>,
+    /// Result `Variable`s of calls to `RESULT_EXC_LOWERING_SCOPE`
+    /// callees whose declared result is `Result<T, PyError>`.  Each
+    /// heads a `Try::branch` diamond that
+    /// [`crate::front::result_exc::rewire_result_exc_call_sites`]
+    /// rewires into `ExitSwitch::LastException` exits after the body
+    /// lowering completes.
+    result_exc_call_results: Vec<Variable>,
 }
 
 impl<'a> Lowering<'a> {
@@ -1041,6 +1095,7 @@ impl<'a> Lowering<'a> {
             binop_result_locals: compute_binop_result_locals(body),
             index_elem_alias: std::collections::HashMap::new(),
             infallible_result_locals: std::collections::HashSet::new(),
+            result_exc_call_results: Vec::new(),
         })
     }
 
@@ -3214,6 +3269,15 @@ impl<'a> Lowering<'a> {
             .graph
             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
         self.local_var[dest_local] = Some(result_var.clone());
+        // Capture scoped `Result<T, PyError>` call results for the
+        // `?`-diamond rewiring pass (`front::result_exc`) that runs
+        // after the body lowering completes.
+        if let OpKind::Call { target, .. } = &op_kind
+            && crate::front::result_exc::call_target_in_scope(target)
+            && crate::front::result_exc::tyref_is_result_of_pyerror(&call.dest.ty, self.llbc)
+        {
+            self.result_exc_call_results.push(result_var.clone());
+        }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var),
             kind: op_kind,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4210,7 +4210,9 @@ fn trait_impl_trait_path_for_fundecl(llbc: &Llbc, fd: &FunDecl) -> Option<String
         .and_then(serde_json::Value::as_u64)?;
     let trait_impls = llbc.trait_impls_raw();
     let ti = trait_impls.get(trait_impl_id as usize)?;
-    // `impl_trait` is a TraitDeclRef; its trait-decl id field is `id`.
+    // `impl_trait` is a TraitDeclRef `{"id": <trait_decl_id>,
+    // "generics": {...}}` — same shape `resolve_impl_owner_adt_def_id`
+    // reads `generics.types[0]` from.
     let trait_id = ti
         .as_object()?
         .get("impl_trait")?

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1875,29 +1875,35 @@ impl<'a> Lowering<'a> {
             }
             ProjectionElem::Tagged(v) => {
                 if let Some(field_payload) = v.as_object().and_then(|m| m.get("Field")) {
-                    // Adt-container writes resolve the declared field
-                    // name / owner / type, mirroring the typed
-                    // `FieldRead` arm in `resolve_place` — an
-                    // asymmetric synthetic label (`Adt_<idx>`) would
-                    // make the rtyper's `getfieldrepr` miss the attr
-                    // the paired read registered under its real name.
-                    if let Some((owner_root, field_name, _field_ty)) =
-                        self.resolve_adt_field(field_payload)
-                    {
-                        OpKind::FieldWrite {
-                            base,
-                            field: FieldDescriptor::new(field_name, Some(owner_root)),
-                            value,
-                            ty: tyref_to_value_type(dest_ty, self.llbc),
-                        }
-                    } else {
-                        let label = field_label_from_payload(field_payload);
-                        OpKind::FieldWrite {
-                            base,
-                            field: FieldDescriptor::new(label, None),
-                            value,
-                            ty: ValueType::Int,
-                        }
+                    // Resolve the field through its TypeDecl exactly
+                    // like the read side (`resolve_place` Field arm):
+                    // the descriptor must carry the same
+                    // (`field_name`, `owner_root`) shape or no
+                    // downstream owner-keyed consumer can match it —
+                    // jtransform's vable matcher rejects a `None`
+                    // owner against an owner-rooted config, so e.g.
+                    // `PyFrame.valuestackdepth` writes stayed plain
+                    // `setfield` while the paired reads rewrote to
+                    // `getfield_vable`.  The Adt case derives the
+                    // written value's kind from `dest_ty` (a Ref field
+                    // must not be stamped `Int`); the bare-label
+                    // fallback keeps non-Adt containers lowering as
+                    // before.
+                    let (field, ty) = match self.resolve_adt_field(field_payload) {
+                        Some((owner_root, field_name, _field_ty)) => (
+                            FieldDescriptor::new(field_name, Some(owner_root)),
+                            tyref_to_value_type(dest_ty, self.llbc),
+                        ),
+                        None => (
+                            FieldDescriptor::new(field_label_from_payload(field_payload), None),
+                            ValueType::Int,
+                        ),
+                    };
+                    OpKind::FieldWrite {
+                        base,
+                        field,
+                        value,
+                        ty,
                     }
                 } else if let Some(index_payload) = v.as_object().and_then(|m| m.get("Index")) {
                     let idx_var = self.index_offset_var(mir_bb, index_payload)?;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -850,7 +850,19 @@ pub fn lower_fun_decl_with_static_addrs(
 ///   removal to keep untouched graphs byte-identical.
 fn simplify_lowered_graph(graph: &mut FunctionGraph) {
     crate::model::eliminate_empty_blocks(graph);
-    if crate::model::remove_assertion_errors(graph) > 0 {
+    let mut dirty = crate::model::remove_assertion_errors(graph) > 0;
+    // Constant-condition arms (`if WITHPREBUILTINT { … }` with the
+    // config const folded by `const_eval_global`) collapse to the
+    // taken link and the dead arm is emptied — the registry lift
+    // (`translate_op`) walks blocks by index, so a disconnected arm
+    // reading an unliftable static (`SMALL_INTS`) would otherwise
+    // still fail the whole graph.  `constant_fold_graph` link
+    // folding (backendopt/constfold.py).
+    if crate::model::fold_constant_exitswitch(graph) > 0 {
+        crate::model::clear_unreachable_blocks(graph);
+        dirty = true;
+    }
+    if dirty {
         crate::model::prune_dead_phis(graph);
     }
 }

--- a/majit/majit-translate/src/front/mir_dispatch.rs
+++ b/majit/majit-translate/src/front/mir_dispatch.rs
@@ -140,11 +140,15 @@ fn build_arm_body_graph(
             .last()
             .is_some_and(|leaf| leaf.starts_with("execute_")) =>
         {
-            Some((segments.last().unwrap().clone(), args.clone()))
+            Some((segments.clone(), args.clone()))
         }
         _ => None,
     });
-    if let Some((handler_leaf, args)) = tail_call {
+    if let Some((handler_segments, args)) = tail_call {
+        let handler_leaf = handler_segments
+            .last()
+            .cloned()
+            .expect("tail-call segments are non-empty (leaf matched above)");
         let forwarded: Vec<String> = args
             .iter()
             .map(|arg| {
@@ -160,7 +164,18 @@ fn build_arm_body_graph(
                     })
             })
             .collect();
-        let handler_path = CallPath::from_segments([handler_leaf]);
+        // Keep the dispatcher callsite's full Charon-qualified segments.
+        // `CallControl::find_all_graphs_bfs` walked this same callsite
+        // (the switch-target block of `execute_opcode_step`) and inserted
+        // the qualified spelling into `candidate_graphs`; truncating to
+        // the bare leaf here made `guess_call_kind` resolve the wrapper's
+        // tail-call through a non-candidate alias spelling and classify it
+        // `Residual` — every arm degenerated to a blackbox
+        // `residual_call_r_r(<symbolic hash>, …)` instead of the
+        // `inline_call` into the already-drained per-opcode jitcode
+        // (`call.py:117-139 guess_call_kind` keys candidacy on graph
+        // identity; pyre's path-keyed set needs the spelling to match).
+        let handler_path = CallPath::from_segments(handler_segments);
         return build_tail_call_wrapper(name, params, &handler_path, &forwarded);
     }
 

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -72,6 +72,7 @@ pub mod mir;
 pub mod mir_dispatch;
 pub mod opcode_wrapper;
 pub mod raise;
+pub(crate) mod result_exc;
 pub mod semantic;
 pub mod typestr;
 

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -64,15 +64,20 @@ use majit_charon_reader::Llbc;
 use majit_charon_reader::ullbc::TyRef;
 
 use crate::flowspace::model::Variable;
-use crate::model::{
-    CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType,
-};
+use crate::model::{CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType};
 
 /// Callees whose `Result<T, PyError>` surface lowers to raise links.
 /// Grown deliberately (same staging discipline as
 /// `REQUIRED_METHOD_DEVIRT_SCOPE` in `lib.rs`); replaced by a
 /// whole-program conformance scan once every caller shape is covered.
-const RESULT_EXC_LOWERING_SCOPE: &[&str] = &["pop_value"];
+const RESULT_EXC_LOWERING_SCOPE: &[&str] = &[
+    "pop_value",
+    "store_local_value",
+    "opcode_store_fast",
+    "store_fast",
+    "opcode_store_fast_store_fast",
+    "store_fast_store_fast",
+];
 
 /// True when `name_path`'s leaf is a scoped callee.
 pub(crate) fn in_result_exc_scope(name_path: &str) -> bool {
@@ -85,9 +90,7 @@ pub(crate) fn in_result_exc_scope(name_path: &str) -> bool {
 pub(crate) fn call_target_in_scope(target: &CallTarget) -> bool {
     let leaf = match target {
         CallTarget::Method { name, .. } => name.as_str(),
-        CallTarget::FunctionPath { segments } => {
-            segments.last().map(String::as_str).unwrap_or("")
-        }
+        CallTarget::FunctionPath { segments } => segments.last().map(String::as_str).unwrap_or(""),
         _ => return false,
     };
     RESULT_EXC_LOWERING_SCOPE.contains(&leaf)
@@ -96,14 +99,14 @@ pub(crate) fn call_target_in_scope(target: &CallTarget) -> bool {
 /// Resolve the JSON body behind a generics slot — `{"Deduplicated":
 /// id}` indirections through the dedup table, `{"HashConsedValue":
 /// [id, body]}` inline pairs, anything else as-is.
-fn ty_json_body<'l>(
-    v: &'l serde_json::Value,
-    llbc: &'l Llbc,
-) -> Option<&'l serde_json::Value> {
+fn ty_json_body<'l>(v: &'l serde_json::Value, llbc: &'l Llbc) -> Option<&'l serde_json::Value> {
     if let Some(id) = v.get("Deduplicated").and_then(serde_json::Value::as_u64) {
         return llbc.dedup_body(id);
     }
-    if let Some(arr) = v.get("HashConsedValue").and_then(serde_json::Value::as_array) {
+    if let Some(arr) = v
+        .get("HashConsedValue")
+        .and_then(serde_json::Value::as_array)
+    {
         return arr.get(1);
     }
     Some(v)
@@ -148,7 +151,13 @@ fn result_ctor_kind(target: &CallTarget) -> Option<bool> {
     let CallTarget::SyntheticTransparentCtor { name, owner_path } = target else {
         return None;
     };
-    if owner_path != &["core".to_string(), "result".to_string(), "Result".to_string()] {
+    if owner_path
+        != &[
+            "core".to_string(),
+            "result".to_string(),
+            "Result".to_string(),
+        ]
+    {
         return None;
     }
     match name.as_str() {
@@ -161,11 +170,18 @@ fn result_ctor_kind(target: &CallTarget) -> Option<bool> {
 /// Callee rule.  Rewrites every `Result::Ok` / `Result::Err` shell
 /// construction that flows into `returnblock` into a plain value
 /// return / a raise link.  Returns the number of rewritten returns.
+/// `tail_forwarded_returns` counts the returns the caller rule already
+/// disposed of (a `return f(...)` of another scoped callee builds no
+/// shell of its own) — a body whose every return is such a forward
+/// legitimately has nothing left to rewrite here.
 ///
 /// Fail-loud on any shape outside the known construction pattern —
 /// a scoped callee with an unrecognised return shape must break the
 /// build, not silently keep its shell.
-pub(crate) fn lower_result_exc_returns(graph: &mut FunctionGraph) -> Result<usize, String> {
+pub(crate) fn lower_result_exc_returns(
+    graph: &mut FunctionGraph,
+    tail_forwarded_returns: usize,
+) -> Result<usize, String> {
     let nblocks = graph.blocks.len();
     let mut rewritten = 0usize;
     for bi in 0..nblocks {
@@ -205,8 +221,15 @@ pub(crate) fn lower_result_exc_returns(graph: &mut FunctionGraph) -> Result<usiz
         // returns a payload-carrying Result (unit payloads would lower
         // with no FieldWrite and need a Void widening).
         let mut fieldwrite_idx: Option<(usize, Variable)> = None;
-        for (i, op) in graph.blocks[bi].operations.iter().enumerate().skip(ctor_idx + 1) {
-            if let OpKind::FieldWrite { base, field, value, .. } = &op.kind
+        for (i, op) in graph.blocks[bi]
+            .operations
+            .iter()
+            .enumerate()
+            .skip(ctor_idx + 1)
+        {
+            if let OpKind::FieldWrite {
+                base, field, value, ..
+            } = &op.kind
                 && *base == ctor_var
             {
                 if field.name != "__pos_0" || fieldwrite_idx.is_some() {
@@ -297,7 +320,7 @@ pub(crate) fn lower_result_exc_returns(graph: &mut FunctionGraph) -> Result<usiz
         }
         rewritten += 1;
     }
-    if rewritten == 0 {
+    if rewritten == 0 && tail_forwarded_returns == 0 {
         return Err(format!(
             "{}: scoped Result-of-PyError callee with no rewritable returns",
             graph.name
@@ -401,24 +424,50 @@ fn verify_forwards_to_returnblock(
     ))
 }
 
+/// What [`rewire_one_call_site`] found at a scoped call site.
+pub(crate) struct RewireOutcome {
+    /// `?`-diamond sites rewired into `LastException` exits.
+    pub diamonds: usize,
+    /// Tail-forwarded sites (`return f(...)` — the callee's `Result`
+    /// IS this graph's return value).  Once the callee is transformed
+    /// the forward already carries `T` and the raise propagates
+    /// implicitly, so no rewrite is needed — but only inside a graph
+    /// that is itself a scoped callee; an unscoped enclosing graph
+    /// would hand `T` to callers still switching on a discriminant.
+    pub tail_forwards: usize,
+}
+
 /// Caller rule.  `results` are the result `Variable`s of calls to
 /// scoped callees (captured during lowering).  Each must sit at the
-/// head of a `Try::branch` diamond, which is rewired into
-/// `ExitSwitch::LastException` exits.  Returns the number of rewired
-/// sites.
+/// head of a `Try::branch` diamond — rewired into
+/// `ExitSwitch::LastException` exits — or tail-forward to
+/// `returnblock` inside a scoped enclosing graph.
 pub(crate) fn rewire_result_exc_call_sites(
     graph: &mut FunctionGraph,
     results: &[Variable],
-) -> Result<usize, String> {
-    let mut rewired = 0usize;
+    enclosing_scoped: bool,
+) -> Result<RewireOutcome, String> {
+    let mut outcome = RewireOutcome {
+        diamonds: 0,
+        tail_forwards: 0,
+    };
     for r in results {
-        rewire_one_call_site(graph, r)?;
-        rewired += 1;
+        if rewire_one_call_site(graph, r, enclosing_scoped)? {
+            outcome.diamonds += 1;
+        } else {
+            outcome.tail_forwards += 1;
+        }
     }
-    Ok(rewired)
+    Ok(outcome)
 }
 
-fn rewire_one_call_site(graph: &mut FunctionGraph, r: &Variable) -> Result<(), String> {
+/// Returns `true` for a rewired diamond, `false` for a (no-op)
+/// tail-forward.
+fn rewire_one_call_site(
+    graph: &mut FunctionGraph,
+    r: &Variable,
+    enclosing_scoped: bool,
+) -> Result<bool, String> {
     let name = graph.name.clone();
     // Block A: contains the call producing `r`; closed by lower_call
     // with a single forwarding exit.
@@ -427,8 +476,19 @@ fn rewire_one_call_site(graph: &mut FunctionGraph, r: &Variable) -> Result<(), S
         .iter()
         .position(|b| b.operations.iter().any(|op| op.result.as_ref() == Some(r)))
         .ok_or_else(|| format!("{name}: scoped call result var has no producer block"))?;
-    let (b, r_b) = follow_single_exit(graph, a, r)
-        .map_err(|e| format!("{name}: call block exit: {e}"))?;
+    // Tail forward: the callee's Result flows straight to returnblock.
+    if forwards_to_returnblock(graph, a, r) {
+        if !enclosing_scoped {
+            return Err(format!(
+                "{name}: tail-forwards a scoped callee's Result out of an \
+                 unscoped graph — add it to RESULT_EXC_LOWERING_SCOPE or \
+                 the callers' discriminant switches read garbage"
+            ));
+        }
+        return Ok(false);
+    }
+    let (b, r_b) =
+        follow_single_exit(graph, a, r).map_err(|e| format!("{name}: call block exit: {e}"))?;
     assert_single_pred(graph, b, &name)?;
     // Block B: `cf = Result::branch(r)`.
     let branch_op_idx = graph.blocks[b]
@@ -452,8 +512,8 @@ fn rewire_one_call_site(graph: &mut FunctionGraph, r: &Variable) -> Result<(), S
         .result
         .clone()
         .ok_or_else(|| format!("{name}: branch() without result var"))?;
-    let (c, cf_c) = follow_single_exit(graph, b, &cf)
-        .map_err(|e| format!("{name}: branch block exit: {e}"))?;
+    let (c, cf_c) =
+        follow_single_exit(graph, b, &cf).map_err(|e| format!("{name}: branch block exit: {e}"))?;
     assert_single_pred(graph, c, &name)?;
     // Block C: `d = cf.__discriminant`; switch d {0 → continue, 1 → break}.
     let disc_var = graph.blocks[c]
@@ -467,9 +527,7 @@ fn rewire_one_call_site(graph: &mut FunctionGraph, r: &Variable) -> Result<(), S
             }
             _ => None,
         })
-        .ok_or_else(|| {
-            format!("{name}: block {c} lacks the ControlFlow __discriminant read")
-        })?;
+        .ok_or_else(|| format!("{name}: block {c} lacks the ControlFlow __discriminant read"))?;
     match &graph.blocks[c].exitswitch {
         Some(ExitSwitch::Value(v)) if *v == disc_var => {}
         other => {
@@ -540,7 +598,39 @@ fn rewire_one_call_site(graph: &mut FunctionGraph, r: &Variable) -> Result<(), S
     ];
     // Blocks B, C and the break arm are now unreachable; the dead-op
     // sweep leaves them to the reachability-walking consumers.
-    Ok(())
+    Ok(true)
+}
+
+/// Probe: does `var` flow from `block`'s exit through pure positional
+/// forwarding into `returnblock`?  The non-erroring twin of
+/// [`verify_forwards_to_returnblock`] — any non-conforming hop means
+/// "not a tail forward" rather than a build failure (the site is then
+/// matched as a diamond, whose own checks fail loud).
+fn forwards_to_returnblock(graph: &FunctionGraph, block: usize, var: &Variable) -> bool {
+    let mut current = block;
+    let mut tracked = var.clone();
+    for _ in 0..graph.blocks.len() {
+        let [link] = graph.blocks[current].exits.as_slice() else {
+            return false;
+        };
+        let Some(pos) = link
+            .args
+            .iter()
+            .position(|a| matches!(a, LinkArg::Value(v) if *v == tracked))
+        else {
+            return false;
+        };
+        if link.target == graph.returnblock {
+            return true;
+        }
+        let target = link.target.0;
+        let Some(next_var) = graph.blocks[target].inputargs.get(pos) else {
+            return false;
+        };
+        tracked = next_var.clone();
+        current = target;
+    }
+    false
 }
 
 /// Map a continue-arm link variable back to its A-scope origin
@@ -603,7 +693,9 @@ fn follow_single_exit(
         .iter()
         .position(|a| matches!(a, LinkArg::Value(v) if v == var))
     else {
-        return Err(format!("block {block}'s exit does not carry the tracked value"));
+        return Err(format!(
+            "block {block}'s exit does not carry the tracked value"
+        ));
     };
     let target = link.target.0;
     let bound = graph.blocks[target]
@@ -667,7 +759,9 @@ fn split_diamond_exits(exits: &[Link], name: &str) -> Result<(Link, Link), Strin
         (Some(c), Some(b), None) => Ok((c, b)),
         (Some(c), None, Some(d)) => Ok((c, d)),
         (None, Some(b), Some(d)) => Ok((d, b)),
-        _ => Err(format!("{name}: ControlFlow switch lacks the 0/1 case pair")),
+        _ => Err(format!(
+            "{name}: ControlFlow switch lacks the 0/1 case pair"
+        )),
     }
 }
 
@@ -705,9 +799,11 @@ fn verify_break_arm_is_reraise(
         ));
     };
     let residual_result = ops.iter().find_map(|op| match &op.kind {
-        OpKind::Call { target: CallTarget::Method { name: m, .. }, args, .. }
-            if m == "from_residual" && args.as_slice() == std::slice::from_ref(&payload_var) =>
-        {
+        OpKind::Call {
+            target: CallTarget::Method { name: m, .. },
+            args,
+            ..
+        } if m == "from_residual" && args.as_slice() == std::slice::from_ref(&payload_var) => {
             op.result.clone()
         }
         _ => None,
@@ -769,14 +865,22 @@ fn collapse_pos0_read(
     // Rename the read's result to the carrier across the block's
     // remaining ops, exitswitch, and exits.
     let rename = |v: &Variable| -> Variable {
-        if *v == read_result { carrier.clone() } else { v.clone() }
+        if *v == read_result {
+            carrier.clone()
+        } else {
+            v.clone()
+        }
     };
     let block = &mut graph.blocks[ti];
     for op in &mut block.operations {
         op.kind = crate::inline::remap_op_kind(&op.kind, &rename);
     }
-    let (sw, exits) =
-        crate::model::remap_control_flow_metadata_var(&block.exitswitch, &block.exits, rename, |b| b);
+    let (sw, exits) = crate::model::remap_control_flow_metadata_var(
+        &block.exitswitch,
+        &block.exits,
+        rename,
+        |b| b,
+    );
     block.exitswitch = sw;
     block.exits = exits;
     Ok(())

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -213,7 +213,8 @@ pub(crate) fn tyref_result_ok_is_unit(ty: &TyRef, llbc: &Llbc) -> bool {
 /// `exceptiontransform.py` would return `Void`.  Drop the return
 /// variable and every arg on the exits feeding it; an empty returnblock
 /// `inputargs` is the void-return shape `graph_result_kind` maps to
-/// `v`.  The now-dead unit producers are left to the dead-op sweep.
+/// `v`.  The now-dead unit producers are swept by the `prune_dead_phis`
+/// pass the codewriter runs immediately after this widen.
 pub(crate) fn widen_unit_return_to_void(graph: &mut FunctionGraph) {
     let returnblock = graph.returnblock;
     for block in &mut graph.blocks {
@@ -762,6 +763,10 @@ fn rewire_one_call_site(
         return Ok(SiteOutcome::Rewrapped);
     };
     assert_single_pred(graph, b, &name)?;
+    // Block B is bypassed by the rewrite (A exits straight to the
+    // continue target); only the `branch` destructuring may carry an
+    // effect, so any other side-effecting op here is unsupported.
+    assert_block_pure_besides(graph, b, &[branch_op_idx], "branch", &name)?;
     let cf = graph.blocks[b].operations[branch_op_idx]
         .result
         .clone()
@@ -770,14 +775,15 @@ fn rewire_one_call_site(
         follow_single_exit(graph, b, &cf).map_err(|e| format!("{name}: branch block exit: {e}"))?;
     assert_single_pred(graph, c, &name)?;
     // Block C: `d = cf.__discriminant`; switch d {0 → continue, 1 → break}.
-    let disc_var = graph.blocks[c]
+    let (disc_idx, disc_var) = graph.blocks[c]
         .operations
         .iter()
-        .find_map(|op| match &op.kind {
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
             OpKind::FieldRead { base, field, .. }
                 if *base == cf_c && field.name == "__discriminant" =>
             {
-                op.result.clone()
+                op.result.clone().map(|r| (i, r))
             }
             _ => None,
         })
@@ -791,6 +797,9 @@ fn rewire_one_call_site(
             ));
         }
     }
+    // Block C is bypassed too; only the discriminant read may carry an
+    // effect.  Reject any extra side-effecting op the switch would drop.
+    assert_block_pure_besides(graph, c, &[disc_idx], "discriminant", &name)?;
     let (continue_link, break_link) = split_diamond_exits(&graph.blocks[c].exits, &name)?;
     // The break arm must be the pure `?` re-raise tail
     // (`__pos_0` read + `from_residual` + return).  A custom handler
@@ -1239,6 +1248,34 @@ fn split_diamond_exits(exits: &[Link], name: &str) -> Result<(Link, Link), Strin
 /// The break arm must be exactly `e = cf.__pos_0; from_residual(e);
 /// → returnblock` — the `?` re-raise tail that the exception link
 /// replaces.  Anything else is a custom handler and must fail loud.
+/// Assert every operation in `block` other than the `recognized`
+/// indices is side-effect-free.  The `?`-diamond rewrite disconnects the
+/// branch / discriminant / break-arm blocks, so an unrecognised
+/// side-effecting op in any of them would be silently bypassed; RPython
+/// exception links are equivalent only when the removed shape is pure
+/// control / unwrap / reraise plumbing.  Pure extras (constants, reads)
+/// are harmless to bypass and are allowed.
+fn assert_block_pure_besides(
+    graph: &FunctionGraph,
+    block: usize,
+    recognized: &[usize],
+    role: &str,
+    name: &str,
+) -> Result<(), String> {
+    for (i, op) in graph.blocks[block].operations.iter().enumerate() {
+        if recognized.contains(&i) {
+            continue;
+        }
+        if !crate::inline::is_pure_op(&op.kind) {
+            return Err(format!(
+                "{name}: {role} block {block} carries a side-effecting operation \
+                 the `?`-diamond rewrite would silently bypass — unsupported shape"
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn verify_break_arm_is_reraise(
     graph: &FunctionGraph,
     break_link: &Link,
@@ -1257,34 +1294,43 @@ fn verify_break_arm_is_reraise(
         .cloned()
         .ok_or_else(|| format!("{name}: break arm target lacks inputarg {pos}"))?;
     let ops = &graph.blocks[e_block].operations;
-    let payload_var = ops.iter().find_map(|op| match &op.kind {
+    let payload = ops.iter().enumerate().find_map(|(i, op)| match &op.kind {
         OpKind::FieldRead { base, field, .. } if *base == cf_e && field.name == "__pos_0" => {
-            op.result.clone()
+            op.result.clone().map(|r| (i, r))
         }
         _ => None,
     });
-    let Some(payload_var) = payload_var else {
+    let Some((pos0_idx, payload_var)) = payload else {
         return Err(format!(
             "{name}: break arm block {e_block} lacks the __pos_0 residual read — \
              custom `?` handler shapes are not supported yet"
         ));
     };
-    let residual_result = ops.iter().find_map(|op| match &op.kind {
+    let residual = ops.iter().enumerate().find_map(|(i, op)| match &op.kind {
         OpKind::Call {
             target: CallTarget::Method { name: m, .. },
             args,
             ..
         } if m == "from_residual" && args.as_slice() == std::slice::from_ref(&payload_var) => {
-            op.result.clone()
+            op.result.clone().map(|r| (i, r))
         }
         _ => None,
     });
-    let Some(residual_result) = residual_result else {
+    let Some((from_residual_idx, residual_result)) = residual else {
         return Err(format!(
             "{name}: break arm block {e_block} lacks the from_residual call — \
              custom `?` handler shapes are not supported yet"
         ));
     };
+    // Only the `__pos_0` read and the `from_residual` call may carry an
+    // effect; any other side-effecting op would be dropped by the rewrite.
+    assert_block_pure_besides(
+        graph,
+        e_block,
+        &[pos0_idx, from_residual_idx],
+        "break arm",
+        name,
+    )?;
     verify_forwards_to_returnblock(graph, e_block, &residual_result)
 }
 

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -170,6 +170,60 @@ pub(crate) fn tyref_is_result_of_pyerror(ty: &TyRef, llbc: &Llbc) -> bool {
     adt_path_of(err_body, llbc).is_some_and(|p| p == "pyre_interpreter::error::PyError")
 }
 
+/// True when `ty` is `Result<(), PyError>` — the Ok payload is the unit
+/// type.  Such a callee returns void after the exception-link lowering
+/// (`exceptiontransform.py` widens the value-encoded result to the inner
+/// type, which is `Void` for the unit case), so its return must be
+/// widened to a genuine void return rather than forwarding the unit
+/// `()` value as a `Ref`-typed shell — see [`widen_unit_return_to_void`].
+pub(crate) fn tyref_result_ok_is_unit(ty: &TyRef, llbc: &Llbc) -> bool {
+    let body = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(v) => v,
+            None => return false,
+        },
+    };
+    if adt_path_of(body, llbc).as_deref() != Some("core::result::Result") {
+        return false;
+    }
+    let Some(ok_slot) = body
+        .get("Adt")
+        .and_then(|a| a.get("generics"))
+        .and_then(|g| g.get("types"))
+        .and_then(|t| t.get(0))
+    else {
+        return false;
+    };
+    crate::front::mir::charon_type_value_to_ast_string(ok_slot, llbc, 0) == "()"
+}
+
+/// Collapse a scoped callee's returnblock to a genuine void return.
+///
+/// A `Result<(), PyError>` callee carries the unit `Ok` payload as a
+/// `Ref`-typed value: the callee rule forwards the `()` aggregate (a
+/// niladic transparent ctor, `front::mir` types every aggregate as
+/// `Ref`), and a tail-forwarded `f(...)?` carries the inner callee's
+/// `Ref` call result.  Either way the returnblock's return variable
+/// colours `GcRef`, so `graph_result_kind` (and thus the call
+/// descriptor's `FUNC.RESULT`) reads `r` for a function that
+/// `exceptiontransform.py` would return `Void`.  Drop the return
+/// variable and every arg on the exits feeding it; an empty returnblock
+/// `inputargs` is the void-return shape `graph_result_kind` maps to
+/// `v`.  The now-dead unit producers are left to the dead-op sweep.
+pub(crate) fn widen_unit_return_to_void(graph: &mut FunctionGraph) {
+    let returnblock = graph.returnblock;
+    for block in &mut graph.blocks {
+        for link in &mut block.exits {
+            if link.target == returnblock {
+                link.args.clear();
+            }
+        }
+    }
+    graph.blocks[returnblock.0].inputargs.clear();
+}
+
 /// Is `target` the `Result::Ok` / `Result::Err` transparent ctor?
 fn result_ctor_kind(target: &CallTarget) -> Option<bool> {
     let CallTarget::SyntheticTransparentCtor { name, owner_path } = target else {

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1,0 +1,783 @@
+//! `Result<T, PyError>` → exception-link lowering.
+//!
+//! ## Positioning
+//!
+//! `front/mod.rs`'s charter mandates that "`?` / `PyResult` must be
+//! lowered to exceptional successor edges of the existing
+//! `Terminator`, matching `rpython/translator/exceptiontransform.py` +
+//! `rpython/jit/codewriter/jtransform.py:rewrite_op_direct_call`".
+//! This module is that lowering.  RPython's exception transformer is
+//! the same bridge run in the opposite direction (exception links →
+//! value encodings for the C backend); Rust source arrives
+//! value-encoded, so pyre runs the inverse: the value-encoded
+//! `Result` idiom becomes the graph's native exception representation
+//! (`ExitSwitch::LastException` exits + `exceptblock` links), the same
+//! way `simplify.py:transform_ovfcheck` converts the value-encoded
+//! `ovfcheck()` idiom into an op with an implicit exception link.
+//!
+//! The residual-call ABI already performs this erasure at every host
+//! boundary (`pyre-interpreter/src/opcode_ops.rs:265
+//! bh_execute_store_subscr`: `Ok` → value, `Err` →
+//! `BH_LAST_EXC_VALUE`), so jitcode-inlined graphs were the only
+//! consumers still seeing `Result` shells — built by niladic
+//! `SyntheticTransparentCtor` residuals that can never execute (a
+//! synthetic ctor has no host symbol) and switched on a
+//! `__discriminant` field read the walker cannot make concrete.
+//!
+//! ## The two rules
+//!
+//! - **Callee rule** ([`lower_result_exc_returns`]): a scoped graph
+//!   whose declared return is `Result<T, PyError>` stops building
+//!   `Ok`/`Err` shells.  `return Ok(v)` links `returnblock` with `v`;
+//!   `return Err(e)` materialises the runtime exception object
+//!   (`PyError::to_exc_object` — the trace-level exception value
+//!   domain is the `W_ExceptionObject` ref, the same value
+//!   `BH_LAST_EXC_VALUE` carries) and closes the block towards
+//!   `exceptblock` with `(op.type(exc), exc)`, exactly the
+//!   `lower_exc_from_raise` tail shape (`flowcontext.py:600`).
+//!
+//! - **Caller rule** ([`rewire_result_exc_call_sites`]): a `?` on a
+//!   call to a scoped callee lowers in MIR as a
+//!   `Try::branch`-diamond — `cf = branch(r)` →
+//!   `switch(cf.__discriminant)` → `{0: continue with cf.__pos_0,
+//!   1: from_residual(cf.__pos_0) → return}`.  The rewrite gives the
+//!   call block `ExitSwitch::LastException` with the normal exit
+//!   jumping straight to the continue arm (the call result *is* `T`
+//!   once the callee raises) and the exception exit propagating to
+//!   `exceptblock` via the `last_exception` / `last_exc_value` link
+//!   pair — RPython's default exception link (`flowspace/model.py`
+//!   `Link.last_exception`), which `flatten.rs` already turns into
+//!   `catch_exception` / rethrow shapes.
+//!
+//! ## Scope discipline
+//!
+//! Both rules must apply together per callee: a transformed callee
+//! returns `T` and raises, so an untransformed caller-side
+//! discriminant switch would read garbage.  Until the whole-program
+//! conformance scan lands, [`RESULT_EXC_LOWERING_SCOPE`] pins the
+//! callee set; every call site of a scoped callee either matches the
+//! `?`-diamond or fails the build loudly (custom `match` handlers
+//! need the caught value bound from `last_exc_value` — a later
+//! widening).
+
+use majit_charon_reader::Llbc;
+use majit_charon_reader::ullbc::TyRef;
+
+use crate::flowspace::model::Variable;
+use crate::model::{
+    CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType,
+};
+
+/// Callees whose `Result<T, PyError>` surface lowers to raise links.
+/// Grown deliberately (same staging discipline as
+/// `REQUIRED_METHOD_DEVIRT_SCOPE` in `lib.rs`); replaced by a
+/// whole-program conformance scan once every caller shape is covered.
+const RESULT_EXC_LOWERING_SCOPE: &[&str] = &["pop_value"];
+
+/// True when `name_path`'s leaf is a scoped callee.
+pub(crate) fn in_result_exc_scope(name_path: &str) -> bool {
+    RESULT_EXC_LOWERING_SCOPE
+        .iter()
+        .any(|leaf| name_path == *leaf || name_path.ends_with(&format!("::{leaf}")))
+}
+
+/// True when a call target's leaf names a scoped callee.
+pub(crate) fn call_target_in_scope(target: &CallTarget) -> bool {
+    let leaf = match target {
+        CallTarget::Method { name, .. } => name.as_str(),
+        CallTarget::FunctionPath { segments } => {
+            segments.last().map(String::as_str).unwrap_or("")
+        }
+        _ => return false,
+    };
+    RESULT_EXC_LOWERING_SCOPE.contains(&leaf)
+}
+
+/// Resolve the JSON body behind a generics slot — `{"Deduplicated":
+/// id}` indirections through the dedup table, `{"HashConsedValue":
+/// [id, body]}` inline pairs, anything else as-is.
+fn ty_json_body<'l>(
+    v: &'l serde_json::Value,
+    llbc: &'l Llbc,
+) -> Option<&'l serde_json::Value> {
+    if let Some(id) = v.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+        return llbc.dedup_body(id);
+    }
+    if let Some(arr) = v.get("HashConsedValue").and_then(serde_json::Value::as_array) {
+        return arr.get(1);
+    }
+    Some(v)
+}
+
+/// `{"Adt": {"id": {"Adt": <id>}, …}}` → the TypeDecl's full name path.
+fn adt_path_of(v: &serde_json::Value, llbc: &Llbc) -> Option<String> {
+    let id = v.get("Adt")?.get("id")?.get("Adt")?.as_u64()?;
+    Some(llbc.type_by_id(id)?.item_meta.name_path())
+}
+
+/// True when `ty` is `core::result::Result<T, E>` with `E` resolving
+/// to the interpreter's `PyError` exception carrier.
+pub(crate) fn tyref_is_result_of_pyerror(ty: &TyRef, llbc: &Llbc) -> bool {
+    let body = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(v) => v,
+            None => return false,
+        },
+    };
+    if adt_path_of(body, llbc).as_deref() != Some("core::result::Result") {
+        return false;
+    }
+    let Some(err_slot) = body
+        .get("Adt")
+        .and_then(|a| a.get("generics"))
+        .and_then(|g| g.get("types"))
+        .and_then(|t| t.get(1))
+    else {
+        return false;
+    };
+    let Some(err_body) = ty_json_body(err_slot, llbc) else {
+        return false;
+    };
+    adt_path_of(err_body, llbc).is_some_and(|p| p == "pyre_interpreter::error::PyError")
+}
+
+/// Is `target` the `Result::Ok` / `Result::Err` transparent ctor?
+fn result_ctor_kind(target: &CallTarget) -> Option<bool> {
+    let CallTarget::SyntheticTransparentCtor { name, owner_path } = target else {
+        return None;
+    };
+    if owner_path != &["core".to_string(), "result".to_string(), "Result".to_string()] {
+        return None;
+    }
+    match name.as_str() {
+        "Ok" => Some(false),
+        "Err" => Some(true),
+        _ => None,
+    }
+}
+
+/// Callee rule.  Rewrites every `Result::Ok` / `Result::Err` shell
+/// construction that flows into `returnblock` into a plain value
+/// return / a raise link.  Returns the number of rewritten returns.
+///
+/// Fail-loud on any shape outside the known construction pattern —
+/// a scoped callee with an unrecognised return shape must break the
+/// build, not silently keep its shell.
+pub(crate) fn lower_result_exc_returns(graph: &mut FunctionGraph) -> Result<usize, String> {
+    let nblocks = graph.blocks.len();
+    let mut rewritten = 0usize;
+    for bi in 0..nblocks {
+        let block_id = crate::model::BlockId(bi);
+        // Locate a Result ctor in this block.
+        let mut ctor: Option<(usize, Variable, bool)> = None;
+        for (i, op) in graph.blocks[bi].operations.iter().enumerate() {
+            if let OpKind::Call { target, args, .. } = &op.kind
+                && let Some(is_err) = result_ctor_kind(target)
+            {
+                if !args.is_empty() {
+                    return Err(format!(
+                        "{}: block {bi} Result ctor with non-empty args — \
+                         operand-carrying ctor shape not expected from front::mir",
+                        graph.name
+                    ));
+                }
+                if ctor.is_some() {
+                    return Err(format!(
+                        "{}: block {bi} has two Result ctors — unsupported shape",
+                        graph.name
+                    ));
+                }
+                let Some(v) = op.result.clone() else {
+                    return Err(format!(
+                        "{}: block {bi} Result ctor without result var",
+                        graph.name
+                    ));
+                };
+                ctor = Some((i, v, is_err));
+            }
+        }
+        let Some((ctor_idx, ctor_var, is_err)) = ctor else {
+            continue;
+        };
+        // Payload FieldWrite (__pos_0).  Required: every scoped callee
+        // returns a payload-carrying Result (unit payloads would lower
+        // with no FieldWrite and need a Void widening).
+        let mut fieldwrite_idx: Option<(usize, Variable)> = None;
+        for (i, op) in graph.blocks[bi].operations.iter().enumerate().skip(ctor_idx + 1) {
+            if let OpKind::FieldWrite { base, field, value, .. } = &op.kind
+                && *base == ctor_var
+            {
+                if field.name != "__pos_0" || fieldwrite_idx.is_some() {
+                    return Err(format!(
+                        "{}: block {bi} Result ctor with unexpected FieldWrite \
+                         {} — only a single __pos_0 payload is supported",
+                        graph.name, field.name
+                    ));
+                }
+                fieldwrite_idx = Some((i, value.clone()));
+            }
+        }
+        let Some((fw_idx, payload)) = fieldwrite_idx else {
+            return Err(format!(
+                "{}: block {bi} Result ctor without a __pos_0 payload write",
+                graph.name
+            ));
+        };
+        // The shell must flow out through this block's single
+        // unconditional exit, and through nothing else.
+        let consumers = count_var_uses(graph, &ctor_var);
+        // ctor result + FieldWrite base + one link arg.
+        if consumers.link_uses != 1 || consumers.op_uses != 1 {
+            return Err(format!(
+                "{}: block {bi} Result shell has unexpected consumers \
+                 (op_uses={}, link_uses={}) — only the payload FieldWrite \
+                 and one exit arg are supported",
+                graph.name, consumers.op_uses, consumers.link_uses
+            ));
+        }
+        if graph.blocks[bi].exits.len() != 1 || graph.blocks[bi].exitswitch.is_some() {
+            return Err(format!(
+                "{}: block {bi} Result shell block has a conditional exit — \
+                 unsupported shape",
+                graph.name
+            ));
+        }
+        // Verify the value reaches returnblock through pure forwarding.
+        verify_forwards_to_returnblock(graph, bi, &ctor_var)?;
+
+        // Drop the ctor + FieldWrite (higher index first).
+        {
+            let ops = &mut graph.blocks[bi].operations;
+            debug_assert!(fw_idx > ctor_idx);
+            ops.remove(fw_idx);
+            ops.remove(ctor_idx);
+        }
+        if is_err {
+            // `return Err(e)` → materialise the runtime exception
+            // object and raise.  The trace-level exception value is
+            // the `W_ExceptionObject` ref (`BH_LAST_EXC_VALUE`'s
+            // domain; the trait leg reads `ob_header.ob_type` off it),
+            // so `PyError::to_exc_object` runs at the raise site.
+            let v_exc = graph
+                .push_op_var(
+                    block_id,
+                    OpKind::Call {
+                        target: CallTarget::method("to_exc_object", Some("PyError".to_string())),
+                        args: vec![payload],
+                        result_ty: ValueType::Ref(None),
+                    },
+                    true,
+                )
+                .expect("to_exc_object call must produce a value");
+            // `op.type(evalue)` — the `lower_exc_from_raise` tail
+            // (`flowcontext.py:600` `w_type = op.type(w_value)`).
+            let v_type = graph
+                .push_op_var(
+                    block_id,
+                    OpKind::Call {
+                        target: CallTarget::function_path(["type"]),
+                        args: vec![v_exc.clone()],
+                        result_ty: ValueType::Ref(None),
+                    },
+                    true,
+                )
+                .expect("op.type(evalue) must produce a value");
+            graph.set_raise_values(block_id, v_type, v_exc);
+        } else {
+            // `return Ok(v)` → forward the payload itself.
+            for link in &mut graph.blocks[bi].exits {
+                for arg in &mut link.args {
+                    if matches!(arg, LinkArg::Value(v) if *v == ctor_var) {
+                        *arg = LinkArg::Value(payload.clone());
+                    }
+                }
+            }
+        }
+        rewritten += 1;
+    }
+    if rewritten == 0 {
+        return Err(format!(
+            "{}: scoped Result-of-PyError callee with no rewritable returns",
+            graph.name
+        ));
+    }
+    Ok(rewritten)
+}
+
+struct UseCounts {
+    op_uses: usize,
+    link_uses: usize,
+}
+
+/// Count uses of `var` as an op operand and as a link arg across the
+/// whole graph (producer `op.result` slots are not uses).
+fn count_var_uses(graph: &FunctionGraph, var: &Variable) -> UseCounts {
+    let mut op_uses = 0usize;
+    let mut link_uses = 0usize;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            op_uses += op_operand_vars(&op.kind)
+                .iter()
+                .filter(|v| *v == var)
+                .count();
+        }
+        for link in &block.exits {
+            link_uses += link
+                .args
+                .iter()
+                .filter(|a| matches!(a, LinkArg::Value(v) if v == var))
+                .count();
+        }
+    }
+    UseCounts { op_uses, link_uses }
+}
+
+/// Operand variables of an op kind, restricted to the kinds the
+/// Result-shell pattern can contain.  Every other kind returns its
+/// operands through the generic arms below.
+fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
+    match kind {
+        OpKind::Call { args, .. } => args.clone(),
+        OpKind::FieldWrite { base, value, .. } => vec![base.clone(), value.clone()],
+        OpKind::FieldRead { base, .. } => vec![base.clone()],
+        OpKind::BinOp { lhs, rhs, .. } => vec![lhs.clone(), rhs.clone()],
+        OpKind::UnaryOp { operand, .. } => vec![operand.clone()],
+        _ => Vec::new(),
+    }
+}
+
+/// Verify `var` flows from `from_block`'s single exit through pure
+/// positional forwarding (single-exit blocks re-exporting the value)
+/// until it lands in `returnblock`.
+fn verify_forwards_to_returnblock(
+    graph: &FunctionGraph,
+    from_block: usize,
+    var: &Variable,
+) -> Result<(), String> {
+    let mut current = from_block;
+    let mut tracked = var.clone();
+    // Bounded by block count — forwarding chains cannot loop without
+    // revisiting a block, which the bound rejects.
+    for _ in 0..graph.blocks.len() {
+        let block = &graph.blocks[current];
+        let [link] = block.exits.as_slice() else {
+            return Err(format!(
+                "{}: block {current} on the Result-return forwarding chain \
+                 has {} exits — unsupported shape",
+                graph.name,
+                block.exits.len()
+            ));
+        };
+        let Some(pos) = link
+            .args
+            .iter()
+            .position(|a| matches!(a, LinkArg::Value(v) if *v == tracked))
+        else {
+            return Err(format!(
+                "{}: Result shell var lost on the forwarding chain at block {current}",
+                graph.name
+            ));
+        };
+        if link.target == graph.returnblock {
+            return Ok(());
+        }
+        let target = link.target.0;
+        let next_block = &graph.blocks[target];
+        let Some(next_var) = next_block.inputargs.get(pos) else {
+            return Err(format!(
+                "{}: forwarding target block {target} has no inputarg at \
+                 position {pos}",
+                graph.name
+            ));
+        };
+        tracked = next_var.clone();
+        current = target;
+    }
+    Err(format!(
+        "{}: Result-return forwarding chain did not reach returnblock",
+        graph.name
+    ))
+}
+
+/// Caller rule.  `results` are the result `Variable`s of calls to
+/// scoped callees (captured during lowering).  Each must sit at the
+/// head of a `Try::branch` diamond, which is rewired into
+/// `ExitSwitch::LastException` exits.  Returns the number of rewired
+/// sites.
+pub(crate) fn rewire_result_exc_call_sites(
+    graph: &mut FunctionGraph,
+    results: &[Variable],
+) -> Result<usize, String> {
+    let mut rewired = 0usize;
+    for r in results {
+        rewire_one_call_site(graph, r)?;
+        rewired += 1;
+    }
+    Ok(rewired)
+}
+
+fn rewire_one_call_site(graph: &mut FunctionGraph, r: &Variable) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: contains the call producing `r`; closed by lower_call
+    // with a single forwarding exit.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| b.operations.iter().any(|op| op.result.as_ref() == Some(r)))
+        .ok_or_else(|| format!("{name}: scoped call result var has no producer block"))?;
+    let (b, r_b) = follow_single_exit(graph, a, r)
+        .map_err(|e| format!("{name}: call block exit: {e}"))?;
+    assert_single_pred(graph, b, &name)?;
+    // Block B: `cf = Result::branch(r)`.
+    let branch_op_idx = graph.blocks[b]
+        .operations
+        .iter()
+        .position(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::Method { name, .. }, args, .. }
+                    if name == "branch" && args.as_slice() == std::slice::from_ref(&r_b)
+            )
+        })
+        .ok_or_else(|| {
+            format!(
+                "{name}: block {b} after a scoped call does not start a \
+                 Try::branch diamond — non-`?` use of a scoped callee's \
+                 Result (custom match handlers are not supported yet)"
+            )
+        })?;
+    let cf = graph.blocks[b].operations[branch_op_idx]
+        .result
+        .clone()
+        .ok_or_else(|| format!("{name}: branch() without result var"))?;
+    let (c, cf_c) = follow_single_exit(graph, b, &cf)
+        .map_err(|e| format!("{name}: branch block exit: {e}"))?;
+    assert_single_pred(graph, c, &name)?;
+    // Block C: `d = cf.__discriminant`; switch d {0 → continue, 1 → break}.
+    let disc_var = graph.blocks[c]
+        .operations
+        .iter()
+        .find_map(|op| match &op.kind {
+            OpKind::FieldRead { base, field, .. }
+                if *base == cf_c && field.name == "__discriminant" =>
+            {
+                op.result.clone()
+            }
+            _ => None,
+        })
+        .ok_or_else(|| {
+            format!("{name}: block {c} lacks the ControlFlow __discriminant read")
+        })?;
+    match &graph.blocks[c].exitswitch {
+        Some(ExitSwitch::Value(v)) if *v == disc_var => {}
+        other => {
+            return Err(format!(
+                "{name}: block {c} exitswitch {other:?} is not the \
+                 ControlFlow discriminant switch"
+            ));
+        }
+    }
+    let (continue_link, break_link) = split_diamond_exits(&graph.blocks[c].exits, &name)?;
+    // The break arm must be the pure `?` re-raise tail
+    // (`__pos_0` read + `from_residual` + return).  A custom handler
+    // arm must not be silently disconnected.
+    verify_break_arm_is_reraise(graph, &break_link, &cf_c, &name)?;
+
+    // Map each continue-arm link arg back to A-scope variables: the
+    // A→B→C chain is pure positional forwarding.
+    let mut normal_args: Vec<LinkArg> = Vec::with_capacity(continue_link.args.len());
+    let mut payload_positions: Vec<usize> = Vec::new();
+    for (i, arg) in continue_link.args.iter().enumerate() {
+        match arg {
+            LinkArg::Const(c) => normal_args.push(LinkArg::Const(c.clone())),
+            LinkArg::Value(v) => {
+                if *v == cf_c {
+                    // The ControlFlow value at the continue edge is the
+                    // unwrapped payload once the callee raises: the
+                    // call result itself flows in its place.
+                    normal_args.push(LinkArg::Value(r.clone()));
+                    payload_positions.push(i);
+                } else {
+                    let v_a = back_substitute(graph, &[(a, b), (b, c)], v, &name)?;
+                    normal_args.push(LinkArg::Value(v_a));
+                }
+            }
+        }
+    }
+    // The continue target reads the payload via `cf.__pos_0`; with the
+    // call result flowing directly, that read collapses to the carried
+    // value itself.
+    let continue_target = continue_link.target;
+    for pos in payload_positions {
+        collapse_pos0_read(graph, continue_target, pos, &name)?;
+    }
+
+    // Rewire A: LastException exits — normal → continue arm,
+    // exception → exceptblock via the default exception link
+    // (`flowspace/model.py` `Link.last_exception` pair; `flatten.rs`
+    // turns the `[last_exception, last_exc_value]` propagation shape
+    // into the rethrow tail).
+    let va = graph.alloc_value_var();
+    let vb = graph.alloc_value_var();
+    let exceptblock = graph.exceptblock;
+    // `exception_exitcase()` marks the link catch-all
+    // (`Link::catches_all_exceptions`), the propagation shape
+    // `flatten.rs` rethrows without a `goto_if_exception_mismatch`.
+    let mut exc_link = Link::new_mixed(
+        vec![LinkArg::Value(va.clone()), LinkArg::Value(vb.clone())],
+        exceptblock,
+        Some(crate::model::exception_exitcase()),
+    );
+    exc_link.last_exception = Some(LinkArg::Value(va));
+    exc_link.last_exc_value = Some(LinkArg::Value(vb));
+    let block_a = &mut graph.blocks[a];
+    block_a.exitswitch = Some(ExitSwitch::LastException);
+    block_a.exits = vec![
+        Link::new_mixed(normal_args, continue_target, None),
+        exc_link,
+    ];
+    // Blocks B, C and the break arm are now unreachable; the dead-op
+    // sweep leaves them to the reachability-walking consumers.
+    Ok(())
+}
+
+/// Map a continue-arm link variable back to its A-scope origin
+/// through the diamond's pure positional forwarding chain.  `chain`
+/// is the ordered `(pred, succ)` edge list from the call block; a
+/// variable that is `succ`'s inputarg maps through `pred`'s single
+/// exit, a variable defined inside an intermediate block cannot flow
+/// back and fails loud.
+fn back_substitute(
+    graph: &FunctionGraph,
+    chain: &[(usize, usize)],
+    var: &Variable,
+    name: &str,
+) -> Result<Variable, String> {
+    let mut current = var.clone();
+    for &(pred, succ) in chain.iter().rev() {
+        let Some(pos) = graph.blocks[succ]
+            .inputargs
+            .iter()
+            .position(|v| *v == current)
+        else {
+            return Err(format!(
+                "{name}: continue-arm value is defined inside diamond block \
+                 {succ} and cannot be carried across the rewired call edge"
+            ));
+        };
+        let [link] = graph.blocks[pred].exits.as_slice() else {
+            return Err(format!(
+                "{name}: diamond forwarding block {pred} has multiple exits"
+            ));
+        };
+        match link.args.get(pos) {
+            Some(LinkArg::Value(v)) => current = v.clone(),
+            other => {
+                return Err(format!(
+                    "{name}: diamond forwarding arg at position {pos} is \
+                     {other:?}, expected a Value"
+                ));
+            }
+        }
+    }
+    Ok(current)
+}
+
+/// `block`'s single exit must carry `var`; returns the target block
+/// index and the inputarg `var` binds to there.
+fn follow_single_exit(
+    graph: &FunctionGraph,
+    block: usize,
+    var: &Variable,
+) -> Result<(usize, Variable), String> {
+    let [link] = graph.blocks[block].exits.as_slice() else {
+        return Err(format!(
+            "block {block} has {} exits, expected 1",
+            graph.blocks[block].exits.len()
+        ));
+    };
+    let Some(pos) = link
+        .args
+        .iter()
+        .position(|a| matches!(a, LinkArg::Value(v) if v == var))
+    else {
+        return Err(format!("block {block}'s exit does not carry the tracked value"));
+    };
+    let target = link.target.0;
+    let bound = graph.blocks[target]
+        .inputargs
+        .get(pos)
+        .cloned()
+        .ok_or_else(|| format!("block {target} lacks inputarg {pos}"))?;
+    Ok((target, bound))
+}
+
+/// The diamond's intermediate blocks must have exactly one
+/// predecessor — the chain we arrived through.
+fn assert_single_pred(graph: &FunctionGraph, block: usize, name: &str) -> Result<(), String> {
+    let preds = graph
+        .blocks
+        .iter()
+        .flat_map(|b| b.exits.iter())
+        .filter(|l| l.target.0 == block)
+        .count();
+    if preds != 1 {
+        return Err(format!(
+            "{name}: diamond block {block} has {preds} predecessors, expected 1"
+        ));
+    }
+    Ok(())
+}
+
+/// Split a discriminant switch's exits into (continue = case 0,
+/// break = case 1).  MIR lowers a two-variant discriminant switch
+/// as one explicit case plus a `default` arm covering the
+/// complementary discriminant (mir.rs `SwitchTargets::SwitchInt`),
+/// so a `default` link stands in for whichever of 0/1 is absent.
+fn split_diamond_exits(exits: &[Link], name: &str) -> Result<(Link, Link), String> {
+    use crate::flowspace::model::ConstValue;
+    use crate::model::ExitCase;
+    if exits.len() != 2 {
+        return Err(format!(
+            "{name}: ControlFlow switch has {} exits, expected 2",
+            exits.len()
+        ));
+    }
+    let mut cont: Option<Link> = None;
+    let mut brk: Option<Link> = None;
+    let mut default: Option<Link> = None;
+    for l in exits {
+        match &l.exitcase {
+            Some(ExitCase::Const(ConstValue::Int(0))) => cont = Some(l.clone()),
+            Some(ExitCase::Const(ConstValue::Int(1))) => brk = Some(l.clone()),
+            Some(ExitCase::Const(ConstValue::UniStr(s))) if s == "default" => {
+                default = Some(l.clone())
+            }
+            _ => {
+                return Err(format!(
+                    "{name}: ControlFlow switch has a non-0/1 exit case {:?}",
+                    l.exitcase
+                ));
+            }
+        }
+    }
+    match (cont, brk, default) {
+        (Some(c), Some(b), None) => Ok((c, b)),
+        (Some(c), None, Some(d)) => Ok((c, d)),
+        (None, Some(b), Some(d)) => Ok((d, b)),
+        _ => Err(format!("{name}: ControlFlow switch lacks the 0/1 case pair")),
+    }
+}
+
+/// The break arm must be exactly `e = cf.__pos_0; from_residual(e);
+/// → returnblock` — the `?` re-raise tail that the exception link
+/// replaces.  Anything else is a custom handler and must fail loud.
+fn verify_break_arm_is_reraise(
+    graph: &FunctionGraph,
+    break_link: &Link,
+    cf_c: &Variable,
+    name: &str,
+) -> Result<(), String> {
+    let pos = break_link
+        .args
+        .iter()
+        .position(|a| matches!(a, LinkArg::Value(v) if v == cf_c))
+        .ok_or_else(|| format!("{name}: break arm does not carry the ControlFlow value"))?;
+    let e_block = break_link.target.0;
+    let cf_e = graph.blocks[e_block]
+        .inputargs
+        .get(pos)
+        .cloned()
+        .ok_or_else(|| format!("{name}: break arm target lacks inputarg {pos}"))?;
+    let ops = &graph.blocks[e_block].operations;
+    let payload_var = ops.iter().find_map(|op| match &op.kind {
+        OpKind::FieldRead { base, field, .. } if *base == cf_e && field.name == "__pos_0" => {
+            op.result.clone()
+        }
+        _ => None,
+    });
+    let Some(payload_var) = payload_var else {
+        return Err(format!(
+            "{name}: break arm block {e_block} lacks the __pos_0 residual read — \
+             custom `?` handler shapes are not supported yet"
+        ));
+    };
+    let residual_result = ops.iter().find_map(|op| match &op.kind {
+        OpKind::Call { target: CallTarget::Method { name: m, .. }, args, .. }
+            if m == "from_residual" && args.as_slice() == std::slice::from_ref(&payload_var) =>
+        {
+            op.result.clone()
+        }
+        _ => None,
+    });
+    let Some(residual_result) = residual_result else {
+        return Err(format!(
+            "{name}: break arm block {e_block} lacks the from_residual call — \
+             custom `?` handler shapes are not supported yet"
+        ));
+    };
+    verify_forwards_to_returnblock(graph, e_block, &residual_result)
+}
+
+/// In the continue-arm target, the `__pos_0` read off the inputarg at
+/// `pos` collapses: the inherited value already *is* the payload.
+/// Deletes the read and renames its result to the inputarg.
+fn collapse_pos0_read(
+    graph: &mut FunctionGraph,
+    target: crate::model::BlockId,
+    pos: usize,
+    name: &str,
+) -> Result<(), String> {
+    let ti = target.0;
+    let carrier = graph.blocks[ti]
+        .inputargs
+        .get(pos)
+        .cloned()
+        .ok_or_else(|| format!("{name}: continue target lacks inputarg {pos}"))?;
+    let read_idx = graph.blocks[ti].operations.iter().position(|op| {
+        matches!(
+            &op.kind,
+            OpKind::FieldRead { base, field, .. }
+                if *base == carrier && field.name == "__pos_0"
+        )
+    });
+    let Some(read_idx) = read_idx else {
+        // The continue arm may legitimately discard the payload
+        // (`let _ = f()?;` or `f()?;` on a non-void T).  Nothing reads
+        // the carrier — but verify so a moved read does not survive
+        // unrewired.
+        let reads = graph.blocks[ti]
+            .operations
+            .iter()
+            .filter(|op| op_operand_vars(&op.kind).contains(&carrier))
+            .count();
+        if reads != 0 {
+            return Err(format!(
+                "{name}: continue target block {ti} uses the ControlFlow \
+                 carrier outside a __pos_0 read — unsupported shape"
+            ));
+        }
+        return Ok(());
+    };
+    let read_result = graph.blocks[ti].operations[read_idx]
+        .result
+        .clone()
+        .ok_or_else(|| format!("{name}: __pos_0 read without result"))?;
+    graph.blocks[ti].operations.remove(read_idx);
+    // Rename the read's result to the carrier across the block's
+    // remaining ops, exitswitch, and exits.
+    let rename = |v: &Variable| -> Variable {
+        if *v == read_result { carrier.clone() } else { v.clone() }
+    };
+    let block = &mut graph.blocks[ti];
+    for op in &mut block.operations {
+        op.kind = crate::inline::remap_op_kind(&op.kind, &rename);
+    }
+    let (sw, exits) =
+        crate::model::remap_control_flow_metadata_var(&block.exitswitch, &block.exits, rename, |b| b);
+    block.exitswitch = sw;
+    block.exits = exits;
+    Ok(())
+}

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -69,7 +69,9 @@ use majit_charon_reader::Llbc;
 use majit_charon_reader::ullbc::TyRef;
 
 use crate::flowspace::model::Variable;
-use crate::model::{CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType};
+use crate::model::{
+    CallFuncPtr, CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType,
+};
 
 /// Callees whose `Result<T, PyError>` surface lowers to raise links.
 /// Grown deliberately, one fail-loud pipeline convergence at a time;
@@ -435,17 +437,167 @@ fn count_var_uses(graph: &FunctionGraph, var: &Variable) -> UseCounts {
     UseCounts { op_uses, link_uses }
 }
 
-/// Operand variables of an op kind, restricted to the kinds the
-/// Result-shell pattern can contain.  Every other kind returns its
-/// operands through the generic arms below.
+/// Every `Variable` operand of an op kind.
+///
+/// `count_var_uses` and the carrier-unused check in `collapse_pos0_read`
+/// rely on this being exhaustive: a missed operand-bearing variant makes
+/// a live `Result`-shell consumer invisible, so the rewrite could still
+/// delete the shell or collapse `__pos_0`.  The match has no wildcard —
+/// a new `OpKind` variant is a compile error here until its operands are
+/// declared, keeping the pass fail-closed.  Producer / constant / marker
+/// kinds carry no operand `Variable` and return empty.
 fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
+    let extend_all = |dst: &mut Vec<Variable>, lists: &[&Vec<Variable>]| {
+        for list in lists {
+            dst.extend(list.iter().cloned());
+        }
+    };
     match kind {
-        OpKind::Call { args, .. } => args.clone(),
-        OpKind::FieldWrite { base, value, .. } => vec![base.clone(), value.clone()],
-        OpKind::FieldRead { base, .. } => vec![base.clone()],
+        OpKind::Input { .. }
+        | OpKind::ConstInt(_)
+        | OpKind::ConstBool(_)
+        | OpKind::ConstFloat(_)
+        | OpKind::ConstRef(_)
+        | OpKind::ConstRefNull
+        | OpKind::ConstRefAddr(_)
+        | OpKind::CurrentTraceLength
+        | OpKind::Live
+        | OpKind::LoopHeader { .. }
+        | OpKind::Abort { .. }
+        | OpKind::LoadStatic { .. } => Vec::new(),
+
+        OpKind::FieldRead { base, .. }
+        | OpKind::VableFieldRead { base, .. }
+        | OpKind::VableForce { base }
+        | OpKind::RecordQuasiImmutField { base, .. } => vec![base.clone()],
+        OpKind::FieldWrite { base, value, .. } | OpKind::VableFieldWrite { base, value, .. } => {
+            vec![base.clone(), value.clone()]
+        }
+        OpKind::ArrayRead { base, index, .. } | OpKind::InteriorFieldRead { base, index, .. } => {
+            vec![base.clone(), index.clone()]
+        }
+        OpKind::ArrayWrite {
+            base, index, value, ..
+        }
+        | OpKind::InteriorFieldWrite {
+            base, index, value, ..
+        } => vec![base.clone(), index.clone(), value.clone()],
+        OpKind::VableArrayRead {
+            base, elem_index, ..
+        } => vec![base.clone(), elem_index.clone()],
+        OpKind::VableArrayWrite {
+            base,
+            elem_index,
+            value,
+            ..
+        } => vec![base.clone(), elem_index.clone(), value.clone()],
+        OpKind::Call { args, .. } | OpKind::JitDebug { args } | OpKind::NewTuple { args } => {
+            args.clone()
+        }
+        OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => vec![cond.clone()],
+        OpKind::GuardValue { value, .. }
+        | OpKind::AssertGreen { value, .. }
+        | OpKind::IsConstant { value, .. }
+        | OpKind::IsVirtual { value, .. } => vec![value.clone()],
+        OpKind::VtableMethodPtr { receiver, .. } => vec![receiver.clone()],
+        OpKind::IsInstance {
+            obj, class_carrier, ..
+        } => vec![obj.clone(), class_carrier.clone()],
         OpKind::BinOp { lhs, rhs, .. } => vec![lhs.clone(), rhs.clone()],
         OpKind::UnaryOp { operand, .. } => vec![operand.clone()],
-        _ => Vec::new(),
+        OpKind::IndirectCall { funcptr, args, .. } => {
+            let mut v = vec![funcptr.clone()];
+            v.extend(args.iter().cloned());
+            v
+        }
+        OpKind::CallElidable {
+            funcptr,
+            args_i,
+            args_r,
+            args_f,
+            ..
+        }
+        | OpKind::CallResidual {
+            funcptr,
+            args_i,
+            args_r,
+            args_f,
+            ..
+        }
+        | OpKind::CallMayForce {
+            funcptr,
+            args_i,
+            args_r,
+            args_f,
+            ..
+        } => {
+            let mut v = Vec::new();
+            if let CallFuncPtr::Value(var) = funcptr {
+                v.push(var.clone());
+            }
+            extend_all(&mut v, &[args_i, args_r, args_f]);
+            v
+        }
+        OpKind::InlineCall {
+            args_i,
+            args_r,
+            args_f,
+            ..
+        } => {
+            let mut v = Vec::new();
+            extend_all(&mut v, &[args_i, args_r, args_f]);
+            v
+        }
+        OpKind::ConditionalCall {
+            condition: gate,
+            args_i,
+            args_r,
+            args_f,
+            ..
+        }
+        | OpKind::ConditionalCallValue {
+            value: gate,
+            args_i,
+            args_r,
+            args_f,
+            ..
+        }
+        | OpKind::RecordKnownResult {
+            result_value: gate,
+            args_i,
+            args_r,
+            args_f,
+            ..
+        } => {
+            let mut v = vec![gate.clone()];
+            extend_all(&mut v, &[args_i, args_r, args_f]);
+            v
+        }
+        OpKind::RecursiveCall {
+            greens_i,
+            greens_r,
+            greens_f,
+            reds_i,
+            reds_r,
+            reds_f,
+            ..
+        }
+        | OpKind::JitMergePoint {
+            greens_i,
+            greens_r,
+            greens_f,
+            reds_i,
+            reds_r,
+            reds_f,
+            ..
+        } => {
+            let mut v = Vec::new();
+            extend_all(
+                &mut v,
+                &[greens_i, greens_r, greens_f, reds_i, reds_r, reds_f],
+            );
+            v
+        }
     }
 }
 
@@ -463,6 +615,22 @@ fn verify_forwards_to_returnblock(
     // revisiting a block, which the bound rejects.
     for _ in 0..graph.blocks.len() {
         let block = &graph.blocks[current];
+        // Every hop after `from_block` must be a pure forwarder — no
+        // operations and no conditional exit — otherwise the value is
+        // inspected or re-derived en route rather than carried untouched
+        // to the returnblock, and deleting the shell / collapsing
+        // `__pos_0` would be unsound.  `from_block` itself is the
+        // producer (it keeps the ctor + `__pos_0` write, or the call),
+        // so it is exempt.
+        if current != from_block && (!block.operations.is_empty() || block.exitswitch.is_some()) {
+            return Err(format!(
+                "{}: block {current} on the Result-return forwarding chain \
+                 is not a pure forwarder ({} ops, exitswitch present: {})",
+                graph.name,
+                block.operations.len(),
+                block.exitswitch.is_some()
+            ));
+        }
         let [link] = block.exits.as_slice() else {
             return Err(format!(
                 "{}: block {current} on the Result-return forwarding chain \
@@ -781,6 +949,18 @@ fn catch_and_rewrap(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Result
     let (e_id, e_inputs) = graph.create_block_with_arg_vars(nonr_args.len() + 2);
     let e_exc_value_in = e_inputs[nonr_args.len() + 1].clone();
     let e_shell: Option<Variable> = if has_r {
+        // `PyError::from_exc_object(exc_value)` is an associated fn (no
+        // `self`), yet it is spelled as a `Method` target with the caught
+        // exception value as `args[0]`.  This is correct here: a
+        // `CallTarget::Method` is a *static* impl-resolution hint
+        // (`call.rs resolve_method` → `for_impl_method(receiver, name)`),
+        // not a runtime `getattr(args[0], name)` dispatch, so args map
+        // positionally to the graph's params — `obj ← exc_value` — exactly
+        // as for the inherent `&self` `to_exc_object` above.  A
+        // `FunctionPath(["PyError", "from_exc_object"])` would instead
+        // resolve to that bare two-segment path, which misses the
+        // module-qualified impl-method registration and falls back to a
+        // symbolic address.
         let v_err = graph
             .push_op_var(
                 e_id,
@@ -891,6 +1071,16 @@ fn forwards_to_returnblock(graph: &FunctionGraph, block: usize, var: &Variable) 
     let mut current = block;
     let mut tracked = var.clone();
     for _ in 0..graph.blocks.len() {
+        // A pure tail forward only crosses empty, unconditional blocks
+        // after the producer `block`; an intermediate block with
+        // operations or a conditional exit inspects the value and is not
+        // a tail forward.
+        if current != block {
+            let b = &graph.blocks[current];
+            if !b.operations.is_empty() || b.exitswitch.is_some() {
+                return false;
+            }
+        }
         let [link] = graph.blocks[current].exits.as_slice() else {
             return false;
         };

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -54,11 +54,16 @@
 //! Both rules must apply together per callee: a transformed callee
 //! returns `T` and raises, so an untransformed caller-side
 //! discriminant switch would read garbage.  Until the whole-program
-//! conformance scan lands, [`RESULT_EXC_LOWERING_SCOPE`] pins the
-//! callee set; every call site of a scoped callee either matches the
-//! `?`-diamond or fails the build loudly (custom `match` handlers
-//! need the caught value bound from `last_exc_value` — a later
-//! widening).
+//! conformance scan lands, [`RESULT_EXC_LOWERING_SCOPE`] plus the
+//! `pyopcode::execute_*` wrapper family pin the callee set; every call
+//! site of a scoped callee either matches the `?`-diamond, tail-forwards
+//! inside a scoped enclosing graph, or — for hand-written `match`
+//! consumers (`eval_loop`, the `eval_loop_jit*` portals whose
+//! `match step_result` merges seven predecessors) — gets the
+//! [`catch_and_rewrap`] treatment: `LastException` exits on the call
+//! block whose arms locally re-encode the `Result` (`Ok(raw)` /
+//! `Err(PyError::from_exc_object(last_exc_value))`), leaving the
+//! downstream destructuring untouched.
 
 use majit_charon_reader::Llbc;
 use majit_charon_reader::ullbc::TyRef;
@@ -79,21 +84,40 @@ const RESULT_EXC_LOWERING_SCOPE: &[&str] = &[
     "store_fast_store_fast",
 ];
 
+/// Dispatch-wrapper family rule: every `pyopcode::execute_*` wrapper —
+/// the per-opcode `execute_<name>` free fns plus `execute_opcode_step`
+/// itself — is scoped as a family.  The wrappers share one shape
+/// (`executor.method(..)?; Ok(StepResult::..)`) and the dispatch arms
+/// tail-forward their `Result`s, so scoping them one-by-one would leave
+/// the dispatch graph returning raw `StepResult` on transformed arms
+/// and `Result` shells on the rest — type-inconsistent for the
+/// custom-match consumers (`eval_loop`, the portals).  The family lands
+/// as a unit; the callee-side type gate
+/// ([`tyref_is_result_of_pyerror`]) still filters non-`Result` returns.
+fn in_execute_wrapper_family(name_path: &str, leaf: &str) -> bool {
+    name_path.contains("pyopcode") && leaf.starts_with("execute_")
+}
+
 /// True when `name_path`'s leaf is a scoped callee.
 pub(crate) fn in_result_exc_scope(name_path: &str) -> bool {
+    let leaf = name_path.rsplit("::").next().unwrap_or(name_path);
     RESULT_EXC_LOWERING_SCOPE
         .iter()
-        .any(|leaf| name_path == *leaf || name_path.ends_with(&format!("::{leaf}")))
+        .any(|scoped| name_path == *scoped || leaf == *scoped)
+        || in_execute_wrapper_family(name_path, leaf)
 }
 
 /// True when a call target's leaf names a scoped callee.
 pub(crate) fn call_target_in_scope(target: &CallTarget) -> bool {
-    let leaf = match target {
-        CallTarget::Method { name, .. } => name.as_str(),
-        CallTarget::FunctionPath { segments } => segments.last().map(String::as_str).unwrap_or(""),
-        _ => return false,
-    };
-    RESULT_EXC_LOWERING_SCOPE.contains(&leaf)
+    match target {
+        CallTarget::Method { name, .. } => RESULT_EXC_LOWERING_SCOPE.contains(&name.as_str()),
+        CallTarget::FunctionPath { segments } => {
+            let leaf = segments.last().map(String::as_str).unwrap_or("");
+            RESULT_EXC_LOWERING_SCOPE.contains(&leaf)
+                || (segments.iter().any(|s| s == "pyopcode") && leaf.starts_with("execute_"))
+        }
+        _ => false,
+    }
 }
 
 /// Resolve the JSON body behind a generics slot — `{"Deduplicated":
@@ -435,13 +459,25 @@ pub(crate) struct RewireOutcome {
     /// that is itself a scoped callee; an unscoped enclosing graph
     /// would hand `T` to callers still switching on a discriminant.
     pub tail_forwards: usize,
+    /// Custom-match sites handled by [`catch_and_rewrap`]: the call
+    /// gets `LastException` exits and the two arms locally rebuild the
+    /// value-encoded `Result` the untouched downstream `match` keeps
+    /// consuming.
+    pub rewrapped: usize,
+}
+
+/// Per-site disposition for [`rewire_one_call_site`].
+enum SiteOutcome {
+    Diamond,
+    TailForward,
+    Rewrapped,
 }
 
 /// Caller rule.  `results` are the result `Variable`s of calls to
-/// scoped callees (captured during lowering).  Each must sit at the
-/// head of a `Try::branch` diamond — rewired into
-/// `ExitSwitch::LastException` exits — or tail-forward to
-/// `returnblock` inside a scoped enclosing graph.
+/// scoped callees (captured during lowering).  Each site is either a
+/// `?`-diamond — rewired into `ExitSwitch::LastException` exits — or a
+/// tail-forward to `returnblock` inside a scoped enclosing graph, or a
+/// custom `match` consumer that gets the catch-and-rewrap treatment.
 pub(crate) fn rewire_result_exc_call_sites(
     graph: &mut FunctionGraph,
     results: &[Variable],
@@ -450,24 +486,23 @@ pub(crate) fn rewire_result_exc_call_sites(
     let mut outcome = RewireOutcome {
         diamonds: 0,
         tail_forwards: 0,
+        rewrapped: 0,
     };
     for r in results {
-        if rewire_one_call_site(graph, r, enclosing_scoped)? {
-            outcome.diamonds += 1;
-        } else {
-            outcome.tail_forwards += 1;
+        match rewire_one_call_site(graph, r, enclosing_scoped)? {
+            SiteOutcome::Diamond => outcome.diamonds += 1,
+            SiteOutcome::TailForward => outcome.tail_forwards += 1,
+            SiteOutcome::Rewrapped => outcome.rewrapped += 1,
         }
     }
     Ok(outcome)
 }
 
-/// Returns `true` for a rewired diamond, `false` for a (no-op)
-/// tail-forward.
 fn rewire_one_call_site(
     graph: &mut FunctionGraph,
     r: &Variable,
     enclosing_scoped: bool,
-) -> Result<bool, String> {
+) -> Result<SiteOutcome, String> {
     let name = graph.name.clone();
     // Block A: contains the call producing `r`; closed by lower_call
     // with a single forwarding exit.
@@ -485,29 +520,26 @@ fn rewire_one_call_site(
                  the callers' discriminant switches read garbage"
             ));
         }
-        return Ok(false);
+        return Ok(SiteOutcome::TailForward);
     }
     let (b, r_b) =
         follow_single_exit(graph, a, r).map_err(|e| format!("{name}: call block exit: {e}"))?;
+    // Block B: `cf = Result::branch(r)`.  A block without the branch
+    // call is a custom-match consumer (hand-written `match` on the
+    // Result, possibly behind a multi-predecessor merge) — handled by
+    // the local catch-and-rewrap arm instead of the diamond rewire.
+    let branch_op_idx = graph.blocks[b].operations.iter().position(|op| {
+        matches!(
+            &op.kind,
+            OpKind::Call { target: CallTarget::Method { name, .. }, args, .. }
+                if name == "branch" && args.as_slice() == std::slice::from_ref(&r_b)
+        )
+    });
+    let Some(branch_op_idx) = branch_op_idx else {
+        catch_and_rewrap(graph, a, r)?;
+        return Ok(SiteOutcome::Rewrapped);
+    };
     assert_single_pred(graph, b, &name)?;
-    // Block B: `cf = Result::branch(r)`.
-    let branch_op_idx = graph.blocks[b]
-        .operations
-        .iter()
-        .position(|op| {
-            matches!(
-                &op.kind,
-                OpKind::Call { target: CallTarget::Method { name, .. }, args, .. }
-                    if name == "branch" && args.as_slice() == std::slice::from_ref(&r_b)
-            )
-        })
-        .ok_or_else(|| {
-            format!(
-                "{name}: block {b} after a scoped call does not start a \
-                 Try::branch diamond — non-`?` use of a scoped callee's \
-                 Result (custom match handlers are not supported yet)"
-            )
-        })?;
     let cf = graph.blocks[b].operations[branch_op_idx]
         .result
         .clone()
@@ -598,7 +630,202 @@ fn rewire_one_call_site(
     ];
     // Blocks B, C and the break arm are now unreachable; the dead-op
     // sweep leaves them to the reachability-walking consumers.
-    Ok(true)
+    Ok(SiteOutcome::Diamond)
+}
+
+/// Custom-match fallback: the call's `Result` is consumed by a
+/// hand-written `match` (eval.rs `eval_loop` dispatches `StepResult` +
+/// the error handler) — possibly behind a multi-predecessor merge
+/// shared with sibling shells (`eval_loop_jit`'s `match step_result`
+/// merges 7 predecessors).  Rewiring that destructuring in place would
+/// need per-predecessor jump threading, so instead the rewrite stays
+/// local to the call edge: the call block gets `LastException` exits
+/// whose two arms REBUILD the value-encoded `Result` the untouched
+/// downstream keeps consuming — the normal arm wraps the raw return in
+/// an `Ok` shell, the exception arm binds the caught `W_ExceptionObject`
+/// back into the `PyError` domain (`PyError::from_exc_object`, the
+/// inverse of the callee rule's `to_exc_object`) and wraps it in an
+/// `Err` shell.  This is the same erasure boundary the residual-call
+/// ABI implements at host calls (`Ok` → value, `Err` →
+/// `BH_LAST_EXC_VALUE`), value-encoded again one block later.  The
+/// rebuilt shells sit in the CALLER's graph next to the sibling shells
+/// the caller already builds for its own returns, so no new shell
+/// exposure is introduced on walked paths.
+fn catch_and_rewrap(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Result<(), String> {
+    use crate::model::BlockId;
+    let name = graph.name.clone();
+    if graph.blocks[a].exitswitch.is_some() {
+        return Err(format!(
+            "{name}: rewrap call block {a} has an exitswitch — expected the \
+             single forwarding exit lower_call installs"
+        ));
+    }
+    let [orig] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!(
+            "{name}: rewrap call block {a} must have a single exit"
+        ));
+    };
+    let orig = orig.clone();
+    if orig.exitcase.is_some() {
+        return Err(format!(
+            "{name}: rewrap call block {a} exit carries an exitcase"
+        ));
+    }
+    let is_r = |arg: &LinkArg| matches!(arg, LinkArg::Value(v) if v == r);
+    let has_r = orig.args.iter().any(|a| is_r(a));
+
+    // --- Normal arm N: receive every Value arg, rebuild `Ok(r)`.
+    let value_args: Vec<LinkArg> = orig
+        .args
+        .iter()
+        .filter(|a| matches!(a, LinkArg::Value(_)))
+        .cloned()
+        .collect();
+    let (n_id, n_inputs) = graph.create_block_with_arg_vars(value_args.len());
+    let n_shell: Option<Variable> = if has_r {
+        let r_value_idx = value_args
+            .iter()
+            .position(|a| is_r(a))
+            .expect("has_r implies a Value position");
+        let payload = n_inputs[r_value_idx].clone();
+        Some(build_shell(graph, n_id, "Ok", payload))
+    } else {
+        None
+    };
+    let mut vi = 0usize;
+    let n_exit_args: Vec<LinkArg> = orig
+        .args
+        .iter()
+        .map(|arg| match arg {
+            LinkArg::Const(c) => LinkArg::Const(c.clone()),
+            LinkArg::Value(_) => {
+                let v = n_inputs[vi].clone();
+                vi += 1;
+                if is_r(arg) {
+                    LinkArg::Value(n_shell.clone().expect("shell built when r flows"))
+                } else {
+                    LinkArg::Value(v)
+                }
+            }
+        })
+        .collect();
+    graph.set_control_flow_metadata(
+        n_id,
+        None,
+        vec![Link::new_mixed(n_exit_args, orig.target, None)],
+    );
+
+    // --- Exception arm E: receive the non-`r` Value args plus the
+    // caught `[exc_type, exc_value]` pair, rebuild `Err(from_exc_object
+    // (exc_value))`.
+    let nonr_args: Vec<LinkArg> = orig
+        .args
+        .iter()
+        .filter(|a| matches!(a, LinkArg::Value(_)) && !is_r(a))
+        .cloned()
+        .collect();
+    let (e_id, e_inputs) = graph.create_block_with_arg_vars(nonr_args.len() + 2);
+    let e_exc_value_in = e_inputs[nonr_args.len() + 1].clone();
+    let e_shell: Option<Variable> = if has_r {
+        let v_err = graph
+            .push_op_var(
+                e_id,
+                OpKind::Call {
+                    target: CallTarget::method("from_exc_object", Some("PyError".to_string())),
+                    args: vec![e_exc_value_in],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .expect("from_exc_object must produce a value");
+        Some(build_shell(graph, e_id, "Err", v_err))
+    } else {
+        None
+    };
+    let mut ei = 0usize;
+    let e_exit_args: Vec<LinkArg> = orig
+        .args
+        .iter()
+        .map(|arg| match arg {
+            LinkArg::Const(c) => LinkArg::Const(c.clone()),
+            LinkArg::Value(_) if is_r(arg) => {
+                LinkArg::Value(e_shell.clone().expect("shell built when r flows"))
+            }
+            LinkArg::Value(_) => {
+                let v = e_inputs[ei].clone();
+                ei += 1;
+                LinkArg::Value(v)
+            }
+        })
+        .collect();
+    graph.set_control_flow_metadata(
+        e_id,
+        None,
+        vec![Link::new_mixed(e_exit_args, orig.target, None)],
+    );
+
+    // --- Rewire A: LastException exits — normal → N, exception → E.
+    let va = graph.alloc_value_var();
+    let vb = graph.alloc_value_var();
+    let a_to_e_args: Vec<LinkArg> = nonr_args
+        .into_iter()
+        .chain([LinkArg::Value(va.clone()), LinkArg::Value(vb.clone())])
+        .collect();
+    let mut exc_link = Link::new_mixed(a_to_e_args, e_id, Some(crate::model::exception_exitcase()));
+    exc_link.last_exception = Some(LinkArg::Value(va));
+    exc_link.last_exc_value = Some(LinkArg::Value(vb));
+    graph.set_control_flow_metadata(
+        BlockId(a),
+        Some(ExitSwitch::LastException),
+        vec![Link::new_mixed(value_args, n_id, None), exc_link],
+    );
+    Ok(())
+}
+
+/// Emit `shell = Result::<variant>(); shell.__pos_0 = payload` into
+/// `block`, mirroring the front lowering's Aggregate shape
+/// (`front/mir.rs` `Rvalue::Aggregate`: niladic transparent ctor + one
+/// FieldWrite per operand, `result: None` on the write).
+fn build_shell(
+    graph: &mut FunctionGraph,
+    block: crate::model::BlockId,
+    variant: &str,
+    payload: Variable,
+) -> Variable {
+    use crate::model::FieldDescriptor;
+    let owner = format!("core::result::Result::{variant}");
+    let shell = graph
+        .push_op_var(
+            block,
+            OpKind::Call {
+                target: CallTarget::synthetic_transparent_ctor_with_owner(
+                    ["core", "result", "Result"]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                    variant,
+                ),
+                args: Vec::new(),
+                result_ty: ValueType::Ref(Some(owner.clone())),
+            },
+            true,
+        )
+        .expect("Result ctor must produce a value");
+    graph.blocks[block.0]
+        .operations
+        .push(crate::model::SpaceOperation {
+            result: None,
+            kind: OpKind::FieldWrite {
+                base: shell.clone(),
+                field: FieldDescriptor {
+                    name: "__pos_0".to_string(),
+                    owner_root: Some(owner),
+                },
+                value: payload,
+                ty: ValueType::Ref(None),
+            },
+        });
+    shell
 }
 
 /// Probe: does `var` flow from `block`'s exit through pure positional

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -67,9 +67,9 @@ use crate::flowspace::model::Variable;
 use crate::model::{CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType};
 
 /// Callees whose `Result<T, PyError>` surface lowers to raise links.
-/// Grown deliberately (same staging discipline as
-/// `REQUIRED_METHOD_DEVIRT_SCOPE` in `lib.rs`); replaced by a
-/// whole-program conformance scan once every caller shape is covered.
+/// Grown deliberately, one fail-loud pipeline convergence at a time;
+/// replaced by a whole-program conformance scan once every caller
+/// shape is covered.
 const RESULT_EXC_LOWERING_SCOPE: &[&str] = &[
     "pop_value",
     "store_local_value",

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -134,6 +134,15 @@ impl StructFieldRegistry {
             .map(|(_, ty)| ty.as_str())
     }
 
+    /// True when `owner` is registered as an enum flat class whose only
+    /// row is the synthetic `__discriminant` tag — a unit-only enum
+    /// (every variant fieldless).  Payload-bearing enums carry the union
+    /// of their variant fields as further rows.
+    pub fn is_unit_only_enum(&self, owner: &str) -> bool {
+        self.lookup_fields(owner)
+            .is_some_and(|rows| matches!(rows, [(name, _)] if name == "__discriminant"))
+    }
+
     fn lookup_fields(&self, owner: &str) -> Option<&[(String, String)]> {
         if let Some(fields) = self.fields.get(owner) {
             return Some(fields.as_slice());

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -404,7 +404,7 @@ fn remap_op(
     SpaceOperation { result, kind }
 }
 
-fn remap_op_kind(
+pub(crate) fn remap_op_kind(
     kind: &OpKind,
     remap_var: &impl Fn(&crate::flowspace::model::Variable) -> crate::flowspace::model::Variable,
 ) -> OpKind {

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -889,8 +889,9 @@ impl Assembler {
                     "encode_regorconst_source: Register kind {:?} does not match \
                      variant-expected kind {expected_kind:?} (PyPy \
                      `assembler.py:164-174` requires the single-byte argcode kind \
-                     and the operand kind to coincide)",
-                    r.kind,
+                     and the operand kind to coincide) — graph {:?}, flatop {:?} \
+                     (set MAJIT_COVERAGE_PANIC=1 to populate the flatop context)",
+                    r.kind, self.current_graph_name, self.current_flatop_debug,
                 );
                 r.index as u8
             }

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3431,39 +3431,9 @@ impl CallControl {
                     // branch above so audit sweeps observe both fallback
                     // surfaces consistently.
                     if std::env::var_os("PYRE_STRICT_TARGET_TO_PATH").is_none() {
-                        let need_tail = name.as_str().to_string();
-                        let receiver_leaf =
-                            receiver.rsplit("::").next().unwrap_or(receiver).to_string();
-                        // `impl_method_leaf_index` pre-filters by
-                        // method-name leaf so only same-leaf
-                        // candidates are scanned for the
-                        // `[..., receiver_leaf, need_tail]` tail.
-                        let empty: Vec<CallPath> = Vec::new();
-                        let leaf_bucket = self
-                            .impl_method_leaf_index
-                            .get(&need_tail)
-                            .unwrap_or(&empty);
-                        let mut matched: Option<&CallPath> = None;
-                        let mut multi = false;
-                        for key in leaf_bucket.iter() {
-                            let segs = &key.segments;
-                            if segs.len() >= 2
-                                && segs
-                                    .get(segs.len() - 2)
-                                    .map(|s| s == &receiver_leaf)
-                                    .unwrap_or(false)
-                            {
-                                if matched.is_some() {
-                                    multi = true;
-                                    break;
-                                }
-                                matched = Some(key);
-                            }
-                        }
-                        if !multi {
-                            if let Some(path) = matched {
-                                return Some(path.clone());
-                            }
+                        if let Some(path) = self.suffix_match_impl_method(receiver, name.as_str())
+                        {
+                            return Some(path);
                         }
                     }
                 }
@@ -3482,6 +3452,61 @@ impl CallControl {
         }
     }
 
+    /// Unique suffix-match of an impl method by bare receiver leaf —
+    /// `[..., receiver_leaf, name]` against `impl_method_leaf_index`.
+    ///
+    /// When the parser walks `impl PyFrame { fn pop(&mut self) {
+    /// self.stack_base() } }`, the inner `self.stack_base()` is
+    /// recorded as `Method { receiver_root: Some("PyFrame") }` — the
+    /// syntactic spelling, not the canonical `pyframe::PyFrame` —
+    /// while `function_graphs` registers the impl method under the
+    /// module-qualified key plus its crate-qualified alias
+    /// publications.  All aliases of one source graph share
+    /// `FunctionGraph.name`, so a multi-alias bucket is deduped by
+    /// graph identity exactly like the FunctionPath leaf-match above
+    /// (`bookkeeper.getdesc(callable)` keys on function-object
+    /// identity); genuinely distinct same-leaf candidates (two types
+    /// sharing a method-name leaf) stay ambiguous and return `None`,
+    /// mirroring Rust's name-resolution ambiguity error rather than
+    /// silently picking one.  The lexicographically smallest alias is
+    /// returned so the resolved `CallPath` is stable across runs and
+    /// lines up with the still-path-keyed registries.
+    fn suffix_match_impl_method(&self, receiver: &str, name: &str) -> Option<CallPath> {
+        let receiver_leaf = receiver.rsplit("::").next().unwrap_or(receiver);
+        let leaf_bucket = self.impl_method_leaf_index.get(name)?;
+        let matches: Vec<&CallPath> = leaf_bucket
+            .iter()
+            .filter(|key| {
+                let segs = &key.segments;
+                segs.len() >= 2 && segs[segs.len() - 2] == receiver_leaf
+            })
+            .collect();
+        if matches.is_empty() {
+            return None;
+        }
+        if matches.len() == 1 {
+            return Some(matches[0].clone());
+        }
+        let first_graph_name = self
+            .function_graphs
+            .get(matches[0])
+            .map(|g| g.name.as_str())?;
+        let all_same = matches.iter().all(|p| {
+            self.function_graphs
+                .get(*p)
+                .map(|g| g.name == first_graph_name)
+                .unwrap_or(false)
+        });
+        if !all_same {
+            return None;
+        }
+        matches
+            .iter()
+            .copied()
+            .min_by(|a, b| a.segments.cmp(&b.segments))
+            .cloned()
+    }
+
     /// RPython `call.py:181-183` uses `getfunctionptr(graph)` to obtain the
     /// integer funcptr identity for a call site. majit prefers a host-bound
     /// trace-call address when one has been registered for the resolved
@@ -3494,6 +3519,29 @@ impl CallControl {
                 .get(&path)
                 .copied()
                 .unwrap_or_else(|| symbolic_fnaddr_for_path(&path));
+        }
+        // Graph-less inherent-method fallback.  `target_to_path`'s
+        // `Method` arm resolves only graph-registered paths (its
+        // suffix-match walks `impl_method_leaf_index`, which is built
+        // from `function_graphs` keys).  Elidable leaf methods
+        // (`PyFrame::nlocals` / `ncells` / …) deliberately register NO
+        // graph — `look_inside_graph` would reject them anyway — and
+        // bind only a host fnaddr (`jit_fnaddr.rs`), so the path
+        // lookup above never fires for the in-impl `self.method()`
+        // spelling.  Try the qualified `[receiver, name]` spelling
+        // against `function_fnaddrs` directly before minting a
+        // symbolic hash, mirroring the FunctionPath arm which returns
+        // 3+-segment paths without a graph-containment check.
+        if let CallTarget::Method {
+            name,
+            receiver_root: Some(receiver),
+            ..
+        } = target
+        {
+            let qualified = CallPath::for_impl_method(receiver, name.as_str());
+            if let Some(&addr) = self.function_fnaddrs.get(&qualified) {
+                return addr;
+            }
         }
         symbolic_fnaddr_for_target(target)
     }
@@ -3652,6 +3700,42 @@ impl CallControl {
             if let Some(g) = self.function_graphs.get(&path) {
                 return Some(g);
             }
+            // Canonicalised spelling — in-impl `self.method()` call
+            // sites carry the bare receiver while registrations use
+            // the defining-module qualifier.
+            let canonical = majit_ir::descr::canonical_struct_name(receiver);
+            if canonical != receiver {
+                let path = CallPath::for_impl_method(&canonical, name);
+                if let Some(g) = self.function_graphs.get(&path) {
+                    return Some(g);
+                }
+            }
+            // Bare-receiver leaf match against the module-qualified
+            // inherent registration (same dedupe as `target_to_path`'s
+            // Method arm).  Must run BEFORE the receiver-agnostic
+            // unique-concrete fallback below: inherent methods
+            // (`PyFrame::pop`) never enter `method_to_impl_types`
+            // (trait-method table), so without this lookup a concrete
+            // receiver whose method exists only as an inherent graph
+            // would fall through and resolve to an unrelated type that
+            // happens to be the table's unique owner of the same
+            // method name (`pop` → dict-strategy pop).
+            if let Some(path) = self.suffix_match_impl_method(receiver, name) {
+                if let Some(g) = self.function_graphs.get(&path) {
+                    return Some(g);
+                }
+            }
+            // Known concrete struct receiver with no matching impl
+            // graph anywhere: do NOT fall through to the
+            // receiver-agnostic unique-concrete fallback — it resolves
+            // to an UNRELATED type that happens to be the table's
+            // unique owner of the method name.  Generic-parameter
+            // receivers (`H` / `handler`) have no
+            // `STRUCT_ORIGIN_REGISTRY` entry (and no `::`), so they
+            // keep the BFS-coverage fallback below.
+            if receiver.contains("::") || canonical != receiver {
+                return None;
+            }
         }
 
         // TODO(parity): retire when annotator wiring publishes
@@ -3715,6 +3799,29 @@ impl CallControl {
         if let Some(receiver) = receiver_root {
             if let Some(impl_name) = impls.iter().copied().find(|t| t.as_str() == receiver) {
                 return Some(impl_name.as_str());
+            }
+            // Bare-receiver leaf match: the table stores canonical
+            // `module::Type` names while in-impl `self.method()` call
+            // sites carry the syntactic bare spelling.  Unique-leaf
+            // only — two canonical types sharing a leaf stay
+            // ambiguous, mirroring [`Self::suffix_match_impl_method`].
+            let receiver_leaf = receiver.rsplit("::").next().unwrap_or(receiver);
+            let leaf_matches: Vec<&String> = impls
+                .iter()
+                .copied()
+                .filter(|t| t.rsplit("::").next().unwrap_or(t) == receiver_leaf)
+                .collect();
+            if leaf_matches.len() == 1 {
+                return Some(leaf_matches[0].as_str());
+            }
+            // Known concrete struct receiver with no matching impl:
+            // suppress the receiver-agnostic fallback (mirrors
+            // [`Self::resolve_method`]) — generic-parameter receivers
+            // keep it.
+            if receiver.contains("::")
+                || majit_ir::descr::canonical_struct_name(receiver) != receiver
+            {
+                return None;
             }
         }
 
@@ -8687,3 +8794,4 @@ mod tests {
         assert_eq!(got[0].index(), 90);
     }
 }
+

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3431,8 +3431,7 @@ impl CallControl {
                     // branch above so audit sweeps observe both fallback
                     // surfaces consistently.
                     if std::env::var_os("PYRE_STRICT_TARGET_TO_PATH").is_none() {
-                        if let Some(path) = self.suffix_match_impl_method(receiver, name.as_str())
-                        {
+                        if let Some(path) = self.suffix_match_impl_method(receiver, name.as_str()) {
                             return Some(path);
                         }
                     }
@@ -8794,4 +8793,3 @@ mod tests {
         assert_eq!(got[0].index(), 90);
     }
 }
-

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -2043,6 +2043,20 @@ impl CallControl {
         crate_alias.push("crate");
         crate_alias.extend(canonical.iter().copied());
         self.register_function_fnaddr(CallPath::from_segments(crate_alias), fnaddr);
+        // Charon names call targets crate-qualified (`name_path()` keeps
+        // the crate root), and `target_to_path` returns 3+-segment
+        // `FunctionPath`s verbatim — so `fnaddr_for_target`'s exact-path
+        // lookup needs the unstripped spelling too.  Without it, every
+        // residual call site that reaches the helper through its
+        // crate-qualified path falls back to the symbolic hash, which
+        // `patch_constants_i_fnaddrs` can never rebind to the runtime
+        // address.
+        if segments.len() > 1 {
+            self.register_function_fnaddr(
+                CallPath::from_segments(segments.iter().copied()),
+                fnaddr,
+            );
+        }
     }
 
     /// Structured binding for an impl-method helper. `impl_type_joined`
@@ -6979,6 +6993,17 @@ mod tests {
         assert_eq!(
             cc.fnaddr_for_target(&CallTarget::function_path([
                 "crate",
+                "helpers",
+                "opaque_call"
+            ])),
+            0x1234
+        );
+        // Charon callsites keep the crate root (`name_path()`), and
+        // `target_to_path` returns 3+-segment FunctionPaths verbatim —
+        // the unstripped spelling must bind too.
+        assert_eq!(
+            cc.fnaddr_for_target(&CallTarget::function_path([
+                "testcrate",
                 "helpers",
                 "opaque_call"
             ])),

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -3471,6 +3471,14 @@ impl CallControl {
     /// returned so the resolved `CallPath` is stable across runs and
     /// lines up with the still-path-keyed registries.
     fn suffix_match_impl_method(&self, receiver: &str, name: &str) -> Option<CallPath> {
+        // The leaf strip below cannot verify the receiver's module, so a
+        // qualified receiver (`pkg_a::Foo`) could bind an unrelated
+        // same-leaf type (`pkg_b::Foo`).  This helper exists only for the
+        // bare in-impl `self.method()` spelling; a qualified receiver must
+        // resolve through the exact / canonical path or not at all.
+        if receiver.contains("::") {
+            return None;
+        }
         let receiver_leaf = receiver.rsplit("::").next().unwrap_or(receiver);
         let leaf_bucket = self.impl_method_leaf_index.get(name)?;
         let matches: Vec<&CallPath> = leaf_bucket
@@ -3537,9 +3545,20 @@ impl CallControl {
             ..
         } = target
         {
-            let qualified = CallPath::for_impl_method(receiver, name.as_str());
-            if let Some(&addr) = self.function_fnaddrs.get(&qualified) {
-                return addr;
+            // In-impl `self.method()` sites carry the bare receiver
+            // (`PyFrame`) while fnaddr bindings register under the
+            // defining-module qualifier; try the canonical spelling too,
+            // mirroring `resolve_method`'s receiver-string fallback.
+            let canonical = majit_ir::descr::canonical_struct_name(receiver);
+            let mut candidates = vec![receiver.as_str()];
+            if canonical != *receiver {
+                candidates.push(canonical.as_str());
+            }
+            for candidate in candidates {
+                let qualified = CallPath::for_impl_method(candidate, name.as_str());
+                if let Some(&addr) = self.function_fnaddrs.get(&qualified) {
+                    return addr;
+                }
             }
         }
         symbolic_fnaddr_for_target(target)
@@ -3799,6 +3818,14 @@ impl CallControl {
             if let Some(impl_name) = impls.iter().copied().find(|t| t.as_str() == receiver) {
                 return Some(impl_name.as_str());
             }
+            // A qualified receiver (`pkg_a::Foo`) that missed the exact
+            // match must not strip to its leaf and bind an unrelated
+            // same-leaf type (`pkg_b::Foo`); the leaf fallback below is
+            // only for the bare in-impl `self.method()` spelling.  Return
+            // None, mirroring [`Self::resolve_method`]'s qualified guard.
+            if receiver.contains("::") {
+                return None;
+            }
             // Bare-receiver leaf match: the table stores canonical
             // `module::Type` names while in-impl `self.method()` call
             // sites carry the syntactic bare spelling.  Unique-leaf
@@ -3817,9 +3844,7 @@ impl CallControl {
             // suppress the receiver-agnostic fallback (mirrors
             // [`Self::resolve_method`]) — generic-parameter receivers
             // keep it.
-            if receiver.contains("::")
-                || majit_ir::descr::canonical_struct_name(receiver) != receiver
-            {
+            if majit_ir::descr::canonical_struct_name(receiver) != receiver {
                 return None;
             }
         }

--- a/majit/majit-translate/src/jit_codewriter/codewriter.rs
+++ b/majit/majit-translate/src/jit_codewriter/codewriter.rs
@@ -606,6 +606,15 @@ impl CodeWriter {
             && graph_result_kind(&rewritten.graph) == 'r'
         {
             crate::front::result_exc::widen_unit_return_to_void(&mut rewritten.graph);
+            // Sweep the unit producers the widen just orphaned.  Clearing
+            // the returnblock args/inputargs leaves the `()` ctor (or a
+            // tail-forwarded `Ref` call result) unread; without a dead-op
+            // pass it would survive into flatten as a value the void
+            // return no longer consumes.  `rpython/translator/simplify.py`
+            // `remove_dead_links_and_setattrs` runs after exceptiontransform
+            // for the same reason — `prune_dead_phis` keeps raising/impure
+            // producers and only drops the genuinely pure dead unit shells.
+            crate::model::prune_dead_phis(&mut rewritten.graph);
         }
         let mut regallocs = crate::jit_codewriter::transform_profile::time_phase(
             "step2_perform_all_register_allocations",

--- a/majit/majit-translate/src/jit_codewriter/codewriter.rs
+++ b/majit/majit-translate/src/jit_codewriter/codewriter.rs
@@ -591,6 +591,22 @@ impl CodeWriter {
         // Stamp canonical exceptblock kinds first so the rtyper-skip
         // path still gets `(etype=Int, evalue=Ref)`.
         crate::regalloc::augment_canonical_exceptblock_on_graph(&mut rewritten.graph);
+        // Void-widening (exceptiontransform parity).  A scoped
+        // `Result<(), PyError>` callee declares `FUNC.RESULT = void`
+        // (`return_type = "()"`, stamped in `front::mir`), but its CFG
+        // still returns the unit `()` as a `Ref`-typed value because
+        // every aggregate lowers to `Ref`.  Collapse the returnblock to a
+        // genuine void return now — after the whole-program annotation
+        // fixpoint, the same ordering `rpython/translator/exceptiontransform.py`
+        // uses by running after rtyping — so flatten emits a void return
+        // and `graph_result_kind` agrees with the declared `v`.  The
+        // `declared==v && cfg==r` gate is exactly the unit-shell case; a
+        // genuinely void CFG (`cfg==v`) needs no rewrite.
+        if callcontrol.declared_return_kind(path) == Some('v')
+            && graph_result_kind(&rewritten.graph) == 'r'
+        {
+            crate::front::result_exc::widen_unit_return_to_void(&mut rewritten.graph);
+        }
         let mut regallocs = crate::jit_codewriter::transform_profile::time_phase(
             "step2_perform_all_register_allocations",
             || crate::regalloc::perform_all_register_allocations(&rewritten.graph),

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -890,20 +890,19 @@ fn analyze_pipeline_from_module_paths(
             // the motivating members are the exception-handler pair
             // whose empty defaults broke generic-dispatch resolution.
             const DEFAULT_SHADOW_DEVIRT_SCOPE: &[&str] = &["push_exc_info", "pop_except"];
-            let devirt: Option<(&str, &front::semantic::SemanticFunction)> = if is_default
-                && DEFAULT_SHADOW_DEVIRT_SCOPE.contains(&method.name.as_str())
-            {
-                trait_method_overrides
-                    .get(&(impl_info.trait_name.as_str(), method.name.as_str()))
-                    .filter(|_| {
-                        trait_concrete_impl_types
-                            .get(impl_info.trait_name.as_str())
-                            .is_some_and(|types| types.len() == 1)
-                    })
-                    .copied()
-            } else {
-                None
-            };
+            let devirt: Option<(&str, &front::semantic::SemanticFunction)> =
+                if is_default && DEFAULT_SHADOW_DEVIRT_SCOPE.contains(&method.name.as_str()) {
+                    trait_method_overrides
+                        .get(&(impl_info.trait_name.as_str(), method.name.as_str()))
+                        .filter(|_| {
+                            trait_concrete_impl_types
+                                .get(impl_info.trait_name.as_str())
+                                .is_some_and(|types| types.len() == 1)
+                        })
+                        .copied()
+                } else {
+                    None
+                };
             // Hints for the direct path follow the graph registered
             // there (RPython binds hints to graph identity).
             let direct_hints: &Vec<String> = match devirt {

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -877,7 +877,22 @@ fn analyze_pipeline_from_module_paths(
             // without an override, and traits with several concrete
             // impl types (the receiver stays ambiguous —
             // indirect-call family territory keeps the default).
-            let devirt: Option<(&str, &front::semantic::SemanticFunction)> = if is_default {
+            //
+            // Staged scope: whole-trait shadowing is blocked on the
+            // classdef-hints-before-BFS annotator work — registering
+            // objspace-heavy overrides (load_attr / call_callable /
+            // binary_op …) pulls their graph closure into the BFS,
+            // where the annotator fails on classdef-less SomeInstance
+            // attr reads and on runtime statics no build-time table
+            // can resolve (`JIT_DRIVER`).  Grown deliberately, one
+            // fail-loud resolution at a time (same staging discipline
+            // as `RESULT_EXC_LOWERING_SCOPE` in `front/result_exc.rs`);
+            // the motivating members are the exception-handler pair
+            // whose empty defaults broke generic-dispatch resolution.
+            const DEFAULT_SHADOW_DEVIRT_SCOPE: &[&str] = &["push_exc_info", "pop_except"];
+            let devirt: Option<(&str, &front::semantic::SemanticFunction)> = if is_default
+                && DEFAULT_SHADOW_DEVIRT_SCOPE.contains(&method.name.as_str())
+            {
                 trait_method_overrides
                     .get(&(impl_info.trait_name.as_str(), method.name.as_str()))
                     .filter(|_| {

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -633,6 +633,25 @@ fn analyze_pipeline_from_module_paths(
     // `mir_graph_lookup` is consulted by the registration loops below
     // (trait-default vs concrete-impl graph fetch).
     let mir_graph_lookup = front::semantic::MirGraphLookup::from_program(&program);
+    // `classdesc.py:749 lookup` MRO walk for generic trait dispatch:
+    // a concrete override shadows the trait default.  `front::mir`
+    // lowers `CallKind::Trait` (a call through a generic `<E: Trait>`
+    // receiver) to the direct path `[<Trait>, <method>]`, and the
+    // registration loop below binds that path for BFS discovery and
+    // `get_jitcode` resolution.  Collect each trait's concrete impl
+    // types and per-method overrides so the direct-path registration
+    // can prefer the unique override: with exactly one concrete impl
+    // in the analyzed program the annotator binds the receiver to
+    // that instantiation, so the MRO finds the override before the
+    // default body.  With several concrete impl types the receiver
+    // stays ambiguous and the default-body registration is kept
+    // (indirect-call family territory).
+    let mut trait_concrete_impl_types: std::collections::HashMap<&str, Vec<&str>> =
+        std::collections::HashMap::new();
+    let mut trait_method_overrides: std::collections::HashMap<
+        (&str, &str),
+        (&str, &front::semantic::SemanticFunction),
+    > = std::collections::HashMap::new();
     for func in &program.functions {
         match (&func.self_ty_root, &func.trait_root) {
             // Concrete trait-impl method: `impl Trait for Type { fn m }`.
@@ -641,8 +660,13 @@ fn analyze_pipeline_from_module_paths(
             // through `register_trait_method` instead would also seed
             // `method_to_impl_types`, flipping `resolve_method`'s
             // name-based lookup for every same-named method.  The trait
-            // identity feeds only the single-impl direct-path binding
-            // (`concrete_trait_methods` consumer below).
+            // identity feeds two complementary direct-path consumers:
+            // the `concrete_trait_methods` loop below binds the unique
+            // impl when the trait method has NO default body, and the
+            // `trait_method_overrides` lookup inside the default-body
+            // registration prefers the unique override over the default
+            // (`classdesc.py:749` — a concrete override shadows the
+            // trait default in the MRO walk).
             (Some(owner), Some(trait_leaf)) => {
                 concrete_trait_methods.push((
                     trait_leaf.clone(),
@@ -654,6 +678,16 @@ fn analyze_pipeline_from_module_paths(
                     func.return_type.clone(),
                     func.hints.clone(),
                 ));
+                let types = trait_concrete_impl_types
+                    .entry(trait_leaf.as_str())
+                    .or_default();
+                if !types.contains(&owner.as_str()) {
+                    types.push(owner.as_str());
+                }
+                trait_method_overrides.insert(
+                    (trait_leaf.as_str(), func.name.as_str()),
+                    (owner.as_str(), func),
+                );
                 canonical_inherent_methods.push(parse::InherentMethodInfo {
                     for_type: owner.clone(),
                     self_ty_root: Some(owner.clone()),
@@ -836,6 +870,31 @@ fn analyze_pipeline_from_module_paths(
         };
         let is_default = impl_info.for_type.starts_with("<default methods of ");
         for method in &impl_info.methods {
+            // `classdesc.py:749 lookup` MRO: on the generic-dispatch
+            // direct path `[<Trait>, <method>]`, the unique concrete
+            // override shadows the trait default body (pre-pass
+            // above).  `None` for concrete-impl entries, defaults
+            // without an override, and traits with several concrete
+            // impl types (the receiver stays ambiguous —
+            // indirect-call family territory keeps the default).
+            let devirt: Option<(&str, &front::semantic::SemanticFunction)> = if is_default {
+                trait_method_overrides
+                    .get(&(impl_info.trait_name.as_str(), method.name.as_str()))
+                    .filter(|_| {
+                        trait_concrete_impl_types
+                            .get(impl_info.trait_name.as_str())
+                            .is_some_and(|types| types.len() == 1)
+                    })
+                    .copied()
+            } else {
+                None
+            };
+            // Hints for the direct path follow the graph registered
+            // there (RPython binds hints to graph identity).
+            let direct_hints: &Vec<String> = match devirt {
+                Some((_, override_info)) => &override_info.hints,
+                None => &method.hints,
+            };
             // Read the MIR-built graph from `program.functions`.
             // `method.graph` (`Option`) remains as a residual fallback
             // for the handful of MIR-uncovered entries, though every
@@ -878,12 +937,25 @@ fn analyze_pipeline_from_module_paths(
                         method.name.as_str(),
                     ]);
                     // Prefer the MIR graph for the direct_path
-                    // registration too; fall back to `method.graph`
-                    // when the lookup has no entry.
-                    let direct_source: Option<model::FunctionGraph> =
-                        mir_graph.cloned().or_else(|| method.graph.clone());
+                    // registration too; fall back to the carried
+                    // graph when the lookup has no entry.  `devirt`
+                    // (hoisted above) swaps in the unique concrete
+                    // override's graph and return type.
+                    let (direct_source, direct_return_type) = match devirt {
+                        Some((impl_type, override_info)) => (
+                            mir_graph_lookup
+                                .lookup_impl_method(impl_type, &method.name)
+                                .cloned()
+                                .or_else(|| Some(override_info.graph.clone())),
+                            override_info.return_type.as_ref(),
+                        ),
+                        None => (
+                            mir_graph.cloned().or_else(|| method.graph.clone()),
+                            method.return_type.as_ref(),
+                        ),
+                    };
                     if let Some(g) = direct_source {
-                        let direct_graph = match &method.return_type {
+                        let direct_graph = match direct_return_type {
                             Some(rt) => g.with_return_type(rt),
                             None => g,
                         };
@@ -901,58 +973,55 @@ fn analyze_pipeline_from_module_paths(
             // `[impl_type, method_name]` path the BFS reads.
             if !method.hints.is_empty() {
                 call_control.register_function_hints_for(path.clone(), method.hints.clone());
-                // Default-method bodies also register under `[trait_name,
-                // method_name]` (see the `register_function_graph(direct_path,
-                // direct_graph)` branch above); mirror the hint registration
-                // so the BFS reaches the same `_reject_function("elidable")`
-                // verdict regardless of which path it walks.
-                if impl_info.for_type.starts_with("<default methods of ") {
-                    let direct_path = crate::parse::CallPath::from_segments([
-                        impl_info.trait_name.as_str(),
-                        method.name.as_str(),
-                    ]);
-                    call_control.register_function_hints_for(direct_path, method.hints.clone());
-                }
             }
-            // RPython: hints bound to graph identity.
-            let default_direct_path = if impl_info.for_type.starts_with("<default methods of ") {
-                Some(crate::parse::CallPath::from_segments([
+            // Default-method bodies also register under `[trait_name,
+            // method_name]` (see the `register_function_graph(direct_path,
+            // direct_graph)` branch above); mirror the hint registration
+            // so the BFS reaches the same `_reject_function("elidable")`
+            // verdict regardless of which path it walks.  `direct_hints`
+            // follows the graph registered there — the override's when
+            // the direct path was devirtualized.
+            if is_default && !direct_hints.is_empty() {
+                let direct_path = crate::parse::CallPath::from_segments([
                     impl_info.trait_name.as_str(),
                     method.name.as_str(),
-                ]))
-            } else {
-                None
-            };
+                ]);
+                call_control.register_function_hints_for(direct_path, direct_hints.clone());
+            }
+            // RPython: hints bound to graph identity.
             for hint in &method.hints {
                 match hint.as_str() {
-                    "elidable" => {
-                        call_control.mark_elidable(path.clone());
-                        if let Some(ref dp) = default_direct_path {
-                            call_control.mark_elidable(dp.clone());
-                        }
-                    }
+                    "elidable" => call_control.mark_elidable(path.clone()),
                     "elidable_cannot_raise" => {
-                        call_control.mark_cannot_raise_assertion(path.clone());
-                        if let Some(ref dp) = default_direct_path {
-                            call_control.mark_cannot_raise_assertion(dp.clone());
-                        }
+                        call_control.mark_cannot_raise_assertion(path.clone())
                     }
                     "elidable_or_memerror" => {
-                        call_control.mark_memerror_only_assertion(path.clone());
-                        if let Some(ref dp) = default_direct_path {
-                            call_control.mark_memerror_only_assertion(dp.clone());
-                        }
+                        call_control.mark_memerror_only_assertion(path.clone())
                     }
-                    "loopinvariant" => {
-                        call_control.mark_loopinvariant(path.clone());
-                        if let Some(ref dp) = default_direct_path {
-                            call_control.mark_loopinvariant(dp.clone());
-                        }
-                    }
+                    "loopinvariant" => call_control.mark_loopinvariant(path.clone()),
                     "close_stack" => call_control.mark_close_stack(path.clone()),
                     "cannot_collect" => call_control.mark_cannot_collect(path.clone()),
                     "gc_effects" => call_control.mark_external_gc_effects(path.clone()),
                     _ => {}
+                }
+            }
+            if is_default {
+                let dp = crate::parse::CallPath::from_segments([
+                    impl_info.trait_name.as_str(),
+                    method.name.as_str(),
+                ]);
+                for hint in direct_hints {
+                    match hint.as_str() {
+                        "elidable" => call_control.mark_elidable(dp.clone()),
+                        "elidable_cannot_raise" => {
+                            call_control.mark_cannot_raise_assertion(dp.clone())
+                        }
+                        "elidable_or_memerror" => {
+                            call_control.mark_memerror_only_assertion(dp.clone())
+                        }
+                        "loopinvariant" => call_control.mark_loopinvariant(dp.clone()),
+                        _ => {}
+                    }
                 }
             }
         }

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2198,6 +2198,109 @@ pub fn remove_assertion_errors(graph: &mut FunctionGraph) -> usize {
     removed
 }
 
+/// Fold a constant exitswitch to its taken link — the model-layer
+/// slice of `constant_fold_graph`'s link folding
+/// (`rpython/translator/backendopt/constfold.py`): when a block's
+/// `exitswitch` Variable is bound in the same block by a constant
+/// (`ConstBool` / `ConstInt`, optionally through the `bool` UnaryOp
+/// wrap [`FunctionGraph::set_branch`] appends), keep only the
+/// matching exit and promote it to an unconditional link.  The dead
+/// condition ops melt away in the caller's [`prune_dead_phis`]
+/// sweep; the disconnected arm is emptied by
+/// [`clear_unreachable_blocks`].  Returns the number of folded
+/// switches.
+pub fn fold_constant_exitswitch(graph: &mut FunctionGraph) -> usize {
+    let mut folded = 0usize;
+    for block_idx in 0..graph.blocks.len() {
+        let block = &graph.blocks[block_idx];
+        let Some(ExitSwitch::Value(sw)) = block.exitswitch.clone() else {
+            continue;
+        };
+        let def_of = |v: &crate::flowspace::model::Variable| {
+            block
+                .operations
+                .iter()
+                .find(|op| op.result.as_ref() == Some(v))
+                .map(|op| &op.kind)
+        };
+        let mut kind = def_of(&sw);
+        if let Some(OpKind::UnaryOp { op, operand, .. }) = kind
+            && op == "bool"
+        {
+            kind = def_of(operand);
+        }
+        // The matched exitcase spellings: an `If` branch carries
+        // `ExitCase::Bool` (`set_branch`), a MIR `SwitchInt` carries
+        // `ExitCase::Const(Int)` plus the `"default"` catch-all arm
+        // (`front::mir` terminator lowering).
+        let (bool_case, int_case) = match kind {
+            Some(OpKind::ConstBool(b)) => (Some(*b), Some(i64::from(*b))),
+            Some(OpKind::ConstInt(n)) => ((*n == 0 || *n == 1).then(|| *n != 0), Some(*n)),
+            _ => continue,
+        };
+        let matches_case = |link: &Link| match &link.exitcase {
+            Some(ExitCase::Bool(b)) => Some(*b) == bool_case,
+            Some(ExitCase::Const(ConstValue::Int(n))) => Some(*n) == int_case,
+            _ => false,
+        };
+        let is_default = |link: &Link| {
+            matches!(
+                &link.exitcase,
+                Some(ExitCase::Const(ConstValue::UniStr(s))) if s == "default"
+            )
+        };
+        let chosen = block
+            .exits
+            .iter()
+            .position(matches_case)
+            .or_else(|| block.exits.iter().position(is_default));
+        let Some(chosen) = chosen else {
+            continue;
+        };
+        let block = &mut graph.blocks[block_idx];
+        let mut taken = block.exits.swap_remove(chosen);
+        taken.exitcase = None;
+        taken.llexitcase = None;
+        block.exits = vec![taken];
+        block.exitswitch = None;
+        folded += 1;
+    }
+    folded
+}
+
+/// Empty every block unreachable from `graph.startblock` in place —
+/// operations, exits, inputargs cleared, the `Vec` slot kept because
+/// `BlockId` doubles as the index.  Needed after
+/// [`fold_constant_exitswitch`] disconnects an arm: the registry
+/// lift (`translate_op`) and [`prune_dead_phis`] both walk blocks by
+/// index, and `prune_dead_phis` pins no-predecessor blocks as extra
+/// entry points, so a disconnected arm would otherwise keep its dead
+/// ops alive.
+pub fn clear_unreachable_blocks(graph: &mut FunctionGraph) {
+    let mut reachable = vec![false; graph.blocks.len()];
+    let mut worklist = vec![graph.startblock];
+    while let Some(b) = worklist.pop() {
+        if std::mem::replace(&mut reachable[b.0], true) {
+            continue;
+        }
+        for link in &graph.blocks[b.0].exits {
+            worklist.push(link.target);
+        }
+    }
+    // The return / except sinks stay even when no live link reaches
+    // them — graph plumbing addresses them unconditionally.
+    reachable[graph.returnblock.0] = true;
+    reachable[graph.exceptblock.0] = true;
+    for (idx, block) in graph.blocks.iter_mut().enumerate() {
+        if !reachable[idx] {
+            block.operations.clear();
+            block.exits.clear();
+            block.inputargs.clear();
+            block.exitswitch = None;
+        }
+    }
+}
+
 /// Remove dead operations and dead inputargs from `graph` per
 /// backward dataflow over operation operands + exitswitches +
 /// `Link.args`-as-dependencies.  Line-by-line port of

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2095,6 +2095,109 @@ pub fn eliminate_empty_blocks(graph: &mut FunctionGraph) {
     }
 }
 
+/// RPython `remove_assertion_errors(graph)` (simplify.py:321-346) over
+/// the front model graph.
+///
+/// ```python
+/// def remove_assertion_errors(graph):
+///     """Remove branches that go directly to raising an AssertionError,
+///     assuming that AssertionError shouldn't occur at run-time.  Note that
+///     this is how implicit exceptions are removed (see _implicit_ in
+///     flowcontext.py).
+///     """
+///     for block in list(graph.iterblocks()):
+///         for i in range(len(block.exits)-1, -1, -1):
+///             exit = block.exits[i]
+///             if not (exit.target is graph.exceptblock and
+///                     exit.args[0] == Constant(AssertionError)):
+///                 continue
+///             if len(block.exits) < 2:
+///                 break
+///             if block.canraise:
+///                 if exit.exitcase is None:
+///                     break
+///                 if len(block.exits) == 2:
+///                     block.exitswitch = None
+///                     exit.exitcase = None
+///             lst = list(block.exits)
+///             del lst[i]
+///             block.recloseblock(*lst)
+/// ```
+///
+/// One extension beyond the upstream body: when the removal leaves a
+/// single exit on a *non-canraise value switch*, the survivor is
+/// promoted to an unconditional link (`block.exitswitch = None;
+/// exits[0].exitcase = None` — `backendopt/removeassert.py:84-89
+/// kill_assertion_link`).  Upstream flow graphs only carry Bool or
+/// last-exception exitswitches into this pass, and `flatten.py
+/// insert_exits` tolerates a leftover single Bool case (`assert
+/// link.exitcase in (None, False, True)`); Rust enum-match lowering
+/// produces Int discriminant switches whose leftover `Int` case that
+/// assert rejects, so the `kill_assertion_link` normalisation applies
+/// here.  For the canraise two-exit case the survivor (`exits[0]`)
+/// already has `exitcase = None`, so the one code path covers both.
+///
+/// Returns the number of removed exits so the caller can gate the
+/// follow-up dead-condition sweep (`removeassert.py:35-37` — "now melt
+/// away the (hopefully) dead operation that compute the condition").
+pub fn remove_assertion_errors(graph: &mut FunctionGraph) -> usize {
+    use crate::flowspace::model::HOST_ENV;
+    let assert_err_class = HOST_ENV
+        .lookup_builtin("AssertionError")
+        .expect("HOST_ENV missing AssertionError");
+    let exceptblock = graph.exceptblock;
+    let mut removed = 0usize;
+    // upstream: `for block in list(graph.iterblocks())`.
+    for block_idx in 0..graph.blocks.len() {
+        let mut i = graph.blocks[block_idx].exits.len();
+        while i > 0 {
+            i -= 1;
+            let block = &graph.blocks[block_idx];
+            let Some(exit) = block.exits.get(i) else {
+                break;
+            };
+            // upstream: `if not (exit.target is graph.exceptblock and
+            // exit.args[0] == Constant(AssertionError)): continue`.
+            let targets_except = exit.target == exceptblock;
+            let args_is_assert_err = matches!(
+                exit.args.first(),
+                Some(LinkArg::Const(c))
+                    if matches!(
+                        &c.value,
+                        ConstValue::HostObject(h) if *h == assert_err_class
+                    )
+            );
+            if !(targets_except && args_is_assert_err) {
+                continue;
+            }
+            // upstream: `if len(block.exits) < 2: break`.
+            if block.exits.len() < 2 {
+                break;
+            }
+            // upstream: `if block.canraise: if exit.exitcase is None:
+            // break`.
+            if block.canraise() && exit.exitcase.is_none() {
+                break;
+            }
+            let exits_len = block.exits.len();
+            let block = &mut graph.blocks[block_idx];
+            // upstream: `lst = list(block.exits); del lst[i];
+            // block.recloseblock(*lst)`.
+            block.exits.remove(i);
+            if exits_len == 2 {
+                // Promote the survivor to an unconditional link —
+                // upstream's canraise arm (`simplify.py:333-335`) plus
+                // the `kill_assertion_link` normalisation for value
+                // switches (`removeassert.py:84-89`, see above).
+                block.exitswitch = None;
+                block.exits[0].exitcase = None;
+            }
+            removed += 1;
+        }
+    }
+    removed
+}
+
 /// Remove dead operations and dead inputargs from `graph` per
 /// backward dataflow over operation operands + exitswitches +
 /// `Link.args`-as-dependencies.  Line-by-line port of
@@ -4244,6 +4347,37 @@ impl FunctionGraph {
         let etype_var = self.alloc_value_var();
         let evalue_var = self.alloc_value_var();
         self.set_goto(block, exceptblock, vec![etype_var, evalue_var]);
+    }
+
+    /// Terminate `block` with the implicit-exception raise shape of
+    /// RPython `RaiseImplicit.nomoreblocks`
+    /// (`flowspace/flowcontext.py:1271-1284`):
+    ///
+    /// ```python
+    /// msg = "implicit %s shouldn't occur" % exc_cls.__name__
+    /// w_type = Constant(AssertionError)
+    /// w_value = Constant(AssertionError(msg))
+    /// link = Link([w_type, w_value], ctx.graph.exceptblock)
+    /// ctx.recorder.crnt_block.closeblock(link)
+    /// ```
+    ///
+    /// Both link args are Constants with `args[0]` carrying the
+    /// `AssertionError` class itself — the shape
+    /// [`remove_assertion_errors`] matches to prune the branch under
+    /// the "AssertionError shouldn't occur at run-time" assumption
+    /// (`simplify.py:321-346`).
+    pub fn set_raise_implicit(&mut self, block: BlockId, exc_name: &str) {
+        use crate::flowspace::model::{Constant, HOST_ENV, HostObject};
+        let assert_err = HOST_ENV
+            .lookup_builtin("AssertionError")
+            .expect("HOST_ENV missing AssertionError");
+        let msg = format!("implicit {exc_name} shouldn't occur");
+        let w_type = LinkArg::Const(Constant::new(ConstValue::HostObject(assert_err.clone())));
+        let w_value = LinkArg::Const(Constant::new(ConstValue::HostObject(
+            HostObject::new_instance(assert_err, vec![ConstValue::UniStr(msg)]),
+        )));
+        let link = Link::new_mixed(vec![w_type, w_value], self.exceptblock, None);
+        self.set_control_flow_metadata(block, None, vec![link]);
     }
 
     /// Terminate `block` with a Link to `exceptblock` carrying the

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2188,9 +2188,12 @@ pub fn remove_assertion_errors(graph: &mut FunctionGraph) -> usize {
                 // Promote the survivor to an unconditional link —
                 // upstream's canraise arm (`simplify.py:333-335`) plus
                 // the `kill_assertion_link` normalisation for value
-                // switches (`removeassert.py:84-89`, see above).
+                // switches (`removeassert.py:84-89`, see above).  Clear
+                // the low-level case too so no branch metadata lingers on
+                // a now-unconditional edge, matching `fold_constant_exitswitch`.
                 block.exitswitch = None;
                 block.exits[0].exitcase = None;
+                block.exits[0].llexitcase = None;
             }
             removed += 1;
         }

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1459,14 +1459,23 @@ pub fn translate_op(
                         // the field-read side uses
                         // (`getuniqueclassdef_for_struct_root`), so
                         // ctor base and attr reads share one
-                        // `HostObject` Arc.
+                        // `HostObject` Arc.  Scoped to unit-only enums
+                        // (flat class rows = `__discriminant` alone):
+                        // a payload-bearing enum's flat class projects
+                        // the union of variant payload rows as classdef
+                        // attrs, and the subclass instance repr would
+                        // have to materialize all of them — walling on
+                        // reprs not yet ported (e.g. `Vec` payload rows
+                        // need rlist.py ListRepr).  Those enums keep
+                        // base-less variant classes until the missing
+                        // reprs land.
                         let enum_base = owner_path.last().and_then(|owner_tail| {
                             let registry = bk.pyre_struct_fields.borrow();
-                            let is_enum = registry.as_ref().is_some_and(|reg| {
-                                reg.field_type(owner_tail, "__discriminant").is_some()
-                            });
+                            let is_unit_enum = registry
+                                .as_ref()
+                                .is_some_and(|reg| reg.is_unit_only_enum(owner_tail));
                             drop(registry);
-                            is_enum.then(|| bk.intern_class_by_qualname(owner_tail))
+                            is_unit_enum.then(|| bk.intern_class_by_qualname(owner_tail))
                         });
                         match enum_base {
                             Some(base) => {

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1435,10 +1435,45 @@ pub fn translate_op(
                             HostObject::new_class(name.clone(), Vec::new())
                         }
                     } else {
+                        let bk = call_registry.bookkeeper();
                         let qualname = format!("{}.{}", owner_path.join("."), name);
-                        call_registry
-                            .bookkeeper()
-                            .intern_class_by_qualname(&qualname)
+                        // A variant ctor's owner tail is the enum type
+                        // itself (`resolve_aggregate_adt` pushes the
+                        // enum leaf onto the variant's owner path); a
+                        // struct ctor's owner tail is its module.  The
+                        // enum registers as a flat class whose first
+                        // row is the synthetic `__discriminant` tag
+                        // (`front::mir` metadata collection) — no
+                        // struct carries one — so that row
+                        // discriminates the two.  Mint the variant
+                        // class as a subclass of the flat enum class:
+                        // sibling variants then union to
+                        // `SomeInstance(enum)` through
+                        // `ClassDef::commonbase` (classdesc.py:251-254)
+                        // exactly as upstream sibling subclasses do in
+                        // `SomeInstance` union (binaryop.py), instead
+                        // of failing `mergeinputargs` with "no common
+                        // base class" (e.g. the per-variant arms of a
+                        // derived `PyErrorKind::clone`).  The flat
+                        // class is interned by the same leaf spelling
+                        // the field-read side uses
+                        // (`getuniqueclassdef_for_struct_root`), so
+                        // ctor base and attr reads share one
+                        // `HostObject` Arc.
+                        let enum_base = owner_path.last().and_then(|owner_tail| {
+                            let registry = bk.pyre_struct_fields.borrow();
+                            let is_enum = registry.as_ref().is_some_and(|reg| {
+                                reg.field_type(owner_tail, "__discriminant").is_some()
+                            });
+                            drop(registry);
+                            is_enum.then(|| bk.intern_class_by_qualname(owner_tail))
+                        });
+                        match enum_base {
+                            Some(base) => {
+                                bk.intern_class_by_qualname_with_bases(&qualname, vec![base])
+                            }
+                            None => bk.intern_class_by_qualname(&qualname),
+                        }
                     };
                     let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(host)));
                     let mut call_args = Vec::with_capacity(arg_hls.len() + 1);

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2929,9 +2929,10 @@ pub fn rtyper_makerepr(
                 )?) as std::sync::Arc<dyn Repr>,
             )
         }
-        SomeValue::List(_) => Err(TyperError::missing_rtype_operation(
-            "SomeList.rtyper_makerepr — port rpython/rtyper/rlist.py ListRepr",
-        )),
+        SomeValue::List(l) => Err(TyperError::missing_rtype_operation(format!(
+            "SomeList.rtyper_makerepr — port rpython/rtyper/rlist.py ListRepr (listdef: {:?})",
+            l.listdef
+        ))),
         SomeValue::Dict(_) => Err(TyperError::missing_rtype_operation(
             "SomeDict.rtyper_makerepr — port rpython/rtyper/rdict.py DictRepr",
         )),

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -28,7 +28,8 @@ fn pop_value_lowers_to_raise_links() {
                     result_ctors += 1;
                 }
                 OpKind::Call {
-                    target: CallTarget::Method { name, .. }, ..
+                    target: CallTarget::Method { name, .. },
+                    ..
                 } if name == "to_exc_object" => to_exc_object_calls += 1,
                 _ => {}
             }
@@ -40,7 +41,10 @@ fn pop_value_lowers_to_raise_links() {
         }
     }
     assert_eq!(result_ctors, 0, "Result shells must be gone");
-    assert_eq!(to_exc_object_calls, 1, "Err arm materialises the exception object");
+    assert_eq!(
+        to_exc_object_calls, 1,
+        "Err arm materialises the exception object"
+    );
     assert!(except_links >= 1, "Err arm raises towards exceptblock");
     eprintln!("pop_value: to_exc_object={to_exc_object_calls} except_links={except_links}");
 }
@@ -50,8 +54,7 @@ fn pop_value_caller_gets_lastexception_exits() {
     let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
     // The SFSF chain's free-fn body pops twice via `?`
     // (pyopcode.rs `opcode_store_fast_store_fast`).
-    let graph =
-        lower_function(&llbc, "opcode_store_fast_store_fast").expect("lower caller");
+    let graph = lower_function(&llbc, "opcode_store_fast_store_fast").expect("lower caller");
     eprintln!("caller graph = {}", graph.name);
     let lastexc_blocks = graph
         .blocks
@@ -67,5 +70,8 @@ fn pop_value_caller_gets_lastexception_exits() {
         })
         .count();
     eprintln!("caller: lastexc_blocks={lastexc_blocks} branch_calls={branch_calls}");
-    assert!(lastexc_blocks >= 1, "pop_value call sites get LastException exits");
+    assert!(
+        lastexc_blocks >= 1,
+        "pop_value call sites get LastException exits"
+    );
 }

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -4,17 +4,35 @@
 use majit_charon_reader::Llbc;
 use majit_translate::front::mir::lower_function;
 use majit_translate::model::{CallTarget, ExitSwitch, OpKind};
+use std::sync::OnceLock;
 
 const INTERP: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../build/llbc/pyre-interpreter.ullbc",
 );
 
+/// Load `pyre-interpreter.ullbc` once and share it across every test.
+///
+/// The corpus is ~224MB on disk and its parsed `serde_json` form is
+/// several GB resident.  Loading it per test means the four tests here
+/// — run concurrently by the default test harness — each hold a full
+/// parse resident at the same time, several times the runner's RAM on
+/// the 16GB CI hosts; the resulting OOM/swap-thrash gets the job killed
+/// (Linux), where a developer machine with more headroom only runs
+/// slowly.  `Llbc` is read-only after `load`, so a single shared parse
+/// behind a `OnceLock` is sufficient: `get_or_init` runs the load
+/// exactly once even under the concurrent test threads, and
+/// `lower_function` only borrows it.
+fn interp() -> &'static Llbc {
+    static LLBC: OnceLock<Llbc> = OnceLock::new();
+    LLBC.get_or_init(|| Llbc::load(INTERP).expect("load pyre-interpreter.ullbc"))
+}
+
 #[test]
 fn pop_value_lowers_to_raise_links() {
-    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
-    let graph = lower_function(&llbc, "pyre_interpreter::eval::<Impl>::pop_value")
-        .expect("lower pop_value");
+    let llbc = interp();
+    let graph =
+        lower_function(llbc, "pyre_interpreter::eval::<Impl>::pop_value").expect("lower pop_value");
     let mut result_ctors = 0usize;
     let mut to_exc_object_calls = 0usize;
     let mut except_links = 0usize;
@@ -51,10 +69,10 @@ fn pop_value_lowers_to_raise_links() {
 
 #[test]
 fn pop_value_caller_gets_lastexception_exits() {
-    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
+    let llbc = interp();
     // The SFSF chain's free-fn body pops twice via `?`
     // (pyopcode.rs `opcode_store_fast_store_fast`).
-    let graph = lower_function(&llbc, "opcode_store_fast_store_fast").expect("lower caller");
+    let graph = lower_function(llbc, "opcode_store_fast_store_fast").expect("lower caller");
     eprintln!("caller graph = {}", graph.name);
     let lastexc_blocks = graph
         .blocks
@@ -97,12 +115,12 @@ fn count_result_ctors(graph: &majit_translate::model::FunctionGraph) -> usize {
 
 #[test]
 fn execute_wrapper_family_lowers_to_raise_links() {
-    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
+    let llbc = interp();
     // The arm wrapper's `Ok(StepResult::Continue)` shell must be gone
     // and the `?` on the scoped `store_fast_store_fast` method must be
     // a LastException diamond.
     let graph = lower_function(
-        &llbc,
+        llbc,
         "pyre_interpreter::pyopcode::execute_store_fast_store_fast",
     )
     .expect("lower wrapper");
@@ -121,9 +139,8 @@ fn execute_wrapper_family_lowers_to_raise_links() {
 
 #[test]
 fn eval_loop_custom_match_gets_catch_and_rewrap() {
-    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
-    let graph =
-        lower_function(&llbc, "pyre_interpreter::eval::eval_loop").expect("lower eval_loop");
+    let llbc = interp();
+    let graph = lower_function(llbc, "pyre_interpreter::eval::eval_loop").expect("lower eval_loop");
     // The execute_opcode_step call block must carry LastException exits.
     let call_block = graph
         .blocks

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -29,6 +29,45 @@ fn interp() -> &'static Llbc {
 }
 
 #[test]
+fn unit_result_callee_declares_void_return() {
+    // A `Result<(), PyError>` scoped callee returns void after the
+    // exception-link lowering, so `front::mir` stamps `return_type =
+    // "()"` (`FUNC.RESULT = void`); the codewriter then collapses the
+    // returnblock to a genuine void return post-annotation.  Without the
+    // stamp the call descriptor would read `r` for the `Ref`-typed unit
+    // `()` shell.  Covered: the callee-rule `Ok(())` (`store_local_value`)
+    // and the tail-forward `f(...)?` (`store_fast` / `store_fast_store_fast`).
+    for name in [
+        "pyre_interpreter::eval::<Impl>::store_local_value",
+        "pyre_interpreter::pyopcode::OpcodeStepExecutor::store_fast",
+        "pyre_interpreter::pyopcode::OpcodeStepExecutor::store_fast_store_fast",
+    ] {
+        let g = lower_function(interp(), name).expect("lower");
+        assert_eq!(
+            g.return_type.as_deref(),
+            Some("()"),
+            "{name}: Result<(), PyError> callee must declare FUNC.RESULT = void"
+        );
+    }
+
+    // A non-unit `Result<T, PyError>` callee is not void-widened:
+    // `pop_value` returns `Result<PyObjectRef, PyError>`, so it carries
+    // no void stamp and keeps its single ref return variable.
+    let pv = lower_function(interp(), "pyre_interpreter::eval::<Impl>::pop_value")
+        .expect("lower pop_value");
+    assert_ne!(
+        pv.return_type.as_deref(),
+        Some("()"),
+        "pop_value returns a value, not void"
+    );
+    assert_eq!(
+        pv.block(pv.returnblock).inputargs.len(),
+        1,
+        "pop_value returns a value; its returnblock keeps the return var"
+    );
+}
+
+#[test]
 fn pop_value_lowers_to_raise_links() {
     let llbc = interp();
     let graph =

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -1,0 +1,71 @@
+//! Result-of-PyError → exception-link lowering: production-LLBC
+//! regression tests for `front::result_exc`.
+
+use majit_charon_reader::Llbc;
+use majit_translate::front::mir::lower_function;
+use majit_translate::model::{CallTarget, ExitSwitch, OpKind};
+
+const INTERP: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../build/llbc/pyre-interpreter.ullbc",
+);
+
+#[test]
+fn pop_value_lowers_to_raise_links() {
+    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
+    let graph = lower_function(&llbc, "pyre_interpreter::eval::<Impl>::pop_value")
+        .expect("lower pop_value");
+    let mut result_ctors = 0usize;
+    let mut to_exc_object_calls = 0usize;
+    let mut except_links = 0usize;
+    for b in &graph.blocks {
+        for op in &b.operations {
+            match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { owner_path, .. },
+                    ..
+                } if owner_path.last().map(String::as_str) == Some("Result") => {
+                    result_ctors += 1;
+                }
+                OpKind::Call {
+                    target: CallTarget::Method { name, .. }, ..
+                } if name == "to_exc_object" => to_exc_object_calls += 1,
+                _ => {}
+            }
+        }
+        for link in &b.exits {
+            if link.target == graph.exceptblock {
+                except_links += 1;
+            }
+        }
+    }
+    assert_eq!(result_ctors, 0, "Result shells must be gone");
+    assert_eq!(to_exc_object_calls, 1, "Err arm materialises the exception object");
+    assert!(except_links >= 1, "Err arm raises towards exceptblock");
+    eprintln!("pop_value: to_exc_object={to_exc_object_calls} except_links={except_links}");
+}
+
+#[test]
+fn pop_value_caller_gets_lastexception_exits() {
+    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
+    // The SFSF chain's free-fn body pops twice via `?`
+    // (pyopcode.rs `opcode_store_fast_store_fast`).
+    let graph =
+        lower_function(&llbc, "opcode_store_fast_store_fast").expect("lower caller");
+    eprintln!("caller graph = {}", graph.name);
+    let lastexc_blocks = graph
+        .blocks
+        .iter()
+        .filter(|b| matches!(b.exitswitch, Some(ExitSwitch::LastException)))
+        .count();
+    let branch_calls = graph
+        .blocks
+        .iter()
+        .flat_map(|b| b.operations.iter())
+        .filter(|op| {
+            matches!(&op.kind, OpKind::Call { target: CallTarget::Method { name, .. }, .. } if name == "branch")
+        })
+        .count();
+    eprintln!("caller: lastexc_blocks={lastexc_blocks} branch_calls={branch_calls}");
+    assert!(lastexc_blocks >= 1, "pop_value call sites get LastException exits");
+}

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -75,3 +75,89 @@ fn pop_value_caller_gets_lastexception_exits() {
         "pop_value call sites get LastException exits"
     );
 }
+
+/// Count Result-shell ctors (`SyntheticTransparentCtor` with owner
+/// `core::result::Result`) in a lowered graph.
+fn count_result_ctors(graph: &majit_translate::model::FunctionGraph) -> usize {
+    graph
+        .blocks
+        .iter()
+        .flat_map(|b| b.operations.iter())
+        .filter(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { owner_path, .. },
+                    ..
+                } if owner_path.last().map(String::as_str) == Some("Result")
+            )
+        })
+        .count()
+}
+
+#[test]
+fn execute_wrapper_family_lowers_to_raise_links() {
+    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
+    // The arm wrapper's `Ok(StepResult::Continue)` shell must be gone
+    // and the `?` on the scoped `store_fast_store_fast` method must be
+    // a LastException diamond.
+    let graph = lower_function(
+        &llbc,
+        "pyre_interpreter::pyopcode::execute_store_fast_store_fast",
+    )
+    .expect("lower wrapper");
+    assert_eq!(
+        count_result_ctors(&graph),
+        0,
+        "wrapper Result shells must be gone"
+    );
+    let lastexc_blocks = graph
+        .blocks
+        .iter()
+        .filter(|b| matches!(b.exitswitch, Some(ExitSwitch::LastException)))
+        .count();
+    assert!(lastexc_blocks >= 1, "wrapper `?` gets LastException exits");
+}
+
+#[test]
+fn eval_loop_custom_match_gets_catch_and_rewrap() {
+    let llbc = Llbc::load(INTERP).expect("load pyre-interpreter.ullbc");
+    let graph =
+        lower_function(&llbc, "pyre_interpreter::eval::eval_loop").expect("lower eval_loop");
+    // The execute_opcode_step call block must carry LastException exits.
+    let call_block = graph
+        .blocks
+        .iter()
+        .find(|b| {
+            b.operations.iter().any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments.last().map(String::as_str) == Some("execute_opcode_step")
+                )
+            })
+        })
+        .expect("eval_loop calls execute_opcode_step");
+    assert!(
+        matches!(call_block.exitswitch, Some(ExitSwitch::LastException)),
+        "custom-match call site gets catch-and-rewrap LastException exits"
+    );
+    // The exception arm re-binds the caught value into the PyError
+    // domain before rebuilding the Err shell.
+    let from_exc_calls = graph
+        .blocks
+        .iter()
+        .flat_map(|b| b.operations.iter())
+        .filter(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::Method { name, .. }, .. }
+                    if name == "from_exc_object"
+            )
+        })
+        .count();
+    assert!(
+        from_exc_calls >= 1,
+        "rewrap exception arm binds PyError::from_exc_object(last_exc_value)"
+    );
+}

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -583,6 +583,14 @@ pub fn register_pyframe_root_walker() {
     majit_gc::set_active_extra_root_walker(Some(walk_pyframe_roots));
 }
 
+/// Flat TLS read of the per-thread `CURRENT_EXCEPTION` slot.
+///
+/// `dont_look_inside` keeps the codewriter from following into the
+/// `LocalKey::with` closure (no extractable graph); calls classify
+/// `Residual` against the fnaddr registered in `jit_trace_fnaddrs()`,
+/// mirroring the trace-side `get_current_exception_fn` cpu helper
+/// binding (`codewriter.rs PlainCannotRaiseNoHeap`).
+#[majit_macros::dont_look_inside]
 pub fn get_current_exception() -> PyObjectRef {
     let ec = crate::call::getexecutioncontext();
     if ec.is_null() {
@@ -591,6 +599,9 @@ pub fn get_current_exception() -> PyObjectRef {
     unsafe { (*ec).sys_exc_value }
 }
 
+/// Flat TLS write of the per-thread `CURRENT_EXCEPTION` slot — same
+/// residual-leaf contract as [`get_current_exception`].
+#[majit_macros::dont_look_inside]
 pub fn set_current_exception(exc: PyObjectRef) {
     let ec = crate::call::getexecutioncontext() as *mut PyExecutionContext;
     if ec.is_null() {
@@ -2731,7 +2742,13 @@ impl OpcodeStepExecutor for PyFrame {
     // PyPy: executioncontext.py enter_frame / normalize_exception
     fn push_exc_info(&mut self) -> Result<(), PyError> {
         let exc = self.pop();
-        // Save previous exception, set current
+        // Save previous exception, set current.  Routed through the
+        // named TLS accessors (not a raw `CURRENT_EXCEPTION.with`
+        // closure) so the codewriter sees two residual-callable leaves
+        // with registered fnaddrs instead of an unresolvable
+        // `LocalKey::with` monomorphization — the same per-thread slot
+        // the compiled trace reads/writes through
+        // `get_current_exception_fn` / `set_current_exception_fn`.
         let prev = get_current_exception();
         set_current_exception(exc);
         // Push "previous exception" for later restore
@@ -2766,7 +2783,8 @@ impl OpcodeStepExecutor for PyFrame {
 
     // ── PopExcept ──
     fn pop_except(&mut self) -> Result<(), PyError> {
-        // Restore previous exc_info from stack
+        // Restore previous exc_info from stack.  Named TLS accessor for
+        // the same codewriter-resolvability reason as `push_exc_info`.
         let prev_exc = self.pop();
         set_current_exception(prev_exc);
         Ok(())

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -511,11 +511,17 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     //
     // PyFrame::nlocals — invoked by `eval.rs:840 pop_value` and is the
     // funcptr the walker reaches when dispatching `PopTop`'s nested
-    // `pop_value` sub-jitcode.
+    // `pop_value` sub-jitcode.  Same dual-shape binding as
+    // `PyFrame::pop` below: the bare `self.nlocals()` spelling inside
+    // the MIR-lowered `pop_value` graph resolves through
+    // `impl_method_owner` to the 2-segment `["PyFrame", "nlocals"]`,
+    // while the module-qualified form is the 3-segment
+    // `["pyframe", "PyFrame", "nlocals"]` — register both.
     let pyframe_nlocals: fn(&crate::pyframe::PyFrame) -> usize = crate::pyframe::PyFrame::nlocals;
-    push_fnaddr(
+    push_alias_pair(
         &mut entries,
         "pyre_interpreter::pyframe::PyFrame::nlocals",
+        "pyre_interpreter::PyFrame::nlocals",
         pyframe_nlocals as *const (),
     );
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -675,6 +675,32 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         code_varnames_len as *const (),
     );
 
+    // Paired-local index decode helpers for the LoadFastLoadFast /
+    // StoreFastLoadFast / StoreFastStoreFast /
+    // LoadFastBorrowLoadFastBorrow arms — same `push_alias_pair`
+    // rationale as `load_fast_var_num_to_index` above.
+    let var_nums_to_first_index: fn(
+        crate::bytecode::Arg<crate::bytecode::oparg::VarNums>,
+        crate::bytecode::OpArg,
+    ) -> usize = crate::pyopcode::var_nums_to_first_index;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::pyopcode::var_nums_to_first_index",
+        "pyre_interpreter::var_nums_to_first_index",
+        var_nums_to_first_index as *const (),
+    );
+
+    let var_nums_to_second_index: fn(
+        crate::bytecode::Arg<crate::bytecode::oparg::VarNums>,
+        crate::bytecode::OpArg,
+    ) -> usize = crate::pyopcode::var_nums_to_second_index;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::pyopcode::var_nums_to_second_index",
+        "pyre_interpreter::var_nums_to_second_index",
+        var_nums_to_second_index as *const (),
+    );
+
     // `PyError::type_error` — invoked by `stack_underflow_error`'s body
     // (`shared_opcode.rs:181-183`). The codewriter resolves it to the
     // 2-segment CallPath `["PyError", "type_error"]` (impl-method shape:

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1245,6 +1245,65 @@ mod tests {
         );
     }
 
+    /// These path spellings are what keep the `pop_value` / paired-local
+    /// / exception-TLS residual calls off the `symbolic_fnaddr_for_path`
+    /// fallback (which SEGVs at trace time); a typo in either the
+    /// module-qualified or root alias would silently regress to a
+    /// symbolic hash, so pin both spellings against the live fnaddr.
+    #[test]
+    fn jit_trace_fnaddrs_covers_pop_value_and_exception_tls_helpers() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+
+        let nlocals: fn(&crate::pyframe::PyFrame) -> usize = crate::pyframe::PyFrame::nlocals;
+        let nlocals = nlocals as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::pyframe::PyFrame::nlocals"],
+            nlocals
+        );
+        assert_eq!(bindings["pyre_interpreter::PyFrame::nlocals"], nlocals);
+
+        let get_exc: fn() -> pyre_object::PyObjectRef = crate::eval::get_current_exception;
+        let get_exc = get_exc as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::eval::get_current_exception"],
+            get_exc
+        );
+        assert_eq!(bindings["pyre_interpreter::get_current_exception"], get_exc);
+
+        let set_exc: fn(pyre_object::PyObjectRef) = crate::eval::set_current_exception;
+        let set_exc = set_exc as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::eval::set_current_exception"],
+            set_exc
+        );
+        assert_eq!(bindings["pyre_interpreter::set_current_exception"], set_exc);
+
+        let first: fn(
+            crate::bytecode::Arg<crate::bytecode::oparg::VarNums>,
+            crate::bytecode::OpArg,
+        ) -> usize = crate::pyopcode::var_nums_to_first_index;
+        let first = first as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::pyopcode::var_nums_to_first_index"],
+            first
+        );
+        assert_eq!(bindings["pyre_interpreter::var_nums_to_first_index"], first);
+
+        let second: fn(
+            crate::bytecode::Arg<crate::bytecode::oparg::VarNums>,
+            crate::bytecode::OpArg,
+        ) -> usize = crate::pyopcode::var_nums_to_second_index;
+        let second = second as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::pyopcode::var_nums_to_second_index"],
+            second
+        );
+        assert_eq!(
+            bindings["pyre_interpreter::var_nums_to_second_index"],
+            second
+        );
+    }
+
     /// Negative parity guard: pyre intentionally does NOT publish a
     /// host fnaddr for `_ll_2_str_eq_nonnull` (see the comment block
     /// at `jit_trace_fnaddrs` next to the `cast_float_to_uint`

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -568,6 +568,31 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         stack_underflow as *const (),
     );
 
+    // `get_current_exception` / `set_current_exception` — the named TLS
+    // accessors `PyFrame::push_exc_info` / `pop_except` (`eval.rs`) call
+    // for the per-thread `CURRENT_EXCEPTION` slot.  Both carry
+    // `#[dont_look_inside]` (the `LocalKey::with` closure inside has no
+    // extractable graph), so the codewriter classifies the calls
+    // `Residual` and needs these bindings to bake real funcptrs instead
+    // of `symbolic_fnaddr_for_path` hashes.  These are the
+    // interpreter-side twins of the trace-side
+    // `get_current_exception_fn` / `set_current_exception_fn` cpu
+    // helpers — same TLS slot, same flat read/write semantics.
+    let get_current_exc: fn() -> pyre_object::PyObjectRef = crate::eval::get_current_exception;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::eval::get_current_exception",
+        "pyre_interpreter::get_current_exception",
+        get_current_exc as *const (),
+    );
+    let set_current_exc: fn(pyre_object::PyObjectRef) = crate::eval::set_current_exception;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::eval::set_current_exception",
+        "pyre_interpreter::set_current_exception",
+        set_current_exc as *const (),
+    );
+
     // `pyframe_get_pycode` / `ncells` / `npure_cellvars` / `PyFrame::ncells`
     // carry `#[elidable_cannot_raise]`.  `call.rs:has_cannot_raise_assertion`
     // only honours the assertion when `function_fnaddrs.contains_key(p)`,

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -312,7 +312,8 @@ pub extern "C" fn bh_execute_store_subscr(executor_ptr: i64) -> i64 {
 /// key, value)` (`codewriter.rs:7042
 /// build_store_subscr_fn_residual_call_r_v_insn`); the runtime
 /// dispatcher calls this thin wrapper to mutate the heap via
-/// `baseobjspace::setitem`.
+/// `baseobjspace::setitem` — `baseobjspace.py` parity for
+/// `ObjSpace.setitem(w_obj, w_key, w_value) → space.descr_setitem(...)`.
 ///
 /// Lives in `pyre-interpreter` so `pyre-jit-trace` can reach the address
 /// through `pyre_interpreter::jit_trace_fnaddrs()` without adding a
@@ -321,23 +322,18 @@ pub extern "C" fn bh_execute_store_subscr(executor_ptr: i64) -> i64 {
 /// helpers (`jit_setitem`, `jit_getitem`, ...).
 ///
 /// Returns 1 on success, 0 on raise (exception object stashed in
-/// `BH_LAST_EXC_VALUE`).  The return-code polarity differs from the
-/// trait-side `jit_setitem` which returns 0 on success and panics on
-/// error — `bh_store_subscr_fn` is fail-soft because residual_call
-/// execution is not a panic site.
+/// `BH_LAST_EXC_VALUE`); the polarity matches the executor's
+/// raise-vs-success ABI for void residual_calls and parallels
+/// `bh_execute_store_subscr` above.  `jit_setitem` upstream of this
+/// (called by `setarrayitem_gc` arms) panics on raise because the
+/// strategy guard upstream proves the raise cannot happen; this
+/// helper covers the residual-call leg where the raise is
+/// observable.
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {
     let obj = obj as pyre_object::PyObjectRef;
     let key = key as pyre_object::PyObjectRef;
     let value = value as pyre_object::PyObjectRef;
-    if obj.is_null() || key.is_null() || value.is_null() {
-        let err = crate::PyError::new(
-            crate::PyErrorKind::TypeError,
-            "store subscript on null operand".to_string(),
-        );
-        majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(err.to_exc_object() as i64));
-        return 0;
-    }
     if let Err(err) = crate::baseobjspace::setitem(obj, key, value) {
         let exc_obj = err.to_exc_object();
         majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1452,6 +1452,33 @@ pub fn load_fast_var_num_to_index(
     var_num.get(op_arg).as_usize()
 }
 
+/// Walker-fold helpers for the paired-local opcode family
+/// (`LoadFastLoadFast` / `StoreFastLoadFast` / `StoreFastStoreFast` /
+/// `LoadFastBorrowLoadFastBorrow`) — same rationale as
+/// [`load_fast_var_num_to_index`]: collapse the third-party
+/// `Arg::get` + `VarNumPair::idx_*` + `VarNum::as_usize` chain under
+/// a first-party `#[elidable_cannot_raise]` wrapper so the walker's
+/// pure-call fold resolves the local index at trace time.
+#[inline]
+#[majit_macros::elidable_cannot_raise]
+pub fn var_nums_to_first_index(
+    var_nums: crate::bytecode::Arg<crate::bytecode::oparg::VarNums>,
+    op_arg: OpArg,
+) -> usize {
+    var_nums.get(op_arg).idx_1().as_usize()
+}
+
+/// Second half of the paired-local index decode — see
+/// [`var_nums_to_first_index`].
+#[inline]
+#[majit_macros::elidable_cannot_raise]
+pub fn var_nums_to_second_index(
+    var_nums: crate::bytecode::Arg<crate::bytecode::oparg::VarNums>,
+    op_arg: OpArg,
+) -> usize {
+    var_nums.get(op_arg).idx_2().as_usize()
+}
+
 /// Walker-fold helper for `code.varnames.len()` — `Vec::len` is a std
 /// method the analyzer cannot tag elidable from its definition site,
 /// so the bounds-check upper bound reaches the walker as an unfolded
@@ -2077,9 +2104,8 @@ where
     let Instruction::LoadFastBorrowLoadFastBorrow { var_nums } = instruction else {
         unreachable!()
     };
-    let pair = var_nums.get(op_arg);
-    let idx1 = pair.idx_1().as_usize();
-    let idx2 = pair.idx_2().as_usize();
+    let idx1 = var_nums_to_first_index(var_nums, op_arg);
+    let idx2 = var_nums_to_second_index(var_nums, op_arg);
     let name1 = if idx1 < code_varnames_len(code) {
         code.varnames[idx1].as_ref()
     } else {
@@ -2105,8 +2131,10 @@ where
     let Instruction::LoadFastLoadFast { var_nums } = instruction else {
         unreachable!()
     };
-    let pair = var_nums.get(op_arg);
-    executor.load_fast_load_fast(pair.idx_1().as_usize(), pair.idx_2().as_usize())?;
+    executor.load_fast_load_fast(
+        var_nums_to_first_index(var_nums, op_arg),
+        var_nums_to_second_index(var_nums, op_arg),
+    )?;
     Ok(StepResult::Continue)
 }
 
@@ -2121,8 +2149,10 @@ where
     let Instruction::StoreFastLoadFast { var_nums } = instruction else {
         unreachable!()
     };
-    let pair = var_nums.get(op_arg);
-    executor.store_fast_load_fast(pair.idx_1().as_usize(), pair.idx_2().as_usize())?;
+    executor.store_fast_load_fast(
+        var_nums_to_first_index(var_nums, op_arg),
+        var_nums_to_second_index(var_nums, op_arg),
+    )?;
     Ok(StepResult::Continue)
 }
 
@@ -2137,8 +2167,10 @@ where
     let Instruction::StoreFastStoreFast { var_nums } = instruction else {
         unreachable!()
     };
-    let pair = var_nums.get(op_arg);
-    executor.store_fast_store_fast(pair.idx_1().as_usize(), pair.idx_2().as_usize())?;
+    executor.store_fast_store_fast(
+        var_nums_to_first_index(var_nums, op_arg),
+        var_nums_to_second_index(var_nums, op_arg),
+    )?;
     Ok(StepResult::Continue)
 }
 

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1669,11 +1669,12 @@ where
     let Instruction::JumpBackward { delta } = instruction else {
         unreachable!()
     };
-    executor.jump_backward(jump_target_backward(
+    let step = executor.jump_backward(jump_target_backward(
         &code.instructions,
         next_instr,
         delta.get(op_arg).as_usize(),
-    ))
+    ))?;
+    Ok(step)
 }
 
 pub fn execute_pop_jump_if_false<E: OpcodeStepExecutor>(
@@ -1908,7 +1909,8 @@ pub fn execute_return_value<E: OpcodeStepExecutor>(
 where
     E: ControlFlowOpcodeHandler,
 {
-    executor.return_value()
+    let step = executor.return_value()?;
+    Ok(step)
 }
 
 pub fn execute_return_generator<E: OpcodeStepExecutor>(
@@ -2845,7 +2847,8 @@ pub fn execute_unsupported<E: OpcodeStepExecutor>(
     executor: &mut E,
     instruction: Instruction,
 ) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
-    executor.unsupported(&instruction)
+    let step = executor.unsupported(&instruction)?;
+    Ok(step)
 }
 
 pub fn execute_opcode_step<E: OpcodeStepExecutor>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2694,8 +2694,10 @@ fn setfield_gc_via_heapcache(
 /// that fires `executor.execute(cpu, metainterp, opnum, fielddescr,
 /// box)` and returns `ConstInt/ConstFloat/ConstPtr(resvalue)` —
 /// recording NO trace op (the value is directly substituted as a Const
-/// literal). The symbolic walker has no `executor.execute` (no cpu /
-/// concrete box pair), so the fast path is structurally unreachable.
+/// literal). The walker's `executor.execute` counterpart is
+/// `field_sanity_load`, so the fast path is implemented: a constant
+/// source register through an always-pure descr folds to the loaded
+/// value as a Const literal with no recorded op.
 ///
 /// Walker behaviour mirrors `_opimpl_getfield_gc_any_pureornot`
 /// uniformly: heapcache hit returns the cached box (no IR op);
@@ -2721,7 +2723,43 @@ fn getfield_gc_via_heapcache(
     let descr = read_descr(code, op, 1, ctx)?;
     let descr_index = descr.index();
 
-    let result = if let Some(cached) = ctx.trace_ctx.heapcache_getfield_cached(obj, descr_index) {
+    // ConstPtr + always-pure fast path (pyjitpl.py:856-860): a constant
+    // source through an immutable descr loads the field now and
+    // substitutes the value as a Const literal, recording no op.
+    let const_pure_result = if obj.is_constant() && descr.is_always_pure() {
+        let load_type = match opcode {
+            OpCode::GetfieldGcI | OpCode::GetfieldGcPureI => Some(majit_ir::Type::Int),
+            OpCode::GetfieldGcR | OpCode::GetfieldGcPureR => Some(majit_ir::Type::Ref),
+            OpCode::GetfieldGcF | OpCode::GetfieldGcPureF => Some(majit_ir::Type::Float),
+            _ => None,
+        };
+        let struct_ptr = match ctx.trace_ctx.box_value(obj) {
+            Some(majit_ir::Value::Ref(struct_ref)) => {
+                let p = struct_ref.0 as i64;
+                (p != 0 && p != usize::MAX as i64).then_some(p)
+            }
+            _ => None,
+        };
+        match (load_type, struct_ptr) {
+            (Some(ty), Some(p)) => {
+                ctx.trace_ctx
+                    .field_sanity_load(p, &descr, ty)
+                    .map(|v| match v {
+                        majit_ir::Value::Int(n) => ctx.trace_ctx.const_int(n),
+                        majit_ir::Value::Ref(r) => ctx.trace_ctx.const_ref(r.0 as i64),
+                        majit_ir::Value::Float(f) => ctx.trace_ctx.const_float(f.to_bits() as i64),
+                        _ => unreachable!("field_sanity_load returns Int/Ref/Float only"),
+                    })
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    let result = if let Some(constant) = const_pure_result {
+        constant
+    } else if let Some(cached) = ctx.trace_ctx.heapcache_getfield_cached(obj, descr_index) {
         // Cache hit (RPython pyjitpl.py:929-947 _opimpl_getfield_gc_any_pureornot):
         //   if upd.currfieldbox is not None:
         //       self.metainterp.staticdata.profiler.count_ops(rop.GETFIELD_GC_I, Counters.HEAPCACHED_OPS)

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1179,22 +1179,22 @@ mod tests {
             .collect();
         assert_eq!(
             jc.code.len(),
-            15,
+            11,
             "PopTop jitcode size shifted — refresh the expected sequence below",
         );
-        // `execute_pop_top` is `pop_value()? ; Ok(StepResult::Continue)`:
-        // one residual call that can raise, then return the prebuilt
-        // `Continue`.  Constants are inlined into the OpRef, so the body is
-        // the `int_copy` arg setup, the `residual_call_r_r` to `pop_value`,
-        // the `live/` jit_merge_point marker, then a direct `ref_return/r`
-        // of the folded `Continue` OpRef.  There is no `catch_exception/L ;
-        // ref_copy/r>r ; reraise/` exception shoulder: the arm has no
-        // exception *handler* (only `?` propagation), so the residual
-        // call's implicit exception edge carries the raise and no explicit
-        // catch/reraise pair is emitted.
+        // The arm wrapper is the single tail-call
+        // `execute_pop_top(executor)`.  `execute_pop_top`'s graph is in
+        // the jitcode closure (`find_all_graphs` BFS discovered it from
+        // the dispatcher callsite), so `guess_call_kind` classifies the
+        // tail-call `Regular` and `handle_regular_call` emits
+        // `inline_call_r_r` with the callee jitcode descr followed by the
+        // mandatory `-live-` marker (jtransform.py:480-481), then the
+        // `ref_return/r` of the callee's result.  The walker recurses into
+        // the `execute_pop_top` jitcode at trace time
+        // (`dispatch_inline_call_dr_kind`) instead of recording a
+        // blackbox residual call.
         let expected: Vec<(String, String)> = [
-            ("int_copy", "i>i"),
-            ("residual_call_r_r", "iRd>r"),
+            ("inline_call_r_r", "dR>r"),
             ("live", ""),
             ("ref_return", "r"),
         ]

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9244,9 +9244,15 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // specialization); see is_foldable_list_method_load_attr.
             | Instruction::LoadAttr { .. }
             | Instruction::StoreAttr { .. }
-            // Instruction::StoreFastStoreFast excluded: routed off the
-            // walker JIT path (kept on trait dispatch) until the SFSF
-            // walker re-enable is unblocked.
+            // Instruction::StoreFastStoreFast excluded: a probe flip
+            // (2026-06-13) confirmed the GcVec-fnaddr SIGBUS the prior
+            // comment described is gone (the #406 result_exc lowering
+            // drained the Result-shell residual chains in pop_value /
+            // store_local_value).  The remaining blocker is shared with
+            // BuildTuple / UnpackSequence: `ResidualCallArgUnbound`
+            // (var_nums payload register unbound) because arm entry seeds
+            // only r0.  Re-enable once arm-entry operand seeding (#405)
+            // lands on dispatch_via_miframe_at_opcode_entry.
             | Instruction::StoreSubscr // handled by dispatch_via_walker_for_opcode entry hook
             // Instruction::PopExcept excluded: same bridge-tracing
             // rationale as PushExcInfo below — its arm manages the


### PR DESCRIPTION
Fix #122

## Summary

Walker-leg expansion groundwork on three fronts plus a bridge-resume fix chain (43 commits, rebased onto current `main`):

**1. `front::result_exc` — Result-of-PyError → exception-link lowering (#406)**
- New lowering pass that rewrites `Result<T, PyError>`-shaped callees/callers into RPython-style exception links: the callee's `Err` return becomes `set_raise_values(to_exc_object(..), type)`, the caller's `Try::branch` diamond becomes `ExitSwitch::LastException` exits, so jitcodes decode to `inline_call` + `catch_exception`/`reraise` with no Result shell ctor or discriminant switch on the traced path.
- Staged behind `RESULT_EXC_LOWERING_SCOPE` (the `pop_value` chain + STORE_FAST family) plus the `pyopcode::execute_*` dispatch-wrapper family, grown one fail-loud resolution at a time; tail-forward shape included.
- Custom-match consumers that don't fit the `?`-diamond shape (`eval_loop`'s `match execute_opcode_step(..)`, and the `eval_loop_jit` / `eval_loop_jit_bridge` portals whose `match step_result` merges the call result with sibling shells across seven predecessors) get a catch-and-rewrap rewrite: the call block gains `LastException` exits whose arms locally re-encode the value-`Result` the untouched downstream keeps consuming — normal arm wraps the raw return in `Ok`, exception arm binds the caught `W_ExceptionObject` back into the `PyError` domain via `PyError::from_exc_object` (the inverse of the callee rule's `to_exc_object`) and wraps it in `Err`. No per-predecessor phi threading needed.
- Prerequisite fix: `resolve_aggregate_adt` now parses TypeDeclRef-object Adt ids, restoring Ok/Err variant identity in jitcode hashing.

**2. Walker-leg parity batch (pyjitpl line ports)**
- `_do_jit_force_virtual` ported to the walker (pyjitpl.py:2153-2172), with release-gil funcbox concrete execution and the `is_constant()` decline gate dropped.
- STORE_SUBSCR walker specialization reordered to execute-then-record; `WalkerFrameOps::guard_class_plain` added for unbox resume helpers.
- Arm-entry operands seeded positionally at opcode entry (#405), unblocking arm walks that read instruction-arg payload registers.
- Walker flips for the exception-handler trio and StoreFastStoreFast were attempted and **reverted** in-branch; the remaining blockers are documented in the exclusion comments (Ok(()) unit-shell lowering, parentless variant-shell descrs).

**3. Annotation/rtyper front fixes (post-rebase analysis cascade)**
- Unique-impl trait-method direct-path devirtualization; default-shadowing devirt staged behind `DEFAULT_SHADOW_DEVIRT_SCOPE` (`push_exc_info`/`pop_except`).
- Trivial global initializers const-evaluated (`WITHPREBUILTINT`-style config reads fold to constants).
- Enum variant ctor classes minted as subclasses of the flat enum class, scoped to unit-only enums (sibling variants union via `ClassDef::commonbase`; payload-bearing enums stay base-less until ListRepr lands).
- Constant exitswitches fold to their taken link and disconnected arms are cleared (`constfold.py` link-folding slice), so dead config arms no longer fail the registry lift.
- `FieldWrite` descriptors now resolve `(owner_root, field_name)` through the field's TypeDecl like the read side — previously every write descriptor carried `owner_root=None`, so no write could ever match the virtualizable field config (`PyFrame.valuestackdepth` writes stayed plain `setfield` while reads rewrote to `getfield_vable`).

**4. Multi-frame guard vable snapshot + bridge-replay resume fix chain**
- Four interlocking fixes that drain the `function_calls` abort storm (census ~2k → 0) and the crashes its repair exposed; they land as one commit because each fix alone surfaces the next failure:
  1. Snapshot vable statics (`last_instr`/`valuestackdepth`) were recomputed from the inlined callee's pc/depth on multi-frame guards, corrupting the portal heap frame at resume — now gated on the frame being the vable frame, with callee guards reading the shared shadow as-is (pyjitpl.py:2597).
  2. Reconstructed inner frames on bridges kept `frame`/`execution_context` = NONE, so a later guard recorded `getfield_gc(NONE)` — the decoded portal-red register slots are now threaded back into the dedicated sym fields, mirroring `setup_bridge_sym`.
  3. `concrete_valuestackdepth` read the heap frame for bridge root frames, but that frame is parked at the resume snapshot during bridge tracing — it now returns None there and the tracked symbolic depth is used.
  4. `handle_fail` skipped the blackhole resume after a successful bridge compile, leaving the live frame at the parked snapshot state (NULL pending-result slot) — the blackhole resume now runs unconditionally, because pyre traces bridges on a `snapshot_for_tracing()` copy (replay model) rather than executing on the live frame as RPython does.

Gates: `pyre/check.py` green on both backends; abort census on `raise_catch_loop` / `tuple_unpacking` / `function_calls` at 0.

## Self-review

gpt-5.5 static parity review (run against this branch) reported, with dispositions:

1. **Regressed parity vs main** — `_do_jit_force_virtual` treated a missing concrete pointer as "unequal", silently recording `PTR_EQ + GUARD_VALUE(0) + CALL_MAY_FORCE_*` where PyPy promotes the observed equality (pyjitpl.py:2166, :1916); main was fail-loud here. **Fixed**: `concrete_ptrs_eq` now returns `Option<bool>` and the helper surfaces the typed error `DispatchError::JitForceVirtualValueNotConcrete` when either concrete is unavailable, restoring main's strictness while keeping the ported body for resolvable compares.
2. **Env-gated diagnostics flagged in the working tree** — `PYRE_PROBE_RESYNC` probes were local debugging aids; they have been removed and are not part of this PR's commits.
3. **Pre-existing mismatches** (tracked, unchanged by this PR): record-time `GUARD_CLASS` split vs fused `GUARD_NONNULL_CLASS` (task #403); walker residual-call after-call gaps (direct assembler/libffi, KEEPALIVE — documented at the dispatcher header with the convergence plan); `OS_NOT_IN_TRACE` fail-loud pending a concrete-execution callback (documented at `do_not_in_trace_call_result`). The `function_calls` abort census previously listed here is now fixed in-branch (summary §4).

— summary and self-review notes written by Claude, reviewed by the author


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Uniform `Result<T, PyError>` lowering and `?`/exception-link rewiring for more consistent error propagation.
  * Stronger constant-folding, projection typing fixes, and unreachable-block pruning for leaner output.
  * More accurate method/impl resolution and improved tail-call detection to reduce residual/blackbox behavior.
  * Better debugging and richer panic context, including more implicit assertion failures.
  * Void-widening of unit-return callees to produce genuine void returns.

* **New Features**
  * Added TLS-backed exception accessor bindings for JIT/residual execution paths.

* **Tests**
  * Extended/added regression coverage for `Result` exception lowering and exception-link rewiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->