### PR TITLE
optimizeopt: object-carry box identity across short-preamble (#9)

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -407,7 +407,7 @@ impl<'a> AssemblerARM64<'a> {
         inputargs: &'a [InputArg],
         operations: &'a [Op],
     ) -> Self {
-        let inputarg_pos = OpTypeIndex::build_inputarg_pos(inputargs);
+        let inputarg_pos = OpTypeIndex::<Op>::build_inputarg_pos(inputargs);
         let op_pos = OpTypeIndex::build_op_pos(operations);
         AssemblerARM64 {
             mc: Assembler::new().unwrap(),

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -1675,7 +1675,7 @@ impl<'a> RegAlloc<'a> {
         let rm = Self::make_gpr_manager();
         let xrm = Self::make_xmm_manager();
         let fm = FrameManager::new(0);
-        let inputarg_pos = OpTypeIndex::build_inputarg_pos(inputargs);
+        let inputarg_pos = OpTypeIndex::<Op>::build_inputarg_pos(inputargs);
         let op_pos = OpTypeIndex::build_op_pos(operations);
         RegAlloc {
             longevity,

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -870,7 +870,7 @@ impl<'a> Assembler386<'a> {
         inputargs: &'a [InputArg],
         operations: &'a [Op],
     ) -> Self {
-        let inputarg_pos = OpTypeIndex::build_inputarg_pos(inputargs);
+        let inputarg_pos = OpTypeIndex::<Op>::build_inputarg_pos(inputargs);
         let op_pos = OpTypeIndex::build_op_pos(operations);
         Assembler386 {
             mc: Assembler::new().unwrap(),

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -371,8 +371,11 @@ struct PendingZero {
 /// Per-rewrite mutable state (not stored on the struct so that
 /// `rewrite_for_gc` can take `&self`).
 struct RewriteState {
-    /// Output operation list.
-    out: Vec<Op>,
+    /// Output operation list. `Rc`-carried so `emit` can hand back a
+    /// BOUND result box — downstream references to a newly emitted op
+    /// live-track its producer instead of fabricating position-only
+    /// boxes (#9 operand-union grind).
+    out: Vec<majit_ir::OpRc>,
     /// Next position index for emitted result ops that do not have an
     /// explicit source position to preserve.
     next_pos: u32,
@@ -581,11 +584,12 @@ impl RewriteState {
             pos
         };
         op.pos.set(pos);
-        self.out.push(op);
+        let rc = std::rc::Rc::new(op);
+        self.out.push(rc.clone());
         if pos.is_none() {
             BoxRef::none()
         } else {
-            BoxRef::new_resop(rt, pos.raw())
+            BoxRef::from_bound_op(&rc)
         }
     }
 
@@ -609,8 +613,9 @@ impl RewriteState {
         };
         self.result_types.insert(pos.raw(), rt);
         op.pos.set(pos);
-        self.out.push(op);
-        BoxRef::new_resop(rt, pos.raw())
+        let rc = std::rc::Rc::new(op);
+        self.out.push(rc.clone());
+        BoxRef::from_bound_op(&rc)
     }
 
     /// rewrite.py:699-711 emitting_an_operation_that_can_collect
@@ -837,7 +842,7 @@ impl RewriteState {
             let scaled_len = self.const_int((stop - start) as i64 * pz.scale);
             let one = self.const_int(1);
 
-            let op = &mut self.out[pz.out_index];
+            let op = &self.out[pz.out_index];
             // resoperation.py:290 AbstractResOp.setarg parity.
             op.setarg(1, scaled_start);
             op.setarg(2, scaled_len);
@@ -3002,7 +3007,13 @@ impl GcRewriter for GcRewriterImpl {
         // Flush any remaining pending zeros at end of trace.
         st.emit_pending_zeros();
 
-        (st.out, st.constants, st.new_constant_types)
+        // Boundary unwrap: the trait still hands the backend a
+        // `Vec<Op>`; the clone preserves bound operands (the operand
+        // `Rc`s keep their producers alive), so no position-only
+        // re-minting happens here. A follow-up slice flips the trait
+        // to `Vec<OpRc>` and removes this clone.
+        let out: Vec<Op> = st.out.iter().map(|rc| (**rc).clone()).collect();
+        (out, st.constants, st.new_constant_types)
     }
 }
 

--- a/majit/majit-ir/src/op_type_index.rs
+++ b/majit/majit-ir/src/op_type_index.rs
@@ -16,9 +16,9 @@ use crate::value::{InputArg, Type};
 /// `inputarg_pos` and `op_pos` are stored as `Cow` so callers may
 /// either let `new` build them eagerly or share pre-built indexes that
 /// outlive the trace (e.g. `RegAlloc<'a>`).
-pub struct OpTypeIndex<'a> {
+pub struct OpTypeIndex<'a, T: AsRef<Op> = Op> {
     inputargs: &'a [InputArg],
-    ops: &'a [Op],
+    ops: &'a [T],
     /// `inputarg_pos[raw] = slice index in inputargs`, sentinel
     /// [`NO_POS`] for unset slots. `arg.index` raw uniqueness is
     /// enforced at build time, mirroring RPython's backend uniqueness
@@ -39,8 +39,8 @@ pub struct OpTypeIndex<'a> {
 /// below `u32::MAX`.
 pub const NO_POS: u32 = u32::MAX;
 
-impl<'a> OpTypeIndex<'a> {
-    pub fn new(inputargs: &'a [InputArg], ops: &'a [Op]) -> Self {
+impl<'a, T: AsRef<Op>> OpTypeIndex<'a, T> {
+    pub fn new(inputargs: &'a [InputArg], ops: &'a [T]) -> Self {
         let inputarg_pos = Self::build_inputarg_pos(inputargs);
         let op_pos = Self::build_op_pos(ops);
         Self {
@@ -55,7 +55,7 @@ impl<'a> OpTypeIndex<'a> {
     /// O(1) — borrows slices instead of rebuilding the position arrays.
     pub fn from_parts(
         inputargs: &'a [InputArg],
-        ops: &'a [Op],
+        ops: &'a [T],
         inputarg_pos: &'a [u32],
         op_pos: &'a [u32],
     ) -> Self {
@@ -107,9 +107,10 @@ impl<'a> OpTypeIndex<'a> {
     /// tag, because pyre's backend boundary keys by raw u32 and would
     /// silently keep only the later op. Hard-panic on raw collision so
     /// the violation surfaces here.
-    pub fn build_op_pos(ops: &[Op]) -> Vec<u32> {
+    pub fn build_op_pos(ops: &[T]) -> Vec<u32> {
         let max_raw = ops
             .iter()
+            .map(|op| op.as_ref())
             .filter(|op| !op.pos.get().is_none() && op.type_ != Type::Void)
             .map(|op| op.pos.get().raw())
             .max();
@@ -118,6 +119,7 @@ impl<'a> OpTypeIndex<'a> {
         };
         let mut pos: Vec<u32> = vec![NO_POS; max_raw as usize + 1];
         for (idx, op) in ops.iter().enumerate() {
+            let op = op.as_ref();
             if op.pos.get().is_none() || op.type_ == Type::Void {
                 continue;
             }
@@ -127,7 +129,7 @@ impl<'a> OpTypeIndex<'a> {
                     "OpTypeIndex: raw {} bound to ops[{}] {:?} and ops[{}] {:?} — Box identity broken",
                     op.pos.get().raw(),
                     pos[r],
-                    ops[pos[r] as usize].opcode,
+                    ops[pos[r] as usize].as_ref().opcode,
                     idx,
                     op.opcode,
                 );
@@ -189,7 +191,7 @@ impl<'a> OpTypeIndex<'a> {
             return None;
         }
         let idx = op_pos_lookup(&self.op_pos, opref.raw() as usize)?;
-        Some(&self.ops[idx])
+        Some(self.ops[idx].as_ref())
     }
 
     /// Inputarg-only type lookup; returns `None` if `opref` does not

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -25,6 +25,14 @@ use crate::resoperation::{OpRc, OpRef};
 use crate::value::{Const, GcRef, InputArgRc, Type, Value};
 use std::rc::Rc;
 
+/// TEMPORARY (#9-④ S0 probe): `PYRE_OPBOX_PROBE=1` logs every surviving
+/// position-only `Operand::Box` mint in [`Operand::from_boxref`].
+fn opbox_probe_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_OPBOX_PROBE").is_some())
+}
+
 /// An operand stored in `Op.args` / `Op.fail_args`.
 ///
 /// Mirror of `OpRef`'s four logical cases, but carrying the producer by
@@ -253,6 +261,17 @@ impl Operand {
         // GC walk preserved). Only position-only boxes remain `Operand::Box`.
         if b.is_constant() {
             return Operand::Const(b.clone());
+        }
+        // TEMPORARY (#9-④ S0 probe): count surviving position-only mints
+        // before grinding `Operand::Box` to zero. Env-gated, off by default.
+        if opbox_probe_enabled() {
+            eprintln!(
+                "[opbox-probe] position-only operand minted: {:?}",
+                b.to_opref()
+            );
+            if std::env::var_os("PYRE_OPBOX_PROBE_BT").is_some() {
+                eprintln!("{}", std::backtrace::Backtrace::force_capture());
+            }
         }
         Operand::Box(b.clone())
     }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -25,14 +25,6 @@ use crate::resoperation::{OpRc, OpRef};
 use crate::value::{Const, GcRef, InputArgRc, Type, Value};
 use std::rc::Rc;
 
-/// TEMPORARY (#9-④ S0 probe): `PYRE_OPBOX_PROBE=1` logs every surviving
-/// position-only `Operand::Box` mint in [`Operand::from_boxref`].
-fn opbox_probe_enabled() -> bool {
-    use std::sync::OnceLock;
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_OPBOX_PROBE").is_some())
-}
-
 /// An operand stored in `Op.args` / `Op.fail_args`.
 ///
 /// Mirror of `OpRef`'s four logical cases, but carrying the producer by
@@ -262,17 +254,12 @@ impl Operand {
         if b.is_constant() {
             return Operand::Const(b.clone());
         }
-        // TEMPORARY (#9-④ S0 probe): count surviving position-only mints
-        // before grinding `Operand::Box` to zero. Env-gated, off by default.
-        if opbox_probe_enabled() {
-            eprintln!(
-                "[opbox-probe] position-only operand minted: {:?}",
-                b.to_opref()
-            );
-            if std::env::var_os("PYRE_OPBOX_PROBE_BT").is_some() {
-                eprintln!("{}", std::backtrace::Backtrace::force_capture());
-            }
-        }
+        // Only position-only boxes remain `Operand::Box`. The optimizer
+        // grind (#9-④) reduced production mints to the S9 cross-phase
+        // residual: export-boundary `get_box_replacement` fallbacks (which
+        // carry their own producerless tripwire) and unmapped Phase-1
+        // short-preamble jump args. Both are producer-less by construction
+        // in the current context.
         Operand::Box(b.clone())
     }
 

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1857,7 +1857,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             if let Some(fail_args) = emitted.fail_args_mut() {
                 for arg in fail_args.iter_mut() {
                     if let Some(bound) = get_local_box_replacement(forwarding, arg.to_opref()) {
-                        *arg = majit_ir::operand::Operand::Box(bound);
+                        *arg = majit_ir::operand::Operand::from_boxref(&bound);
                     }
                 }
             }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1976,9 +1976,21 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             .expect("VirtualizableInfo.array_descrs must cover every array_field");
         let array_info = &vinfo.array_fields[ai];
         let (item_opcode, item_descr, item_base) = match array_info.item_type {
-            Type::Int => (OpCode::GetarrayitemGcI, array_descr.clone(), array_box.clone()),
-            Type::Ref => (OpCode::GetarrayitemGcR, array_descr.clone(), array_box.clone()),
-            Type::Float => (OpCode::GetarrayitemGcF, array_descr.clone(), array_box.clone()),
+            Type::Int => (
+                OpCode::GetarrayitemGcI,
+                array_descr.clone(),
+                array_box.clone(),
+            ),
+            Type::Ref => (
+                OpCode::GetarrayitemGcR,
+                array_descr.clone(),
+                array_box.clone(),
+            ),
+            Type::Float => (
+                OpCode::GetarrayitemGcF,
+                array_descr.clone(),
+                array_box.clone(),
+            ),
             Type::Void => panic!("virtualizable array {ai} has Void item_type"),
         };
         let (item_opcode, item_descr, item_base) = match array_info.storage {
@@ -2416,8 +2428,7 @@ pub fn compile_tmp_callback(
     // inline, carried directly on the OpRef variant.
     let funcbox_ref = OpRef::const_int(jitdriver_sd.portal_runner_adr);
     // Green boxes follow in declaration order.
-    let mut callargs_box: Vec<BoxRef> =
-        Vec::with_capacity(1 + greenboxes.len() + inputargs.len());
+    let mut callargs_box: Vec<BoxRef> = Vec::with_capacity(1 + greenboxes.len() + inputargs.len());
     callargs_box.push(BoxRef::from_opref(funcbox_ref));
     for gb in greenboxes.iter() {
         // history.py:227/268/314 Const{Int,Float,Ptr}.value inline.
@@ -2456,11 +2467,7 @@ pub fn compile_tmp_callback(
     let call_opcode = OpCode::call_for_type(jitdriver_sd.result_type);
     // `compile.py:1132` `call_op = ResOperation(opnum, callargs,
     // descr=jd.portal_calldescr)`.
-    let call_op = std::rc::Rc::new(Op::with_descr(
-        call_opcode,
-        &callargs_box,
-        portal_calldescr,
-    ));
+    let call_op = std::rc::Rc::new(Op::with_descr(call_opcode, &callargs_box, portal_calldescr));
     //
     // `compile.py:1133-1136` `if call_op.type != 'v': finishargs = [call_op]
     // else: finishargs = []`.

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -369,9 +369,9 @@ impl<'a> UnrolledLoopData<'a> {
 /// The backend numbers every guard and finish in a single exit table, so this
 /// helper mirrors that numbering and records only the guard entries that need
 /// resume data plus the corresponding op index for blackhole fallback.
-pub(crate) fn build_guard_metadata(
+pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
     inputargs: &[InputArg],
-    ops: &[majit_ir::Op],
+    ops: &[T],
     pc: u64,
 ) -> (
     crate::optimizeopt::vec_assoc::VecAssoc<u32, crate::resume::ResumeLayoutSummary>,
@@ -389,6 +389,7 @@ pub(crate) fn build_guard_metadata(
     // (the OpRef variant tag, `ty()`); a fail_arg carries its own type
     // regardless of trace position, so no position-keyed side table is needed.
     for (op_idx, op) in ops.iter().enumerate() {
+        let op = op.as_ref();
         let is_guard = op.opcode.is_guard();
         let is_finish = op.opcode == OpCode::Finish;
         if !is_guard && !is_finish {
@@ -1060,10 +1061,10 @@ pub(crate) fn build_guard_metadata(
     (result, exit_layouts)
 }
 
-pub(crate) fn merge_backend_exit_layouts(
+pub(crate) fn merge_backend_exit_layouts<T: AsRef<majit_ir::Op>>(
     exit_layouts: &mut crate::optimizeopt::vec_assoc::VecAssoc<u32, StoredExitLayout>,
     backend_layouts: &[FailDescrLayout],
-    ops: &[majit_ir::Op],
+    ops: &[T],
 ) {
     for layout in backend_layouts {
         // compile.py:861 copy_all_attributes_from parity: when the backend
@@ -1099,7 +1100,7 @@ pub(crate) fn merge_backend_exit_layouts(
         let descr_from_op = layout
             .source_op_index
             .and_then(|idx| ops.get(idx))
-            .and_then(|op| op.getdescr())
+            .and_then(|op| op.as_ref().getdescr())
             .or_else(|| {
                 Some(if layout.is_finish {
                     make_finish_fail_descr_typed(
@@ -1363,10 +1364,10 @@ pub(crate) fn enrich_resume_layout_with_frame_stack(
     }
 }
 
-pub(crate) fn merge_backend_terminal_exit_layouts(
+pub(crate) fn merge_backend_terminal_exit_layouts<T: AsRef<majit_ir::Op>>(
     terminal_exit_layouts: &mut crate::optimizeopt::vec_assoc::VecAssoc<usize, StoredExitLayout>,
     backend_layouts: &[TerminalExitLayout],
-    ops: &[majit_ir::Op],
+    ops: &[T],
 ) {
     for layout in backend_layouts {
         // Pre-resolve the source-op `descr` for backend-only entries so
@@ -1385,7 +1386,7 @@ pub(crate) fn merge_backend_terminal_exit_layouts(
         // downstream readers that probe `entry.descr.is_some_and(...)`
         // (e.g. `assign_guard_hashes` via the backend layout, exit-type
         // resolution paths) keep working uniformly.
-        let source_op = ops.get(layout.op_index);
+        let source_op = ops.get(layout.op_index).map(|op| op.as_ref());
         let is_jump = match source_op {
             Some(op) => op.opcode == OpCode::Jump,
             None => !layout.is_finish,
@@ -1485,9 +1486,13 @@ pub(crate) fn enrich_resume_layout_with_trace_metadata(
     }
 }
 
-pub(crate) fn find_fail_index_for_exit_op(ops: &[majit_ir::Op], op_index: usize) -> Option<u32> {
+pub(crate) fn find_fail_index_for_exit_op<T: AsRef<majit_ir::Op>>(
+    ops: &[T],
+    op_index: usize,
+) -> Option<u32> {
     let mut fail_index = 0u32;
     for (idx, op) in ops.iter().enumerate() {
+        let op = op.as_ref();
         if op.opcode.is_guard() || op.opcode == OpCode::Finish {
             if idx == op_index {
                 return Some(fail_index);
@@ -1498,14 +1503,14 @@ pub(crate) fn find_fail_index_for_exit_op(ops: &[majit_ir::Op], op_index: usize)
     None
 }
 
-pub(crate) fn infer_terminal_exit_layout(
+pub(crate) fn infer_terminal_exit_layout<T: AsRef<majit_ir::Op>>(
     inputargs: &[InputArg],
-    ops: &[majit_ir::Op],
+    ops: &[T],
     owning_key: u64,
     trace_id: u64,
     op_index: usize,
 ) -> Option<CompiledExitLayout> {
-    let op = ops.get(op_index)?;
+    let op = ops.get(op_index)?.as_ref();
     let is_finish = op.opcode == OpCode::Finish;
     if !is_finish && op.opcode != OpCode::Jump {
         return None;
@@ -1568,13 +1573,14 @@ pub(crate) fn infer_terminal_exit_layout(
     })
 }
 
-pub(crate) fn build_terminal_exit_layouts(
+pub(crate) fn build_terminal_exit_layouts<T: AsRef<majit_ir::Op>>(
     inputargs: &[InputArg],
-    ops: &[majit_ir::Op],
+    ops: &[T],
 ) -> crate::optimizeopt::vec_assoc::VecAssoc<usize, StoredExitLayout> {
     let mut layouts: crate::optimizeopt::vec_assoc::VecAssoc<usize, StoredExitLayout> =
         crate::optimizeopt::vec_assoc::VecAssoc::new();
     for (op_index, op) in ops.iter().enumerate() {
+        let op = op.as_ref();
         if op.opcode != OpCode::Finish && op.opcode != OpCode::Jump {
             continue;
         }
@@ -1648,10 +1654,10 @@ pub(crate) fn decode_values_with_layout(
 }
 
 pub(crate) fn normalize_closing_jump_args(
-    mut ops: Vec<Op>,
+    ops: Vec<majit_ir::OpRc>,
     constants: &majit_ir::VecAssoc<u32, majit_ir::Value>,
     num_inputs: usize,
-) -> Vec<Op> {
+) -> Vec<majit_ir::OpRc> {
     let Some(label_args) = ops
         .iter()
         .rev()
@@ -1667,7 +1673,7 @@ pub(crate) fn normalize_closing_jump_args(
         .map(|op| op.pos.get())
         .collect();
 
-    let Some(jump) = ops.iter_mut().rfind(|op| op.opcode == OpCode::Jump) else {
+    let Some(jump) = ops.iter().rfind(|op| op.opcode == OpCode::Jump) else {
         return ops;
     };
 
@@ -1751,7 +1757,7 @@ pub(crate) fn normalize_closing_jump_args(
 /// reads: one length per array field (in `vinfo.array_fields` order), taken
 /// from the concrete virtualizable at trace-start time.
 pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
-    ops: &mut Vec<Op>,
+    ops: &mut Vec<majit_ir::OpRc>,
     inputargs: &mut Vec<InputArg>,
     vinfo: &crate::virtualizable::VirtualizableInfo,
     vable_array_lengths: &[usize],
@@ -2074,10 +2080,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
     for op in original_ops.iter() {
         emit_forwarded_patch_op(&mut extra_ops, op, &mut forwarding, &mut next_opref);
     }
-    // The compiled-loop assembly stage still carries `Vec<Op>` by value
-    // (re-wrapped as `Rc` at the backend boundary); cloning out preserves
-    // the bound operand handles while matching the stage's storage.
-    *ops = extra_ops.iter().map(|rc| (**rc).clone()).collect();
+    *ops = extra_ops;
 }
 
 /// RPython dependency.py requires GUARD_(NO_)OVERFLOW to be scheduled only
@@ -2085,7 +2088,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
 /// intbounds.py:231-242: optimizer raises InvalidLoop for stray overflow
 /// guards. This function is a post-optimization safety net: if any stray
 /// guard survived, strip it to prevent backend panic.
-pub(crate) fn strip_stray_overflow_guards(ops: Vec<Op>) -> Vec<Op> {
+pub(crate) fn strip_stray_overflow_guards(ops: Vec<majit_ir::OpRc>) -> Vec<majit_ir::OpRc> {
     use majit_ir::OpCode;
 
     let mut pending_ovf = false;
@@ -2697,6 +2700,7 @@ mod tests {
         let mut inputargs = vec![InputArg::new_ref(0), InputArg::new_ref(1)];
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
+        let mut ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         patch_new_loop_to_load_virtualizable_fields(
             &mut ops,
             &mut inputargs,
@@ -2774,6 +2778,7 @@ mod tests {
         ];
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
+        let mut ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         patch_new_loop_to_load_virtualizable_fields(
             &mut ops,
             &mut inputargs,

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1783,61 +1783,64 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
     // discarded when the function returns; its lifetime mirrors the
     // single in-place loop rewrite that RPython's `_forwarded` model
     // accomplishes via Box mutation. No semantic divergence.
-    fn set_local_forwarded(forwarding: &mut Vec<OpRef>, source: OpRef, target: OpRef) {
+    fn set_local_forwarded(forwarding: &mut Vec<Option<BoxRef>>, source: OpRef, target: BoxRef) {
         if source.is_none() || source.is_constant() {
             return;
         }
         let idx = source.raw() as usize;
         if idx >= forwarding.len() {
-            forwarding.resize(idx + 1, OpRef::NONE);
+            forwarding.resize(idx + 1, None);
         }
-        forwarding[idx] = target;
+        forwarding[idx] = Some(target);
     }
 
-    fn get_local_box_replacement(forwarding: &[OpRef], mut opref: OpRef) -> OpRef {
+    fn get_local_box_replacement(
+        forwarding: &[Option<BoxRef>],
+        mut opref: OpRef,
+    ) -> Option<BoxRef> {
         if opref.is_none() || opref.is_constant() {
-            return opref;
+            return None;
         }
+        let mut found = None;
         loop {
             let idx = opref.raw() as usize;
-            if idx >= forwarding.len() {
-                return opref;
+            match forwarding.get(idx) {
+                Some(Some(next)) => {
+                    opref = next.to_opref();
+                    found = Some(next.clone());
+                }
+                _ => return found,
             }
-            let next = forwarding[idx];
-            if next.is_none() {
-                return opref;
-            }
-            opref = next;
         }
     }
 
     fn emit_forwarded_patch_op(
-        extra_ops: &mut Vec<Op>,
+        extra_ops: &mut Vec<majit_ir::OpRc>,
         op: &Op,
-        forwarding: &mut Vec<OpRef>,
+        forwarding: &mut Vec<Option<BoxRef>>,
         next_opref: &mut u32,
     ) {
         let mut emitted = op.clone();
         let mut replaced = false;
+        // compile.py:414-418 `orig_op.set_forwarded(op)` — recorded after
+        // the emitted op is reference-counted below so the forwarding
+        // target is the producer object itself.
+        let mut forwarded_source: Option<OpRef> = None;
 
         for i in 0..op.num_args() {
             let orig_arg = op.arg(i);
-            let arg = get_local_box_replacement(forwarding, orig_arg.to_opref());
-            if orig_arg.to_opref() != arg {
+            if let Some(bound) = get_local_box_replacement(forwarding, orig_arg.to_opref()) {
                 if !replaced {
                     emitted = op.copy_and_change(op.opcode, None, None);
                     if op.result_type() != Type::Void && !op.pos.get().is_none() {
                         let new_pos = OpRef::op_typed(*next_opref, op.result_type());
                         *next_opref += 1;
                         emitted.pos.set(new_pos);
-                        // compile.py:414-418 `orig_op.set_forwarded(op)`:
-                        // in the flat OpRef model this temporary vector is
-                        // the local equivalent of Box._forwarded.
-                        set_local_forwarded(forwarding, op.pos.get(), new_pos);
+                        forwarded_source = Some(op.pos.get());
                     }
                     replaced = true;
                 }
-                emitted.setarg(i, BoxRef::from_opref(arg));
+                emitted.setarg(i, bound);
             }
         }
 
@@ -1847,13 +1850,17 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             }
             if let Some(fail_args) = emitted.fail_args_mut() {
                 for arg in fail_args.iter_mut() {
-                    *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(
-                        get_local_box_replacement(forwarding, arg.to_opref()),
-                    ));
+                    if let Some(bound) = get_local_box_replacement(forwarding, arg.to_opref()) {
+                        *arg = majit_ir::operand::Operand::Box(bound);
+                    }
                 }
             }
         }
 
+        let emitted = std::rc::Rc::new(emitted);
+        if let Some(source) = forwarded_source {
+            set_local_forwarded(forwarding, source, BoxRef::from_bound_op(&emitted));
+        }
         extra_ops.push(emitted);
     }
 
@@ -1866,14 +1873,13 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
         return;
     }
 
-    let expanded_inputargs: Vec<InputArg> =
-        inputargs.iter().map(|ia| ia.fresh_value_copy()).collect();
+    let expanded_inputargs: Vec<majit_ir::InputArgRc> = inputargs
+        .iter()
+        .map(|ia| std::rc::Rc::new(ia.fresh_value_copy()))
+        .collect();
 
     // compile.py:429-430 — vable_box = inputargs[index_of_virtualizable].
-    let vable_box = OpRef::input_arg_typed(
-        expanded_inputargs[index_of_virtualizable].index,
-        expanded_inputargs[index_of_virtualizable].tp,
-    );
+    let vable_box = BoxRef::from_bound_inputarg(&expanded_inputargs[index_of_virtualizable]);
 
     // compile.py keeps Box identities disjoint automatically; in the flat
     // OpRef model we must allocate above every runtime ref already reachable
@@ -1904,8 +1910,9 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
         .map(|m| m + 1)
         .unwrap_or(0);
 
-    let mut forwarding = vec![OpRef::NONE; (max_runtime_ref as usize).saturating_add(1)];
-    let mut extra_ops: Vec<Op> = Vec::new();
+    let mut forwarding: Vec<Option<BoxRef>> =
+        vec![None; (max_runtime_ref as usize).saturating_add(1)];
+    let mut extra_ops: Vec<majit_ir::OpRc> = Vec::new();
     let mut i = num_red_args;
 
     // compile.py:432 — loop.inputargs = inputargs[:i].
@@ -1934,11 +1941,12 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             OpRef::input_arg_typed(expanded_inputargs[i].index, expanded_inputargs[i].tp);
         let new_opref = OpRef::op_typed(next_opref, field.field_type);
         next_opref += 1;
-        let mut op = Op::new(opcode, &[BoxRef::from_opref(vable_box)]);
+        let mut op = Op::new(opcode, &[vable_box.clone()]);
         op.pos.set(new_opref);
         op.setdescr(descr);
+        let op = std::rc::Rc::new(op);
+        set_local_forwarded(&mut forwarding, old_opref, BoxRef::from_bound_op(&op));
         extra_ops.push(op);
-        set_local_forwarded(&mut forwarding, old_opref, new_opref);
         i += 1;
     }
 
@@ -1954,9 +1962,11 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
         // GETFIELD_GC_R(vable_box, array_field_descr) → array pointer (Ref-typed).
         let array_opref = OpRef::ref_op(next_opref);
         next_opref += 1;
-        let mut arr_load = Op::new(OpCode::GetfieldGcR, &[BoxRef::from_opref(vable_box)]);
+        let mut arr_load = Op::new(OpCode::GetfieldGcR, &[vable_box.clone()]);
         arr_load.pos.set(array_opref);
         arr_load.setdescr(array_field_descr.clone());
+        let arr_load = std::rc::Rc::new(arr_load);
+        let array_box = BoxRef::from_bound_op(&arr_load);
         extra_ops.push(arr_load);
 
         let array_descr = vinfo
@@ -1966,9 +1976,9 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             .expect("VirtualizableInfo.array_descrs must cover every array_field");
         let array_info = &vinfo.array_fields[ai];
         let (item_opcode, item_descr, item_base) = match array_info.item_type {
-            Type::Int => (OpCode::GetarrayitemGcI, array_descr.clone(), array_opref),
-            Type::Ref => (OpCode::GetarrayitemGcR, array_descr.clone(), array_opref),
-            Type::Float => (OpCode::GetarrayitemGcF, array_descr.clone(), array_opref),
+            Type::Int => (OpCode::GetarrayitemGcI, array_descr.clone(), array_box.clone()),
+            Type::Ref => (OpCode::GetarrayitemGcR, array_descr.clone(), array_box.clone()),
+            Type::Float => (OpCode::GetarrayitemGcF, array_descr.clone(), array_box.clone()),
             Type::Void => panic!("virtualizable array {ai} has Void item_type"),
         };
         let (item_opcode, item_descr, item_base) = match array_info.storage {
@@ -1992,7 +2002,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
                 // RPython's flat GC-array layout — out of scope.
                 let ptr_opref = OpRef::int_op(next_opref);
                 next_opref += 1;
-                let mut ptr_load = Op::new(OpCode::GetfieldGcI, &[BoxRef::from_opref(array_opref)]);
+                let mut ptr_load = Op::new(OpCode::GetfieldGcI, &[array_box.clone()]);
                 ptr_load.pos.set(ptr_opref);
                 ptr_load.setdescr(majit_ir::descr::make_field_descr(
                     ptr_offset,
@@ -2000,6 +2010,8 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
                     Type::Int,
                     ArrayFlag::Unsigned,
                 ));
+                let ptr_load = std::rc::Rc::new(ptr_load);
+                let ptr_box = BoxRef::from_bound_op(&ptr_load);
                 extra_ops.push(ptr_load);
 
                 let raw_opcode = match array_info.item_type {
@@ -2013,7 +2025,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
                     crate::virtualizable::item_size_for_type(array_info.item_type),
                     array_info.item_type,
                 );
-                (raw_opcode, raw_descr, ptr_opref)
+                (raw_opcode, raw_descr, ptr_box)
             }
         };
         for index in 0..array_len {
@@ -2027,15 +2039,13 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             next_opref += 1;
             let mut elem_op = Op::new(
                 item_opcode,
-                &[
-                    BoxRef::from_opref(item_base),
-                    BoxRef::from_opref(const_opref),
-                ],
+                &[item_base.clone(), BoxRef::from_opref(const_opref)],
             );
             elem_op.pos.set(new_opref);
             elem_op.setdescr(item_descr.clone());
+            let elem_op = std::rc::Rc::new(elem_op);
+            set_local_forwarded(&mut forwarding, old_opref, BoxRef::from_bound_op(&elem_op));
             extra_ops.push(elem_op);
-            set_local_forwarded(&mut forwarding, old_opref, new_opref);
             i += 1;
         }
     }
@@ -2052,7 +2062,10 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
     for op in original_ops.iter() {
         emit_forwarded_patch_op(&mut extra_ops, op, &mut forwarding, &mut next_opref);
     }
-    *ops = extra_ops;
+    // The compiled-loop assembly stage still carries `Vec<Op>` by value
+    // (re-wrapped as `Rc` at the backend boundary); cloning out preserves
+    // the bound operand handles while matching the stage's storage.
+    *ops = extra_ops.iter().map(|rc| (**rc).clone()).collect();
 }
 
 /// RPython dependency.py requires GUARD_(NO_)OVERFLOW to be scheduled only
@@ -2375,13 +2388,13 @@ pub fn compile_tmp_callback(
     //         elif kind == history.FLOAT: box = InputArgFloat()
     //         ...
     //         inputargs.append(box)
-    let inputargs: Vec<InputArg> = red_arg_types
+    let inputargs: Vec<majit_ir::InputArgRc> = red_arg_types
         .iter()
         .enumerate()
         .map(|(i, kind)| match kind {
-            Type::Int => InputArg::new_int(i as u32),
-            Type::Ref => InputArg::new_ref(i as u32),
-            Type::Float => InputArg::new_float(i as u32),
+            Type::Int => InputArg::new_int_rc(i as u32),
+            Type::Ref => InputArg::new_ref_rc(i as u32),
+            Type::Float => InputArg::new_float_rc(i as u32),
             Type::Void => panic!("compile_tmp_callback: void red arg is invalid"),
         })
         .collect();
@@ -2403,8 +2416,9 @@ pub fn compile_tmp_callback(
     // inline, carried directly on the OpRef variant.
     let funcbox_ref = OpRef::const_int(jitdriver_sd.portal_runner_adr);
     // Green boxes follow in declaration order.
-    let mut callargs: Vec<OpRef> = Vec::with_capacity(1 + greenboxes.len() + inputargs.len());
-    callargs.push(funcbox_ref);
+    let mut callargs_box: Vec<BoxRef> =
+        Vec::with_capacity(1 + greenboxes.len() + inputargs.len());
+    callargs_box.push(BoxRef::from_opref(funcbox_ref));
     for gb in greenboxes.iter() {
         // history.py:227/268/314 Const{Int,Float,Ptr}.value inline.
         let g_ref = match *gb {
@@ -2413,13 +2427,12 @@ pub fn compile_tmp_callback(
             Value::Float(f) => OpRef::const_float(f),
             Value::Void => panic!("compile_tmp_callback: void greenbox"),
         };
-        callargs.push(g_ref);
+        callargs_box.push(BoxRef::from_opref(g_ref));
     }
-    // Red args — inputargs occupy contiguous low OpRefs. Use
-    // `InputArg::opref()` so each typed inputarg keeps its
-    // resoperation.py:719/727/739 variant.
+    // Red args — bound to the inputarg objects themselves
+    // (resoperation.py:719/727/739 InputArg{Int,Float,Ref}).
     for ia in inputargs.iter() {
-        callargs.push(ia.opref());
+        callargs_box.push(BoxRef::from_bound_inputarg(ia));
     }
     //
     let portal_calldescr = jitdriver_sd
@@ -2443,8 +2456,11 @@ pub fn compile_tmp_callback(
     let call_opcode = OpCode::call_for_type(jitdriver_sd.result_type);
     // `compile.py:1132` `call_op = ResOperation(opnum, callargs,
     // descr=jd.portal_calldescr)`.
-    let callargs_box: Vec<BoxRef> = callargs.iter().map(|a| BoxRef::from_opref(*a)).collect();
-    let mut call_op = Op::with_descr(call_opcode, &callargs_box, portal_calldescr);
+    let call_op = std::rc::Rc::new(Op::with_descr(
+        call_opcode,
+        &callargs_box,
+        portal_calldescr,
+    ));
     //
     // `compile.py:1133-1136` `if call_op.type != 'v': finishargs = [call_op]
     // else: finishargs = []`.
@@ -2453,7 +2469,7 @@ pub fn compile_tmp_callback(
     // `OpRef::NONE` so dynasm/cranelift backends that only emit a store
     // when `op.pos != NONE` (e.g. `x86/assembler.rs` CALL handler) don't
     // produce a bogus result slot.
-    let finishargs: Vec<OpRef> = if jitdriver_sd.result_type == Type::Void {
+    let finishargs_box: Vec<BoxRef> = if jitdriver_sd.result_type == Type::Void {
         Vec::new()
     } else {
         // The CALL writes to the first free OpRef after inputargs.
@@ -2461,7 +2477,7 @@ pub fn compile_tmp_callback(
         // box of a typed CALL is a typed ResOp variant.
         let call_result_ref = OpRef::op_typed(num_inputs, jitdriver_sd.result_type);
         call_op.pos.set(call_result_ref);
-        vec![call_result_ref]
+        vec![BoxRef::from_bound_op(&call_op)]
     };
     //
     // `compile.py:1138-1144` operations = [call_op,
@@ -2470,12 +2486,12 @@ pub fn compile_tmp_callback(
     let mut guard_op = Op::with_descr(OpCode::GuardNoException, &[], propagate_exc_descr);
     // `compile.py:1144` `operations[1].setfailargs([])` — no fail args.
     guard_op.setfailargs(smallvec![]);
-    let finishargs_box: Vec<BoxRef> = finishargs.iter().map(|a| BoxRef::from_opref(*a)).collect();
     let finish_op = Op::with_descr(OpCode::Finish, &finishargs_box, portal_finishtoken);
-    let operations: Vec<majit_ir::OpRc> = vec![call_op, guard_op, finish_op]
-        .into_iter()
-        .map(std::rc::Rc::new)
-        .collect();
+    let operations: Vec<majit_ir::OpRc> = vec![
+        call_op,
+        std::rc::Rc::new(guard_op),
+        std::rc::Rc::new(finish_op),
+    ];
     //
     // `compile.py:1145` `operations = get_deep_immutable_oplist(operations)` —
     // pyre has no immutable-list transformation.
@@ -2486,8 +2502,12 @@ pub fn compile_tmp_callback(
     // variant (history.py:227/268/314), so the backend pool is left
     // empty for `compile_tmp_callback`.
     backend.set_constants_pool(majit_ir::VecAssoc::new());
+    // The backend boundary takes `&[InputArg]` by value (the flat OpRef
+    // encoding survives past this point); identity ends here.
+    let backend_inputargs: Vec<InputArg> =
+        inputargs.iter().map(|ia| ia.fresh_value_copy()).collect();
     backend.compile_loop(
-        &inputargs,
+        &backend_inputargs,
         &operations,
         Arc::get_mut(&mut jitcell_token)
             .expect("tmp callback JitCellToken must stay uniquely owned until backend compile"),

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -486,11 +486,45 @@ impl TreeLoop {
         }
         let new_inputargs_count = new_ia_boxes.len() as u32;
 
-        let new_inputargs: Vec<InputArg> = new_ia_types
+        let new_inputargs: Vec<majit_ir::InputArgRc> = new_ia_types
             .iter()
             .enumerate()
-            .map(|(i, &tp)| InputArg::from_type(tp, i as u32))
+            .map(|(i, &tp)| std::rc::Rc::new(InputArg::from_type(tp, i as u32)))
             .collect();
+
+        // Bind a remapped operand to its producer in the NEW namespace:
+        // ops re-emitted below appear in program order, so a consumer's
+        // producer Rc always exists by the time the consumer is built
+        // (history.py cut_trace_from re-emission keeps SSA order). NONE
+        // and Const positions carry their value inline.
+        let bind_remapped = |r: OpRef,
+                             producers: &[OpRc],
+                             inputargs: &[majit_ir::InputArgRc]|
+         -> BoxRef {
+            if r.is_none() || r.is_constant() {
+                return BoxRef::from_opref(r);
+            }
+            if matches!(
+                r,
+                OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+            ) {
+                match inputargs.get(r.raw() as usize) {
+                    Some(ia) => return BoxRef::from_bound_inputarg(ia),
+                    None => {
+                        debug_assert!(false, "cut-trace operand references missing inputarg {r:?}");
+                        return BoxRef::from_opref(r);
+                    }
+                }
+            }
+            let idx = (r.raw() - new_inputargs_count) as usize;
+            match producers.get(idx) {
+                Some(rc) => BoxRef::from_bound_op(rc),
+                None => {
+                    debug_assert!(false, "cut-trace operand references unbuilt producer {r:?}");
+                    BoxRef::from_opref(r)
+                }
+            }
+        };
 
         // Phase 5: Re-emit escaped ops as prefix, assigning fresh OpRefs.
         // Result type comes from the original op's opcode so the new OpRef
@@ -528,7 +562,7 @@ impl TreeLoop {
         };
 
         // Build prefix ops (re-emitted escaped definitions).
-        let mut prefix_ops: Vec<Op> = Vec::with_capacity(op_escaped.len());
+        let mut new_ops: Vec<OpRc> = Vec::with_capacity(op_escaped.len() + cut_ops.len());
         for (pi, &r) in op_escaped.iter().enumerate() {
             let op_idx = (r.raw() - num_original_inputargs) as usize;
             let orig_op = &self.ops[op_idx];
@@ -540,19 +574,21 @@ impl TreeLoop {
                 new_inputargs_count + pi as u32,
                 new_op.opcode.result_type(),
             ));
-            // optimizer.py:651-652 setarg loop parity.
+            // optimizer.py:651-652 setarg loop parity; operands bind to
+            // the new-namespace producers built so far.
             for i in 0..new_op.num_args() {
                 let arg = new_op.arg(i);
-                new_op.setarg(i, BoxRef::from_opref(remap_ref(&arg.to_opref())));
+                new_op.setarg(
+                    i,
+                    bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs),
+                );
             }
             // Prefix ops don't need fail_args (they're not guards).
             new_op.clearfailargs();
-            prefix_ops.push(new_op);
+            new_ops.push(std::rc::Rc::new(new_op));
         }
 
         // Phase 6: Remap post-cut ops.
-        let mut new_ops: Vec<Op> = Vec::with_capacity(prefix_ops.len() + cut_ops.len());
-        new_ops.extend(prefix_ops);
         for (i, op) in cut_ops.iter().enumerate() {
             // Deep-clone through the Rc: re-emitted post-cut ops carry
             // fresh identity in the new trace per history.py:cut_trace_from
@@ -565,7 +601,10 @@ impl TreeLoop {
             // optimizer.py:651-652 setarg loop parity.
             for j in 0..new_op.num_args() {
                 let arg = new_op.arg(j);
-                new_op.setarg(j, BoxRef::from_opref(remap_ref(&arg.to_opref())));
+                new_op.setarg(
+                    j,
+                    bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs),
+                );
             }
             if let Some(fa) = new_op.fail_args_mut() {
                 for arg in fa.iter_mut() {
@@ -580,7 +619,7 @@ impl TreeLoop {
                     )));
                 }
             }
-            new_ops.push(new_op);
+            new_ops.push(std::rc::Rc::new(new_op));
         }
 
         // opencoder.py parity: carry snapshots through cut_trace_from.
@@ -629,7 +668,7 @@ impl TreeLoop {
                 }
             })
             .collect();
-        TreeLoop::with_snapshots(new_inputargs, new_ops, remapped_snapshots)
+        TreeLoop::from_oprc(new_inputargs, new_ops, remapped_snapshots)
     }
 }
 

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -614,7 +614,7 @@ impl TreeLoop {
                     // later by store_final_boxes_in_guard. Rewrite kept as
                     // a release safety net.
                     debug_assert!(false, "cut-trace op carried fail_args: {:?}", new_op.opcode);
-                    *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(remap_ref(
+                    *arg = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(remap_ref(
                         &arg.to_opref(),
                     )));
                 }

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -202,13 +202,16 @@ pub struct TraceIterator<'a> {
     /// opencoder.py:252 self.trace
     pub trace: &'a [majit_ir::OpRc],
     /// opencoder.py:255 self._cache: per-iterator map from raw trace
-    /// position to fresh box (OpRef) materialized for this iteration.
-    /// In RPython this is `[None] * trace._index`; here `Vec<Option<OpRef>>`.
-    pub _cache: Vec<Option<OpRef>>,
+    /// position to the fresh box OBJECT materialized for this iteration.
+    /// In RPython this is `[None] * trace._index` holding the fresh
+    /// `cls()` ResOperation / `inputarg_from_tp` objects themselves;
+    /// here `Vec<Option<BoxRef>>` carrying the bound `Rc` handles.
+    pub _cache: Vec<Option<BoxRef>>,
     /// opencoder.py:259-262 self.inputargs: fresh inputarg boxes for this
-    /// iteration. Each is an `OpRef` allocated from the iterator's
-    /// `_fresh` counter at construction time.
-    pub inputargs: Vec<OpRef>,
+    /// iteration. Each is a freshly allocated `InputArg` object whose
+    /// position comes from the iterator's `_fresh` counter at
+    /// construction time (`rop.inputarg_from_tp(arg.type)`).
+    pub inputargs: Vec<majit_ir::InputArgRc>,
     /// opencoder.py:268 self.start
     pub start: usize,
     /// opencoder.py:269 self.pos
@@ -270,9 +273,9 @@ impl<'a> TraceIterator<'a> {
             .max()
             .unwrap_or(0);
         let cache_size = ((max_pos as usize) + 1).max(num_inputargs);
-        let mut _cache: Vec<Option<OpRef>> = vec![None; cache_size];
+        let mut _cache: Vec<Option<BoxRef>> = vec![None; cache_size];
         let mut _fresh = start_fresh;
-        let inputargs: Vec<OpRef>;
+        let inputargs: Vec<majit_ir::InputArgRc>;
         if let Some(force) = force_inputargs {
             // opencoder.py:259-262 self.inputargs =
             //     [rop.inputarg_from_tp(arg.type) for arg in force_inputargs]
@@ -291,7 +294,7 @@ impl<'a> TraceIterator<'a> {
                             arg
                         )
                     });
-                    let r = OpRef::input_arg_typed(_fresh, tp);
+                    let r = InputArg::from_type_rc(tp, _fresh);
                     _fresh += 1;
                     r
                 })
@@ -301,7 +304,7 @@ impl<'a> TraceIterator<'a> {
                 if p >= _cache.len() {
                     _cache.resize(p + 1, None);
                 }
-                _cache[p] = Some(inputargs[i]);
+                _cache[p] = Some(BoxRef::from_bound_inputarg(&inputargs[i]));
             }
         } else {
             // opencoder.py:264-267 self.inputargs =
@@ -311,13 +314,13 @@ impl<'a> TraceIterator<'a> {
             inputargs = inputarg_types
                 .iter()
                 .map(|&tp| {
-                    let r = OpRef::input_arg_typed(_fresh, tp);
+                    let r = InputArg::from_type_rc(tp, _fresh);
                     _fresh += 1;
                     r
                 })
                 .collect();
             for i in 0..num_inputargs {
-                _cache[i] = Some(inputargs[i]);
+                _cache[i] = Some(BoxRef::from_bound_inputarg(&inputargs[i]));
             }
         }
         TraceIterator {
@@ -335,8 +338,8 @@ impl<'a> TraceIterator<'a> {
     }
 
     /// opencoder.py:286-289 _get(self, i).
-    fn _get(&self, i: usize) -> OpRef {
-        match self._cache.get(i).copied().flatten() {
+    fn _get(&self, i: usize) -> BoxRef {
+        match self._cache.get(i).cloned().flatten() {
             Some(res) => res,
             None => panic!(
                 "TraceIterator._get cache miss at {i} (cache_len={}, pos={}, start={}, end={}, index={}, start_index={}, fresh={})",
@@ -361,10 +364,11 @@ impl<'a> TraceIterator<'a> {
     /// In RPython this dispatches on the tag (TAGBOX/TAGINT/TAGCONSTPTR/
     /// TAGCONSTOTHER). majit's OpRef carries the tag implicitly: constants
     /// have `OpRef >= CONST_BASE`, NONE is `u32::MAX`. Both pass through
-    /// unchanged; only TAGBOX-equivalent OpRefs go through `_get`.
-    fn _untag(&self, opref: OpRef) -> OpRef {
+    /// unchanged (value-inline const box); only TAGBOX-equivalent OpRefs
+    /// go through `_get`, which returns the cached fresh box object.
+    fn _untag(&self, opref: OpRef) -> BoxRef {
         if opref.is_none() || opref.is_constant() {
-            opref
+            BoxRef::from_opref(opref)
         } else {
             self._get(opref.raw() as usize)
         }
@@ -383,15 +387,24 @@ impl<'a> TraceIterator<'a> {
     /// trace position (which is monotonic for non-void ops in a
     /// well-formed trace), so `_index - 1` lands on the same cache slot
     /// the previous `next()` call wrote.
-    pub fn replace_last_cached(&mut self, oldbox: OpRef, new_box: OpRef) {
+    pub fn replace_last_cached(&mut self, oldbox: OpRef, new_box: BoxRef) {
         let last_idx = (self._index - 1) as usize;
-        debug_assert_eq!(self._cache[last_idx], Some(oldbox));
+        // opencoder.py:283 `assert self._cache[self._index - 1] is oldbox`
+        // — checked by encoding here since callers identify the old box
+        // by its OpRef.
+        debug_assert_eq!(
+            self._cache[last_idx].as_ref().map(|b| b.to_opref()),
+            Some(oldbox)
+        );
         self._cache[last_idx] = Some(new_box);
     }
 
     /// opencoder.py:362-406 next() — produce the next operation as a fresh
-    /// box (`cls()` in RPython) with translated args.
-    pub fn next(&mut self) -> Option<majit_ir::Op> {
+    /// box (`cls()` in RPython) with translated args. The returned `OpRc`
+    /// IS the cached box object: a later arg referencing this op's raw
+    /// trace position resolves (via `_untag` → `_get`) to a clone of the
+    /// same `Rc` handle, matching RPython's `_cache[i] is res` identity.
+    pub fn next(&mut self) -> Option<majit_ir::OpRc> {
         if self.done() {
             return None;
         }
@@ -401,13 +414,11 @@ impl<'a> TraceIterator<'a> {
         // opencoder.py:379-387: for i in range(argnum):
         //     res.setarg(i, self._untag(self._next()))
         for i in 0..res.num_args() {
-            res.setarg(i, BoxRef::from_opref(self._untag(res.arg(i).to_opref())));
+            res.setarg(i, self._untag(res.arg(i).to_opref()));
         }
         if let Some(fa) = res.fail_args_mut() {
             for arg in fa.iter_mut() {
-                *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(
-                    self._untag(arg.to_opref()),
-                ));
+                *arg = majit_ir::operand::Operand::Box(self._untag(arg.to_opref()));
             }
         }
         // RPython opencoder.py:399-401:
@@ -429,6 +440,7 @@ impl<'a> TraceIterator<'a> {
         // monotonic `op_count`).
         let is_void_result =
             src.pos.get().is_none() || src.opcode.result_type() == majit_ir::Type::Void;
+        let mut cache_slot: Option<usize> = None;
         if !is_void_result {
             let orig = src.pos.get().raw() as usize;
             if orig >= self._cache.len() {
@@ -444,8 +456,8 @@ impl<'a> TraceIterator<'a> {
             // `opcode.result_type()`.
             let fresh = OpRef::op_typed(self._fresh, src.opcode.result_type());
             self._fresh += 1;
-            self._cache[orig] = Some(fresh);
             res.pos.set(fresh);
+            cache_slot = Some(orig);
             // RPython `_index` parity: advance past the cache slot we
             // just wrote. In RPython this happens via `_index += 1`
             // because `_index` == cache slot index; in majit the cache
@@ -465,6 +477,13 @@ impl<'a> TraceIterator<'a> {
             res.pos.set(f);
         } else {
             res.pos.set(src.pos.get());
+        }
+        let res = std::rc::Rc::new(res);
+        // opencoder.py:400-401 `self._cache[self._index] = res` — cache
+        // the fresh op OBJECT itself so later references resolve to the
+        // same identity.
+        if let Some(orig) = cache_slot {
+            self._cache[orig] = Some(BoxRef::from_bound_op(&res));
         }
         // self._count += 1
         self._count += 1;
@@ -2837,6 +2856,17 @@ mod tests {
         op
     }
 
+    /// Helper: project the iterator's fresh inputarg objects onto their
+    /// OpRef encodings for positional assertions.
+    fn inputarg_oprefs(iter: &TraceIterator<'_>) -> Vec<OpRef> {
+        iter.inputargs.iter().map(|ia| ia.opref()).collect()
+    }
+
+    /// Helper: project a `_cache` slot onto its OpRef encoding.
+    fn cache_opref(iter: &TraceIterator<'_>, i: usize) -> Option<OpRef> {
+        iter._cache[i].as_ref().map(|b| b.to_opref())
+    }
+
     #[test]
     fn test_trace_iterator_next_basic() {
         // opencoder.py:362-406 TraceIterator.next() parity:
@@ -2855,9 +2885,9 @@ mod tests {
         // as InputArgInt(0..2), op results follow as BoxInt(2..).
         let ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         let mut iter = TraceIterator::new(&ops, 0, ops.len(), None, &inputarg_types, 0);
-        assert_eq!(iter.inputargs, vec![iarg(0), iarg(1)]);
-        assert_eq!(iter._cache[0], Some(iarg(0)));
-        assert_eq!(iter._cache[1], Some(iarg(1)));
+        assert_eq!(inputarg_oprefs(&iter), vec![iarg(0), iarg(1)]);
+        assert_eq!(cache_opref(&iter, 0), Some(iarg(0)));
+        assert_eq!(cache_opref(&iter, 1), Some(iarg(1)));
 
         // First IntAdd: result at fresh BoxInt(2), args translated via cache.
         let r1 = iter.next().unwrap();
@@ -2915,7 +2945,7 @@ mod tests {
         while let Some(op) = p2.next() {
             p2_ops.push(op);
         }
-        assert_eq!(p2.inputargs, vec![iarg(4), iarg(5)]);
+        assert_eq!(inputarg_oprefs(&p2), vec![iarg(4), iarg(5)]);
         assert_eq!(p2_ops[0].pos.get(), iop(6));
         assert_eq!(p2_ops[0].arg(0).to_opref(), iarg(4));
         assert_eq!(p2_ops[0].arg(1).to_opref(), iarg(5));
@@ -2981,8 +3011,8 @@ mod tests {
         // replace_last_cached(oldbox=BoxInt(101), new_box=BoxInt(999))
         // must target _cache[_index - 1] = _cache[1], where the last
         // write placed BoxInt(101).
-        iter.replace_last_cached(iop(101), iop(999));
-        assert_eq!(iter._cache[1], Some(iop(999)));
+        iter.replace_last_cached(iop(101), BoxRef::from_opref(iop(999)));
+        assert_eq!(cache_opref(&iter, 1), Some(iop(999)));
 
         // The next op references raw pos 1 as its first arg, so the
         // replaced value should flow through _untag → _get.
@@ -3036,10 +3066,10 @@ mod tests {
         let mut iter = TraceIterator::new(&ops, 0, ops.len(), None, &inputarg_types, 100);
 
         assert_eq!(
-            iter.inputargs,
+            inputarg_oprefs(&iter),
             vec![rarg(100), rarg(101), iarg(102), iarg(103)]
         );
-        assert_eq!(iter._cache[1], Some(rarg(101)));
+        assert_eq!(cache_opref(&iter, 1), Some(rarg(101)));
 
         let op0 = iter.next().unwrap();
         assert_eq!(op0.pos.get(), iop(104));
@@ -3060,7 +3090,7 @@ mod tests {
             vec![iop(104), rarg(101)]
         );
         assert_eq!(op1.pos.get(), rop(105));
-        assert_eq!(iter._cache[1], Some(rop(105)));
+        assert_eq!(cache_opref(&iter, 1), Some(rop(105)));
 
         let finish = iter.next().unwrap();
         assert_eq!(

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -418,7 +418,7 @@ impl<'a> TraceIterator<'a> {
         }
         if let Some(fa) = res.fail_args_mut() {
             for arg in fa.iter_mut() {
-                *arg = majit_ir::operand::Operand::Box(self._untag(arg.to_opref()));
+                *arg = majit_ir::operand::Operand::from_boxref(&self._untag(arg.to_opref()));
             }
         }
         // RPython opencoder.py:399-401:

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3824,7 +3824,7 @@ mod tests {
             &[object, resolved],
             &[BoxRef::from_opref(object), BoxRef::from_opref(resolved)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
-                op: preamble_op.clone(),
+                op: std::rc::Rc::new(preamble_op.clone()),
                 res: BoxRef::from_opref(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3822,7 +3822,7 @@ mod tests {
         preamble_op.pos.set(source);
         ctx.initialize_imported_short_preamble_builder(
             &[object, resolved],
-            &[object, resolved],
+            &[BoxRef::from_opref(object), BoxRef::from_opref(resolved)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: preamble_op.clone(),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3825,6 +3825,7 @@ mod tests {
             &[BoxRef::from_opref(object), BoxRef::from_opref(resolved)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: preamble_op.clone(),
+                res: BoxRef::from_opref(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),
                 invented_name: false,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2716,10 +2716,15 @@ impl OptContext {
             exported_short_boxes
                 .iter()
                 .map(|entry| {
+                    // `materialize_box_at`, not `from_bound_op`: a
+                    // const-folded entry carries an inline-Const pos,
+                    // which resolves to its Const box.
+                    let res = self.materialize_box_at(entry.op.pos.get());
                     (
                         entry.op.pos.get(),
                         crate::optimizeopt::shortpreamble::ProducedShortOp {
                             kind: entry.kind.clone(),
+                            res,
                             preamble_op: std::rc::Rc::new(entry.op.clone()),
                             invented_name: entry.invented_name,
                             same_as_source: entry.same_as_source.clone(),
@@ -2939,8 +2944,10 @@ impl OptContext {
                     if let Some(d) = produced_op.preamble_op.getdescr() {
                         op.setdescr(d);
                     }
+                    let res = self.materialize_box_at(op.pos.get());
                     let new_pop = ProducedShortOp {
                         kind: PreambleOpKind::Pure,
+                        res,
                         preamble_op: std::rc::Rc::new(op),
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),
@@ -2977,8 +2984,10 @@ impl OptContext {
                             let mut op = Op::new(opcode, &[self.materialize_box_at(obj)]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
+                            let res = self.materialize_box_at(op.pos.get());
                             ProducedShortOp {
                                 kind: PreambleOpKind::Heap,
+                                res,
                                 preamble_op: std::rc::Rc::new(op),
                                 invented_name: produced_op.invented_name,
                                 same_as_source: produced_op.same_as_source.clone(),
@@ -3015,8 +3024,10 @@ impl OptContext {
                             let mut op = Op::new(opcode, &[obj_b, index_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
+                            let res = self.materialize_box_at(op.pos.get());
                             ProducedShortOp {
                                 kind: PreambleOpKind::Heap,
+                                res,
                                 preamble_op: std::rc::Rc::new(op),
                                 invented_name: produced_op.invented_name,
                                 same_as_source: produced_op.same_as_source.clone(),
@@ -3052,8 +3063,10 @@ impl OptContext {
                         &[self.materialize_box_at(func_opref)],
                     );
                     op.pos.set(replay_pos(*source, produced_op));
+                    let res = self.materialize_box_at(op.pos.get());
                     let new_pop = ProducedShortOp {
                         kind: PreambleOpKind::LoopInvariant,
+                        res,
                         preamble_op: std::rc::Rc::new(op),
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2725,7 +2725,7 @@ impl OptContext {
                         crate::optimizeopt::shortpreamble::ProducedShortOp {
                             kind: entry.kind.clone(),
                             res,
-                            preamble_op: std::rc::Rc::new(entry.op.clone()),
+                            preamble_op: std::rc::Rc::new((*entry.op).clone()),
                             invented_name: entry.invented_name,
                             same_as_source: entry.same_as_source.clone(),
                         },

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -655,13 +655,13 @@ pub struct OptContext {
     /// the exported loop-header inputargs.
     pub exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
     /// unroll.py:480 `short_inputargs = sb.create_short_inputargs(label_args
-    /// + virtuals)` — the ShortBoxes-derived short-preamble inputargs,
-    /// carried from the preview pass (optimizer.rs, where the ShortBoxes
-    /// object lives) to `export_state_with_bounds` through the same channel
-    /// as `exported_short_boxes`. Position projection of the renamed
-    /// inputarg boxes; equals the export-site `label_args + virtuals`
-    /// recompute (measured identical across the corpus, 2026-06-11).
-    pub exported_short_inputargs: Vec<OpRef>,
+    /// + virtuals)` — the ShortBoxes-stored renamed inputarg boxes
+    /// themselves, carried from the preview pass (optimizer.rs, where the
+    /// ShortBoxes object lives) to `export_state_with_bounds` through the
+    /// same channel as `exported_short_boxes`. Position projection equals
+    /// the export-site `label_args + virtuals` recompute (measured
+    /// identical across the corpus, 2026-06-11).
+    pub exported_short_inputargs: Vec<crate::r#box::BoxRef>,
     /// optimizer.py: `can_replace_guards` — disable guard replacement during
     /// bridge compilation. Defaults to true for preamble.
     pub can_replace_guards: bool,
@@ -2709,7 +2709,7 @@ impl OptContext {
     pub fn initialize_imported_short_preamble_builder(
         &mut self,
         label_args: &[OpRef],
-        short_inputargs: &[OpRef],
+        short_inputargs: &[crate::r#box::BoxRef],
         exported_short_boxes: &[crate::optimizeopt::shortpreamble::PreambleOp],
     ) {
         let produced: Vec<(OpRef, crate::optimizeopt::shortpreamble::ProducedShortOp)> =
@@ -2758,7 +2758,7 @@ impl OptContext {
     pub fn initialize_imported_short_preamble_builder_from_short_boxes(
         &mut self,
         short_args: &[OpRef],
-        short_inputargs: &[OpRef],
+        short_inputargs: &[crate::r#box::BoxRef],
         short_boxes: &[(OpRef, crate::optimizeopt::shortpreamble::ProducedShortOp)],
         short_box_const_values: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::Value>,
         result_map: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
@@ -9943,7 +9943,10 @@ mod imported_short_preamble_fallback_tests {
             OptContext::with_inputarg_types(16, &[majit_ir::Type::Ref, majit_ir::Type::Ref]);
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
-            &[OpRef::int_op(7), OpRef::int_op(8)],
+            &[
+                crate::r#box::BoxRef::from_opref(OpRef::int_op(7)),
+                crate::r#box::BoxRef::from_opref(OpRef::int_op(8)),
+            ],
             &[],
         );
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -646,6 +646,17 @@ pub struct OptContext {
     /// PreambleOp)` with linear-scan insert/pop/contains. The pool stays
     /// small per trace (one entry per imported pure short-preamble op),
     /// so O(n) operations are acceptable.
+    ///
+    /// The key stays the box's `OpRef` position rather than PyPy's box
+    /// identity (`unroll.py:37` keys by the box object). This is a
+    /// PRE-EXISTING-ADAPTATION beyond the Vec-vs-dict shape: the insert key
+    /// is the Phase-1 preamble source box (`force_op_from_preamble_op`,
+    /// `preamble_op.op`) while the `force_box` pop key is the Phase-2 body
+    /// box resolved to a position (`get_replacement_opref`) — two distinct
+    /// `Rc`s sharing one position across the peel boundary. A `BoxRef`
+    /// `Rc::ptr_eq` key would silent-miss the pop. Re-keying to box identity
+    /// is gated on the same short-preamble / InputArg identity unification
+    /// that defers `resolve_box_box`'s InputArg arm (#9/S9).
     pub(crate) potential_extra_ops: Vec<(OpRef, crate::optimizeopt::info::PreambleOp)>,
     /// RPython unroll.py: live ExtendedShortPreambleBuilder while replaying an
     /// existing target token's short preamble.

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2909,6 +2909,29 @@ impl OptContext {
                     crate::optimizeopt::ImportedShortPureArg::Const(_, r) => r,
                 })
             };
+        // shortpreamble.py:283-296 produce_arg object-carry: a dependency
+        // arg is the dep's replay op OBJECT (upstream returns
+        // `produced_short_boxes[op].preamble_op`). Bind dep args to the
+        // dep entry's replay Rc (the same dual-key dict the builder will
+        // hold — last insert wins, matching VecAssoc overwrite), so
+        // `use_box` reads deps off the operand binding instead of a
+        // position-keyed side map. Slot / Const args keep the positional
+        // materialization.
+        let dep_or_materialize =
+            |ctx: &mut Self, produced: &[(OpRef, ProducedShortOp)], r: OpRef| {
+                // shortpreamble.py:288 Const arm: the arg is the Const box
+                // itself — a const-folded entry carries an inline-Const
+                // pos/key, which must not bind to the replay op.
+                if r.is_constant() {
+                    return ctx.materialize_box_at(r);
+                }
+                produced
+                    .iter()
+                    .rev()
+                    .find(|(k, _)| *k == r)
+                    .map(|(_, dep)| crate::r#box::BoxRef::from_bound_op(&dep.preamble_op))
+                    .unwrap_or_else(|| ctx.materialize_box_at(r))
+            };
 
         for (source, produced_op) in short_boxes {
             // Some ProducedShortOps (PreambleOpKind::Heap with non-getfield /
@@ -2934,7 +2957,7 @@ impl OptContext {
                     }
                     let resolved_arg_boxes: Vec<crate::r#box::BoxRef> = resolved_args
                         .iter()
-                        .map(|a| self.materialize_box_at(*a))
+                        .map(|a| dep_or_materialize(self, &produced, *a))
                         .collect();
                     let mut op = Op::new(
                         pure_call_opcode(produced_op.preamble_op.opcode),
@@ -2981,7 +3004,8 @@ impl OptContext {
                                 majit_ir::Type::Float => OpCode::GetfieldGcF,
                                 majit_ir::Type::Void => return false,
                             };
-                            let mut op = Op::new(opcode, &[self.materialize_box_at(obj)]);
+                            let obj_b = dep_or_materialize(self, &produced, obj);
+                            let mut op = Op::new(opcode, &[obj_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             let res = self.materialize_box_at(op.pos.get());
@@ -3019,8 +3043,8 @@ impl OptContext {
                                 Some(r) => r,
                                 None => return false,
                             };
-                            let obj_b = self.materialize_box_at(obj);
-                            let index_b = self.materialize_box_at(index_opref);
+                            let obj_b = dep_or_materialize(self, &produced, obj);
+                            let index_b = dep_or_materialize(self, &produced, index_opref);
                             let mut op = Op::new(opcode, &[obj_b, index_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
@@ -3058,10 +3082,8 @@ impl OptContext {
                     {
                         return false;
                     }
-                    let mut op = Op::new(
-                        loop_invariant_opcode(result_type),
-                        &[self.materialize_box_at(func_opref)],
-                    );
+                    let func_b = dep_or_materialize(self, &produced, func_opref);
+                    let mut op = Op::new(loop_invariant_opcode(result_type), &[func_b]);
                     op.pos.set(replay_pos(*source, produced_op));
                     let res = self.materialize_box_at(op.pos.get());
                     let new_pop = ProducedShortOp {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2861,16 +2861,20 @@ impl Optimizer {
                     preamble_op.pos.set(canonical_result);
                     // optimizer.py:651-652 force_box loop parity.
                     //
-                    // Resolve POSITIONALLY (get_box_replacement on the
-                    // encoded position), not through the operand's bound
-                    // object: replay-op args carry the dep replay handle
-                    // (produce_arg, shortpreamble.py:285) whose forwarded
-                    // slot is empty — only the body producer registered at
-                    // the same position carries the Phase-1 forwarding to
-                    // the canonical end box this export boundary needs.
-                    // (A dep handle bound to an already-rewritten sibling
-                    // resolves to the same canonical box either way —
-                    // get_box_replacement is idempotent on canonicals.)
+                    // Resolve POSITIONALLY when a producer is registered at
+                    // this slot: replay-op args carry the dep replay handle
+                    // (produce_arg, shortpreamble.py:285) whose forwarded slot
+                    // is empty, so only the body producer registered at the
+                    // same position carries the Phase-1 forwarding to the
+                    // canonical end box this export boundary needs.
+                    //
+                    // When positional resolution finds NO producer, the carried
+                    // handle is unforwarded and resolves to itself
+                    // (resoperation.py:57-68): keep the handle OBJECT instead of
+                    // re-minting a producer-less position-only box, so its
+                    // identity (and the `Operand::Op`/`InputArg` shed) survives
+                    // the export. The encoded OpRef is identical either way
+                    // (`from_opref(arg.to_opref()) == arg.to_opref()`).
                     for i in 0..preamble_op.num_args() {
                         let arg = preamble_op.arg(i);
                         // The `OpRef::none()` sentinel has no producer box
@@ -2880,7 +2884,10 @@ impl Optimizer {
                         if arg.is_none() {
                             continue;
                         }
-                        preamble_op.setarg(i, ctx.get_box_replacement(arg.to_opref()));
+                        let resolved = ctx
+                            .get_box_replacement_box(arg.to_opref())
+                            .unwrap_or_else(|| arg.clone());
+                        preamble_op.setarg(i, resolved);
                     }
                     if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
                         for arg in fail_args.iter_mut() {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3194,9 +3194,9 @@ impl Optimizer {
                                     false,
                                     "position-only failarg hit const-compact remap: {arg_opref:?}"
                                 );
-                                *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(
-                                    arg_opref.with_raw(new_pos),
-                                ));
+                                *arg = majit_ir::operand::Operand::from_boxref(
+                                    &BoxRef::from_opref(arg_opref.with_raw(new_pos)),
+                                );
                             }
                         }
                     }
@@ -3303,7 +3303,9 @@ impl Optimizer {
                                 arg_opref == pre,
                                 "position-only exported-short-box failarg remapped: {pre:?}"
                             );
-                            *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(arg_opref));
+                            *arg = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(
+                                arg_opref,
+                            ));
                         }
                     }
                     // same_as_source: same rule as res below — the stored

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1908,6 +1908,9 @@ impl Optimizer {
         let ops_rc: Vec<majit_ir::OpRc> =
             ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
         self.run_optimize_from_inputs(&ops_rc, constants, num_inputs, false)
+            .into_iter()
+            .map(|rc| (*rc).clone())
+            .collect()
     }
 
     /// `OpRc`-threading entry for callers that hold the canonical
@@ -1921,17 +1924,17 @@ impl Optimizer {
         ops: &[majit_ir::OpRc],
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
-    ) -> Vec<Op> {
+    ) -> Vec<majit_ir::OpRc> {
         self.run_optimize_from_inputs(ops, constants, num_inputs, true)
     }
 
-    fn run_optimize_from_inputs(
+    pub(crate) fn run_optimize_from_inputs(
         &mut self,
         ops: &[majit_ir::OpRc],
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
         input_ops_from_ops: bool,
-    ) -> Vec<Op> {
+    ) -> Vec<majit_ir::OpRc> {
         // Ensure new ops get positions beyond all original trace positions.
         // Original ops keep their tracer-assigned positions; new ops (constants,
         // force materializations) must not collide with them.
@@ -1969,7 +1972,7 @@ impl Optimizer {
         inputarg_base: u32,
         start_next_pos: u32,
         input_ops_from_ops: bool,
-    ) -> Vec<Op> {
+    ) -> Vec<majit_ir::OpRc> {
         use majit_ir::OpRef;
         // Test-only auto-seed of `trace_inputargs` from the variant
         // tags of any InputArg*/IntOp/FloatOp/RefOp OpRef that references
@@ -3392,7 +3395,7 @@ impl Optimizer {
             }
         }
         self.final_ctx = Some(ctx);
-        ops.into_iter().map(|rc| (*rc).clone()).collect()
+        ops
     }
 
     /// unroll.py:183-236: optimize_bridge()
@@ -3411,7 +3414,7 @@ impl Optimizer {
     /// optimizer's exported_loop_state for the new target token.
     pub(crate) fn optimize_bridge(
         &mut self,
-        ops: &[Op],
+        ops: &[majit_ir::OpRc],
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
         front_target_tokens: &mut Vec<crate::optimizeopt::unroll::TargetToken>,
@@ -3433,7 +3436,7 @@ impl Optimizer {
         // base into `optimize_with_constants_and_inputs_at` so step 3
         // seeds inputarg types at the shifted slots.
         bridge_inputarg_base: u32,
-    ) -> (Vec<Op>, bool) {
+    ) -> (Vec<majit_ir::OpRc>, bool) {
         // bridgeopt.py:124-185: deserialize_optimizer_knowledge
         // Store as pending — setup() inside optimize_with_constants_and_inputs
         // clears pass state, so we apply AFTER setup.
@@ -3471,15 +3474,13 @@ impl Optimizer {
             .map(|p| p + 1)
             .unwrap_or(bridge_inputarg_base + num_inputs as u32)
             .max(bridge_inputarg_base + num_inputs as u32);
-        let ops_rc: Vec<majit_ir::OpRc> =
-            ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
         // Bridge ops are a fresh `TraceIterator`'s planted UNBOUND resop slots
         // (`bind_input_resops` binds them later, after `input_ops` is built),
         // so the input-ops seed is empty; producer lookup runs off `resop_refs`
         // (populated by `bind_input_resops`).
         self.explicit_input_ops_seed = Some(Vec::new());
         let optimized_ops = self.optimize_with_constants_and_inputs_at(
-            &ops_rc,
+            ops,
             constants,
             num_inputs,
             bridge_inputarg_base,
@@ -3538,7 +3539,7 @@ impl Optimizer {
                 );
                 self.send_extra_operation(&jump_op, &mut ctx);
                 let mut result = optimized_ops;
-                result.extend(ctx.new_operations.drain(..).map(|rc| (*rc).clone()));
+                result.extend(ctx.new_operations.drain(..));
                 return (result, false);
             }
             return (optimized_ops, false);
@@ -3614,7 +3615,7 @@ impl Optimizer {
                     );
                     self.send_extra_operation(&jump_op, &mut ctx);
                     let mut result = optimized_ops;
-                    result.extend(ctx.new_operations.drain(..).map(|rc| (*rc).clone()));
+                    result.extend(ctx.new_operations.drain(..));
                     return (result, false);
                 }
                 return (optimized_ops, false);
@@ -3624,7 +3625,7 @@ impl Optimizer {
         // unroll.py:212-213: vs is None → matched, JUMP redirected
         if vs.is_none() {
             let mut result = optimized_ops;
-            result.extend(ctx.new_operations.drain(..).map(|rc| (*rc).clone()));
+            result.extend(ctx.new_operations.drain(..));
             return (result, false);
         }
 
@@ -3674,7 +3675,7 @@ impl Optimizer {
         // unroll.py:226-227: vs is None → matched with forced boxes
         if vs2.is_none() {
             let mut result = optimized_ops;
-            result.extend(ctx.new_operations.drain(..).map(|rc| (*rc).clone()));
+            result.extend(ctx.new_operations.drain(..));
             return (result, false);
         }
 
@@ -3697,7 +3698,7 @@ impl Optimizer {
             );
             self.send_extra_operation(&jump_op, &mut ctx);
             let mut result = optimized_ops;
-            result.extend(ctx.new_operations.drain(..).map(|rc| (*rc).clone()));
+            result.extend(ctx.new_operations.drain(..));
             (result, false)
         } else {
             (optimized_ops, false)

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2872,11 +2872,21 @@ impl Optimizer {
                     // resolves to the same canonical box either way —
                     // get_box_replacement is idempotent on canonicals.)
                     for i in 0..preamble_op.num_args() {
-                        let arg = preamble_op.arg(i).to_opref();
-                        preamble_op.setarg(i, ctx.get_box_replacement(arg));
+                        let arg = preamble_op.arg(i);
+                        // The `OpRef::none()` sentinel has no producer box
+                        // (`materialize_box_at` doc) — routing it through the
+                        // producer lookup is meaningless and trips the
+                        // `get_box_replacement` "box must exist" debug tripwire.
+                        if arg.is_none() {
+                            continue;
+                        }
+                        preamble_op.setarg(i, ctx.get_box_replacement(arg.to_opref()));
                     }
                     if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
                         for arg in fail_args.iter_mut() {
+                            if arg.is_none() {
+                                continue;
+                            }
                             *arg = majit_ir::operand::Operand::from_boxref(
                                 &ctx.get_box_replacement(arg.to_opref()),
                             );

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3274,10 +3274,18 @@ impl Optimizer {
                             *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(arg_opref));
                         }
                     }
-                    if let Some(ref mut src) = entry.same_as_source {
-                        let mut src_opref = src.to_opref();
-                        remap_opref(&mut src_opref);
-                        *src = BoxRef::from_opref(src_opref);
+                    // same_as_source: same rule as res below — the stored
+                    // box object is shared with the preview ProducedShortOp,
+                    // so rewrite its position Cell in place instead of
+                    // replacing it with a fresh position-only mint.
+                    if let Some(ref src) = entry.same_as_source {
+                        if let Some(op) = src.bound_op() {
+                            src.set_position(op.pos.get().raw());
+                        } else {
+                            let mut src_opref = src.to_opref();
+                            remap_opref(&mut src_opref);
+                            src.set_position(src_opref.raw());
+                        }
                     }
                     // res: a bound box live-tracks its producer through the
                     // op handle — the producer's `Op.pos` was already

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2827,13 +2827,30 @@ impl Optimizer {
             // `exported_short_boxes` below).
             ctx.exported_short_inputargs =
                 short_boxes.create_short_inputargs(&preview_short_args);
+            // Single-object carry: each exported entry keeps the preview
+            // ProducedShortOp's replay Rc, so the pos/arg canonicalization
+            // below lands on the object that dep-replay operands reference
+            // (upstream exports the ResOperation objects themselves,
+            // unroll.py:478-487). The per-entry rewrites require each entry
+            // to own a distinct Rc.
+            #[cfg(debug_assertions)]
+            {
+                let mut seen: Vec<*const majit_ir::Op> = Vec::with_capacity(produced.len());
+                for (_, p) in &produced {
+                    let ptr = std::rc::Rc::as_ptr(&p.preamble_op);
+                    debug_assert!(
+                        !seen.contains(&ptr),
+                        "exported short boxes share a replay OpRc at {:?}",
+                        p.preamble_op.pos.get()
+                    );
+                    seen.push(ptr);
+                }
+            }
             ctx.exported_short_boxes = produced
                 .into_iter()
                 .map(|(result, produced)| {
                     let canonical_result = ctx.get_replacement_opref(result);
-                    // Deep-clone: dual map entries share the replay OpRc;
-                    // the pos/arg rewrites below must stay per-entry.
-                    let mut preamble_op = (*produced.preamble_op).clone();
+                    let preamble_op = produced.preamble_op.clone();
                     // RPython parity: key and preamble_op.pos must be the
                     // same resolved value. Independent get_box_replacement
                     // calls can diverge when forwarding chains differ.
@@ -2848,12 +2865,15 @@ impl Optimizer {
                     // slot is empty — only the body producer registered at
                     // the same position carries the Phase-1 forwarding to
                     // the canonical end box this export boundary needs.
+                    // (A dep handle bound to an already-rewritten sibling
+                    // resolves to the same canonical box either way —
+                    // get_box_replacement is idempotent on canonicals.)
                     for i in 0..preamble_op.num_args() {
                         let arg = preamble_op.arg(i).to_opref();
                         preamble_op.setarg(i, ctx.get_box_replacement(arg));
                     }
-                    if let Some(fail_args) = preamble_op.fail_args_mut() {
-                        for arg in fail_args {
+                    if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
+                        for arg in fail_args.iter_mut() {
                             *arg = majit_ir::operand::Operand::from_boxref(
                                 &ctx.get_box_replacement(arg.to_opref()),
                             );
@@ -3264,7 +3284,7 @@ impl Optimizer {
                         );
                         entry.op.setarg(i, BoxRef::from_opref(arg));
                     }
-                    if let Some(fa) = entry.op.fail_args_mut() {
+                    if let Some(fa) = entry.op.fail_args.borrow_mut().as_mut() {
                         for arg in fa.iter_mut() {
                             // Bound failargs live-track the producer's
                             // already-remapped pos (same rule as the args
@@ -6271,7 +6291,7 @@ mod tests {
             &[OpRef::int_op(0)],
             &[BoxRef::from_opref(OpRef::int_op(0))],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
-                op: preamble_op.clone(),
+                op: std::rc::Rc::new(preamble_op.clone()),
                 res: BoxRef::from_opref(OpRef::int_op(14)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2825,11 +2825,8 @@ impl Optimizer {
             // label_args + virtuals)` — read off the ShortBoxes object and
             // carry to export_state through the ctx channel (sibling of
             // `exported_short_boxes` below).
-            ctx.exported_short_inputargs = short_boxes
-                .create_short_inputargs(&preview_short_args)
-                .iter()
-                .map(|b| b.to_opref())
-                .collect();
+            ctx.exported_short_inputargs =
+                short_boxes.create_short_inputargs(&preview_short_args);
             ctx.exported_short_boxes = produced
                 .into_iter()
                 .map(|(result, produced)| {
@@ -3200,8 +3197,14 @@ impl Optimizer {
                 for arg in &mut state.renamed_inputargs {
                     remap_opref(arg);
                 }
-                for arg in &mut state.short_inputargs {
-                    remap_opref(arg);
+                for arg in &state.short_inputargs {
+                    // Renamed-box positions track op compaction through the
+                    // shared `set_position` Cell (no-op for InputArg/Const
+                    // kinds, whose positions are not subject to compaction);
+                    // every holder of the same box object sees the update.
+                    let mut opref = arg.to_opref();
+                    remap_opref(&mut opref);
+                    arg.set_position(opref.raw());
                 }
                 // Remap exported_infos keys (Const keys pass through)
                 let old_infos = std::mem::take(&mut state.exported_infos);
@@ -6231,7 +6234,7 @@ mod tests {
         ctx.make_constant(OpRef::int_op(10_000), majit_ir::Value::Int(0));
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::int_op(0)],
-            &[OpRef::int_op(0)],
+            &[BoxRef::from_opref(OpRef::int_op(0))],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: preamble_op.clone(),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2840,8 +2840,17 @@ impl Optimizer {
                     // Use canonical_result (resolved key) for both.
                     preamble_op.pos.set(canonical_result);
                     // optimizer.py:651-652 force_box loop parity.
+                    //
+                    // Resolve POSITIONALLY (get_box_replacement on the
+                    // encoded position), not through the operand's bound
+                    // object: replay-op args carry the dep replay handle
+                    // (produce_arg, shortpreamble.py:285) whose forwarded
+                    // slot is empty — only the body producer registered at
+                    // the same position carries the Phase-1 forwarding to
+                    // the canonical end box this export boundary needs.
                     for i in 0..preamble_op.num_args() {
-                        preamble_op.setarg(i, ctx.resolve_box_box(&preamble_op.arg(i)));
+                        let arg = preamble_op.arg(i).to_opref();
+                        preamble_op.setarg(i, ctx.get_box_replacement(arg));
                     }
                     if let Some(fail_args) = preamble_op.fail_args_mut() {
                         for arg in fail_args {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2852,6 +2852,11 @@ impl Optimizer {
                     }
                     crate::optimizeopt::shortpreamble::PreambleOp {
                         op: preamble_op,
+                        // short_op.res travels with the entry — the SAME
+                        // box object the preview ProducedShortOp carries,
+                        // so the export/re-import round trip preserves
+                        // upstream Box identity.
+                        res: produced.res.clone(),
                         kind: produced.kind,
                         label_arg_idx: short_boxes.lookup_label_arg(canonical_result),
                         invented_name: produced.invented_name,
@@ -3273,6 +3278,19 @@ impl Optimizer {
                         let mut src_opref = src.to_opref();
                         remap_opref(&mut src_opref);
                         *src = BoxRef::from_opref(src_opref);
+                    }
+                    // res: a bound box live-tracks its producer through the
+                    // op handle — the producer's `Op.pos` was already
+                    // remapped above, so refreshing the position Cell from
+                    // it is idempotent (no double-map). Position-only mints
+                    // (test fixtures) go through the remap table instead;
+                    // `set_position` is a no-op for InputArg/Const kinds.
+                    if let Some(op) = entry.res.bound_op() {
+                        entry.res.set_position(op.pos.get().raw());
+                    } else {
+                        let mut res_opref = entry.res.to_opref();
+                        remap_opref(&mut res_opref);
+                        entry.res.set_position(res_opref.raw());
                     }
                 }
             }
@@ -6237,6 +6255,7 @@ mod tests {
             &[BoxRef::from_opref(OpRef::int_op(0))],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: preamble_op.clone(),
+                res: BoxRef::from_opref(OpRef::int_op(14)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1313,9 +1313,13 @@ mod tests {
             Some(idx) => (0..=idx as u32).map(OpRef::int_op).collect(),
             None => vec![OpRef::int_op(0)],
         };
+        let short_inputarg_boxes: Vec<crate::r#box::BoxRef> = short_inputargs
+            .iter()
+            .map(|&a| crate::r#box::BoxRef::from_opref(a))
+            .collect();
         ctx.initialize_imported_short_preamble_builder(
             &short_inputargs,
-            &short_inputargs,
+            &short_inputarg_boxes,
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: preamble_op,
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1322,6 +1322,7 @@ mod tests {
             &short_inputarg_boxes,
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: preamble_op,
+                res: crate::r#box::BoxRef::from_opref(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx,
                 invented_name: false,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1321,7 +1321,7 @@ mod tests {
             &short_inputargs,
             &short_inputarg_boxes,
             &[crate::optimizeopt::shortpreamble::PreambleOp {
-                op: preamble_op,
+                op: std::rc::Rc::new(preamble_op),
                 res: crate::r#box::BoxRef::from_opref(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1334,14 +1334,23 @@ mod tests {
         if source != OpRef::NONE {
             // PreambleOp.op carries the Box itself (shortpreamble.py:12).
             let source_box = ctx.materialize_box_at(source);
-            let pop = crate::optimizeopt::info::PreambleOp {
-                op: source_box.clone(),
-                invented_name: false,
-                preamble_op: {
-                    let mut same_as = Op::new(OpCode::SameAsI, &[source_box]);
+            // Production threads the builder's replay Rc into the pop
+            // (produce_op family); mirror that here so use_box receives
+            // the same object the builder entry carries.
+            let replay = ctx
+                .imported_short_preamble_builder
+                .as_ref()
+                .and_then(|b| b.produced_short_op(source))
+                .map(|p| p.preamble_op)
+                .unwrap_or_else(|| {
+                    let mut same_as = Op::new(OpCode::SameAsI, &[source_box.clone()]);
                     same_as.pos.set(source);
                     std::rc::Rc::new(same_as)
-                },
+                });
+            let pop = crate::optimizeopt::info::PreambleOp {
+                op: source_box,
+                invented_name: false,
+                preamble_op: replay,
             };
             ctx.set_potential_extra_op(source, pop);
         }
@@ -2708,7 +2717,7 @@ mod tests {
                 majit_ir::OopSpecIndex::None,
             ),
         );
-        let imported = crate::optimizeopt::ImportedShortPureOp::new(
+        let mut imported = crate::optimizeopt::ImportedShortPureOp::new(
             &mut ctx,
             OpCode::CallPureI,
             Some(call_descr.clone()),
@@ -2728,6 +2737,15 @@ mod tests {
             (*imported.pop.preamble_op).clone(),
             Some(1),
         );
+        // Production threads the builder's replay Rc into the pop
+        // (produce_pure); mirror it so use_box sees one object.
+        if let Some(p) = ctx
+            .imported_short_preamble_builder
+            .as_ref()
+            .and_then(|b| b.produced_short_op(OpRef::int_op(1)))
+        {
+            imported.pop.preamble_op = p.preamble_op;
+        }
         ctx.imported_short_pure_ops.push(imported);
 
         pass.setup();

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -60,9 +60,8 @@ impl Renamer {
             if let Some(fail_args) = op.fail_args_mut() {
                 for arg in fail_args.iter_mut() {
                     if let Some(renamed) = self.lookup(arg.to_opref()) {
-                        *arg = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(
-                            renamed,
-                        ));
+                        *arg =
+                            majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(renamed));
                     }
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -55,20 +55,16 @@ impl Renamer {
         if op.opcode.is_guard() {
             // renamer.py:27: TODO op.rd_snapshot = self.rename_rd_snapshot(...)
             // renamer.py:28-29: failargs = self.rename_failargs(op, clone=True)
+            // renamer.py:36-40: `self.rename_map.get(arg, arg)` — a missed
+            // lookup keeps the SAME box object, so only hits are rewritten.
             if let Some(fail_args) = op.fail_args_mut() {
-                let cloned: Vec<OpRef> = fail_args
-                    .iter()
-                    .map(|arg| {
-                        let opref = arg.to_opref();
-                        self.lookup(opref).unwrap_or(opref)
-                    })
-                    .collect();
-                fail_args.clear();
-                fail_args.extend(
-                    cloned
-                        .into_iter()
-                        .map(|r| majit_ir::operand::Operand::Box(BoxRef::from_opref(r))),
-                );
+                for arg in fail_args.iter_mut() {
+                    if let Some(renamed) = self.lookup(arg.to_opref()) {
+                        *arg = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(
+                            renamed,
+                        ));
+                    }
+                }
             }
         }
 

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1395,15 +1395,51 @@ impl ProducedShortOp {
         // single-table `imported_short_pure_ops` covers both because
         // `pure.rs` consults it for both arms during `optimize_pure_op` and
         // `optimize_call_pure_*`.
-        let imported = crate::optimizeopt::ImportedShortPureOp::new(
-            ctx,
-            opcode,
-            self.preamble_op.getdescr(),
-            args,
-            result_opref,
-            source,
-            self.invented_name,
-        );
+        // shortpreamble.py:121 `PreambleOp(op, preamble_op, ...)` — the
+        // replay op is the SAME object ShortPreambleBuilder.__init__
+        // seeded (one ResOperation per short box, threaded end to end).
+        // The builder was installed by
+        // `initialize_imported_short_preamble_builder_from_short_boxes`
+        // just before this produce_op loop; reuse its replay Rc instead
+        // of rebuilding an equal-content op. Fallback keeps the local
+        // construction for harnesses that call produce_op standalone.
+        let builder_pop = ctx
+            .imported_short_preamble_builder
+            .as_ref()
+            .and_then(|b| b.produced_short_op(source));
+        let imported = match builder_pop {
+            Some(p) => {
+                debug_assert_eq!(
+                    p.preamble_op.pos.get(),
+                    if self.invented_name {
+                        result_opref
+                    } else {
+                        source
+                    },
+                    "builder replay pos diverged from produce_pure replay rule"
+                );
+                crate::optimizeopt::ImportedShortPureOp {
+                    opcode,
+                    descr: self.preamble_op.getdescr(),
+                    args,
+                    result: result_opref,
+                    pop: crate::optimizeopt::info::PreambleOp {
+                        op: ctx.materialize_box_at(source),
+                        invented_name: self.invented_name,
+                        preamble_op: p.preamble_op.clone(),
+                    },
+                }
+            }
+            None => crate::optimizeopt::ImportedShortPureOp::new(
+                ctx,
+                opcode,
+                self.preamble_op.getdescr(),
+                args,
+                result_opref,
+                source,
+                self.invented_name,
+            ),
+        };
         ctx.imported_short_pure_ops.push(imported);
         // shortpreamble.py:432-440 add_preamble_op + 437-438 extra_same_as:
         // RPython collects the SameAs op into `short_preamble_producer.extra_same_as`
@@ -1494,11 +1530,27 @@ impl ProducedShortOp {
         // distinct Op object, so this slot juggling is the pyre adaptation
         // of that Box-identity invariant.
         getfield_op.pos.set(result_opref);
+        // shortpreamble.py:75 `PreambleOp(self.res, preamble_op, ...)` —
+        // the stored replay is the builder's object (one ResOperation per
+        // short box); see produce_pure for the threading rationale.
+        let replay_rc = ctx
+            .imported_short_preamble_builder
+            .as_ref()
+            .and_then(|b| b.produced_short_op(source))
+            .map(|p| {
+                debug_assert_eq!(
+                    p.preamble_op.pos.get(),
+                    result_opref,
+                    "builder replay pos diverged from produce_heap_field rule"
+                );
+                p.preamble_op
+            })
+            .unwrap_or_else(|| std::rc::Rc::new(getfield_op.clone()));
         let pop = crate::optimizeopt::info::PreambleOp {
             // PreambleOp.op carries the Box itself (shortpreamble.py:12).
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
-            preamble_op: std::rc::Rc::new(getfield_op.clone()),
+            preamble_op: replay_rc,
         };
         let parent_descr = getfield_op
             .with_field_descr(|fd| fd.get_parent_descr())
@@ -1614,11 +1666,26 @@ impl ProducedShortOp {
         // result_opref. See produce_heap_field for the Box-identity-vs-flat-OpRef
         // adaptation rationale.
         getarrayitem_op.pos.set(result_opref);
+        // shortpreamble.py:84 `PreambleOp(self.res, preamble_op, ...)` —
+        // stored replay is the builder's object; see produce_pure.
+        let replay_rc = ctx
+            .imported_short_preamble_builder
+            .as_ref()
+            .and_then(|b| b.produced_short_op(source))
+            .map(|p| {
+                debug_assert_eq!(
+                    p.preamble_op.pos.get(),
+                    result_opref,
+                    "builder replay pos diverged from produce_heap_array_item rule"
+                );
+                p.preamble_op
+            })
+            .unwrap_or_else(|| std::rc::Rc::new(getarrayitem_op.clone()));
         let pop = crate::optimizeopt::info::PreambleOp {
             // PreambleOp.op carries the Box itself (shortpreamble.py:12).
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
-            preamble_op: std::rc::Rc::new(getarrayitem_op.clone()),
+            preamble_op: replay_rc,
         };
         if obj_resolved.is_constant()
             || ctx

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -333,6 +333,11 @@ pub enum PreambleOpKind {
 pub struct PreambleOp {
     /// The operation to replay.
     pub op: Op,
+    /// `short_op.res` — the result box this entry produces. Identity-
+    /// bearing on exported entries (threaded from the preview
+    /// `ProducedShortOp.res`); on potential-op entries it is a
+    /// position-only mint that `add_op_to_short` re-resolves via ctx.
+    pub res: crate::r#box::BoxRef,
     /// Classification of this operation.
     pub kind: PreambleOpKind,
     /// Index of the argument in the label (None if not a label arg).
@@ -601,6 +606,7 @@ impl ShortBoxes {
             // shortpreamble.py:371-373: const_short_boxes.append(HeapOp(...))
             let label_arg_idx = self.lookup_label_arg(result);
             self.const_short_boxes.push(PreambleOp {
+                res: BoxRef::from_opref(op.pos.get()),
                 op,
                 kind: PreambleOpKind::Heap,
                 label_arg_idx,
@@ -641,15 +647,15 @@ impl ShortBoxes {
         }
         let label_arg_idx = self.lookup_label_arg(arg);
         // shortpreamble.py:257 `ShortInputArg(box, renamed)` — the SAME_AS
-        // replay arg is the label-arg Box itself; bind its producer.
-        let mut same_as = Op::new(
-            OpCode::same_as_for_type(arg_type),
-            &[ctx.materialize_box_at(arg)],
-        );
+        // replay arg is the label-arg Box itself (= `res`); bind its
+        // producer once and share the object.
+        let arg_box = ctx.materialize_box_at(arg);
+        let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[arg_box.clone()]);
         same_as.pos.set(arg);
         self.potential_ops.insert(
             arg,
             PotentialShortOp::Preamble(PreambleOp {
+                res: arg_box,
                 op: same_as,
                 kind: PreambleOpKind::InputArg,
                 label_arg_idx,
@@ -849,6 +855,7 @@ impl ShortBoxes {
     pub fn add_potential_op(&mut self, label_arg_idx: Option<usize>, op: Op, kind: PreambleOpKind) {
         let result = op.pos.get();
         let pop = PotentialShortOp::Preamble(PreambleOp {
+            res: BoxRef::from_opref(result),
             op,
             kind,
             label_arg_idx,
@@ -929,6 +936,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_guard(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.guards.push(PreambleOp {
+            res: BoxRef::from_opref(op.pos.get()),
             op,
             kind: PreambleOpKind::Guard,
             label_arg_idx,
@@ -941,6 +949,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_pure_op(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.pure_ops.push(PreambleOp {
+            res: BoxRef::from_opref(op.pos.get()),
             op,
             kind: PreambleOpKind::Pure,
             label_arg_idx,
@@ -953,6 +962,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_heap_op(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.heap_ops.push(PreambleOp {
+            res: BoxRef::from_opref(op.pos.get()),
             op,
             kind: PreambleOpKind::Heap,
             label_arg_idx,
@@ -965,6 +975,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_loopinvariant_op(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.loopinvariant_ops.push(PreambleOp {
+            res: BoxRef::from_opref(op.pos.get()),
             op,
             kind: PreambleOpKind::LoopInvariant,
             label_arg_idx,
@@ -2929,11 +2940,10 @@ pub fn produced_short_boxes_from_exported_boxes(
                 preamble_op.pos.get(),
                 ProducedShortOp {
                     kind: entry.kind.clone(),
-                    // Position-only mint at the export boundary: the
-                    // exported `PreambleOp` entries do not carry the
-                    // Phase-1 res box (re-homes with
-                    // `ExportedState.exported_short_boxes`).
-                    res: BoxRef::from_opref(preamble_op.pos.get()),
+                    // shortpreamble.py:58/110 short_op.res — the exported
+                    // entry carries the Phase-1 res box across the
+                    // boundary; reuse the SAME object.
+                    res: entry.res.clone(),
                     preamble_op: std::rc::Rc::new(preamble_op),
                     invented_name: entry.invented_name,
                     same_as_source: entry.same_as_source.clone(),
@@ -3287,6 +3297,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(7));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::int_op(7)),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3304,6 +3315,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(8));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::int_op(8)),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3347,6 +3359,7 @@ mod tests {
         let exported = vec![
             PreambleOp {
                 op: ovf,
+                res: BoxRef::from_opref(OpRef::int_op(20)),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3354,6 +3367,7 @@ mod tests {
             },
             PreambleOp {
                 op: guard,
+                res: BoxRef::none(),
                 kind: PreambleOpKind::Guard,
                 label_arg_idx: None,
                 invented_name: false,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -332,7 +332,12 @@ pub enum PreambleOpKind {
 #[derive(Clone, Debug)]
 pub struct PreambleOp {
     /// The operation to replay.
-    pub op: Op,
+    ///
+    /// Carried as an [`majit_ir::OpRc`] so the exported entry, the derived
+    /// `ProducedShortOp.preamble_op`, and replay-arg operands can share one
+    /// object across the export/import boundary (upstream `preamble_op` is
+    /// one ResOperation object, shortpreamble.py:283-296).
+    pub op: majit_ir::OpRc,
     /// `short_op.res` — the result box this entry produces. Identity-
     /// bearing on exported entries (threaded from the preview
     /// `ProducedShortOp.res`); on potential-op entries it is a
@@ -364,7 +369,7 @@ impl PreambleOp {
         ctx: &mut crate::optimizeopt::OptContext,
     ) -> Option<ProducedShortOp> {
         let preamble_op = match &self.kind {
-            PreambleOpKind::InputArg | PreambleOpKind::Guard => self.op.clone(),
+            PreambleOpKind::InputArg | PreambleOpKind::Guard => (*self.op).clone(),
             PreambleOpKind::Heap => {
                 // shortpreamble.py:91-102 HeapOp.add_op_to_short:
                 //   preamble_arg = sb.produce_arg(sop.getarg(0))
@@ -607,7 +612,7 @@ impl ShortBoxes {
             let label_arg_idx = self.lookup_label_arg(result);
             self.const_short_boxes.push(PreambleOp {
                 res: BoxRef::from_opref(op.pos.get()),
-                op,
+                op: std::rc::Rc::new(op),
                 kind: PreambleOpKind::Heap,
                 label_arg_idx,
                 invented_name: false,
@@ -656,7 +661,7 @@ impl ShortBoxes {
             arg,
             PotentialShortOp::Preamble(PreambleOp {
                 res: arg_box,
-                op: same_as,
+                op: std::rc::Rc::new(same_as),
                 kind: PreambleOpKind::InputArg,
                 label_arg_idx,
                 invented_name: false,
@@ -890,7 +895,7 @@ impl ShortBoxes {
         let result = op.pos.get();
         let pop = PotentialShortOp::Preamble(PreambleOp {
             res: BoxRef::from_opref(result),
-            op,
+            op: std::rc::Rc::new(op),
             kind,
             label_arg_idx,
             invented_name: false,
@@ -971,7 +976,7 @@ impl CollectedExtendedShortPreambleBuilder {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.guards.push(PreambleOp {
             res: BoxRef::from_opref(op.pos.get()),
-            op,
+            op: std::rc::Rc::new(op),
             kind: PreambleOpKind::Guard,
             label_arg_idx,
             invented_name: false,
@@ -984,7 +989,7 @@ impl CollectedExtendedShortPreambleBuilder {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.pure_ops.push(PreambleOp {
             res: BoxRef::from_opref(op.pos.get()),
-            op,
+            op: std::rc::Rc::new(op),
             kind: PreambleOpKind::Pure,
             label_arg_idx,
             invented_name: false,
@@ -997,7 +1002,7 @@ impl CollectedExtendedShortPreambleBuilder {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.heap_ops.push(PreambleOp {
             res: BoxRef::from_opref(op.pos.get()),
-            op,
+            op: std::rc::Rc::new(op),
             kind: PreambleOpKind::Heap,
             label_arg_idx,
             invented_name: false,
@@ -1010,7 +1015,7 @@ impl CollectedExtendedShortPreambleBuilder {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.loopinvariant_ops.push(PreambleOp {
             res: BoxRef::from_opref(op.pos.get()),
-            op,
+            op: std::rc::Rc::new(op),
             kind: PreambleOpKind::LoopInvariant,
             label_arg_idx,
             invented_name: false,
@@ -1063,7 +1068,7 @@ impl CollectedExtendedShortPreambleBuilder {
                     }
                 }
                 ShortPreambleOp {
-                    op: preamble_op.op,
+                    op: (*preamble_op.op).clone(),
                     arg_mapping,
                     fail_arg_mapping,
                 }
@@ -3010,7 +3015,7 @@ pub fn produced_short_boxes_from_exported_boxes(
         .iter()
         .filter(|entry| !entry.op.opcode.is_guard_overflow())
         .map(|entry| {
-            let mut preamble_op = entry.op.clone();
+            let mut preamble_op = (*entry.op).clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..preamble_op.num_args() {
                 if let Some(renamed) = inputarg_rename(preamble_op.arg(i).to_opref()) {
@@ -3392,7 +3397,7 @@ mod tests {
                         ],
                     );
                     op.pos.set(OpRef::int_op(7));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::int_op(7)),
                 kind: PreambleOpKind::Pure,
@@ -3410,7 +3415,7 @@ mod tests {
                         ],
                     );
                     op.pos.set(OpRef::int_op(8));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::int_op(8)),
                 kind: PreambleOpKind::Pure,
@@ -3455,7 +3460,7 @@ mod tests {
 
         let exported = vec![
             PreambleOp {
-                op: ovf,
+                op: std::rc::Rc::new(ovf),
                 res: BoxRef::from_opref(OpRef::int_op(20)),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
@@ -3463,7 +3468,7 @@ mod tests {
                 same_as_source: None,
             },
             PreambleOp {
-                op: guard,
+                op: std::rc::Rc::new(guard),
                 res: BoxRef::none(),
                 kind: PreambleOpKind::Guard,
                 label_arg_idx: None,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1776,6 +1776,19 @@ impl AbstractShortPreambleBuilderState {
         if invented_name {
             // shortpreamble.py:436-437: extra_same_as carries the resolved
             // box itself; a producer-bound box sheds to a live operand.
+            //
+            // Measured dead fallback: every `invented_name = true` writer
+            // carries `Some(same_as_source)` — the sole production writer
+            // is the compound-alias path (`alt.invented_name = true` +
+            // `alt.same_as_source = Some(...)`), `add_preamble_op_from_pop`
+            // always passes `Some(pop.op)`, and the export/re-import paths
+            // copy both fields as a pair. Fallback kept as a release
+            // safety net.
+            debug_assert!(
+                same_as_source.is_some(),
+                "invented_name without same_as_source at {:?}",
+                replay_op.pos.get()
+            );
             let source = same_as_source.unwrap_or_else(|| op.clone());
             let mut same_as = Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
             same_as.pos.set(op.to_opref());

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2129,31 +2129,29 @@ impl ShortPreambleBuilder {
     /// shortpreamble.py:382-407: use_box(box, preamble_op, optimizer)
     /// Non-recursive. Called by force_op_from_preamble (unroll.py:32).
     ///
-    /// RPython passes `preamble_op.preamble_op` directly — no lookup miss
-    /// possible. majit prefers the produced_short_boxes lookup (which may
-    /// carry a Phase-2 remapped pos), and falls back to `fallback_op` from
-    /// info::PreambleOp when absent.
+    /// RPython passes `preamble_op.preamble_op` directly — the replay op
+    /// IS the carried object, so there is no entry-selection lookup. The
+    /// pop's replay Rc is the builder's own object (threaded by the
+    /// produce_op family), verified by the debug probe below.
     pub fn use_box(
         &mut self,
         source: OpRef,
-        fallback_op: &Op,
+        preamble_op: &majit_ir::OpRc,
         arg_guards: &[Op],
         result_guards: &[Op],
     ) {
-        let preamble_op = match self.produced_short_boxes.get(&source) {
-            Some(produced) => produced.preamble_op.clone(),
-            None => {
-                if crate::optimizeopt::majit_log_enabled() {
-                    eprintln!(
-                        "[jit][use_box] produced_short_boxes miss for {source:?}, using fallback"
-                    );
-                }
-                std::rc::Rc::new(fallback_op.clone())
-            }
-        };
+        #[cfg(debug_assertions)]
+        if let Some(produced) = self.produced_short_boxes.get(&source) {
+            debug_assert!(
+                std::rc::Rc::ptr_eq(&produced.preamble_op, preamble_op),
+                "use_box pop replay diverged from builder entry at {source:?}"
+            );
+        }
+        #[cfg(not(debug_assertions))]
+        let _ = source;
         let pos_to_key = build_pos_to_key(&self.produced_short_boxes);
         self.state.use_box(
-            &preamble_op,
+            preamble_op,
             &VecSet::new(),
             &self.produced_short_boxes,
             &pos_to_key,
@@ -2704,28 +2702,26 @@ impl ExtendedShortPreambleBuilder {
     /// shortpreamble.py:478-481: use_box — pop JUMP, add deps, re-append JUMP.
     /// Called by force_op_from_preamble (unroll.py:32).
     ///
-    /// RPython passes `preamble_op.preamble_op` directly. majit uses the
-    /// produced_short_boxes lookup for the Phase-2 remapped op, with
-    /// `fallback_op` from info::PreambleOp as the safety net.
+    /// RPython passes `preamble_op.preamble_op` directly — the pop's
+    /// replay Rc is the carried object (threaded by the produce_op
+    /// family); the debug probe checks it against the builder entry.
     pub fn use_box(
         &mut self,
         source: OpRef,
-        fallback_op: &Op,
+        preamble_op: &majit_ir::OpRc,
         arg_guards: &[Op],
         result_guards: &[Op],
     ) {
-        let raw_op = match self.produced_short_boxes.get(&source) {
-            Some(produced) => (*produced.preamble_op).clone(),
-            None => {
-                if crate::optimizeopt::majit_log_enabled() {
-                    eprintln!(
-                        "[jit][use_box ext] produced_short_boxes miss for {source:?}, using fallback"
-                    );
-                }
-                fallback_op.clone()
-            }
-        };
-        let preamble_op = self.remap_op(&raw_op);
+        #[cfg(debug_assertions)]
+        if let Some(produced) = self.produced_short_boxes.get(&source) {
+            debug_assert!(
+                std::rc::Rc::ptr_eq(&produced.preamble_op, preamble_op),
+                "ext use_box pop replay diverged from builder entry at {source:?}"
+            );
+        }
+        #[cfg(not(debug_assertions))]
+        let _ = source;
+        let preamble_op = self.remap_op(preamble_op);
         let canonical = preamble_op.pos.get();
         // shortpreamble.py:479: jump_op = self.short.pop()
         let jump_op = self.short.pop();

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -373,7 +373,6 @@ impl PreambleOp {
                 //   else:
                 //       preamble_op = ResOperation(sop.getopnum(), [preamble_arg, sop.getarg(1)], descr=sop.getdescr())
                 let preamble_arg = sb.produce_arg(ctx, self.op.arg(0).to_opref())?;
-                let preamble_arg = ctx.materialize_box_at(preamble_arg);
                 let args: smallvec::SmallVec<[BoxRef; 3]> = if self.op.opcode.is_getfield() {
                     smallvec::smallvec![preamble_arg]
                 } else {
@@ -393,10 +392,7 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| {
-                        sb.produce_arg(ctx, arg.to_opref())
-                            .map(|r| ctx.materialize_box_at(r))
-                    })
+                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()))
                     .collect::<Option<smallvec::SmallVec<[BoxRef; 3]>>>()?;
                 let opnum = if self.op.opcode.is_call() {
                     match self.op.opcode {
@@ -420,10 +416,7 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| {
-                        sb.produce_arg(ctx, arg.to_opref())
-                            .map(|r| ctx.materialize_box_at(r))
-                    })
+                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()))
                     .collect::<Option<smallvec::SmallVec<[BoxRef; 3]>>>()?;
                 let opnum = match self.op.opcode {
                     OpCode::CallI => OpCode::CallLoopinvariantI,
@@ -676,7 +669,7 @@ impl ShortBoxes {
         &mut self,
         ctx: &mut crate::optimizeopt::OptContext,
         opref: OpRef,
-    ) -> Option<OpRef> {
+    ) -> Option<BoxRef> {
         // shortpreamble.py:284 `if op in self.produced_short_boxes` — the
         // dict membership is Box identity; resolve the position to its
         // canonical box once for both identity-keyed checks. Const args
@@ -684,27 +677,50 @@ impl ShortBoxes {
         if !opref.is_constant() {
             let key = ctx.materialize_box_at(opref);
             if let Some(existing) = self.produced_short_boxes.get(&key) {
-                return Some(existing.preamble_op.pos.get());
+                // shortpreamble.py:285 `return ...preamble_op` — the
+                // dependency's replay op object itself, so preamble-op
+                // args carry the dep replay handle.
+                //
+                // ShortInputArg: upstream `preamble_op` IS the inputarg
+                // box (shortpreamble.py:255-259), not an op. pyre models
+                // the replay as a SAME_AS op squatting the inputarg
+                // position; binding to that op retags the position into
+                // the op namespace (from_bound_op derives the OpRef from
+                // the box kind), so return the carried res box instead.
+                if existing.kind == PreambleOpKind::InputArg {
+                    return Some(existing.res.clone());
+                }
+                return Some(BoxRef::from_bound_op(&existing.preamble_op));
             }
             if self.boxes_in_production.contains(&key) {
                 return None;
             }
         }
         // shortpreamble.py:288 isinstance(op, Const) → return op.
+        if opref.is_constant() {
+            return Some(BoxRef::from_opref(opref));
+        }
         // pyre tracks iteration-known constants (body-typed OpRefs proven
         // constant for this pass) in `known_constants`; those are this
         // stage's `Const` boxes, mirroring `use_box`/`insert_dep_recursive`.
-        if opref.is_constant() || self.known_constants.contains(&opref) {
-            return Some(opref);
+        if self.known_constants.contains(&opref) {
+            return Some(ctx.materialize_box_at(opref));
         }
         if self.potential_ops.iter().any(|(k, _)| *k == opref) {
-            return self
-                .materialize_one(ctx, opref)
-                .map(|produced| produced.preamble_op.pos.get());
+            // shortpreamble.py:291-294 `r = self.add_op_to_short(...);
+            // return r.preamble_op`. ShortInputArg: res box, see the
+            // produced arm above.
+            return self.materialize_one(ctx, opref).map(|produced| {
+                if produced.kind == PreambleOpKind::InputArg {
+                    produced.res.clone()
+                } else {
+                    BoxRef::from_bound_op(&produced.preamble_op)
+                }
+            });
         }
         // Label args are always available as inputs (RPython: isinstance(op, InputArgIntOp))
-        if self.short_inputargs.iter().any(|a| a.to_opref() == opref) {
-            return Some(opref);
+        if let Some(arg) = self.short_inputargs.iter().find(|a| a.to_opref() == opref) {
+            return Some(arg.clone());
         }
         None
     }
@@ -831,7 +847,7 @@ impl ShortBoxes {
                 continue;
             };
             // shortpreamble.py:277-278: copy_and_change(opnum, [preamble_arg] + args[1:])
-            let mut new_args = vec![ctx.materialize_box_at(preamble_arg)];
+            let mut new_args = vec![preamble_arg];
             new_args.extend_from_slice(&getfield_op.getarglist()[1..]);
             let mut new_op = Op::with_descr(
                 getfield_op.opcode,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -655,6 +655,14 @@ impl ShortBoxes {
         // replay arg is the label-arg Box itself (= `res`); bind its
         // producer once and share the object.
         let arg_box = ctx.materialize_box_at(arg);
+        // shortpreamble.py:255-259 — `short_inputargs` carry those same
+        // label-arg Box objects. Rebind the position-only skeleton slot
+        // from `with_label_args` so every consumer (create_short_inputargs
+        // → ExportedState → produced_short_boxes rename) shares the
+        // canonical producer-bound box.
+        if let Some(idx) = label_arg_idx {
+            self.short_inputargs[idx] = arg_box.clone();
+        }
         let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[arg_box.clone()]);
         same_as.pos.set(arg);
         self.potential_ops.insert(

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1175,13 +1175,13 @@ fn imported_const_opref(
 pub(crate) fn classify_short_arg(
     ctx: &mut crate::optimizeopt::OptContext,
     arg: OpRef,
-    short_inputargs: &[OpRef],
+    short_inputargs: &[BoxRef],
     short_args: &[OpRef],
     produced_results: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
     imported_constants: &mut crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
     short_box_const_values: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::Value>,
 ) -> Option<crate::optimizeopt::ImportedShortPureArg> {
-    if let Some(slot) = short_inputargs.iter().position(|&i| i == arg) {
+    if let Some(slot) = short_inputargs.iter().position(|i| i.to_opref() == arg) {
         return short_args
             .get(slot)
             .copied()
@@ -1237,7 +1237,7 @@ impl ProducedShortOp {
             OpRef,
             crate::optimizeopt::info::OpInfo,
         >,
-        short_inputargs: &[OpRef],
+        short_inputargs: &[BoxRef],
         short_args: &[OpRef],
         result_map: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
         produced_results: &mut crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
@@ -1308,7 +1308,7 @@ impl ProducedShortOp {
     fn produce_pure(
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
-        short_inputargs: &[OpRef],
+        short_inputargs: &[BoxRef],
         short_args: &[OpRef],
         result_map: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
         produced_results: &mut crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
@@ -1425,7 +1425,7 @@ impl ProducedShortOp {
             OpRef,
             crate::optimizeopt::info::OpInfo,
         >,
-        short_inputargs: &[OpRef],
+        short_inputargs: &[BoxRef],
         short_args: &[OpRef],
         result_map: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
         produced_results: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
@@ -1534,7 +1534,7 @@ impl ProducedShortOp {
             OpRef,
             crate::optimizeopt::info::OpInfo,
         >,
-        short_inputargs: &[OpRef],
+        short_inputargs: &[BoxRef],
         short_args: &[OpRef],
         result_map: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
         produced_results: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
@@ -1660,7 +1660,7 @@ impl ProducedShortOp {
     fn produce_loop_invariant(
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
-        short_inputargs: &[OpRef],
+        short_inputargs: &[BoxRef],
         short_args: &[OpRef],
         result_map: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
         produced_results: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
@@ -1989,27 +1989,24 @@ impl ShortPreambleBuilder {
     pub fn new(
         label_args: &[OpRef],
         short_boxes: &[(OpRef, ProducedShortOp)],
-        short_inputargs: &[OpRef],
+        short_inputargs: &[BoxRef],
     ) -> Self {
         let mut produced_short_boxes = VecAssoc::new();
         for (k, v) in short_boxes {
             produced_short_boxes.insert(*k, v.clone());
         }
-        // shortpreamble.py:430 stores the renamed InputArg box objects.
-        // The OpRef slice arrives from exported (position-domain) data, so
-        // mint the position-only boxes once here; every later read (Label
-        // args, membership) shares these box objects.
-        let inputarg_oprefs = if short_inputargs.is_empty() {
-            label_args
+        // shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
+        // store the caller's renamed-box objects themselves. The empty
+        // fallback (test paths without an exported preview list) mints
+        // position-only boxes from the label args once.
+        let short_inputargs = if short_inputargs.is_empty() {
+            label_args.iter().map(|&a| BoxRef::from_opref(a)).collect()
         } else {
-            short_inputargs
+            short_inputargs.to_vec()
         };
         ShortPreambleBuilder {
             state: AbstractShortPreambleBuilderState {
-                short_inputargs: inputarg_oprefs
-                    .iter()
-                    .map(|&a| BoxRef::from_opref(a))
-                    .collect(),
+                short_inputargs,
                 ..AbstractShortPreambleBuilderState::default()
             },
             produced_short_boxes,
@@ -2905,14 +2902,17 @@ pub fn extract_short_preamble(peeled_ops: &[Op]) -> ShortPreamble {
 /// option (b)) without duplicating the rename logic.
 pub fn produced_short_boxes_from_exported_boxes(
     label_args: &[OpRef],
-    short_inputargs: &[OpRef],
+    short_inputargs: &[BoxRef],
     exported_short_boxes: &[PreambleOp],
 ) -> Vec<(OpRef, ProducedShortOp)> {
-    let inputarg_rename = |arg: OpRef| -> Option<OpRef> {
+    // optimizer.py:651-652 setarg(renamed_inputargs[i]) — the renamed
+    // operand IS the stored short-inputarg box object, not a fresh
+    // equal-positioned mint.
+    let inputarg_rename = |arg: OpRef| -> Option<&BoxRef> {
         label_args
             .iter()
             .position(|&a| a == arg)
-            .and_then(|i| short_inputargs.get(i).copied())
+            .and_then(|i| short_inputargs.get(i))
     };
     exported_short_boxes
         .iter()
@@ -2922,7 +2922,7 @@ pub fn produced_short_boxes_from_exported_boxes(
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..preamble_op.num_args() {
                 if let Some(renamed) = inputarg_rename(preamble_op.arg(i).to_opref()) {
-                    preamble_op.setarg(i, BoxRef::from_opref(renamed));
+                    preamble_op.setarg(i, renamed.clone());
                 }
             }
             if let Some(fail_args) = preamble_op.fail_args_mut() {
@@ -2937,7 +2937,7 @@ pub fn produced_short_boxes_from_exported_boxes(
                             false,
                             "imported short-box fail_arg hit inputarg rename: {arg:?}"
                         );
-                        *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(renamed));
+                        *arg = majit_ir::operand::Operand::from_boxref(renamed);
                     }
                 }
             }
@@ -2964,7 +2964,7 @@ pub fn produced_short_boxes_from_exported_boxes(
 /// re-running the rename + filter pass.
 pub fn build_short_preamble_from_produced_boxes(
     label_args: &[OpRef],
-    short_inputargs: &[OpRef],
+    short_inputargs: &[BoxRef],
     produced: &[(OpRef, ProducedShortOp)],
 ) -> ShortPreamble {
     let mut builder = ShortPreambleBuilder::new(label_args, produced, short_inputargs);
@@ -2983,7 +2983,7 @@ pub fn build_short_preamble_from_produced_boxes(
 
 pub fn build_short_preamble_from_exported_boxes(
     label_args: &[OpRef],
-    short_inputargs: &[OpRef],
+    short_inputargs: &[BoxRef],
     exported_short_boxes: &[PreambleOp],
 ) -> ShortPreamble {
     let produced =
@@ -3324,7 +3324,10 @@ mod tests {
 
         let sp = build_short_preamble_from_exported_boxes(
             &[OpRef::int_op(0), OpRef::int_op(1)],
-            &[OpRef::int_op(10), OpRef::int_op(11)],
+            &[
+                BoxRef::from_opref(OpRef::int_op(10)),
+                BoxRef::from_opref(OpRef::int_op(11)),
+            ],
             &exported,
         );
         assert_eq!(sp.ops.len(), 2);
@@ -3337,7 +3340,10 @@ mod tests {
     #[test]
     fn test_build_short_preamble_from_exported_boxes_skips_standalone_overflow_guards() {
         let label_args = vec![OpRef::int_op(10), OpRef::int_op(11)];
-        let short_inputargs = vec![OpRef::int_op(100), OpRef::int_op(101)];
+        let short_inputargs = vec![
+            BoxRef::from_opref(OpRef::int_op(100)),
+            BoxRef::from_opref(OpRef::int_op(101)),
+        ];
 
         let mut ovf = Op::new(
             OpCode::IntAddOvf,
@@ -3416,7 +3422,10 @@ mod tests {
         let mut builder = ShortPreambleBuilder::new(
             &[OpRef::int_op(0), OpRef::int_op(1)],
             &produced,
-            &[OpRef::int_op(0), OpRef::int_op(1)],
+            &[
+                BoxRef::from_opref(OpRef::int_op(0)),
+                BoxRef::from_opref(OpRef::int_op(1)),
+            ],
         );
 
         let used = builder.add_op_to_short(OpRef::int_op(8)).unwrap();
@@ -3709,8 +3718,11 @@ mod tests {
 
         let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
-        let mut builder =
-            ShortPreambleBuilder::new(&[OpRef::int_op(10)], &produced, &[OpRef::int_op(10)]);
+        let mut builder = ShortPreambleBuilder::new(
+            &[OpRef::int_op(10)],
+            &produced,
+            &[BoxRef::from_opref(OpRef::int_op(10))],
+        );
         let used = builder.add_op_to_short(OpRef::int_op(10)).unwrap();
         assert!(builder.add_preamble_op(OpRef::int_op(10)));
         assert_eq!(used.opcode, OpCode::IntAddOvf);
@@ -3763,8 +3775,11 @@ mod tests {
             .map(|(result, _)| *result)
             .unwrap();
 
-        let mut builder =
-            ShortPreambleBuilder::new(&[OpRef::int_op(20)], &produced, &[OpRef::int_op(20)]);
+        let mut builder = ShortPreambleBuilder::new(
+            &[OpRef::int_op(20)],
+            &produced,
+            &[BoxRef::from_opref(OpRef::int_op(20))],
+        );
         assert!(builder.add_preamble_op(alias_result));
         let extra = builder.extra_same_as();
         assert_eq!(extra.len(), 1);
@@ -3782,7 +3797,11 @@ mod tests {
 
     #[test]
     fn test_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
-        let mut builder = ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[OpRef::int_op(7)]);
+        let mut builder = ShortPreambleBuilder::new(
+            &[OpRef::int_op(7)],
+            &[],
+            &[BoxRef::from_opref(OpRef::int_op(7))],
+        );
         let mut replay_op = Op::new(
             OpCode::GetfieldGcI,
             &[BoxRef::from_opref(OpRef::int_op(30))],
@@ -3818,7 +3837,11 @@ mod tests {
 
     #[test]
     fn test_extended_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
-        let sb = ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[OpRef::int_op(7)]);
+        let sb = ShortPreambleBuilder::new(
+            &[OpRef::int_op(7)],
+            &[],
+            &[BoxRef::from_opref(OpRef::int_op(7))],
+        );
         let mut builder = ExtendedShortPreambleBuilder::new(0, &sb);
         let mut replay_op = Op::new(
             OpCode::GetfieldGcI,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -432,6 +432,9 @@ impl PreambleOp {
         };
         Some(ProducedShortOp {
             kind: self.kind.clone(),
+            // shortpreamble.py:120/85/170 `ProducedShortOp(self, ...)` —
+            // short_op.res is the original result box; resolve canonical.
+            res: ctx.materialize_box_at(self.op.pos.get()),
             preamble_op: std::rc::Rc::new(preamble_op),
             invented_name: self.invented_name,
             same_as_source: self.same_as_source.clone(),
@@ -515,6 +518,10 @@ impl PotentialShortOp {
                         });
                         let alias = ctx.alloc_op_position_typed(tp);
                         alt.preamble_op.pos.set(alias);
+                        // shortpreamble.py:329 `lst[i].short_op.res =
+                        // new_name` — the alias entry's res becomes the
+                        // freshly invented name.
+                        alt.res = ctx.materialize_box_at(alias);
                         alt.invented_name = true;
                         // shortpreamble.py:328 `ResOperation(opnum, [shortop.res])`
                         // — the alias source is the Box itself; resolve to
@@ -812,6 +819,7 @@ impl ShortBoxes {
             new_op.pos.set(getfield_op.pos.get());
             // shortpreamble.py:279: ProducedShortOp(short_op, preamble_op)
             short_boxes.push(ProducedShortOp {
+                res: ctx.materialize_box_at(getfield_op.pos.get()),
                 preamble_op: std::rc::Rc::new(new_op),
                 kind: PreambleOpKind::Heap,
                 invented_name: false,
@@ -1081,49 +1089,20 @@ impl CompoundOp {
     }
 }
 
-/// shortpreamble.py: ShortInputArg — a short op that represents
-/// a label input argument (no actual operation needed, just maps
-/// a preamble value to a label arg position).
-#[derive(Clone, Debug)]
-pub struct ShortInputArg {
-    /// The result OpRef.
-    pub res: OpRef,
-    /// The preamble operation that produces this value.
-    pub preamble_op: majit_ir::OpRc,
-}
-
-impl ShortInputArg {
-    /// shortpreamble.py: ShortInputArg.add_op_to_short(sb)
-    ///
-    /// Returns a ProducedShortOp wrapping the preamble_op.
-    /// For input args, the preamble_op is just forwarded.
-    pub fn add_op_to_short(&self) -> ProducedShortOp {
-        ProducedShortOp {
-            kind: PreambleOpKind::InputArg,
-            // Deep-clone: the compound-alias path retags the produced
-            // entry's pos (alt.preamble_op.pos.set) and must not reach
-            // back into this ShortInputArg's stored op.
-            preamble_op: std::rc::Rc::new((*self.preamble_op).clone()),
-            invented_name: false,
-            same_as_source: None,
-        }
-    }
-
-    /// shortpreamble.py: ShortInputArg.produce_op(opt, ...)
-    ///
-    /// For input args, produce_op is a no-op — the value is
-    /// already available as a label argument.
-    pub fn produce_op(&self) {
-        // No-op: the value is directly available from label args
-    }
-}
-
 /// shortpreamble.py: ProducedShortOp — wraps a short op with its
 /// preamble counterpart for emission during bridge compilation.
+///
+/// The upstream `ShortInputArg` role (shortpreamble.py:223-240) is
+/// played by `PreambleOp { kind: InputArg }` entries; the separate
+/// caller-less struct mirror was removed.
 #[derive(Clone, Debug)]
 pub struct ProducedShortOp {
     /// The short op classification.
     pub kind: PreambleOpKind,
+    /// `short_op.res` (shortpreamble.py:58/110/151/224) — the result box
+    /// this short op produces. `add_preamble_op` reads it back as the
+    /// `PreambleOp.op` box (upstream `produce_op` passes `self.res`).
+    pub res: crate::r#box::BoxRef,
     /// The preamble operation to replay.
     pub preamble_op: majit_ir::OpRc,
     /// Whether this short op uses an invented SameAs result.
@@ -2128,8 +2107,10 @@ impl ShortPreambleBuilder {
         let Some(produced) = self.produced_short_boxes.get(&result).cloned() else {
             return false;
         };
-        self.state
-            .record_preamble_use(BoxRef::from_opref(result), &produced);
+        // shortpreamble.py:435 `op = preamble_op.op.get_box_replacement()`
+        // — the stored res box, not a fresh equal-positioned mint.
+        let res = produced.res.clone();
+        self.state.record_preamble_use(res, &produced);
         true
     }
 
@@ -2596,7 +2577,10 @@ impl ExtendedShortPreambleBuilder {
         let Some(produced) = self.produced_short_boxes.get(&result).cloned() else {
             return false;
         };
-        self.add_tracked_preamble_op(BoxRef::from_opref(result), &produced);
+        // shortpreamble.py:466 `op = preamble_op.op.get_box_replacement()`
+        // — the stored res box, not a fresh equal-positioned mint.
+        let res = produced.res.clone();
+        self.add_tracked_preamble_op(res, &produced);
         true
     }
 
@@ -2945,6 +2929,11 @@ pub fn produced_short_boxes_from_exported_boxes(
                 preamble_op.pos.get(),
                 ProducedShortOp {
                     kind: entry.kind.clone(),
+                    // Position-only mint at the export boundary: the
+                    // exported `PreambleOp` entries do not carry the
+                    // Phase-1 res box (re-homes with
+                    // `ExportedState.exported_short_boxes`).
+                    res: BoxRef::from_opref(preamble_op.pos.get()),
                     preamble_op: std::rc::Rc::new(preamble_op),
                     invented_name: entry.invented_name,
                     same_as_source: entry.same_as_source.clone(),
@@ -3384,6 +3373,7 @@ mod tests {
                 OpRef::int_op(7),
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
+                    res: BoxRef::from_opref(OpRef::int_op(7)),
                     preamble_op: {
                         let mut op = Op::new(
                             OpCode::IntAdd,
@@ -3403,6 +3393,7 @@ mod tests {
                 OpRef::int_op(8),
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
+                    res: BoxRef::from_opref(OpRef::int_op(8)),
                     preamble_op: {
                         let mut op = Op::new(
                             OpCode::IntMul,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2201,8 +2201,12 @@ pub struct ExtendedShortPreambleBuilder {
     used_boxes: Vec<OpRef>,
     short_jump_args: Vec<OpRef>,
     pub target_token: u64,
-    /// RPython parity: remap Phase 1 preamble OpRefs → current inputarg OpRefs.
-    phase1_to_inputarg: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
+    /// RPython parity: remap Phase 1 preamble OpRefs → current inputargs.
+    /// Values are the current-namespace boxes, bound to their producers at
+    /// `setup()` insertion (the mapping values in unroll.py:396 are the
+    /// jump-arg Box objects themselves), so the remap `setarg` writes
+    /// produce live-tracking bound operands instead of frozen positions.
+    phase1_to_inputarg: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, BoxRef>,
     /// B.6.4 canonical dedup keyed by `produced.preamble_op.pos`. Mirrors
     /// `AbstractShortPreambleBuilderState.recorded_canonical_results` —
     /// `produced_short_boxes` carries dual entries (source-key plus
@@ -2262,7 +2266,7 @@ impl ExtendedShortPreambleBuilder {
         for (source, target) in self.phase1_to_inputarg.iter_mut() {
             let mut source_copy = *source;
             visit_opref(&mut source_copy, visitor);
-            visit_opref(target, visitor);
+            target.walk_const_ptr_refs(visitor);
         }
         let recorded_canonical_results = std::mem::take(&mut self.recorded_canonical_results);
         for mut opref in recorded_canonical_results {
@@ -2304,8 +2308,15 @@ impl ExtendedShortPreambleBuilder {
     /// so the caller (`jump_to_existing_trace`) can fall back to
     /// `jump_to_preamble` instead of attempting to inline a broken short
     /// preamble.
-    pub fn setup(&mut self, short_preamble: &ShortPreamble, label_args: &[OpRef]) -> bool {
-        // Build Phase 1 → current inputarg remap from arg_mapping.
+    pub fn setup(
+        &mut self,
+        short_preamble: &ShortPreamble,
+        label_args: &[OpRef],
+        ctx: &mut crate::optimizeopt::OptContext,
+    ) -> bool {
+        // Build Phase 1 → current inputarg remap from arg_mapping. The
+        // values bind to their current-namespace producers here, where the
+        // ctx is available — the remap reads below are `&self`.
         self.phase1_to_inputarg.clear();
         for entry in &short_preamble.ops {
             for &(arg_pos, label_idx) in &entry.arg_mapping {
@@ -2313,7 +2324,8 @@ impl ExtendedShortPreambleBuilder {
                     let phase1_ref = phase1_ref.to_opref();
                     if let Some(&current_inputarg) = label_args.get(label_idx) {
                         if phase1_ref != current_inputarg {
-                            self.phase1_to_inputarg.insert(phase1_ref, current_inputarg);
+                            self.phase1_to_inputarg
+                                .insert(phase1_ref, ctx.materialize_box_at(current_inputarg));
                         }
                     }
                 }
@@ -2337,8 +2349,8 @@ impl ExtendedShortPreambleBuilder {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
                 let arg = op.arg(i);
-                if let Some(&remapped) = self.phase1_to_inputarg.get(&arg.to_opref()) {
-                    op.setarg(i, BoxRef::from_opref(remapped));
+                if let Some(remapped) = self.phase1_to_inputarg.get(&arg.to_opref()) {
+                    op.setarg(i, remapped.clone());
                 }
             }
             // RPython use_box arg loop: insert missing deps before this op.
@@ -2364,12 +2376,19 @@ impl ExtendedShortPreambleBuilder {
             self.short.push(op);
         }
         // JUMP sentinel at end (RPython: short[-1] is always JUMP)
-        let jump_args: Vec<OpRef> = short_preamble
+        let jump_args_box: Vec<BoxRef> = short_preamble
             .jump_args
             .iter()
-            .map(|arg| self.phase1_to_inputarg.get(arg).copied().unwrap_or(*arg))
+            .map(|arg| {
+                self.phase1_to_inputarg
+                    .get(arg)
+                    .cloned()
+                    // Unmapped Phase 1 jump arg: no current-namespace
+                    // producer to bind; position-only box as before.
+                    .unwrap_or_else(|| BoxRef::from_opref(*arg))
+            })
             .collect();
-        let jump_args_box: Vec<BoxRef> = jump_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let jump_args: Vec<OpRef> = jump_args_box.iter().map(|b| b.to_opref()).collect();
         self.short.push(Op::new(OpCode::Jump, &jump_args_box));
         // Reset state
         self.extra_same_as = self.base_extra_same_as.clone();
@@ -2431,8 +2450,8 @@ impl ExtendedShortPreambleBuilder {
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..dep_op.num_args() {
             let a = dep_op.arg(i);
-            if let Some(&remapped) = self.phase1_to_inputarg.get(&a.to_opref()) {
-                dep_op.setarg(i, BoxRef::from_opref(remapped));
+            if let Some(remapped) = self.phase1_to_inputarg.get(&a.to_opref()) {
+                dep_op.setarg(i, remapped.clone());
             }
         }
         // Recurse into dep's own args first (transitive). If any sub-dep
@@ -2585,8 +2604,8 @@ impl ExtendedShortPreambleBuilder {
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..remapped.num_args() {
             let arg = remapped.arg(i);
-            if let Some(&r) = self.phase1_to_inputarg.get(&arg.to_opref()) {
-                remapped.setarg(i, BoxRef::from_opref(r));
+            if let Some(r) = self.phase1_to_inputarg.get(&arg.to_opref()) {
+                remapped.setarg(i, r.clone());
             }
         }
         remapped

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -456,7 +456,11 @@ pub struct ShortBoxes {
     potential_ops: VecAssoc<OpRef, PotentialShortOp>,
     /// shortpreamble.py:250 self.produced_short_boxes = {}
     /// (insertion order preserved by VecAssoc for deterministic export.)
-    produced_short_boxes: VecAssoc<OpRef, ProducedShortOp>,
+    /// Keyed by the result Box (`shortop.res`), compared by object
+    /// identity (shortpreamble.py:317/338) — lookups resolve their
+    /// position through `ctx.materialize_box_at`, which memoizes one
+    /// box per producer, so the same position yields the same object.
+    produced_short_boxes: VecAssoc<BoxRef, ProducedShortOp>,
     /// shortpreamble.py: const_short_boxes
     const_short_boxes: Vec<PreambleOp>,
     /// RPython shortpreamble.py: Const boxes are directly admissible in
@@ -473,9 +477,10 @@ pub struct ShortBoxes {
     /// once here and compared by position.
     short_inputargs: Vec<BoxRef>,
     /// shortpreamble.py: boxes_in_production — cycle-detection set
-    /// for `materialize_one` recursion. Active set is bounded by
-    /// recursion depth (linear scan suffices).
-    boxes_in_production: VecSet<OpRef>,
+    /// for `materialize_one` recursion, keyed by the result Box
+    /// (shortpreamble.py:314 `self.boxes_in_production[shortop.res]`).
+    /// Active set is bounded by recursion depth (linear scan suffices).
+    boxes_in_production: VecSet<BoxRef>,
     /// The number of label args.
     pub num_label_args: usize,
 }
@@ -532,7 +537,9 @@ impl PotentialShortOp {
                         // — the alias source is the Box itself; resolve to
                         // the canonical (possibly producer-bound) box.
                         alt.same_as_source = Some(ctx.materialize_box_at(compound.res));
-                        sb.produced_short_boxes.insert(alias, alt.clone());
+                        // shortpreamble.py:333 `self.produced_short_boxes[
+                        // new_name] = lst[i]` — keyed by the alias box.
+                        sb.produced_short_boxes.insert(alt.res.clone(), alt.clone());
                     }
                     Some(chosen)
                 }
@@ -670,11 +677,18 @@ impl ShortBoxes {
         ctx: &mut crate::optimizeopt::OptContext,
         opref: OpRef,
     ) -> Option<OpRef> {
-        if let Some(existing) = self.produced_short_boxes.get(&opref) {
-            return Some(existing.preamble_op.pos.get());
-        }
-        if self.boxes_in_production.iter().any(|x| *x == opref) {
-            return None;
+        // shortpreamble.py:284 `if op in self.produced_short_boxes` — the
+        // dict membership is Box identity; resolve the position to its
+        // canonical box once for both identity-keyed checks. Const args
+        // never key either set (they route to the Const arm below).
+        if !opref.is_constant() {
+            let key = ctx.materialize_box_at(opref);
+            if let Some(existing) = self.produced_short_boxes.get(&key) {
+                return Some(existing.preamble_op.pos.get());
+            }
+            if self.boxes_in_production.contains(&key) {
+                return None;
+            }
         }
         // shortpreamble.py:288 isinstance(op, Const) → return op.
         // pyre tracks iteration-known constants (body-typed OpRefs proven
@@ -724,17 +738,21 @@ impl ShortBoxes {
         ctx: &mut crate::optimizeopt::OptContext,
         result: OpRef,
     ) -> Option<ProducedShortOp> {
-        if let Some(existing) = self.produced_short_boxes.get(&result) {
+        // shortpreamble.py:311-339 add_op_to_short — guard, cycle set,
+        // and final insert all key on `shortop.res` Box identity.
+        let key = ctx.materialize_box_at(result);
+        if let Some(existing) = self.produced_short_boxes.get(&key) {
             return Some(existing.clone());
         }
-        if self.boxes_in_production.iter().any(|x| *x == result) {
+        if self.boxes_in_production.contains(&key) {
             return None;
         }
         let candidate = self.potential_ops.get(&result)?.clone();
-        self.boxes_in_production.insert(result);
-        let produced = candidate.add_op_to_short(self, ctx)?;
-        self.produced_short_boxes.insert(result, produced.clone());
-        self.boxes_in_production.remove(&result);
+        self.boxes_in_production.insert(key.clone());
+        let produced = candidate.add_op_to_short(self, ctx);
+        self.boxes_in_production.remove(&key);
+        let produced = produced?;
+        self.produced_short_boxes.insert(key, produced.clone());
         Some(produced)
     }
 
@@ -749,7 +767,7 @@ impl ShortBoxes {
         }
         self.produced_short_boxes
             .iter()
-            .map(|(k, v)| (*k, v.clone()))
+            .map(|(k, v)| (k.to_opref(), v.clone()))
             .collect()
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1925,15 +1925,15 @@ impl AbstractShortPreambleBuilderState {
     /// + guards to short), then appends preamble_op + result guards.
     /// Called by force_op_from_preamble (unroll.py:32).
     ///
-    /// RPython passes `preamble_op` directly (there is no lookup miss).
-    /// `all_produced` + `pos_to_key` are still needed to resolve dependency
-    /// args whose Phase-2 OpRefs differ from `produced_short_boxes` keys.
+    /// Dependency args carry the dep's replay op object (produce_arg
+    /// object-carry); a non-input, non-const arg whose bound op still
+    /// holds the builder's `set_forwarded` marker IS a short-box replay
+    /// op — append it and consume the marker (upstream
+    /// `arg.set_forwarded(None)`, shortpreamble.py:391-396).
     fn use_box(
         &mut self,
         preamble_op: &majit_ir::OpRc,
         already_in_short: &VecSet<OpRef>,
-        all_produced: &VecAssoc<OpRef, ProducedShortOp>,
-        pos_to_key: &VecAssoc<OpRef, OpRef>,
         arg_guards: &[Op],
         result_guards: &[Op],
     ) -> Op {
@@ -1945,33 +1945,34 @@ impl AbstractShortPreambleBuilderState {
         }
         // shortpreamble.py:383-396: iterate preamble_op args
         for arg in preamble_op.getarglist().iter() {
-            let arg = arg.to_opref();
-            if self.short_results.contains(&arg)
-                || already_in_short.contains(&arg)
-                || self.short_inputargs.iter().any(|a| a.to_opref() == arg)
-                || self.known_constants.contains(&arg)
+            let arg_opref = arg.to_opref();
+            if self.short_results.contains(&arg_opref)
+                || already_in_short.contains(&arg_opref)
+                || self
+                    .short_inputargs
+                    .iter()
+                    .any(|a| a.to_opref() == arg_opref)
+                || self.known_constants.contains(&arg_opref)
             {
                 continue;
             }
-            // shortpreamble.py:393: self.short.append(arg)
-            // Look up dep by key first, then by preamble_op.pos reverse index.
-            // In RPython, Box identity makes this lookup trivial. In majit,
-            // produce_arg returns preamble_op.pos which may differ from the
-            // produced_short_boxes key.
-            let dep = all_produced
-                .get(&arg)
-                .or_else(|| pos_to_key.get(&arg).and_then(|key| all_produced.get(key)));
-            if let Some(dep) = dep {
-                let dep_canonical = dep.preamble_op.pos.get();
-                if !self.short_results.contains(&dep_canonical)
-                    && !already_in_short.contains(&dep_canonical)
-                {
-                    self.short_results.insert(dep_canonical);
-                    self.short.push(dep.preamble_op.clone());
-                    if dep.preamble_op.opcode.is_ovf() {
-                        self.short
-                            .push(std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[])));
-                    }
+            // shortpreamble.py:390-396: `arg.get_forwarded() is None` →
+            // pass; otherwise append the arg (the dep replay op itself)
+            // and consume the marker.
+            let Some(dep) = arg.bound_op() else { continue };
+            if matches!(&*dep.forwarded.borrow(), crate::r#box::Forwarded::None) {
+                continue;
+            }
+            *dep.forwarded.borrow_mut() = crate::r#box::Forwarded::None;
+            let dep_canonical = dep.pos.get();
+            if !self.short_results.contains(&dep_canonical)
+                && !already_in_short.contains(&dep_canonical)
+            {
+                self.short_results.insert(dep_canonical);
+                self.short.push(dep.clone());
+                if dep.opcode.is_ovf() {
+                    self.short
+                        .push(std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[])));
                 }
             }
         }
@@ -1985,6 +1986,10 @@ impl AbstractShortPreambleBuilderState {
             self.short
                 .push(std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[])));
         }
+        // shortpreamble.py:401-402: `info = preamble_op.get_forwarded();
+        // preamble_op.set_forwarded(None)` — consume the own marker so a
+        // later consumer's arg walk doesn't re-append this op.
+        *preamble_op.forwarded.borrow_mut() = crate::r#box::Forwarded::None;
         // shortpreamble.py:405-406: info.make_guards(preamble_op, self.short, optimizer)
         self.short
             .extend(result_guards.iter().cloned().map(std::rc::Rc::new));
@@ -2089,6 +2094,19 @@ impl ShortPreambleBuilder {
     ) -> Self {
         let mut produced_short_boxes = VecAssoc::new();
         for (k, v) in short_boxes {
+            // shortpreamble.py:414-425: __init__ plants
+            // `preamble_op.set_forwarded(info)` on every replay op. The
+            // exported infos themselves are seeded through ctx position
+            // slots (`set_preamble_forwarded_info`), so the on-object
+            // marker is the empty_info analog: its presence tells
+            // `use_box` "this operand is a short-box replay op", and
+            // consuming it (`set_forwarded(None)`) is the dedup.
+            // `OpInfo::Unknown` never appears in exported infos
+            // (mod.rs guard), so the marker is unambiguous; Op::clone
+            // resets `forwarded`, so built ShortPreamble copies never
+            // carry it.
+            *v.preamble_op.forwarded.borrow_mut() =
+                crate::r#box::Forwarded::Info(crate::optimizeopt::info::OpInfo::Unknown);
             produced_short_boxes.insert(*k, v.clone());
         }
         // shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
@@ -2170,15 +2188,8 @@ impl ShortPreambleBuilder {
         }
         #[cfg(not(debug_assertions))]
         let _ = source;
-        let pos_to_key = build_pos_to_key(&self.produced_short_boxes);
-        self.state.use_box(
-            preamble_op,
-            &VecSet::new(),
-            &self.produced_short_boxes,
-            &pos_to_key,
-            arg_guards,
-            result_guards,
-        );
+        self.state
+            .use_box(preamble_op, &VecSet::new(), arg_guards, result_guards);
     }
 
     pub fn produced_short_op(&self, result: OpRef) -> Option<ProducedShortOp> {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -367,14 +367,21 @@ impl UnrollOptimizer {
     /// Redirect the closing JUMP to the preamble entry token
     /// (target_tokens[0], virtual_state=None). Only changes the
     /// descriptor, keeping arglist intact — RPython parity.
-    pub fn jump_to_preamble(body_ops: &[Op], preamble_target: &TargetToken) -> Vec<Op> {
+    pub fn jump_to_preamble(
+        body_ops: &[majit_ir::OpRc],
+        preamble_target: &TargetToken,
+    ) -> Vec<majit_ir::OpRc> {
         assert!(
             preamble_target.virtual_state.is_none(),
             "jump_to_preamble expects the start/preamble target token"
         );
         let mut result = body_ops.to_vec();
-        if let Some(jump) = result.iter_mut().rfind(|op| op.opcode == OpCode::Jump) {
+        if let Some(idx) = result.iter().rposition(|op| op.opcode == OpCode::Jump) {
+            // Re-clone before the descr write: the input Rc may still be
+            // registered in the optimizer's producer stores.
+            let jump = (*result[idx]).clone();
             jump.setdescr(preamble_target.as_jump_target_descr());
+            result[idx] = std::rc::Rc::new(jump);
         }
         result
     }
@@ -427,7 +434,7 @@ impl UnrollOptimizer {
         ops: &[Op],
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
-    ) -> (Vec<Op>, usize) {
+    ) -> (Vec<majit_ir::OpRc>, usize) {
         self.optimize_trace_with_constants_and_inputs_vable(ops, constants, num_inputs, None)
     }
 
@@ -444,7 +451,7 @@ impl UnrollOptimizer {
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
         vable_config: Option<crate::optimizeopt::virtualize::VirtualizableConfig>,
-    ) -> (Vec<Op>, usize) {
+    ) -> (Vec<majit_ir::OpRc>, usize) {
         self.optimize_trace_with_constants_and_inputs_vable_out(
             ops,
             constants,
@@ -465,34 +472,33 @@ impl UnrollOptimizer {
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
         vable_config: Option<crate::optimizeopt::virtualize::VirtualizableConfig>,
-        phase1_out: Option<&mut Option<(Vec<Op>, ExportedState)>>,
-    ) -> (Vec<Op>, usize) {
+        phase1_out: Option<&mut Option<(Vec<majit_ir::OpRc>, ExportedState)>>,
+    ) -> (Vec<majit_ir::OpRc>, usize) {
         // compile.py:362: if imported_state is pre-set (compile_retrace path),
         // skip Phase 1 and go directly to Phase 2 with the imported state.
-        let (mut exported_state, consts_p1, p1_ops) = if let Some(pre_imported) =
-            self.imported_state.take()
-        {
-            // RPython uses object identity for Boxes, so a TraceIterator over a
-            // retrace can never numerically collide with the already optimized
-            // partial preamble. Majit's OpRef is the identity; when Phase 1 is
-            // skipped, recover the partial preamble high-water from the imported
-            // state before allocating Phase 2 input/result OpRefs.
-            self.next_global_opref = self
-                .next_global_opref
-                .max(num_inputs as u32)
-                .max(pre_imported.opref_high_water());
-            // Retrace path: Phase 1 already done; preamble ops are in
-            // the caller's partial_trace, not produced here.
-            // RPython: same Optimizer persists patchguardop. Recover here.
-            if self.phase1_patchguardop.is_none() {
-                self.phase1_patchguardop = pre_imported.patchguardop.clone();
-            }
-            (pre_imported, constants.clone(), Vec::new())
-        } else {
-            // ── Phase 1: PreambleCompileData.optimize() ──
-            // ── Phase 1: optimize_preamble (compile.py:275-276) ──
-            let mut consts_p1 = constants.clone();
-            let mut opt_p1 = match vable_config.as_ref() {
+        let (mut exported_state, consts_p1, p1_ops) =
+            if let Some(pre_imported) = self.imported_state.take() {
+                // RPython uses object identity for Boxes, so a TraceIterator over a
+                // retrace can never numerically collide with the already optimized
+                // partial preamble. Majit's OpRef is the identity; when Phase 1 is
+                // skipped, recover the partial preamble high-water from the imported
+                // state before allocating Phase 2 input/result OpRefs.
+                self.next_global_opref = self
+                    .next_global_opref
+                    .max(num_inputs as u32)
+                    .max(pre_imported.opref_high_water());
+                // Retrace path: Phase 1 already done; preamble ops are in
+                // the caller's partial_trace, not produced here.
+                // RPython: same Optimizer persists patchguardop. Recover here.
+                if self.phase1_patchguardop.is_none() {
+                    self.phase1_patchguardop = pre_imported.patchguardop.clone();
+                }
+                (pre_imported, constants.clone(), Vec::new())
+            } else {
+                // ── Phase 1: PreambleCompileData.optimize() ──
+                // ── Phase 1: optimize_preamble (compile.py:275-276) ──
+                let mut consts_p1 = constants.clone();
+                let mut opt_p1 = match vable_config.as_ref() {
                 Some(c) => {
                     crate::optimizeopt::optimizer::Optimizer::default_pipeline_with_virtualizable(
                         c.clone(),
@@ -500,255 +506,250 @@ impl UnrollOptimizer {
                 }
                 None => crate::optimizeopt::optimizer::Optimizer::default_pipeline(),
             };
-            opt_p1.all_descrs = std::mem::take(&mut self.all_descrs);
-            opt_p1.callinfocollection = self.callinfocollection.clone();
-            opt_p1.cpu = self.cpu.clone();
-            opt_p1.trace_inputargs = self.trace_inputargs.clone();
-            opt_p1.snapshot_boxes = self.snapshot_boxes.clone();
-            opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
-            opt_p1.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
-            opt_p1.snapshot_vref_boxes = self.snapshot_vref_boxes.clone();
-            opt_p1.snapshot_frame_pcs = self.snapshot_frame_pcs.clone();
-            self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
-                &mut opt_p1.snapshot_boxes,
-                &mut opt_p1.snapshot_vable_boxes,
-                &mut opt_p1.snapshot_vref_boxes,
-            ]));
-            opt_p1.call_pure_results = self.call_pure_results.clone();
-            // RPython optimize_preamble (unroll.py:101-103): flush=False.
-            // JUMP/FINISH is NOT sent through the pass pipeline; it's
-            // returned in info.jump_op for Phase 2 to consume.
-            opt_p1.skip_flush = true;
-            // RPython unroll.py:101-103 `optimize_preamble` calls
-            // `propagate_all_forward(trace.get_iter())`. `trace.get_iter()`
-            // is a fresh `TraceIterator` whose `next()` produces a freshly
-            // allocated `cls()` ResOperation for every visited op.
-            //
-            // Phase 1 routes the input ops through `TraceIterator::new`
-            // with `start_fresh = 0`. The recorder emits ops at
-            // monotonically increasing positions starting from
-            // `num_inputs` (recorder.rs `record_op` uses `op_count` for
-            // BOTH inputargs and ops, and ops follow inputargs), and
-            // `TraceIterator::next` allocates fresh OpRefs from `_fresh`
-            // which is also seeded at `num_inputs` after the inputarg
-            // pre-seed loop. Both void and non-void ops advance `_fresh`
-            // (see opencoder.rs::next), so the freshly produced OpRef
-            // sequence is bit-identical to the input — this wrap is a
-            // structural alignment with RPython's `trace.get_iter()`
-            // call site, not a functional change.
-            // opencoder.py:264 `inputarg_from_tp(arg.type)` — fresh inputargs
-            // are typed via `self.trace_inputargs`, the recorder-supplied
-            // Box list (length must equal `num_inputs`). Derive the &[Type]
-            // surface TraceIterator expects from each Box's variant tag
-            // (resoperation.py:719/727/739).
-            debug_assert_eq!(self.trace_inputargs.len(), num_inputs);
-            let p1_inputarg_types: Vec<majit_ir::Type> = self
-                .trace_inputargs
-                .iter()
-                .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
-                .collect();
-            // Wrap input ops as `Vec<OpRc>` so TraceIterator's `&[OpRc]`
-            // surface receives shared identity (history.py:528). The
-            // deep-clone here corresponds to PyPy's `cls()` per-op fresh
-            // allocation inside `TraceIterator.next` (opencoder.py:399-401).
-            let ops_oprc: Vec<majit_ir::OpRc> =
-                ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
-            let mut p1_iter = crate::opencoder::TraceIterator::new(
-                &ops_oprc,
-                0,
-                ops_oprc.len(),
-                None,
-                &p1_inputarg_types,
-                0, // start_fresh = 0 — inputargs at [0..num_inputs)
-            );
-            // Clone-out boundary: the optimizer entry below still takes
-            // `&[Op]` by value; `Op::clone` preserves the bound operand
-            // handles minted by the iterator (Rc clones), so bindings
-            // survive the copy. Dissolves when the stage flips to
-            // `Vec<OpRc>` end-to-end.
-            let mut p1_ops_in: Vec<Op> = Vec::with_capacity(ops.len());
-            while let Some(op) = p1_iter.next() {
-                p1_ops_in.push((*op).clone());
-            }
-            let p1_iter_fresh_hw = p1_iter._fresh;
-            // compile.py:275 `PreambleCompileData(trace, jumpargs, ...)` —
-            // the recorded JUMP arglist is the preamble's `runtime_boxes`
-            // (live_arg_boxes captured at the merge point). Capture it into a
-            // local here; `opt_p1.runtime_boxes` cannot carry it because
-            // `setup()` clears that field at the start of every optimize run
-            // (optimizer.rs `self.runtime_boxes.clear()`). Threaded into the
-            // exported state below so the peeled-loop close reads it as
-            // `state.runtime_boxes` (unroll.py:105 → :153/166) rather than the
-            // peeled body's own jump args.
-            let recorded_jump_args: Vec<OpRef> = ops
-                .iter()
-                .rfind(|op| op.opcode == OpCode::Jump)
-                .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
-                .unwrap_or_default();
-            // Hand opt_p1 the per-iter BoxRef pool that p1_iter
-            // allocated (slice 77b.A). trace.get_iter() per-call
-            // inputarg_from_tp(...) / cls() — each phase optimizes against a
-            // fresh Box identity set so _forwarded mutations cannot alias
-            // across phases.
-            //
-            // Const BoxRefs are NOT cached: `get_box_replacement_box`
-            // allocates `BoxRef::new_const(value)` per call from `const_pool`
-            // (`history.py:220` ConstInt(value) per-call-site parity).
-            // opt_p1's entry path seeds `const_pool` from the shared
-            // `constants` map (`optimizer.rs:1944`).
-            // unroll.py:100-110 `optimize_preamble` has no
-            // SpeculativeError catch — Phase 1 corresponds to the
-            // preamble, whose gcrefs are concrete runtime values
-            // from the recorded interpreter and never raise
-            // SpeculativeError under correct construction.  A raise
-            // here is a real bug and must propagate.
-            // Phase 1's input ops are the same recorder ops the seed names,
-            // so its `input_ops` can come from the seed too — only the read
-            // source changes; `_forwarded` writes are untouched. No
-            // forwarding yet at Phase 1 setup, so the seed is trivially the
-            // authoritative source here.
-            if let Some(seed) = &self.phase2_input_ops_seed {
-                opt_p1.explicit_input_ops_seed = Some(seed.clone());
-            }
-            let p1_ops =
-                opt_p1.optimize_with_constants_and_inputs(&p1_ops_in, &mut consts_p1, num_inputs);
-            // RPython parity: Phase 1 optimizer may discover new constants
-            // via make_constant (e.g., constant-folded heap reads, guard
-            // class pointers). These live on the BoxRef forwarded chain
-            // (and in `ctx.const_pool` for const-namespace OpRefs) but
-            // not in `consts_p1` (which was only seeded from the input
-            // constants). Merge them back so
-            // build_short_preamble_from_exported_boxes can capture all
-            // constants referenced by short preamble ops.
-            if let Some(ref final_ctx) = opt_p1.final_ctx {
-                // history.py:220 box.type parity: every `Value` carries its
-                // Const class identity intrinsically; no companion type map
-                // needs threading alongside.
-                crate::optimizeopt::optimizer::merge_backend_constants_from_ctx(
-                    final_ctx,
-                    &mut consts_p1,
+                opt_p1.all_descrs = std::mem::take(&mut self.all_descrs);
+                opt_p1.callinfocollection = self.callinfocollection.clone();
+                opt_p1.cpu = self.cpu.clone();
+                opt_p1.trace_inputargs = self.trace_inputargs.clone();
+                opt_p1.snapshot_boxes = self.snapshot_boxes.clone();
+                opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
+                opt_p1.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
+                opt_p1.snapshot_vref_boxes = self.snapshot_vref_boxes.clone();
+                opt_p1.snapshot_frame_pcs = self.snapshot_frame_pcs.clone();
+                self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
+                    &mut opt_p1.snapshot_boxes,
+                    &mut opt_p1.snapshot_vable_boxes,
+                    &mut opt_p1.snapshot_vref_boxes,
+                ]));
+                opt_p1.call_pure_results = self.call_pure_results.clone();
+                // RPython optimize_preamble (unroll.py:101-103): flush=False.
+                // JUMP/FINISH is NOT sent through the pass pipeline; it's
+                // returned in info.jump_op for Phase 2 to consume.
+                opt_p1.skip_flush = true;
+                // RPython unroll.py:101-103 `optimize_preamble` calls
+                // `propagate_all_forward(trace.get_iter())`. `trace.get_iter()`
+                // is a fresh `TraceIterator` whose `next()` produces a freshly
+                // allocated `cls()` ResOperation for every visited op.
+                //
+                // Phase 1 routes the input ops through `TraceIterator::new`
+                // with `start_fresh = 0`. The recorder emits ops at
+                // monotonically increasing positions starting from
+                // `num_inputs` (recorder.rs `record_op` uses `op_count` for
+                // BOTH inputargs and ops, and ops follow inputargs), and
+                // `TraceIterator::next` allocates fresh OpRefs from `_fresh`
+                // which is also seeded at `num_inputs` after the inputarg
+                // pre-seed loop. Both void and non-void ops advance `_fresh`
+                // (see opencoder.rs::next), so the freshly produced OpRef
+                // sequence is bit-identical to the input — this wrap is a
+                // structural alignment with RPython's `trace.get_iter()`
+                // call site, not a functional change.
+                // opencoder.py:264 `inputarg_from_tp(arg.type)` — fresh inputargs
+                // are typed via `self.trace_inputargs`, the recorder-supplied
+                // Box list (length must equal `num_inputs`). Derive the &[Type]
+                // surface TraceIterator expects from each Box's variant tag
+                // (resoperation.py:719/727/739).
+                debug_assert_eq!(self.trace_inputargs.len(), num_inputs);
+                let p1_inputarg_types: Vec<majit_ir::Type> = self
+                    .trace_inputargs
+                    .iter()
+                    .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
+                    .collect();
+                // Wrap input ops as `Vec<OpRc>` so TraceIterator's `&[OpRc]`
+                // surface receives shared identity (history.py:528). The
+                // deep-clone here corresponds to PyPy's `cls()` per-op fresh
+                // allocation inside `TraceIterator.next` (opencoder.py:399-401).
+                let ops_oprc: Vec<majit_ir::OpRc> =
+                    ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
+                let mut p1_iter = crate::opencoder::TraceIterator::new(
+                    &ops_oprc,
+                    0,
+                    ops_oprc.len(),
+                    None,
+                    &p1_inputarg_types,
+                    0, // start_fresh = 0 — inputargs at [0..num_inputs)
                 );
-            }
-            let p1_ni = opt_p1.final_num_inputs();
+                let mut p1_ops_in: Vec<majit_ir::OpRc> = Vec::with_capacity(ops.len());
+                while let Some(op) = p1_iter.next() {
+                    p1_ops_in.push(op);
+                }
+                let p1_iter_fresh_hw = p1_iter._fresh;
+                // compile.py:275 `PreambleCompileData(trace, jumpargs, ...)` —
+                // the recorded JUMP arglist is the preamble's `runtime_boxes`
+                // (live_arg_boxes captured at the merge point). Capture it into a
+                // local here; `opt_p1.runtime_boxes` cannot carry it because
+                // `setup()` clears that field at the start of every optimize run
+                // (optimizer.rs `self.runtime_boxes.clear()`). Threaded into the
+                // exported state below so the peeled-loop close reads it as
+                // `state.runtime_boxes` (unroll.py:105 → :153/166) rather than the
+                // peeled body's own jump args.
+                let recorded_jump_args: Vec<OpRef> = ops
+                    .iter()
+                    .rfind(|op| op.opcode == OpCode::Jump)
+                    .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
+                    .unwrap_or_default();
+                // Hand opt_p1 the per-iter BoxRef pool that p1_iter
+                // allocated (slice 77b.A). trace.get_iter() per-call
+                // inputarg_from_tp(...) / cls() — each phase optimizes against a
+                // fresh Box identity set so _forwarded mutations cannot alias
+                // across phases.
+                //
+                // Const BoxRefs are NOT cached: `get_box_replacement_box`
+                // allocates `BoxRef::new_const(value)` per call from `const_pool`
+                // (`history.py:220` ConstInt(value) per-call-site parity).
+                // opt_p1's entry path seeds `const_pool` from the shared
+                // `constants` map (`optimizer.rs:1944`).
+                // unroll.py:100-110 `optimize_preamble` has no
+                // SpeculativeError catch — Phase 1 corresponds to the
+                // preamble, whose gcrefs are concrete runtime values
+                // from the recorded interpreter and never raise
+                // SpeculativeError under correct construction.  A raise
+                // here is a real bug and must propagate.
+                // Phase 1's input ops are the same recorder ops the seed names,
+                // so its `input_ops` can come from the seed too — only the read
+                // source changes; `_forwarded` writes are untouched. No
+                // forwarding yet at Phase 1 setup, so the seed is trivially the
+                // authoritative source here.
+                if let Some(seed) = &self.phase2_input_ops_seed {
+                    opt_p1.explicit_input_ops_seed = Some(seed.clone());
+                }
+                let p1_ops =
+                    opt_p1.run_optimize_from_inputs(&p1_ops_in, &mut consts_p1, num_inputs, false);
+                // RPython parity: Phase 1 optimizer may discover new constants
+                // via make_constant (e.g., constant-folded heap reads, guard
+                // class pointers). These live on the BoxRef forwarded chain
+                // (and in `ctx.const_pool` for const-namespace OpRefs) but
+                // not in `consts_p1` (which was only seeded from the input
+                // constants). Merge them back so
+                // build_short_preamble_from_exported_boxes can capture all
+                // constants referenced by short preamble ops.
+                if let Some(ref final_ctx) = opt_p1.final_ctx {
+                    // history.py:220 box.type parity: every `Value` carries its
+                    // Const class identity intrinsically; no companion type map
+                    // needs threading alongside.
+                    crate::optimizeopt::optimizer::merge_backend_constants_from_ctx(
+                        final_ctx,
+                        &mut consts_p1,
+                    );
+                }
+                let p1_ni = opt_p1.final_num_inputs();
 
-            match opt_p1.exported_loop_state.take() {
-                Some(mut state) => {
-                    // unroll.py:105 `export_state(..., runtime_boxes, ...)` —
-                    // carry the recorded JUMP args into ExportedState so the
-                    // peeled-loop close passes them to generate_guards as
-                    // `state.runtime_boxes` (unroll.py:153/166).
-                    state.runtime_boxes = recorded_jump_args.clone();
-                    // end_arg_types is already populated by
-                    // `Optimizer::optimize_with_constants_and_inputs_at`
-                    // using the optimizer-visible `ctx.opref_type()` (see
-                    // optimizer.rs:2405-2416). Overwriting it here with
-                    // `opcode.result_type()` + `Type::Ref` default would
-                    // retype Phase 1 inputarg OpRefs (absent from `p1_ops`)
-                    // as `Ref`, which later feeds the cross-type forward
-                    // assertion in `OptContext::make_equal_to`.
-                    // RPython Phase 1 → Phase 2 heap cache transfer:
-                    // RPython does NOT serialize heap cache in ExportedState.
-                    // HeapOps in the short preamble are replayed during Phase 2's
-                    // inline_short_preamble, populating the heap cache naturally
-                    // through OptHeap. serialize_optheap is only for bridgeopt.
-                    // opencoder.py:271 _index parity: Phase 2's TraceIterator
-                    // must allocate fresh boxes ABOVE Phase 1's high water
-                    // mark so the two phases' OpRef namespaces are disjoint
-                    // (RPython relies on Python identity to distinguish them;
-                    // majit relies on disjoint integer ranges). The high
-                    // water is `final_ctx.next_pos` after Phase 1 emit, with
-                    // a floor of `num_inputs` for empty traces.
-                    // Phase 1's emit-side high water (`final_ctx.next_pos`)
-                    // reflects only the positions `ctx.reserve_pos` handed
-                    // out; the per-iteration TraceIterator additionally
-                    // allocates fresh OpRefs via its `_fresh` counter and
-                    // those values can exceed `next_pos` for traces where
-                    // Phase 1 dropped or folded many ops. Taking the max
-                    // with `p1_iter_fresh_hw` keeps Phase 2's inputarg base
-                    // strictly above every OpRef Phase 1 ever allocated,
-                    // so Phase 2's own fresh OpRefs cannot collide with
-                    // positions in `phase1_emit_ops` / typed snapshots.
-                    self.next_global_opref = opt_p1
-                        .final_ctx
-                        .as_ref()
-                        .map(|c| c.next_pos)
-                        .unwrap_or(num_inputs as u32)
-                        .max(num_inputs as u32)
-                        .max(p1_iter_fresh_hw);
-                    // RPython Box type parity: Phase 1's emit ops carry
-                    // `op.type_` intrinsically; Phase 2's `op_at` reads it
-                    // directly to resolve cross-phase OpRefs that appear as
-                    // imported_label_args / fail_args / record_same_as
-                    // sources (history.py:220 parity).
-                    self.phase1_emit_ops = std::mem::take(&mut opt_p1.phase1_emit_ops);
-                    // RPython: same Optimizer instance keeps patchguardop.
-                    if self.phase1_patchguardop.is_none() {
-                        self.phase1_patchguardop = opt_p1.patchguardop.clone();
+                match opt_p1.exported_loop_state.take() {
+                    Some(mut state) => {
+                        // unroll.py:105 `export_state(..., runtime_boxes, ...)` —
+                        // carry the recorded JUMP args into ExportedState so the
+                        // peeled-loop close passes them to generate_guards as
+                        // `state.runtime_boxes` (unroll.py:153/166).
+                        state.runtime_boxes = recorded_jump_args.clone();
+                        // end_arg_types is already populated by
+                        // `Optimizer::optimize_with_constants_and_inputs_at`
+                        // using the optimizer-visible `ctx.opref_type()` (see
+                        // optimizer.rs:2405-2416). Overwriting it here with
+                        // `opcode.result_type()` + `Type::Ref` default would
+                        // retype Phase 1 inputarg OpRefs (absent from `p1_ops`)
+                        // as `Ref`, which later feeds the cross-type forward
+                        // assertion in `OptContext::make_equal_to`.
+                        // RPython Phase 1 → Phase 2 heap cache transfer:
+                        // RPython does NOT serialize heap cache in ExportedState.
+                        // HeapOps in the short preamble are replayed during Phase 2's
+                        // inline_short_preamble, populating the heap cache naturally
+                        // through OptHeap. serialize_optheap is only for bridgeopt.
+                        // opencoder.py:271 _index parity: Phase 2's TraceIterator
+                        // must allocate fresh boxes ABOVE Phase 1's high water
+                        // mark so the two phases' OpRef namespaces are disjoint
+                        // (RPython relies on Python identity to distinguish them;
+                        // majit relies on disjoint integer ranges). The high
+                        // water is `final_ctx.next_pos` after Phase 1 emit, with
+                        // a floor of `num_inputs` for empty traces.
+                        // Phase 1's emit-side high water (`final_ctx.next_pos`)
+                        // reflects only the positions `ctx.reserve_pos` handed
+                        // out; the per-iteration TraceIterator additionally
+                        // allocates fresh OpRefs via its `_fresh` counter and
+                        // those values can exceed `next_pos` for traces where
+                        // Phase 1 dropped or folded many ops. Taking the max
+                        // with `p1_iter_fresh_hw` keeps Phase 2's inputarg base
+                        // strictly above every OpRef Phase 1 ever allocated,
+                        // so Phase 2's own fresh OpRefs cannot collide with
+                        // positions in `phase1_emit_ops` / typed snapshots.
+                        self.next_global_opref = opt_p1
+                            .final_ctx
+                            .as_ref()
+                            .map(|c| c.next_pos)
+                            .unwrap_or(num_inputs as u32)
+                            .max(num_inputs as u32)
+                            .max(p1_iter_fresh_hw);
+                        // RPython Box type parity: Phase 1's emit ops carry
+                        // `op.type_` intrinsically; Phase 2's `op_at` reads it
+                        // directly to resolve cross-phase OpRefs that appear as
+                        // imported_label_args / fail_args / record_same_as
+                        // sources (history.py:220 parity).
+                        self.phase1_emit_ops = std::mem::take(&mut opt_p1.phase1_emit_ops);
+                        // RPython: same Optimizer instance keeps patchguardop.
+                        if self.phase1_patchguardop.is_none() {
+                            self.phase1_patchguardop = opt_p1.patchguardop.clone();
+                        }
+                        state.patchguardop = opt_p1.patchguardop.clone();
+                        self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
+                        // Box.type parity: retain Phase 1's renamed_inputargs so
+                        // the backend can read the reduced LABEL's declared types
+                        // off each typed InputArg OpRef. Clone only the field we
+                        // need to avoid keeping Phase 1 short preamble data alive
+                        // longer than before.
+                        let mut final_exported_state = ExportedState {
+                            end_args: Vec::new(),
+                            next_iteration_args: Vec::new(),
+                            end_arg_types: Vec::new(),
+                            virtual_state: state.virtual_state.clone(),
+                            exported_infos: crate::optimizeopt::vec_assoc::VecAssoc::new(),
+                            exported_short_boxes: Vec::new(),
+                            short_boxes: Vec::new(),
+                            short_box_const_values: crate::optimizeopt::vec_assoc::VecAssoc::new(),
+                            short_preamble: None,
+                            renamed_inputargs: state.renamed_inputargs.clone(),
+                            short_inputargs: Vec::new(),
+                            runtime_boxes: Vec::new(),
+                            patchguardop: None,
+                            phase1_emit_high_water: self.next_global_opref,
+                            partial_trace_inputargs: Vec::new(),
+                            partial_trace_operations: Vec::new(),
+                            rooted_refs: Vec::new(),
+                            rooted_const_ptr_slots: Vec::new(),
+                            shadow_stack_base: 0,
+                        };
+                        final_exported_state.root_all_gcrefs();
+                        self.final_exported_state = Some(final_exported_state);
+                        (state, consts_p1, p1_ops)
                     }
-                    state.patchguardop = opt_p1.patchguardop.clone();
-                    self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
-                    // Box.type parity: retain Phase 1's renamed_inputargs so
-                    // the backend can read the reduced LABEL's declared types
-                    // off each typed InputArg OpRef. Clone only the field we
-                    // need to avoid keeping Phase 1 short preamble data alive
-                    // longer than before.
-                    let mut final_exported_state = ExportedState {
-                        end_args: Vec::new(),
-                        next_iteration_args: Vec::new(),
-                        end_arg_types: Vec::new(),
-                        virtual_state: state.virtual_state.clone(),
-                        exported_infos: crate::optimizeopt::vec_assoc::VecAssoc::new(),
-                        exported_short_boxes: Vec::new(),
-                        short_boxes: Vec::new(),
-                        short_box_const_values: crate::optimizeopt::vec_assoc::VecAssoc::new(),
-                        short_preamble: None,
-                        renamed_inputargs: state.renamed_inputargs.clone(),
-                        short_inputargs: Vec::new(),
-                        runtime_boxes: Vec::new(),
-                        patchguardop: None,
-                        phase1_emit_high_water: self.next_global_opref,
-                        partial_trace_inputargs: Vec::new(),
-                        partial_trace_operations: Vec::new(),
-                        rooted_refs: Vec::new(),
-                        rooted_const_ptr_slots: Vec::new(),
-                        shadow_stack_base: 0,
-                    };
-                    final_exported_state.root_all_gcrefs();
-                    self.final_exported_state = Some(final_exported_state);
-                    (state, consts_p1, p1_ops)
-                }
-                None => {
-                    *constants = consts_p1;
-                    // Take back the descriptor table grown during Phase 1's pass
-                    // (`ensure_descr_index` appends at guard-resume serialization),
-                    // mirroring the Some branch's restore above. Without this the
-                    // non-peeled path drops those descriptors and publishes a stale
-                    // `all_descrs` back over the global table.
-                    self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
-                    // RPython: compile_loop uses flush=True — terminal op
-                    // (Finish/Jump) goes through the pass pipeline normally.
-                    // majit: flush=False stores it in terminal_op; restore it
-                    // here for non-peeled traces that return directly.
-                    let mut ops = p1_ops;
-                    if let Some(terminal) = opt_p1.terminal_op.take() {
-                        ops.push(terminal);
+                    None => {
+                        *constants = consts_p1;
+                        // Take back the descriptor table grown during Phase 1's pass
+                        // (`ensure_descr_index` appends at guard-resume serialization),
+                        // mirroring the Some branch's restore above. Without this the
+                        // non-peeled path drops those descriptors and publishes a stale
+                        // `all_descrs` back over the global table.
+                        self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
+                        // RPython: compile_loop uses flush=True — terminal op
+                        // (Finish/Jump) goes through the pass pipeline normally.
+                        // majit: flush=False stores it in terminal_op; restore it
+                        // here for non-peeled traces that return directly.
+                        let mut ops = p1_ops;
+                        if let Some(terminal) = opt_p1.terminal_op.take() {
+                            ops.push(std::rc::Rc::new(terminal));
+                        }
+                        // `compile.py:245` `jitcell_token.target_tokens = [target_token]`
+                        // / `:290` `jitcell_token.target_tokens = [start_descr]` —
+                        // PyPy unconditionally publishes one preamble target token
+                        // for any successful compile path (compile_simple_loop +
+                        // compile_loop both).  Phase 2 is bypassed here (no
+                        // exported_loop_state) but the loop still compiles, so
+                        // mirror the unconditional preamble registration so that
+                        // `JitCellToken.target_tokens` is non-empty at the
+                        // `has_compiled_targets` (`pyjitpl.py:3898`) read site.
+                        self.ensure_preamble_target_token();
+                        let loop_arity = closing_loop_contract_arity(&ops, p1_ni);
+                        self.clear_compile_snapshot_roots();
+                        return (ops, loop_arity);
                     }
-                    // `compile.py:245` `jitcell_token.target_tokens = [target_token]`
-                    // / `:290` `jitcell_token.target_tokens = [start_descr]` —
-                    // PyPy unconditionally publishes one preamble target token
-                    // for any successful compile path (compile_simple_loop +
-                    // compile_loop both).  Phase 2 is bypassed here (no
-                    // exported_loop_state) but the loop still compiles, so
-                    // mirror the unconditional preamble registration so that
-                    // `JitCellToken.target_tokens` is non-empty at the
-                    // `has_compiled_targets` (`pyjitpl.py:3898`) read site.
-                    self.ensure_preamble_target_token();
-                    let loop_arity = closing_loop_contract_arity(&ops, p1_ni);
-                    self.clear_compile_snapshot_roots();
-                    return (ops, loop_arity);
                 }
-            }
-        };
+            };
         self.clear_compile_snapshot_roots();
         // unroll.py:454 end_args carry type via Box; export_state already
         // populated `exported_state.end_arg_types` from ctx.
@@ -916,10 +917,9 @@ impl UnrollOptimizer {
             &p2_inputarg_types,
             phase2_inputarg_base, // fresh inputargs at [phase2_inputarg_base..)
         );
-        // Clone-out boundary — see the Phase 1 drive loop above.
-        let mut p2_ops_in: Vec<Op> = Vec::with_capacity(ops.len());
+        let mut p2_ops_in: Vec<majit_ir::OpRc> = Vec::with_capacity(ops.len());
         while let Some(op) = iter.next() {
-            p2_ops_in.push((*op).clone());
+            p2_ops_in.push(op);
         }
         let p2_high_water = iter._fresh;
         let p2_cache = iter._cache;
@@ -989,10 +989,6 @@ impl UnrollOptimizer {
         // unroll.py:119-123 — Phase 2 (peeled loop) raises
         // SpeculativeError on speculative-fold paths; convert
         // to InvalidLoop so the caller's catch handles it.
-        let p2_ops_in_rc: Vec<majit_ir::OpRc> = p2_ops_in
-            .iter()
-            .map(|op| std::rc::Rc::new(op.clone()))
-            .collect();
         // Seed Phase 2's `input_ops` from the recorder `Rc<Op>` (same `Rc`,
         // same Phase-1 `_forwarded`) so `input_ops` is the authoritative
         // producer store. A `Some(empty)` (cut path) leaves it empty.
@@ -1001,7 +997,7 @@ impl UnrollOptimizer {
         }
         let p2_ops = with_speculative_to_invalid_loop(|| {
             opt_p2.optimize_with_constants_and_inputs_at(
-                &p2_ops_in_rc,
+                &p2_ops_in,
                 &mut consts_p2,
                 body_num_inputs,
                 phase2_inputarg_base, // inputarg_base — Phase 2 inputargs at [phase2_inputarg_base..)
@@ -1619,10 +1615,7 @@ impl UnrollOptimizer {
             if jumped && redirected_tail_ops.is_empty() {
                 // Only take jump_ctx ops if we don't already have
                 // a self-loop Jump from the retrace path.
-                redirected_tail_ops = std::mem::take(&mut jump_ctx.new_operations)
-                    .into_iter()
-                    .map(|rc| (*rc).clone())
-                    .collect();
+                redirected_tail_ops = std::mem::take(&mut jump_ctx.new_operations);
                 // Check if the redirected Jump targets the current body token
                 // (last in target_tokens) or an external token from a previous
                 // compilation.  The Cranelift backend compiles each trace as a
@@ -1706,11 +1699,8 @@ impl UnrollOptimizer {
                     // partial-inline operations already appended to
                     // _newoperations.
                     opt_p2.send_extra_operation(&end_jump, &mut final_ctx);
-                    let redirected_tail_ops: Vec<Op> =
-                        std::mem::take(&mut final_ctx.new_operations)
-                            .into_iter()
-                            .map(|rc| (*rc).clone())
-                            .collect();
+                    let redirected_tail_ops: Vec<majit_ir::OpRc> =
+                        std::mem::take(&mut final_ctx.new_operations);
                     opt_p2.final_ctx = Some(final_ctx);
                     body_ops = splice_redirected_tail(&body_ops, &redirected_tail_ops);
                 } else {
@@ -1769,7 +1759,7 @@ impl UnrollOptimizer {
             });
         }
         crate::optimizeopt::optimizer::sanitize_backend_constants_for_ops(
-            &combined,
+            combined.iter().map(|op| &**op),
             &mut consts_p2,
         );
         if crate::debug::have_debug_prints() {
@@ -1792,13 +1782,15 @@ impl UnrollOptimizer {
     /// RPython compile.py uses the optimized loop state's inputargs contract,
     /// not a stale input counter. When majit falls back to the phase-1 trace,
     /// derive the live loop arity from the actual closing Label/Jump.
-    pub fn closing_loop_contract_arity(ops: &[Op], fallback: usize) -> usize {
+    pub fn closing_loop_contract_arity<T: AsRef<Op>>(ops: &[T], fallback: usize) -> usize {
         closing_loop_contract_arity(ops, fallback)
     }
 
     /// Count the guards in an optimized trace (for retrace_limit checks).
-    pub fn count_guards(ops: &[Op]) -> u32 {
-        ops.iter().filter(|op| op.opcode.is_guard()).count() as u32
+    pub fn count_guards<T: AsRef<Op>>(ops: &[T]) -> u32 {
+        ops.iter()
+            .filter(|op| op.as_ref().opcode.is_guard())
+            .count() as u32
     }
 
     /// unroll.py: _map_args(mapping, arglist)
@@ -1822,7 +1814,10 @@ impl UnrollOptimizer {
     /// unroll.py: disable_retracing_if_max_retrace_guards(ops, target_token)
     /// If the trace has too many guards, disable retracing for this location.
     /// Returns true if retracing was disabled.
-    pub fn disable_retracing_if_max_retrace_guards(ops: &[Op], max_retrace_guards: u32) -> bool {
+    pub fn disable_retracing_if_max_retrace_guards<T: AsRef<Op>>(
+        ops: &[T],
+        max_retrace_guards: u32,
+    ) -> bool {
         let guard_count = Self::count_guards(ops);
         guard_count > max_retrace_guards
     }
@@ -1837,8 +1832,9 @@ impl UnrollOptimizer {
     }
 }
 
-fn closing_loop_contract_arity(ops: &[Op], fallback: usize) -> usize {
+fn closing_loop_contract_arity<T: AsRef<Op>>(ops: &[T], fallback: usize) -> usize {
     ops.iter()
+        .map(|op| op.as_ref())
         .rev()
         .find_map(|op| match op.opcode {
             OpCode::Label | OpCode::Jump => Some(op.num_args()),
@@ -2794,12 +2790,15 @@ impl OptUnroll {
     /// When the peeled body contains more guards than `max_retrace_guards`,
     /// set `retraced_count = u32::MAX` on the targeting JitCellToken so that
     /// future bridges jump to the preamble instead of requesting a retrace.
-    pub fn disable_retracing_if_max_retrace_guards(
-        ops: &[majit_ir::Op],
+    pub fn disable_retracing_if_max_retrace_guards<T: AsRef<Op>>(
+        ops: &[T],
         retraced_count: &mut u32,
         max_retrace_guards: u32,
     ) {
-        let guard_count = ops.iter().filter(|op| op.opcode.is_guard()).count();
+        let guard_count = ops
+            .iter()
+            .filter(|op| op.as_ref().opcode.is_guard())
+            .count();
         if guard_count > max_retrace_guards as usize {
             *retraced_count = u32::MAX;
         }
@@ -4311,11 +4310,19 @@ fn assemble_peeled_trace(
     constants: &majit_ir::VecAssoc<u32, majit_ir::Value>,
     start_label_descr: Option<DescrRef>,
     loop_label_descr: Option<DescrRef>,
-) -> Vec<Op> {
+) -> Vec<majit_ir::OpRc> {
     let mut ctx = assemble_test_context(p1_ops, p2_ops, body_num_inputs);
+    let p1_ops_rc: Vec<majit_ir::OpRc> = p1_ops
+        .iter()
+        .map(|op| std::rc::Rc::new(op.clone()))
+        .collect();
+    let p2_ops_rc: Vec<majit_ir::OpRc> = p2_ops
+        .iter()
+        .map(|op| std::rc::Rc::new(op.clone()))
+        .collect();
     assemble_peeled_trace_with_jump_args(
-        p1_ops,
-        p2_ops,
+        &p1_ops_rc,
+        &p2_ops_rc,
         label_args,
         start_label_args,
         extra_label_args,
@@ -4353,19 +4360,19 @@ fn assemble_test_context(p1_ops: &[Op], p2_ops: &[Op], body_num_inputs: usize) -
 /// `pos=alias.result` per entry so the body's reference to the alias result
 /// has a defining op.
 fn emit_alias_same_as_for_imports(
-    result: &mut Vec<Op>,
+    result: &mut Vec<majit_ir::OpRc>,
     imported_short_aliases: &[crate::optimizeopt::ImportedShortAlias],
 ) {
     for alias in imported_short_aliases {
         let mut op = Op::new(alias.same_as_opcode, &[alias.same_as_source.clone()]);
         op.pos.set(alias.result);
-        result.push(op);
+        result.push(std::rc::Rc::new(op));
     }
 }
 
 fn assemble_peeled_trace_with_jump_args(
-    p1_ops: &[Op],
-    p2_ops: &[Op],
+    p1_ops: &[majit_ir::OpRc],
+    p2_ops: &[majit_ir::OpRc],
     label_args: &[OpRef],
     start_label_args: &[OpRef],
     extra_label_args: &[OpRef],
@@ -4379,7 +4386,7 @@ fn assemble_peeled_trace_with_jump_args(
     loop_label_descr: Option<DescrRef>,
     _p1_end_args: &[OpRef],
     ctx: &mut crate::optimizeopt::OptContext,
-) -> Vec<Op> {
+) -> Vec<majit_ir::OpRc> {
     let mut result =
         Vec::with_capacity(p1_ops.len() + p2_ops.len() + 1 + imported_short_aliases.len());
     let mut filtered_extra_label_args = Vec::new();
@@ -4434,7 +4441,7 @@ fn assemble_peeled_trace_with_jump_args(
         let mut start_label = Op::new(OpCode::Label, &start_label_args_box);
         start_label.pos.set(OpRef::NONE);
         start_label.setdescr(start_label_descr);
-        result.push(start_label);
+        result.push(std::rc::Rc::new(start_label));
     }
 
     // Preamble: everything except Jump
@@ -4442,7 +4449,7 @@ fn assemble_peeled_trace_with_jump_args(
         if op.opcode == OpCode::Jump {
             break;
         }
-        result.push(op.clone());
+        result.push(std::rc::Rc::new((**op).clone()));
     }
 
     // max_pos must account for ALL p1_ops positions, including SameAs
@@ -4654,8 +4661,8 @@ fn assemble_peeled_trace_with_jump_args(
     if let Some(d) = loop_label_descr {
         label_op.setdescr(d);
     }
-    result.extend(fallthrough_aliases);
-    result.push(label_op);
+    result.extend(fallthrough_aliases.into_iter().map(std::rc::Rc::new));
+    result.push(std::rc::Rc::new(label_op));
 
     // Body: 2-pass remap (inputarg refs -> label args, body results -> fresh boxes)
     let max_label_arg_pos = full_label_args
@@ -4763,7 +4770,7 @@ fn assemble_peeled_trace_with_jump_args(
     let mut defs_since_inner_label: majit_ir::vec_set::VecSet<OpRef> =
         majit_ir::vec_set::VecSet::new();
     for (op_idx, op) in p2_ops.iter().enumerate() {
-        let mut new_op = op.clone();
+        let mut new_op = (**op).clone();
         let mut original_args = op.getarglist_copy();
         if let Some(&mapped_pos) = body_result_remap.get(&op.pos.get()) {
             new_op.pos.set(mapped_pos);
@@ -5047,7 +5054,7 @@ fn assemble_peeled_trace_with_jump_args(
         // fail_index for the sharing-path guard. Both phases of the
         // unroll optimizer therefore emit body guards with unique
         // descrs already; no post-process re-stamping is needed.
-        result.push(new_op);
+        result.push(std::rc::Rc::new(new_op));
         if op.opcode == OpCode::Label {
             current_inner_label_index = Some(result.len() - 1);
             defs_since_inner_label.clear();
@@ -5061,7 +5068,10 @@ fn assemble_peeled_trace_with_jump_args(
     result
 }
 
-fn splice_redirected_tail(body_ops: &[Op], redirected_tail_ops: &[Op]) -> Vec<Op> {
+fn splice_redirected_tail(
+    body_ops: &[majit_ir::OpRc],
+    redirected_tail_ops: &[majit_ir::OpRc],
+) -> Vec<majit_ir::OpRc> {
     let mut result = Vec::with_capacity(body_ops.len() + redirected_tail_ops.len());
     let split_idx = body_ops
         .iter()
@@ -5072,14 +5082,14 @@ fn splice_redirected_tail(body_ops: &[Op], redirected_tail_ops: &[Op]) -> Vec<Op
     result
 }
 
-fn replace_terminal_jump(body_ops: &[Op], jump_op: Op) -> Vec<Op> {
+fn replace_terminal_jump(body_ops: &[majit_ir::OpRc], jump_op: Op) -> Vec<majit_ir::OpRc> {
     let mut result = Vec::with_capacity(body_ops.len() + 1);
     let split_idx = body_ops
         .iter()
         .rposition(|op| op.opcode == OpCode::Jump)
         .unwrap_or(body_ops.len());
     result.extend_from_slice(&body_ops[..split_idx]);
-    result.push(jump_op);
+    result.push(std::rc::Rc::new(jump_op));
     result
 }
 
@@ -5484,6 +5494,7 @@ mod tests {
         ];
         let preamble_target = TargetToken::new_preamble(7);
 
+        let body_ops: Vec<majit_ir::OpRc> = body_ops.into_iter().map(std::rc::Rc::new).collect();
         let result = UnrollOptimizer::jump_to_preamble(&body_ops, &preamble_target);
         assert_eq!(result[1].opcode, OpCode::Jump);
         assert_eq!(
@@ -5530,6 +5541,7 @@ mod tests {
         let mut jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(2))]);
         jump.setdescr(TargetToken::new_preamble(7).as_jump_target_descr());
 
+        let body_ops: Vec<majit_ir::OpRc> = body_ops.into_iter().map(std::rc::Rc::new).collect();
         let result = replace_terminal_jump(&body_ops, jump);
 
         assert_eq!(result.len(), 2);
@@ -7161,9 +7173,17 @@ mod tests {
             majit_ir::VecAssoc::from([(OpRef::void_op(857).raw(), majit_ir::Value::Int(2))]);
 
         let mut ctx = assemble_test_context(&p1_ops, &p2_ops, 1);
+        let p1_ops_rc: Vec<majit_ir::OpRc> = p1_ops
+            .iter()
+            .map(|op| std::rc::Rc::new(op.clone()))
+            .collect();
+        let p2_ops_rc: Vec<majit_ir::OpRc> = p2_ops
+            .iter()
+            .map(|op| std::rc::Rc::new(op.clone()))
+            .collect();
         let combined = assemble_peeled_trace_with_jump_args(
-            &p1_ops,
-            &p2_ops,
+            &p1_ops_rc,
+            &p2_ops_rc,
             &[OpRef::int_op(10)],
             &[OpRef::int_op(0)],
             &[OpRef::int_op(22), OpRef::void_op(857), OpRef::int_op(150)],
@@ -7730,6 +7750,9 @@ mod tests {
             ),
         ];
 
+        let body_ops: Vec<majit_ir::OpRc> = body_ops.into_iter().map(std::rc::Rc::new).collect();
+        let redirected_tail: Vec<majit_ir::OpRc> =
+            redirected_tail.into_iter().map(std::rc::Rc::new).collect();
         let spliced = splice_redirected_tail(&body_ops, &redirected_tail);
         assert_eq!(spliced.len(), 3);
         assert_eq!(spliced[0].opcode, OpCode::IntAdd);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2116,6 +2116,7 @@ impl ExportedState {
             visitor: &mut dyn FnMut(&mut GcRef),
         ) {
             visit_op(&produced.preamble_op, visitor);
+            produced.res.walk_const_ptr_refs(visitor);
             if let Some(source) = produced.same_as_source.as_ref() {
                 source.walk_const_ptr_refs(visitor);
             }
@@ -5624,6 +5625,7 @@ mod tests {
             old_ref,
             ProducedShortOp {
                 kind: PreambleOpKind::Pure,
+                res: BoxRef::from_opref(old_ref),
                 preamble_op: std::rc::Rc::new(Op::new(
                     OpCode::SameAsR,
                     &[BoxRef::from_opref(old_ref)],

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4801,17 +4801,21 @@ fn assemble_peeled_trace_with_jump_args(
             };
         // optimizer.py:651-652 force_box loop pattern:
         //   for i in range(op.numargs()): op.setarg(i, ...)
+        // Only remap hits are rewritten; a miss keeps the existing operand
+        // (a bound operand stays live-tracking instead of degrading to a
+        // position-only re-mint of the same position).
         for i in 0..new_op.num_args() {
-            new_op.setarg(
-                i,
-                BoxRef::from_opref(remap_body_arg(
-                    new_op.arg(i).to_opref(),
-                    &assembly_alias_remap,
-                    &body_result_remap,
-                    &seen_body_defs,
-                    &visible_before_label,
-                )),
+            let arg = new_op.arg(i).to_opref();
+            let mapped = remap_body_arg(
+                arg,
+                &assembly_alias_remap,
+                &body_result_remap,
+                &seen_body_defs,
+                &visible_before_label,
             );
+            if mapped != arg {
+                new_op.setarg(i, BoxRef::from_opref(mapped));
+            }
         }
         if new_op.opcode == OpCode::Label {
             let mut seen_after_label_defs = majit_ir::vec_set::VecSet::new();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5624,7 +5624,7 @@ mod tests {
             VirtualState::new(vec![VirtualStateInfo::Constant(Value::Ref(old))]),
             exported_infos,
             vec![PreambleOp {
-                op: Op::new(OpCode::SameAsR, &[BoxRef::from_opref(old_ref)]),
+                op: std::rc::Rc::new(Op::new(OpCode::SameAsR, &[BoxRef::from_opref(old_ref)])),
                 res: BoxRef::from_opref(old_ref),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
@@ -6394,7 +6394,7 @@ mod tests {
                         field_descr.clone(),
                     );
                     op.pos.set(OpRef::int_op(11));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::int_op(11)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
@@ -6454,7 +6454,7 @@ mod tests {
                         field_descr.clone(),
                     );
                     op.pos.set(OpRef::int_op(11));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::int_op(11)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
@@ -6512,7 +6512,7 @@ mod tests {
                 op: {
                     let mut op = Op::new(OpCode::CallLoopinvariantI, &[BoxRef::from_opref(func)]);
                     op.pos.set(OpRef::int_op(11));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::int_op(11)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
@@ -6570,7 +6570,7 @@ mod tests {
                 op: {
                     let mut op = Op::new(OpCode::CallLoopinvariantI, &[BoxRef::from_opref(func)]);
                     op.pos.set(source);
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
@@ -6630,7 +6630,7 @@ mod tests {
                         ],
                     );
                     op.pos.set(OpRef::int_op(20));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::int_op(20)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
@@ -6718,7 +6718,7 @@ mod tests {
                         majit_ir::descr::make_field_descr_full(56, 0, 8, Type::Ref, false),
                     );
                     op.pos.set(OpRef::ref_op(19));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::ref_op(19)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
@@ -6794,7 +6794,7 @@ mod tests {
                         ],
                     );
                     op.pos.set(OpRef::int_op(30));
-                    op
+                    std::rc::Rc::new(op)
                 },
                 res: BoxRef::from_opref(OpRef::int_op(30)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2106,6 +2106,7 @@ impl ExportedState {
             visitor: &mut dyn FnMut(&mut GcRef),
         ) {
             visit_op(&entry.op, visitor);
+            entry.res.walk_const_ptr_refs(visitor);
             if let Some(source) = entry.same_as_source.as_ref() {
                 source.walk_const_ptr_refs(visitor);
             }
@@ -2217,6 +2218,7 @@ impl ExportedState {
 
         for preamble_op in &self.exported_short_boxes {
             visit_op(&preamble_op.op, &mut visit);
+            visit(preamble_op.res.to_opref());
             if let Some(source) = preamble_op.same_as_source.as_ref() {
                 visit(source.to_opref());
             }
@@ -5613,6 +5615,7 @@ mod tests {
             exported_infos,
             vec![PreambleOp {
                 op: Op::new(OpCode::SameAsR, &[BoxRef::from_opref(old_ref)]),
+                res: BoxRef::from_opref(old_ref),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -6383,6 +6386,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::int_op(11)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6442,6 +6446,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::int_op(11)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6499,6 +6504,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::int_op(11)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6556,6 +6562,7 @@ mod tests {
                     op.pos.set(source);
                     op
                 },
+                res: BoxRef::from_opref(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
                 label_arg_idx: Some(0),
                 invented_name: false,
@@ -6615,6 +6622,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(20));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::int_op(20)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -6702,6 +6710,7 @@ mod tests {
                     op.pos.set(OpRef::ref_op(19));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::ref_op(19)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: None,
                 invented_name: false,
@@ -6777,6 +6786,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(30));
                     op
                 },
+                res: BoxRef::from_opref(OpRef::int_op(30)),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: true,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3721,8 +3721,7 @@ impl OptUnroll {
                                 "non-guard short-preamble op carried fail_args: {:?}",
                                 new_op.opcode
                             );
-                            *arg =
-                                majit_ir::operand::Operand::Box(ctx.materialize_box_at(mapped));
+                            *arg = majit_ir::operand::Operand::Box(ctx.materialize_box_at(mapped));
                         }
                     }
                 }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3654,7 +3654,10 @@ impl OptUnroll {
                     // indicate a structural mismatch (e.g., cross-loop bridge
                     // with incompatible short preamble). Raise InvalidLoop.
                     match mapping.get(&arg.to_opref()) {
-                        Some(&mapped) => new_op.setarg(i, BoxRef::from_opref(mapped)),
+                        // unroll.py:367: mapping values are the replayed op
+                        // objects; bind to the registered producer (memoized
+                        // on box_cache) rather than minting an unbound box.
+                        Some(&mapped) => new_op.setarg(i, ctx.materialize_box_at(mapped)),
                         None => {
                             // RPython: _map_args raises KeyError for unmapped
                             // args. This is equivalent to InvalidLoop — the
@@ -3712,7 +3715,8 @@ impl OptUnroll {
                                 "non-guard short-preamble op carried fail_args: {:?}",
                                 new_op.opcode
                             );
-                            *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(mapped));
+                            *arg =
+                                majit_ir::operand::Operand::Box(ctx.materialize_box_at(mapped));
                         }
                     }
                 }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4771,6 +4771,11 @@ fn assemble_peeled_trace_with_jump_args(
     let mut current_inner_label_index: Option<usize> = None;
     let mut defs_since_inner_label: majit_ir::vec_set::VecSet<OpRef> =
         majit_ir::vec_set::VecSet::new();
+    // Combined-trace position → emitted clone, so remap hits bind to the
+    // body clone producer instead of re-minting a position-only box (SSA:
+    // a remapped arg's target clone was pushed in an earlier iteration).
+    let mut emitted_at: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, majit_ir::OpRc> =
+        crate::optimizeopt::vec_assoc::VecAssoc::new();
     for (op_idx, op) in p2_ops.iter().enumerate() {
         let mut new_op = (**op).clone();
         let mut original_args = op.getarglist_copy();
@@ -4814,7 +4819,11 @@ fn assemble_peeled_trace_with_jump_args(
                 &visible_before_label,
             );
             if mapped != arg {
-                new_op.setarg(i, BoxRef::from_opref(mapped));
+                let boxed = match emitted_at.get(&mapped) {
+                    Some(rc) => BoxRef::from_bound_op(rc),
+                    None => BoxRef::from_opref(mapped),
+                };
+                new_op.setarg(i, boxed);
             }
         }
         if new_op.opcode == OpCode::Label {
@@ -5000,7 +5009,11 @@ fn assemble_peeled_trace_with_jump_args(
                     if seen_body_defs.contains(&a.to_opref())
                         && !visible_before_label.contains(&a.to_opref())
                     {
-                        *a = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(mapped));
+                        let boxed = match emitted_at.get(&mapped) {
+                            Some(rc) => BoxRef::from_bound_op(rc),
+                            None => BoxRef::from_opref(mapped),
+                        };
+                        *a = majit_ir::operand::Operand::from_boxref(&boxed);
                     }
                 }
             }
@@ -5060,7 +5073,11 @@ fn assemble_peeled_trace_with_jump_args(
         // fail_index for the sharing-path guard. Both phases of the
         // unroll optimizer therefore emit body guards with unique
         // descrs already; no post-process re-stamping is needed.
-        result.push(std::rc::Rc::new(new_op));
+        let new_rc = std::rc::Rc::new(new_op);
+        if new_rc.result_type() != Type::Void && !new_rc.pos.get().is_none() {
+            emitted_at.insert(new_rc.pos.get(), new_rc.clone());
+        }
+        result.push(new_rc);
         if op.opcode == OpCode::Label {
             current_inner_label_index = Some(result.len() - 1);
             defs_since_inner_label.clear();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3408,7 +3408,7 @@ impl OptUnroll {
                         // add_op_to_short returned None" path: drop the
                         // peeled trace and let the unroll caller raise
                         // InvalidLoop, falling back to jump_to_preamble.
-                        if !builder.setup(&sp, label_args) {
+                        if !builder.setup(&sp, label_args, ctx) {
                             target_token.short_preamble_producer = Some(builder);
                             std::panic::panic_any(crate::optimize::InvalidLoop(
                                 "short preamble has unresolvable Phase 1 args",

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3720,7 +3720,9 @@ impl OptUnroll {
                                 "non-guard short-preamble op carried fail_args: {:?}",
                                 new_op.opcode
                             );
-                            *arg = majit_ir::operand::Operand::Box(ctx.materialize_box_at(mapped));
+                            *arg = majit_ir::operand::Operand::from_boxref(
+                                &ctx.materialize_box_at(mapped),
+                            );
                         }
                     }
                 }
@@ -4994,7 +4996,7 @@ fn assemble_peeled_trace_with_jump_args(
                     if seen_body_defs.contains(&a.to_opref())
                         && !visible_before_label.contains(&a.to_opref())
                     {
-                        *a = majit_ir::operand::Operand::Box(BoxRef::from_opref(mapped));
+                        *a = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(mapped));
                     }
                 }
             }
@@ -5186,7 +5188,8 @@ impl OptUnroll {
             if let Some(fa) = peeled.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                        *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(new_ref));
+                        *arg =
+                            majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(new_ref));
                     }
                 }
             }
@@ -5233,7 +5236,8 @@ impl OptUnroll {
             if let Some(fa) = body_op.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                        *arg = majit_ir::operand::Operand::Box(BoxRef::from_opref(new_ref));
+                        *arg =
+                            majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(new_ref));
                     }
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1916,8 +1916,10 @@ pub struct ExportedState {
     /// (history.py:220), so consumers read the type via `OpRef::ty()` —
     /// RPython `info.renamed_inputargs` Box parity, no parallel type array.
     pub renamed_inputargs: Vec<OpRef>,
-    /// Short inputargs for the short preamble.
-    pub short_inputargs: Vec<OpRef>,
+    /// Short inputargs for the short preamble — the renamed inputarg box
+    /// objects themselves (shortpreamble.py:430 / unroll.py:480), shared
+    /// with the renamed operands inside `short_boxes`.
+    pub short_inputargs: Vec<crate::r#box::BoxRef>,
     /// unroll.py: runtime_boxes — live values at the original jump point.
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
     /// Default `Vec::new()` until the export site populates it; callers
@@ -2006,7 +2008,7 @@ impl ExportedState {
         >,
         exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
         renamed_inputargs: Vec<OpRef>,
-        short_inputargs: Vec<OpRef>,
+        short_inputargs: Vec<crate::r#box::BoxRef>,
     ) -> Self {
         // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
         // pre-derives the per-OpRef ProducedShortOp view (with label-arg
@@ -2141,7 +2143,9 @@ impl ExportedState {
             short_preamble.walk_const_ptr_refs_mut(visitor);
         }
         visit_oprefs(&mut self.renamed_inputargs, visitor);
-        visit_oprefs(&mut self.short_inputargs, visitor);
+        for arg in &self.short_inputargs {
+            arg.walk_const_ptr_refs(visitor);
+        }
         visit_oprefs(&mut self.runtime_boxes, visitor);
         if let Some(patchguardop) = self.patchguardop.as_ref() {
             visit_op(patchguardop, visitor);
@@ -2193,8 +2197,8 @@ impl ExportedState {
         for &opref in &self.renamed_inputargs {
             visit(opref);
         }
-        for &opref in &self.short_inputargs {
-            visit(opref);
+        for arg in &self.short_inputargs {
+            visit(arg.to_opref());
         }
         for &opref in &self.runtime_boxes {
             visit(opref);
@@ -2857,13 +2861,21 @@ impl OptUnroll {
         // `label_args + virtuals` (measured identical across the corpus);
         // paths that never ran the preview (test ExportedState setups) fall
         // back to the local recompute.
-        let short_inputargs = if ctx.exported_short_inputargs.is_empty() {
-            short_args.clone()
+        let short_inputargs: Vec<crate::r#box::BoxRef> = if ctx.exported_short_inputargs.is_empty()
+        {
+            short_args
+                .iter()
+                .map(|&a| crate::r#box::BoxRef::from_opref(a))
+                .collect()
         } else {
             debug_assert_eq!(
-                ctx.exported_short_inputargs, short_args,
+                ctx.exported_short_inputargs
+                    .iter()
+                    .map(|b| b.to_opref())
+                    .collect::<Vec<_>>(),
+                short_args,
                 "preview-pass create_short_inputargs diverged from the \
-                 export-site label_args + virtuals recompute"
+                     export-site label_args + virtuals recompute"
             );
             ctx.exported_short_inputargs.clone()
         };
@@ -3915,7 +3927,7 @@ impl OptUnroll {
                     if let Some(slot) = exported_state
                         .short_inputargs
                         .iter()
-                        .position(|&arg| arg == *source)
+                        .position(|arg| arg.to_opref() == *source)
                     {
                         short_args.get(slot).copied()
                     } else {
@@ -5364,7 +5376,7 @@ mod tests {
             crate::optimizeopt::vec_assoc::VecAssoc::new(),
             Vec::new(),
             vec![OpRef::int_op(14)],
-            vec![OpRef::int_op(23)],
+            vec![BoxRef::from_opref(OpRef::int_op(23))],
         );
 
         assert_eq!(exported.opref_high_water(), 110);
@@ -5606,7 +5618,7 @@ mod tests {
                 same_as_source: Some(BoxRef::from_opref(old_ref)),
             }],
             vec![old_ref],
-            vec![old_ref],
+            vec![BoxRef::from_opref(old_ref)],
         );
         state.short_boxes.push((
             old_ref,
@@ -5652,7 +5664,7 @@ mod tests {
         assert_eq!(state.end_args[0], new_ref);
         assert_eq!(state.next_iteration_args[0], new_ref);
         assert_eq!(state.renamed_inputargs[0], new_ref);
-        assert_eq!(state.short_inputargs[0], new_ref);
+        assert_eq!(state.short_inputargs[0].to_opref(), new_ref);
         assert_eq!(state.runtime_boxes[0], new_ref);
         assert!(state.exported_infos.get(&new_ref).is_some());
         assert_eq!(state.exported_short_boxes[0].op.arg(0).to_opref(), new_ref);
@@ -6548,7 +6560,7 @@ mod tests {
                 same_as_source: None,
             }],
             Vec::new(),
-            vec![source],
+            vec![BoxRef::from_opref(source)],
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
             8,
@@ -6584,7 +6596,11 @@ mod tests {
         );
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::int_op(0), OpRef::int_op(1), OpRef::int_op(2)],
-            &[OpRef::int_op(10), OpRef::int_op(11), OpRef::int_op(12)],
+            &[
+                BoxRef::from_opref(OpRef::int_op(10)),
+                BoxRef::from_opref(OpRef::int_op(11)),
+                BoxRef::from_opref(OpRef::int_op(12)),
+            ],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
                     let mut op = Op::new(
@@ -6669,10 +6685,10 @@ mod tests {
                 OpRef::ref_op(3),
             ],
             &[
-                OpRef::ref_op(10),
-                OpRef::ref_op(11),
-                OpRef::ref_op(12),
-                OpRef::ref_op(13),
+                BoxRef::from_opref(OpRef::ref_op(10)),
+                BoxRef::from_opref(OpRef::ref_op(11)),
+                BoxRef::from_opref(OpRef::ref_op(12)),
+                BoxRef::from_opref(OpRef::ref_op(13)),
             ],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -561,9 +561,14 @@ impl UnrollOptimizer {
                 &p1_inputarg_types,
                 0, // start_fresh = 0 — inputargs at [0..num_inputs)
             );
+            // Clone-out boundary: the optimizer entry below still takes
+            // `&[Op]` by value; `Op::clone` preserves the bound operand
+            // handles minted by the iterator (Rc clones), so bindings
+            // survive the copy. Dissolves when the stage flips to
+            // `Vec<OpRc>` end-to-end.
             let mut p1_ops_in: Vec<Op> = Vec::with_capacity(ops.len());
             while let Some(op) = p1_iter.next() {
-                p1_ops_in.push(op);
+                p1_ops_in.push((*op).clone());
             }
             let p1_iter_fresh_hw = p1_iter._fresh;
             // compile.py:275 `PreambleCompileData(trace, jumpargs, ...)` —
@@ -911,9 +916,10 @@ impl UnrollOptimizer {
             &p2_inputarg_types,
             phase2_inputarg_base, // fresh inputargs at [phase2_inputarg_base..)
         );
+        // Clone-out boundary — see the Phase 1 drive loop above.
         let mut p2_ops_in: Vec<Op> = Vec::with_capacity(ops.len());
         while let Some(op) = iter.next() {
-            p2_ops_in.push(op);
+            p2_ops_in.push((*op).clone());
         }
         let p2_high_water = iter._fresh;
         let p2_cache = iter._cache;
@@ -935,8 +941,8 @@ impl UnrollOptimizer {
             }
             p2_cache
                 .get(opref.raw() as usize)
-                .copied()
-                .flatten()
+                .and_then(|slot| slot.as_ref())
+                .map(|b| b.to_opref())
                 .unwrap_or_else(|| {
                     panic!(
                         "phase2 snapshot remap cache miss for {opref:?} \

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -5070,12 +5070,17 @@ impl<M: Clone> MetaInterp<M> {
                 .is_some_and(|op| op.opcode == OpCode::Label)
         {
             // compile.py:251-259 compile_simple_loop synthesizes
-            // LABEL(inputargs) before the optimized body.
+            // LABEL(inputargs) before the optimized body. The retry path's
+            // root_inputargs are value copies of `trace.inputargs`
+            // (inputargs_cloned above); bind the label args to the
+            // TreeLoop's canonical InputArgRc producers instead of
+            // re-minting position-only boxes.
             let mut label_op = majit_ir::Op::new(
                 majit_ir::OpCode::Label,
-                &root_inputargs
+                &trace
+                    .inputargs
                     .iter()
-                    .map(|ia| BoxRef::from_opref(ia.opref()))
+                    .map(BoxRef::from_bound_inputarg)
                     .collect::<Vec<_>>(),
             );
             label_op.pos.set(majit_ir::OpRef::NONE);
@@ -5205,11 +5210,15 @@ impl<M: Clone> MetaInterp<M> {
             if let Some(label_op) = compiled_ops.iter().find(|op| op.opcode == OpCode::Label) {
                 label_op.setdescr(target_token.as_jump_target_descr());
             } else {
+                // Same canonical-producer bind as the Label synthesis
+                // above: the retry path's inputargs mirror
+                // `trace.inputargs` slot-for-slot.
                 let mut label_op = majit_ir::Op::new(
                     majit_ir::OpCode::Label,
-                    &inputargs
+                    &trace
+                        .inputargs
                         .iter()
-                        .map(|ia| BoxRef::from_opref(ia.opref()))
+                        .map(BoxRef::from_bound_inputarg)
                         .collect::<Vec<_>>(),
                 );
                 label_op.pos.set(majit_ir::OpRef::NONE);

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -575,7 +575,7 @@ struct PreparedBridgeTrace {
     pending_bridge_rd: Option<PendingBridgeRd>,
 }
 
-fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<OpRef>]) -> OpRef {
+fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<crate::r#box::BoxRef>]) -> OpRef {
     if opref.is_none() || opref.is_constant() {
         return opref;
     }
@@ -587,8 +587,8 @@ fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<OpRef>]) -> OpRef {
     // OpRefs the recorder produced for this bridge.
     cache
         .get(opref.raw() as usize)
-        .copied()
-        .flatten()
+        .and_then(|slot| slot.as_ref())
+        .map(|b| b.to_opref())
         .unwrap_or_else(|| {
             panic!(
                 "translate_trace_iter_opref cache miss for {opref:?} (cache_len={})",
@@ -599,7 +599,7 @@ fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<OpRef>]) -> OpRef {
 
 fn translate_trace_iter_box_map(
     mut box_map: SnapshotBoxes,
-    cache: &[Option<OpRef>],
+    cache: &[Option<crate::r#box::BoxRef>],
 ) -> SnapshotBoxes {
     for boxes in box_map.iter_mut().flatten() {
         for boxref in boxes.iter_mut() {
@@ -647,14 +647,17 @@ fn prepare_bridge_trace_for_optimizer(
         &bridge_inputarg_types,
         bridge_inputarg_base,
     );
+    // Clone-out boundary: `PreparedBridgeTrace.ops` is still `Vec<Op>`
+    // by value; `Op::clone` preserves the bound operand handles minted
+    // by the iterator (Rc clones).
     let mut ops = Vec::with_capacity(bridge_ops.len());
     while let Some(op) = iter.next() {
-        ops.push(op);
+        ops.push((*op).clone());
     }
     let inputargs = bridge_inputargs
         .iter()
-        .zip(iter.inputargs.iter().copied())
-        .map(|(arg, opref)| InputArg::from_type(arg.tp, opref.raw()))
+        .zip(iter.inputargs.iter())
+        .map(|(arg, ia)| InputArg::from_type(arg.tp, ia.opref().raw()))
         .collect();
     let cache = iter._cache;
     let snapshot_boxes = translate_trace_iter_box_map(snapshot_boxes, &cache);

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -216,7 +216,7 @@ fn make_simple_compile_views<'a>(
 /// than installing an unsound loop.
 ///
 /// Returns the offending slot index, or `None` when the contract is consistent.
-fn cross_loop_cut_label_jump_null_guard_slot(ops: &[Op]) -> Option<usize> {
+fn cross_loop_cut_label_jump_null_guard_slot(ops: &[majit_ir::OpRc]) -> Option<usize> {
     let label = ops.first().filter(|op| op.opcode == OpCode::Label)?;
     let jump = ops.last().filter(|op| op.opcode == OpCode::Jump)?;
     let label_slots: Vec<OpRef> = (0..label.num_args())

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -249,7 +249,7 @@ pub(crate) struct CompiledTrace {
     /// Inputargs for this trace, used to recover typed exit layouts during blackhole replay.
     pub(crate) inputargs: Vec<InputArg>,
     /// Optimized ops for blackhole fallback from compiled guard failures.
-    pub(crate) ops: Vec<majit_ir::Op>,
+    pub(crate) ops: Vec<majit_ir::OpRc>,
     /// Typed constant pool paired with `ops` for blackhole fallback.
     /// history.py:220/261/307 `ConstInt`/`ConstFloat`/`ConstPtr` pin
     /// type with value, so `Const` carries both — the legacy
@@ -565,7 +565,7 @@ fn snapshot_map_from_trace_snapshots(
 }
 
 struct PreparedBridgeTrace {
-    ops: Vec<Op>,
+    ops: Vec<OpRc>,
     inputargs: Vec<InputArg>,
     snapshot_boxes: SnapshotBoxes,
     snapshot_frame_sizes: SnapshotFrameSizes,
@@ -647,12 +647,9 @@ fn prepare_bridge_trace_for_optimizer(
         &bridge_inputarg_types,
         bridge_inputarg_base,
     );
-    // Clone-out boundary: `PreparedBridgeTrace.ops` is still `Vec<Op>`
-    // by value; `Op::clone` preserves the bound operand handles minted
-    // by the iterator (Rc clones).
     let mut ops = Vec::with_capacity(bridge_ops.len());
     while let Some(op) = iter.next() {
-        ops.push((*op).clone());
+        ops.push(op);
     }
     let inputargs = bridge_inputargs
         .iter()
@@ -685,8 +682,8 @@ fn prepare_bridge_trace_for_optimizer(
 
 fn normalize_root_loop_entry_contract(
     inputargs: Vec<InputArg>,
-    optimized_ops: Vec<Op>,
-) -> Result<(Vec<InputArg>, Vec<Op>), (usize, usize)> {
+    optimized_ops: Vec<majit_ir::OpRc>,
+) -> Result<(Vec<InputArg>, Vec<majit_ir::OpRc>), (usize, usize)> {
     let last_jump = optimized_ops
         .iter()
         .rev()
@@ -846,7 +843,7 @@ impl<M> CompiledEntry<M> {
 /// Scanning them mirrors RPython's Box-identity model where every
 /// referenced Box keeps the parent trace alive: any OpRef the trace
 /// touches must be reflected in the high-water mark.
-fn compute_next_global_opref(inputargs: &[InputArg], ops: &[majit_ir::Op]) -> u32 {
+fn compute_next_global_opref<T: AsRef<majit_ir::Op>>(inputargs: &[InputArg], ops: &[T]) -> u32 {
     fn opref_high_water(r: OpRef) -> u32 {
         if r.is_none() || r.is_constant() {
             0
@@ -862,6 +859,7 @@ fn compute_next_global_opref(inputargs: &[InputArg], ops: &[majit_ir::Op]) -> u3
     let from_ops = ops
         .iter()
         .map(|op| {
+            let op = op.as_ref();
             let mut hw = opref_high_water(op.pos.get());
             for a in op.getarglist().iter() {
                 hw = hw.max(opref_high_water(a.to_opref()));
@@ -904,7 +902,7 @@ pub struct PartialTrace {
     /// variants store the value inline (history.py:227/268/314), so
     /// `compile_retrace` reuses `partial.ops` verbatim without any
     /// separate constants side table.
-    pub(crate) ops: Vec<Op>,
+    pub(crate) ops: Vec<majit_ir::OpRc>,
     /// Inputargs from the partial trace.
     pub(crate) inputargs: Vec<InputArg>,
 }
@@ -4384,7 +4382,7 @@ impl<M: Clone> MetaInterp<M> {
     pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
         &self,
         inputargs: &mut Vec<InputArg>,
-        ops: &mut Vec<Op>,
+        ops: &mut Vec<majit_ir::OpRc>,
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         driver_descriptor: Option<&crate::jitdriver::JitDriverStaticData>,
         orig_vable_ptr: *const u8,
@@ -4855,7 +4853,10 @@ impl<M: Clone> MetaInterp<M> {
         // Phase 2 InvalidLoop. Phase 1 writes to phase1_out on the caller's
         // stack BEFORE Phase 2 starts. If Phase 2 panics, phase1_out still
         // holds the Phase 1 results.
-        let mut phase1_out: Option<(Vec<Op>, crate::optimizeopt::unroll::ExportedState)> = None;
+        let mut phase1_out: Option<(
+            Vec<majit_ir::OpRc>,
+            crate::optimizeopt::unroll::ExportedState,
+        )> = None;
         let optimize_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             unroll_opt.optimize_trace_with_constants_and_inputs_vable_out(
                 &trace_ops,
@@ -4928,12 +4929,17 @@ impl<M: Clone> MetaInterp<M> {
                         // `Rc<Op>`), so producer lookup resolves identity.
                         simple_opt.explicit_input_ops_seed =
                             Some(preamble_data.base.operations().to_vec());
+                        let trace_ops_snapshot_rc: Vec<majit_ir::OpRc> = trace_ops_snapshot
+                            .iter()
+                            .map(|op| std::rc::Rc::new(op.clone()))
+                            .collect();
                         let retry_result =
                             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                simple_opt.optimize_with_constants_and_inputs(
-                                    &trace_ops_snapshot,
+                                simple_opt.run_optimize_from_inputs(
+                                    &trace_ops_snapshot_rc,
                                     &mut retry_constants,
                                     num_trace_inputargs,
+                                    false,
                                 )
                             }));
                         match retry_result {
@@ -4982,12 +4988,18 @@ impl<M: Clone> MetaInterp<M> {
             if vec_gate && vec_size != 0 && !retried_without_unroll {
                 // vector.py:124 `user_code = not jitdriver_sd.vec and warmstate.vec_all`.
                 let user_code = !driver_vec && self.warm_state.vec_all();
+                // Vectorizer-internal stage still carries `Vec<Op>`;
+                // convert at this (vec_all-gated) boundary.
+                let plain_ops: Vec<Op> = optimized_ops.iter().map(|rc| (**rc).clone()).collect();
                 crate::optimizeopt::vector::apply_loop_vectorization(
-                    optimized_ops,
+                    plain_ops,
                     vec_size,
                     self.warm_state.vec_cost() as i32,
                     user_code,
                 )
+                .into_iter()
+                .map(std::rc::Rc::new)
+                .collect()
             } else {
                 optimized_ops
             }
@@ -5067,7 +5079,7 @@ impl<M: Clone> MetaInterp<M> {
                     .collect::<Vec<_>>(),
             );
             label_op.pos.set(majit_ir::OpRef::NONE);
-            optimized_ops.insert(0, label_op);
+            optimized_ops.insert(0, std::rc::Rc::new(label_op));
         }
         let (inputargs, optimized_ops) = match normalize_root_loop_entry_contract(
             root_inputargs,
@@ -5187,16 +5199,10 @@ impl<M: Clone> MetaInterp<M> {
 
         let front_target_tokens = if retried_without_unroll {
             let target_token = crate::optimizeopt::unroll::TargetToken::new_loop(token_num);
-            if let Some(jump_op) = compiled_ops
-                .last_mut()
-                .filter(|op| op.opcode == OpCode::Jump)
-            {
+            if let Some(jump_op) = compiled_ops.last().filter(|op| op.opcode == OpCode::Jump) {
                 jump_op.setdescr(target_token.as_jump_target_descr());
             }
-            if let Some(label_op) = compiled_ops
-                .iter_mut()
-                .find(|op| op.opcode == OpCode::Label)
-            {
+            if let Some(label_op) = compiled_ops.iter().find(|op| op.opcode == OpCode::Label) {
                 label_op.setdescr(target_token.as_jump_target_descr());
             } else {
                 let mut label_op = majit_ir::Op::new(
@@ -5208,7 +5214,7 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 label_op.pos.set(majit_ir::OpRef::NONE);
                 label_op.setdescr(target_token.as_jump_target_descr());
-                compiled_ops.insert(0, label_op);
+                compiled_ops.insert(0, std::rc::Rc::new(label_op));
             }
             vec![target_token]
         } else if unroll_opt.target_tokens.is_empty() {
@@ -5260,13 +5266,6 @@ impl<M: Clone> MetaInterp<M> {
         // handle VStr/VUni at the backend layer (dynasm) get a no-op.
         self.backend
             .set_callinfocollection(self.callinfocollection.clone());
-        // Wrap optimizer-output `Vec<Op>` into `Vec<OpRc>` for the
-        // backend's `&[OpRc]` boundary (history.py:528 ResOperation
-        // identity at trace level).
-        let compiled_ops_rc: Vec<majit_ir::OpRc> = compiled_ops
-            .iter()
-            .map(|op| std::rc::Rc::new(op.clone()))
-            .collect();
         // compile.py:532-546 `debug_start("jit-backend") +
         // profiler.start_backend() ... try: do_compile_loop ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
@@ -5277,7 +5276,7 @@ impl<M: Clone> MetaInterp<M> {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 self.backend.compile_loop(
                     &inputargs,
-                    &compiled_ops_rc,
+                    &compiled_ops,
                     Arc::get_mut(&mut token)
                         .expect("JitCellToken must stay uniquely owned until backend compile"),
                 )
@@ -5328,7 +5327,7 @@ impl<M: Clone> MetaInterp<M> {
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py:213 record_loop_or_bridge — record this loop's
                 // CALL_ASSEMBLER / JUMP keepalive targets.
-                self.record_loop_or_bridge(&token, &mut compiled_ops, trace_id);
+                self.record_loop_or_bridge(&token, &compiled_ops, trace_id);
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] compiled loop at key={}, num_inputs={}",
@@ -5824,7 +5823,7 @@ impl<M: Clone> MetaInterp<M> {
     pub fn retrace_needed(
         &mut self,
         green_key: u64,
-        ops: Vec<Op>,
+        ops: Vec<majit_ir::OpRc>,
         inputargs: Vec<InputArg>,
         mut exported_state: crate::optimizeopt::unroll::ExportedState,
     ) {
@@ -6168,14 +6167,9 @@ impl<M: Clone> MetaInterp<M> {
         let compile_result = {
             let _backend_scope = self.staticdata.profiler.enter_backend();
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                // Wrap to `Vec<OpRc>` for the backend's trait boundary.
-                let combined_ops_rc: Vec<majit_ir::OpRc> = combined_ops
-                    .iter()
-                    .map(|op| std::rc::Rc::new(op.clone()))
-                    .collect();
                 self.backend.compile_loop(
                     &inputargs,
-                    &combined_ops_rc,
+                    &combined_ops,
                     Arc::get_mut(&mut token)
                         .expect("JitCellToken must stay uniquely owned until backend compile"),
                 )
@@ -6220,7 +6214,7 @@ impl<M: Clone> MetaInterp<M> {
                 }
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py:213 record_loop_or_bridge.
-                self.record_loop_or_bridge(&token, &mut combined_ops, trace_id);
+                self.record_loop_or_bridge(&token, &combined_ops, trace_id);
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] compiled retrace at key={}, num_inputs={}",
@@ -6711,10 +6705,6 @@ impl<M: Clone> MetaInterp<M> {
         // handle VStr/VUni at the backend layer (dynasm) get a no-op.
         self.backend
             .set_callinfocollection(self.callinfocollection.clone());
-        let optimized_ops_rc: Vec<majit_ir::OpRc> = optimized_ops
-            .iter()
-            .map(|op| std::rc::Rc::new(op.clone()))
-            .collect();
         // compile.py:532-546 `debug_start("jit-backend") +
         // profiler.start_backend() ... try: do_compile_loop ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
@@ -6722,7 +6712,7 @@ impl<M: Clone> MetaInterp<M> {
             let _backend_guard = self.staticdata.profiler.enter_backend();
             self.backend.compile_loop(
                 &inputargs,
-                &optimized_ops_rc,
+                &optimized_ops,
                 Arc::get_mut(&mut token)
                     .expect("JitCellToken must stay uniquely owned until backend compile"),
             )
@@ -6732,7 +6722,7 @@ impl<M: Clone> MetaInterp<M> {
                 self.assign_guard_hashes(token.as_ref());
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py:213 record_loop_or_bridge.
-                self.record_loop_or_bridge(&token, &mut optimized_ops, trace_id);
+                self.record_loop_or_bridge(&token, &optimized_ops, trace_id);
                 let (mut resume_data, mut exit_layouts) =
                     compile::build_guard_metadata(&inputargs, &optimized_ops, green_key);
                 let mut terminal_exit_layouts =
@@ -7031,10 +7021,7 @@ impl<M: Clone> MetaInterp<M> {
         // mirror onto JCT for `has_compiled_targets` (`pyjitpl.py:3898`).
         token.record_target_token(target_token.as_jump_target_descr());
         let mut compiled_ops = optimized_ops.clone();
-        if let Some(jump_op) = compiled_ops
-            .last_mut()
-            .filter(|op| op.opcode == OpCode::Jump)
-        {
+        if let Some(jump_op) = compiled_ops.last().filter(|op| op.opcode == OpCode::Jump) {
             jump_op.setdescr(target_token.as_jump_target_descr());
         }
         let mut label_op = majit_ir::Op::new(
@@ -7046,7 +7033,7 @@ impl<M: Clone> MetaInterp<M> {
         );
         label_op.pos.set(majit_ir::OpRef::NONE);
         label_op.setdescr(target_token.as_jump_target_descr());
-        compiled_ops.insert(0, label_op);
+        compiled_ops.insert(0, std::rc::Rc::new(label_op));
 
         // compile.py:504-511 send_loop_to_backend virtualizable hook —
         // simple-loop compile path must also reload virtualizable fields on
@@ -7071,10 +7058,6 @@ impl<M: Clone> MetaInterp<M> {
         // handle VStr/VUni at the backend layer (dynasm) get a no-op.
         self.backend
             .set_callinfocollection(self.callinfocollection.clone());
-        let compiled_ops_rc: Vec<majit_ir::OpRc> = compiled_ops
-            .iter()
-            .map(|op| std::rc::Rc::new(op.clone()))
-            .collect();
         // compile.py:532-546 `debug_start("jit-backend") +
         // profiler.start_backend() ... try: do_compile_loop ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
@@ -7082,7 +7065,7 @@ impl<M: Clone> MetaInterp<M> {
             let _backend_guard = self.staticdata.profiler.enter_backend();
             self.backend.compile_loop(
                 &inputargs,
-                &compiled_ops_rc,
+                &compiled_ops,
                 Arc::get_mut(&mut token)
                     .expect("JitCellToken must stay uniquely owned until backend compile"),
             )
@@ -7092,7 +7075,7 @@ impl<M: Clone> MetaInterp<M> {
                 self.assign_guard_hashes(token.as_ref());
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py:213 record_loop_or_bridge.
-                self.record_loop_or_bridge(&token, &mut compiled_ops, trace_id);
+                self.record_loop_or_bridge(&token, &compiled_ops, trace_id);
                 let (mut resume_data, mut exit_layouts) =
                     compile::build_guard_metadata(&inputargs, &compiled_ops, green_key);
                 let mut terminal_exit_layouts =
@@ -8117,7 +8100,7 @@ impl<M: Clone> MetaInterp<M> {
     fn record_loop_or_bridge(
         &self,
         original: &Arc<JitCellToken>,
-        ops: &mut [majit_ir::Op],
+        ops: &[majit_ir::OpRc],
         trace_id: u64,
     ) {
         // `compile.py:178-179` `assert original_jitcell_token.generation > 0`.
@@ -8136,7 +8119,7 @@ impl<M: Clone> MetaInterp<M> {
         }
         //
         // `compile.py:183` `for op in loop.operations`.
-        for op in ops.iter_mut() {
+        for op in ops.iter() {
             // `compile.py:184 descr = op.getdescr()`. Clone the Arc
             // (single atomic bump) so the rest of this loop iteration
             // can hold the descr value while still freely mutating
@@ -9103,13 +9086,9 @@ impl<M: Clone> MetaInterp<M> {
         let compile_result = {
             let _backend_scope = self.staticdata.profiler.enter_backend();
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let optimized_ops_rc: Vec<majit_ir::OpRc> = optimized_ops
-                    .iter()
-                    .map(|op| std::rc::Rc::new(op.clone()))
-                    .collect();
                 self.backend.compile_loop(
                     bridge_inputargs,
-                    &optimized_ops_rc,
+                    &optimized_ops,
                     Arc::get_mut(&mut token)
                         .expect("JitCellToken must stay uniquely owned until backend compile"),
                 )
@@ -9128,7 +9107,7 @@ impl<M: Clone> MetaInterp<M> {
                 self.assign_guard_hashes(token.as_ref());
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py:213 record_loop_or_bridge.
-                self.record_loop_or_bridge(&token, &mut optimized_ops, trace_id);
+                self.record_loop_or_bridge(&token, &optimized_ops, trace_id);
                 let (mut resume_data, mut exit_layouts) = compile::build_guard_metadata(
                     bridge_inputargs,
                     &optimized_ops,
@@ -9753,11 +9732,6 @@ impl<M: Clone> MetaInterp<M> {
                 .get(&fail_descr.trace_id())
                 .and_then(|tr| tr.exit_layouts.get(&fail_descr.fail_index_per_trace()))
                 .and_then(|sl| sl.recovery_layout.clone());
-            // Wrap to `Vec<OpRc>` for the backend's trait boundary.
-            let optimized_ops_rc_for_bridge: Vec<majit_ir::OpRc> = optimized_ops
-                .iter()
-                .map(|op| std::rc::Rc::new(op.clone()))
-                .collect();
             // compile.py:589-599 `debug_start("jit-backend") +
             // profiler.start_backend() ... try: do_compile_bridge ...
             // finally: ... profiler.end_backend() +
@@ -9768,7 +9742,7 @@ impl<M: Clone> MetaInterp<M> {
                     self.backend.compile_bridge(
                         fail_descr,
                         bridge_inputargs,
-                        &optimized_ops_rc_for_bridge,
+                        &optimized_ops,
                         &source_jct,
                         previous_tokens,
                         caller_recovery_layout.as_ref(),
@@ -17777,7 +17751,7 @@ mod tests {
             10,
         );
         meta.partial_trace = Some(PartialTrace {
-            ops: vec![op],
+            ops: vec![std::rc::Rc::new(op)],
             inputargs: Vec::new(),
         });
 
@@ -17805,7 +17779,7 @@ mod tests {
             BoxRef::from_opref(OpRef::const_int(123)),
         ]);
         meta.partial_trace = Some(PartialTrace {
-            ops: vec![guard],
+            ops: vec![std::rc::Rc::new(guard)],
             inputargs: Vec::new(),
         });
 
@@ -17941,6 +17915,7 @@ mod tests {
             ),
         ];
 
+        let ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         let err =
             normalize_root_loop_entry_contract(inputargs, ops).expect_err("missing LABEL rejects");
         assert_eq!(err, (0, 3));
@@ -17959,6 +17934,7 @@ mod tests {
             OpRef::NONE.raw(),
         )];
 
+        let ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         let err =
             normalize_root_loop_entry_contract(inputargs, ops).expect_err("missing LABEL rejects");
         assert_eq!(err, (0, 2));
@@ -18120,7 +18096,7 @@ mod tests {
             trace_id,
             CompiledTrace {
                 inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
-                ops,
+                ops: ops.into_iter().map(std::rc::Rc::new).collect(),
                 constants,
                 exit_layouts: crate::optimizeopt::vec_assoc::VecAssoc::new(),
                 terminal_exit_layouts: crate::optimizeopt::vec_assoc::VecAssoc::new(),
@@ -18690,7 +18666,7 @@ mod tests {
             trace_id,
             CompiledTrace {
                 inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
-                ops,
+                ops: ops.into_iter().map(std::rc::Rc::new).collect(),
                 constants: constants_typed,
                 exit_layouts,
                 terminal_exit_layouts,


### PR DESCRIPTION
Part of https://github.com/youknowone/pyre/issues/47

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Continues the #47 / #9 box-identity work: the optimizer should key its
state on **box object identity** (RPython `_args[i]` holds the producer
object directly), instead of pyre's flat `OpRef` position encoding that
round-trips through `find_producer_op` and re-mints producer-less boxes
on every miss. This branch threads the producer `Rc<Op>` / `Rc<InputArg>`
through the short-preamble export/import boundary and the compiled-ops
stage so operands carry their producer object end-to-end.

Main threads:

- **Short-preamble box-identity carry.** `ShortBoxes` /
  `ProducedShortOp` / `PreambleOp` re-homed to carry the `short_op.res`
  box and the replay `OpRc`; `produced_short_boxes` keyed by the result
  box; `produce_arg` / `use_box` return the dependency's replay object
  (marker walk, `shortpreamble.py:382/391-402`) instead of re-resolving a
  position. `phase1_to_inputarg` remap values bound to producers.
- **Compiled-ops stage `Vec<Op>` → `Vec<OpRc>`.** The optimizer hands the
  backend its `Rc`s directly, dissolving the `pyjitpl` re-wrap/clone
  boundaries; `opencoder`'s `TraceIterator` caches the fresh op objects
  (`opencoder.py:399-401`); `majit-gc`'s rewriter emits bound result
  boxes.
- **Operand object-carry at import/patch sites.** `compile.rs`
  virtualizable patch + tmp callback, `unroll.rs` inline-short-preamble
  mapped args, `history.rs` cut-trace, and the assemble remap hits all
  bind to the new-namespace producer instead of minting position-only
  boxes.
- **Export replay-op args.** On a positional miss the export keeps the
  carried handle object (`get_box_replacement_box().unwrap_or_else(arg
  .clone())`) instead of re-minting a producer-less box — the unforwarded
  box resolves to itself (`resoperation.py:57-68`), encoding-identical.

This shrinks the residual position-only `Operand::Box` mints toward zero
(the prerequisite for retiring `from_opref` / `box_cache` /
`find_producer_op` and deleting the `BoxRef` wrapper). The remaining
mints are the cross-phase short-preamble jump args and guard `fail_args`,
tracked separately.

Verification per slice: `cargo test -p majit-metainterp --features dynasm
--lib` and `--features cranelift --lib`; `python ./pyre/check.py
--backend dynasm` and `--backend cranelift`; `nested_loop` `MAJIT_LOG` IR
byte-identical where the slice is meant to be behavior-preserving.

### Code review (CodeRabbit) — adjudicated

Two findings were genuine in-scope defects and are fixed; three are
pre-existing structural items whose fixes are separate scoped efforts.

- **Fixed — exported `PreambleOp.res` canonicalization.** The export set
  `op.pos` to `get_replacement_opref(result)` but carried `res` as the
  unresolved `materialize_box_at(result)`; when Phase 1 const-folds the
  result, `op.pos` (a `ConstInt`) and `res` (the pre-fold `IntOp`)
  diverged. `res` now resolves the same root, matching
  `shortpreamble.py:435 op.get_box_replacement()`.
- **Fixed — `phase1_emit_ops` on the retrace path.** The skip-Phase-1
  branch left the producer pool empty while the non-skip path populates it,
  so a const-folded preamble producer reachable only via `phase1_emit_ops`
  was dropped on retrace. Restored from the imported state's
  `partial_trace_operations` (idempotent; readers dedup).
- **Deferred — gc rewriter `Vec<OpRc>` → `Vec<Op>` boundary.** Not a
  correctness bug (the clone preserves bound operands via the operand
  `Rc`s); removing it flips the `GcRewriter` trait return type through both
  backends' assembly entry, the documented follow-up slice.
- **Deferred — compile-snapshot raw-pointer roots.** Pre-existing,
  pervasive GC-rooting mechanism (7+ sites) with a documented
  same-thread / no-realloc-in-window invariant; the snapshot vectors are
  not grown inside the rooted window, so no live UAF. A `(vector-id,
  index)` representation is a separate hardening effort.
- **Deferred — short-input `OpRef` round-trip.** No collision in practice
  (`label_args + virtuals` are position-distinct; the `from_opref` arm is a
  test-only fallback); the OpRef-keyed match is part of the planned
  `BoxRef`-identity re-key (#115).

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal compiler architecture to improve code efficiency and maintainability across the optimization pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
