### PR TITLE
range/bool/_locale PyPy parity fixes

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1219,13 +1219,13 @@ fn range_index_method(args: &[PyObjectRef]) -> PyResult {
             }
         }
     }
-    Err(PyError::value_error(format!(
-        "{} is not in range",
-        unsafe { crate::display::py_repr(needle) }
-    )))
+    // `space.sequence_index` miss (`descroperation.py` `sequence_index`).
+    Err(PyError::value_error(
+        "sequence.index(x): x not in sequence".to_string(),
+    ))
 }
 
-/// `range.__iter__()` — fresh `rangeiterator` / `longrange_iterator`.
+/// `range.__iter__()` — fresh `range_iterator` (word-fit or bignum cursor).
 fn range_iter_method(args: &[PyObjectRef]) -> PyResult {
     iter(args[0])
 }
@@ -3489,6 +3489,11 @@ pub fn int_w(obj: PyObjectRef) -> Result<i64, PyError> {
         return Err(PyError::type_error(
             "an integer is required (got type float)",
         ));
+    }
+    // `is_int` is true for a bool (`BOOL_TYPE`); a bool reads through
+    // `w_bool_get_value`, not the int accessor, so test `is_bool` first.
+    if unsafe { pyre_object::pyobject::is_bool(obj) } {
+        return Ok(unsafe { pyre_object::boolobject::w_bool_get_value(obj) } as i64);
     }
     // intobject.py:558 `W_IntObject._int_w` — self.intval. Fast path.
     if unsafe { pyre_object::pyobject::is_int(obj) } {
@@ -6136,15 +6141,16 @@ pub fn float_w(obj: PyObjectRef) -> Result<f64, PyError> {
         if pyre_object::is_float(obj) {
             return Ok(pyre_object::w_float_get_value(obj));
         }
-        if pyre_object::pyobject::is_int(obj) {
-            return Ok(pyre_object::intobject::w_int_get_value(obj) as f64);
-        }
+        // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first.
         if pyre_object::pyobject::is_bool(obj) {
             return Ok(if pyre_object::boolobject::w_bool_get_value(obj) {
                 1.0
             } else {
                 0.0
             });
+        }
+        if pyre_object::pyobject::is_int(obj) {
+            return Ok(pyre_object::intobject::w_int_get_value(obj) as f64);
         }
         if pyre_object::pyobject::is_long(obj) {
             use num_traits::ToPrimitive;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4481,15 +4481,16 @@ fn _hash_frozenset(items: &[i64]) -> i64 {
 /// siphash24 from a workspace dep.
 pub fn hash_value(obj: PyObjectRef) -> i64 {
     unsafe {
-        if is_int(obj) {
-            return _hash_int(w_int_get_value(obj));
-        }
+        // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first.
         if is_bool(obj) {
             return if pyre_object::w_bool_get_value(obj) {
                 1
             } else {
                 0
             };
+        }
+        if is_int(obj) {
+            return _hash_int(w_int_get_value(obj));
         }
         if is_long(obj) {
             return _hash_long(pyre_object::w_long_get_value(obj));

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3694,16 +3694,18 @@ impl OpcodeStepExecutor for PyFrame {
             unsafe {
                 if pyre_object::is_str(*part) {
                     result.push_wtf8(pyre_object::w_str_get_wtf8(*part));
-                } else if pyre_object::is_int(*part) {
-                    result.push_str(&pyre_object::w_int_get_value(*part).to_string());
-                } else if pyre_object::is_none(*part) {
-                    result.push_str("None");
                 } else if pyre_object::is_bool(*part) {
+                    // `is_int` is true for a bool, so test `is_bool` first; a
+                    // bool renders "True"/"False", not its int value.
                     result.push_str(if pyre_object::w_bool_get_value(*part) {
                         "True"
                     } else {
                         "False"
                     });
+                } else if pyre_object::is_int(*part) {
+                    result.push_str(&pyre_object::w_int_get_value(*part).to_string());
+                } else if pyre_object::is_none(*part) {
+                    result.push_str("None");
                 } else {
                     result.push_str("<object>");
                 }

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -186,25 +186,48 @@ pub fn register_module(ns: &mut DictStorage) {
                 #[cfg(all(unix, feature = "host_env"))]
                 {
                     let lc = rustpython_host_env::locale::localeconv_data();
-                    // `_w_copy_grouping` appends a trailing 0 to a non-empty
-                    // grouping; the host helper already strips the C
-                    // terminator (`interp_locale.py:36-40`).
-                    let grouping_of = |g: &[libc::c_char]| -> Vec<i64> {
-                        let mut v: Vec<i64> = g.iter().map(|&x| x as i64).collect();
+                    // `_w_copy_grouping` (`interp_locale.py:36-40`): every byte
+                    // of the C grouping string up to its NUL is one group size
+                    // (a `CHAR_MAX` element stays `127`), then a trailing `0`
+                    // is appended to a non-empty list. Read the grouping
+                    // straight from `localeconv()` because the host helper
+                    // stops at the first `CHAR_MAX`, dropping it.
+                    let grouping_of = |ptr: *const libc::c_char| -> Vec<i64> {
+                        let mut v: Vec<i64> = Vec::new();
+                        if !ptr.is_null() {
+                            let mut cur = ptr;
+                            unsafe {
+                                while *cur != 0 {
+                                    v.push(*cur as u8 as i64);
+                                    cur = cur.add(1);
+                                }
+                            }
+                        }
                         if !v.is_empty() {
                             v.push(0);
                         }
                         v
                     };
+                    let raw = unsafe { libc::localeconv() };
+                    let (grouping, mon_grouping) = if raw.is_null() {
+                        (Vec::new(), Vec::new())
+                    } else {
+                        unsafe {
+                            (
+                                grouping_of((*raw).grouping),
+                                grouping_of((*raw).mon_grouping),
+                            )
+                        }
+                    };
                     let data = LocaleConvData {
                         decimal_point: lc.decimal_point.clone(),
                         thousands_sep: lc.thousands_sep.clone(),
-                        grouping: grouping_of(&lc.grouping),
+                        grouping,
                         int_curr_symbol: lc.int_curr_symbol.clone(),
                         currency_symbol: lc.currency_symbol.clone(),
                         mon_decimal_point: lc.mon_decimal_point.clone(),
                         mon_thousands_sep: lc.mon_thousands_sep.clone(),
-                        mon_grouping: grouping_of(&lc.mon_grouping),
+                        mon_grouping,
                         positive_sign: lc.positive_sign.clone(),
                         negative_sign: lc.negative_sign.clone(),
                         int_frac_digits: lc.int_frac_digits as i64,

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -105,10 +105,11 @@ pub fn register_module(ns: &mut DictStorage) {
                 msg: &str,
             ) -> Result<i64, crate::PyError> {
                 let v = unsafe {
-                    if pyre_object::is_int(w) {
-                        pyre_object::w_int_get_value(w)
-                    } else if pyre_object::is_bool(w) {
+                    // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first.
+                    if pyre_object::is_bool(w) {
                         pyre_object::w_bool_get_value(w) as i64
+                    } else if pyre_object::is_int(w) {
+                        pyre_object::w_int_get_value(w)
                     } else {
                         return Err(crate::PyError::value_error(msg.to_string()));
                     }

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -111,13 +111,14 @@ pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             }
             result_float as i64
         } else {
-            let sec = if is_int(args[0]) {
+            let sec = if is_bool(args[0]) {
+                // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first.
+                boolobject::w_bool_get_value(args[0]) as i64
+            } else if is_int(args[0]) {
                 w_int_get_value(args[0])
             } else if pyre_object::pyobject::is_long(args[0]) {
                 let big = pyre_object::longobject::w_long_get_value(args[0]);
                 i64::try_from(big).map_err(|_| overflow())?
-            } else if is_bool(args[0]) {
-                boolobject::w_bool_get_value(args[0]) as i64
             } else {
                 // `timeutils.py:31` — `space.bigint_w(w_secs)` applies
                 // `space.int`, so an object with `__int__` / `__index__` is

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -26,10 +26,12 @@ pub use crate::{PyError, PyErrorKind, PyResult};
 /// Extract a BigInt from an int or long object.
 
 unsafe fn as_bigint(obj: PyObjectRef) -> BigInt {
-    if is_int(obj) {
-        BigInt::from(w_int_get_value(obj))
-    } else if is_bool(obj) {
+    // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first; a bool
+    // reads through `w_bool_get_value`, not the int accessor.
+    if is_bool(obj) {
         BigInt::from(w_bool_get_value(obj) as i64)
+    } else if is_int(obj) {
+        BigInt::from(w_int_get_value(obj))
     } else {
         w_long_get_value(obj).clone()
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -584,7 +584,10 @@ pub fn init_typeobjects() {
         );
         reg.insert(
             &pyre_object::rangeobject::LONG_RANGE_ITER_TYPE as *const PyType as usize,
-            new_typeobject_with_base("longrange_iterator", |_| {}, object_type) as usize,
+            // `W_AbstractRangeIterator.typedef` names every range-iterator
+            // class `range_iterator` (`functional.py`); the word-fit and bignum
+            // iterators share that public name though they are distinct types.
+            new_typeobject_with_base("range_iterator", |_| {}, object_type) as usize,
         );
         reg.insert(
             &pyre_object::cellobject::CELL_TYPE as *const PyType as usize,

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -277,10 +277,12 @@ pub unsafe fn w_range_fields(obj: PyObjectRef) -> (PyObjectRef, PyObjectRef, PyO
 /// `obj` must be a valid int, long, or bool object.
 pub unsafe fn range_obj_to_bigint(obj: PyObjectRef) -> BigInt {
     unsafe {
-        if is_int(obj) {
-            BigInt::from(crate::intobject::w_int_get_value(obj))
-        } else if is_bool(obj) {
+        // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first;
+        // a bool reads through `w_bool_get_value`, not the int accessor.
+        if is_bool(obj) {
             BigInt::from(crate::boolobject::w_bool_get_value(obj) as i64)
+        } else if is_int(obj) {
+            BigInt::from(crate::intobject::w_int_get_value(obj))
         } else {
             crate::longobject::w_long_get_value(obj).clone()
         }
@@ -302,10 +304,11 @@ pub fn range_bigint_to_obj(value: BigInt) -> PyObjectRef {
 /// `obj` must be a valid int/long/bool object.
 pub unsafe fn range_obj_as_i64(obj: PyObjectRef) -> Option<i64> {
     unsafe {
-        if is_int(obj) {
-            Some(crate::intobject::w_int_get_value(obj))
-        } else if is_bool(obj) {
+        // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first.
+        if is_bool(obj) {
             Some(crate::boolobject::w_bool_get_value(obj) as i64)
+        } else if is_int(obj) {
+            Some(crate::intobject::w_int_get_value(obj))
         } else {
             use num_traits::ToPrimitive;
             crate::longobject::w_long_get_value(obj).to_i64()
@@ -568,7 +571,7 @@ pub fn range_length_big(start: &BigInt, stop: &BigInt, step: &BigInt) -> BigInt 
 // `step` and `len` stay wrapped (set once at construction); only the
 // machine-int `index` advances, so no GC pointer field is ever mutated.
 
-#[pyre_class("longrange_iterator", type_id = 8, static_name = "LONG_RANGE_ITER")]
+#[pyre_class("range_iterator", type_id = 8, static_name = "LONG_RANGE_ITER")]
 pub struct W_LongRangeIterator {
     pub start: PyObjectRef,
     pub step: PyObjectRef,

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -567,16 +567,17 @@ pub fn range_length_big(start: &BigInt, stop: &BigInt, step: &BigInt) -> BigInt 
 // ── Long range iterator ──
 //
 // `objspace/std/iterobject.py W_LongRangeIterator` — the cursor `iter()`
-// produces for a range whose bounds exceed a machine word.  `start`,
-// `step` and `len` stay wrapped (set once at construction); only the
-// machine-int `index` advances, so no GC pointer field is ever mutated.
+// produces for a range whose bounds exceed a machine word.  `start`, `step`
+// and `len` are set once at construction; `index` is a wrapped integer that
+// advances by one each step (`self.w_index`), so the cursor keeps arbitrary
+// precision and never overflows for a range longer than a machine word.
 
 #[pyre_class("range_iterator", type_id = 8, static_name = "LONG_RANGE_ITER")]
 pub struct W_LongRangeIterator {
     pub start: PyObjectRef,
     pub step: PyObjectRef,
     pub len: PyObjectRef,
-    pub index: i64,
+    pub index: PyObjectRef,
 }
 
 /// Allocate a `W_LongRangeIterator`.
@@ -589,6 +590,8 @@ pub fn w_long_range_iter_new(
     crate::gc_roots::pin_root(start);
     crate::gc_roots::pin_root(step);
     crate::gc_roots::pin_root(len);
+    let index = crate::intobject::w_int_new(0);
+    crate::gc_roots::pin_root(index);
     W_LongRangeIterator::allocate(W_LongRangeIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -597,7 +600,7 @@ pub fn w_long_range_iter_new(
         start,
         step,
         len,
-        index: 0,
+        index,
     })
 }
 
@@ -616,7 +619,7 @@ pub unsafe fn w_long_range_iter_len(obj: PyObjectRef) -> BigInt {
     unsafe {
         let it = obj as *const W_LongRangeIterator;
         let len = range_obj_to_bigint((*it).len);
-        let rem = len - BigInt::from((*it).index);
+        let rem = len - range_obj_to_bigint((*it).index);
         if rem < BigInt::from(0) {
             BigInt::from(0)
         } else {
@@ -632,7 +635,7 @@ pub unsafe fn w_long_range_iter_len(obj: PyObjectRef) -> BigInt {
 pub unsafe fn w_long_range_iter_has_next(obj: PyObjectRef) -> bool {
     unsafe {
         let it = obj as *const W_LongRangeIterator;
-        BigInt::from((*it).index) < range_obj_to_bigint((*it).len)
+        range_obj_to_bigint((*it).index) < range_obj_to_bigint((*it).len)
     }
 }
 
@@ -644,17 +647,20 @@ pub unsafe fn w_long_range_iter_has_next(obj: PyObjectRef) -> bool {
 pub unsafe fn w_long_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
     unsafe {
         let it = obj as *mut W_LongRangeIterator;
-        let index = (*it).index;
+        let index = range_obj_to_bigint((*it).index);
         let len = range_obj_to_bigint((*it).len);
-        if BigInt::from(index) >= len {
+        if index >= len {
             return None;
         }
         let start = range_obj_to_bigint((*it).start);
         let step = range_obj_to_bigint((*it).step);
-        let value = start + BigInt::from(index) * step;
-        // Only the machine-int index is mutated; the wrapped fields stay
-        // immutable, so no GC pointer field is overwritten.
-        (*it).index = index + 1;
+        // `w_result = self.w_index * self.w_step + self.w_start`, then
+        // `self.w_index = self.w_index + 1` (wrapped, arbitrary precision).
+        let value = start + index.clone() * step;
+        let _roots = crate::gc_roots::push_roots();
+        let next_index = range_bigint_to_obj(index + BigInt::from(1));
+        crate::gc_roots::pin_root(next_index);
+        (*it).index = next_index;
         Some(range_bigint_to_obj(value))
     }
 }


### PR DESCRIPTION
Fix https://github.com/youknowone/pyre/issues/82

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Continues the `rustpython-host_env` integration (#82) with PyPy-parity fixes for `range`, range iterators, `bool` unwrapping, and `_locale`.

- **Wrapped long-range iterator index.** `W_LongRangeIterator.index` is now a wrapped (bignum-capable) `PyObjectRef` instead of an `i64`, advancing by a bignum add each step (PyPy `self.w_index`). Iterating a range longer than a machine word no longer overflows the cursor. The field is a `PyObjectRef`, so the iterator now traces it; the struct size is unchanged.
- **bool-before-int unwrapping.** `is_int` is true for `BOOL_TYPE`, and `W_BoolObject` has a distinct layout (`boolval: bool`, not `intval: i64`), so reading a bool through the i64 accessor is unsafe. The following sites now test `is_bool` before `is_int` and read through `w_bool_get_value`: `range_obj_to_bigint` / `range_obj_as_i64`, `int_w`, `float_w`, `hash_value`, `build_string`, `descroperation::as_bigint`, `time.sleep` seconds, and `itertools.islice` argument parsing. `build_string` now renders a bool as `True`/`False` instead of its int value.
- **`range.index` miss text.** A non-int needle that misses now raises `sequence.index(x): x not in sequence` (`sequence_index`); the int/long path keeps `<x> is not in range`.
- **Range iterator type name.** The bignum cursor's `__name__` is `range_iterator`, the same public name as the word-fit cursor (`W_AbstractRangeIterator.typedef`).
- **`localeconv` grouping.** `grouping` / `mon_grouping` are read directly from `localeconv()` so a `CHAR_MAX` (127) element is preserved (the host helper stops at the first `CHAR_MAX`); every byte is mapped up to NUL, then a trailing `0` is appended.

Testing: `check.py` dynasm 49/49, cranelift 49/49; `cargo test -p pyre-object` 173/0.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
