### PR TITLE
interp: validate format specs and print() sep/end; dispatch __format__ overrides; module-qualified repr

### DIFF
--- a/pyre/bench/synth/dunder_repr_str_errors.py
+++ b/pyre/bench/synth/dunder_repr_str_errors.py
@@ -74,10 +74,42 @@ print("str-format-strsub", "hi".__format__(StrSubRaisingStr(">5")))
 print("object-format-strsub", object().__format__(StrSubRaisingStr("")) != "")
 show("int-format-nonstr", lambda: (12).__format__(34))
 
-# print(sep=, end=): None selects the default, a str subclass uses its
-# stored value, and a non-str raises TypeError. (A str subclass __str__
-# override is intentionally not exercised here — CPython str()-ifies the
-# separator while PyPy writes it directly, so they diverge.)
+
+# `format()` / f-strings dispatch a `__format__` override, including one on
+# a builtin subclass (which `is_instance` alone would miss).
+class FmtInt(int):
+    def __format__(self, spec):
+        return "fi:" + spec
+
+
+print("subclass-format-override", format(FmtInt(5), ">3"), f"{FmtInt(5):^4}")
+
+
+# `__format__` is a type-level special method: an instance-dict attribute does
+# not shadow it (the instance below still formats via `object.__format__`), and
+# a non-function descriptor override (e.g. `staticmethod`) on a builtin subclass
+# is dispatched through the descriptor protocol rather than formatting the
+# underlying value.
+class PlainObj:
+    pass
+
+
+_inst = PlainObj()
+_inst.__format__ = lambda spec: "INST"
+print("inst-dict-format-ignored", format(_inst, "") == str(_inst))
+
+
+class StaticFmt(int):
+    __format__ = staticmethod(lambda spec: "sf:" + spec)
+
+
+print("staticmethod-format-override", format(StaticFmt(7), ">3"))
+
+# print(sep=, end=): None selects the default, a str subclass is rendered
+# through str() (Py_PRINT_RAW), and a non-str raises TypeError. (A str
+# subclass with a __str__ override is intentionally not exercised here —
+# 3.14 calls __str__ while PyPy reads storage, so the check.py oracles
+# diverge; PlainSep has no override, so all agree.)
 class PlainSep(str):
     pass
 

--- a/pyre/bench/synth/dunder_repr_str_errors.py
+++ b/pyre/bench/synth/dunder_repr_str_errors.py
@@ -67,5 +67,12 @@ print("complex-strsub", complex(StrSubRaisingStr("1")) == 1.0)
 print("format-strsub", format(12, StrSubRaisingStr("04d")), format(255, StrSubRaisingStr("x")))
 show("format-nonstr-spec", lambda: format(12, 34))
 
+# `type.__format__` (int/float/str/bool) and `object.__format__` read the
+# spec storage directly too.
+print("int-format-strsub", (12).__format__(StrSubRaisingStr("04d")))
+print("str-format-strsub", "hi".__format__(StrSubRaisingStr(">5")))
+print("object-format-strsub", object().__format__(StrSubRaisingStr("")) != "")
+show("int-format-nonstr", lambda: (12).__format__(34))
+
 # Normal formatting is unaffected.
 print("normal", repr([1, 2]), str({3: 4}), repr((1,)), ascii("x"))

--- a/pyre/bench/synth/dunder_repr_str_errors.py
+++ b/pyre/bench/synth/dunder_repr_str_errors.py
@@ -44,7 +44,7 @@ show("leaf-repr-raise", lambda: repr(MyInt(7)))
 show("nonstr-repr", lambda: repr(NonStrRepr()))
 show("list-elem", lambda: repr([RaisesRepr()]))
 show("dict-key", lambda: repr({RaisesRepr(): 1}))
-show("tuple-elem", lambda: str((RaisesStr(),)))
+show("tuple-elem", lambda: str((RaisesRepr(),)))
 show("format-r", lambda: "{!r}".format(RaisesRepr()))
 show("percent-s", lambda: "%s" % RaisesStr())
 show("fstring", lambda: f"{RaisesRepr()!r}")
@@ -73,6 +73,19 @@ print("int-format-strsub", (12).__format__(StrSubRaisingStr("04d")))
 print("str-format-strsub", "hi".__format__(StrSubRaisingStr(">5")))
 print("object-format-strsub", object().__format__(StrSubRaisingStr("")) != "")
 show("int-format-nonstr", lambda: (12).__format__(34))
+
+# print(sep=, end=): None selects the default, a str subclass uses its
+# stored value, and a non-str raises TypeError. (A str subclass __str__
+# override is intentionally not exercised here — CPython str()-ifies the
+# separator while PyPy writes it directly, so they diverge.)
+class PlainSep(str):
+    pass
+
+
+print("a", "b", sep=PlainSep("-"))
+print("pend-none", end=None)
+show("print-end-int", lambda: print("x", end=5))
+show("print-sep-int", lambda: print("x", sep=5, end="\n"))
 
 # Normal formatting is unaffected.
 print("normal", repr([1, 2]), str({3: 4}), repr((1,)), ascii("x"))

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -763,7 +763,7 @@ pub(crate) unsafe fn normalize_slice(
 /// `get` (`space.get`) first, then called with `args_w` alone, so
 /// `@staticmethod` / `@classmethod` / custom-descriptor dunders receive the
 /// arguments PyPy gives them.
-unsafe fn get_and_call_function(
+pub(crate) unsafe fn get_and_call_function(
     w_descr: PyObjectRef,
     w_obj: PyObjectRef,
     w_type: PyObjectRef,
@@ -4373,6 +4373,68 @@ pub(crate) unsafe fn lookup_in_type_where(w_type: PyObjectRef, name: &str) -> Op
     // typeobject.py:510 — `_pure_lookup_where_with_method_cache(name, version_tag)`.
     let v = _pure_lookup_where_with_method_cache(w_type, w_name, version_tag);
     if v.is_null() { None } else { Some(v) }
+}
+
+/// `objspace.py:817 getfulltypename` — the type name used by the default
+/// object repr.  A heaptype renders as `<module>.<qualname>` when it
+/// carries a string `__module__`; a builtin type is just its `name`.
+///
+/// # Safety
+/// `w_obj` must be a valid, non-null `PyObject`.
+pub unsafe fn getfulltypename(w_obj: PyObjectRef) -> String {
+    match crate::typedef::r#type(w_obj) {
+        Some(w_type) => getfulltypename_of_type(w_type),
+        None => "object".to_string(),
+    }
+}
+
+/// [`getfulltypename`] for an already-resolved type.
+///
+/// # Safety
+/// `w_type` must be a valid `W_TypeObject`.
+pub unsafe fn getfulltypename_of_type(w_type: PyObjectRef) -> String {
+    if !pyre_object::w_type_is_heaptype(w_type) {
+        return w_type_get_name(w_type).to_string();
+    }
+    // `w_type.getqualname(space)` — an explicit `__qualname__` set in the
+    // class body, else the bare name.
+    let qualname = match lookup_in_type_where(w_type, "__qualname__") {
+        Some(qn) if is_str(qn) => w_str_get_value(qn).to_string(),
+        _ => w_type_get_name(w_type).to_string(),
+    };
+    // `w_type.lookup("__module__")` prepends a string module name; a
+    // non-string `__module__` is ignored (`utf8_w` raises `TypeError`).
+    match lookup_in_type(w_type, "__module__") {
+        Some(m) if is_str(m) => format!("{}.{qualname}", w_str_get_value(m)),
+        _ => qualname,
+    }
+}
+
+/// `typeobject.py:797 descr_repr` name component — the `module.qualname`
+/// rendered inside `<class '…'>` when a heaptype carries a string
+/// `__module__` other than `builtins`, else the bare `name` (a builtin
+/// type's dotted `name` already carries its module).
+///
+/// # Safety
+/// `w_type` must be a valid `W_TypeObject`.
+pub unsafe fn type_repr_qualified_name(w_type: PyObjectRef) -> String {
+    let name = w_type_get_name(w_type).to_string();
+    if !pyre_object::w_type_is_heaptype(w_type) {
+        return name;
+    }
+    let module = lookup_in_type_where(w_type, "__module__")
+        .filter(|m| is_str(*m))
+        .map(|m| w_str_get_value(m).to_string());
+    match module {
+        Some(m) if m != "builtins" => {
+            let qualname = match lookup_in_type_where(w_type, "__qualname__") {
+                Some(qn) if is_str(qn) => w_str_get_value(qn).to_string(),
+                _ => name,
+            };
+            format!("{m}.{qualname}")
+        }
+        _ => name,
+    }
 }
 
 /// `callmethod.py:25-85 LOAD_METHOD` fast-path decision, shared by the

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5803,24 +5803,11 @@ fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 fn builtin_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     assert!(!args.is_empty(), "format() takes at least one argument");
     let value = args[0];
+    // `format_spec` must be a `str`; its stored value is used directly
+    // without invoking a `str` subclass `__str__` (bltinmodule.c
+    // `builtin_format_impl`).
     let spec = if args.len() > 1 {
-        let a = args[1];
-        // `format_spec` must be a `str`; its stored value is used
-        // directly without invoking a `str` subclass `__str__`
-        // (bltinmodule.c `builtin_format_impl`).
-        if unsafe { pyre_object::is_str(a) } {
-            unsafe { pyre_object::w_str_get_value(a).to_string() }
-        } else {
-            let tn = unsafe {
-                match crate::typedef::r#type(a) {
-                    Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
-                    None => (*(*a).ob_type).name.to_string(),
-                }
-            };
-            return Err(crate::PyError::type_error(format!(
-                "format() argument 2 must be str, not {tn}"
-            )));
-        }
+        crate::type_methods::read_format_spec(args[1], "format() argument 2")?
     } else {
         String::new()
     };

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1000,6 +1000,30 @@ pub fn new_builtin_module_dict() -> pyre_object::PyObjectRef {
     w_dict
 }
 
+/// `print`'s `sep`/`end`: `None` selects the default and a non-`str` is
+/// a TypeError ("sep must be None or a string, not …").  A `str` value is
+/// written directly (`app_io.py print_`: `file.write(sep)`), so its
+/// stored value is used without invoking a `str` subclass `__str__`.
+fn print_separator(
+    val: Option<PyObjectRef>,
+    name: &str,
+    default: &str,
+) -> Result<String, crate::PyError> {
+    let Some(v) = val else {
+        return Ok(default.to_string());
+    };
+    if unsafe { pyre_object::is_none(v) } {
+        return Ok(default.to_string());
+    }
+    if unsafe { pyre_object::is_str(v) } {
+        return Ok(unsafe { pyre_object::w_str_get_value(v) }.to_string());
+    }
+    Err(crate::PyError::type_error(format!(
+        "{name} must be None or a string, not {}",
+        crate::type_methods::arg_type_name(v)
+    )))
+}
+
 /// `print(*args)` — write space-separated str representations to stdout.
 fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // Check if last arg is a kwargs dict (from CALL_KW builtin dispatch).
@@ -1015,14 +1039,8 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let sep_key = w_str_new("sep");
         let end_val = unsafe { pyre_object::w_dict_lookup(kwargs, end_key) };
         let sep_val = unsafe { pyre_object::w_dict_lookup(kwargs, sep_key) };
-        let end_str = end_val
-            .map(|v| unsafe { crate::py_str(v) })
-            .transpose()?
-            .unwrap_or_else(|| "\n".to_string());
-        let sep_str = sep_val
-            .map(|v| unsafe { crate::py_str(v) })
-            .transpose()?
-            .unwrap_or_else(|| " ".to_string());
+        let end_str = print_separator(end_val, "end", "\n")?;
+        let sep_str = print_separator(sep_val, "sep", " ")?;
         (&args[..args.len() - 1], end_str, sep_str)
     } else {
         (args, "\n".to_string(), " ".to_string())

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1000,23 +1000,24 @@ pub fn new_builtin_module_dict() -> pyre_object::PyObjectRef {
     w_dict
 }
 
-/// `print`'s `sep`/`end`: `None` selects the default and a non-`str` is
-/// a TypeError ("sep must be None or a string, not …").  A `str` value is
-/// written directly (`app_io.py print_`: `file.write(sep)`), so its
-/// stored value is used without invoking a `str` subclass `__str__`.
-fn print_separator(
+/// `print`'s `sep`/`end` type check, applied up front: `None` (or absent)
+/// selects the default and a non-`str` is a TypeError ("sep must be None or
+/// a string, not <type>").  A `str` value is returned for the caller to
+/// render at write time with `Py_PRINT_RAW`, which goes through `str()`, so
+/// a `str` subclass `__str__` override is honored — and a raising one
+/// surfaces only after the preceding argument has already been written.
+fn print_sep_check(
     val: Option<PyObjectRef>,
     name: &str,
-    default: &str,
-) -> Result<String, crate::PyError> {
+) -> Result<Option<PyObjectRef>, crate::PyError> {
     let Some(v) = val else {
-        return Ok(default.to_string());
+        return Ok(None);
     };
     if unsafe { pyre_object::is_none(v) } {
-        return Ok(default.to_string());
+        return Ok(None);
     }
     if unsafe { pyre_object::is_str(v) } {
-        return Ok(unsafe { pyre_object::w_str_get_value(v) }.to_string());
+        return Ok(Some(v));
     }
     Err(crate::PyError::type_error(format!(
         "{name} must be None or a string, not {}",
@@ -1039,18 +1040,31 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let sep_key = w_str_new("sep");
         let end_val = unsafe { pyre_object::w_dict_lookup(kwargs, end_key) };
         let sep_val = unsafe { pyre_object::w_dict_lookup(kwargs, sep_key) };
-        let end_str = print_separator(end_val, "end", "\n")?;
-        let sep_str = print_separator(sep_val, "sep", " ")?;
-        (&args[..args.len() - 1], end_str, sep_str)
+        // The type check is up front; the str() rendering happens at write
+        // time so a raising `__str__` leaves the preceding output in place.
+        let end_obj = print_sep_check(end_val, "end")?;
+        let sep_obj = print_sep_check(sep_val, "sep")?;
+        (&args[..args.len() - 1], end_obj, sep_obj)
     } else {
-        (args, "\n".to_string(), " ".to_string())
+        (args, None, None)
     };
 
-    let parts: Vec<String> = positional
-        .iter()
-        .map(|&obj| unsafe { crate::py_str(obj) })
-        .collect::<Result<Vec<String>, _>>()?;
-    crate::print_output(&format!("{}{}", parts.join(&sep), end));
+    // `bltinmodule.c print_impl` writes incrementally: `str(arg)`, then the
+    // separator before each following arg, then `end`.  Each `str()` may
+    // raise, leaving the bytes already emitted on the stream.
+    for (i, &obj) in positional.iter().enumerate() {
+        if i > 0 {
+            match sep {
+                Some(s) => crate::print_output(&unsafe { crate::py_str(s)? }),
+                None => crate::print_output(" "),
+            }
+        }
+        crate::print_output(&unsafe { crate::py_str(obj)? });
+    }
+    match end {
+        Some(e) => crate::print_output(&unsafe { crate::py_str(e)? }),
+        None => crate::print_output("\n"),
+    }
     Ok(w_none())
 }
 
@@ -5817,22 +5831,22 @@ fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     }
 }
 
-/// `format(value, format_spec='')` — PyPy: operation.py format
+/// `format(value, format_spec='')` — operation.py format → space.format
 fn builtin_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     assert!(!args.is_empty(), "format() takes at least one argument");
     let value = args[0];
-    // `format_spec` must be a `str`; its stored value is used directly
-    // without invoking a `str` subclass `__str__` (bltinmodule.c
-    // `builtin_format_impl`).
+    // `builtin_format_impl`: the `format_spec` must be a `str` — validated
+    // here, before dispatch, so `format(value, 34)` reports `format()
+    // argument 2 must be str, not int` for any `value`.  Its stored value is
+    // used directly (no `str` subclass `__str__`), then `format_value_dispatch`
+    // applies it — dispatching a `__format__` override (including a builtin
+    // subclass's) or, for a plain builtin, the shared spec parser; the same
+    // path f-string `{v:spec}` and `"{:spec}".format(v)` use.
     let spec = if args.len() > 1 {
         crate::type_methods::read_format_spec(args[1], "format() argument 2")?
     } else {
         String::new()
     };
-    // `PyObject_Format(value, spec)`: dispatch to a user-defined
-    // `__format__` when present, else the shared spec parser (empty spec →
-    // `str(value)`) — the same path f-string `{v:spec}` and
-    // `"{:spec}".format(v)` use, so all three produce identical output.
     let s = crate::type_methods::format_value_dispatch(value, &spec)?;
     Ok(pyre_object::w_str_from_wtf8(s))
 }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -505,7 +505,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             };
             format!("{class_name}({inner})")
         } else if std::ptr::eq(tp, &TYPE_TYPE as *const PyType) {
-            let name = pyre_object::w_type_get_name(obj);
+            let name = crate::baseobjspace::type_repr_qualified_name(obj);
             format!("<class '{name}'>")
         } else if std::ptr::eq(tp, &pyre_object::UNION_TYPE as *const PyType) {
             // PyPy: UnionType.__repr__ → " | ".join([_repr_item(x) for x in self.__args__])
@@ -606,11 +606,11 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             if let Some(s) = try_call_dunder(obj, "__str__")? {
                 return Ok(s);
             }
-            let w_type = pyre_object::w_instance_get_type(obj);
-            let name = pyre_object::w_type_get_name(w_type);
+            let name = crate::baseobjspace::getfulltypename(obj);
             format!("<{name} object at {obj:?}>")
         } else {
-            format!("<{} object at {:?}>", (*tp).name, obj)
+            let name = crate::baseobjspace::getfulltypename(obj);
+            format!("<{name} object at {obj:?}>")
         };
         Ok(formatted)
     }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1390,13 +1390,35 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, cr
     }
 }
 
+/// Read a format spec's stored string value. The spec must be a `str`
+/// (or subclass); its `__str__` is not consulted, so a raising override
+/// does not leak out of formatting.  `arg_desc` names the argument in
+/// the TypeError raised when the spec is not a `str`.
+pub(crate) fn read_format_spec(
+    spec_obj: PyObjectRef,
+    arg_desc: &str,
+) -> Result<String, crate::PyError> {
+    if unsafe { is_str(spec_obj) } {
+        return Ok(unsafe { w_str_get_value(spec_obj) }.to_string());
+    }
+    let tn = unsafe {
+        match crate::typedef::r#type(spec_obj) {
+            Some(tp) => w_type_get_name(tp).to_string(),
+            None => (*(*spec_obj).ob_type).name.to_string(),
+        }
+    };
+    Err(crate::PyError::type_error(format!(
+        "{arg_desc} must be str, not {tn}"
+    )))
+}
+
 /// `int/float/str/bool.__format__(self, format_spec)` — formats `self`
 /// through the shared spec parser without re-dispatching to an instance
 /// `__format__` (which `format_value_dispatch` would do for subclasses,
 /// risking recursion).  An empty spec collapses to `str(self)`.
 pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let spec = if args.len() > 1 {
-        unsafe { crate::py_str(args[1])? }
+        read_format_spec(args[1], "__format__() argument")?
     } else {
         String::new()
     };

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1390,6 +1390,17 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, cr
     }
 }
 
+/// The type name of `obj` for a TypeError message — the `w_class` name
+/// for instances, else the storage type name.
+pub(crate) fn arg_type_name(obj: PyObjectRef) -> String {
+    unsafe {
+        match crate::typedef::r#type(obj) {
+            Some(tp) => w_type_get_name(tp).to_string(),
+            None => (*(*obj).ob_type).name.to_string(),
+        }
+    }
+}
+
 /// Read a format spec's stored string value. The spec must be a `str`
 /// (or subclass); its `__str__` is not consulted, so a raising override
 /// does not leak out of formatting.  `arg_desc` names the argument in
@@ -1401,14 +1412,9 @@ pub(crate) fn read_format_spec(
     if unsafe { is_str(spec_obj) } {
         return Ok(unsafe { w_str_get_value(spec_obj) }.to_string());
     }
-    let tn = unsafe {
-        match crate::typedef::r#type(spec_obj) {
-            Some(tp) => w_type_get_name(tp).to_string(),
-            None => (*(*spec_obj).ob_type).name.to_string(),
-        }
-    };
     Err(crate::PyError::type_error(format!(
-        "{arg_desc} must be str, not {tn}"
+        "{arg_desc} must be str, not {}",
+        arg_type_name(spec_obj)
     )))
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1357,27 +1357,51 @@ pub fn format_with_spec_public(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, 
     format_with_spec(val, spec)
 }
 
+/// Bind the type-level `__format__` descriptor `meth` to `val` and call it
+/// with `spec_obj`, requiring a `str` result.  Dispatching the looked-up
+/// `meth` (rather than a fresh instance lookup) keeps `__format__` a
+/// type-level special method — an instance-dict `__format__` is ignored —
+/// and binds a `@staticmethod` / `@classmethod` / other descriptor override
+/// through the descriptor protocol.  The spec is passed through untouched so
+/// the type's own `__format__` runs its validation.
+pub(crate) fn call_format_dispatch(
+    val: PyObjectRef,
+    meth: PyObjectRef,
+    spec_obj: PyObjectRef,
+) -> Result<Wtf8Buf, crate::PyError> {
+    unsafe {
+        let w_type = crate::typedef::r#type(val).unwrap_or(pyre_object::PY_NULL);
+        let result = crate::baseobjspace::get_and_call_function(meth, val, w_type, &[spec_obj])?;
+        if !pyre_object::is_str(result) {
+            return Err(crate::PyError::type_error(format!(
+                "__format__ must return a str, not {}",
+                arg_type_name(result)
+            )));
+        }
+        Ok(pyre_object::w_str_get_wtf8(result).to_wtf8_buf())
+    }
+}
+
 /// `PyObject_Format` — when `val` is a class instance whose type defines
 /// `__format__`, dispatch to it (the result must be a `str`); otherwise
 /// apply the shared builtin spec parser, with an empty spec collapsing to
 /// `str(value)`.  Shared by `format()`, the `FormatSimple`/`FormatWithSpec`
 /// f-string opcodes, and `str.format` field formatting.
 pub fn format_value_dispatch(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
-    unsafe {
-        if is_instance(val) && crate::baseobjspace::lookup(val, "__format__").is_some() {
+    // A class instance always dispatches to its `__format__` (its own
+    // override or the inherited `object.__format__`).  A builtin subclass
+    // dispatches whenever it overrides `__format__` with anything other than
+    // the inherited builtin default — a `def`, `@staticmethod`,
+    // `@classmethod`, or any non-`BUILTIN_FUNCTION_TYPE` descriptor; the
+    // builtin default takes the fast path below, which formats the
+    // underlying value directly.  `__format__` is resolved on the type (not
+    // the instance) so an instance-dict attribute does not shadow it.
+    if let Some(meth) = unsafe { crate::baseobjspace::lookup(val, "__format__") } {
+        if unsafe { is_instance(val) }
+            || !unsafe { py_type_check(meth, &crate::function::BUILTIN_FUNCTION_TYPE) }
+        {
             let spec_obj = pyre_object::w_str_new(spec);
-            let result = crate::baseobjspace::call_method(val, "__format__", &[spec_obj]);
-            if result.is_null() {
-                return Err(crate::call::take_call_error()
-                    .unwrap_or_else(|| crate::PyError::type_error("__format__ failed")));
-            }
-            if !pyre_object::is_str(result) {
-                return Err(crate::PyError::type_error(format!(
-                    "__format__ must return a str, not {}",
-                    (*(*result).ob_type).name
-                )));
-            }
-            return Ok(pyre_object::w_str_get_wtf8(result).to_wtf8_buf());
+            return call_format_dispatch(val, meth, spec_obj);
         }
     }
     if spec.is_empty() {
@@ -1393,6 +1417,9 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, cr
 /// The type name of `obj` for a TypeError message — the `w_class` name
 /// for instances, else the storage type name.
 pub(crate) fn arg_type_name(obj: PyObjectRef) -> String {
+    if obj.is_null() {
+        return "object".to_string();
+    }
     unsafe {
         match crate::typedef::r#type(obj) {
             Some(tp) => w_type_get_name(tp).to_string(),
@@ -1403,13 +1430,14 @@ pub(crate) fn arg_type_name(obj: PyObjectRef) -> String {
 
 /// Read a format spec's stored string value. The spec must be a `str`
 /// (or subclass); its `__str__` is not consulted, so a raising override
-/// does not leak out of formatting.  `arg_desc` names the argument in
-/// the TypeError raised when the spec is not a `str`.
+/// does not leak out of formatting.  `arg_desc` names the argument in the
+/// `TypeError` raised for a non-`str` spec (`format()` reports `format()
+/// argument 2`, a type's `__format__` reports `__format__() argument`).
 pub(crate) fn read_format_spec(
     spec_obj: PyObjectRef,
     arg_desc: &str,
 ) -> Result<String, crate::PyError> {
-    if unsafe { is_str(spec_obj) } {
+    if !spec_obj.is_null() && unsafe { is_str(spec_obj) } {
         return Ok(unsafe { w_str_get_value(spec_obj) }.to_string());
     }
     Err(crate::PyError::type_error(format!(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7519,7 +7519,8 @@ fn init_object_type(ns: &mut DictStorage) {
                     return Ok(pyre_object::w_str_new(""));
                 }
                 if args.len() > 1 {
-                    let spec = unsafe { crate::py_str(args[1])? };
+                    let spec =
+                        crate::type_methods::read_format_spec(args[1], "__format__() argument")?;
                     if !spec.is_empty() {
                         return Err(crate::PyError::type_error(
                             "unsupported format string passed to object.__format__",

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7479,8 +7479,8 @@ fn init_object_type(ns: &mut DictStorage) {
                 let obj = args[0];
                 unsafe {
                     if pyre_object::is_instance(obj) {
-                        let w_type = pyre_object::w_instance_get_type(obj);
-                        let name = pyre_object::w_type_get_name(w_type);
+                        // `w_obj.getrepr(space, '%s object' % fulltypename)`.
+                        let name = crate::baseobjspace::getfulltypename(obj);
                         return Ok(pyre_object::w_str_new(&format!(
                             "<{name} object at {obj:?}>"
                         )));
@@ -7519,12 +7519,17 @@ fn init_object_type(ns: &mut DictStorage) {
                     return Ok(pyre_object::w_str_new(""));
                 }
                 if args.len() > 1 {
+                    // object.__format__(self, format_spec): the spec must be
+                    // a `str` (a `bytes` spec is rejected like any other
+                    // non-`str`); a non-empty one is unsupported, an empty
+                    // one falls through to `str(self)`.
                     let spec =
                         crate::type_methods::read_format_spec(args[1], "__format__() argument")?;
                     if !spec.is_empty() {
-                        return Err(crate::PyError::type_error(
-                            "unsupported format string passed to object.__format__",
-                        ));
+                        return Err(crate::PyError::type_error(format!(
+                            "unsupported format string passed to {}.__format__",
+                            crate::type_methods::arg_type_name(args[0])
+                        )));
                     }
                 }
                 Ok(pyre_object::w_str_new(&unsafe { crate::py_str(args[0])? }))


### PR DESCRIPTION
Followup #112

## Summary

Aligns format-spec reading, `print(sep=, end=)`, and `object`/`type` repr with Python 3.14 semantics. Follow-up to the #151 code review.

- **Format specs.** `format(value, spec)` validates that `spec` is a `str` before dispatching (`TypeError: format() argument 2 must be str, not <type>`); `int`/`float`/`str`/`bool.__format__` and `object.__format__` read the spec's stored value and reject a non-`str` with `TypeError: __format__() argument must be str, not <type>`. `object.__format__` also rejects `bytes`, and raises `unsupported format string passed to <type>.__format__` for a non-empty spec. A non-`str` `__format__` return raises `__format__ must return a str, not <type>`. A shared `type_methods::read_format_spec` (with `arg_type_name` for the message text) replaces the three inline `py_str` calls, so a `str`-subclass `__str__` override is not consulted when reading a spec.

- **`__format__` override dispatch.** `format()` / f-strings dispatch a user `__format__` override, including one defined on a builtin subclass. `__format__` is resolved on the **type** and any non-builtin override — a `def`, `@staticmethod`, `@classmethod`, or other descriptor — is bound and called through the descriptor protocol (`get_and_call_function`); the builtin default keeps the fast path. An instance-dict `__format__` therefore does not shadow the type's, and a descriptor override on a builtin subclass is invoked rather than formatting the underlying value.

- **`print(sep=, end=)`.** `None` selects the default; a non-`str` raises `TypeError: sep/end must be None or a string, not <type>` (previously `None` rendered as `"None"` and a non-`str` separator was silently coerced). A `str` (or subclass) is rendered through `str()` (`Py_PRINT_RAW`), and output is streamed argument-by-argument, so a `__str__` that raises mid-print leaves the already-written prefix in place.

- **Module-qualified repr.** `object` / instance `__repr__` and `type` repr render the module-qualified name (`baseobjspace::getfulltypename` / `type_repr_qualified_name`), omitting the `builtins` module.

`bench/synth/dunder_repr_str_errors.py` covers the `__format__` spec paths and override dispatch (a `def` and a `@staticmethod` on a builtin subclass, plus an instance-dict `__format__` that must be ignored), the non-`str` spec / `sep` / `end` `TypeError`s, the `None`-default separator, and tuple-element `__repr__` propagation. `check.py` passes on both backends.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7 -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
