### PR TITLE
follow-up #143: gate method binding on default __getattribute__, fix builtin-form list.pop replay, forward type.__dict__ GC root

### DIFF
--- a/pyre/bench/synth/getattribute_override_no_bind.py
+++ b/pyre/bench/synth/getattribute_override_no_bind.py
@@ -1,13 +1,19 @@
-# A non-default `__getattribute__` must suppress LOAD_METHOD self-binding.
-# The override returns the raw function object (`type(self).__dict__[name]`),
-# never a bound method, so `c.f(...)` must call `f(...)` with exactly the
-# supplied positionals — no implicit self.  `compute_load_method_bound`
-# (shared by the interpreter `load_method` and the blackhole
-# `bh_load_method_self_fn`) used to infer the binding from MRO shape alone and
-# wrongly prepend self, inflating `len(args)` by one.
+# Two regressions in one hot loop:
 #
-# Straight-line so it stays in the interpreter: a hot loop calling through a
-# custom `__getattribute__` trips a separate, pre-existing JIT crash.
+# 1. Binding: a non-default `__getattribute__` must suppress LOAD_METHOD
+#    self-binding.  The override returns the raw function object
+#    (`type(self).__dict__[name]`), never a bound method, so `c.f(i)` calls
+#    `f(i)` (a single positional, no implicit self).  `compute_load_method_bound`
+#    (shared by the interpreter `load_method` and the blackhole
+#    `bh_load_method_self_fn`) used to infer the binding from MRO shape alone
+#    and wrongly prepend self, making `len(args)` 2 instead of 1.
+#
+# 2. GC: `type.__dict__` caches its canonical `W_DictObject` in the type
+#    namespace's off-GC `DictStorage.mirror_target`.  The moving collector did
+#    not forward that field, so once the loop's allocations triggered a minor
+#    collection the cache dangled and the next `__dict__` access returned a
+#    wild pointer (SIGSEGV in `getitem`).  The loop count is large enough to
+#    force collections through the blackhole-resumed `__getattribute__`.
 class C:
     def f(*args):
         return len(args)
@@ -16,7 +22,13 @@ class C:
         return type(self).__dict__[name]
 
 
-c = C()
-print(c.f())
-print(c.f(1))
-print(c.f(1, 2))
+def run(c, n):
+    total = 0
+    i = 0
+    while i < n:
+        total += c.f(i)
+        i += 1
+    return total
+
+
+print(run(C(), 300000))

--- a/pyre/bench/synth/getattribute_override_no_bind.py
+++ b/pyre/bench/synth/getattribute_override_no_bind.py
@@ -1,0 +1,22 @@
+# A non-default `__getattribute__` must suppress LOAD_METHOD self-binding.
+# The override returns the raw function object (`type(self).__dict__[name]`),
+# never a bound method, so `c.f(...)` must call `f(...)` with exactly the
+# supplied positionals — no implicit self.  `compute_load_method_bound`
+# (shared by the interpreter `load_method` and the blackhole
+# `bh_load_method_self_fn`) used to infer the binding from MRO shape alone and
+# wrongly prepend self, inflating `len(args)` by one.
+#
+# Straight-line so it stays in the interpreter: a hot loop calling through a
+# custom `__getattribute__` trips a separate, pre-existing JIT crash.
+class C:
+    def f(*args):
+        return len(args)
+
+    def __getattribute__(self, name):
+        return type(self).__dict__[name]
+
+
+c = C()
+print(c.f())
+print(c.f(1))
+print(c.f(1, 2))

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2125,6 +2125,17 @@ pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str
             let shadowed =
                 crate::objspace::std::mapdict::instance_node_getdictvalue(obj, name).is_some();
             let w_type = pyre_object::w_instance_get_type(obj);
+            // callmethod.py:33 `w_type.has_object_getattribute()`: a non-default
+            // `__getattribute__` produced `attr` through the override rather
+            // than the default descriptor path, so the MRO-shape binding
+            // inference below does not apply.  `_PyObject_GetMethod` skips the
+            // self-binding optimization for a custom `tp_getattro` (pushes
+            // NULL), so an override returning the raw descriptor must call as a
+            // plain function, not a bound method.  This is the same gate
+            // `load_method_fast_path` applies before its fast path.
+            if !pyre_object::typeobject::w_type_get_uses_object_getattribute(w_type) {
+                return PY_NULL;
+            }
             let raw = crate::baseobjspace::lookup_in_type(w_type, name);
             match raw {
                 _ if shadowed => PY_NULL,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -256,6 +256,16 @@ pub unsafe fn type_walk_namespace_values(
                 for slot in value_slots {
                     forward(&mut *slot);
                 }
+                // The lazily-cached canonical `W_DictObject` that
+                // `type.__dict__` returns (`dict_storage_to_dict_kind`'s
+                // `mirror_target`) is GC-managed but reachable only through
+                // this off-GC storage field; forward it so a minor
+                // collection that relocates or reclaims it updates the
+                // cache instead of returning a dangling pointer on the next
+                // `__dict__` access.
+                if let Some(slot) = (*dict_ptr).mirror_target_slot_mut() {
+                    forward(slot);
+                }
             }
         }
     }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -364,6 +364,21 @@ impl DictStorage {
         self.mirror_target
     }
 
+    /// Mutable handle to the `mirror_target` slot for in-place GC
+    /// forwarding (`None` when no mirror is bound).  The cached canonical
+    /// `W_DictObject` is GC-managed and reachable only through this off-GC
+    /// field, so an owner's root walk must forward it or a moving
+    /// collection relocates/reclaims the dict and leaves the cache
+    /// dangling.
+    #[inline]
+    pub fn mirror_target_slot_mut(&mut self) -> Option<&mut pyre_object::PyObjectRef> {
+        if self.mirror_target.is_null() {
+            None
+        } else {
+            Some(&mut self.mirror_target)
+        }
+    }
+
     /// Reallocate `values` to fit at least `min_cap` entries, copying
     /// the live prefix. Upstream `_ll_list_resize_really`
     /// (rlist.py:262-267) parity.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5862,10 +5862,16 @@ impl MIFrame {
         list: OpRef,
         concrete_list: PyObjectRef,
         concrete_len: usize,
+        // Generic-call replay shape when the fast path bails: `[]` for the
+        // bound-method form `xs.pop()` (`callable` is the bound method) and
+        // `[receiver]` for the builtin form `list.pop(xs)` (`callable` is the
+        // unbound builtin, so an empty list must record `list.pop(xs)` to
+        // raise IndexError rather than `list.pop()`'s arity TypeError).
+        fallback_args: &[OpRef],
     ) -> Result<OpRef, PyError> {
         if concrete_list.is_null() || concrete_len == 0 {
             // Caller's guard ensures concrete_len > 0; defensive fallback.
-            return self.trace_call_callable(callable, &[]);
+            return self.trace_call_callable(callable, fallback_args);
         }
         unsafe {
             if is_list(concrete_list) {
@@ -5886,7 +5892,7 @@ impl MIFrame {
                 }
             }
         }
-        self.trace_call_callable(callable, &[])
+        self.trace_call_callable(callable, fallback_args)
     }
 
     /// Direct trace path for `list.reverse()`.
@@ -5939,6 +5945,13 @@ impl MIFrame {
         index: OpRef,
         concrete_list: PyObjectRef,
         concrete_index: PyObjectRef,
+        // Operand-stack shape to replay when the fast path bails to the
+        // generic residual: `[index]` for the bound-method form `xs.pop(i)`
+        // (`callable` is the bound method) and `[receiver, index]` for the
+        // builtin form `list.pop(xs, i)` (`callable` is the unbound builtin,
+        // so the receiver must be re-supplied for the wrong-exception cases to
+        // match the concrete call).
+        fallback_args: &[OpRef],
     ) -> Result<OpRef, PyError> {
         // Pick the strategy-specific length field so the inline length update
         // mirrors `generated_list_pop_by_strategy`. A null / non-list / mixed
@@ -5958,8 +5971,7 @@ impl MIFrame {
             }
         };
         let Some((strategy_id, len_descr)) = strategy else {
-            // The method-form generic call shape is `callable(index)`.
-            return self.trace_call_callable(callable, &[index]);
+            return self.trace_call_callable(callable, fallback_args);
         };
         // The `jit_list_pop_at` residual panics on an out-of-range index
         // instead of raising IndexError, so the fast path may only be taken
@@ -5975,7 +5987,7 @@ impl MIFrame {
             }
         };
         let Some(concrete_key) = concrete_key else {
-            return self.trace_call_callable(callable, &[index]);
+            return self.trace_call_callable(callable, fallback_args);
         };
         let concrete_len = unsafe { w_list_len(concrete_list) } as i64;
         let normalized_key = if concrete_key < 0 {
@@ -5984,7 +5996,7 @@ impl MIFrame {
             concrete_key
         };
         if normalized_key < 0 || normalized_key >= concrete_len {
-            return self.trace_call_callable(callable, &[index]);
+            return self.trace_call_callable(callable, fallback_args);
         }
         let len_descr_idx = len_descr.index();
         let result = self.with_ctx(|this, ctx| {
@@ -6279,6 +6291,9 @@ impl MIFrame {
                         args[0],
                         inner_self,
                         concrete_args[0],
+                        // Bound method: the receiver is inside `callable`, so
+                        // the generic shape is `callable(index)`.
+                        &[args[0]],
                     );
                 }
                 if args.len() == 0 && canonical_list_method("pop") == Some(inner_func) {
@@ -6288,7 +6303,8 @@ impl MIFrame {
                     });
                     let self_ref = recover_self(self);
                     let concrete_len = unsafe { w_list_len(inner_self) };
-                    let res = self.list_pop_value(callable, self_ref, inner_self, concrete_len);
+                    let res =
+                        self.list_pop_value(callable, self_ref, inner_self, concrete_len, &[]);
                     self.with_ctx(|this, ctx| this.pop_call_replay_stack(ctx, args.len()))?;
                     return res;
                 }
@@ -6381,6 +6397,9 @@ impl MIFrame {
                         args[1],
                         concrete_args[0],
                         concrete_args[1],
+                        // Unbound builtin: the receiver is the explicit first
+                        // arg, so the generic shape is `list.pop(xs, i)`.
+                        &[args[0], args[1]],
                     );
                 }
                 if args.len() == 1
@@ -6388,7 +6407,15 @@ impl MIFrame {
                     && !concrete_args.first().copied().unwrap_or(PY_NULL).is_null()
                     && is_list(concrete_args[0])
                 {
-                    self.dm143_mark_heap_mutated();
+                    let concrete_len = w_list_len(concrete_args[0]);
+                    // Mark the mutation only once the concrete pop is known to
+                    // have removed an element: `call_callable` already ran the
+                    // builtin concretely, but on an empty list it raised
+                    // without mutating, so `dm143_advance_live_locals` must not
+                    // advance across that non-mutating iteration.
+                    if concrete_len > 0 {
+                        self.dm143_mark_heap_mutated();
+                    }
                     self.with_ctx(|this, ctx| {
                         this.implement_guard_value(ctx, callable, concrete_callable as i64)
                     });
@@ -6402,9 +6429,16 @@ impl MIFrame {
                             call_pc,
                         )
                     });
-                    let concrete_len = w_list_len(concrete_args[0]);
-                    let res =
-                        self.list_pop_value(callable, args[0], concrete_args[0], concrete_len);
+                    let res = self.list_pop_value(
+                        callable,
+                        args[0],
+                        concrete_args[0],
+                        concrete_len,
+                        // Unbound builtin: re-supply the receiver so an empty
+                        // list records `list.pop(xs)` (IndexError), not
+                        // `list.pop()` (arity TypeError).
+                        &[args[0]],
+                    );
                     self.with_ctx(|this, ctx| {
                         this.pop_call_replay_stack_self_in_args(ctx, args.len())
                     })?;

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3206,7 +3206,18 @@ pub extern "C" fn bh_load_attr_fn(obj: i64, w_code_ptr: i64, name_idx: i64) -> i
         &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
             as *const pyre_interpreter::CodeObject)
     };
+    // `name_idx` is a `co_names` index baked into the residual call by the
+    // codewriter from the originating LOAD_ATTR oparg, so it is in range for
+    // the code object loaded out of the resume frame.  The bound is a codegen
+    // invariant rather than a runtime-reachable error (a negative index would
+    // wrap to a huge `usize` and trip the same check), so assert it in debug
+    // and degrade to a null result in release.
     let idx = name_idx as usize;
+    debug_assert!(
+        idx < code.names.len(),
+        "bh_load_attr_fn name_idx {idx} out of range ({} names) — codegen invariant",
+        code.names.len()
+    );
     if idx >= code.names.len() {
         return 0;
     }
@@ -3236,7 +3247,15 @@ pub extern "C" fn bh_load_method_self_fn(
         &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
             as *const pyre_interpreter::CodeObject)
     };
+    // Same `co_names`-index codegen invariant as `bh_load_attr_fn`; the
+    // release-path `PY_NULL` is also the legitimate "no self prepended"
+    // result, so the debug assert is what catches an invalid index.
     let idx = name_idx as usize;
+    debug_assert!(
+        idx < code.names.len(),
+        "bh_load_method_self_fn name_idx {idx} out of range ({} names) — codegen invariant",
+        code.names.len()
+    );
     if idx >= code.names.len() {
         return pyre_object::PY_NULL as i64;
     }

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1248,6 +1248,48 @@ mod tests {
     }
 
     #[test]
+    fn test_jit_list_pop_at_returns_and_shifts() {
+        let list = w_list_new(vec![w_int_new(10), w_int_new(20), w_int_new(30)]);
+        let popped = jit_list_pop_at(list as i64, 1) as PyObjectRef;
+        unsafe {
+            assert_eq!(crate::intobject::w_int_get_value(popped), 20);
+            assert_eq!(w_list_len(list), 2);
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 0).unwrap()),
+                10
+            );
+            assert_eq!(
+                crate::intobject::w_int_get_value(w_list_getitem(list, 1).unwrap()),
+                30
+            );
+        }
+    }
+
+    #[test]
+    fn test_jit_list_pop_at_normalizes_negative_index() {
+        let list = w_list_new(vec![w_int_new(10), w_int_new(20), w_int_new(30)]);
+        let popped = jit_list_pop_at(list as i64, -1) as PyObjectRef;
+        unsafe {
+            assert_eq!(crate::intobject::w_int_get_value(popped), 30);
+            assert_eq!(w_list_len(list), 2);
+        }
+    }
+
+    #[test]
+    fn test_jit_list_pop_at_out_of_range_is_rejected() {
+        // `jit_list_pop_at` panics on an out-of-range index (an `extern "C"`
+        // panic aborts rather than unwinds, so the contract is asserted on the
+        // `w_list_pop` it guards on: a `None` is what drives the panic).  The
+        // tracer only emits the helper behind a runtime in-range guard.
+        let list = w_list_new(vec![w_int_new(10)]);
+        unsafe {
+            assert!(w_list_pop(list, 5).is_none());
+            assert!(w_list_pop(list, -5).is_none());
+            assert_eq!(w_list_len(list), 1);
+        }
+    }
+
+    #[test]
     fn test_list_uses_integer_strategy_for_homogeneous_ints() {
         let list = w_list_new(vec![w_int_new(1), w_int_new(2), w_int_new(3)]);
         unsafe {


### PR DESCRIPTION
follow-up #143

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Follow-up to #159 (the merged #143 JIT list-specialization PR). Two strands: post-merge review fixes for the #143 work, and a pre-existing GC crash uncovered while testing them.

### Review fixes (`17100d67b9`)

- **Method-binding gate.** `compute_load_method_bound` now returns `PY_NULL` when the receiver's type does not use the default `__getattribute__`. The override already produced the attribute, so the MRO-shape binding inference must not prepend `self`/`cls`. Shared by the interpreter `load_method` and the blackhole `bh_load_method_self_fn`.
- **Builtin-form `list.pop` replay.** `list_pop_value` / `list_pop_at_value` take `fallback_args`, so the generic-call fallback keeps the explicit receiver for the builtin form (`list.pop(xs)` / `list.pop(xs, i)`) instead of recording the bound-method shape (`list.pop()` / `list.pop(i)`), which raised an arity `TypeError` / wrong exception on the empty-list and non-int/out-of-range cases.
- **dm143 empty-pop guard.** Builtin no-index pop marks dm143 heap mutation only when the concrete list is non-empty, so an empty-list pop (which raises without mutating) does not tag the loop for `dm143_advance_live_locals`.
- **Codegen invariant.** `bh_load_attr_fn` / `bh_load_method_self_fn` `debug_assert` the `name_idx` in-range codegen invariant before the release-path defensive return.
- **Unit tests** for `jit_list_pop_at`: pop-and-shift, negative-index normalization, out-of-range rejection.

### GC crash fix (`fab81b6afd`)

`type.__dict__` lazily caches its canonical `W_DictObject` in the type namespace's off-GC `DictStorage.mirror_target` (`dict_storage_to_dict_kind`). `type_walk_namespace_values` forwarded the namespace entry values but not `mirror_target`, so a minor collection reclaimed/relocated the cached dict while the field kept a stale pointer — the next `type.__dict__` returned a wild object (null `ob_type`), crashing `getitem`'s "not subscriptable" formatting.

The walk now forwards the `mirror_target` slot (covering both the `walk_type_dicts_gc` root walk and the type custom trace, which share the helper); `DictStorage::mirror_target_slot_mut` performs the in-place forward. Reproduces when a hot loop resolves attributes through a custom `__getattribute__` that reads `type(self).__dict__[name]`: the per-iteration allocations trigger collection inside the blackhole-resumed getattr. Instance and module `__dict__` hot loops were verified unaffected (their canonical dicts are rooted through other paths).

### Testing

`synth/getattribute_override_no_bind.py` (upgraded from straight-line to the hot-loop form) exercises the binding gate, blackhole resume, and the GC fix together. `pyre/check.py` is 52/52 on both backends (dynasm, cranelift).

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmark script for method binding scenarios
  * Added unit tests for list pop operations including edge cases

* **Chores**
  * Updated interpreter method binding optimization and garbage collection handling
  * Enhanced garbage collection root tracking for type objects
  * Refined JIT trace generation for list operations and fallback paths
  * Added debug validation for interpreter code element bounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->