### PR TITLE
x86 jit: break cvtsi2sd false dependency with a zeroing idiom

### DIFF
--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -3170,7 +3170,12 @@ impl<'a> Assembler386<'a> {
                             16
                         }
                     };
-                    dynasm!(self.mc ; .arch x64 ; cvtsi2sd Rx(dst.value), Rq(sr));
+                    // cvtsi2sd preserves the destination's high 64 bits, so it
+                    // carries a false dependency on the register's prior value.
+                    // In a loop that reuses the same xmm, this serialises the
+                    // conversion against the previous iteration. Break it with a
+                    // zeroing idiom (eliminated at register rename, zero latency).
+                    dynasm!(self.mc ; .arch x64 ; pxor Rx(dst.value), Rx(dst.value) ; cvtsi2sd Rx(dst.value), Rq(sr));
                 }
             }
             OpCode::CastFloatToInt => {
@@ -6273,8 +6278,11 @@ impl<'a> Assembler386<'a> {
     /// CAST_INT_TO_FLOAT: result = (f64)arg0
     fn genop_cast_int_to_float(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
+        // Break cvtsi2sd's false dependency on the destination's prior value
+        // (it preserves the high 64 bits) with a zeroing idiom.
         dynasm!(self.mc
             ; .arch x64
+            ; pxor xmm0, xmm0
             ; cvtsi2sd xmm0, rax
         );
         self.store_d0_to_result(op.pos.get());

--- a/rpython/jit/backend/x86/assembler.py
+++ b/rpython/jit/backend/x86/assembler.py
@@ -1471,6 +1471,11 @@ class Assembler386(BaseAssembler, VectorAssemblerMixin):
         self.mc.CVTTSD2SI(resloc, arglocs[0])
 
     def genop_cast_int_to_float(self, op, arglocs, resloc):
+        # CVTSI2SD preserves the high 64 bits of the destination, so it carries
+        # a false dependency on the register's prior value.  In a loop reusing
+        # the same XMM this serialises the conversion against the previous
+        # iteration; break it with a zeroing idiom (eliminated at rename).
+        self.mc.PXOR_xx(resloc.value, resloc.value)
         self.mc.CVTSI2SD(resloc, arglocs[0])
 
     def genop_cast_float_to_singlefloat(self, op, arglocs, resloc):


### PR DESCRIPTION
CVTSI2SD preserves the destination's high 64 bits, carrying a false dependency on the register's prior value. In a loop that reuses the same xmm this serialises the int->float conversion against the previous iteration. Emit a pxor zeroing idiom (eliminated at register rename) before the conversion to break it.

float_loop: dynasm 0.27s -> 0.14s (matches cranelift); nbody 0.44 -> 0.17s. Output unchanged: cvtsi2sd overwrites the low 64 bits, so zeroing the rest is semantically inert for scalar doubles.

- rpython/jit/backend/x86/assembler.py: PXOR before CVTSI2SD
- majit dynasm backend: same, both cast_int_to_float emission paths

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced performance of integer-to-float conversion operations on the x86_64 architecture by addressing register dependency issues that could cause performance degradation in loops and repeated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->