### PR TITLE
Blackhole guard-failure resume: exception routing, deopt abort-rollback, GC heap-array dispatch

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7183,6 +7183,24 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "setarrayitem_gc_f/rifd".to_string(),
         majit_translate::insns::BC_SETARRAYITEM_GC_F,
     );
+    // Constant-operand "_C" forms, emitted when the array length / store
+    // index is a compile-time constant — a fixed-size tuple/list build
+    // (`new_array_clear/cd>r`) and its element stores
+    // (`setarrayitem_gc_r/rcrd`). Whether the assembler emits the `_C` or
+    // the register form depends on constant folding during
+    // `make_jitcodes`, so a guard failure resuming forward through a
+    // constant-size build must dispatch these too. Their `bhimpl_*`
+    // handlers are already wired in `wire_bhimpl_handlers` below; without
+    // the map entry `wire_handler` silently no-ops and the byte stays
+    // unwired (`dispatch_step` panics on `0xd8`).
+    insns.insert(
+        "setarrayitem_gc_r/rcrd".to_string(),
+        majit_translate::insns::BC_SETARRAYITEM_GC_R_C,
+    );
+    insns.insert(
+        "new_array_clear/cd>r".to_string(),
+        majit_translate::insns::BC_NEW_ARRAY_CLEAR_C,
+    );
     builder.setup_insns(&insns);
     // `setup_insns` already derives `op_live` and `op_catch_exception`
     // from the registered canonical subset above.  `rvmprof_code/ii` is

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7183,10 +7183,11 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "setarrayitem_gc_f/rifd".to_string(),
         majit_translate::insns::BC_SETARRAYITEM_GC_F,
     );
-    // Constant-operand "_C" forms, emitted when the array length / store
-    // index is a compile-time constant — a fixed-size tuple/list build
-    // (`new_array_clear/cd>r`) and its element stores
-    // (`setarrayitem_gc_r/rcrd`). Whether the assembler emits the `_C` or
+    // Constant-operand "_C" forms, emitted when the array length, store
+    // index, or store value is a compile-time constant — a fixed-size
+    // tuple/list build (`new_array_clear/cd>r`) and its element stores
+    // (`setarrayitem_gc_r/rcrd`, const index; `setarrayitem_gc_i/ricd`,
+    // const int value).Whether the assembler emits the `_C` or
     // the register form depends on constant folding during
     // `make_jitcodes`, so a guard failure resuming forward through a
     // constant-size build must dispatch these too. Their `bhimpl_*`
@@ -7196,6 +7197,10 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     insns.insert(
         "setarrayitem_gc_r/rcrd".to_string(),
         majit_translate::insns::BC_SETARRAYITEM_GC_R_C,
+    );
+    insns.insert(
+        "setarrayitem_gc_i/ricd".to_string(),
+        majit_translate::insns::BC_SETARRAYITEM_GC_I_C,
     );
     insns.insert(
         "new_array_clear/cd>r".to_string(),

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7133,6 +7133,56 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "hint_force_virtualizable/r".to_string(),
         majit_translate::insns::BC_HINT_FORCE_VIRTUALIZABLE,
     );
+    // GC heap array allocation + element access — emitted by BUILD_TUPLE /
+    // BUILD_LIST (`new_array_clear` + `setarrayitem_gc_*`) and subscript
+    // load/store (`getarrayitem_gc_*`). Unlike the vable family above
+    // (which addresses the virtualizable frame), these touch ordinary heap
+    // arrays. A guard failure that resumes forward through a tuple/list
+    // build or an array element access must dispatch them; their `bhimpl_*`
+    // handlers are wired in `wire_bhimpl_handlers` below. Canonical bytes
+    // per `insns.rs` (blackhole.py:1311-1359). `getarrayitem_gc_*_pure` is
+    // the immutable-array (e.g. tuple) read shape, aliased to the same
+    // handler.
+    insns.insert(
+        "new_array_clear/id>r".to_string(),
+        majit_translate::insns::BC_NEW_ARRAY_CLEAR,
+    );
+    insns.insert(
+        "getarrayitem_gc_i/rid>i".to_string(),
+        majit_translate::insns::BC_GETARRAYITEM_GC_I,
+    );
+    insns.insert(
+        "getarrayitem_gc_r/rid>r".to_string(),
+        majit_translate::insns::BC_GETARRAYITEM_GC_R_RID,
+    );
+    insns.insert(
+        "getarrayitem_gc_f/rid>f".to_string(),
+        majit_translate::insns::BC_GETARRAYITEM_GC_F,
+    );
+    insns.insert(
+        "getarrayitem_gc_i_pure/rid>i".to_string(),
+        majit_translate::insns::BC_GETARRAYITEM_GC_I_PURE,
+    );
+    insns.insert(
+        "getarrayitem_gc_r_pure/rid>r".to_string(),
+        majit_translate::insns::BC_GETARRAYITEM_GC_R_PURE,
+    );
+    insns.insert(
+        "getarrayitem_gc_f_pure/rid>f".to_string(),
+        majit_translate::insns::BC_GETARRAYITEM_GC_F_PURE,
+    );
+    insns.insert(
+        "setarrayitem_gc_i/riid".to_string(),
+        majit_translate::insns::BC_SETARRAYITEM_GC_I,
+    );
+    insns.insert(
+        "setarrayitem_gc_r/rird".to_string(),
+        majit_translate::insns::BC_SETARRAYITEM_GC_R,
+    );
+    insns.insert(
+        "setarrayitem_gc_f/rifd".to_string(),
+        majit_translate::insns::BC_SETARRAYITEM_GC_F,
+    );
     builder.setup_insns(&insns);
     // `setup_insns` already derives `op_live` and `op_catch_exception`
     // from the registered canonical subset above.  `rvmprof_code/ii` is

--- a/pyre/bench/synth/array_deopt_resume.py
+++ b/pyre/bench/synth/array_deopt_resume.py
@@ -1,0 +1,29 @@
+# GC heap-array ops on the blackhole guard-failure resume path. The loop
+# body reads and writes a list (getarrayitem_gc_i / setarrayitem_gc_i) and
+# the function returns a tuple (new_array_clear + setarrayitem_gc_r +
+# newtuple) at loop exit, where the `i < N` guard fails and execution
+# resumes forward in the blackhole. Those GC-array opcodes were absent from
+# the production blackhole builder's dispatch table, so any deopt resuming
+# through a tuple/list build or an array element access panicked with an
+# unwired opcode. A traced loop that never deopts through these ops would
+# not cover them.
+N = 40000
+
+
+def work(n):
+    buf = [0, 0, 0, 0]
+    total = 0
+    i = 0
+    while i < n:
+        d = (i % 7) + 1
+        buf[i % 4] = (buf[i % 4] + (i * 13 + 5) // d) % 1000003
+        total = (total + buf[i % 4]) % 1000003
+        i += 1
+    return total, buf[0], buf[1], buf[2], buf[3]
+
+
+def main():
+    print(work(N))
+
+
+main()

--- a/pyre/bench/synth/check_exc_match_invalid_class.py
+++ b/pyre/bench/synth/check_exc_match_invalid_class.py
@@ -1,0 +1,28 @@
+# CHECK_EXC_MATCH against a non-exception target. The loop warms up with a
+# valid except class so the trace JIT-compiles, then on the final iteration the
+# except target becomes a non-exception (int 5). cmp_exc_match raises TypeError
+# when the target is not an exception class / tuple of exception classes; the
+# JIT residual path must raise it too (not silently produce a bool and let the
+# original exception propagate). The TypeError is caught by an outer handler so
+# the output is deterministic. Deterministic.
+def f(n):
+    caught_value = 0
+    caught_type = 0
+    for i in range(n):
+        target = ValueError if i < n - 1 else 5
+        try:
+            try:
+                raise ValueError("x")
+            except target:
+                caught_value += 1
+        except TypeError:
+            caught_type += 1
+    return caught_value, caught_type
+
+
+def main():
+    cv, ct = f(20000)
+    print("final", cv, ct)
+
+
+main()

--- a/pyre/bench/synth/exception_loop_warmup.py
+++ b/pyre/bench/synth/exception_loop_warmup.py
@@ -1,0 +1,33 @@
+# Warm-up-then-raise exception handling: the loop runs cleanly long enough to
+# compile, then a nested try/(try-finally)/except starts raising only after the
+# warm-up window. The post-warm-up raise is therefore NOT in the recorded trace,
+# so the guard failure resumes in the blackhole and the exception must hop
+# floordiv -> inner finally -> reraise -> outer except entirely under blackhole
+# control. Benches that raise from iteration 1 do not exercise this path.
+N = 40000
+
+
+def nested(n):
+    acc = 0
+    i = 0
+    while i < n:
+        v = 1
+        try:
+            try:
+                if i >= 2000 and i % 19 == 0:
+                    acc //= 0
+                v = 2
+            finally:
+                v += 10
+        except ZeroDivisionError:
+            v += 100
+        acc = (acc + v + i % 3) % 1000003
+        i += 1
+    return acc
+
+
+def main():
+    print(nested(N))
+
+
+main()

--- a/pyre/bench/synth/exception_multi_handler_warmup.py
+++ b/pyre/bench/synth/exception_multi_handler_warmup.py
@@ -1,0 +1,44 @@
+# Multi-except dispatch + counter-only handler bodies on the blackhole
+# guard-failure resume path. The loop warms up exception-free (so the trace
+# compiles the no-exception path), then raises ZeroDivisionError and
+# IndexError after warm-up. Each `except` body only bumps a counter and the
+# `try` result is dead — the shape that exposed two resume bugs:
+#   - every exception matched the FIRST `except` unconditionally (the type
+#     dispatch fell through to a blanket match), so the second clause was
+#     never reached, and
+#   - a single matched exception ESCAPED because the CHECK_EXC_MATCH bool
+#     was pinned to a scratch register the following truth test never read,
+#     so the handler was skipped.
+# A trace that raises from iteration 1 records the handler and never needs
+# the resume path; only warm-up-then-raise reaches it.
+N = 24000
+
+
+def work(n):
+    data = [3, 1, 4, 1, 5]
+    zdiv = 0
+    idxe = 0
+    i = 0
+    while i < n:
+        if i < 2000:
+            d = 1
+            j = 0
+        else:
+            d = i % 2  # 0 on even i -> ZeroDivisionError
+            j = i % 9  # > 4 -> IndexError (data has 5 elements)
+        try:
+            q = (i + 1) // d
+            v = data[j]
+        except ZeroDivisionError:
+            zdiv += 1
+        except IndexError:
+            idxe += 1
+        i += 1
+    return zdiv, idxe
+
+
+def main():
+    print(work(N))
+
+
+main()

--- a/pyre/bench/synth/generator_tree_recursion.py
+++ b/pyre/bench/synth/generator_tree_recursion.py
@@ -1,0 +1,46 @@
+# Generator-driven accumulation over recursive tree/linear results. The
+# tree_sum recursion once silently miscompiled on cranelift (first checksum
+# already wrong) and recovered a regalloc panic on dynasm. Deterministic;
+# after k > 7000 the generator switches to a different recursive mix
+# (post-warm-up branch divergence).
+MOD = 1000003
+
+
+def tree_sum(n):
+    if n <= 1:
+        return n + 1
+    if n % 2 == 0:
+        return (tree_sum(n // 2) * 2 + tree_sum(n // 2 - 1)) % MOD
+    return (tree_sum((n - 1) // 2) + n) % MOD
+
+
+def deep(n):
+    if n <= 0:
+        return 3
+    return (deep(n - 1) + n * n) % MOD
+
+
+def gen_values(limit):
+    k = 1
+    while k <= limit:
+        if k > 7000:
+            n = (k * 11) % 523 + 2
+            yield (tree_sum(n) * 3 + deep(n % 67)) % MOD
+        else:
+            n = (k * 7) % 311 + 2
+            yield (tree_sum(n) + k) % MOD
+        k += 1
+
+
+def main():
+    acc = 0
+    cnt = 0
+    for v in gen_values(9000):
+        acc = (acc + v) % MOD
+        cnt += 1
+        if cnt % 1800 == 0:
+            print("checksum3", cnt, acc)
+    print("final3", acc, cnt)
+
+
+main()

--- a/pyre/bench/synth/nested_loop_gate_switch.py
+++ b/pyre/bench/synth/nested_loop_gate_switch.py
@@ -1,0 +1,46 @@
+# Two nested hot loops with a guard-set switch keyed on the outer phase; the
+# inner late arm (touching a None-or-int local) only executes once the global
+# count crosses 5000, forcing bridge deopts mid-run. This once panicked on
+# cranelift ("external JUMP target must be a registered LoopTargetDescr").
+# Deterministic.
+def inner(x, label, hold, gate):
+    s = 0
+    j = 0
+    while j < 40:
+        if (x + j) % 3 == 0:
+            s += j
+        elif (x + j) % 3 == 1:
+            s += len(label)
+        else:
+            if gate and j % 17 == 0:
+                if hold is None:
+                    hold = j
+                else:
+                    hold = None
+                s += 1 if hold is None else hold
+            s += 2
+        j += 1
+    return s, hold
+
+
+def main():
+    total = 0
+    label = "lo"
+    hold = None
+    count = 0
+    outer = 0
+    while outer < 400:
+        gate = count > 5000
+        s, hold = inner(outer, label, hold, gate)
+        total += s
+        count += 40
+        if outer % 50 == 0:
+            label = "hihi" if (outer // 50) % 2 == 1 else "lo"
+            hm = -1 if hold is None else hold
+            print("chk", outer, count, total, label, hm)
+        outer += 1
+    hm = -1 if hold is None else hold
+    print("final", total, count, label, hm)
+
+
+main()

--- a/pyre/bench/synth/polymorphic_slot_retype.py
+++ b/pyre/bench/synth/polymorphic_slot_retype.py
@@ -1,0 +1,50 @@
+# Polymorphic accumulator slots cycling int/str/None in a hot loop, with rare
+# retype arms (int->str, str->None) opening after warm-up so the compiled
+# trace takes bridges. A deopt-resumed frame once pushed past the valuestack
+# capacity (load_small_int OOB) on this shape. Deterministic.
+def step(state, i):
+    a, b, c = state
+    if i % 5 == 0:
+        a += i % 7
+    elif i % 5 == 1:
+        if b is None:
+            b = "n"
+        else:
+            b = "s" if (i & 2) else "t"
+        a += ord(b[0]) % 5
+    elif i % 5 == 2:
+        if isinstance(c, int):
+            c += 2
+        else:
+            c = len(c)
+        a -= 1
+    else:
+        a += 1
+    return a, b, c
+
+
+def main():
+    a = 0
+    b = None
+    c = 0
+    total = 0
+    n = 26000
+    for i in range(n):
+        a, b, c = step((a, b, c), i)
+        if i > 6000:
+            if i % 101 == 0:
+                c = "w" * ((i % 3) + 1)
+            if i % 113 == 0:
+                b = None
+        if isinstance(c, str):
+            total += len(c)
+        else:
+            total += c % 3
+        if i % 4000 == 0:
+            bs = "-" if b is None else b
+            cs = c if isinstance(c, str) else str(c % 1000)
+            print("chk", i, a % 100000, bs, cs, total)
+    print("final", a, total, b is None, c if isinstance(c, str) else c % 9973)
+
+
+main()

--- a/pyre/bench/synth/recursion_memo_branch.py
+++ b/pyre/bench/synth/recursion_memo_branch.py
@@ -1,0 +1,46 @@
+# Memoized vs plain recursion with post-warm-up branch divergence. The
+# memo-dict store (memo[n] = r) once died with a TypeError after warm-up
+# (an empty-string type name from a clobbered class read on the dict-store
+# path during a deopt-resumed recursive frame). Deterministic; divergence
+# (deeper args, branch flip) starts after iteration 7000.
+MOD = 1000003
+
+memo = {}
+
+
+def rec_memo(n):
+    if n <= 1:
+        return n
+    if n in memo:
+        return memo[n]
+    if n % 2 == 0:
+        r = (rec_memo(n // 2) * 3 + 7) % MOD
+    else:
+        r = (rec_memo(n - 1) + n * 5) % MOD
+    memo[n] = r
+    return r
+
+
+def rec_plain(n):
+    if n <= 1:
+        return n
+    if n % 2 == 0:
+        return (rec_plain(n // 2) * 3 + 7) % MOD
+    return (rec_plain(n - 1) + n * 5) % MOD
+
+
+def main():
+    acc = 0
+    for i in range(1, 9001):
+        n = (i * 37) % 211 + 2
+        if i > 7000:
+            n = n * 31 + 1
+            acc = (acc + rec_plain(n) * 2 + rec_memo(n)) % MOD
+        else:
+            acc = (acc + rec_memo(n) + rec_plain(n)) % MOD
+        if i % 1500 == 0:
+            print("checksum1", i, acc)
+    print("final1", acc, len(memo))
+
+
+main()

--- a/pyre/bench/synth/short_circuit_side_effects.py
+++ b/pyre/bench/synth/short_circuit_side_effects.py
@@ -1,0 +1,59 @@
+# Short-circuit and/or chains whose operands call side-effecting helpers,
+# inside a hot loop whose first operand flips truthiness after warm-up. The
+# helpers bump global counters; the computed totals were always correct, but
+# the counters over-counted under the JIT because an aborted trace (or a
+# guard-failure replay) re-executed iterations whose side effects had already
+# committed once. Output is byte-exact vs the interpreter only if every
+# helper call runs exactly once per iteration across warm-up, tracing,
+# aborts, bridges, and deopts.
+counters = [0, 0, 0]
+
+
+def side_a(v):
+    counters[0] = counters[0] + 1
+    return v
+
+
+def side_b(v):
+    counters[1] = counters[1] + 1
+    return v
+
+
+def side_c(v):
+    counters[2] = counters[2] + 1
+    return v
+
+
+def main():
+    total = 0
+    i = 0
+    N = 20000
+    while i < N:
+        # Late flip: the and-chain's first operand is truthy until i=12000,
+        # then always falsy so the chain short-circuits early.
+        if i < 12000:
+            x = i % 7 + 1
+        else:
+            x = 0
+
+        if side_a(x) and side_b(i % 5) and side_c(i % 11 + 1):
+            total += 1
+        else:
+            total -= 2
+
+        if side_a(x) or side_b(i % 4) or side_c(i % 9):
+            total += 3
+        else:
+            total -= 4
+
+        if (side_a(x) and side_b(i % 3)) or side_c(i % 2):
+            total += 5
+
+        if i % 4000 == 3999:
+            print("ck", i, total, counters[0], counters[1], counters[2])
+        i += 1
+
+    print("final", total, counters[0], counters[1], counters[2])
+
+
+main()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -5368,6 +5368,31 @@ except (ValueError, 42):
     }
 
     #[test]
+    fn test_check_exc_match_against_matches_by_actual_type() {
+        // pyopcode.py:1040 `return space.exception_match(space.type(w_1), w_2)`:
+        // the left operand is matched by its *actual* type, never treated as
+        // an unconditional success.  Guards the three shapes the residual
+        // `bh_compare_fn` (call_jit.rs) and the BC `check_exc_match` share:
+        //   * a matching exception instance   -> true
+        //   * a non-matching exception class  -> false (an `except` clause
+        //     past the first must not spuriously match)
+        //   * a non-exception value           -> false (matched by `type(v)`,
+        //     whose MRO holds no exception class)
+        let (_result, frame) = run_exec_frame(
+            "exc = ValueError(\"boom\")\nplain = 5\nvalue_error = ValueError\ntype_error = TypeError",
+        );
+        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let exc = *w_globals.get("exc").expect("missing exc");
+        let plain = *w_globals.get("plain").expect("missing plain");
+        let value_error = *w_globals.get("value_error").expect("missing value_error");
+        let type_error = *w_globals.get("type_error").expect("missing type_error");
+
+        assert!(check_exc_match_against(exc, value_error));
+        assert!(!check_exc_match_against(exc, type_error));
+        assert!(!check_exc_match_against(plain, value_error));
+    }
+
+    #[test]
     fn test_try_finally() {
         let source = "\
 result = 0

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9724,6 +9724,17 @@ fn try_walker_load_global_cell_fold(
     if stored.is_null() || unsafe { pyre_object::celldict::is_int_mutable_cell(stored) } {
         return Ok(false);
     }
+    // The fast path const-folds `stored` (the slot's raw value, or the
+    // `ObjectMutableCell`) as the elidable `jit_namespace_cell_lookup`
+    // result.  That bakes its address into the trace / guard resume data.
+    // The collector is moving, so a `stored` still in the nursery at trace
+    // time relocates nursery->oldgen afterwards and the baked address
+    // dangles (a `memo` dict grown in the loop is the canonical case).  Fall
+    // through to the residual live lookup, which re-reads the slot each call
+    // and follows the relocation, when `stored` can still move.
+    if majit_gc::can_move(majit_ir::GcRef(stored as usize)) {
+        return Ok(false);
+    }
     let is_obj_cell = unsafe { pyre_object::celldict::is_object_mutable_cell(stored) };
     let result_obj = unsafe { pyre_object::celldict::unwrap_cell(stored) };
 

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -208,8 +208,9 @@ pub struct PyJitCodePayload {
     pub code_ptr: *const pyre_interpreter::CodeObject,
     /// pyre-only wrapper identity for trace-side jitcode lookup.
     pub w_code: *const (),
-    /// True if the jitcode contains BC_ABORT opcodes (unsupported bytecodes).
-    /// Precomputed at compile time to avoid repeated bytecode scanning.
+    /// True if the jitcode contains an `abort` or `abort_permanent` opcode
+    /// (unsupported bytecodes / emission-time bail-outs). Precomputed at
+    /// compile time to avoid repeated bytecode scanning.
     pub has_abort: bool,
     /// Python PC of the jit_merge_point opcode (trace entry header).
     pub merge_point_pc: Option<usize>,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1622,6 +1622,23 @@ pub fn portal_red_regs_at(jitcode_index: i32) -> (u16, u16) {
 /// `metadata.stack_slot_color_map` first, bounded to the LIVE stack
 /// prefix at the current PC. Only if no live stack slot owns the color
 /// can the color fall back through the local slot -> color map.
+/// `PYRE_VABLE_DECODE_PROBE=1` gate for the #238 decode-equivalence probe
+/// in `restore_guard_failure_values`.  Cached: deopt is a hot-ish path and
+/// `std::env::var_os` per call would distort the measurement.
+fn vable_decode_probe_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_VABLE_DECODE_PROBE").is_some())
+}
+
+/// `PYRE_VABLE_DECODE_SKIP_COLOR=1` gate for the #238 flip candidate in
+/// `restore_guard_failure_values`: rely solely on the positional vable
+/// section restore (`consume_vable_info` → `write_from_resume_data_partial`)
+/// and skip the color-inversion overlay.
+fn vable_decode_skip_color_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_VABLE_DECODE_SKIP_COLOR").is_some())
+}
+
 pub(crate) fn semantic_ref_slot_for_reg_color(
     nlocals: usize,
     stack_only: usize,
@@ -7864,6 +7881,49 @@ impl JitState for PyreJitState {
             return self.validate_frame();
         }
 
+        // PYRE_VABLE_DECODE_PROBE=1 — #238 equivalence probe.  The rd_numb
+        // deopt path already restores the whole virtualizable positionally
+        // BEFORE this function runs (`resume.rs consume_vable_info` →
+        // `write_from_resume_data_partial`, resume.py:1399-1408).  This
+        // function then overlays the per-frame liveness section through the
+        // `semantic_ref_slot_for_reg_color` color inversion — pyre's
+        // deviation from upstream, where per-frame sections fill blackhole
+        // REGISTERS and never touch the vable (blackhole.py:1376+).  If the
+        // overlay never changes observable frame state, the color-inversion
+        // decode (and the slot↔color machinery feeding it) is retirable.
+        let probe_pre: Option<(Vec<pyre_object::PyObjectRef>, usize, usize)> =
+            if vable_decode_probe_enabled() {
+                self.locals_cells_stack_array().map(|arr| {
+                    (
+                        arr.as_slice().to_vec(),
+                        self.next_instr(),
+                        self.valuestackdepth(),
+                    )
+                })
+            } else {
+                None
+            };
+
+        // PYRE_VABLE_DECODE_SKIP_COLOR=1 — #238 flip candidate.  Trust the
+        // positional `write_from_resume_data_partial` restore exclusively
+        // (upstream shape: per-frame sections never write the vable) and
+        // skip both the static-field re-writes and the color-inversion
+        // liveness loop below.  Keeps the frame validation and the
+        // stale-slot clear (blackhole fresh-frame parity), which the vable
+        // section restore does not perform.
+        if vable_decode_skip_color_enabled() {
+            if !self.validate_frame() {
+                return false;
+            }
+            let vsd = self.valuestackdepth();
+            if let Some(arr) = self.locals_cells_stack_array_mut() {
+                for i in vsd..arr.len() {
+                    arr[i] = pyre_object::PY_NULL;
+                }
+            }
+            return true;
+        }
+
         // virtualizable.py:126-137 write_from_resume_data_partial:
         // ALL static fields in unroll_static_fields order.
         if let Some(last_instr) = values
@@ -8126,6 +8186,43 @@ impl JitState for PyreJitState {
         if let Some(arr) = self.locals_cells_stack_array_mut() {
             for i in vsd..arr.len() {
                 arr[i] = pyre_object::PY_NULL;
+            }
+        }
+
+        if let Some((pre_arr, pre_ni, pre_vsd)) = probe_pre {
+            let post_ni = self.next_instr();
+            let post_vsd = self.valuestackdepth();
+            // Compare only the live prefix [0..vsd]; slots beyond are dead
+            // by definition (and were just NULL-cleared above).
+            let mut changed = 0usize;
+            let mut details = String::new();
+            let cmp_len = post_vsd.min(pre_arr.len());
+            if let Some(arr) = self.locals_cells_stack_array() {
+                let post = arr.as_slice();
+                for (i, &pre) in pre_arr.iter().enumerate().take(cmp_len.min(post.len())) {
+                    if pre != post[i] {
+                        changed += 1;
+                        if changed <= 4 {
+                            details.push_str(&format!(
+                                " slot{}:{:#x}->{:#x}",
+                                i, pre as usize, post[i] as usize
+                            ));
+                        }
+                    }
+                }
+            }
+            if changed > 0 || pre_ni != post_ni || pre_vsd != post_vsd {
+                eprintln!(
+                    "[vable-decode-probe] DIFF frame={:#x} live_pc={} changed={}/{} \
+                     ni {}->{} vsd {}->{}{}",
+                    self.frame, live_pc, changed, cmp_len, pre_ni, post_ni, pre_vsd, post_vsd,
+                    details
+                );
+            } else {
+                eprintln!(
+                    "[vable-decode-probe] clean frame={:#x} live_pc={} slots={}",
+                    self.frame, live_pc, cmp_len
+                );
             }
         }
         true

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7438,16 +7438,48 @@ impl JitState for PyreJitState {
             sym.vable_lastblock,
             sym.vable_w_globals,
         ];
-        // virtualizable.py:139 load_list_of_boxes parity: both halves of
-        // virtualizable_boxes come from the resume-data stream — OpRefs via
-        // bridge_decode_box returns (OpRef, Value) pairs.
-        // No heap read. The seed helper pads short arrays with const-NULL
+        // virtualizable.py:139 load_list_of_boxes parity: the OpRef half of
+        // virtualizable_boxes comes from the resume-data stream
+        // (`bridge_decode_box`). The CONCRETE array shadow, however, is read
+        // from the restored live virtualizable — NOT from the resume-decoded
+        // `vable_array_values`. Those decoded values are off-heap copies of
+        // young GC pointers captured at guard-fail time; a minor collection
+        // during bridge setup (residual virtual materialization / op recording
+        // allocates) moves the referenced objects but cannot forward the
+        // off-heap decode Vec, leaving dangling pointers that crash the walk's
+        // getarrayitem_vable. The live frame (`sym.concrete_vable_ptr`,
+        // restored by `decode_and_restore_guard_failure`) sits on the
+        // CURRENT_FRAME chain, so `walk_pyframe_roots` forwards its
+        // `locals_cells_stack_w` items on every collection — its slots are
+        // always live. Read them directly, mirroring the root-trace seed
+        // (`read_all_boxes` from the rooted portal frame). Falls back to the
+        // decoded values only when no live pointer is bound (unit-test /
+        // init-before-run). The seed helper pads short arrays with const-NULL
         // OpRef; match that here by padding concrete values with
         // Value::Ref(GcRef::NULL) to the same length.
+        let live_array_values: Vec<majit_ir::Value> = if sym.concrete_vable_ptr.is_null() {
+            vable_array_values.clone()
+        } else {
+            let f =
+                unsafe { &*(sym.concrete_vable_ptr as *const pyre_interpreter::pyframe::PyFrame) };
+            let lp = f.locals_cells_stack_w;
+            if lp.is_null() {
+                vable_array_values.clone()
+            } else {
+                let arr = unsafe { &*lp };
+                let base = arr.items_ptr() as *const pyre_object::PyObjectRef;
+                let n = bridge_array_len.min(arr.len());
+                (0..n)
+                    .map(|i| {
+                        majit_ir::Value::Ref(majit_ir::GcRef(unsafe { *base.add(i) } as usize))
+                    })
+                    .collect()
+            }
+        };
         let mut concrete_values = Vec::with_capacity(vable_scalar_values.len() + bridge_array_len);
         concrete_values.extend_from_slice(&vable_scalar_values);
-        let taken_concrete = vable_array_values.len().min(bridge_array_len);
-        concrete_values.extend_from_slice(&vable_array_values[..taken_concrete]);
+        let taken_concrete = live_array_values.len().min(bridge_array_len);
+        concrete_values.extend_from_slice(&live_array_values[..taken_concrete]);
         while concrete_values.len() < vable_scalar_values.len() + bridge_array_len {
             concrete_values.push(majit_ir::Value::Ref(majit_ir::GcRef::NULL));
         }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -971,22 +971,6 @@ pub fn frame_locals_cells_stack_array_ref(ctx: &mut TraceCtx, frame: OpRef) -> O
     frame_locals_cells_stack_array(ctx, frame)
 }
 
-/// Read-only JitCode lookup by CodeObject-wrapper pointer.
-///
-/// Blackhole/resume paths must not invoke compilation. Returns null
-/// if the code was not installed by the setup-time
-/// `CodeWriter.make_jitcodes()` result.
-///
-/// Uses the same canonical raw-code comparison as
-/// `MetaInterpStaticData::compiled_jitcode_lookup`; callers still
-/// pass the wrapper `w_code`, and the lookup normalizes it internally.
-pub(crate) fn jitcode_lookup(code: *const ()) -> *const JitCode {
-    ensure_finish_setup();
-    METAINTERP_SD
-        .with(|r| r.borrow().compiled_jitcode_lookup(code))
-        .unwrap_or(std::ptr::null())
-}
-
 /// warmspot.py:282 metainterp_sd.jitcodes[jitcode_index]:
 /// Resolve jitcode_index (sequential int from snapshot numbering)
 /// to the corresponding CodeObject pointer.
@@ -1622,23 +1606,6 @@ pub fn portal_red_regs_at(jitcode_index: i32) -> (u16, u16) {
 /// `metadata.stack_slot_color_map` first, bounded to the LIVE stack
 /// prefix at the current PC. Only if no live stack slot owns the color
 /// can the color fall back through the local slot -> color map.
-/// `PYRE_VABLE_DECODE_PROBE=1` gate for the #238 decode-equivalence probe
-/// in `restore_guard_failure_values`.  Cached: deopt is a hot-ish path and
-/// `std::env::var_os` per call would distort the measurement.
-fn vable_decode_probe_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_VABLE_DECODE_PROBE").is_some())
-}
-
-/// `PYRE_VABLE_DECODE_SKIP_COLOR=1` gate for the #238 flip candidate in
-/// `restore_guard_failure_values`: rely solely on the positional vable
-/// section restore (`consume_vable_info` → `write_from_resume_data_partial`)
-/// and skip the color-inversion overlay.
-fn vable_decode_skip_color_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_VABLE_DECODE_SKIP_COLOR").is_some())
-}
-
 pub(crate) fn semantic_ref_slot_for_reg_color(
     nlocals: usize,
     stack_only: usize,
@@ -3598,19 +3565,6 @@ pub(crate) fn boxed_slot_value_for_type(_slot_type: Type, value: &Value) -> PyOb
         Value::Int(v) => w_int_new(*v),
         Value::Float(v) => pyre_object::floatobject::w_float_new(*v),
         Value::Ref(r) => r.as_usize() as PyObjectRef,
-        Value::Void => PY_NULL,
-    }
-}
-
-/// virtualizable.py:126/139 parity: box value for frame array slot.
-/// Frame array items (locals_cells_stack_w[*]) are declared as GCREF
-/// (interp_jit.py:25). The optimizer may unbox ints/floats in fail_args;
-/// this function re-boxes them for the frame. Ref values pass through.
-pub(crate) fn virtualizable_box_value(value: &Value) -> PyObjectRef {
-    match value {
-        Value::Ref(r) => r.as_usize() as PyObjectRef,
-        Value::Int(v) => w_int_new(*v),
-        Value::Float(v) => pyre_object::floatobject::w_float_new(*v),
         Value::Void => PY_NULL,
     }
 }
@@ -7881,348 +7835,21 @@ impl JitState for PyreJitState {
             return self.validate_frame();
         }
 
-        // PYRE_VABLE_DECODE_PROBE=1 — #238 equivalence probe.  The rd_numb
-        // deopt path already restores the whole virtualizable positionally
-        // BEFORE this function runs (`resume.rs consume_vable_info` →
-        // `write_from_resume_data_partial`, resume.py:1399-1408).  This
-        // function then overlays the per-frame liveness section through the
-        // `semantic_ref_slot_for_reg_color` color inversion — pyre's
-        // deviation from upstream, where per-frame sections fill blackhole
-        // REGISTERS and never touch the vable (blackhole.py:1376+).  If the
-        // overlay never changes observable frame state, the color-inversion
-        // decode (and the slot↔color machinery feeding it) is retirable.
-        let probe_pre: Option<(Vec<pyre_object::PyObjectRef>, usize, usize)> =
-            if vable_decode_probe_enabled() {
-                self.locals_cells_stack_array().map(|arr| {
-                    (
-                        arr.as_slice().to_vec(),
-                        self.next_instr(),
-                        self.valuestackdepth(),
-                    )
-                })
-            } else {
-                None
-            };
-
-        // PYRE_VABLE_DECODE_SKIP_COLOR=1 — #238 flip candidate.  Trust the
-        // positional `write_from_resume_data_partial` restore exclusively
-        // (upstream shape: per-frame sections never write the vable) and
-        // skip both the static-field re-writes and the color-inversion
-        // liveness loop below.  Keeps the frame validation and the
-        // stale-slot clear (blackhole fresh-frame parity), which the vable
-        // section restore does not perform.
-        if vable_decode_skip_color_enabled() {
-            if !self.validate_frame() {
-                return false;
-            }
-            let vsd = self.valuestackdepth();
-            if let Some(arr) = self.locals_cells_stack_array_mut() {
-                for i in vsd..arr.len() {
-                    arr[i] = pyre_object::PY_NULL;
-                }
-            }
-            return true;
+        // The rd_numb deopt path restores the whole virtualizable
+        // positionally before this runs (`resume.rs consume_vable_info` →
+        // `write_from_resume_data_partial`, resume.py:1399-1408).  The
+        // per-frame liveness section fills the blackhole REGISTERS and never
+        // touches the vable (blackhole.py:1376+), so the positional restore
+        // is authoritative for the frame.  Validate it and clear stale slots
+        // beyond valuestackdepth (blackhole fresh-frame parity), which the
+        // vable section restore does not perform.
+        if !self.validate_frame() {
+            return false;
         }
-
-        // virtualizable.py:126-137 write_from_resume_data_partial:
-        // ALL static fields in unroll_static_fields order.
-        if let Some(last_instr) = values
-            .get(crate::virtualizable_gen::SYM_LAST_INSTR_IDX as usize)
-            .map(value_to_usize)
-        {
-            self.set_last_instr(last_instr);
-        }
-        if let Some(code) = values
-            .get(crate::virtualizable_gen::SYM_PYCODE_IDX as usize)
-            .map(value_to_usize)
-        {
-            self.set_pycode(code);
-        }
-        if let Some(vsd) = values
-            .get(crate::virtualizable_gen::SYM_VALUESTACKDEPTH_IDX as usize)
-            .map(value_to_usize)
-        {
-            // Sanity check: vsd must not exceed the frame's total capacity
-            // (nlocals + stacksize). A bad vsd from stale guard recovery
-            // values can corrupt the frame and crash in as_mut_slice.
-            let max_vsd = self
-                .locals_cells_stack_array()
-                .map(|arr| arr.len())
-                .unwrap_or(0);
-            let safe_vsd = vsd.min(max_vsd);
-            self.set_valuestackdepth(safe_vsd);
-        }
-        if let Some(ns) = values
-            .get(crate::virtualizable_gen::SYM_W_GLOBALS_IDX as usize)
-            .map(value_to_usize)
-        {
-            self.set_w_globals(ns);
-        }
-
-        let nlocals = self.local_count();
-        let stack_only = self.valuestackdepth().saturating_sub(nlocals);
-        // resume.py:1077 consume_boxes(info, boxes_i, boxes_r, boxes_f) parity:
-        // RPython's consume_boxes uses position_info (liveness at resume PC)
-        // to map compact active_boxes back to register indices. Dead registers
-        // are skipped in the compact array — only live registers advance the
-        // value index.
-        //
-        // values[3..] = compact active_boxes from get_list_of_active_boxes,
-        // which filters by liveness. Use the same liveness table to restore.
-        // Two distinct pointers for the same PyFrame.pycode:
-        //   - `w_code_ptr`  : Python CodeObject WRAPPER (`PyObjectRef`).
-        //                     Key used by `jitcode_for`/`jitcode_lookup`
-        //                     (see trace_opcode.rs:3501/:3580 and
-        //                     state.rs:1908 — all pass the wrapper).
-        //   - `raw_code_ptr`: unwrapped Rust `CodeObject`. Consumed by
-        //                     `liveness_for` (the LiveVars cache key).
-        let (w_code_ptr, raw_code_ptr) = if self.frame != 0 {
-            let w_code = unsafe {
-                *((self.frame as *const u8).add(crate::frame_layout::PYFRAME_PYCODE_OFFSET)
-                    as *const *const ())
-            };
-            if !w_code.is_null() {
-                let raw = unsafe {
-                    pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
-                        as *const pyre_interpreter::CodeObject
-                };
-                (w_code, raw)
-            } else {
-                (std::ptr::null(), std::ptr::null())
-            }
-        } else {
-            (std::ptr::null(), std::ptr::null())
-        };
-        // resume.py:1383: info = blackholeinterp.get_current_position_info()
-        // blackhole.py:337: position was set by setposition(jitcode, pc) where
-        // pc comes from rd_numb — the same orgpc used by get_list_of_active_boxes.
-        // next_instr = orgpc + 1 + caches, which may have different liveness.
-        // `self.resume_pc` is the rd_numb pc word (set from
-        // `RebuiltFrame.pc`), so it may carry the after-residual-call
-        // marker.  Split it: `live_pc` is the plain Python PC for all
-        // py_pc-keyed liveness lookups, `live_after_residual_call`
-        // selects the post-call resume map below.
-        let live_pc_raw = self.resume_pc.take().unwrap_or_else(|| self.next_instr());
-        let (live_pc, live_after_residual_call) = {
-            let (p, a) = majit_ir::resumedata::decode_resume_pc(live_pc_raw as i32);
-            (p as usize, a)
-        };
-        let mut idx = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;
-        // resume.py:1077 consume_boxes parity — iterate the SAME
-        // `all_liveness` BC_LIVE data the encoder used in
-        // `trace_opcode.rs::get_list_of_active_boxes`. For every live
-        // reg color, reverse-map through the current jitcode's live
-        // stack-slot colors before falling back to the local inputarg
-        // prefix. This keeps the encoder/decoder contract aligned on
-        // jitcode SSA liveness rather than the LiveVars approximation.
-        //
-        // Falls back to the LiveVars path below only when the frame's
-        // code is not (yet) registered or has no pc_map entry — i.e.
-        // the same fallback branch trace_opcode.rs:313-334 takes.
-        let decoded_via_jitcode: bool = (|| {
-            if w_code_ptr.is_null() {
-                return false;
-            }
-            let jc_ptr = jitcode_lookup(w_code_ptr);
-            if jc_ptr.is_null() {
-                return false;
-            }
-            let jc = unsafe { &*jc_ptr };
-            let payload = &jc.payload;
-            // G.4.3 portal-bridge writeback: positional iteration over
-            // `0..stack_base + depth_at_py_pc[live_pc]`, paired with the
-            // encoder's positional emit in
-            // `trace_opcode.rs::get_list_of_active_boxes` and the
-            // count check in `frame_value_count_at`.  Skips the canonical
-            // `all_liveness` path (whose register indices are for the
-            // dispatch loop, not the user PyFrame) and routes each
-            // consumed value to `set_local_at` / `set_stack_at` by the
-            // same `reg < stack_base` split the canonical path uses
-            // below.
-            //
-            // `metadata.stack_base = nlocals + ncells` (G.3h), the same
-            // value `local_count()` derives from `concrete_nlocals(frame)`
-            // — but reading from metadata makes the encoder/decoder
-            // symmetric source explicit (G.4.3a-fix: pre-fix code mixed
-            // `local_count() = stack_base` here with `nlocals_from_code()
-            // = varnames.len()` in the count callback, breaking parity
-            // for closure-bearing functions).
-            if payload.is_portal_bridge() {
-                let stack_base = payload.metadata.stack_base;
-                let depth = payload
-                    .metadata
-                    .depth_at_py_pc
-                    .get(live_pc)
-                    .copied()
-                    .unwrap_or(0) as usize;
-                let target_count = stack_base + depth;
-                for reg in 0..target_count {
-                    if let Some(value) = values.get(idx) {
-                        let boxed = virtualizable_box_value(value);
-                        if reg < stack_base {
-                            let _ = self.set_local_at(reg, boxed);
-                        } else {
-                            let stack_idx = reg - stack_base;
-                            if stack_idx < stack_only {
-                                let _ = self.set_stack_at(stack_idx, boxed);
-                            }
-                        }
-                    }
-                    idx += 1;
-                }
-                return true;
-            }
-            let resolved_jit_pc = if live_after_residual_call {
-                payload.after_residual_call_resume_pc_for(live_pc)
-            } else {
-                payload.resume_jitcode_pc_for(live_pc)
-            };
-            let Some(jit_pc) = resolved_jit_pc else {
-                return false;
-            };
-            let all_liveness = liveness_info_snapshot();
-            let off = payload.jitcode.get_live_vars_info(jit_pc, op_live());
-            if off + 2 >= all_liveness.len() {
-                return false;
-            }
-            let length_i = all_liveness[off] as u32;
-            let length_r = all_liveness[off + 1] as u32;
-            let length_f = all_liveness[off + 2] as u32;
-            let mut cursor = off + 3;
-            use majit_translate::liveness::LivenessIterator;
-            // Route Ref-bank live-register
-            // colors through `metadata.stack_slot_color_map` (forward
-            // map: stack slot d → post-rename color). Currently with
-            // input-arg pinning the map is `[nlocals, nlocals+1, ...]`
-            // so the lookup is currently identity; without the
-            // pinning, stack colors may differ from `nlocals + d` and
-            // the map is the single source of truth for the
-            // `color → stack-slot-index` reverse lookup the heap
-            // writeback needs.
-            let local_color_map: &[u16] = &payload.metadata.pyre_color_for_semantic_local;
-            let stack_color_map: &[u16] = &payload.metadata.stack_slot_color_map;
-            let live_local_indices: Vec<usize> = {
-                let code_ptr = if !payload.code_ptr.is_null() {
-                    payload.code_ptr
-                } else {
-                    raw_code_ptr
-                };
-                if code_ptr.is_null() {
-                    Vec::new()
-                } else {
-                    let live_vars = crate::liveness::liveness_for(code_ptr);
-                    (0..nlocals)
-                        .filter(|&local_idx| live_vars.is_local_live(live_pc, local_idx))
-                        .collect()
-                }
-            };
-            for (is_ref_bank, length) in [(false, length_i), (true, length_r), (false, length_f)] {
-                if length == 0 {
-                    continue;
-                }
-                let mut it = LivenessIterator::new(cursor, length, &all_liveness);
-                while let Some(reg_idx) = it.next() {
-                    let reg = reg_idx as usize;
-                    if let Some(value) = values.get(idx) {
-                        let boxed = virtualizable_box_value(value);
-                        if is_ref_bank {
-                            if let Some(slot_idx) = semantic_ref_slot_for_reg_color(
-                                nlocals,
-                                stack_only,
-                                local_color_map,
-                                stack_color_map,
-                                &live_local_indices,
-                                reg,
-                            ) {
-                                if slot_idx < nlocals {
-                                    let _ = self.set_local_at(slot_idx, boxed);
-                                } else {
-                                    let _ = self.set_stack_at(slot_idx - nlocals, boxed);
-                                }
-                            } else if reg < nlocals
-                                && matches!(value, Value::Int(_) | Value::Float(_))
-                            {
-                                // Runtime resume values are authoritative for
-                                // kind.  A stale Ref-bank liveness entry can
-                                // still carry an unboxed Int/Float fail arg;
-                                // box it into the semantic local without
-                                // widening Ref color reverse-mapping for
-                                // actual Ref values.
-                                let _ = self.set_local_at(reg, boxed);
-                            }
-                        } else if reg < nlocals {
-                            // Int/Float bank register indices are not Ref colors:
-                            // do not route them through
-                            // semantic_ref_slot_for_reg_color.  For the
-                            // current frame-local case, the jitcode liveness
-                            // uses the semantic local index; box the raw value
-                            // back into PyFrame.locals_cells_stack_w.
-                            let _ = self.set_local_at(reg, boxed);
-                        }
-                    }
-                    idx += 1;
-                }
-                cursor = it.offset;
-            }
-            true
-        })();
-        if !decoded_via_jitcode {
-            // The out-of-range-pc source that previously reached this
-            // branch is eliminated, and the bridge-resume tests run on the
-            // real trace-side jitcode registration path
-            // (`ensure_jitcode_index`). Unconditional panic — any hit is a
-            // bug.
-            panic!(
-                "bridge resume decode: jitcode path failed — \
-                 w_code_ptr={:p} raw_code_ptr={:p} live_pc={} \
-                 nlocals={} stack_only={}. Phase X-0/X-1 removed all \
-                 known triggers; further hits are bugs.",
-                w_code_ptr, raw_code_ptr, live_pc, nlocals, stack_only
-            );
-        }
-
-        // Clear stale slots beyond valuestackdepth (blackhole fresh frame parity).
         let vsd = self.valuestackdepth();
         if let Some(arr) = self.locals_cells_stack_array_mut() {
             for i in vsd..arr.len() {
                 arr[i] = pyre_object::PY_NULL;
-            }
-        }
-
-        if let Some((pre_arr, pre_ni, pre_vsd)) = probe_pre {
-            let post_ni = self.next_instr();
-            let post_vsd = self.valuestackdepth();
-            // Compare only the live prefix [0..vsd]; slots beyond are dead
-            // by definition (and were just NULL-cleared above).
-            let mut changed = 0usize;
-            let mut details = String::new();
-            let cmp_len = post_vsd.min(pre_arr.len());
-            if let Some(arr) = self.locals_cells_stack_array() {
-                let post = arr.as_slice();
-                for (i, &pre) in pre_arr.iter().enumerate().take(cmp_len.min(post.len())) {
-                    if pre != post[i] {
-                        changed += 1;
-                        if changed <= 4 {
-                            details.push_str(&format!(
-                                " slot{}:{:#x}->{:#x}",
-                                i, pre as usize, post[i] as usize
-                            ));
-                        }
-                    }
-                }
-            }
-            if changed > 0 || pre_ni != post_ni || pre_vsd != post_vsd {
-                eprintln!(
-                    "[vable-decode-probe] DIFF frame={:#x} live_pc={} changed={}/{} \
-                     ni {}->{} vsd {}->{}{}",
-                    self.frame, live_pc, changed, cmp_len, pre_ni, post_ni, pre_vsd, post_vsd,
-                    details
-                );
-            } else {
-                eprintln!(
-                    "[vable-decode-probe] clean frame={:#x} live_pc={} slots={}",
-                    self.frame, live_pc, cmp_len
-                );
             }
         }
         true
@@ -10449,91 +10076,45 @@ mod tests {
     }
 
     #[test]
-    fn test_restore_guard_failure_uses_runtime_value_kinds_for_virtualizable_locals() {
-        use majit_ir::GcRef;
-        use majit_translate::liveness::encode_liveness;
-        use pyre_interpreter::pyframe::PyFrame;
-        use pyre_interpreter::{ConstantData, compile_exec};
+    #[ignore = "PyreSym::new_uninit hits the Phase X-1 skeleton-panic since the \
+                debug-only fallback was removed; needs a populated-jitcode harness."]
+    fn test_load_local_checked_value_respects_symbolic_local_type() {
+        let run_case = |symbolic_type: Type, name: &str, expected_guard: Option<OpCode>| {
+            let mut ctx = TraceCtx::for_test(1);
+            // The slot type matches `symbolic_type` (resoperation.py:719/727/739
+            // InputArg{Int,Float,Ref}); Void has no inputarg variant in RPython.
+            let local = OpRef::input_arg_typed(0, symbolic_type);
+            let mut sym = PyreSym::new_uninit(OpRef::NONE);
+            sym.registers_r = vec![local];
+            sym.symbolic_local_types = vec![symbolic_type];
+            sym.nlocals = 1;
 
-        let module = compile_exec("def f(a, b, c):\n    i = 0\n    return i\nf(1, 2, 3)\n")
-            .expect("test code should compile");
-        let code = module
-            .constants
-            .iter()
-            .find_map(|constant| match constant {
-                ConstantData::Code { code } if code.obj_name.as_str() == "f" => {
-                    Some((**code).clone())
-                }
-                _ => None,
-            })
-            .expect("test source should contain function code");
+            let mut state = MIFrame {
+                ctx: &mut ctx,
+                sym: &mut sym,
+                fallthrough_pc: 0,
+                parent_frames: Vec::new(),
+                pending_result_stack_idx: None,
+                pending_result_type: None,
+                pending_inline_frame: None,
+                residual_call_pc: None,
+                orgpc: 0,
+                concrete_frame_addr: 0,
+                pre_opcode_registers_r: None,
+                pre_opcode_semantic_depth: None,
+            };
 
-        let mut frame = PyFrame::new(code.clone());
-        frame.fix_array_ptrs();
-        let frame_ptr = (&mut *frame) as *mut PyFrame as usize;
+            let loaded =
+                <MIFrame as LocalOpcodeHandler>::load_local_checked_value(&mut state, 0, name)
+                    .expect("local should load");
+            assert_eq!(loaded.opref, local);
 
-        // Register a jitcode keyed on frame.pycode so jitcode_lookup is
-        // non-null (else restore_guard_failure_values panics unconditionally
-        // at state.rs:8115). Publish a liveness buffer marking all four
-        // locals live in the Ref bank (length_r=4, colors 0..3): with a
-        // skeleton jitcode's empty color map, semantic_ref_slot_for_reg_color
-        // maps reg→slot identity (state.rs:1649), so the four array values
-        // land in locals 0..3. Local 3 carries Value::Int(7); the runtime
-        // value kind boxes it back as a real int regardless of the stale
-        // Ref slot type.
-        let mut all_liveness = vec![0u8, 4, 0];
-        all_liveness.extend(encode_liveness(&[0, 1, 2, 3]));
-        install_test_jitcode_with_liveness(&code, frame.pycode, &all_liveness, 1);
-
-        // Resume at the jitcode's single BC_LIVE (jit byte 0). In production
-        // resume_pc is the rd_numb pc; here next_instr would otherwise become
-        // last_instr+1 = 9 (out of the function's pc_map range) before the
-        // liveness lookup, so pin the lookup pc explicitly.
-        let mut state = PyreJitState {
-            frame: frame_ptr,
-            resume_pc: Some(0),
+            let tree_loop = ctx.into_tree_loop();
+            assert_eq!(tree_loop.ops.last().map(|op| op.opcode), expected_guard);
         };
-        state.set_next_instr(0);
-        state.set_valuestackdepth(4);
-        let meta = PyreMeta {
-            num_locals: 4,
-            ns_len: 0,
-            valuestackdepth: 4,
-            array_capacity: 4,
-            trace_extra_reds: 0,
-            has_virtualizable: true,
-            // Stale trace-entry types: all locals looked boxed refs when the
-            // trace started, but guard failure can still carry a raw int in
-            // slot `i`.
-            slot_types: vec![Type::Ref, Type::Ref, Type::Ref, Type::Ref],
-        };
-        let values = vec![
-            Value::Ref(GcRef(frame_ptr)),             // frame
-            Value::Ref(GcRef(0)),                     // ec (extra_red)
-            Value::Int(8),                            // last_instr
-            Value::Ref(GcRef(frame.pycode as usize)), // pycode
-            Value::Int(4),                            // valuestackdepth
-            Value::Ref(GcRef(0)),                     // debugdata
-            Value::Ref(GcRef(0)),                     // lastblock
-            Value::Ref(GcRef(0)),                     // w_globals
-            Value::Ref(GcRef(w_int_new(1) as usize)), // local a
-            Value::Ref(GcRef(w_int_new(2) as usize)), // local b
-            Value::Ref(GcRef(w_int_new(3) as usize)), // local c
-            Value::Int(7),                            // local i
-        ];
 
-        assert!(<PyreJitState as JitState>::restore_guard_failure_values(
-            &mut state,
-            &meta,
-            &values,
-            &majit_metainterp::blackhole::ExceptionState::default(),
-        ));
-
-        assert_eq!(state.next_instr(), 9);
-        assert_eq!(state.valuestackdepth(), 4);
-        let restored_i = state.local_at(3).expect("local i should be restored");
-        assert!(unsafe { is_int(restored_i) });
-        assert_eq!(unsafe { w_int_get_value(restored_i) }, 7);
+        run_case(Type::Int, "j", None);
+        run_case(Type::Ref, "b", Some(OpCode::GuardNonnull));
     }
 
     #[test]

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1436,6 +1436,40 @@ fn jit_blackhole_resume_from_guard(
     None
 }
 
+/// RAII guard registering each slot of the `#326` rollback snapshot's
+/// `locals` copy as a GC root for the duration of `bh.run()`.  The snapshot
+/// is a plain `Vec<PyObjectRef>` holding raw object pointers; the collector
+/// is moving (incminimark nursery -> oldgen copying), so a minor collection
+/// during the forward run would relocate those objects and leave the Vec
+/// holding from-space pointers.  Registering each element slot makes the
+/// root walker forward them in place (`collector.rs` reads `*slot`, copies,
+/// writes back), so the abort arm restores the live pointers rather than
+/// stale ones.  Mirrors `LocalsRoot` / the callee-locals root in `call.rs`.
+struct VableRollbackRoots {
+    slots: Vec<*mut *mut u8>,
+}
+
+impl VableRollbackRoots {
+    fn register(base: *const PyObjectRef, len: usize) -> Self {
+        let mut slots = Vec::with_capacity(len);
+        for i in 0..len {
+            let slot = unsafe { base.add(i) } as *mut *mut u8;
+            if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
+                slots.push(slot);
+            }
+        }
+        Self { slots }
+    }
+}
+
+impl Drop for VableRollbackRoots {
+    fn drop(&mut self) {
+        for &slot in &self.slots {
+            pyre_object::gc_hook::try_gc_remove_root(slot);
+        }
+    }
+}
+
 /// resume.py:1312 blackhole_from_resumedata parity:
 /// Decode rd_numb via ResumeDataDirectReader, build blackhole chain,
 /// run _run_forever.
@@ -1615,10 +1649,12 @@ pub fn blackhole_resume_via_rd_numb(
     //
     // The snapshot holds raw `PyObjectRef`s across `bh.run()`; the GC is a
     // moving collector (#336), so a minor collection during the run could
-    // relocate these and this snapshot would have to be registered as a GC
-    // root — tracked with #336.  Capture the snapshotted frame pointer too,
-    // so the abort arm can confirm the frame that aborted is the same one
-    // this state belongs to before restoring it.
+    // relocate these.  `VableRollbackRoots` below registers each `locals`
+    // slot with the root walker so the collector forwards them in place and
+    // the abort arm restores live pointers, not from-space ones.  Capture
+    // the snapshotted frame pointer too, so the abort arm can confirm the
+    // frame that aborted is the same one this state belongs to before
+    // restoring it.
     let vable_rollback: Option<(*mut PyFrame, Vec<PyObjectRef>, usize, isize)> = {
         let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
         if frame_ptr.is_null() {
@@ -1633,6 +1669,11 @@ pub fn blackhole_resume_via_rd_numb(
             ))
         }
     };
+    // Keep the snapshot's locals rooted for the whole forward run / abort
+    // window; dropped (roots removed) when this function returns.
+    let _vable_rollback_roots = vable_rollback
+        .as_ref()
+        .map(|(_, locals, _, _)| VableRollbackRoots::register(locals.as_ptr(), locals.len()));
 
     // blackhole.py:1794-1795 resume_in_blackhole:
     //   current_exc = _prepare_resume_from_failure(guard_opnum, deadframe)

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3116,6 +3116,30 @@ pub extern "C" fn bh_call_fn_8(
     )
 }
 
+/// Per-arity `bh_call_fn_<n>` thunks for nargs 9..=14, sharing the
+/// `(callable, null_or_self, arg0..arg{n-1})` ABI of the explicit
+/// `bh_call_fn_0..8` above.  nargs=14 (16 i64 params) is the ceiling
+/// the backend dispatch table (`call_stub.rs::dispatch_arity_body!`,
+/// `MAX_HOST_CALL_ARITY` = 16) supports; CALL with nargs > 14 falls
+/// through to `emit_abort_permanent!`.
+macro_rules! bh_call_fn_arity {
+    ($name:ident; $($arg:ident),+ $(,)?) => {
+        pub extern "C" fn $name(callable: i64, null_or_self: i64, $($arg: i64),+) -> i64 {
+            bh_call_fn_impl(
+                callable as PyObjectRef,
+                null_or_self as PyObjectRef,
+                &[$($arg as PyObjectRef),+],
+            )
+        }
+    };
+}
+bh_call_fn_arity!(bh_call_fn_9; a0, a1, a2, a3, a4, a5, a6, a7, a8);
+bh_call_fn_arity!(bh_call_fn_10; a0, a1, a2, a3, a4, a5, a6, a7, a8, a9);
+bh_call_fn_arity!(bh_call_fn_11; a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+bh_call_fn_arity!(bh_call_fn_12; a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
+bh_call_fn_arity!(bh_call_fn_13; a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+bh_call_fn_arity!(bh_call_fn_14; a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+
 /// blackhole.py:1224 bhimpl_residual_call: cpu.bh_call_r.
 /// RPython: cpu.bh_call_r (llmodel.py:816) invokes calldescr.call_stub_r
 /// directly — a plain function-pointer call, no portal_runner indirection.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4027,6 +4027,17 @@ pub extern "C" fn bh_compare_fn(lhs: i64, rhs: i64, op_code: i64) -> i64 {
     // proper exception type object, which made every `except SomeError:`
     // appear to match — wrong for any clause beyond the first.
     if op_code == 10 {
+        // Validate the match target is an exception class / tuple of exception
+        // classes first (`cmp_exc_match`, pyopcode.py:1034-1039), raising
+        // TypeError otherwise.  The BC handler runs
+        // `validate_check_exc_match_class` before the bool-returning
+        // `check_exc_match_against`, so the residual path must too — `except 5:`
+        // (or a tuple with a non-exception member) raises instead of silently
+        // producing a bool.
+        if let Err(err) = pyre_interpreter::eval::validate_check_exc_match_class(rhs) {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            return 0;
+        }
         let matched = pyre_interpreter::eval::check_exc_match_against(lhs, rhs);
         return pyre_object::w_bool_from(matched) as i64;
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1613,16 +1613,20 @@ pub fn blackhole_resume_via_rd_numb(
     // mutates it, so the abort arm can roll it back and the interpreter's
     // re-run applies each side effect exactly once.
     //
-    // Objects are immortal under the current GC (no move/collect), so
-    // holding raw `PyObjectRef`s across `bh.run()` is safe; this snapshot
-    // would have to be registered as a GC root if that ever changes.
-    let vable_rollback: Option<(Vec<PyObjectRef>, usize, isize)> = {
-        let frame_ptr = bh.virtualizable_ptr as *const PyFrame;
+    // The snapshot holds raw `PyObjectRef`s across `bh.run()`; the GC is a
+    // moving collector (#336), so a minor collection during the run could
+    // relocate these and this snapshot would have to be registered as a GC
+    // root — tracked with #336.  Capture the snapshotted frame pointer too,
+    // so the abort arm can confirm the frame that aborted is the same one
+    // this state belongs to before restoring it.
+    let vable_rollback: Option<(*mut PyFrame, Vec<PyObjectRef>, usize, isize)> = {
+        let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
         if frame_ptr.is_null() {
             None
         } else {
             let frame = unsafe { &*frame_ptr };
             Some((
+                frame_ptr,
                 frame.locals_w().as_slice().to_vec(),
                 frame.valuestackdepth,
                 frame.last_instr,
@@ -1702,9 +1706,17 @@ pub fn blackhole_resume_via_rd_numb(
             // from the guard resume PC with the pre-blackhole frame state,
             // so every side effect (the aborting opcode's included) is
             // applied exactly once instead of twice.
-            if let Some((locals, vsd, last_instr)) = &vable_rollback {
+            if let Some((snap_frame_ptr, locals, vsd, last_instr)) = &vable_rollback {
                 let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
-                if !frame_ptr.is_null() {
+                // Roll back only when the frame that aborted is the same one
+                // the snapshot was captured from.  The `_run_forever` loop
+                // reassigns `bh` to a caller on callee return / exception
+                // propagation; a later abort then lands on the caller frame,
+                // whose valuestackdepth / last_instr would be clobbered with
+                // the callee's snapshot.  A per-frame snapshot for that
+                // multi-frame case is the #124 stack-snapshot epic; until
+                // then, skip rather than corrupt the caller frame.
+                if !frame_ptr.is_null() && frame_ptr == *snap_frame_ptr {
                     let frame = unsafe { &mut *frame_ptr };
                     let arr = frame.locals_w_mut().as_mut_slice();
                     // The locals_cells_stack array length is fixed for a

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3426,15 +3426,16 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     }
 }
 
-/// `_load_global` residual (pyopcode.py:958-969).  Resolves the namespace from
-/// the callee's OWN `w_code` (`w_code_get_w_globals`, GC-forwarded at call
-/// time), NOT the `namespace_ptr` operand: the walker emits `namespace_ptr` as
-/// the cell-fold recogniser's hint, but the frame register it reads from
-/// aliases the outermost frame on a chained / inlined-callee resume.  `w_code`
-/// is the callee's own promoted constant, so its live globals are always the
-/// correct, relocation-following dict.  The live frame is passed explicitly so
-/// `_load_global` can mirror `self.get_builtin()` in compiled residual-call
-/// paths as well as blackhole.  namei is the raw oparg from LOAD_GLOBAL:
+/// `_load_global` residual (pyopcode.py:958-969).  Resolves the namespace via
+/// the executing frame's `get_w_globals()` when the live frame OWNS this
+/// `w_code` (`frame.pycode == w_code`) — honoring an `exec(code, ns)`
+/// frame-specific namespace — and falls back to the callee's own promoted
+/// `w_code` globals otherwise (an inlined / chained callee's frame register
+/// aliases an outer frame, so it is not this code's frame).  The
+/// `namespace_ptr` operand is ignored for the same aliasing reason; it
+/// survives only as the cell-fold recogniser's hint.  The live frame is also
+/// passed so `self.get_builtin()` works in compiled residual-call paths as
+/// well as blackhole.  namei is the raw oparg from LOAD_GLOBAL:
 /// name_idx = namei >> 1.
 pub extern "C" fn bh_load_global_fn(
     namespace_ptr: i64,
@@ -3455,6 +3456,7 @@ pub extern "C" fn bh_load_global_fn(
 
     let varname = code.names[idx].as_ref();
     let _ = namespace_ptr;
+    let parent_frame_ptr = frame_ptr as *const PyFrame;
     // pypy/interpreter/pyopcode.py:958-969 `_load_global`:
     //   w_value = self.space.finditem_str(self.get_w_globals(), varname)
     //   if w_value is None:
@@ -3462,20 +3464,28 @@ pub extern "C" fn bh_load_global_fn(
     //       if w_value is None:
     //           self._load_global_failed(w_varname)
     //
-    // Resolve the namespace from the callee's OWN `W_Code` at call time
-    // rather than the `namespace_ptr` operand.  The walker reads the
-    // operand namespace from `getfield_vable_r(frame, w_globals)`, but the
-    // frame register aliases the OUTERMOST frame on a chained blackhole /
-    // inlined-callee resume, so a non-portal callee would see the caller's
-    // globals (or a null when the frame register is unseeded).  `w_code` is
-    // the callee's own promoted constant, and reading `w_globals` from it at
-    // call time yields the current (GC-forwarded) module dict — the value
-    // the const-folding `frontend_global_flow_value` resolved statically,
-    // but live, so a relocated dict (a growing `memo`) is followed instead
-    // of dangling.  `namespace_ptr` survives only as the
-    // `try_walker_load_global_cell_fold` recogniser's hint.
-    let w_globals =
-        unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) };
+    // `self.get_w_globals()` (pyframe.py:129-133) is the executing frame's
+    // own namespace: the per-frame `w_globals` an `exec(code, ns)` installs
+    // in `debug_data`, falling back to the code's bound `w_globals` when
+    // there is no override.  Use it whenever the live frame OWNS this
+    // `w_code` (`frame.pycode == w_code`), so a compiled `LOAD_GLOBAL`
+    // resolves against the executing frame's globals — not the code's
+    // original module dict — exactly as the interpreter does.
+    //
+    // A frame that does NOT own this `w_code` is an aliased OUTER frame on a
+    // chained blackhole / inlined-callee resume (the same aliasing makes the
+    // `namespace_ptr` operand unusable, hence ignored above).  Resolve from
+    // the callee's own promoted `w_code` constant: reading `w_globals` from
+    // it yields the current (GC-forwarded) module dict the const-folding
+    // `frontend_global_flow_value` resolved statically, but live, so a
+    // relocated dict (a growing `memo`) is followed instead of dangling.
+    let w_globals = if !parent_frame_ptr.is_null()
+        && unsafe { (*parent_frame_ptr).pycode } as usize == w_code_ptr as usize
+    {
+        unsafe { (*parent_frame_ptr).get_w_globals() }
+    } else {
+        unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) }
+    };
     if !w_globals.is_null() {
         let globals = unsafe { &*w_globals };
         if let Some(w_value) = pyre_interpreter::dict_storage_get(globals, varname) {
@@ -3486,7 +3496,6 @@ pub extern "C" fn bh_load_global_fn(
     // Residual helper adaptation: `self` is the live portal frame passed as
     // an explicit Ref argument, so `self.get_builtin()` maps to
     // PyFrame::get_builtin() without relying on blackhole-only TLS.
-    let parent_frame_ptr = frame_ptr as *const PyFrame;
     if !parent_frame_ptr.is_null() {
         let w_builtin = unsafe { (*parent_frame_ptr).get_builtin() };
         if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3385,11 +3385,16 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     }
 }
 
-/// jtransform.py parity: namespace and code come from getfield_vable_r; the
-/// live frame is passed explicitly so `_load_global` can mirror
-/// `self.get_builtin()` in compiled residual-call paths as well as blackhole.
-/// namespace = getfield_vable_r(frame, w_globals), code = getfield_vable_r(frame, pycode).
-/// namei is the raw oparg from LOAD_GLOBAL: name_idx = namei >> 1.
+/// `_load_global` residual (pyopcode.py:958-969).  Resolves the namespace from
+/// the callee's OWN `w_code` (`w_code_get_w_globals`, GC-forwarded at call
+/// time), NOT the `namespace_ptr` operand: the walker emits `namespace_ptr` as
+/// the cell-fold recogniser's hint, but the frame register it reads from
+/// aliases the outermost frame on a chained / inlined-callee resume.  `w_code`
+/// is the callee's own promoted constant, so its live globals are always the
+/// correct, relocation-following dict.  The live frame is passed explicitly so
+/// `_load_global` can mirror `self.get_builtin()` in compiled residual-call
+/// paths as well as blackhole.  namei is the raw oparg from LOAD_GLOBAL:
+/// name_idx = namei >> 1.
 pub extern "C" fn bh_load_global_fn(
     namespace_ptr: i64,
     w_code_ptr: i64,
@@ -3408,7 +3413,7 @@ pub extern "C" fn bh_load_global_fn(
     }
 
     let varname = code.names[idx].as_ref();
-    let w_globals_obj = namespace_ptr as pyre_object::PyObjectRef;
+    let _ = namespace_ptr;
     // pypy/interpreter/pyopcode.py:958-969 `_load_global`:
     //   w_value = self.space.finditem_str(self.get_w_globals(), varname)
     //   if w_value is None:
@@ -3416,14 +3421,23 @@ pub extern "C" fn bh_load_global_fn(
     //       if w_value is None:
     //           self._load_global_failed(w_varname)
     //
-    // Dispatch through the dict strategy on the globals object
-    // (`dictmultiobject.py:113-115 getitem_str`) so module dicts and
-    // plain dicts (exec/eval globals, no dict_storage_proxy) are both
-    // handled — matching the interpreter `load_global_value`.
-    if !w_globals_obj.is_null() {
-        if let Some(w_value) =
-            unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals_obj, varname) }
-        {
+    // Resolve the namespace from the callee's OWN `W_Code` at call time
+    // rather than the `namespace_ptr` operand.  The walker reads the
+    // operand namespace from `getfield_vable_r(frame, w_globals)`, but the
+    // frame register aliases the OUTERMOST frame on a chained blackhole /
+    // inlined-callee resume, so a non-portal callee would see the caller's
+    // globals (or a null when the frame register is unseeded).  `w_code` is
+    // the callee's own promoted constant, and reading `w_globals` from it at
+    // call time yields the current (GC-forwarded) module dict — the value
+    // the const-folding `frontend_global_flow_value` resolved statically,
+    // but live, so a relocated dict (a growing `memo`) is followed instead
+    // of dangling.  `namespace_ptr` survives only as the
+    // `try_walker_load_global_cell_fold` recogniser's hint.
+    let w_globals =
+        unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) };
+    if !w_globals.is_null() {
+        let globals = unsafe { &*w_globals };
+        if let Some(w_value) = pyre_interpreter::dict_storage_get(globals, varname) {
             return w_value as i64;
         }
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1600,6 +1600,36 @@ pub fn blackhole_resume_via_rd_numb(
         eprintln!("[blackhole-resume] rd_numb path, chain built, running _run_forever",);
     }
 
+    // #326 blackhole-continuation rollback snapshot.  The blackhole
+    // commits every STORE_FAST / operand push to the virtualizable heap
+    // frame as it runs forward (`setarrayitem_vable_*` /
+    // `setfield_vable_i`).  If it later aborts — an opcode pyre cannot
+    // translate emits `BC_ABORT_PERMANENT` — the deopt drops back to the
+    // plain interpreter, which re-runs from the guard's resume PC.  But
+    // the heap frame still carries the aborted run's partial forward
+    // mutations, so any side effect already committed before the abort is
+    // applied a second time.  Capture the live frame here, right after the
+    // resume restore put it at the guard snapshot and before `bh.run()`
+    // mutates it, so the abort arm can roll it back and the interpreter's
+    // re-run applies each side effect exactly once.
+    //
+    // Objects are immortal under the current GC (no move/collect), so
+    // holding raw `PyObjectRef`s across `bh.run()` is safe; this snapshot
+    // would have to be registered as a GC root if that ever changes.
+    let vable_rollback: Option<(Vec<PyObjectRef>, usize, isize)> = {
+        let frame_ptr = bh.virtualizable_ptr as *const PyFrame;
+        if frame_ptr.is_null() {
+            None
+        } else {
+            let frame = unsafe { &*frame_ptr };
+            Some((
+                frame.locals_w().as_slice().to_vec(),
+                frame.valuestackdepth,
+                frame.last_instr,
+            ))
+        }
+    };
+
     // blackhole.py:1794-1795 resume_in_blackhole:
     //   current_exc = _prepare_resume_from_failure(guard_opnum, deadframe)
     //   _run_forever(blackholeinterp, current_exc)
@@ -1666,6 +1696,26 @@ pub fn blackhole_resume_via_rd_numb(
             };
         }
         if bh.aborted {
+            // #326: roll the virtualizable heap frame back to the guard
+            // snapshot captured before `bh.run()`, discarding this aborted
+            // run's partial forward mutations.  The interpreter resumes
+            // from the guard resume PC with the pre-blackhole frame state,
+            // so every side effect (the aborting opcode's included) is
+            // applied exactly once instead of twice.
+            if let Some((locals, vsd, last_instr)) = &vable_rollback {
+                let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
+                if !frame_ptr.is_null() {
+                    let frame = unsafe { &mut *frame_ptr };
+                    let arr = frame.locals_w_mut().as_mut_slice();
+                    // The locals_cells_stack array length is fixed for a
+                    // frame's lifetime; restore it verbatim.
+                    if arr.len() == locals.len() {
+                        arr.copy_from_slice(locals);
+                    }
+                    frame.valuestackdepth = *vsd;
+                    frame.last_instr = *last_instr;
+                }
+            }
             if nbody_debug {
                 eprintln!(
                     "[nbody-debug] blackhole_resume_via_rd_numb failed: bh.aborted position={} last_opcode_position={}",

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1935,6 +1935,11 @@ pub fn trace_and_compile_from_bridge(
     frame: &mut PyFrame,
     raw_values: &[i64],
     exit_layout: &majit_metainterp::CompiledExitLayout,
+    // `cpu.grab_exc_value(deadframe)` (llmodel.py:240): the pending
+    // exception this guard failure carries, or 0. Threaded so the bridge
+    // tracer can decline a pending-exception resume at a non-exception
+    // guard (see the deferral below).
+    guard_exc: i64,
 ) -> bool {
     use crate::eval::build_jit_state;
     use crate::jit::state::PyreEnv;
@@ -2083,6 +2088,54 @@ pub fn trace_and_compile_from_bridge(
         }
         let (driver, _) = crate::eval::driver_pair();
         driver.last_bridge_is_exception_guard = false;
+    }
+
+    // A pending exception at a NON-exception guard means a may-force
+    // residual call both raised and forced the frame, so GUARD_NOT_FORCED
+    // failed before GUARD_NO_EXCEPTION ran. That guard's resume_pc is the
+    // no-exception semantic fallthrough (the next opcode, e.g.
+    // RETURN_VALUE), so a normal-path bridge walk would trace the return
+    // of the NULL call result — emitting `Finish(NONE)` with no
+    // return-value box — and run the post-call residual ops concretely on
+    // a NULL operand. Decline the bridge and resume in the blackhole,
+    // which propagates the pending exception to its `catch_exception`
+    // handler exactly once. Skipping the walk also prevents the walk's
+    // concrete side effects from double-applying the handler's mutations
+    // against the post-blackhole replay.
+    //
+    // GUARD_NOT_FORCED is not an exception guard, so it does not stash the
+    // raised value into `jf_guard_exc` (`guard_exc` is 0 here); the live
+    // signal is the backend `pos_exception` cell the compiled
+    // GUARD_NO_EXCEPTION reads. A stale cell only over-declines (the
+    // blackhole resume with `guard_exc == 0` runs the no-exception
+    // continuation, identical to the prior panic-then-fallback path), so
+    // this never changes a result — only whether a bridge is attached.
+    let pending_exc = guard_exc != 0 || {
+        #[cfg(feature = "cranelift")]
+        {
+            majit_backend_cranelift::jit_exc_class_raw() != 0
+        }
+        #[cfg(all(feature = "dynasm", not(feature = "cranelift")))]
+        {
+            majit_backend_dynasm::jit_exc_class_raw() != 0
+        }
+        #[cfg(not(any(feature = "cranelift", feature = "dynasm")))]
+        {
+            false
+        }
+    };
+    if pending_exc && !last_bridge_is_exception_guard {
+        if majit_metainterp::majit_log_enabled() {
+            eprintln!(
+                "[jit][bridge-trace] decline (pending exc at non-exception guard) key={} trace={} fail={} resume_pc={}",
+                green_key, trace_id, fail_index, resume_pc
+            );
+        }
+        let (driver, _) = crate::eval::driver_pair();
+        if driver.is_tracing() {
+            driver.meta_interp_mut().abort_trace(false);
+        }
+        return false;
     }
 
     // pyjitpl.py:2841 interpret(): after start_retrace_from_guard, RPython
@@ -2314,7 +2367,10 @@ fn jit_ca_handle_guard_failure(
     // with the matching `start_compiling` even on panic.
     let compiled = {
         let _guard = crate::eval::GuardCompilingScope::new(&descr_arc);
-        trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout)
+        // CALL_ASSEMBLER guard failures grab their callee exception on the
+        // blackhole leg, not here; pass 0 so the non-exception-guard
+        // deferral keys only off the general guard path's `guard_exc`.
+        trace_and_compile_from_bridge(&descr_arc, frame, raw_values, &exit_layout, 0)
     };
 
     if majit_metainterp::majit_log_enabled() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3879,6 +3879,7 @@ fn handle_fail(
     _owning_key: u64,
     exit_layout: &CompiledExitLayout,
     raw_values: &[i64],
+    guard_exc: i64,
     _info: &majit_metainterp::virtualizable::VirtualizableInfo,
 ) -> HandleFailOutcome {
     // compile.py:702-703: must_compile() AND not stack_almost_full()
@@ -3906,6 +3907,7 @@ fn handle_fail(
                     frame,
                     raw_values,
                     exit_layout,
+                    guard_exc,
                 )
             };
             if compiled {
@@ -4177,6 +4179,7 @@ fn execute_assembler(
                 owning_key,
                 exit_layout,
                 raw_values,
+                guard_exc,
                 info,
             ) {
                 HandleFailOutcome::BridgeCompiled => Some(LoopResult::ContinueRunningNormally),
@@ -4436,6 +4439,7 @@ fn bound_reached(
                 owning_key,
                 exit_layout,
                 raw_values,
+                guard_exc,
                 info,
             ) {
                 HandleFailOutcome::BridgeCompiled => {
@@ -4613,6 +4617,7 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
                 owning_key,
                 exit_layout,
                 raw_values,
+                guard_exc,
                 info,
             ) {
                 HandleFailOutcome::BridgeCompiled => {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9546,18 +9546,24 @@ impl CodeWriter {
         // pyre-only PyJitCode.has_abort: a "this jitcode cannot be
         // blackhole-dispatched, pipe straight to the interpreter" flag.
         // RPython has no such flag (rpython/jit/codewriter/jitcode.py:14
-        // — no abort tracking on JitCode). Upstream's `Assembler.abort()`
-        // (assembler.py:177-181, bhimpl_abort) emits BC_ABORT so the
-        // blackhole raises SwitchToBlackhole(ABORT_ESCAPE) at runtime;
-        // `abort_permanent()` is a different pyre-only bytecode we emit
-        // for genuinely unsupported Python opcodes, and its execution
-        // path already raises/aborts correctly from the blackhole. We
-        // keep has_abort narrowly scoped to `abort()` emissions (matches
-        // the JitCodeBuilder flag shape) so the flag's meaning doesn't
-        // drift into "assembler overflow" or "abort_permanent present"
-        // — both of which the assembler/blackhole already handle without
-        // a front-end gate.
-        let has_abort = assembler.has_abort_flag();
+        // — no abort tracking on JitCode), because upstream's blackhole
+        // never aborts: every Python opcode lowers, so a guard-failure
+        // resume always runs the jitcode forward to completion.  pyre
+        // deviates with `abort` / `abort_permanent` opcodes for ops it
+        // cannot lower; a blackhole that hits one mid-run has already
+        // committed the preceding side effects (locals/stack to the
+        // vable, and any observable residual call) and then drops to the
+        // interpreter, which re-runs the region and double-applies them.
+        // So a jitcode carrying EITHER opcode must skip the blackhole
+        // entirely and resume the plain interpreter from the guard
+        // snapshot, where every effect runs exactly once.
+        //
+        // `has_abort` is computed from the production stream after the
+        // splice below (`ssarepr.insns`).  It cannot be read here via
+        // `assembler.has_abort_flag()`: the builder only assembles the
+        // stream inside `finalize_jitcode`
+        // (`finish_with_positions_from`), so the flag is still false at
+        // this point in the pipeline.
 
         // `simplify_graph` (`translator.py:55-56`) parity: collapse the
         // empty forwarding blocks `mergeblock` supersede left behind
@@ -9890,6 +9896,21 @@ impl CodeWriter {
         }
         ssarepr.insns = spliced.insns;
         ssarepr.pc_first_insn_pos = spliced.pc_first_insn_pos;
+        // has_abort (see the note above the splice): scan the production
+        // stream for an `abort` / `abort_permanent` opcode.  `flatten_graph`
+        // always serializes these even though the bail-out severs the
+        // block's CFG successor, so the opcode is present in
+        // `ssarepr.insns` whenever the jitcode can reach a non-lowerable
+        // op.  A jitcode that contains one must skip the blackhole resume
+        // (`resolve_jitcode` returns `None`) so its guard failures replay
+        // through the plain interpreter exactly once.
+        let has_abort = ssarepr.insns.iter().any(|insn| {
+            matches!(
+                insn,
+                super::flatten::Insn::Op { opname, .. }
+                    if opname == "abort" || opname == "abort_permanent"
+            )
+        });
         // Per-PC `-live-` marker indices feeding `filter_liveness_in_place`
         // (translated through its `remove_repeated_live` remap), and the
         // sparse after-residual-call resume anchors — both derived from the

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7267,8 +7267,7 @@ impl CodeWriter {
                                     .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
                             } else {
                                 let name_idx = raw_namei as usize >> 1;
-                                let name =
-                                    code.names.get(name_idx).map(|name| name.as_str());
+                                let name = code.names.get(name_idx).map(|name| name.as_str());
                                 let w_globals = unsafe {
                                     pyre_interpreter::w_code_get_w_globals(
                                         w_code as pyre_object::PyObjectRef,
@@ -7334,10 +7333,8 @@ impl CodeWriter {
                                         .map(super::flow::FlowValue::from)
                                         .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
                                 } else {
-                                    name.and_then(|nm| {
-                                        frontend_global_flow_value(w_code, nm)
-                                    })
-                                    .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                                    name.and_then(|nm| frontend_global_flow_value(w_code, nm))
+                                        .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
                                 }
                             };
                             if let super::flow::FlowValue::Variable(v) = &result_value {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3235,10 +3235,12 @@ fn new_shadow_graph(code: &CodeObject) -> super::flow::FunctionGraph {
 }
 
 fn attach_catch_exception_edge(
+    code: &CodeObject,
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
     target: &SpamBlockRef,
     source_state: &FrameState,
+    site: &ExceptionCatchSite,
 ) -> super::flow::LinkRef {
     // `flowcontext.py:148-149 guessexception` sets
     // `block.exitswitch = c_last_exception` before the link is
@@ -3257,7 +3259,26 @@ fn attach_catch_exception_edge(
     // sets `last_exception` to the fresh pair, so the same
     // Variables can be threaded into BOTH `link.args` (via
     // `getoutputargs` below) AND `link.extravars`.
-    let edge_state = exception_landing_state(graph, source_state);
+    //
+    // Reshape the cloned state to the handler-entry layout: unwind the
+    // operand stack to the handler's try-level `stack_depth`, push the
+    // `lasti` box (when flagged) and the exception value, and retarget
+    // `next_offset` to the handler PC — the exact transform
+    // `handler_entry_state_from_catch_site` applies when it builds the
+    // catch landing's framestate / inputargs.  A `raise` reached from a
+    // DEEPER operand-stack PC (e.g. mid-expression, inside a call's
+    // argument build-up) otherwise leaves `edge_state` at the raise
+    // point's stack depth and `next_offset`, so it is NOT union-
+    // compatible with the landing (`FrameState::union` declines on the
+    // `next_offset` / stack-length mismatch and `update_catch_landing_
+    // state` silently keeps the landing as-is).  The positional
+    // `getoutputargs` then shifts every arg past the stack delta,
+    // pairing a Ref slot with the landing's `last_exception` Int slot —
+    // surfacing downstream as an `int_copy` kind-mismatch at assemble
+    // time and as an `enforce_input_args` colour collision when the
+    // shifted CFG coalesce pair merges two landing inputargs.
+    let seeded = exception_landing_state(graph, source_state);
+    let edge_state = handler_entry_state_from_catch_site(code, graph, &seeded, site);
 
     // Update the landing block's framestate / inputargs from the
     // edge state.  Note: RPython models each
@@ -5698,17 +5719,18 @@ impl CodeWriter {
                 // normal-control-flow Link (fallthrough / goto) is
                 // added by its own emit macro so the two edges coexist
                 // on `Block.exits`.
-                let landing = catch_sites
+                let site = catch_sites
                     .iter()
                     .find(|s| s.landing_label == catch_label)
                     .expect("catch_sites entry for catch_label")
-                    .landing
                     .clone();
                 attach_catch_exception_edge(
+                    code,
                     &mut graph,
                     &current_block.block(),
-                    &landing,
+                    &site.landing,
                     &current_state,
+                    &site,
                 );
             }};
         }
@@ -11018,6 +11040,22 @@ mod tests {
             .expect("expected nested function code object")
     }
 
+    // Minimal `ExceptionCatchSite` for the `attach_catch_exception_edge`
+    // tests: a try-level stack depth of 0 with no `lasti` push and a
+    // handler PC at offset 0.  `handler_entry_state_from_catch_site`
+    // unwinds the edge state to this depth and pushes the exception value,
+    // matching the landing block's handler-entry layout.
+    fn synthetic_catch_site(landing: &SpamBlockRef) -> ExceptionCatchSite {
+        ExceptionCatchSite {
+            landing_label: 0,
+            handler_py_pc: 0,
+            stack_depth: 0,
+            push_lasti: false,
+            lasti_py_pc: 0,
+            landing: landing.clone(),
+        }
+    }
+
     fn fresh_variable_factory(start: u32) -> impl FnMut(Option<Kind>) -> Variable {
         let mut next_id = start;
         move |kind| {
@@ -12513,9 +12551,16 @@ mod tests {
         let catch_ref = SpamBlockRef::new(catch_block.clone(), None);
         let source_state = FrameState::new(Vec::new(), Vec::new(), None, Vec::new(), 0);
         let startblock_ref = graph.startblock.clone();
+        let site = synthetic_catch_site(&catch_ref);
 
-        let link =
-            attach_catch_exception_edge(&mut graph, &startblock_ref, &catch_ref, &source_state);
+        let link = attach_catch_exception_edge(
+            &code,
+            &mut graph,
+            &startblock_ref,
+            &catch_ref,
+            &source_state,
+            &site,
+        );
         let startblock = graph.startblock.borrow();
 
         assert_eq!(
@@ -12546,9 +12591,16 @@ mod tests {
             0,
         );
         let startblock_ref = graph.startblock.clone();
+        let site = synthetic_catch_site(&catch_ref);
 
-        let link =
-            attach_catch_exception_edge(&mut graph, &startblock_ref, &catch_ref, &source_state);
+        let link = attach_catch_exception_edge(
+            &code,
+            &mut graph,
+            &startblock_ref,
+            &catch_ref,
+            &source_state,
+            &site,
+        );
 
         let link_borrow = link.borrow();
         assert!(link_borrow.last_exception.is_some());
@@ -12571,19 +12623,28 @@ mod tests {
         let source_state =
             FrameState::new(vec![Some(local.into())], Vec::new(), None, Vec::new(), 0);
         let startblock_ref = graph.startblock.clone();
+        let site = synthetic_catch_site(&catch_ref);
 
         assert!(
             catch_block.borrow().inputargs.is_empty(),
             "catch landing block starts with no inputargs"
         );
 
-        attach_catch_exception_edge(&mut graph, &startblock_ref, &catch_ref, &source_state);
+        attach_catch_exception_edge(
+            &code,
+            &mut graph,
+            &startblock_ref,
+            &catch_ref,
+            &source_state,
+            &site,
+        );
 
         let inputargs = catch_block.borrow().inputargs.clone();
         assert_eq!(
             inputargs.len(),
-            3,
-            "expected 1 local + 2 exception Variables, got {:?}",
+            4,
+            "handler-entry layout: 1 local + the pushed exception value + \
+             the (last_exception, last_exc_value) pair, got {:?}",
             inputargs
         );
         assert!(

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7908,16 +7908,18 @@ impl CodeWriter {
                             // (which has no RERAISE bytecode — its
                             // `Reraise.nomoreblocks` calls reraise
                             // directly into the exception link).
-                            // Suppress catch_exception adjacency:
-                            // RERAISE's source FrameState has had
-                            // POP_EXCEPT mutate the stack, which
-                            // makes the catch-landing union path
+                            // Attach the byte-adjacent catch when this
+                            // RERAISE PC is itself inside an outer
+                            // exception_table range: `emit_raise!` only
+                            // emits the catch when `catch_for_pc[py_pc]`
+                            // is Some, otherwise it falls through to
+                            // `exceptblock`. The catch-landing union path
                             // (`attach_catch_exception_edge` →
-                            // `getoutputargs_with_positions`)
-                            // mismatched against the explicit-raise
-                            // shape that earlier raise sites already
-                            // populated into the same landing.
-                            emit_raise!(exc_reg, exc_value, py_pc as i64, false);
+                            // `handler_entry_state_from_catch_site`)
+                            // reshapes the POP_EXCEPT-mutated source stack
+                            // to the handler try-level, so the landing no
+                            // longer mismatches the explicit-raise shape.
+                            emit_raise!(exc_reg, exc_value, py_pc as i64, true);
                         }
 
                         Instruction::WithExceptStart => {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9629,24 +9629,18 @@ impl CodeWriter {
         // pyre-only PyJitCode.has_abort: a "this jitcode cannot be
         // blackhole-dispatched, pipe straight to the interpreter" flag.
         // RPython has no such flag (rpython/jit/codewriter/jitcode.py:14
-        // — no abort tracking on JitCode), because upstream's blackhole
-        // never aborts: every Python opcode lowers, so a guard-failure
-        // resume always runs the jitcode forward to completion.  pyre
-        // deviates with `abort` / `abort_permanent` opcodes for ops it
-        // cannot lower; a blackhole that hits one mid-run has already
-        // committed the preceding side effects (locals/stack to the
-        // vable, and any observable residual call) and then drops to the
-        // interpreter, which re-runs the region and double-applies them.
-        // So a jitcode carrying EITHER opcode must skip the blackhole
-        // entirely and resume the plain interpreter from the guard
-        // snapshot, where every effect runs exactly once.
-        //
-        // `has_abort` is computed from the production stream after the
-        // splice below (`ssarepr.insns`).  It cannot be read here via
-        // `assembler.has_abort_flag()`: the builder only assembles the
-        // stream inside `finalize_jitcode`
-        // (`finish_with_positions_from`), so the flag is still false at
-        // this point in the pipeline.
+        // — no abort tracking on JitCode). Upstream's `Assembler.abort()`
+        // (assembler.py:177-181, bhimpl_abort) emits BC_ABORT so the
+        // blackhole raises SwitchToBlackhole(ABORT_ESCAPE) at runtime;
+        // `abort_permanent()` is a different pyre-only bytecode we emit
+        // for genuinely unsupported Python opcodes, and its execution
+        // path already raises/aborts correctly from the blackhole. We
+        // keep has_abort narrowly scoped to `abort()` emissions (matches
+        // the JitCodeBuilder flag shape) so the flag's meaning doesn't
+        // drift into "assembler overflow" or "abort_permanent present"
+        // — both of which the assembler/blackhole already handle without
+        // a front-end gate.
+        let has_abort = assembler.has_abort_flag();
 
         // `simplify_graph` (`translator.py:55-56`) parity: collapse the
         // empty forwarding blocks `mergeblock` supersede left behind
@@ -9979,21 +9973,6 @@ impl CodeWriter {
         }
         ssarepr.insns = spliced.insns;
         ssarepr.pc_first_insn_pos = spliced.pc_first_insn_pos;
-        // has_abort (see the note above the splice): scan the production
-        // stream for an `abort` / `abort_permanent` opcode.  `flatten_graph`
-        // always serializes these even though the bail-out severs the
-        // block's CFG successor, so the opcode is present in
-        // `ssarepr.insns` whenever the jitcode can reach a non-lowerable
-        // op.  A jitcode that contains one must skip the blackhole resume
-        // (`resolve_jitcode` returns `None`) so its guard failures replay
-        // through the plain interpreter exactly once.
-        let has_abort = ssarepr.insns.iter().any(|insn| {
-            matches!(
-                insn,
-                super::flatten::Insn::Op { opname, .. }
-                    if opname == "abort" || opname == "abort_permanent"
-            )
-        });
         // Per-PC `-live-` marker indices feeding `filter_liveness_in_place`
         // (translated through its `remove_repeated_live` remap), and the
         // sparse after-residual-call resume anchors — both derived from the

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4730,7 +4730,7 @@ impl CodeWriter {
                 },
             load_global_fn:
                 HelperHandle {
-                    idx: _load_global_fn_idx,
+                    idx: load_global_fn_idx,
                     flavor: _load_global_fn_flavor,
                 },
             compare_fn:
@@ -7187,12 +7187,78 @@ impl CodeWriter {
                             if is_portal {
                                 let _ = ssarepr.fresh_var(Kind::Ref, scratch_ref_base).0;
                             }
-                            let name_idx = raw_namei as usize >> 1;
-                            let result_value = code
-                                .names
-                                .get(name_idx)
-                                .and_then(|name| frontend_global_flow_value(w_code, name.as_ref()))
-                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            // #336: in the PORTAL jitcode, load the global at
+                            // RUNTIME from the live frame instead of const-
+                            // folding the resolved object's address into the
+                            // jitcode constant pool.  Const-folding bakes a raw
+                            // pointer into `constants_r`, which the moving
+                            // (incminimark) GC does not forward; a global object
+                            // still young at build time and relocated afterwards
+                            // (e.g. a `memo` dict mutated in the loop) leaves a
+                            // dangling pointer the blackhole resume then reads.
+                            // The register-form namespace (`getfield_vable_r`,
+                            // field 5 = the live `w_globals_obj`) lets
+                            // `try_walker_load_global_cell_fold` hoist the lookup
+                            // to a GC-safe live cell read (`QuasiimmutField` +
+                            // `jit_namespace_cell_lookup`), so the value is read
+                            // through the forwarded dict every iteration; the
+                            // `bh_load_global_fn` residual fallback derives the
+                            // namespace from `w_code`'s live `w_globals`.  pycode
+                            // (r1) is the jitcode's own promoted `W_Code`; the
+                            // frame (r2) feeds `get_builtin()`.
+                            //
+                            // This is portal-only.  In a non-portal callee the
+                            // frame register aliases the outermost frame on a
+                            // chained / inlined-callee resume, and the extra
+                            // `getfield_vable_r` graph op misallocates against
+                            // the inlined locals; such a callee keeps the
+                            // `flowcontext.py:856-859 find_global` const-fold,
+                            // which the inliner needs as a foldable constant call
+                            // target.  Read-only module globals (functions) are
+                            // promoted to the non-moving oldgen before any
+                            // jitcode build, so their const-folded addresses are
+                            // stable.
+                            let result_value: super::flow::FlowValue = if is_portal {
+                                let ns_var = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "getfield_vable_r",
+                                    vable_getfield_ref_graph_args(
+                                        frame_var.into(),
+                                        VABLE_NAMESPACE_FIELD_IDX,
+                                    ),
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
+                                let code_const: super::flow::FlowValue =
+                                    super::flow::Constant::new(
+                                        super::flow::ConstantValue::Signed(w_code as i64),
+                                        Some(Kind::Ref),
+                                    )
+                                    .into();
+                                let loaded = residual_call!(
+                                    load_global_fn_idx,
+                                    CallFlavor::Plain,
+                                    majit_ir::PyreHelperKind::LoadGlobal,
+                                    vec![super::flow::Constant::signed(raw_namei).into()],
+                                    vec![ns_var.into(), code_const, frame_var.into()],
+                                    vec![],
+                                    vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
+                                    ResKind::Ref,
+                                    py_pc as i64,
+                                );
+                                loaded
+                                    .map(super::flow::FlowValue::from)
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                            } else {
+                                let name_idx = raw_namei as usize >> 1;
+                                code.names
+                                    .get(name_idx)
+                                    .and_then(|name| {
+                                        frontend_global_flow_value(w_code, name.as_str())
+                                    })
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                            };
                             if let super::flow::FlowValue::Variable(v) = &result_value {
                                 pin!(Some(*v), loaded_dst_reg);
                             }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3475,6 +3475,12 @@ struct FnPtrIndices {
     call_fn_6: HelperHandle,
     call_fn_7: HelperHandle,
     call_fn_8: HelperHandle,
+    call_fn_9: HelperHandle,
+    call_fn_10: HelperHandle,
+    call_fn_11: HelperHandle,
+    call_fn_12: HelperHandle,
+    call_fn_13: HelperHandle,
+    call_fn_14: HelperHandle,
     get_current_exception_fn: HelperHandle,
     set_current_exception_fn: HelperHandle,
     load_attr_fn: HelperHandle,
@@ -3684,7 +3690,7 @@ fn register_helper_fn_pointers(
     // `load_global_fn`.  Bound after the existing fn_ptrs to preserve
     // their indices.
     let getattr_fn = bind(assembler, cpu.getattr_fn as *const (), CallFlavor::Plain);
-    // LOOKUP_METHOD lowering (appended last to preserve fn_ptr indices).
+    // LOOKUP_METHOD lowering (appended to preserve fn_ptr indices).
     // `bh_load_attr_fn` calls `baseobjspace::getattr`, which can run user
     // `__getattribute__` (forces virtualizables) and raise `AttributeError`
     // → `MayForce`.  `bh_load_method_self_fn` is the pure binding decision —
@@ -3869,6 +3875,17 @@ fn register_helper_fn_pointers(
         cpu.newlist_from_array_fn as *const (),
         CallFlavor::Plain,
     );
+    // Per-arity CALL helpers for nargs 9..=14 (every `call_fn_N` is bound
+    // `MayForce`).  Bound after the existing fn_ptrs to preserve their
+    // indices.  The arity ceiling is nargs=14 (16 i64 params: callable +
+    // null_or_self + 14 args); the backend dispatch table tops out at
+    // `MAX_HOST_CALL_ARITY` = 16.
+    let call_fn_9 = bind(assembler, cpu.call_fn_9 as *const (), CallFlavor::MayForce);
+    let call_fn_10 = bind(assembler, cpu.call_fn_10 as *const (), CallFlavor::MayForce);
+    let call_fn_11 = bind(assembler, cpu.call_fn_11 as *const (), CallFlavor::MayForce);
+    let call_fn_12 = bind(assembler, cpu.call_fn_12 as *const (), CallFlavor::MayForce);
+    let call_fn_13 = bind(assembler, cpu.call_fn_13 as *const (), CallFlavor::MayForce);
+    let call_fn_14 = bind(assembler, cpu.call_fn_14 as *const (), CallFlavor::MayForce);
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -3895,6 +3912,12 @@ fn register_helper_fn_pointers(
         call_fn_6,
         call_fn_7,
         call_fn_8,
+        call_fn_9,
+        call_fn_10,
+        call_fn_11,
+        call_fn_12,
+        call_fn_13,
+        call_fn_14,
         get_current_exception_fn,
         set_current_exception_fn,
         load_attr_fn,
@@ -4804,6 +4827,36 @@ impl CodeWriter {
                     idx: call_fn_8_idx,
                     flavor: _call_fn_8_flavor,
                 },
+            call_fn_9:
+                HelperHandle {
+                    idx: call_fn_9_idx,
+                    flavor: _call_fn_9_flavor,
+                },
+            call_fn_10:
+                HelperHandle {
+                    idx: call_fn_10_idx,
+                    flavor: _call_fn_10_flavor,
+                },
+            call_fn_11:
+                HelperHandle {
+                    idx: call_fn_11_idx,
+                    flavor: _call_fn_11_flavor,
+                },
+            call_fn_12:
+                HelperHandle {
+                    idx: call_fn_12_idx,
+                    flavor: _call_fn_12_flavor,
+                },
+            call_fn_13:
+                HelperHandle {
+                    idx: call_fn_13_idx,
+                    flavor: _call_fn_13_flavor,
+                },
+            call_fn_14:
+                HelperHandle {
+                    idx: call_fn_14_idx,
+                    flavor: _call_fn_14_flavor,
+                },
             get_current_exception_fn:
                 HelperHandle {
                     idx: get_current_exception_fn_idx,
@@ -4964,9 +5017,9 @@ impl CodeWriter {
                 store_name_fn_idx,
                 newtuple_from_array_fn_idx,
                 newlist_from_array_fn_idx,
-                // `[u16; 9]` indexed by nargs (0..=8).  `call_fn_idx` (nargs=1)
-                // is the unsuffixed binding from line 3153; the suffixed
-                // 0/2..=8 fill the surrounding slots.
+                // `[u16; 15]` indexed by nargs (0..=14).  `call_fn_idx`
+                // (nargs=1) is the unsuffixed general binding; the suffixed
+                // 0/2..=14 fill the surrounding slots.
                 call_fn_idx_by_nargs: [
                     call_fn_0_idx,
                     call_fn_idx,
@@ -4977,6 +5030,12 @@ impl CodeWriter {
                     call_fn_6_idx,
                     call_fn_7_idx,
                     call_fn_8_idx,
+                    call_fn_9_idx,
+                    call_fn_10_idx,
+                    call_fn_11_idx,
+                    call_fn_12_idx,
+                    call_fn_13_idx,
+                    call_fn_14_idx,
                 ],
                 load_attr_fn_idx,
                 load_method_self_fn_idx,
@@ -7257,8 +7316,10 @@ impl CodeWriter {
                             // RPython blackhole.py: call_int_function transmutes
                             // to the correct arity. Each nargs needs a matching
                             // extern "C" fn with that many i64 parameters.
-                            // nargs > 8 → abort_permanent (no matching helper).
-                            let call_result_value = if nargs > 8 {
+                            // nargs > 14 → abort_permanent (no matching helper;
+                            // the backend dispatch tops out at 16 i64 args =
+                            // callable + null_or_self + 14).
+                            let call_result_value = if nargs > 14 {
                                 fresh_ref_value(&mut graph)
                             } else {
                                 // Graph-side `simple_call(callable,
@@ -7290,7 +7351,7 @@ impl CodeWriter {
                                 pin!(Some(result), stack_base + current_depth);
                                 result.into()
                             };
-                            if nargs > 8 {
+                            if nargs > 14 {
                                 emit_abort_permanent!(py_pc);
                             }
                             push_and_bump!(call_result_value, py_pc);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7207,17 +7207,32 @@ impl CodeWriter {
                             // (r1) is the jitcode's own promoted `W_Code`; the
                             // frame (r2) feeds `get_builtin()`.
                             //
-                            // This is portal-only.  In a non-portal callee the
-                            // frame register aliases the outermost frame on a
-                            // chained / inlined-callee resume, and the extra
-                            // `getfield_vable_r` graph op misallocates against
-                            // the inlined locals; such a callee keeps the
+                            // The register-form namespace is portal-only.  In a
+                            // non-portal callee the frame register aliases the
+                            // outermost frame on a chained / inlined-callee
+                            // resume, and the extra `getfield_vable_r` graph op
+                            // misallocates against the inlined locals.  A
+                            // non-portal callee instead keeps the
                             // `flowcontext.py:856-859 find_global` const-fold,
                             // which the inliner needs as a foldable constant call
-                            // target.  Read-only module globals (functions) are
-                            // promoted to the non-moving oldgen before any
-                            // jitcode build, so their const-folded addresses are
-                            // stable.
+                            // target — EXCEPT when the resolved global is a
+                            // mutable container (dict / list / set).  Such a
+                            // container is grown in place and relocates
+                            // nursery->oldgen after the jitcode is built, so its
+                            // const-folded address dangles when the blackhole
+                            // resumes the unfused callee (dynasm SIGSEGVs;
+                            // cranelift null-softens the read).  Resolve those
+                            // through the `bh_load_global_fn` residual whose
+                            // namespace operand is the callee's module dict
+                            // OBJECT (`dict_storage_to_dict`, built eagerly at
+                            // `PyFrame.__init__` so it reaches the non-moving
+                            // oldgen before any jitcode build): the cell-fold
+                            // then reads the container value live through that
+                            // stable dict every iteration instead of baking the
+                            // relocating value.  Functions / classes / modules
+                            // are created at module load and promoted to the
+                            // non-moving oldgen before any jitcode build, so
+                            // const-folding them stays GC-safe.
                             let result_value: super::flow::FlowValue = if is_portal {
                                 let ns_var = emit_graph_op_with_result(
                                     &mut graph,
@@ -7252,12 +7267,78 @@ impl CodeWriter {
                                     .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
                             } else {
                                 let name_idx = raw_namei as usize >> 1;
-                                code.names
-                                    .get(name_idx)
-                                    .and_then(|name| {
-                                        frontend_global_flow_value(w_code, name.as_str())
+                                let name =
+                                    code.names.get(name_idx).map(|name| name.as_str());
+                                let w_globals = unsafe {
+                                    pyre_interpreter::w_code_get_w_globals(
+                                        w_code as pyre_object::PyObjectRef,
+                                    )
+                                };
+                                // Classify the resolved global: a globals-only
+                                // lookup suffices since builtins are never the
+                                // user-mutated containers this gate targets.
+                                let global_is_relocatable_container = !w_globals.is_null()
+                                    && name
+                                        .and_then(|nm| {
+                                            pyre_interpreter::dict_storage_get(
+                                                unsafe { &*w_globals },
+                                                nm,
+                                            )
+                                        })
+                                        .is_some_and(|obj| unsafe {
+                                            pyre_object::is_dict(obj)
+                                                || pyre_object::is_list(obj)
+                                                || pyre_object::is_set(obj)
+                                        });
+                                if global_is_relocatable_container {
+                                    // The namespace operand is the callee's
+                                    // module dict OBJECT.  `PyFrame.__init__`
+                                    // builds `w_globals_obj` eagerly
+                                    // (`dict_storage_to_dict`), so by jitcode
+                                    // build time it is already in the non-moving
+                                    // oldgen and const-folding ITS pointer is
+                                    // GC-safe.  `try_walker_load_global_cell_fold`
+                                    // reads the container VALUE live through it
+                                    // each iteration, so the relocating value is
+                                    // never baked.  A container is never a call
+                                    // target, so the cell-fold's deep-inline
+                                    // call mis-resolution does not apply.
+                                    let ns_obj =
+                                        pyre_interpreter::baseobjspace::dict_storage_to_dict(
+                                            w_globals,
+                                        );
+                                    let ns_const: super::flow::FlowValue =
+                                        super::flow::Constant::new(
+                                            super::flow::ConstantValue::Signed(ns_obj as i64),
+                                            Some(Kind::Ref),
+                                        )
+                                        .into();
+                                    let code_const: super::flow::FlowValue =
+                                        super::flow::Constant::new(
+                                            super::flow::ConstantValue::Signed(w_code as i64),
+                                            Some(Kind::Ref),
+                                        )
+                                        .into();
+                                    let loaded = residual_call!(
+                                        load_global_fn_idx,
+                                        CallFlavor::Plain,
+                                        majit_ir::PyreHelperKind::LoadGlobal,
+                                        vec![super::flow::Constant::signed(raw_namei).into()],
+                                        vec![ns_const, code_const, frame_var.into()],
+                                        vec![],
+                                        vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
+                                        ResKind::Ref,
+                                        py_pc as i64,
+                                    );
+                                    loaded
+                                        .map(super::flow::FlowValue::from)
+                                        .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                                } else {
+                                    name.and_then(|nm| {
+                                        frontend_global_flow_value(w_code, nm)
                                     })
                                     .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                                }
                             };
                             if let super::flow::FlowValue::Variable(v) = &result_value {
                                 pin!(Some(*v), loaded_dst_reg);

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -30,11 +30,15 @@ pub struct Cpu {
     pub call_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// Per-arity `bhimpl_residual_call_<n>` helpers
     /// (`call_fn_0(callable, null_or_self)` ...
-    /// `call_fn_8(callable, null_or_self, a0..a7)`).  RPython
+    /// `call_fn_14(callable, null_or_self, a0..a13)`).  RPython
     /// `bhimpl_residual_call_r_r` carries no frame; the parent frame is
     /// resolved from the execution context inside `bh_call_fn_impl`.  A
     /// non-null `null_or_self` is the method receiver — the helper
-    /// prepends it as arg0 (eval.rs:3216-3226).
+    /// prepends it as arg0 (eval.rs:3216-3226).  The arity ceiling is
+    /// nargs=14: each helper takes `callable + null_or_self + nargs`
+    /// i64s, and the backend dispatch table (`call_stub.rs::
+    /// dispatch_arity_body!`, `MAX_HOST_CALL_ARITY` = 16) tops out at
+    /// 16 i64 arguments.
     pub call_fn_0: extern "C" fn(i64, i64) -> i64,
     pub call_fn_2: extern "C" fn(i64, i64, i64, i64) -> i64,
     pub call_fn_3: extern "C" fn(i64, i64, i64, i64, i64) -> i64,
@@ -43,6 +47,48 @@ pub struct Cpu {
     pub call_fn_6: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
     pub call_fn_7: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
     pub call_fn_8: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
+    pub call_fn_9: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
+    pub call_fn_10:
+        extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
+    pub call_fn_11:
+        extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
+    pub call_fn_12:
+        extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
+    pub call_fn_13: extern "C" fn(
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+    ) -> i64,
+    pub call_fn_14: extern "C" fn(
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+    ) -> i64,
     /// `bhimpl_load_global` — namespace/code from getfield_vable_r plus live frame.
     pub load_global_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// LOOKUP_METHOD attribute half — `(obj, code, name_idx) → attr`.
@@ -236,6 +282,12 @@ impl Cpu {
             call_fn_6: crate::call_jit::bh_call_fn_6,
             call_fn_7: crate::call_jit::bh_call_fn_7,
             call_fn_8: crate::call_jit::bh_call_fn_8,
+            call_fn_9: crate::call_jit::bh_call_fn_9,
+            call_fn_10: crate::call_jit::bh_call_fn_10,
+            call_fn_11: crate::call_jit::bh_call_fn_11,
+            call_fn_12: crate::call_jit::bh_call_fn_12,
+            call_fn_13: crate::call_jit::bh_call_fn_13,
+            call_fn_14: crate::call_jit::bh_call_fn_14,
             load_global_fn: crate::call_jit::bh_load_global_fn,
             load_attr_fn: crate::call_jit::bh_load_attr_fn,
             load_method_self_fn: crate::call_jit::bh_load_method_self_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -5660,7 +5660,7 @@ where
         return None;
     }
     let nargs = op.args.len() - 2;
-    if nargs > 14 {
+    if nargs >= ctx.call_fn_idx_by_nargs.len() {
         return None;
     }
     // First arg is the callable, second the CALL opcode's null_or_self
@@ -8268,7 +8268,7 @@ mod tests {
             store_name_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -10658,6 +10658,70 @@ mod tests {
             }
             _ => panic!("expected Insn::Op, got {insn:?}"),
         }
+    }
+
+    #[test]
+    fn lower_simple_call_hlop_nargs_boundary() {
+        // `nargs == call_fn_idx_by_nargs.len() - 1` (14) is the widest CALL
+        // the residual table can dispatch; `nargs == len()` (15) has no
+        // matching helper and must fall through to passthrough (`None`) so
+        // the walker's `abort_permanent` branch handles it.  Pins the guard
+        // to the table length so growing the table can't silently desync the
+        // bound.
+        let (mut ctx, _code, _name) = load_attr_lowering_fixture();
+        let max_nargs = ctx.call_fn_idx_by_nargs.len() - 1; // 14
+        ctx.call_fn_idx_by_nargs[max_nargs] = 77;
+
+        // `[callable, null_or_self, arg0..arg(n-1)]`, all distinct Ref vars.
+        let build_op = |n: usize| {
+            let args: Vec<_> = (0..n + 2)
+                .map(|i| Variable::new(VariableId(i as u32), Kind::Ref).into())
+                .collect();
+            let result = Variable::new(VariableId(1000), Kind::Ref);
+            super::super::flow::SpaceOperation::new("simple_call", args, Some(result.into()), 0)
+        };
+        let mut get_register = |var: Variable| Register {
+            kind: Kind::Ref,
+            index: var.id.0 as u16,
+        };
+        let mut lower_constant = |_c: &Constant| unreachable!("test uses Variables only");
+
+        // nargs == 14 → lowers to a residual_call_r_r carrying every arg.
+        let op_max = build_op(max_nargs);
+        let insn = super::lower_simple_call_hlop_to_insn(
+            &op_max,
+            &ctx,
+            &mut get_register,
+            &mut lower_constant,
+        )
+        .expect("nargs == 14 must lower (widest supported CALL)");
+        match insn {
+            Insn::Op { opname, args, .. } => {
+                assert_eq!(opname, "residual_call_r_r");
+                match &args[1] {
+                    Operand::ListOfKind(list) => assert_eq!(
+                        list.content.len(),
+                        max_nargs + 2,
+                        "ListR carries [callable, null_or_self, args...]"
+                    ),
+                    other => panic!("expected ListOfKind Ref, got {other:?}"),
+                }
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+
+        // nargs == 15 → no helper in the table → passthrough (None).
+        let op_over = build_op(max_nargs + 1);
+        assert!(
+            super::lower_simple_call_hlop_to_insn(
+                &op_over,
+                &ctx,
+                &mut get_register,
+                &mut lower_constant,
+            )
+            .is_none(),
+            "nargs == call_fn_idx_by_nargs.len() must fall through to passthrough"
+        );
     }
 
     /// Shared fixture for the LOAD_ATTR-family lowering tests: a

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3174,13 +3174,13 @@ pub struct LoweringContext {
     /// (`jtransform.py:414 rewrite_call`) — the parent frame is
     /// resolved at runtime inside the call helper, not threaded as a
     /// leading operand.
-    /// Indexed by nargs (`call_fn_idx_by_nargs[nargs]`): `[u16; 9]` keeps the
-    /// statically-known 0..=8 arity range position-indexed.
-    /// `simple_call` HLOps with nargs > 8 are walker non-orthodox
+    /// Indexed by nargs (`call_fn_idx_by_nargs[nargs]`): `[u16; 15]` keeps the
+    /// statically-known 0..=14 arity range position-indexed.
+    /// `simple_call` HLOps with nargs > 14 are walker non-orthodox
     /// (the walker emits `abort_permanent` instead and skips the
     /// HLOp record), so the lowering arm returns `None`
-    /// (passthrough) on nargs > 8.
-    pub call_fn_idx_by_nargs: [u16; 9],
+    /// (passthrough) on nargs > 14.
+    pub call_fn_idx_by_nargs: [u16; 15],
     /// `load_attr_fn` descrs-pool index — see codewriter.rs
     /// `register_helper_fn_pointers` for the production source
     /// (`bind(assembler, cpu.load_attr_fn, CallFlavor::MayForce)`).
@@ -5634,12 +5634,12 @@ where
 /// `jtransform.py:414 rewrite_call` (the lowered ListR shape is
 /// detailed in the body comment below).
 ///
-/// Arity dispatch: nargs = op.args.len() - 1 selects
+/// Arity dispatch: nargs = op.args.len() - 2 selects
 /// `ctx.call_fn_idx_by_nargs[nargs]`.  Walker contract: CALL with
-/// nargs > 8 takes the `abort_permanent` branch (codewriter.rs:6118-
-/// 6133) and does NOT record `simple_call` on the graph, so a
-/// graph-side `simple_call` with nargs > 8 indicates walker
-/// non-orthodoxy — return `None` (passthrough).
+/// nargs > 14 takes the `abort_permanent` branch and does NOT record
+/// `simple_call` on the graph, so a graph-side `simple_call` with
+/// nargs > 14 indicates walker non-orthodoxy — return `None`
+/// (passthrough).
 ///
 /// Returns `None` for non-`simple_call` opnames so the caller can
 /// fall through to other lowering arms.
@@ -5660,7 +5660,7 @@ where
         return None;
     }
     let nargs = op.args.len() - 2;
-    if nargs > 8 {
+    if nargs > 14 {
         return None;
     }
     // First arg is the callable, second the CALL opcode's null_or_self
@@ -6900,7 +6900,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -7055,7 +7055,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -7197,7 +7197,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -7302,7 +7302,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -7451,7 +7451,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -7645,7 +7645,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -7888,7 +7888,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -7997,7 +7997,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8050,7 +8050,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8180,7 +8180,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8327,7 +8327,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8378,7 +8378,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8436,7 +8436,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8521,7 +8521,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8569,7 +8569,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8631,7 +8631,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8709,7 +8709,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8772,7 +8772,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8850,7 +8850,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8904,7 +8904,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -8958,7 +8958,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -9017,7 +9017,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -9090,7 +9090,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -10262,7 +10262,7 @@ mod tests {
             store_name_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             load_attr_fn_idx: 0,
             load_method_self_fn_idx: 0,
             store_attr_fn_idx: 0,
@@ -10545,7 +10545,7 @@ mod tests {
         // frame-less `bhimpl_residual_call_r_r` ABI.
         let callable_var = Variable::new(VariableId(8), Kind::Ref);
         let result_var = Variable::new(VariableId(9), Kind::Ref);
-        let mut call_fn_idx_by_nargs = [0u16; 9];
+        let mut call_fn_idx_by_nargs = [0u16; 15];
         call_fn_idx_by_nargs[0] = 42;
         let ctx = LoweringContext {
             binary_op_fn_idx: 0,
@@ -10672,7 +10672,7 @@ mod tests {
             store_subscr_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
-            call_fn_idx_by_nargs: [0; 9],
+            call_fn_idx_by_nargs: [0; 15],
             getattr_fn_idx: 0,
             load_attr_fn_idx: 91,
             load_method_self_fn_idx: 92,


### PR DESCRIPTION
#27

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Correctness fixes for exceptions and deopt resume on the blackhole
(guard-failure) path. These surface when a JIT-compiled hot loop warms up
exception-free and then raises — or otherwise deopts — at which point the
compiled trace never recorded a handler and execution resumes in the
blackhole interpreter, where several reconstruction bugs lived.

### Exception routing at catch landings

- Route a raising residual call to the post-operand cursor before scanning
  for the byte-adjacent `catch_exception`, and emit a byte-adjacent catch on
  `RERAISE` inside an outer `try`. Fixes a nested
  `try`/`try-finally`/`except` whose exception escaped uncaught.
- Match `CHECK_EXC_MATCH` against a class/tuple operand via
  `exception_match(type(exc), E)` instead of falling through to an
  unconditional match, so multiple `except` clauses no longer all route to
  the first one.
- Push the `CHECK_EXC_MATCH` result stack-direct (pin to the TOS register,
  like `COMPARE_OP`) so the following truth test reads it. Previously the
  result was pinned to a scratch register while a disconnected fresh ref was
  pushed; when the register allocator colored them differently nothing
  bridged the two, the truth test read an unwritten (NULL) stack register,
  and the handler was skipped (the exception escaped).
- Propagate exceptions raised by the JIT builtin-op helpers instead of
  panicking.
- Reshape the catch-exception edge state to the handler-entry layout,
  fixing an `enforce_input_args` color-ordering panic on custom-exception
  hot loops.

### Deopt / abort resume

- Resume the blackhole forward with abort-rollback instead of the
  `has_abort` skip gate, fixing a cold-branch side-effect double-apply and
  an inlined-callee frame underflow.
- Derive `PyJitCode.has_abort` from the assembled stream so abort jitcodes
  bypass the blackhole.
- Decline bridge compilation for a pending exception at a non-exception
  guard.
- Register the GC heap-array family (`new_array_clear`,
  `get`/`setarrayitem_gc_*`) in the production blackhole builder's dispatch
  table. A tuple/array build or element access on the deopt-resume path
  previously panicked with an unwired opcode (`0xd6`), because the curated
  `insns` map stopped the dispatch table at byte 168.
- Drop the jit-trace vable-decode color overlay and rely on positional
  restore.

### Supporting

- Extend the per-arity blackhole call helpers to `nargs ≤ 14` on the
  `null_or_self` ABI.
- New synthetic regression benches (output-only, no perf gate):
  `exception_loop_warmup`, `exception_multi_handler_warmup`,
  `array_deopt_resume`.

### Verification

`pyre/check.py`: dynasm 60/60 + cranelift 60/60. Crate tests: pyre-jit
266/0, pyre-jit-trace 252/0, majit-metainterp 1280/0.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: gpt-5.5 (via `codex exec -s read-only`, no files modified)

Prompt:

> Assess by static analysis whether our changes in `git diff origin/main...HEAD -- '*.rs'` are equivalent to the corresponding RPython/PyPy source code. The RPython and PyPy sources are available locally. If anything was ported incorrectly, report every instance in detail. Organize the report into: 1. Cases where our patch regressed PyPy parity compared to origin/main; 2. Other mismatches introduced by our patch; 3. Mismatches that already existed before this patch; 4. Structural adaptations. Mark Python 3.11-vs-3.14 / opcode / GIL / RPython-vs-Rust differences under "Structural adaptations."

### Answer

**1. Patch regressions vs `origin/main`** — none found. Several touched
areas are parity *restorations* (RERAISE catch adjacency, residual-call
exception cursor, heap-array blackhole registration, binary-op helper
exception publication into the backend exception cell).

**2. Other mismatches introduced by this patch**

- Incomplete `CHECK_EXC_MATCH` port: the new `bh_compare_fn` op_code==10
  class-object branch called `check_exc_match_against` directly, but PyPy's
  `cmp_exc_match` (`pyopcode.py:1034-1040`) first validates the target is an
  exception class / tuple of exception classes, raising `TypeError`
  otherwise. The interpreter splits this into `validate_check_exc_match_class`
  (run by the BC handler) + the bool-returning `check_exc_match_against`; the
  residual path skipped the validation, so `except 5:` (or a tuple with a
  non-exception member) produced a bool and let the original exception
  propagate uncaught.
  **→ Fixed:** the class-object branch now runs
  `validate_check_exc_match_class` first and raises `TypeError` on failure,
  matching the interpreter. Regression bench
  `synth/check_exc_match_invalid_class` added (warm-up with a valid except
  class, then an int target). dynasm + cranelift byte-exact.

**3. Pre-existing mismatches** (not introduced by this patch; follow-up
candidates)

- `bh_compare_fn` comparison failures and the `STORE_SUBSCR` blackhole helper
  publish exceptions only into `BH_LAST_EXC_VALUE`, not the backend exception
  cell (`_store_exception`, `llmodel.py:194-199`). The binary-op helper was
  fixed to publish both in this PR; the comparison / store-subscr helpers
  remain value-cell-only. Only matters for a compiled trace's
  `GUARD_NO_EXCEPTION` (the blackhole reads `BH_LAST_EXC_VALUE` and is
  unaffected).

**4. Structural adaptations** (classified as necessary pyre adaptations, not
incorrect ports): CPython exception-table reconstruction in the codewriter;
RERAISE byte-adjacent catch; residual-call blackhole exception-cursor
adjustment (`blackhole.py:396-422`); heap-array blackhole dispatch
registration (`blackhole.py:1321-1358`); abort-rollback for forward blackhole
resume; the guard-failure virtualizable-restore split; host-call arity
expansion/cap for `simple_call`.

_Note: the review covered `origin/main...HEAD`, which includes follow-up
commits not yet pushed to the PR branch (the exception/deopt benches and the
section-2 fix above)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guard-failure and blackhole call exception handling to prevent incorrect exception propagation and double application of effects.
  * Corrected `CHECK_EXC_MATCH` behavior to use accurate exception matching semantics.
* **Performance Improvements**
  * Extended residual/function call lowering to support up to 14 arguments.
  * Improved GC heap array opcode dispatch and operand/result alignment for faster array operations.
* **Documentation**
  * Updated JIT trace comments for clearer intent around abort signaling.
* **Tests**
  * Added new benchmark scripts covering exception handling, deoptimization/blackhole resume, and array behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
