### PR TITLE
Short-preamble box-identity carry + canonical-box keystone (#47/#9)

### DIFF
--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1015,7 +1015,13 @@ impl GcRewriterImpl {
         // guard for the next iteration to pick up.
         let mut new_guard = op.clone();
         if let Some(fa) = new_guard.fail_args_mut() {
-            fa[idx] = Operand::Box(same_pos);
+            // `same_pos` is bound to the freshly-emitted SAME_AS producer
+            // (emit_result returns `from_bound_op`), so lower it to the
+            // live-tracking `Operand::Op` rather than a frozen position-only
+            // `Operand::Box` (#9): the failarg then auto-tracks the producer's
+            // `op.pos` if it is renumbered, matching RPython's box-identity
+            // failarg.
+            fa[idx] = Operand::from_boxref(&same_pos);
         }
         // pos is reassigned when emit/emit_result runs on the substituted op.
         new_guard.pos.set(OpRef::NONE);

--- a/majit/majit-ir/src/field_entry.rs
+++ b/majit/majit-ir/src/field_entry.rs
@@ -36,6 +36,14 @@ pub struct PreambleOp {
     /// RPython: PreambleOp.preamble_op — the actual replay operation
     /// for the short preamble. Always present (RPython parity).
     pub preamble_op: crate::resoperation::OpRc,
+    /// Original result box an invented SameAs name aliases — the
+    /// compound-dedup winner's `res`, threaded from
+    /// `ProducedShortOp.same_as_source`. Lets an imported pop reproduce the
+    /// builder map entry's `same_as(original)` at `add_preamble_op_from_pop`
+    /// instead of `same_as(invented_name)` (a self-alias). `None` for
+    /// non-invented entries (`invented_name == false`), where the SameAs
+    /// arm is never taken.
+    pub same_as_source: Option<crate::box_ref::BoxRef>,
 }
 
 /// RPython _fields[] element — either a concrete value or a PreambleOp sentinel.

--- a/majit/majit-ir/src/field_entry.rs
+++ b/majit/majit-ir/src/field_entry.rs
@@ -102,6 +102,19 @@ impl FieldEntry {
         }
     }
 
+    /// Box analog of [`as_seen_opref`](Self::as_seen_opref): the carried
+    /// `BoxRef` rather than its resolved `OpRef` position. Used where the
+    /// caller keys a box-identity (`Rc::ptr_eq`) map by the field's Phase 1
+    /// box — `_expand_infos_from_virtual` (export) and
+    /// `setinfo_from_preamble_list` (import) read the same shared virtual
+    /// info, so the returned boxes coincide by identity.
+    pub fn as_seen_box(&self) -> crate::box_ref::BoxRef {
+        match self {
+            FieldEntry::Value(b) => b.clone(),
+            FieldEntry::Preamble(pop) => pop.op.clone(),
+        }
+    }
+
     /// Consume and extract the `PreambleOp` if this is a `Preamble` entry.
     pub fn into_preamble(self) -> Option<PreambleOp> {
         match self {

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -493,6 +493,12 @@ impl PtrInfo {
                 FieldEntry::Preamble(pop) => {
                     pop.op.walk_const_ptr_refs(visitor);
                     pop.preamble_op.walk_const_ptr_refs_mut(visitor);
+                    // An invented ref-typed alias can carry a `ConstPtr`
+                    // `same_as_source`; walk it so a moving GC updates the
+                    // pointer before the cached preamble emits its `SameAs`.
+                    if let Some(src) = &pop.same_as_source {
+                        src.walk_const_ptr_refs(visitor);
+                    }
                 }
             }
         }

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1160,6 +1160,14 @@ pub trait BoxEnv {
     fn get_box_replacement_not_const(&self, opref: OpRef) -> OpRef {
         self.get_box_replacement(opref)
     }
+    /// resume.py:202 `box.get_box_replacement()` returning the canonical box
+    /// OBJECT, not just its OpRef. The resume-numbering maps (#160/S11
+    /// `LiveboxMap`, `cached_boxes`, `cached_virtuals`) key by box identity —
+    /// RPython's dict-by-`is` — so this must return the ONE canonical `Rc`
+    /// per logical box (memoized per producer `Op`/`InputArg` via `box_cache`)
+    /// so two reaches of one box compare `Rc::ptr_eq`. Const is classified by
+    /// `is_const` / `getconst` before any map insert and never reaches here.
+    fn get_box_replacement_boxref(&self, opref: OpRef) -> BoxRef;
     /// resume.py:204 — isinstance(box, Const)
     fn is_const(&self, opref: OpRef) -> bool;
     /// Constant value + type. Only valid when is_const returns true.

--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -63,7 +63,9 @@ pub fn serialize_optimizer_knowledge(
     let available_boxes: Vec<OpRef> = liveboxes
         .iter()
         .filter_map(|opt| *opt)
-        .filter(|opref| numb_state.liveboxes.contains_key(*opref))
+        // #160/S11: liveboxes is box-keyed; resolve each backend position to
+        // its canonical box for the membership probe.
+        .filter(|opref| numb_state.liveboxes.contains_key(&env.get_box_replacement_boxref(*opref)))
         .collect();
 
     // bridgeopt.py:74-88: known classes bitfield

--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -65,7 +65,11 @@ pub fn serialize_optimizer_knowledge(
         .filter_map(|opt| *opt)
         // #160/S11: liveboxes is box-keyed; resolve each backend position to
         // its canonical box for the membership probe.
-        .filter(|opref| numb_state.liveboxes.contains_key(&env.get_box_replacement_boxref(*opref)))
+        .filter(|opref| {
+            numb_state
+                .liveboxes
+                .contains_key(&env.get_box_replacement_boxref(*opref))
+        })
         .collect();
 
     // bridgeopt.py:74-88: known classes bitfield

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -405,7 +405,7 @@ impl CachedField {
             let mut op =
                 Op::with_descr(opcode, &[ctx.materialize_box_at(structbox)], descr.clone());
             op.pos.set(cached_val);
-            sb.add_heap_op(op);
+            sb.add_heap_op(ctx, op);
         }
     }
 }
@@ -654,7 +654,7 @@ impl ArrayCachedItem {
             let idx_b = ctx.materialize_box_at(idx_ref);
             let mut op = Op::with_descr(opcode, &[arraybox_b, idx_b], descr.clone());
             op.pos.set(cached_val);
-            sb.add_heap_op(op);
+            sb.add_heap_op(ctx, op);
         }
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4077,6 +4077,7 @@ mod tests {
                     op: BoxRef::from_opref(source),
                     invented_name: false,
                     preamble_op: std::rc::Rc::new(preamble_op),
+                    same_as_source: None,
                 },
             );
         })

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1669,14 +1669,18 @@ impl OptHeap {
             .map(|arg| ctx.resolve_box_box(&arg).to_opref())
             .collect();
         while let Some(owner) = stack.pop() {
+            // heap.py:173-174 resolves the owner through `get_box_replacement`
+            // at every use. A dependency recorded in `heapc_deps` carries the
+            // box that was canonical at escape time; its producer can be
+            // forwarded afterwards (`make_equal_to`), so re-resolve here before
+            // the dedup and the owner record, mirroring the canonical seed args.
+            let owner = ctx.get_replacement_opref(owner);
             if owners.contains(&owner) {
                 continue;
             }
             owners.push(owner);
             if let Some(owner_box) = ctx.get_box_replacement_box(owner) {
                 if let Some(deps) = self.heapc_deps.get(&owner_box) {
-                    // deps were stored as canonical boxes at escape_from_write,
-                    // so the position view is already the canonical OpRef.
                     stack.extend(deps.iter().map(|dep| dep.to_opref()));
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1874,6 +1874,7 @@ mod tests {
             op: BoxRef::from_opref(OpRef::int_op(88)),
             invented_name: false,
             preamble_op: std::rc::Rc::new(replay),
+            same_as_source: None,
         };
         info.set_preamble_item(1, pop.clone());
 
@@ -1903,6 +1904,7 @@ mod tests {
             op: BoxRef::from_opref(OpRef::int_op(88)),
             invented_name: false,
             preamble_op: std::rc::Rc::new(replay),
+            same_as_source: None,
         };
         info.set_preamble_field(3, pop);
 

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -3362,6 +3362,15 @@ impl Optimization for OptIntBounds {
                 .get_box_replacement_box(arg)
                 .map(|b| b.to_opref())
                 .unwrap_or(arg);
+            // optimizer.py:118-119 `setintbound`: an IntBound is never stored
+            // on a Const (history.py:220 a Const carries its value inline);
+            // unroll.py:483 likewise skips Const args when exporting info, so
+            // a Const resolved arg has no preamble bound to carry across the
+            // peel boundary. The consumer already recovers a Const's bound via
+            // `synthesize_const_info` before this table is consulted.
+            if resolved.is_constant() {
+                continue;
+            }
             if !matches!(ctx.opref_type(resolved), Some(majit_ir::Type::Int)) {
                 continue;
             }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2896,7 +2896,7 @@ impl OptContext {
         result_map: &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
         mut imported_constants: &mut crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef>,
         exported_infos: &crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            crate::r#box::BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
     ) -> bool {
@@ -2977,7 +2977,17 @@ impl OptContext {
             }
         };
         for (source, produced_op) in short_boxes {
-            if let Some(info) = exported_infos.get(source) {
+            // shortpreamble.py:417-421: op = produced_op.short_op.res;
+            //     if isinstance(op, Const): info = optimizer.getinfo(op)
+            //     else: info = exported_infos.get(op, None)
+            // Look up by the result BOX (`produced_op.res`) — the exporter keyed
+            // `_expand_info(produced_op.res)` by the same Rc (cloned from the
+            // shared `exported_short_boxes` entry), so the box-identity lookup
+            // hits. Const results are skipped (unroll.py:483 export skips them).
+            if produced_op.res.to_opref().is_constant() {
+                continue;
+            }
+            if let Some(info) = exported_infos.get(&produced_op.res) {
                 self.set_preamble_forwarded_info(replay_pos(*source, produced_op), info);
             }
         }
@@ -3641,7 +3651,7 @@ impl OptContext {
         op: OpRef,
         preamble_info_handle: &std::rc::Rc<std::cell::RefCell<PtrInfo>>,
         exported_infos: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::info::OpInfo>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, crate::optimizeopt::info::OpInfo>,
         >,
     ) {
         let op = self.get_replacement_opref(op);
@@ -3683,20 +3693,23 @@ impl OptContext {
                 ));
             }
             if let Some(infos) = exported_infos {
-                let items: Vec<OpRef> = match &*preamble_info_handle.borrow() {
-                    PtrInfo::Virtual(v) => v.fields.iter().map(|(_, r)| r.to_opref()).collect(),
-                    PtrInfo::VirtualArray(a) => a.items.iter().map(|b| b.to_opref()).collect(),
-                    PtrInfo::VirtualStruct(s) => {
-                        s.fields.iter().map(|(_, r)| r.to_opref()).collect()
-                    }
-                    PtrInfo::VirtualArrayStruct(a) => a
-                        .element_fields
-                        .iter()
-                        .flat_map(|row| row.iter().map(|(_, r)| r.to_opref()))
-                        .collect(),
-                    PtrInfo::VirtualRawBuffer(r) => r.buffer.values(),
-                    _ => Vec::new(),
-                };
+                // unroll.py:61-62: setinfo_from_preamble_list(
+                //     preamble_info.all_items(), exported_infos).
+                // Read field BOXES via `all_items()` — the SAME accessor the
+                // exporter (`_expand_infos_from_virtual`) walks on this shared
+                // `PtrInfo` cell, so the box-identity (`Rc::ptr_eq`) lookup hits.
+                // Using `all_items()` (not a per-variant arm) keeps export/import
+                // symmetric: `VirtualRawBuffer`/`VirtualArrayStruct` return `[]`
+                // here exactly as on the export side (RPython
+                // `RawBufferPtrInfo.all_items()` is also empty), so the import
+                // never iterates raw-buffer slots and never calls
+                // `clear_forwarded` on a `from_opref`-minted unbound box.
+                let items: Vec<crate::r#box::BoxRef> = preamble_info_handle
+                    .borrow()
+                    .all_items()
+                    .iter()
+                    .map(|(_, e)| e.as_seen_box())
+                    .collect();
                 self.setinfo_from_preamble_list(&items, infos);
             }
             return;
@@ -3796,36 +3809,36 @@ impl OptContext {
     /// logic, so this method becomes the literal unroll.py loop body.
     fn setinfo_from_preamble_list(
         &mut self,
-        items: &[OpRef],
+        items: &[crate::r#box::BoxRef],
         exported_infos: &crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            crate::r#box::BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
     ) {
-        for &item in items {
-            if item.is_none() {
+        for item in items {
+            // unroll.py:42-43: if item is None: continue
+            if item.to_opref().is_none() {
                 continue;
             }
-            // unroll.py:45-46: i = infos.get(item, None)
-            match exported_infos.get(&item).cloned() {
+            // unroll.py:45-46: i = infos.get(item, None) — keyed by the field
+            // box. `item` is read from the SAME shared virtual `PtrInfo` that
+            // the exporter walked (`_expand_infos_from_virtual`), so the
+            // box-identity (`Rc::ptr_eq`) lookup hits exactly when RPython's
+            // box-keyed dict does.
+            match exported_infos.get(item).cloned() {
                 Some(info) => {
                     // unroll.py:47: self.setinfo_from_preamble(item, i, infos)
-                    self.setinfo_from_preamble_item(item, &info, exported_infos);
+                    self.setinfo_from_preamble_item(item.to_opref(), &info, exported_infos);
                 }
                 None => {
                     // unroll.py:49: item.set_forwarded(None)
-                    // "let's not inherit stuff we don't know anything about"
-                    // Clears `item`'s OWN slot, not the chain terminal —
-                    // `resolve_to_boxref` returns the BoxRef bound to item's
-                    // canonical `_forwarded` host directly, without
-                    // `get_box_replacement` walking. For a const-namespace
-                    // OpRef it returns a fresh `BoxRef::new_const` whose
-                    // `clear_forwarded` is a no-op (Const has no
-                    // `_forwarded`), matching RPython where
-                    // `Const.set_forwarded` raises.
-                    if let Some(b) = self.resolve_to_boxref(item) {
-                        b.clear_forwarded();
-                    }
+                    // "let's not inherit stuff we don't know anything about".
+                    // Clears `item`'s OWN forwarded slot directly — `item` is
+                    // the raw field box (RPython passes the unresolved
+                    // `all_items()` box here). `clear_forwarded` is a no-op for
+                    // a Const box (Const has no `_forwarded`), matching RPython
+                    // where `Const.set_forwarded` raises.
+                    item.clear_forwarded();
                 }
             }
         }
@@ -3843,7 +3856,7 @@ impl OptContext {
         op: OpRef,
         preamble_info: &crate::optimizeopt::info::OpInfo,
         exported_infos: &crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            crate::r#box::BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
     ) {
@@ -3913,7 +3926,7 @@ impl OptContext {
         op: OpRef,
         preamble_info: &crate::optimizeopt::info::OpInfo,
         exported_infos: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::info::OpInfo>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, crate::optimizeopt::info::OpInfo>,
         >,
     ) {
         use crate::optimizeopt::info::OpInfo;

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4354,6 +4354,16 @@ impl OptContext {
     /// matching upstream totality and the `a-producerless` arm of
     /// `classify_s9_fallback` ("an unforwarded box returns itself").
     pub fn get_box_replacement(&self, opref: OpRef) -> crate::r#box::BoxRef {
+        // The sentinel `OpRef::none()` (absent operand: empty fail_arg slot,
+        // unset lazy setfield) is not a value-bearing position — its total
+        // resolution is the `none()` box itself, which `from_opref` already
+        // round-trips below. Resolve it here so the "box must exist" assert
+        // and the `s9_probe`/`from_opref` fallback apply only to value-bearing
+        // positions, matching the explicit NONE handling in `resolve_to_boxref`
+        // / `materialize_box_at` / `clear_forwarded`.
+        if opref.is_none() {
+            return crate::r#box::BoxRef::none();
+        }
         if let Some(b) = self.get_box_replacement_box(opref) {
             return b;
         }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -435,6 +435,7 @@ impl ImportedShortPureOp {
         result: OpRef,
         source: OpRef,
         invented_name: bool,
+        same_as_source: Option<crate::r#box::BoxRef>,
     ) -> Self {
         let replay_args: Vec<OpRef> = args
             .iter()
@@ -500,6 +501,7 @@ impl ImportedShortPureOp {
                 op: pop_op,
                 invented_name,
                 preamble_op: std::rc::Rc::new(replay),
+                same_as_source,
             },
         }
     }
@@ -10299,6 +10301,7 @@ mod imported_short_preamble_fallback_tests {
             op: crate::r#box::BoxRef::from_opref(OpRef::int_op(41)),
             invented_name: false,
             preamble_op: std::rc::Rc::new(replay_op),
+            same_as_source: None,
         };
 
         let forced = ctx.force_op_from_preamble_op(&pop);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3695,7 +3695,10 @@ impl OptContext {
         op: OpRef,
         preamble_info_handle: &std::rc::Rc<std::cell::RefCell<PtrInfo>>,
         exported_infos: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, crate::optimizeopt::info::OpInfo>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<
+                crate::r#box::BoxRef,
+                crate::optimizeopt::info::OpInfo,
+            >,
         >,
     ) {
         let op = self.get_replacement_opref(op);
@@ -3970,7 +3973,10 @@ impl OptContext {
         op: OpRef,
         preamble_info: &crate::optimizeopt::info::OpInfo,
         exported_infos: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, crate::optimizeopt::info::OpInfo>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<
+                crate::r#box::BoxRef,
+                crate::optimizeopt::info::OpInfo,
+            >,
         >,
     ) {
         use crate::optimizeopt::info::OpInfo;

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -937,6 +937,24 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
         self.ctx.get_replacement_opref(opref)
     }
 
+    fn get_box_replacement_boxref(&self, opref: OpRef) -> crate::r#box::BoxRef {
+        // resume.py:202 box.get_box_replacement() as a box OBJECT. The canonical
+        // host is the producer Op / InputArg, so two reaches of one logical box
+        // return the same memoized Rc (ptr_eq) — the #160/S11 livebox dedup key.
+        self.ctx.get_box_replacement_box(opref).unwrap_or_else(|| {
+            // #160/S11 tripwire: a non-Const numbering key that resolves through
+            // the from_opref fallback would mint a fresh, non-ptr_eq box and
+            // corrupt the livebox dedup. #157 drained these fires to zero;
+            // PYRE_S11_TRIPWIRE surfaces any regression across the corpus.
+            if std::env::var_os("PYRE_S11_TRIPWIRE").is_some() {
+                eprintln!(
+                    "[s11-tripwire] get_box_replacement_boxref from_opref fallback on {opref:?}"
+                );
+            }
+            crate::r#box::BoxRef::from_opref(self.ctx.get_replacement_opref(opref))
+        })
+    }
+
     fn get_box_replacement_not_const(&self, opref: OpRef) -> OpRef {
         // resoperation.py:64-65 not_const arm. The resume liveboxes boundary
         // is legitimately OpRef-keyed (rd_numb wire format), so resolve

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2839,27 +2839,40 @@ impl OptContext {
         short_inputargs: &[crate::r#box::BoxRef],
         exported_short_boxes: &[crate::optimizeopt::shortpreamble::PreambleOp],
     ) {
-        let produced: Vec<(OpRef, crate::optimizeopt::shortpreamble::ProducedShortOp)> =
-            exported_short_boxes
-                .iter()
-                .map(|entry| {
-                    // `materialize_box_at`, not `from_bound_op`: a
-                    // const-folded entry carries an inline-Const pos,
-                    // which resolves to its Const box.
-                    let res = self.materialize_box_at(entry.op.pos.get());
-                    (
-                        entry.op.pos.get(),
-                        crate::optimizeopt::shortpreamble::ProducedShortOp {
-                            kind: entry.kind.clone(),
-                            res,
-                            preamble_op: std::rc::Rc::new((*entry.op).clone()),
-                            invented_name: entry.invented_name,
-                            same_as_source: entry.same_as_source.clone(),
-                        },
-                    )
-                })
-                .collect();
-        let mut builder = crate::optimizeopt::shortpreamble::ShortPreambleBuilder::new(
+        let produced: Vec<(
+            crate::r#box::BoxRef,
+            crate::optimizeopt::shortpreamble::ProducedShortOp,
+        )> = exported_short_boxes
+            .iter()
+            .map(|entry| {
+                // `materialize_box_at`, not `from_bound_op`: a
+                // const-folded entry carries an inline-Const pos,
+                // which resolves to its Const box. The map keys by this res
+                // box (#146/S8); the single-op re-export lookup (pure.rs)
+                // reproduces it via `materialize_box_at(source)`.
+                //
+                // materialize_box_at is NON-idempotent for an unregistered
+                // ResOp pos: the first call mints a fresh `new_resop` box and
+                // registers a synthetic producer; subsequent calls resolve
+                // that synthetic to a stable `from_bound_op` box. The lookup is
+                // itself a subsequent call, so the warm-up call registers the
+                // synthetic and the second (stable) box is the real key.
+                let pos = entry.op.pos.get();
+                let _ = self.materialize_box_at(pos);
+                let res = self.materialize_box_at(pos);
+                (
+                    res.clone(),
+                    crate::optimizeopt::shortpreamble::ProducedShortOp {
+                        kind: entry.kind.clone(),
+                        res,
+                        preamble_op: std::rc::Rc::new((*entry.op).clone()),
+                        invented_name: entry.invented_name,
+                        same_as_source: entry.same_as_source.clone(),
+                    },
+                )
+            })
+            .collect();
+        let builder = crate::optimizeopt::shortpreamble::ShortPreambleBuilder::new(
             label_args,
             &produced,
             short_inputargs,
@@ -2992,7 +3005,17 @@ impl OptContext {
             }
         }
 
+        // `produced` (OpRef dual-key: source + result_opref) is internal
+        // scaffolding for `dep_or_materialize` below, which resolves a
+        // dependency arg by its replay position. `builder_entries` is the
+        // #146/S8 builder map: ONE entry per short box keyed by the Phase-1
+        // carried res box (`produced_op.res`, the same Rc the produce loop
+        // reads as `self.res`). The carried box is invariant to the
+        // invented-name replay-position aliasing the dual key compensates for,
+        // so the builder map collapses to a single box-identity key.
         let mut produced: Vec<(OpRef, ProducedShortOp)> = Vec::with_capacity(short_boxes.len());
+        let mut builder_entries: Vec<(crate::r#box::BoxRef, ProducedShortOp)> =
+            Vec::with_capacity(short_boxes.len());
         let mut produced_results: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef> =
             crate::optimizeopt::vec_assoc::VecAssoc::new();
         // shortpreamble.py:PreambleOp.add_op_to_short — Pure ops whose
@@ -3112,6 +3135,7 @@ impl OptContext {
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),
                     };
+                    builder_entries.push((produced_op.res.clone(), new_pop.clone()));
                     produced.push((*source, new_pop.clone()));
                     if *source != result_opref {
                         produced.push((result_opref, new_pop));
@@ -3196,6 +3220,7 @@ impl OptContext {
                         }
                         _ => continue,
                     };
+                    builder_entries.push((produced_op.res.clone(), new_pop.clone()));
                     produced.push((*source, new_pop.clone()));
                     if *source != result_opref {
                         produced.push((result_opref, new_pop));
@@ -3230,6 +3255,7 @@ impl OptContext {
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),
                     };
+                    builder_entries.push((produced_op.res.clone(), new_pop.clone()));
                     produced.push((*source, new_pop.clone()));
                     if *source != result_opref {
                         produced.push((result_opref, new_pop));
@@ -3240,7 +3266,7 @@ impl OptContext {
             }
         }
 
-        let mut builder = ShortPreambleBuilder::new(short_args, &produced, short_inputargs);
+        let mut builder = ShortPreambleBuilder::new(short_args, &builder_entries, short_inputargs);
         for &opref in imported_constants.values() {
             builder.note_known_constant(opref);
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3351,8 +3351,23 @@ impl Optimizer {
                     remap_opref(&mut opref);
                     *arg = crate::r#box::BoxRef::from_opref(opref);
                 };
-                for arg in &mut state.next_iteration_args {
-                    remap_boxref(arg);
+                // next_iteration_args now carries the canonical Phase-1 boxes that
+                // double as exported_infos keys. Remap by `set_position` (as
+                // short_inputargs below) to preserve box identity across
+                // compaction: a `from_opref` re-mint would sever the ptr_eq carry
+                // that import_state's exported_infos lookup depends on.
+                for arg in &state.next_iteration_args {
+                    let opref = arg.to_opref();
+                    // Const args carry their value inline (no body position):
+                    // `set_position` is a Const no-op and `opref.raw()` panics on
+                    // an inline-Const OpRef, so skip them. Their Rc identity (the
+                    // exported_infos key) is preserved untouched.
+                    if opref.is_constant() {
+                        continue;
+                    }
+                    let mut opref = opref;
+                    remap_opref(&mut opref);
+                    arg.set_position(opref.raw());
                 }
                 for arg in &mut state.end_args {
                     remap_boxref(arg);
@@ -3369,19 +3384,13 @@ impl Optimizer {
                     remap_opref(&mut opref);
                     arg.set_position(opref.raw());
                 }
-                // Remap exported_infos keys (Const keys pass through)
-                let old_infos = std::mem::take(&mut state.exported_infos);
-                for (key, value) in old_infos {
-                    let new_key = if key.is_constant() {
-                        key
-                    } else {
-                        remap
-                            .get(&key.raw())
-                            .map(|&p| key.with_raw(p))
-                            .unwrap_or(key)
-                    };
-                    state.exported_infos.insert(new_key, value);
-                }
+                // exported_infos is keyed by box identity (Rc::ptr_eq), so its keys
+                // need NO position remap — the lookup matches by Rc, not OpRef. The
+                // keys are the same Rcs as next_iteration_args (for end_args) /
+                // bound producer boxes (for label/short-box args), whose positions
+                // already moved through the shared set_position Cell above; a
+                // mem::take + re-insert under a remapped OpRef would only re-mint
+                // fresh non-ptr_eq keys and break the carry.
                 // Remap exported short boxes
                 for entry in &mut state.exported_short_boxes {
                     // Cell::get() returns a copy; the previous

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -67,12 +67,13 @@ pub struct Optimizer {
     last_guard_op_idx: Option<usize>,
     /// optimizer.py:241/304/632-634 `replaces_guard` — maps an emitted
     /// guard op to its replacement. RPython keys this dict by the guard
-    /// `op` object itself (object identity); pyre keys by `op.pos:
-    /// OpRef`. The parity invariant is that `alloc_op_position` issues
-    /// a fresh OpRef per emitted guard so OpRef → Op is bijective on
-    /// the guard subspace, matching RPython's object-identity keying.
-    /// No site re-uses an OpRef across distinct guard ops.
-    replaces_guard: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, Op>,
+    /// `op` object itself (object identity); pyre keys by the guard op's
+    /// canonical box (`BoxRef`, compared by `Rc::ptr_eq`), the box-identity
+    /// analog of `op is op`. Every key is resolved through
+    /// `ctx.get_box_replacement(op.pos)` so insert and lookup agree on the
+    /// canonical box. Guard ops are never Const, so the key is always a
+    /// ptr-stable ResOp box.
+    replaces_guard: crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, Op>,
     /// optimizer.py: `pendingfields` — heap fields that need to be
     /// written back before the next guard (lazy set forcing).
     pendingfields: Vec<Op>,
@@ -202,8 +203,10 @@ pub struct Optimizer {
     /// at `setup_optimizations` time.
     pub cpu: std::sync::Arc<dyn crate::cpu::Cpu>,
     /// optimizer.py:246 `self._emittedoperations = {}`. Tracks the
-    /// set of OpRefs the optimizer has emitted (or that
-    /// `replace_guard_op` substituted in place of an emitted op).
+    /// set of ops the optimizer has emitted (or that `replace_guard_op`
+    /// substituted in place of an emitted op). RPython keys this set by
+    /// the op object (`op in self._emittedoperations` is identity-keyed);
+    /// pyre keys by the emitted op's canonical box (`BoxRef`, `Rc::ptr_eq`).
     /// Populated at:
     /// - `emit_operation` after `ctx.emit` (optimizer.py:674
     ///   `self._emittedoperations[op] = None` inside _emit_operation).
@@ -212,11 +215,10 @@ pub struct Optimizer {
     ///
     /// Read by `as_operation(opref, required_opnum)` (optimizer.py:369-377)
     /// which returns the opref iff it has been emitted *and* its opcode
-    /// matches the optional `required_opnum`. Used by callers that need
-    /// to verify an OpRef refers to an actually-emitted op before
-    /// reasoning about descriptor-shared guards or other emit-bound
-    /// metadata.
-    pub emitted_operations: majit_ir::vec_set::VecSet<OpRef>,
+    /// matches the optional `required_opnum`. The lookup resolves the
+    /// queried opref through `ctx.get_box_replacement` so it compares the
+    /// same canonical box the insert recorded.
+    pub emitted_operations: majit_ir::vec_set::VecSet<BoxRef>,
     /// One-shot explicit `input_ops` seed for the next
     /// `optimize_with_constants_and_inputs_at` run. When `Some`, the
     /// canonical producer `Rc<Op>` slice is used directly as
@@ -1220,9 +1222,17 @@ impl Optimizer {
 
     /// optimizer.py: notice_guard_future_condition(op)
     /// Record that a guard at the given position should be replaced
-    /// with the given op when the future condition is realized.
-    pub fn notice_guard_future_condition(&mut self, guard_pos: OpRef, replacement: Op) {
-        self.replaces_guard.insert(guard_pos, replacement);
+    /// with the given op when the future condition is realized. Keyed by
+    /// the replaced guard's canonical box (`ctx.get_box_replacement`) so
+    /// the emit-time lookup compares the same box.
+    pub fn notice_guard_future_condition(
+        &mut self,
+        ctx: &OptContext,
+        guard_pos: OpRef,
+        replacement: Op,
+    ) {
+        self.replaces_guard
+            .insert(ctx.get_box_replacement(guard_pos), replacement);
     }
 
     /// optimizer.py:713: replace_guard_op(old_op_pos, new_op)
@@ -1232,10 +1242,12 @@ impl Optimizer {
     /// the new guard takes over the emit identity, so it must enter
     /// the emit set even though it was substituted post-hoc rather
     /// than directly emitted via `_emit_operation`.
-    pub fn replace_guard_op(&mut self, old_pos: OpRef, new_guard: Op) {
+    pub fn replace_guard_op(&mut self, ctx: &OptContext, old_pos: OpRef, new_guard: Op) {
         let new_pos = new_guard.pos.get();
-        self.replaces_guard.insert(old_pos, new_guard);
-        self.emitted_operations.insert(new_pos);
+        self.replaces_guard
+            .insert(ctx.get_box_replacement(old_pos), new_guard);
+        self.emitted_operations
+            .insert(ctx.get_box_replacement(new_pos));
     }
 
     /// optimizer.py:369-377 `as_operation(op, required_opnum=-1)`:
@@ -1266,7 +1278,10 @@ impl Optimizer {
                 return None;
             }
         }
-        if self.emitted_operations.contains(&opref) {
+        if self
+            .emitted_operations
+            .contains(&ctx.get_box_replacement(opref))
+        {
             Some(opref)
         } else {
             None
@@ -4239,7 +4254,10 @@ impl Optimizer {
 
             // optimizer.py:632-635: replaces_guard check BEFORE emit_guard_operation.
             if self.can_replace_guards {
-                if let Some(replacement) = self.replaces_guard.remove(&op.pos.get()) {
+                if let Some(replacement) = self
+                    .replaces_guard
+                    .remove(&ctx.get_box_replacement(op.pos.get()))
+                {
                     let target_pos = replacement.pos.get().raw() as usize;
                     if target_pos < ctx.new_operations.len() {
                         if std::env::var_os("MAJIT_LOG").is_some() {
@@ -4321,8 +4339,10 @@ impl Optimizer {
         // optimizer.py:674 `self._emittedoperations[op] = None` — record
         // the freshly emitted op so `as_operation` can later confirm it
         // is in the emit set before downstream callers reason about
-        // descriptor-sharing or other emit-bound state.
-        self.emitted_operations.insert(emitted);
+        // descriptor-sharing or other emit-bound state. Keyed by the
+        // emitted op's canonical box (the box-identity analog of `op`).
+        self.emitted_operations
+            .insert(ctx.get_box_replacement(emitted));
         // optimizer.py:84-92 `_emit_operation` clears the REMOVED
         // sentinel on each successful emit. Cross-pass readers
         // (rewrite.py:712-718 `optimize_GUARD_NO_EXCEPTION`) see the

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3262,17 +3262,18 @@ impl Optimizer {
                     if arg.is_constant() {
                         continue;
                     }
-                    if let Some(&new_pos) = remap.get(&arg.raw()) {
-                        // Measured dead (PYRE_REMAP_PROBE 2026-06-11: 0 fires
-                        // across check.py corpus + lib tests) — every
-                        // non-const operand reaching const-compact is
-                        // producer-bound. The rewrite stays as a safety net
-                        // until the loop retires with OpRef demotion (#9).
-                        debug_assert!(
-                            false,
+                    // A non-const operand reaching const-compact is always
+                    // producer-bound (skipped by `arg_is_bound` above), so a
+                    // position-only operand at a remapped slot is unreachable
+                    // (PYRE_REMAP_PROBE 2026-06-11: 0 fires across check.py
+                    // corpus + lib tests). The #9 grind retires the
+                    // position-only rewrite; a hard guard replaces it so any
+                    // regression panics instead of silently minting a stale
+                    // position-only box.
+                    if remap.contains_key(&arg.raw()) {
+                        unreachable!(
                             "position-only non-const operand hit const-compact remap: {arg:?}"
                         );
-                        op.setarg(i, BoxRef::from_opref(arg.with_raw(new_pos)));
                     }
                 }
                 if let Some(fail_args) = op.fail_args.borrow_mut().as_mut() {
@@ -3286,18 +3287,11 @@ impl Optimizer {
                             continue;
                         }
                         let arg_opref = arg.to_opref();
-                        if !arg_opref.is_constant() {
-                            if let Some(&new_pos) = remap.get(&arg_opref.raw()) {
-                                // Measured dead, same evidence as the args
-                                // loop above.
-                                debug_assert!(
-                                    false,
-                                    "position-only failarg hit const-compact remap: {arg_opref:?}"
-                                );
-                                *arg = majit_ir::operand::Operand::from_boxref(
-                                    &BoxRef::from_opref(arg_opref.with_raw(new_pos)),
-                                );
-                            }
+                        // Unreachable, same evidence as the args loop above.
+                        if !arg_opref.is_constant() && remap.contains_key(&arg_opref.raw()) {
+                            unreachable!(
+                                "position-only failarg hit const-compact remap: {arg_opref:?}"
+                            );
                         }
                     }
                 }
@@ -3382,15 +3376,16 @@ impl Optimizer {
                         let mut arg = entry.op.arg(i).to_opref();
                         let pre = arg;
                         remap_opref(&mut arg);
-                        // Measured dead (PYRE_REMAP_PROBE 2026-06-11): no
-                        // position-only exported-short-box operand was ever
-                        // remapped; rewrite kept as a safety net until the
-                        // loop retires with OpRef demotion (#9).
-                        debug_assert!(
+                        // A position-only exported-short-box operand is never
+                        // remapped (PYRE_REMAP_PROBE 2026-06-11: 0 fires), so
+                        // its frozen position stays valid and needs no rewrite.
+                        // A hard guard replaces the position-only re-mint (#9):
+                        // any regression panics instead of silently leaving a
+                        // stale position.
+                        assert!(
                             arg == pre,
                             "position-only exported-short-box arg remapped: {pre:?}"
                         );
-                        entry.op.setarg(i, BoxRef::from_opref(arg));
                     }
                     if let Some(fa) = entry.op.fail_args.borrow_mut().as_mut() {
                         for arg in fa.iter_mut() {
@@ -3403,14 +3398,13 @@ impl Optimizer {
                             let mut arg_opref = arg.to_opref();
                             let pre = arg_opref;
                             remap_opref(&mut arg_opref);
-                            // Measured dead, same evidence as the args loop.
-                            debug_assert!(
+                            // Never remapped (same evidence) — frozen position
+                            // stays valid, no rewrite; a hard guard replaces the
+                            // position-only re-mint (#9).
+                            assert!(
                                 arg_opref == pre,
                                 "position-only exported-short-box failarg remapped: {pre:?}"
                             );
-                            *arg = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(
-                                arg_opref,
-                            ));
                         }
                     }
                     // same_as_source: same rule as res below — the stored

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -6511,6 +6511,7 @@ mod tests {
                     op.pos.set(OpRef::op_typed(14, op.result_type()));
                     std::rc::Rc::new(op)
                 },
+                same_as_source: None,
             },
         );
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1220,19 +1220,24 @@ impl Optimizer {
         self.last_guard_op_idx
     }
 
-    /// optimizer.py: notice_guard_future_condition(op)
-    /// Record that a guard at the given position should be replaced
-    /// with the given op when the future condition is realized. Keyed by
-    /// the replaced guard's canonical box (`ctx.get_box_replacement`) so
-    /// the emit-time lookup compares the same box.
+    /// optimizer.py:307 replace_guard: `self.replaces_guard[op] = value.last_guard_pos`.
+    /// Record that a guard at the given position should be replaced when the
+    /// future condition is realized. PyPy keys `replaces_guard` by the raw `op`
+    /// object identity, and `_emit_operation` (optimizer.py:660) looks it up by
+    /// the raw `orig_op` — both before `get_box_replacement`. `resolve_to_boxref`
+    /// yields that producer box (chain root, before `_forwarded`), so insert and
+    /// the emit-time lookup compare the same raw box.
+    /// (The method keeps its historical name; the body performs replace_guard's
+    /// insert.)
     pub fn notice_guard_future_condition(
         &mut self,
         ctx: &OptContext,
         guard_pos: OpRef,
         replacement: Op,
     ) {
-        self.replaces_guard
-            .insert(ctx.get_box_replacement(guard_pos), replacement);
+        if let Some(box_ref) = ctx.resolve_to_boxref(guard_pos) {
+            self.replaces_guard.insert(box_ref, replacement);
+        }
     }
 
     /// optimizer.py:713: replace_guard_op(old_op_pos, new_op)
@@ -1244,8 +1249,14 @@ impl Optimizer {
     /// than directly emitted via `_emit_operation`.
     pub fn replace_guard_op(&mut self, ctx: &OptContext, old_pos: OpRef, new_guard: Op) {
         let new_pos = new_guard.pos.get();
-        self.replaces_guard
-            .insert(ctx.get_box_replacement(old_pos), new_guard);
+        // replaces_guard is keyed by the raw `op` identity (optimizer.py:307),
+        // so resolve to the producer box without following `_forwarded`.
+        if let Some(box_ref) = ctx.resolve_to_boxref(old_pos) {
+            self.replaces_guard.insert(box_ref, new_guard);
+        }
+        // optimizer.py:747 `self._emittedoperations[new_op] = None` — new_op is
+        // the canonical (get_box_replacement'd) emitted op, so this insert stays
+        // canonical, matching the emit-set keying in `_emit_operation`.
         self.emitted_operations
             .insert(ctx.get_box_replacement(new_pos));
     }
@@ -1278,13 +1289,14 @@ impl Optimizer {
                 return None;
             }
         }
-        if self
-            .emitted_operations
-            .contains(&ctx.get_box_replacement(opref))
-        {
-            Some(opref)
-        } else {
-            None
+        // optimizer.py:374 `if op in self._emittedoperations` keys by the op's
+        // own (raw) identity, not its forwarded replacement. `resolve_to_boxref`
+        // is the producer box (chain root, before `_forwarded`); the emit set is
+        // populated with the canonical box, so this matches iff the raw op is the
+        // canonical op — exactly PyPy's `op in _emittedoperations`.
+        match ctx.resolve_to_boxref(opref) {
+            Some(box_ref) if self.emitted_operations.contains(&box_ref) => Some(opref),
+            _ => None,
         }
     }
 
@@ -4253,10 +4265,13 @@ impl Optimizer {
             // and clears it.
 
             // optimizer.py:632-635: replaces_guard check BEFORE emit_guard_operation.
+            // optimizer.py:660 `orig_op in self.replaces_guard` keys by the raw
+            // `orig_op` identity (before get_box_replacement), so resolve to the
+            // producer box without following `_forwarded`.
             if self.can_replace_guards {
-                if let Some(replacement) = self
-                    .replaces_guard
-                    .remove(&ctx.get_box_replacement(op.pos.get()))
+                if let Some(replacement) = ctx
+                    .resolve_to_boxref(op.pos.get())
+                    .and_then(|box_ref| self.replaces_guard.remove(&box_ref))
                 {
                     let target_pos = replacement.pos.get().raw() as usize;
                     if target_pos < ctx.new_operations.len() {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1664,7 +1664,8 @@ impl Optimizer {
     /// The exported loop state should record the boxes that survive the end of
     /// the preamble after virtuals have been forced into a loop-carried shape.
     pub fn force_at_the_end_of_preamble(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
-        let mut rec: majit_ir::vec_set::VecSet<OpRef> = majit_ir::vec_set::VecSet::new();
+        let mut rec: majit_ir::vec_set::VecSet<crate::r#box::BoxRef> =
+            majit_ir::vec_set::VecSet::new();
         self.force_at_the_end_of_preamble_rec(opref, ctx, &mut rec)
     }
 
@@ -1672,7 +1673,7 @@ impl Optimizer {
         &mut self,
         opref: OpRef,
         ctx: &mut OptContext,
-        rec: &mut majit_ir::vec_set::VecSet<OpRef>,
+        rec: &mut majit_ir::vec_set::VecSet<crate::r#box::BoxRef>,
     ) -> OpRef {
         let resolved = ctx.get_replacement_opref(opref);
         let resolved_box = ctx.get_box_replacement_box(opref);
@@ -1710,10 +1711,16 @@ impl Optimizer {
                 | crate::optimizeopt::info::PtrInfo::VirtualArray(_)
                 | crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(_)
         ) {
-            if rec.contains(&resolved) {
+            // info.py:231 `rec[self] = None` keys the recursion guard by the
+            // virtual's PtrInfo object identity; in pyre one virtual head box
+            // <-> one PtrInfo, so key by the canonical resolved box.
+            let resolved_box_key = resolved_box
+                .clone()
+                .expect("virtual PtrInfo implies a resolved box");
+            if rec.contains(&resolved_box_key) {
                 return resolved;
             }
-            rec.insert(resolved);
+            rec.insert(resolved_box_key);
             info.force_at_the_end_of_preamble(|child| {
                 self.force_at_the_end_of_preamble_rec(child, ctx, rec)
             });

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1342,11 +1342,13 @@ mod tests {
             let source_box = ctx.materialize_box_at(source);
             // Production threads the builder's replay Rc into the pop
             // (produce_op family); mirror that here so use_box receives
-            // the same object the builder entry carries.
+            // the same object the builder entry carries. The builder keys by
+            // its entry res (`materialize_box_at(pos)`); `source_box` is the
+            // memoized box for the same position, so the lookup hits.
             let replay = ctx
                 .imported_short_preamble_builder
                 .as_ref()
-                .and_then(|b| b.produced_short_op(source))
+                .and_then(|b| b.produced_short_op(&source_box))
                 .map(|p| p.preamble_op)
                 .unwrap_or_else(|| {
                     let mut same_as = Op::new(OpCode::SameAsI, &[source_box.clone()]);
@@ -2753,11 +2755,14 @@ mod tests {
             Some(1),
         );
         // Production threads the builder's replay Rc into the pop
-        // (produce_pure); mirror it so use_box sees one object.
+        // (produce_pure); mirror it so use_box sees one object. #146/S8: the
+        // builder keys by the entry res box (`materialize_box_at(pos)`); the
+        // memoized box for the same position hits.
+        let src1 = ctx.materialize_box_at(OpRef::int_op(1));
         if let Some(p) = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(OpRef::int_op(1)))
+            .and_then(|b| b.produced_short_op(&src1))
         {
             imported.pop.preamble_op = p.preamble_op;
         }

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1297,10 +1297,10 @@ impl Optimization for OptPure {
     fn produce_potential_short_preamble_ops(
         &self,
         sb: &mut crate::optimizeopt::shortpreamble::ShortBoxes,
-        _ctx: &mut OptContext,
+        ctx: &mut OptContext,
     ) {
         for op in &self.short_preamble_pure_ops {
-            sb.add_pure_op(op.clone());
+            sb.add_pure_op(ctx, op.clone());
         }
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1357,6 +1357,8 @@ mod tests {
                 op: source_box,
                 invented_name: false,
                 preamble_op: replay,
+                // Non-invented imported pure re-export: no SameAs alias.
+                same_as_source: None,
             };
             ctx.set_potential_extra_op(source, pop);
         }
@@ -2687,6 +2689,7 @@ mod tests {
             OpRef::int_op(2),
             OpRef::int_op(2),
             false,
+            None,
         );
         ctx.imported_short_pure_ops.push(imported);
 
@@ -2742,6 +2745,7 @@ mod tests {
             OpRef::int_op(1),
             OpRef::int_op(1),
             false,
+            None,
         );
         initialize_imported_short_pure_builder(
             &mut ctx,

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -2040,6 +2040,9 @@ impl Optimization for OptRewrite {
                                     op: source_box,
                                     invented_name: false,
                                     preamble_op: std::rc::Rc::new(replay),
+                                    // Non-invented loop-invariant producer: the
+                                    // SameAs arm is never taken, so no source.
+                                    same_as_source: None,
                                 }),
                             );
                         }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -2261,10 +2261,10 @@ impl Optimization for OptRewrite {
     fn produce_potential_short_preamble_ops(
         &self,
         sb: &mut crate::optimizeopt::shortpreamble::ShortBoxes,
-        _ctx: &mut OptContext,
+        ctx: &mut OptContext,
     ) {
         for (_, op) in &self.loop_invariant_producer {
-            sb.add_loopinvariant_op(op.clone());
+            sb.add_loopinvariant_op(ctx, op.clone());
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2119,21 +2119,6 @@ fn build_short_preamble_struct_from_ops(
 ///
 /// Builds the replayable short preamble from exported short boxes, while also
 /// collecting `used_boxes`, `short_preamble_jump`, and `extra_same_as`.
-///
-/// Build reverse index: preamble_op.pos → key for entries where they differ.
-/// In RPython, Box identity makes this unnecessary. In majit, produce_arg
-/// returns preamble_op.pos which may differ from the key in produced_short_boxes.
-fn build_pos_to_key(produced: &VecAssoc<OpRef, ProducedShortOp>) -> VecAssoc<OpRef, OpRef> {
-    let mut out = VecAssoc::new();
-    for (key, prod) in produced.iter() {
-        let pos = prod.preamble_op.pos.get();
-        if *key != pos {
-            out.insert(pos, *key);
-        }
-    }
-    out
-}
-
 #[derive(Clone, Debug)]
 pub struct ShortPreambleBuilder {
     state: AbstractShortPreambleBuilderState,
@@ -2503,7 +2488,6 @@ impl ExtendedShortPreambleBuilder {
         // Build single short list with inline dep resolution.
         let inputargs_set: VecSet<OpRef> = label_args.iter().copied().collect();
         let constants_set: VecSet<u32> = short_preamble.constants.keys().copied().collect();
-        let pos_to_key = build_pos_to_key(&self.produced_short_boxes);
         self.short.clear();
         self.short_results.clear();
         for entry in &short_preamble.ops {
@@ -2519,7 +2503,7 @@ impl ExtendedShortPreambleBuilder {
             // Recursive: deps of deps are also inserted (transitive closure).
             for arg in op.getarglist().iter() {
                 let arg = arg.to_opref();
-                if !self.insert_dep_recursive(arg, &inputargs_set, &constants_set, &pos_to_key) {
+                if !self.insert_dep_recursive(arg, &inputargs_set, &constants_set) {
                     if crate::optimizeopt::majit_log_enabled() {
                         eprintln!(
                             "[jit] short_preamble setup: dropping inline (unresolved arg {:?} in op pos={:?} opcode={:?})",
@@ -2583,7 +2567,6 @@ impl ExtendedShortPreambleBuilder {
         arg: OpRef,
         inputargs_set: &VecSet<OpRef>,
         constants_set: &VecSet<u32>,
-        pos_to_key: &VecAssoc<OpRef, OpRef>,
     ) -> bool {
         // history.py:227/268/314 inline-Const variants short-circuit
         // before `arg.raw()` (which panics on inline) — covered by
@@ -2598,16 +2581,27 @@ impl ExtendedShortPreambleBuilder {
         {
             return true;
         }
-        // shortpreamble.py:284-285 — `op in self.produced_short_boxes`.
-        // RPython uses Box identity; pyre needs both direct lookup and the
-        // reverse `preamble_op.pos → key` lookup because produce_arg may
-        // return a `.pos` distinct from the original key.
-        let dep = self.produced_short_boxes.get(&arg).cloned().or_else(|| {
-            pos_to_key
-                .get(&arg)
-                .and_then(|key| self.produced_short_boxes.get(key).cloned())
-        });
+        // shortpreamble.py:284-285 — `op in self.produced_short_boxes`,
+        // keyed by Box identity. Every entry is keyed by its own
+        // `preamble_op.pos` (produced_short_boxes_from_exported_boxes), so the
+        // map key equals the producer position a dep arg references — the
+        // direct lookup is exact, matching RPython's single Box-identity
+        // lookup. The former `preamble_op.pos → key` reverse index was a
+        // vestige of an earlier export that keyed by something other than the
+        // replay pos; it can never fire now (key == pos by construction).
+        let dep = self.produced_short_boxes.get(&arg).cloned();
         let Some(dep) = dep else {
+            // Tripwire: a reverse `preamble_op.pos == arg` entry must not exist
+            // when the direct lookup misses — that would mean some insert path
+            // broke the `key == preamble_op.pos` invariant the deletion relies on.
+            debug_assert!(
+                !self
+                    .produced_short_boxes
+                    .iter()
+                    .any(|(_, prod)| prod.preamble_op.pos.get() == arg),
+                "produced_short_boxes key != preamble_op.pos at {arg:?}: \
+                 direct lookup missed but a pos-keyed entry exists"
+            );
             return false;
         };
         let dep_pos = dep.preamble_op.pos.get();
@@ -2628,7 +2622,7 @@ impl ExtendedShortPreambleBuilder {
         let dep_op_args = dep_op.getarglist_copy();
         for dep_arg in dep_op_args.iter() {
             let dep_arg = dep_arg.to_opref();
-            if !self.insert_dep_recursive(dep_arg, inputargs_set, constants_set, pos_to_key) {
+            if !self.insert_dep_recursive(dep_arg, inputargs_set, constants_set) {
                 return false;
             }
         }
@@ -2824,8 +2818,11 @@ impl ExtendedShortPreambleBuilder {
         let jump_op = self.short.pop();
         // shortpreamble.py:480: AbstractShortPreambleBuilder.use_box(...)
         if !self.short_results.contains(&canonical) {
-            let pos_to_key = build_pos_to_key(&self.produced_short_boxes);
-            // Add deps for each arg
+            // Add deps for each arg. produced_short_boxes is keyed by each
+            // entry's own `preamble_op.pos`, so a dep arg (a producer position)
+            // hits its entry directly — RPython single Box-identity lookup. The
+            // former `preamble_op.pos → key` reverse index can never fire
+            // (key == pos by construction) and was removed.
             for arg in preamble_op.getarglist().iter() {
                 let arg = arg.to_opref();
                 if self.short_results.contains(&arg)
@@ -2834,11 +2831,7 @@ impl ExtendedShortPreambleBuilder {
                 {
                     continue;
                 }
-                let dep = self.produced_short_boxes.get(&arg).or_else(|| {
-                    pos_to_key
-                        .get(&arg)
-                        .and_then(|key| self.produced_short_boxes.get(key))
-                });
+                let dep = self.produced_short_boxes.get(&arg);
                 if let Some(dep) = dep {
                     let dep_pos = dep.preamble_op.pos.get();
                     if !self.short_results.contains(&dep_pos) {

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -447,7 +447,12 @@ impl PreambleOp {
 #[derive(Clone, Debug, Default)]
 pub struct ShortBoxes {
     /// shortpreamble.py:249 self.potential_ops = OrderedDict()
-    potential_ops: VecAssoc<OpRef, PotentialShortOp>,
+    /// Keyed by the producer's result Box, compared by object identity
+    /// (shortpreamble.py:259/290) — every insert/lookup resolves its
+    /// position through `ctx.materialize_box_at`, which memoizes one box
+    /// per producer, so the same position yields the same object. Const
+    /// results never key this map (they route to `const_short_boxes`).
+    potential_ops: VecAssoc<BoxRef, PotentialShortOp>,
     /// shortpreamble.py:250 self.produced_short_boxes = {}
     /// (insertion order preserved by VecAssoc for deterministic export.)
     /// Keyed by the result Box (`shortop.res`), compared by object
@@ -587,7 +592,7 @@ impl ShortBoxes {
     pub fn is_reachable(&self, opref: OpRef) -> bool {
         self.label_args.iter().any(|&a| a == opref)
             || opref.is_constant()
-            || self.potential_ops.iter().any(|(k, _)| *k == opref)
+            || self.potential_ops.iter().any(|(k, _)| k.to_opref() == opref)
     }
 
     pub fn note_known_constant(&mut self, opref: OpRef) {
@@ -598,15 +603,15 @@ impl ShortBoxes {
         self.known_constants.insert(opref);
     }
 
-    fn add_op(&mut self, result: OpRef, pop: PotentialShortOp) {
-        self.potential_ops.insert(result, pop);
+    fn add_op(&mut self, key: BoxRef, pop: PotentialShortOp) {
+        self.potential_ops.insert(key, pop);
     }
 
     /// Add a pure operation as a short-box candidate.
     /// shortpreamble.py: sb.add_pure_op(op)
-    pub fn add_pure_op(&mut self, op: Op) {
+    pub fn add_pure_op(&mut self, ctx: &mut crate::optimizeopt::OptContext, op: Op) {
         let result = op.pos.get();
-        self.add_potential_op(self.lookup_label_arg(result), op, PreambleOpKind::Pure);
+        self.add_potential_op(ctx, self.lookup_label_arg(result), op, PreambleOpKind::Pure);
     }
 
     /// shortpreamble.py:369-374 add_heap_op(op, getfield_op)
@@ -615,7 +620,7 @@ impl ShortBoxes {
     /// a constant, route to `const_short_boxes` (RPython:
     /// `if isinstance(op, Const): self.const_short_boxes.append(HeapOp(op, getfield_op))`).
     /// Otherwise it joins `potential_ops` as a heap candidate.
-    pub fn add_heap_op(&mut self, op: Op) {
+    pub fn add_heap_op(&mut self, ctx: &mut crate::optimizeopt::OptContext, op: Op) {
         let result = op.pos.get();
         if result.is_constant() || self.known_constants.contains(&result) {
             // shortpreamble.py:371-373: const_short_boxes.append(HeapOp(...))
@@ -630,13 +635,14 @@ impl ShortBoxes {
             });
             return;
         }
-        self.add_potential_op(self.lookup_label_arg(result), op, PreambleOpKind::Heap);
+        self.add_potential_op(ctx, self.lookup_label_arg(result), op, PreambleOpKind::Heap);
     }
 
     /// Add a loop-invariant call as a short-box candidate.
-    pub fn add_loopinvariant_op(&mut self, op: Op) {
+    pub fn add_loopinvariant_op(&mut self, ctx: &mut crate::optimizeopt::OptContext, op: Op) {
         let result = op.pos.get();
         self.add_potential_op(
+            ctx,
             self.lookup_label_arg(result),
             op,
             PreambleOpKind::LoopInvariant,
@@ -693,11 +699,18 @@ impl ShortBoxes {
         // original `box`; the SAME_AS replay arg is that box. Exported
         // entries carry original positions and are renamed to the matching
         // `short_inputargs` slot at import (`produced_short_boxes_from_exported_boxes`).
+        // Warm up the canonical box so `arg_box` (the `potential_ops` key) is
+        // the memoized box every later `materialize_box_at(arg)` lookup also
+        // returns (ptr_eq), keeping the BoxRef-keyed map ptr-stable.
+        let _ = ctx.materialize_box_at(arg);
         let arg_box = ctx.materialize_box_at(arg);
         let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[arg_box.clone()]);
         same_as.pos.set(arg);
+        // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
+        // — keyed by the label-arg Box itself; `arg_box` is its canonical
+        // (producer-bound) box, shared with `res`.
         self.potential_ops.insert(
-            arg,
+            arg_box.clone(),
             PotentialShortOp::Preamble(PreambleOp {
                 res: arg_box,
                 op: std::rc::Rc::new(same_as),
@@ -750,7 +763,7 @@ impl ShortBoxes {
         if self.known_constants.contains(&opref) {
             return Some(ctx.materialize_box_at(opref));
         }
-        if self.potential_ops.iter().any(|(k, _)| *k == opref) {
+        if self.potential_ops.iter().any(|(k, _)| k.to_opref() == opref) {
             // shortpreamble.py:291-294 `r = self.add_op_to_short(...);
             // return r.preamble_op`. ShortInputArg: res box, see the
             // produced arm above.
@@ -810,7 +823,7 @@ impl ShortBoxes {
         if self.boxes_in_production.contains(&key) {
             return None;
         }
-        let candidate = self.potential_ops.get(&result)?.clone();
+        let candidate = self.potential_ops.get(&key)?.clone();
         self.boxes_in_production.insert(key.clone());
         let produced = candidate.add_op_to_short(self, ctx);
         self.boxes_in_production.remove(&key);
@@ -824,7 +837,7 @@ impl ShortBoxes {
         &mut self,
         ctx: &mut crate::optimizeopt::OptContext,
     ) -> Vec<(OpRef, ProducedShortOp)> {
-        let keys: Vec<OpRef> = self.potential_ops.iter().map(|(k, _)| *k).collect();
+        let keys: Vec<OpRef> = self.potential_ops.iter().map(|(k, _)| k.to_opref()).collect();
         for key in keys {
             let _ = self.materialize_one(ctx, key);
         }
@@ -933,8 +946,22 @@ impl ShortBoxes {
 
     /// shortpreamble.py: add_potential_op(op, pop)
     /// Add a produced operation to the short boxes at the given position.
-    pub fn add_potential_op(&mut self, label_arg_idx: Option<usize>, op: Op, kind: PreambleOpKind) {
+    pub fn add_potential_op(
+        &mut self,
+        ctx: &mut crate::optimizeopt::OptContext,
+        label_arg_idx: Option<usize>,
+        op: Op,
+        kind: PreambleOpKind,
+    ) {
         let result = op.pos.get();
+        // shortpreamble.py:290 `self.potential_ops[op]` — keyed by the
+        // producer's result Box; resolve the position to its canonical box.
+        // The first `materialize_box_at` on an unregistered ResOp position
+        // mints a placeholder distinct from the memoized synthetic returned
+        // by every subsequent call; warm it up so the insert key here and
+        // the lookup keys in `materialize_one`/`produce_arg` are ptr_eq.
+        let _ = ctx.materialize_box_at(result);
+        let key = ctx.materialize_box_at(result);
         let pop = PotentialShortOp::Preamble(PreambleOp {
             res: BoxRef::from_opref(result),
             op: std::rc::Rc::new(op),
@@ -943,7 +970,7 @@ impl ShortBoxes {
             invented_name: false,
             same_as_source: None,
         });
-        let next = match self.potential_ops.get(&result) {
+        let next = match self.potential_ops.get(&key) {
             Some(prev) => PotentialShortOp::Compound(CompoundOp {
                 res: result,
                 one: Box::new(pop),
@@ -951,7 +978,7 @@ impl ShortBoxes {
             }),
             None => pop,
         };
-        self.add_op(result, next);
+        self.add_op(key, next);
     }
 }
 
@@ -3747,6 +3774,7 @@ mod tests {
         let mut sb =
             ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(11), OpRef::int_op(12)]);
         assert_eq!(sb.num_label_args, 3);
+        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
@@ -3755,15 +3783,14 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(20));
-        sb.add_pure_op(pure);
+        sb.add_pure_op(&mut __ctx, pure);
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
             &[BoxRef::from_opref(OpRef::int_op(10))],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(21));
-        sb.add_heap_op(heap);
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
+        sb.add_heap_op(&mut __ctx, heap);
         let produced = sb.produced_ops(&mut __ctx);
         assert_eq!(produced.len(), 2);
     }
@@ -3771,6 +3798,7 @@ mod tests {
     #[test]
     fn test_short_boxes_reject_unknown_nonconstant_dependency() {
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10)]);
+        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
@@ -3779,9 +3807,8 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(20));
-        sb.add_pure_op(pure);
+        sb.add_pure_op(&mut __ctx, pure);
 
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
         // The label arg OpRef::int_op(10) itself is produced (as ShortInputArg),
         // but the pure op depending on unknown OpRef::int_op(999) is rejected.
@@ -3795,6 +3822,7 @@ mod tests {
     fn test_short_boxes_accept_known_constant_dependency() {
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10)]);
         sb.note_known_constant(OpRef::int_op(999));
+        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
@@ -3803,9 +3831,8 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(20));
-        sb.add_pure_op(pure);
+        sb.add_pure_op(&mut __ctx, pure);
 
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
         assert_eq!(produced.len(), 1);
         let pure = produced
@@ -3827,6 +3854,7 @@ mod tests {
     fn test_short_boxes_compound_prefers_non_heap_and_emits_invented_alias() {
         let mut sb =
             ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(30), OpRef::int_op(31)]);
+        let mut __ctx = crate::optimizeopt::OptContext::new(0);
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -3834,7 +3862,7 @@ mod tests {
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(10));
-        sb.add_potential_op(Some(0), heap, PreambleOpKind::Heap);
+        sb.add_potential_op(&mut __ctx, Some(0), heap, PreambleOpKind::Heap);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
@@ -3844,9 +3872,8 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(10));
-        sb.add_potential_op(Some(0), pure, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, Some(0), pure, PreambleOpKind::Pure);
 
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
         assert_eq!(produced.len(), 2);
 
@@ -3873,6 +3900,7 @@ mod tests {
     fn test_short_boxes_nested_compound_emits_multiple_invented_aliases() {
         let mut sb =
             ShortBoxes::with_label_args(&[OpRef::int_op(20), OpRef::int_op(30), OpRef::int_op(31)]);
+        let mut __ctx = crate::optimizeopt::OptContext::new(0);
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -3880,11 +3908,11 @@ mod tests {
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(Some(0), heap, PreambleOpKind::Heap);
+        sb.add_potential_op(&mut __ctx, Some(0), heap, PreambleOpKind::Heap);
 
         let mut loopinv = Op::new(OpCode::CallI, &[BoxRef::from_opref(OpRef::int_op(30))]);
         loopinv.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(Some(0), loopinv, PreambleOpKind::LoopInvariant);
+        sb.add_potential_op(&mut __ctx, Some(0), loopinv, PreambleOpKind::LoopInvariant);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
@@ -3894,9 +3922,8 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(Some(0), pure, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, Some(0), pure, PreambleOpKind::Pure);
 
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
         assert_eq!(produced.len(), 3);
 
@@ -3930,10 +3957,9 @@ mod tests {
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(10));
-        sb.add_heap_op(heap);
+        sb.add_heap_op(&mut ctx, heap);
 
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
-        let produced = sb.produced_ops(&mut __ctx);
+        let produced = sb.produced_ops(&mut ctx);
         assert_eq!(produced.len(), 2);
 
         let chosen = produced
@@ -3992,6 +4018,7 @@ mod tests {
     fn test_rpython_short_preamble_builder_add_op_to_short_builds_label_short_and_jump() {
         let mut sb =
             ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(30), OpRef::int_op(31)]);
+        let mut __ctx = crate::optimizeopt::OptContext::new(0);
 
         let mut ovf = Op::new(
             OpCode::IntAddOvf,
@@ -4001,9 +4028,8 @@ mod tests {
             ],
         );
         ovf.pos.set(OpRef::int_op(10));
-        sb.add_potential_op(Some(0), ovf, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, Some(0), ovf, PreambleOpKind::Pure);
 
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
         // #146/S8: the builder map keys by the entry res Box; re-key the
         // produced_ops list (keyed by `preamble_op.pos`) to res for new() and
@@ -4047,6 +4073,7 @@ mod tests {
     fn test_rpython_short_preamble_builder_tracks_extra_same_as() {
         let mut sb =
             ShortBoxes::with_label_args(&[OpRef::int_op(20), OpRef::int_op(30), OpRef::int_op(31)]);
+        let mut __ctx = crate::optimizeopt::OptContext::new(0);
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -4054,7 +4081,7 @@ mod tests {
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(Some(0), heap, PreambleOpKind::Heap);
+        sb.add_potential_op(&mut __ctx, Some(0), heap, PreambleOpKind::Heap);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
@@ -4064,9 +4091,8 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(Some(0), pure, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, Some(0), pure, PreambleOpKind::Pure);
 
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
         let (alias_result, alias_res) = produced
             .iter()

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1469,7 +1469,7 @@ impl ProducedShortOp {
         let builder_pop = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(source));
+            .and_then(|b| b.produced_short_op(&self.res));
         let imported = match builder_pop {
             Some(p) => {
                 debug_assert_eq!(
@@ -1599,7 +1599,7 @@ impl ProducedShortOp {
         let replay_rc = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(source))
+            .and_then(|b| b.produced_short_op(&self.res))
             .map(|p| {
                 debug_assert_eq!(
                     p.preamble_op.pos.get(),
@@ -1733,7 +1733,7 @@ impl ProducedShortOp {
         let replay_rc = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(source))
+            .and_then(|b| b.produced_short_op(&self.res))
             .map(|p| {
                 debug_assert_eq!(
                     p.preamble_op.pos.get(),
@@ -2118,15 +2118,23 @@ fn build_short_preamble_struct_from_ops(
 #[derive(Clone, Debug)]
 pub struct ShortPreambleBuilder {
     state: AbstractShortPreambleBuilderState,
-    /// Stays `OpRef`-keyed: see `produced_short_op` for why the position key
-    /// is load-bearing and resists the #146/S8 `BoxRef` re-key.
-    produced_short_boxes: VecAssoc<OpRef, ProducedShortOp>,
+    /// shortpreamble.py:250 `self.produced_short_boxes = {}` — keyed by the
+    /// short-box res Box identity (`shortop.res`), looked up by box everywhere
+    /// (produce_arg/use_box/add_op_to_short). #146/S8 re-keyed this from the
+    /// flat-OpRef position (which needed a dual source/result_opref key for
+    /// invented names) to the single carried res box: `self.res` at the
+    /// cross-peel produce loop, `materialize_box_at(pos)` at the single-op
+    /// re-export. The carried box is invariant to the replay-position aliasing
+    /// the dual key compensated for, so the two entries collapse to one. The
+    /// PYRE_S8B_HARNESS census measured this lookup agreeing with the former
+    /// position key on every live firing across the bench corpus.
+    produced_short_boxes: VecAssoc<BoxRef, ProducedShortOp>,
 }
 
 impl ShortPreambleBuilder {
     pub fn new(
         label_args: &[OpRef],
-        short_boxes: &[(OpRef, ProducedShortOp)],
+        short_boxes: &[(BoxRef, ProducedShortOp)],
         short_inputargs: &[BoxRef],
     ) -> Self {
         let mut produced_short_boxes = VecAssoc::new();
@@ -2144,7 +2152,15 @@ impl ShortPreambleBuilder {
             // carry it.
             *v.preamble_op.forwarded.borrow_mut() =
                 crate::r#box::Forwarded::Info(crate::optimizeopt::info::OpInfo::Unknown);
-            produced_short_boxes.insert(*k, v.clone());
+            // Const res boxes are ptr-unstable (minted fresh per resolution),
+            // so they can never be a stable box-identity key; export already
+            // filters const short boxes (optimizer.rs:2942) so this is inert
+            // for the live path, and the single-op re-export passes the
+            // memoized `materialize_box_at(pos)` box.
+            if k.to_opref().is_constant() {
+                continue;
+            }
+            produced_short_boxes.insert(k.clone(), v.clone());
         }
         // shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
         // store the caller's renamed-box objects themselves. The empty
@@ -2170,34 +2186,35 @@ impl ShortPreambleBuilder {
 
     fn use_box_recursive(
         &mut self,
-        result: OpRef,
-        visiting: &mut VecSet<OpRef>,
+        result: &BoxRef,
+        visiting: &mut VecSet<BoxRef>,
     ) -> Option<majit_ir::OpRc> {
-        let produced = self.produced_short_boxes.get(&result)?.clone();
+        let produced = self.produced_short_boxes.get(result)?.clone();
         let canonical_result = produced.preamble_op.pos.get();
         if self.state.short_results.contains(&canonical_result) {
             return Some(produced.preamble_op);
         }
-        if !visiting.insert(result) {
+        if !visiting.insert(result.clone()) {
             return None;
         }
         for arg in produced.preamble_op.getarglist().iter() {
-            let arg = arg.to_opref();
             // shortpreamble.py:288 isinstance(arg, Const) → skip
-            if arg.is_constant() {
+            if arg.to_opref().is_constant() {
                 continue;
             }
-            if self.produced_short_boxes.iter().any(|(k, _)| *k == arg) {
+            // shortpreamble.py:284-285 `if op in self.produced_short_boxes`:
+            // the dependency check is by the arg Box identity.
+            if self.produced_short_boxes.get(arg).is_some() {
                 let _ = self.use_box_recursive(arg, visiting);
             }
         }
-        visiting.remove(&result);
-        Some(self.state.append_to_short(result, &produced))
+        visiting.remove(result);
+        Some(self.state.append_to_short(result.to_opref(), &produced))
     }
 
     /// shortpreamble.py:310: add_op_to_short — recursive, used during
     /// export-time create_short_boxes to resolve transitive dependencies.
-    pub fn add_op_to_short(&mut self, result: OpRef) -> Option<Op> {
+    pub fn add_op_to_short(&mut self, result: &BoxRef) -> Option<Op> {
         self.use_box_recursive(result, &mut VecSet::new())
             .map(|op| (*op).clone())
     }
@@ -2217,7 +2234,11 @@ impl ShortPreambleBuilder {
         result_guards: &[Op],
     ) {
         #[cfg(debug_assertions)]
-        if let Some(produced) = self.produced_short_boxes.get(&source) {
+        if let Some((_, produced)) = self
+            .produced_short_boxes
+            .iter()
+            .find(|(_, p)| p.preamble_op.pos.get() == source)
+        {
             debug_assert!(
                 std::rc::Rc::ptr_eq(&produced.preamble_op, preamble_op),
                 "use_box pop replay diverged from builder entry at {source:?}"
@@ -2239,18 +2260,19 @@ impl ShortPreambleBuilder {
     /// `produce_heap_array_item` re-export (pure.rs/shortpreamble.rs, via
     /// `OptContext.imported_short_preamble_builder`).
     ///
-    /// The `OpRef` (position) key is LOAD-BEARING and must not be re-keyed to
-    /// `BoxRef`(produced.res): the lookup runs at produce time, BEFORE a
-    /// Phase-2 box for `result` exists. Resolving `result` through the live
-    /// `OptContext` does not yield `produced.res` — measured 75 agree / 114
-    /// diverge, the divergences split between `get_box_replacement_box(result)
-    /// == None` (no Phase-2 box has been produced yet, so there is nothing to
-    /// key by) and a distinct Phase-2 producer box (the imported `produced.res`
-    /// is a Phase-1 object with no shared identity across the peel boundary).
-    /// The position bridges the imported Phase-1 res and the Phase-2 produce-
-    /// time slot precisely because no box identity links them at this point.
-    pub fn produced_short_op(&self, result: OpRef) -> Option<ProducedShortOp> {
-        self.produced_short_boxes.get(&result).cloned()
+    /// #146/S8: keyed by the short-box res Box identity (`shortop.res`), the
+    /// carried box the produce loop holds as `self.res`. This replaced the
+    /// flat-OpRef position key, whose dual source/result_opref entries
+    /// compensated for invented-name replay-position aliasing; the carried box
+    /// is invariant to that aliasing so the entries collapse to one. The prior
+    /// "blocked" verdict (75 agree / 114 diverge) measured the WRONG box:
+    /// `get_box_replacement_box(source)`, a Phase-2 re-resolution that mints a
+    /// fresh non-`ptr_eq` box. The carried Phase-1 res is shared across the
+    /// peel boundary (an `Rc::clone` of the exported short-box res), so the
+    /// box-identity lookup hits — PYRE_S8B_HARNESS measured 82/82 agreement
+    /// with the former position key on every live firing across the corpus.
+    pub fn produced_short_op(&self, res: &BoxRef) -> Option<ProducedShortOp> {
+        self.produced_short_boxes.get(res).cloned()
     }
 
     /// shortpreamble.py:432-440: add_preamble_op(preamble_op)
@@ -2290,8 +2312,8 @@ impl ShortPreambleBuilder {
         );
     }
 
-    pub fn add_preamble_op(&mut self, result: OpRef) -> bool {
-        let Some(produced) = self.produced_short_boxes.get(&result).cloned() else {
+    pub fn add_preamble_op(&mut self, result: &BoxRef) -> bool {
+        let Some(produced) = self.produced_short_boxes.get(result).cloned() else {
             return false;
         };
         // shortpreamble.py:435 `op = preamble_op.op.get_box_replacement()`
@@ -2449,7 +2471,16 @@ impl ExtendedShortPreambleBuilder {
 
     pub fn new(target_token: u64, sb: &ShortPreambleBuilder) -> Self {
         ExtendedShortPreambleBuilder {
-            produced_short_boxes: sb.produced_short_boxes.clone(),
+            // The live builder now keys `produced_short_boxes` by the short-box
+            // res Box (#146/S8); this builder keys by `preamble_op.pos` (the
+            // assert in `ensure_dep_from_produced`), so re-key on copy.
+            produced_short_boxes: {
+                let mut m = crate::optimizeopt::vec_assoc::VecAssoc::new();
+                for (_, p) in sb.produced_short_boxes.iter() {
+                    m.insert(p.preamble_op.pos.get(), p.clone());
+                }
+                m
+            },
             short_inputargs: sb.short_inputargs().to_vec(),
             short: Vec::new(),
             short_results: VecSet::new(),
@@ -3167,16 +3198,34 @@ pub fn build_short_preamble_from_produced_boxes(
     short_inputargs: &[BoxRef],
     produced: &[(OpRef, ProducedShortOp)],
 ) -> ShortPreamble {
-    let mut builder = ShortPreambleBuilder::new(label_args, produced, short_inputargs);
+    // #146/S8: the builder map keys by the entry res Box (`p.res`, the carried
+    // Phase-1 short-box result). The input slice is keyed by `preamble_op.pos`;
+    // re-key to res for the builder map and the use_box driving loop (const res
+    // is ptr-unstable and never a key — export filters it).
+    //
+    // Correctness here rests on the OUTER loop below: it calls add_op_to_short
+    // on EVERY entry in input order, which is dependency order (RPython
+    // create_short_boxes appends deps before consumers). `use_box_recursive`'s
+    // dep pre-append is a best-effort ordering aid whose box-identity dep
+    // lookup may miss (an op's dep arg need not Rc::ptr_eq the dependency's res
+    // box), but a miss only drops the redundant recursive append — the outer
+    // loop still emits every entry in valid def-before-use order. This path is
+    // a corpus-dead fallback (rebuilt preamble is Some in the measured corpus).
+    let entries: Vec<(BoxRef, ProducedShortOp)> = produced
+        .iter()
+        .filter(|(_, p)| !p.res.to_opref().is_constant())
+        .map(|(_, p)| (p.res.clone(), p.clone()))
+        .collect();
+    let mut builder = ShortPreambleBuilder::new(label_args, &entries, short_inputargs);
     // history.py:227/268/314 — inline-Const variants carry the value on
     // the OpRef; `is_constant()` returns true intrinsically and the
     // `is_reachable` / `add_heap_op` checks short-circuit before
     // consulting `known_constants`. There are no constant pool entries
     // to seed into `known_constants` and the `loop_constants`
     // parameter has been retired.
-    for (result, _) in produced {
-        let _ = builder.add_op_to_short(*result);
-        let _ = builder.add_preamble_op(*result);
+    for (res, _) in &entries {
+        let _ = builder.add_op_to_short(res);
+        let _ = builder.add_preamble_op(res);
     }
     builder.build_short_preamble_struct()
 }
@@ -3589,20 +3638,22 @@ mod tests {
 
     #[test]
     fn test_rpython_short_preamble_builder_add_op_to_short_recurses_dependencies() {
+        // #146/S8: the builder map keys by the short-box res Box identity, and a
+        // dependency is found when an op's arg Box Rc::ptr_eq's the dep's res
+        // (RPython box-identity `if arg in produced_short_boxes`). Express the
+        // B-depends-on-A edge by sharing A's res Rc as B's IntMul arg(0).
+        let in0 = BoxRef::from_opref(OpRef::int_op(0));
+        let in1 = BoxRef::from_opref(OpRef::int_op(1));
+        let res7 = BoxRef::from_opref(OpRef::int_op(7));
+        let res8 = BoxRef::from_opref(OpRef::int_op(8));
         let produced = vec![
             (
-                OpRef::int_op(7),
+                res7.clone(),
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
-                    res: BoxRef::from_opref(OpRef::int_op(7)),
+                    res: res7.clone(),
                     preamble_op: {
-                        let mut op = Op::new(
-                            OpCode::IntAdd,
-                            &[
-                                BoxRef::from_opref(OpRef::int_op(0)),
-                                BoxRef::from_opref(OpRef::int_op(1)),
-                            ],
-                        );
+                        let mut op = Op::new(OpCode::IntAdd, &[in0.clone(), in1.clone()]);
                         op.pos.set(OpRef::int_op(7));
                         std::rc::Rc::new(op)
                     },
@@ -3611,18 +3662,12 @@ mod tests {
                 },
             ),
             (
-                OpRef::int_op(8),
+                res8.clone(),
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
-                    res: BoxRef::from_opref(OpRef::int_op(8)),
+                    res: res8.clone(),
                     preamble_op: {
-                        let mut op = Op::new(
-                            OpCode::IntMul,
-                            &[
-                                BoxRef::from_opref(OpRef::int_op(7)),
-                                BoxRef::from_opref(OpRef::int_op(1)),
-                            ],
-                        );
+                        let mut op = Op::new(OpCode::IntMul, &[res7.clone(), in1.clone()]);
                         op.pos.set(OpRef::int_op(8));
                         std::rc::Rc::new(op)
                     },
@@ -3634,15 +3679,12 @@ mod tests {
         let mut builder = ShortPreambleBuilder::new(
             &[OpRef::int_op(0), OpRef::int_op(1)],
             &produced,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
+            &[in0.clone(), in1.clone()],
         );
 
-        let used = builder.add_op_to_short(OpRef::int_op(8)).unwrap();
-        assert!(builder.add_preamble_op(OpRef::int_op(7)));
-        assert!(builder.add_preamble_op(OpRef::int_op(8)));
+        let used = builder.add_op_to_short(&res8).unwrap();
+        assert!(builder.add_preamble_op(&res7));
+        assert!(builder.add_preamble_op(&res8));
         assert_eq!(used.opcode, OpCode::IntMul);
         let short = builder.build_short_preamble();
         assert_eq!(short[1].opcode, OpCode::IntAdd);
@@ -3963,13 +4005,25 @@ mod tests {
 
         let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
+        // #146/S8: the builder map keys by the entry res Box; re-key the
+        // produced_ops list (keyed by `preamble_op.pos`) to res for new() and
+        // look up by the res box of the int_op(10) entry.
+        let entries: Vec<(BoxRef, ProducedShortOp)> =
+            produced.iter().map(|(_, p)| (p.res.clone(), p.clone())).collect();
+        let res10 = produced
+            .iter()
+            .find(|(r, _)| *r == OpRef::int_op(10))
+            .unwrap()
+            .1
+            .res
+            .clone();
         let mut builder = ShortPreambleBuilder::new(
             &[OpRef::int_op(10)],
-            &produced,
+            &entries,
             &[BoxRef::from_opref(OpRef::int_op(10))],
         );
-        let used = builder.add_op_to_short(OpRef::int_op(10)).unwrap();
-        assert!(builder.add_preamble_op(OpRef::int_op(10)));
+        let used = builder.add_op_to_short(&res10).unwrap();
+        assert!(builder.add_preamble_op(&res10));
         assert_eq!(used.opcode, OpCode::IntAddOvf);
         assert_eq!(builder.used_boxes(), &[OpRef::int_op(10)]);
 
@@ -4014,18 +4068,22 @@ mod tests {
 
         let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let produced = sb.produced_ops(&mut __ctx);
-        let alias_result = produced
+        let (alias_result, alias_res) = produced
             .iter()
             .find(|(result, pop)| *result != OpRef::int_op(20) && pop.invented_name)
-            .map(|(result, _)| *result)
+            .map(|(result, pop)| (*result, pop.res.clone()))
             .unwrap();
 
+        // #146/S8: re-key the produced_ops list to res for new() + look up the
+        // invented-name alias entry by its res box.
+        let entries: Vec<(BoxRef, ProducedShortOp)> =
+            produced.iter().map(|(_, p)| (p.res.clone(), p.clone())).collect();
         let mut builder = ShortPreambleBuilder::new(
             &[OpRef::int_op(20)],
-            &produced,
+            &entries,
             &[BoxRef::from_opref(OpRef::int_op(20))],
         );
-        assert!(builder.add_preamble_op(alias_result));
+        assert!(builder.add_preamble_op(&alias_res));
         let extra = builder.extra_same_as();
         assert_eq!(extra.len(), 1);
         assert_eq!(extra[0].opcode, OpCode::SameAsI);

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -592,7 +592,10 @@ impl ShortBoxes {
     pub fn is_reachable(&self, opref: OpRef) -> bool {
         self.label_args.iter().any(|&a| a == opref)
             || opref.is_constant()
-            || self.potential_ops.iter().any(|(k, _)| k.to_opref() == opref)
+            || self
+                .potential_ops
+                .iter()
+                .any(|(k, _)| k.to_opref() == opref)
     }
 
     pub fn note_known_constant(&mut self, opref: OpRef) {
@@ -763,7 +766,11 @@ impl ShortBoxes {
         if self.known_constants.contains(&opref) {
             return Some(ctx.materialize_box_at(opref));
         }
-        if self.potential_ops.iter().any(|(k, _)| k.to_opref() == opref) {
+        if self
+            .potential_ops
+            .iter()
+            .any(|(k, _)| k.to_opref() == opref)
+        {
             // shortpreamble.py:291-294 `r = self.add_op_to_short(...);
             // return r.preamble_op`. ShortInputArg: res box, see the
             // produced arm above.
@@ -837,7 +844,11 @@ impl ShortBoxes {
         &mut self,
         ctx: &mut crate::optimizeopt::OptContext,
     ) -> Vec<(OpRef, ProducedShortOp)> {
-        let keys: Vec<OpRef> = self.potential_ops.iter().map(|(k, _)| k.to_opref()).collect();
+        let keys: Vec<OpRef> = self
+            .potential_ops
+            .iter()
+            .map(|(k, _)| k.to_opref())
+            .collect();
         for key in keys {
             let _ = self.materialize_one(ctx, key);
         }
@@ -4034,8 +4045,10 @@ mod tests {
         // #146/S8: the builder map keys by the entry res Box; re-key the
         // produced_ops list (keyed by `preamble_op.pos`) to res for new() and
         // look up by the res box of the int_op(10) entry.
-        let entries: Vec<(BoxRef, ProducedShortOp)> =
-            produced.iter().map(|(_, p)| (p.res.clone(), p.clone())).collect();
+        let entries: Vec<(BoxRef, ProducedShortOp)> = produced
+            .iter()
+            .map(|(_, p)| (p.res.clone(), p.clone()))
+            .collect();
         let res10 = produced
             .iter()
             .find(|(r, _)| *r == OpRef::int_op(10))
@@ -4102,8 +4115,10 @@ mod tests {
 
         // #146/S8: re-key the produced_ops list to res for new() + look up the
         // invented-name alias entry by its res box.
-        let entries: Vec<(BoxRef, ProducedShortOp)> =
-            produced.iter().map(|(_, p)| (p.res.clone(), p.clone())).collect();
+        let entries: Vec<(BoxRef, ProducedShortOp)> = produced
+            .iter()
+            .map(|(_, p)| (p.res.clone(), p.clone()))
+            .collect();
         let mut builder = ShortPreambleBuilder::new(
             &[OpRef::int_op(20)],
             &entries,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1490,6 +1490,7 @@ impl ProducedShortOp {
                         op: ctx.materialize_box_at(source),
                         invented_name: self.invented_name,
                         preamble_op: p.preamble_op.clone(),
+                        same_as_source: self.same_as_source.clone(),
                     },
                 }
             }
@@ -1501,6 +1502,7 @@ impl ProducedShortOp {
                 result_opref,
                 source,
                 self.invented_name,
+                self.same_as_source.clone(),
             ),
         };
         ctx.imported_short_pure_ops.push(imported);
@@ -1614,6 +1616,7 @@ impl ProducedShortOp {
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
             preamble_op: replay_rc,
+            same_as_source: self.same_as_source.clone(),
         };
         let parent_descr = getfield_op
             .with_field_descr(|fd| fd.get_parent_descr())
@@ -1749,6 +1752,7 @@ impl ProducedShortOp {
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
             preamble_op: replay_rc,
+            same_as_source: self.same_as_source.clone(),
         };
         let obj_box = ctx.get_box_replacement_box(obj_resolved);
         if obj_resolved.is_constant()
@@ -1923,9 +1927,9 @@ impl AbstractShortPreambleBuilderState {
             // carries `Some(same_as_source)` — the sole production writer
             // is the compound-alias path (`alt.invented_name = true` +
             // `alt.same_as_source = Some(...)`), `add_preamble_op_from_pop`
-            // always passes `Some(pop.op)`, and the export/re-import paths
-            // copy both fields as a pair. Fallback kept as a release
-            // safety net.
+            // passes the pop's threaded `same_as_source`, and the
+            // export/re-import paths copy both fields as a pair. Fallback
+            // kept as a release safety net.
             debug_assert!(
                 same_as_source.is_some(),
                 "invented_name without same_as_source at {:?}",
@@ -2256,23 +2260,32 @@ impl ShortPreambleBuilder {
     ///   self.used_boxes.append(op)
     ///   self.short_preamble_jump.append(preamble_op.preamble_op)
     ///
-    /// The `else` arm below is that unconditional pattern. The `if` arm
-    /// (map lookup) is a pyre-only side table and CANNOT yet collapse onto
-    /// the `else`: for an invented-name CompoundOp alternate the map entry's
-    /// `same_as_source` is the ORIGINAL aliased box, whereas the carried
-    /// `info::PreambleOp` only knows `op` (the invented SameAs name itself).
-    /// `record_imported_preamble_use` builds `same_as(source)`, so the `else`
-    /// arm would emit `same_as(invented_name)` — a self-alias — instead of
-    /// `same_as(original)`. (Empirically: map source `IntOp(14)` vs carried
-    /// `op` `IntOp(30)`.) Collapsing this (#149) requires threading
-    /// `same_as_source` onto `info::PreambleOp` (field_entry::PreambleOp) at
-    /// the export sites so the carried pop reproduces the map entry's record.
+    /// The `else` arm below is that unconditional pattern. Both arms now
+    /// alias the carried `same_as_source` (#149/S8f): `field_entry::PreambleOp`
+    /// carries the ORIGINAL box an invented-name CompoundOp alternate aliases
+    /// (threaded from `ProducedShortOp.same_as_source` at the produce_* export
+    /// sites), so the `else` arm emits `same_as(original)` rather than the old
+    /// `same_as(op)` self-alias (op being the invented SameAs name). The `if`
+    /// arm (map lookup) is retained behind an equivalence `debug_assert!` that
+    /// the carried `same_as_source` reproduces the map entry's; once green
+    /// across the corpus it collapses onto the `else`, deleting this lookup.
     pub fn add_preamble_op_from_pop(
         &mut self,
         preamble_op: &crate::optimizeopt::info::PreambleOp,
         resolved_op: crate::r#box::BoxRef,
     ) {
         if let Some(produced) = self.produced_short_boxes.get(&preamble_op.op.to_opref()) {
+            // #149 equivalence harness: while the builder map still holds this
+            // entry, the carried pop's `same_as_source` must reproduce the
+            // map entry's, so the `else` arm could replace this lookup (S8f
+            // builder-map collapse). Compared by position; the boxes may be
+            // distinct objects across the export/import boundary.
+            debug_assert_eq!(
+                preamble_op.same_as_source.as_ref().map(|b| b.to_opref()),
+                produced.same_as_source.as_ref().map(|b| b.to_opref()),
+                "carried pop same_as_source diverged from builder map at {:?}",
+                preamble_op.op.to_opref()
+            );
             self.state.record_preamble_use(resolved_op, produced);
         } else {
             // shortpreamble.py:432-440: same 4-line pattern via common helper.
@@ -2281,7 +2294,7 @@ impl ShortPreambleBuilder {
                 resolved_op,
                 replay_op,
                 preamble_op.invented_name,
-                Some(preamble_op.op.clone()),
+                preamble_op.same_as_source.clone(),
             );
         }
     }
@@ -2708,7 +2721,18 @@ impl ExtendedShortPreambleBuilder {
             }
             let op = resolved_key;
             if preamble_op.invented_name {
-                let source = preamble_op.op.clone();
+                // shortpreamble.py:436-437: alias the carried original
+                // (same_as_source), matching `add_tracked_preamble_op`; the
+                // resolved box is the release fallback when none was threaded.
+                debug_assert!(
+                    preamble_op.same_as_source.is_some(),
+                    "invented_name without same_as_source at {:?}",
+                    replay_op.pos.get()
+                );
+                let source = preamble_op
+                    .same_as_source
+                    .clone()
+                    .unwrap_or_else(|| resolved_op.clone());
                 let mut same_as =
                     Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
                 same_as.pos.set(op);
@@ -4026,6 +4050,9 @@ mod tests {
             op: BoxRef::from_opref(OpRef::int_op(14)),
             invented_name: true,
             preamble_op: std::rc::Rc::new(replay_op),
+            // Imported invented-name pop carries the original it aliases;
+            // the else arm reads it to emit `same_as(source)`.
+            same_as_source: Some(BoxRef::from_opref(OpRef::int_op(14))),
         };
 
         builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));
@@ -4067,6 +4094,9 @@ mod tests {
             op: BoxRef::from_opref(OpRef::int_op(14)),
             invented_name: true,
             preamble_op: std::rc::Rc::new(replay_op),
+            // Imported invented-name pop carries the original it aliases;
+            // the else arm reads it to emit `same_as(source)`.
+            same_as_source: Some(BoxRef::from_opref(OpRef::int_op(14))),
         };
 
         builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2260,43 +2260,31 @@ impl ShortPreambleBuilder {
     ///   self.used_boxes.append(op)
     ///   self.short_preamble_jump.append(preamble_op.preamble_op)
     ///
-    /// The `else` arm below is that unconditional pattern. Both arms now
-    /// alias the carried `same_as_source` (#149/S8f): `field_entry::PreambleOp`
+    /// This is that unconditional pattern (#149/S8f collapse): the prior
+    /// produced_short_boxes map lookup is gone. `field_entry::PreambleOp` now
     /// carries the ORIGINAL box an invented-name CompoundOp alternate aliases
     /// (threaded from `ProducedShortOp.same_as_source` at the produce_* export
-    /// sites), so the `else` arm emits `same_as(original)` rather than the old
-    /// `same_as(op)` self-alias (op being the invented SameAs name). The `if`
-    /// arm (map lookup) is retained behind an equivalence `debug_assert!` that
-    /// the carried `same_as_source` reproduces the map entry's; once green
-    /// across the corpus it collapses onto the `else`, deleting this lookup.
+    /// sites), so the carried pop reproduces the former map entry's record:
+    /// `op` resolves to `resolved_op`, and `invented_name` / `same_as_source`
+    /// match — the SameAs emits `same_as(original)` rather than the old
+    /// `same_as(op)` self-alias (op being the invented SameAs name).
     pub fn add_preamble_op_from_pop(
         &mut self,
         preamble_op: &crate::optimizeopt::info::PreambleOp,
         resolved_op: crate::r#box::BoxRef,
     ) {
-        if let Some(produced) = self.produced_short_boxes.get(&preamble_op.op.to_opref()) {
-            // #149 equivalence harness: while the builder map still holds this
-            // entry, the carried pop's `same_as_source` must reproduce the
-            // map entry's, so the `else` arm could replace this lookup (S8f
-            // builder-map collapse). Compared by position; the boxes may be
-            // distinct objects across the export/import boundary.
-            debug_assert_eq!(
-                preamble_op.same_as_source.as_ref().map(|b| b.to_opref()),
-                produced.same_as_source.as_ref().map(|b| b.to_opref()),
-                "carried pop same_as_source diverged from builder map at {:?}",
-                preamble_op.op.to_opref()
-            );
-            self.state.record_preamble_use(resolved_op, produced);
-        } else {
-            // shortpreamble.py:432-440: same 4-line pattern via common helper.
-            let replay_op = &preamble_op.preamble_op;
-            self.state.record_imported_preamble_use(
-                resolved_op,
-                replay_op,
-                preamble_op.invented_name,
-                preamble_op.same_as_source.clone(),
-            );
-        }
+        // shortpreamble.py:432-440: unconditional add_preamble_op. The carried
+        // pop reproduces the builder map entry's record — `op` resolves to the
+        // same `resolved_op`, and `invented_name` / `same_as_source` are
+        // threaded through `field_entry::PreambleOp` — so the
+        // produced_short_boxes lookup is no longer consulted here (#149/S8f).
+        let replay_op = &preamble_op.preamble_op;
+        self.state.record_imported_preamble_use(
+            resolved_op,
+            replay_op,
+            preamble_op.invented_name,
+            preamble_op.same_as_source.clone(),
+        );
     }
 
     pub fn add_preamble_op(&mut self, result: OpRef) -> bool {

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2537,9 +2537,17 @@ impl ExtendedShortPreambleBuilder {
                 self.phase1_to_inputarg
                     .get(&arg.to_opref())
                     .cloned()
-                    // Unmapped Phase 1 jump arg: no current-namespace
-                    // producer to bind; position-only box as before.
-                    .unwrap_or_else(|| arg.clone())
+                    .unwrap_or_else(|| {
+                        // Unmapped Phase 1 jump arg (no rename): resolve the
+                        // Phase-2 producer registered at this position — the
+                        // inlined short box op or the label inputarg — so the
+                        // JUMP arg carries the producer object instead of a
+                        // producer-less position-only box. Mirrors the mapped
+                        // arm, which binds via `materialize_box_at`; falls back
+                        // to a position-only box only if no producer exists.
+                        ctx.get_box_replacement_box(arg.to_opref())
+                            .unwrap_or_else(|| BoxRef::from_opref(arg.to_opref()))
+                    })
             })
             .collect();
         self.short.push(Op::new(OpCode::Jump, &jump_args_box));

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2122,6 +2122,8 @@ fn build_short_preamble_struct_from_ops(
 #[derive(Clone, Debug)]
 pub struct ShortPreambleBuilder {
     state: AbstractShortPreambleBuilderState,
+    /// Stays `OpRef`-keyed: see `produced_short_op` for why the position key
+    /// is load-bearing and resists the #146/S8 `BoxRef` re-key.
     produced_short_boxes: VecAssoc<OpRef, ProducedShortOp>,
 }
 
@@ -2231,6 +2233,26 @@ impl ShortPreambleBuilder {
             .use_box(preamble_op, &VecSet::new(), arg_guards, result_guards);
     }
 
+    /// shortpreamble.py:284-285 `op in self.produced_short_boxes`.
+    ///
+    /// This is the SOLE corpus-live lookup of any `produced_short_boxes` map
+    /// (the ExtendedShortPreambleBuilder lookups never execute; this builder's
+    /// `use_box_recursive`/`add_preamble_op` lookups never execute either —
+    /// measured over the full bench corpus). The live callers reuse the
+    /// builder's replay Rc during `produce_pure`/`produce_heap_field`/
+    /// `produce_heap_array_item` re-export (pure.rs/shortpreamble.rs, via
+    /// `OptContext.imported_short_preamble_builder`).
+    ///
+    /// The `OpRef` (position) key is LOAD-BEARING and must not be re-keyed to
+    /// `BoxRef`(produced.res): the lookup runs at produce time, BEFORE a
+    /// Phase-2 box for `result` exists. Resolving `result` through the live
+    /// `OptContext` does not yield `produced.res` — measured 75 agree / 114
+    /// diverge, the divergences split between `get_box_replacement_box(result)
+    /// == None` (no Phase-2 box has been produced yet, so there is nothing to
+    /// key by) and a distinct Phase-2 producer box (the imported `produced.res`
+    /// is a Phase-1 object with no shared identity across the peel boundary).
+    /// The position bridges the imported Phase-1 res and the Phase-2 produce-
+    /// time slot precisely because no box identity links them at this point.
     pub fn produced_short_op(&self, result: OpRef) -> Option<ProducedShortOp> {
         self.produced_short_boxes.get(&result).cloned()
     }
@@ -2346,6 +2368,13 @@ impl ShortPreambleBuilder {
 /// `use_box()` pops JUMP, appends deps/guards/op, re-appends JUMP.
 #[derive(Clone, Debug)]
 pub struct ExtendedShortPreambleBuilder {
+    /// Stays `OpRef`-keyed. `setup()` populates this map (and the GC walk +
+    /// constructor clone read it), but EVERY key-lookup of it
+    /// (insert_dep_recursive / use_box_recursive / use_box /
+    /// add_preamble_op_from_pop / add_preamble_op / produced_short_op) is dead
+    /// over the full bench corpus — measured. A #146/S8 `BoxRef` re-key here is
+    /// therefore unverifiable (the gate cannot exercise the silent-miss
+    /// surface), like the deferred vectorizer maps.
     produced_short_boxes: VecAssoc<OpRef, ProducedShortOp>,
     short_inputargs: Vec<BoxRef>,
     /// shortpreamble.py:460: self.short = short — single ops list (base + JUMP sentinel)

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1305,7 +1305,7 @@ impl ProducedShortOp {
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
         exported_infos: &crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
         short_inputargs: &[BoxRef],
@@ -1531,7 +1531,7 @@ impl ProducedShortOp {
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
         exported_infos: &crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
         short_inputargs: &[BoxRef],
@@ -1576,9 +1576,7 @@ impl ProducedShortOp {
         // shortpreamble.py:66-68: if g.getarg(0) in exported_infos:
         //     setinfo_from_preamble(g.getarg(0), exported_infos[...])
         // Pass the Rc handle (unroll.py:61 identity preservation).
-        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) =
-            exported_infos.get(&object_arg.to_opref())
-        {
+        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg) {
             ctx.setinfo_from_preamble(obj_resolved, rc, Some(exported_infos));
         }
         let mut getfield_op = Op::new(
@@ -1657,7 +1655,7 @@ impl ProducedShortOp {
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
         exported_infos: &crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
         short_inputargs: &[BoxRef],
@@ -1714,9 +1712,7 @@ impl ProducedShortOp {
         // getarrayitem: if the base object has exported info, import it
         // before ensuring heap/array PtrInfo.
         // Pass the Rc handle (unroll.py:61 identity preservation).
-        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) =
-            exported_infos.get(&object_arg.to_opref())
-        {
+        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg) {
             ctx.setinfo_from_preamble(obj_resolved, rc, Some(exported_infos));
         }
         let index_const = ctx.make_constant_int(index);

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2249,17 +2249,24 @@ impl ShortPreambleBuilder {
     /// shortpreamble.py:432-440: add_preamble_op(preamble_op)
     /// Called from optimizer.force_box when popping from potential_extra_ops.
     ///
-    /// RPython unconditionally appends to used_boxes and short_preamble_jump
-    /// without any produced_short_boxes lookup:
+    /// RPython unconditionally uses the carried `preamble_op` with no
+    /// produced_short_boxes lookup:
     ///   op = preamble_op.op.get_box_replacement()
+    ///   if preamble_op.invented_name: self.extra_same_as.append(op)
     ///   self.used_boxes.append(op)
     ///   self.short_preamble_jump.append(preamble_op.preamble_op)
-    /// shortpreamble.py:432-440: add_preamble_op(preamble_op)
-    /// RPython unconditionally appends:
-    ///   op = preamble_op.op.get_box_replacement()
-    ///   self.used_boxes.append(op)
-    ///   self.short_preamble_jump.append(preamble_op.preamble_op)
-    /// shortpreamble.py:432-440: add_preamble_op(preamble_op)
+    ///
+    /// The `else` arm below is that unconditional pattern. The `if` arm
+    /// (map lookup) is a pyre-only side table and CANNOT yet collapse onto
+    /// the `else`: for an invented-name CompoundOp alternate the map entry's
+    /// `same_as_source` is the ORIGINAL aliased box, whereas the carried
+    /// `info::PreambleOp` only knows `op` (the invented SameAs name itself).
+    /// `record_imported_preamble_use` builds `same_as(source)`, so the `else`
+    /// arm would emit `same_as(invented_name)` — a self-alias — instead of
+    /// `same_as(original)`. (Empirically: map source `IntOp(14)` vs carried
+    /// `op` `IntOp(30)`.) Collapsing this (#149) requires threading
+    /// `same_as_source` onto `info::PreambleOp` (field_entry::PreambleOp) at
+    /// the export sites so the carried pop reproduces the map entry's record.
     pub fn add_preamble_op_from_pop(
         &mut self,
         preamble_op: &crate::optimizeopt::info::PreambleOp,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6754,6 +6754,7 @@ mod tests {
             OpRef::int_op(11),
             OpRef::int_op(11),
             false,
+            None,
         );
         assert_eq!(ctx2.imported_short_pure_ops, vec![expected]);
     }
@@ -6919,6 +6920,7 @@ mod tests {
         let pop = crate::optimizeopt::info::PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(20)),
             invented_name: produced.invented_name,
+            same_as_source: produced.same_as_source.clone(),
             preamble_op: produced.preamble_op,
         };
         let forced = ctx.force_op_from_preamble_op(&pop);
@@ -7025,6 +7027,7 @@ mod tests {
         let pop = crate::optimizeopt::info::PreambleOp {
             op: b_src.clone(),
             invented_name: produced.invented_name,
+            same_as_source: produced.same_as_source.clone(),
             preamble_op: produced.preamble_op,
         };
         let forced = ctx.force_op_from_preamble_op(&pop);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6957,11 +6957,12 @@ mod tests {
             }],
         );
 
+        let src20 = ctx.materialize_box_at(OpRef::int_op(20));
         let produced = ctx
             .imported_short_preamble_builder
             .as_ref()
             .unwrap()
-            .produced_short_op(OpRef::int_op(20))
+            .produced_short_op(&src20)
             .unwrap();
         let pop = crate::optimizeopt::info::PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(20)),
@@ -7057,11 +7058,12 @@ mod tests {
                 same_as_source: None,
             }],
         );
+        let src19 = ctx.materialize_box_at(OpRef::ref_op(19));
         let produced = ctx
             .imported_short_preamble_builder
             .as_ref()
             .unwrap()
-            .produced_short_op(OpRef::ref_op(19))
+            .produced_short_op(&src19)
             .unwrap();
         // Path B (B.6.7-heap-field): produce_heap_field no longer installs
         // make_equal_to, but the test still walks the get_box_replacement

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -100,8 +100,8 @@ fn root_forwarded_gcref(
     forwarded: &crate::r#box::Forwarded,
     info_constant_field: ExportedGcRefField,
     const_ref_field: ExportedGcRefField,
-    dummy_key: OpRef,
-    rooted_refs: &mut Vec<(OpRef, ExportedGcRefField, usize)>,
+    dummy_key: BoxRef,
+    rooted_refs: &mut Vec<(BoxRef, ExportedGcRefField, usize)>,
 ) {
     use crate::optimizeopt::info::{OpInfo, PtrInfo};
     if let crate::r#box::Forwarded::Info(OpInfo::Ptr(rc)) = forwarded {
@@ -109,7 +109,7 @@ fn root_forwarded_gcref(
         match &*info {
             PtrInfo::Constant(gcref) if !gcref.is_null() => {
                 let ss_idx = majit_gc::shadow_stack::push(*gcref);
-                rooted_refs.push((dummy_key, info_constant_field, ss_idx));
+                rooted_refs.push((dummy_key.clone(), info_constant_field, ss_idx));
             }
             // PtrInfo::Instance.known_class is an immortal vtable integer
             // (ConstInt), never a traced ref — no rooting needed.
@@ -1943,7 +1943,7 @@ pub struct ExportedState {
     /// Majit uses the existing `OpInfo` enum (info.rs:137) as the discriminated
     /// union of these three cases.
     pub exported_infos:
-        crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::info::OpInfo>,
+        crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::info::OpInfo>,
     /// RPython shortpreamble.py: produced short boxes in preamble order.
     /// This preserves the original preamble ops so the active path can build
     /// short preambles without re-extracting them from the peeled trace.
@@ -2032,8 +2032,11 @@ pub struct ExportedState {
     /// (resoperation.py:233-242 `_forwarded` host).
     pub(crate) partial_trace_operations: Vec<majit_ir::OpRc>,
     /// Shadow stack rooting for GcRef values in exported_infos.
-    /// (OpRef key, field kind, shadow stack index).
-    rooted_refs: Vec<(OpRef, ExportedGcRefField, usize)>,
+    /// (BoxRef key, field kind, shadow stack index). The key is the
+    /// `exported_infos` BoxRef key for `InfoPtrInfoConstant` entries; other
+    /// field kinds carry the `BoxRef::none()` sentinel since they never key
+    /// back into `exported_infos`.
+    rooted_refs: Vec<(BoxRef, ExportedGcRefField, usize)>,
     /// Shadow stack slots for every inline `ConstPtr.value` reachable from
     /// this ExportedState's Rust object graph. RPython traces these fields as
     /// normal Const object attributes; pyre records the walk order and copies
@@ -2076,10 +2079,10 @@ impl ExportedState {
     /// unroll.py: ExportedState.__init__
     pub fn new(
         end_args: Vec<OpRef>,
-        next_iteration_args: Vec<OpRef>,
+        next_iteration_args: Vec<BoxRef>,
         virtual_state: crate::optimizeopt::virtualstate::VirtualState,
         exported_infos: crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
         exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
@@ -2111,10 +2114,11 @@ impl ExportedState {
             );
         ExportedState {
             end_args: end_args.iter().map(|&a| BoxRef::from_opref(a)).collect(),
-            next_iteration_args: next_iteration_args
-                .iter()
-                .map(|&a| BoxRef::from_opref(a))
-                .collect(),
+            // unroll.py:467 `next_iteration_args = end_args` — carry the literal
+            // Phase-1 boxes (the same Rcs used as `exported_infos` keys) so the
+            // import-state lookup is a ptr_eq hit. NOT `from_opref` (which would
+            // mint fresh producer-less Rcs and sever the carry identity).
+            next_iteration_args,
             end_arg_types: Vec::new(),
             virtual_state,
             exported_infos,
@@ -2228,7 +2232,7 @@ impl ExportedState {
         visit_boxrefs(&self.next_iteration_args, visitor);
         self.virtual_state.walk_const_ptr_refs_mut(visitor);
         for (key, info) in self.exported_infos.iter_entries_mut() {
-            visit_opref(key, visitor);
+            key.walk_const_ptr_refs(visitor);
             visit_op_info(info, visitor);
         }
         for entry in &mut self.exported_short_boxes {
@@ -2323,8 +2327,8 @@ impl ExportedState {
             visit(arg.to_opref());
         }
 
-        for (&opref, info) in &self.exported_infos {
-            visit(opref);
+        for (key, info) in &self.exported_infos {
+            visit(key.to_opref());
             if let crate::optimizeopt::info::OpInfo::Ptr(rc) = info {
                 let children = rc.borrow().visitor_walk_recursive();
                 for child in children {
@@ -2408,15 +2412,15 @@ impl ExportedState {
         self.release_roots();
         self.shadow_stack_base = majit_gc::shadow_stack::depth();
         // ── exported_infos GcRef fields ──
-        let mut keys: Vec<OpRef> = self.exported_infos.keys().copied().collect();
-        // Sort for determinism. Const variants (history.py:189-220) sort
-        // separately via the inline `i64` payload — `.raw()` would panic
-        // on inline-Const OpRefs.
-        keys.sort_by_key(|k| match k {
-            OpRef::ConstInt(v) => (1u8, *v as u64),
+        let mut keys: Vec<BoxRef> = self.exported_infos.keys().cloned().collect();
+        // Sort for determinism via the key's resolved OpRef position. Const
+        // variants (history.py:189-220) sort separately via the inline
+        // payload — `.raw()` would panic on inline-Const OpRefs.
+        keys.sort_by_key(|k| match k.to_opref() {
+            OpRef::ConstInt(v) => (1u8, v as u64),
             OpRef::ConstFloat(v) => (1u8, v.to_bits()),
             OpRef::ConstPtr(v) => (1u8, v.0 as u64),
-            _ => (0u8, k.raw() as u64),
+            other => (0u8, other.raw() as u64),
         });
         for key in keys {
             if let Some(OpInfo::Ptr(rc)) = self.exported_infos.get(&key) {
@@ -2441,11 +2445,9 @@ impl ExportedState {
         // ── virtual_state GcRef fields ──
         // VirtualStateInfo::KnownClass, Virtual{known_class}, Constant(Ref)
         // The rooted_refs `key` slot here just tags the field origin;
-        // these entries are not keyed back into a typed-OpRef map, so
-        // use the canonical `OpRef::NONE` sentinel rather than a raw
-        // u32::MAX placeholder that would diverge from `OpRef::None`
-        // under variant-aware Eq/Hash.
-        let dummy_key = OpRef::NONE;
+        // these entries dispatch on the field kind and never key back into
+        // `exported_infos`, so use the producer-less `BoxRef::none()` sentinel.
+        let dummy_key = BoxRef::none();
         for (i, entry) in self.virtual_state.state.iter().enumerate() {
             match &entry.info {
                 // KnownClass.class_ptr and Virtual.known_class are immortal
@@ -2453,7 +2455,7 @@ impl ExportedState {
                 VirtualStateInfo::Constant(Value::Ref(gcref)) if !gcref.is_null() => {
                     let ss_idx = majit_gc::shadow_stack::push(*gcref);
                     self.rooted_refs.push((
-                        dummy_key,
+                        dummy_key.clone(),
                         ExportedGcRefField::VirtualStateConstantRef(i),
                         ss_idx,
                     ));
@@ -2475,8 +2477,11 @@ impl ExportedState {
                 && !gcref.is_null()
             {
                 let ss_idx = majit_gc::shadow_stack::push(*gcref);
-                self.rooted_refs
-                    .push((key, ExportedGcRefField::ShortBoxConstValue(key), ss_idx));
+                self.rooted_refs.push((
+                    BoxRef::none(),
+                    ExportedGcRefField::ShortBoxConstValue(key),
+                    ss_idx,
+                ));
             }
         }
         // ── partial_trace `_forwarded` GcRef fields ──
@@ -2492,7 +2497,7 @@ impl ExportedState {
                 &forwarded,
                 ExportedGcRefField::PartialTraceInputArgInfoPtrInfoConstant(i),
                 ExportedGcRefField::PartialTraceInputArgConstRef(i),
-                dummy_key,
+                dummy_key.clone(),
                 &mut self.rooted_refs,
             );
         }
@@ -2502,7 +2507,7 @@ impl ExportedState {
                 &forwarded,
                 ExportedGcRefField::PartialTraceOpInfoPtrInfoConstant(i),
                 ExportedGcRefField::PartialTraceOpConstRef(i),
-                dummy_key,
+                dummy_key.clone(),
                 &mut self.rooted_refs,
             );
         }
@@ -2546,11 +2551,11 @@ impl ExportedState {
             .map(|rc| Rc::as_ptr(rc) as usize)
             .collect();
         let mut virtual_state_dirty = false;
-        for &(key, ref field, ss_idx) in &self.rooted_refs {
+        for &(ref key, ref field, ss_idx) in &self.rooted_refs {
             let updated = majit_gc::shadow_stack::get(ss_idx);
             match field {
                 ExportedGcRefField::InfoPtrInfoConstant => {
-                    if let Some(info) = self.exported_infos.get_mut(&key) {
+                    if let Some(info) = self.exported_infos.get_mut(key) {
                         *info = crate::optimizeopt::info::OpInfo::ptr(PtrInfo::Constant(updated));
                     }
                 }
@@ -2962,11 +2967,24 @@ impl OptUnroll {
         let virtual_state = crate::optimizeopt::virtualstate::export_state(&end_args, ctx);
         // unroll.py:459-461: infos = {}; for arg in end_args: _expand_info(arg, infos)
         let mut infos: crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         > = crate::optimizeopt::vec_assoc::VecAssoc::new();
-        for &arg in &end_args {
-            self.expand_info(arg, ctx, exported_int_bounds, &mut infos);
+        // Resolve the ONE canonical box per end_arg up front: it is the
+        // exported_infos key AND (unroll.py:467 next_iteration_args = end_args)
+        // the carried import key, so they are the identical Rc and import_state's
+        // lookup is a ptr_eq hit for const / inputarg / resop alike. Computing it
+        // once is load-bearing for Const: get_box_replacement_box mints a fresh
+        // Const box per call, so two calls would NOT be ptr_eq.
+        let end_arg_boxes: Vec<BoxRef> = end_args
+            .iter()
+            .map(|&a| {
+                ctx.get_box_replacement_box(a)
+                    .unwrap_or_else(|| BoxRef::from_opref(a))
+            })
+            .collect();
+        for (arg, arg_box) in end_args.iter().zip(end_arg_boxes.iter()) {
+            self.expand_info(*arg, arg_box, ctx, exported_int_bounds, &mut infos);
         }
         // unroll.py:462-463 `label_args, virtuals =
         //   virtual_state.make_inputargs_and_virtuals(end_args, self.optimizer)`.
@@ -2975,7 +2993,10 @@ impl OptUnroll {
             .expect("export_state make_inputargs_and_virtuals failed");
         // unroll.py:464-465: for arg in label_args: _expand_info(arg, infos)
         for &arg in &label_args {
-            self.expand_info(arg, ctx, exported_int_bounds, &mut infos);
+            let arg_box = ctx
+                .get_box_replacement_box(arg)
+                .unwrap_or_else(|| BoxRef::from_opref(arg));
+            self.expand_info(arg, &arg_box, ctx, exported_int_bounds, &mut infos);
         }
         let mut short_args = label_args.to_vec();
         short_args.extend(virtuals);
@@ -3035,10 +3056,21 @@ impl OptUnroll {
                 &short_inputargs,
                 &exported_short_boxes,
             );
+        // unroll.py:481-484:
+        //     for produced_op in short_boxes:
+        //         op = produced_op.short_op.res
+        //         if not isinstance(op, Const):
+        //             self._expand_info(op, infos)
+        // Key by the short_op result BOX (`produced_op.res`). Every
+        // `produced_short_boxes_from_exported_boxes` invocation clones `res`
+        // from the same `exported_short_boxes[k].res` (shortpreamble.rs:3113),
+        // so the consumer-side
+        // `initialize_imported_short_preamble_builder_from_short_boxes` lookup
+        // re-derives the identical Rc and the box-identity lookup hits.
         for (_, produced_op) in &short_boxes_for_info {
-            let op = produced_op.preamble_op.pos.get();
+            let op = produced_op.res.to_opref();
             if !op.is_constant() {
-                self.expand_info(op, ctx, exported_int_bounds, &mut infos);
+                self.expand_info(op, &produced_op.res, ctx, exported_int_bounds, &mut infos);
             }
         }
 
@@ -3058,11 +3090,13 @@ impl OptUnroll {
         // RPython sidesteps this naturally because `box._forwarded` persists
         // across phases. virtualstate.py make_inputargs assumes shared state
         // ⇒ same forwarded target.
-        // unroll.py:458 `end_args = [get_box_replacement(arg) for arg in end_args]`.
-        let resolved_next_iteration_args: Vec<OpRef> = end_args
-            .iter()
-            .map(|&a| ctx.get_replacement_opref(a))
-            .collect();
+        // unroll.py:458/467 `end_args = [get_box_replacement(arg) ...]`;
+        // `next_iteration_args = end_args`. Carry the SAME canonical box Rcs
+        // already resolved as the exported_infos keys (`end_arg_boxes`), so the
+        // import lookup is a ptr_eq hit. Each box's `.to_opref()` yields the
+        // resolved (post-forwarding) position, so consumers that read `.to_opref()`
+        // see the same value the prior `get_replacement_opref` form produced.
+        let resolved_next_iteration_args: Vec<BoxRef> = end_arg_boxes;
         // Phase B B1: `produced_short_boxes` is derived from
         // `exported_short_boxes` lazily at the consumer site
         // (`build_short_preamble_from_produced_boxes` in `import_state`)
@@ -3180,26 +3214,16 @@ impl OptUnroll {
     fn expand_info(
         &self,
         arg: OpRef,
+        arg_box: &BoxRef,
         ctx: &OptContext,
         exported_int_bounds: Option<
             &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>,
         >,
         infos: &mut crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
     ) {
-        let resolved = ctx.get_replacement_opref(arg);
-        if infos.contains_key(&resolved) {
-            // Also store under the original key so import_state can
-            // find the info using the unresolved next_iteration_args key.
-            if arg != resolved {
-                if let Some(info) = infos.get(&resolved).cloned() {
-                    infos.insert(arg, info);
-                }
-            }
-            return;
-        }
         // unroll.py:438-443 `_expand_info`:
         //     if arg in infos:
         //         return
@@ -3208,6 +3232,16 @@ impl OptUnroll {
         //         if info.is_virtual():
         //             self._expand_infos_from_virtual(info, infos)
         //
+        // Keyed by `arg_box`, the ONE canonical Phase-1 box the caller resolved
+        // for this arg (shared verbatim with the `next_iteration_args` carry so
+        // the import lookup is a ptr_eq hit). The dual OpRef-key insert is gone:
+        // a ptr-stable BoxRef key tracks its position through the shared
+        // set_position Cell across compaction, so there is no resolved-vs-original
+        // OpRef drift left to bridge.
+        if infos.contains_key(arg_box) {
+            return;
+        }
+        let resolved = ctx.get_replacement_opref(arg);
         // RPython stores the entry only when `info` is truthy — a falsy
         // `info` (None) simply skips the insert, so downstream
         // `setinfo_from_preamble_list` at unroll.py:45-51 sees "no entry"
@@ -3215,16 +3249,11 @@ impl OptUnroll {
         let Some(info) = self.collect_exported_info(resolved, ctx, exported_int_bounds) else {
             return;
         };
-        let resolved_box = ctx.get_box_replacement_box(arg);
         let has_fields = matches!(
-            resolved_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)),
+            ctx.peek_ptr_info(arg_box),
             Some(pi) if pi.is_virtual() || !pi.all_items().is_empty()
         );
-        infos.insert(resolved, info.clone());
-        // Also store under the original (unresolved) key.
-        if arg != resolved {
-            infos.insert(arg, info);
-        }
+        infos.insert(arg_box.clone(), info);
         if has_fields {
             self.expand_infos_from_virtual(resolved, ctx, exported_int_bounds, infos);
         }
@@ -3239,34 +3268,31 @@ impl OptUnroll {
             &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>,
         >,
         infos: &mut crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
     ) {
         let opref_box = ctx.get_box_replacement_box(opref);
-        let fields: Vec<OpRef> = match opref_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
-            Some(crate::optimizeopt::info::PtrInfo::Virtual(v)) => {
-                v.fields.iter().map(|(_, r)| r.to_opref()).collect()
-            }
-            Some(crate::optimizeopt::info::PtrInfo::VirtualStruct(v)) => {
-                v.fields.iter().map(|(_, r)| r.to_opref()).collect()
-            }
-            Some(crate::optimizeopt::info::PtrInfo::VirtualArray(v)) => {
-                v.items.iter().map(|b| b.to_opref()).collect()
-            }
-            Some(crate::optimizeopt::info::PtrInfo::Instance(v)) if !v.fields.is_empty() => {
-                v.fields.iter().map(|(_, e)| e.as_seen_opref()).collect()
-            }
-            Some(crate::optimizeopt::info::PtrInfo::Struct(v)) if !v.fields.is_empty() => {
-                v.fields.iter().map(|(_, e)| e.as_seen_opref()).collect()
-            }
-            _ => return,
+        // unroll.py:445-450 `_expand_infos_from_virtual`:
+        //     items = info.all_items()
+        //     for item in items:
+        //         if item is None: continue
+        //         self._expand_info(item, infos)
+        // Key each field by its raw `all_items()` box, NOT a re-resolved OpRef.
+        // `peek_ptr_info` returns the SAME `Rc<RefCell<PtrInfo>>` cell whose
+        // handle `collect_exported_info` stores as the `exported_infos` value
+        // (unroll.rs:4226 `ptr_info_handle`), so the import-side reader
+        // (`setinfo_from_preamble_list`) walks the same `v.fields` and the
+        // box-identity (`Rc::ptr_eq`) lookup hits.
+        let Some(info) = opref_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) else {
+            return;
         };
-        for field in fields {
-            if field.is_none() {
+        for (_, entry) in info.all_items() {
+            let field_box = entry.as_seen_box();
+            if field_box.to_opref().is_none() {
                 continue;
             }
-            self.expand_info(field, ctx, exported_int_bounds, infos);
+            self.expand_info(field_box.to_opref(), &field_box, ctx, exported_int_bounds, infos);
         }
     }
 
@@ -4014,8 +4040,11 @@ impl OptUnroll {
             "import_state: next_iteration_args mismatch"
         );
         // for i, target in enumerate(exported_state.next_iteration_args):
-        for (i, target) in exported_state.next_iteration_args.iter().enumerate() {
-            let target = target.to_opref();
+        for (i, carried) in exported_state.next_iteration_args.iter().enumerate() {
+            // `carried` is the literal Phase-1 box (the same Rc used as the
+            // exported_infos key); `.to_opref()` is its resolved position, used
+            // only for the forwarding plumbing below.
+            let target = carried.to_opref();
             // source = targetargs[i]
             let source = targetargs[i];
             // assert source is not target — see commit log for the
@@ -4048,8 +4077,10 @@ impl OptUnroll {
                 );
             }
             // info = exported_state.exported_infos.get(target, None)
-            // if info is not None:
-            if let Some(info) = exported_state.exported_infos.get(&target) {
+            // Look up by the carried Phase-1 box (the same Rc the exporter used
+            // as the key) — a ptr_eq hit, with no Phase-2 re-resolution that would
+            // mint a fresh (non-ptr_eq) Const/InputArg box.
+            if let Some(info) = exported_state.exported_infos.get(carried) {
                 //     self.optimizer.setinfo_from_preamble(source, info,
                 //                                     exported_state.exported_infos)
                 self.setinfo_from_preamble(source, info, &exported_state.exported_infos, ctx);
@@ -4335,7 +4366,7 @@ impl OptUnroll {
         opref: OpRef,
         info: &crate::optimizeopt::info::OpInfo,
         exported_infos: &crate::optimizeopt::vec_assoc::VecAssoc<
-            OpRef,
+            BoxRef,
             crate::optimizeopt::info::OpInfo,
         >,
         ctx: &mut OptContext,
@@ -5609,7 +5640,10 @@ mod tests {
     fn test_exported_state_high_water_covers_retrace_namespace() {
         let exported = ExportedState::new(
             vec![OpRef::int_op(52)],
-            vec![OpRef::int_op(109), OpRef::const_int(3)],
+            vec![
+                BoxRef::from_opref(OpRef::int_op(109)),
+                BoxRef::from_opref(OpRef::const_int(3)),
+            ],
             crate::optimizeopt::virtualstate::VirtualState::new(Vec::new()),
             crate::optimizeopt::vec_assoc::VecAssoc::new(),
             Vec::new(),
@@ -5840,7 +5874,10 @@ mod tests {
         let old_ref = OpRef::const_ptr(old);
         let new_ref = OpRef::const_ptr(new);
         let mut exported_infos = crate::optimizeopt::vec_assoc::VecAssoc::new();
-        exported_infos.insert(old_ref, OpInfo::ptr(PtrInfo::Constant(old)));
+        exported_infos.insert(
+            BoxRef::from_opref(old_ref),
+            OpInfo::ptr(PtrInfo::Constant(old)),
+        );
         let mut short_box_const_values = crate::optimizeopt::vec_assoc::VecAssoc::new();
         short_box_const_values.insert(old_ref, Value::Ref(old));
         let mut constants = crate::optimizeopt::vec_assoc::VecAssoc::new();
@@ -5848,7 +5885,7 @@ mod tests {
 
         let mut state = ExportedState::new(
             vec![old_ref],
-            vec![old_ref],
+            vec![BoxRef::from_opref(old_ref)],
             VirtualState::new(vec![VirtualStateInfo::Constant(Value::Ref(old))]),
             exported_infos,
             vec![PreambleOp {
@@ -5910,7 +5947,10 @@ mod tests {
         assert_eq!(state.renamed_inputargs[0].to_opref(), new_ref);
         assert_eq!(state.short_inputargs[0].to_opref(), new_ref);
         assert_eq!(state.runtime_boxes[0].to_opref(), new_ref);
-        assert!(state.exported_infos.get(&new_ref).is_some());
+        assert!(state
+            .exported_infos
+            .keys()
+            .any(|k| k.to_opref() == new_ref));
         assert_eq!(state.exported_short_boxes[0].op.arg(0).to_opref(), new_ref);
         assert_eq!(
             state.exported_short_boxes[0]
@@ -6566,7 +6606,13 @@ mod tests {
         );
 
         assert_eq!(
-            match exported.exported_infos.get(&OpRef::int_op(21)).unwrap() {
+            match exported
+                .exported_infos
+                .iter()
+                .find(|(k, _)| k.to_opref() == OpRef::int_op(21))
+                .map(|(_, v)| v)
+                .unwrap()
+            {
                 crate::optimizeopt::info::OpInfo::IntBound(b) => {
                     let b = b.borrow();
                     Some((b.lower, b.upper))
@@ -6832,7 +6878,7 @@ mod tests {
         let phase2_result = OpRef::int_op(3);
         let exported = ExportedState::new(
             vec![source],
-            vec![source],
+            vec![BoxRef::from_opref(source)],
             crate::optimizeopt::virtualstate::VirtualState::new(Vec::new()),
             crate::optimizeopt::vec_assoc::VecAssoc::new(),
             vec![crate::optimizeopt::shortpreamble::PreambleOp {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -491,8 +491,17 @@ impl UnrollOptimizer {
                     .next_global_opref
                     .max(num_inputs as u32)
                     .max(pre_imported.opref_high_water());
-                // Retrace path: Phase 1 already done; preamble ops are in
-                // the caller's partial_trace, not produced here.
+                // Retrace path: Phase 1 already done; the preamble producers
+                // live in the imported state's `partial_trace_operations`
+                // (export records them there from `phase1_emit_ops`, #104). The
+                // non-skip path populates `self.phase1_emit_ops` from `opt_p1`;
+                // restore the same pool here so Phase 2's producer lookup
+                // (`new_operations ∪ phase1_emit_ops ∪ resop_refs`) can reach a
+                // const-folded preamble producer that no other store carries.
+                // RPython keeps box `_forwarded` reachable across the retrace;
+                // this is the pyre analog. (Readers dedup, so double-coverage
+                // with `resop_refs` is idempotent.)
+                self.phase1_emit_ops = pre_imported.partial_trace_operations.clone();
                 // RPython: same Optimizer persists patchguardop. Recover here.
                 if self.phase1_patchguardop.is_none() {
                     self.phase1_patchguardop = pre_imported.patchguardop.clone();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3303,7 +3303,13 @@ impl OptUnroll {
             if field_box.to_opref().is_none() {
                 continue;
             }
-            self.expand_info(field_box.to_opref(), &field_box, ctx, exported_int_bounds, infos);
+            self.expand_info(
+                field_box.to_opref(),
+                &field_box,
+                ctx,
+                exported_int_bounds,
+                infos,
+            );
         }
     }
 
@@ -5958,10 +5964,7 @@ mod tests {
         assert_eq!(state.renamed_inputargs[0].to_opref(), new_ref);
         assert_eq!(state.short_inputargs[0].to_opref(), new_ref);
         assert_eq!(state.runtime_boxes[0].to_opref(), new_ref);
-        assert!(state
-            .exported_infos
-            .keys()
-            .any(|k| k.to_opref() == new_ref));
+        assert!(state.exported_infos.keys().any(|k| k.to_opref() == new_ref));
         assert_eq!(state.exported_short_boxes[0].op.arg(0).to_opref(), new_ref);
         assert_eq!(
             state.exported_short_boxes[0]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2978,9 +2978,15 @@ impl OptUnroll {
         // Const box per call, so two calls would NOT be ptr_eq.
         let end_arg_boxes: Vec<BoxRef> = end_args
             .iter()
-            .map(|&a| {
-                ctx.get_box_replacement_box(a)
-                    .unwrap_or_else(|| BoxRef::from_opref(a))
+            .map(|&a| match ctx.get_box_replacement_box(a) {
+                Some(b) => b,
+                // The None arm fires only for an unregistered ResOp position
+                // (Const / InputArg always resolve); #157 drained those fires
+                // to zero. materialize_box_at mints+registers a canonical
+                // synthetic so this key is ptr-stable and a later resolve hits
+                // the same host — not a producer-less from_opref box that would
+                // miss the exported_infos / next_iteration_args ptr_eq carry.
+                None => ctx.materialize_box_at(a),
             })
             .collect();
         for (arg, arg_box) in end_args.iter().zip(end_arg_boxes.iter()) {
@@ -2993,9 +2999,14 @@ impl OptUnroll {
             .expect("export_state make_inputargs_and_virtuals failed");
         // unroll.py:464-465: for arg in label_args: _expand_info(arg, infos)
         for &arg in &label_args {
-            let arg_box = ctx
-                .get_box_replacement_box(arg)
-                .unwrap_or_else(|| BoxRef::from_opref(arg));
+            let arg_box = match ctx.get_box_replacement_box(arg) {
+                Some(b) => b,
+                // Same canonical-key fallback as end_arg_boxes above: an
+                // unregistered ResOp position (drained to zero by #157) mints a
+                // canonical synthetic instead of a producer-less from_opref box,
+                // keeping the exported_infos key ptr-stable.
+                None => ctx.materialize_box_at(arg),
+            };
             self.expand_info(arg, &arg_box, ctx, exported_int_bounds, &mut infos);
         }
         let mut short_args = label_args.to_vec();

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -83,19 +83,20 @@ pub const NULLREF: i16 = ((-1i32 << 2) | TAGCONST as i32) as i16;
 pub const UNINITIALIZED_TAG: i16 = ((-2i32 << 2) | TAGCONST as i32) as i16;
 pub const TAG_CONST_OFFSET: i32 = 0;
 
-/// Ordered livebox map: OpRef → i16 tag.
+/// Ordered livebox map: canonical box (`Rc::ptr_eq`) → i16 tag.
 ///
-/// resume.py:137/370: RPython uses `dict` keyed by the actual Box object.
-/// In Python 3 that dict is insertion-ordered, and `_number_virtuals`
-/// iterates it directly. The no-HashMap house rule replaces the Rust
-/// `IndexMap` backing with `VecAssoc<OpRef, i16>` (linear scan, dict-
-/// assignment semantics, preserved insertion order) — same observable
-/// shape for the four call sites here while keeping the full typed
-/// OpRef variant as the identity (resoperation.py:38 `same_box`).
-/// A raw-position Vec would collapse `InputArgInt(0)` and `IntOp(0)`,
-/// which are distinct RPython Box objects.
+/// resume.py:137/370: RPython uses `dict` keyed by the actual Box object
+/// (object `is` identity). In Python 3 that dict is insertion-ordered, and
+/// `_number_virtuals` iterates it directly. #160/S11 keys this map by the
+/// canonical [`BoxRef`](crate::r#box::BoxRef) (`Rc::ptr_eq` = PyPy `box is
+/// box`), the faithful port of the dict-by-`is`; the no-HashMap house rule
+/// keeps the `VecAssoc` backing (linear scan, dict-assignment semantics,
+/// preserved insertion order). Two reaches of one logical box resolve to one
+/// memoized Rc (via `from_bound_op`/`from_bound_inputarg`) and collapse to one
+/// key; distinct boxes — e.g. an `InputArg` vs a `ResOp` result — stay
+/// distinct, where a raw-position key could have aliased them.
 ///
-/// Invariant: keys are never `Const*` OpRefs. Per `resume.py:204-205`
+/// Invariant: keys are never Const boxes. Per `resume.py:204-205`
 /// `_number_boxes`, `isinstance(box, Const)` short-circuits to
 /// `self.getconst(box)` and the result is never written into
 /// `numb_state.liveboxes`. Only the `else` branch (line 207-223,
@@ -104,7 +105,7 @@ pub const TAG_CONST_OFFSET: i32 = 0;
 /// debug builds rather than silently producing an out-of-RPython-shape
 /// numbering state.
 pub struct LiveboxMap {
-    entries: majit_ir::vec_assoc::VecAssoc<majit_ir::OpRef, i16>,
+    entries: majit_ir::vec_assoc::VecAssoc<crate::r#box::BoxRef, i16>,
 }
 
 impl LiveboxMap {
@@ -115,31 +116,30 @@ impl LiveboxMap {
     }
 
     #[inline(always)]
-    pub fn get(&self, opref: majit_ir::OpRef) -> Option<i16> {
-        self.entries.get(&opref).copied()
+    pub fn get(&self, b: &crate::r#box::BoxRef) -> Option<i16> {
+        self.entries.get(b).copied()
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, opref: majit_ir::OpRef, value: i16) {
+    pub fn insert(&mut self, b: crate::r#box::BoxRef, value: i16) {
         debug_assert!(
-            !opref.is_constant(),
-            "LiveboxMap::insert: Const* OpRef {:?} violates resume.py:204-223 \
+            b.const_value().is_none(),
+            "LiveboxMap::insert: Const box {b:?} violates resume.py:204-223 \
              `_number_boxes` invariant — `isinstance(box, Const)` is encoded \
              via `getconst(box)` and never enters numb_state.liveboxes",
-            opref
         );
-        self.entries.insert(opref, value);
+        self.entries.insert(b, value);
     }
 
     #[inline(always)]
-    pub fn contains_key(&self, opref: majit_ir::OpRef) -> bool {
-        self.entries.contains_key(&opref)
+    pub fn contains_key(&self, b: &crate::r#box::BoxRef) -> bool {
+        self.entries.contains_key(b)
     }
 
-    /// Iterate over all (typed OpRef, tag) pairs in RPython dict insertion
-    /// order.
-    pub fn iter(&self) -> impl Iterator<Item = (majit_ir::OpRef, i16)> + '_ {
-        self.entries.iter().map(|(opref, v)| (*opref, *v))
+    /// Iterate over all (canonical box, tag) pairs in RPython dict insertion
+    /// order (Rc::ptr_eq identity = PyPy `box is box`).
+    pub fn iter(&self) -> impl Iterator<Item = (crate::r#box::BoxRef, i16)> + '_ {
+        self.entries.iter().map(|(b, v)| (b.clone(), *v))
     }
 }
 
@@ -363,6 +363,12 @@ pub struct SimpleBoxEnv {
     pub types: crate::optimizeopt::vec_assoc::VecAssoc<u32, majit_ir::Type>,
     pub virtuals: majit_ir::vec_set::VecSet<u32>,
     pub virtual_fields: crate::optimizeopt::vec_assoc::VecAssoc<u32, majit_ir::VirtualFieldsInfo>,
+    /// #160/S11: one canonical BoxRef per replacement-walked OpRef. This env
+    /// holds no producer Ops, so it memoizes here to give `Rc::ptr_eq` dedup
+    /// parity with production (where `from_bound_op` memoizes on the Op).
+    box_cache: std::cell::RefCell<
+        crate::optimizeopt::vec_assoc::VecAssoc<majit_ir::OpRef, crate::r#box::BoxRef>,
+    >,
 }
 
 impl SimpleBoxEnv {
@@ -373,6 +379,7 @@ impl SimpleBoxEnv {
             types: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             virtuals: majit_ir::vec_set::VecSet::new(),
             virtual_fields: crate::optimizeopt::vec_assoc::VecAssoc::new(),
+            box_cache: std::cell::RefCell::new(crate::optimizeopt::vec_assoc::VecAssoc::new()),
         }
     }
 }
@@ -396,6 +403,19 @@ impl BoxEnv for SimpleBoxEnv {
             opref = next;
         }
         opref
+    }
+
+    fn get_box_replacement_boxref(&self, opref: majit_ir::OpRef) -> crate::r#box::BoxRef {
+        // #160/S11: no producer Ops here, so memoize one BoxRef per
+        // replacement-walked OpRef to mirror production's from_bound_op
+        // memoization — two reaches of one logical box share an Rc (ptr_eq).
+        let root = self.get_box_replacement(opref);
+        if let Some(b) = self.box_cache.borrow().get(&root) {
+            return b.clone();
+        }
+        let b = crate::r#box::BoxRef::from_opref(root);
+        self.box_cache.borrow_mut().insert(root, b.clone());
+        b
     }
 
     // resoperation.py:64-65 not_const arm: stop one hop before reaching
@@ -3104,8 +3124,8 @@ pub struct ResumeDataLoopMemo {
     /// Becomes storage.rd_consts (resume.py:467).
     ///
     /// resume.py:150-151 — cached box/virtual numbering.
-    pub cached_boxes: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, i32>,
-    pub cached_virtuals: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, i32>,
+    pub cached_boxes: crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, i32>,
+    pub cached_virtuals: crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, i32>,
     /// resume.py:153-155 — statistics.
     pub nvirtuals: usize,
     pub nvholes: usize,
@@ -3285,19 +3305,19 @@ impl ResumeDataLoopMemo {
     /// RPython version mutates `boxes` list:
     /// - cached: `boxes[-num - 1] = box`
     /// - new: `boxes.append(box); num = -len(boxes)`
-    pub fn assign_number_to_box(&mut self, box_id: OpRef, boxes: &mut Vec<OpRef>) -> i32 {
-        if let Some(&num) = self.cached_boxes.get(&box_id) {
+    pub fn assign_number_to_box(&mut self, b: &crate::r#box::BoxRef, boxes: &mut Vec<OpRef>) -> i32 {
+        if let Some(&num) = self.cached_boxes.get(b) {
             // resume.py:268: boxes[-num - 1] = box
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
-                boxes[idx] = box_id;
+                boxes[idx] = b.to_opref();
             }
             return num;
         }
         // resume.py:270-271: boxes.append(box); num = -len(boxes)
-        boxes.push(box_id);
+        boxes.push(b.to_opref());
         let num = -(boxes.len() as i32);
-        self.cached_boxes.insert(box_id, num);
+        self.cached_boxes.insert(b.clone(), num);
         num
     }
 
@@ -3305,30 +3325,30 @@ impl ResumeDataLoopMemo {
     /// RPython's `new_liveboxes = [None] * memo.num_cached_boxes()`.
     pub fn assign_number_to_box_opt(
         &mut self,
-        box_id: OpRef,
+        b: &crate::r#box::BoxRef,
         boxes: &mut Vec<Option<OpRef>>,
     ) -> i32 {
-        if let Some(&num) = self.cached_boxes.get(&box_id) {
+        if let Some(&num) = self.cached_boxes.get(b) {
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
-                boxes[idx] = Some(box_id);
+                boxes[idx] = Some(b.to_opref());
             }
             return num;
         }
-        boxes.push(Some(box_id));
+        boxes.push(Some(b.to_opref()));
         let num = -(boxes.len() as i32);
-        self.cached_boxes.insert(box_id, num);
+        self.cached_boxes.insert(b.clone(), num);
         num
     }
 
     /// resume.py:278 assign_number_to_virtual — returns a negative number.
-    pub fn assign_number_to_virtual(&mut self, box_id: OpRef) -> i32 {
-        if let Some(&num) = self.cached_virtuals.get(&box_id) {
+    pub fn assign_number_to_virtual(&mut self, b: &crate::r#box::BoxRef) -> i32 {
+        if let Some(&num) = self.cached_virtuals.get(b) {
             return num;
         }
         // resume.py:283: num = self.cached_virtuals[box] = -len(self.cached_virtuals) - 1
         let num = -(self.num_cached_virtuals() as i32) - 1;
-        self.cached_virtuals.insert(box_id, num);
+        self.cached_virtuals.insert(b.clone(), num);
         num
     }
 
@@ -3385,13 +3405,18 @@ impl ResumeDataLoopMemo {
         }
         // resume.py:371 — constants are handled by _gettagged
         // (TAGCONST/TAGINT) and don't need livebox slots.
-        let is_c = env.is_const(opref);
-        let in_env = liveboxes_from_env.contains_key(opref);
-        let in_new = new_liveboxes.contains_key(opref);
-        if is_c || in_env || in_new {
+        if env.is_const(opref) {
             return;
         }
-        new_liveboxes.insert(opref, UNASSIGNED);
+        // #160/S11: key by the canonical box (Rc::ptr_eq = PyPy `box is`).
+        // `opref` is already replacement-walked by the caller, so re-walking
+        // through get_box_replacement_boxref is idempotent and yields the one
+        // memoized Rc per logical box.
+        let b = env.get_box_replacement_boxref(opref);
+        if liveboxes_from_env.contains_key(&b) || new_liveboxes.contains_key(&b) {
+            return;
+        }
+        new_liveboxes.insert(b, UNASSIGNED);
     }
 
     /// resume.py:359-368 register_virtual_fields — stamp a virtual
@@ -3405,13 +3430,15 @@ impl ResumeDataLoopMemo {
     fn register_virtual_box(
         &self,
         virtualbox: majit_ir::OpRef,
+        env: &dyn majit_ir::BoxEnv,
         liveboxes_from_env: &LiveboxMap,
         new_liveboxes: &mut LiveboxMap,
     ) {
-        let tagged = liveboxes_from_env
-            .get(virtualbox)
-            .unwrap_or(UNASSIGNEDVIRTUAL);
-        new_liveboxes.insert(virtualbox, tagged);
+        // #160/S11: key by the canonical box (Rc::ptr_eq). virtualbox is
+        // replacement-walked by the caller; re-walking is idempotent.
+        let b = env.get_box_replacement_boxref(virtualbox);
+        let tagged = liveboxes_from_env.get(&b).unwrap_or(UNASSIGNEDVIRTUAL);
+        new_liveboxes.insert(b, tagged);
     }
 
     /// resume.py:454-509 `_number_virtuals(liveboxes, num_env_virtuals)`.
@@ -3447,23 +3474,24 @@ impl ResumeDataLoopMemo {
         // resoperation.py:38 same_box parity: keys carry the typed OpRef
         // each entry was inserted with so virtual numbering preserves
         // `box.type` (history.py:220).
-        let keys: Vec<(OpRef, i16)> = new_liveboxes.iter().collect();
-        for (opref_id, tagged) in keys {
+        // #160/S11: new_liveboxes.iter() yields the canonical box directly.
+        let keys: Vec<(crate::r#box::BoxRef, i16)> = new_liveboxes.iter().collect();
+        for (box_id, tagged) in keys {
             let (_, tagbits) = untag(tagged);
             if tagbits == TAGBOX {
                 // resume.py:472-473: index = assign_number_to_box; liveboxes[box] = tag(index, TAGBOX)
-                let index = self.assign_number_to_box_opt(opref_id, &mut new_boxes_list);
+                let index = self.assign_number_to_box_opt(&box_id, &mut new_boxes_list);
                 if let Ok(t) = tag(index, TAGBOX) {
-                    new_liveboxes.insert(opref_id, t);
+                    new_liveboxes.insert(box_id, t);
                 }
                 count += 1;
             } else {
                 debug_assert_eq!(tagbits, TAGVIRTUAL);
                 if tagged_eq(tagged, UNASSIGNEDVIRTUAL) {
                     // resume.py:479-480: index = assign_number_to_virtual; liveboxes[box] = tag(index, TAGVIRTUAL)
-                    let index = self.assign_number_to_virtual(opref_id);
+                    let index = self.assign_number_to_virtual(&box_id);
                     if let Ok(t) = tag(index, TAGVIRTUAL) {
-                        new_liveboxes.insert(opref_id, t);
+                        new_liveboxes.insert(box_id, t);
                     }
                 }
             }
@@ -3502,10 +3530,12 @@ impl ResumeDataLoopMemo {
                 // Check both numb_state.liveboxes (env virtuals) and
                 // new_liveboxes (nested virtuals discovered via worklist).
                 let opref = opref_id;
+                // #160/S11: liveboxes is box-keyed; form the canonical box.
+                let b = env.get_box_replacement_boxref(opref);
                 let tagged = numb_state
                     .liveboxes
-                    .get(opref)
-                    .or_else(|| new_liveboxes.get(opref))
+                    .get(&b)
+                    .or_else(|| new_liveboxes.get(&b))
                     .unwrap_or(UNASSIGNEDVIRTUAL);
                 let (num, _) = untag(tagged);
                 // RPython uses Python negative indexing: virtuals[-1] = virtuals[len-1].
@@ -3531,17 +3561,19 @@ impl ResumeDataLoopMemo {
                                 let (val, tp) = env.get_const(opref);
                                 return self.getconst(val, tp);
                             }
-                            if let Some(t) = numb_state.liveboxes.get(opref) {
+                            // #160/S11: livebox / cached maps are box-keyed.
+                            let b = env.get_box_replacement_boxref(opref);
+                            if let Some(t) = numb_state.liveboxes.get(&b) {
                                 return t;
                             }
-                            if let Some(t) = new_liveboxes.get(opref) {
+                            if let Some(t) = new_liveboxes.get(&b) {
                                 if tagged_eq(t, UNASSIGNED) {
-                                    if let Some(&num) = self.cached_boxes.get(&opref) {
+                                    if let Some(&num) = self.cached_boxes.get(&b) {
                                         return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                                     }
                                 }
                                 if tagged_eq(t, UNASSIGNEDVIRTUAL) {
-                                    if let Some(&num) = self.cached_virtuals.get(&opref) {
+                                    if let Some(&num) = self.cached_virtuals.get(&b) {
                                         return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                                     }
                                 }
@@ -3669,19 +3701,22 @@ impl ResumeDataLoopMemo {
             let (val, tp) = env.get_const(opref);
             return self.getconst(val, tp);
         }
+        // #160/S11: key the livebox / cached maps by the canonical box
+        // (Rc::ptr_eq). `opref` is already replacement-walked by the caller.
+        let b = env.get_box_replacement_boxref(opref);
         // resume.py:566-567: liveboxes_from_env → existing tag
-        if let Some(tagged) = liveboxes_from_env.get(opref) {
+        if let Some(tagged) = liveboxes_from_env.get(&b) {
             return tagged;
         }
-        if let Some(tagged) = new_liveboxes.get(opref) {
+        if let Some(tagged) = new_liveboxes.get(&b) {
             // Resolve UNASSIGNED to real cached number
             if tagged_eq(tagged, UNASSIGNED) {
-                if let Some(&num) = self.cached_boxes.get(&opref) {
+                if let Some(&num) = self.cached_boxes.get(&b) {
                     return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                 }
             }
             if tagged_eq(tagged, UNASSIGNEDVIRTUAL) {
-                if let Some(&num) = self.cached_virtuals.get(&opref) {
+                if let Some(&num) = self.cached_virtuals.get(&b) {
                     return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                 }
             }
@@ -3726,8 +3761,12 @@ impl ResumeDataLoopMemo {
                 numb_state.append_short(tagged);
                 continue;
             }
+            // #160/S11: key liveboxes by the canonical box (Rc::ptr_eq =
+            // PyPy `box is`). `opref` is replacement-walked above and non-const
+            // here (Const short-circuited via the is_const branch).
+            let b = env.get_box_replacement_boxref(opref);
             // resume.py:206-208: liveboxes
-            if let Some(tagged) = numb_state.liveboxes.get(opref) {
+            if let Some(tagged) = numb_state.liveboxes.get(&b) {
                 numb_state.append_short(tagged);
                 continue;
             }
@@ -3783,7 +3822,7 @@ impl ResumeDataLoopMemo {
                 numb_state.num_boxes += 1;
                 t
             };
-            numb_state.liveboxes.insert(opref, tagged);
+            numb_state.liveboxes.insert(b, tagged);
             numb_state.append_short(tagged);
         }
         Ok(())
@@ -3945,7 +3984,10 @@ impl ResumeDataLoopMemo {
         // resume.py:419-426: visitor_walk_recursive — worklist for nested virtuals.
         let mut virtual_worklist: Vec<majit_ir::OpRef> = Vec::new();
 
-        for (opref, tagged) in numb_state.liveboxes.iter() {
+        for (b, tagged) in numb_state.liveboxes.iter() {
+            // #160/S11: liveboxes is now box-keyed; the serialized livebox
+            // vector + virtual worklist stay OpRef-based (backend positions).
+            let opref = b.to_opref();
             let (i, tagbits) = untag(tagged);
             if tagbits == TAGBOX {
                 if (i as usize) < liveboxes.len() {
@@ -3986,6 +4028,7 @@ impl ResumeDataLoopMemo {
                     {
                         self.register_virtual_box(
                             resolved,
+                            env,
                             &numb_state.liveboxes,
                             &mut new_liveboxes,
                         );
@@ -4022,7 +4065,7 @@ impl ResumeDataLoopMemo {
             // UNASSIGNEDVIRTUAL (overwriting the UNASSIGNED that register_box
             // installed above) so _number_virtuals numbers it as a virtual
             // rather than a livebox — otherwise it would be force-boxed.
-            self.register_virtual_box(fieldbox, &numb_state.liveboxes, &mut new_liveboxes);
+            self.register_virtual_box(fieldbox, env, &numb_state.liveboxes, &mut new_liveboxes);
             for &field_opref in &vf.field_oprefs {
                 self.register_box(field_opref, env, &numb_state.liveboxes, &mut new_liveboxes);
                 let resolved = env.get_box_replacement(field_opref);
@@ -4030,7 +4073,7 @@ impl ResumeDataLoopMemo {
                     && !virtual_fields.contains_key(&resolved)
                     && (env.is_virtual_ref(resolved) || env.is_virtual_raw(resolved))
                 {
-                    self.register_virtual_box(resolved, &numb_state.liveboxes, &mut new_liveboxes);
+                    self.register_virtual_box(resolved, env, &numb_state.liveboxes, &mut new_liveboxes);
                     virtual_worklist.push(resolved);
                 }
             }
@@ -4056,6 +4099,7 @@ impl ResumeDataLoopMemo {
                     {
                         self.register_virtual_box(
                             resolved,
+                            env,
                             &numb_state.liveboxes,
                             &mut new_liveboxes,
                         );
@@ -4472,14 +4516,17 @@ mod tests {
     #[test]
     fn livebox_map_preserves_box_identity_and_insertion_order() {
         let mut liveboxes = LiveboxMap::new();
-        let input = majit_ir::OpRef::input_arg_int(0);
-        let op = majit_ir::OpRef::int_op(0);
+        // Two distinct logical boxes — an InputArg and a ResOp result. Under
+        // Rc::ptr_eq keying they stay distinct keys (PyPy `box is box`), never
+        // collapsed by a shared raw slot index.
+        let input = crate::r#box::BoxRef::from_opref(majit_ir::OpRef::input_arg_int(0));
+        let op = crate::r#box::BoxRef::from_opref(majit_ir::OpRef::int_op(0));
 
-        liveboxes.insert(input, UNASSIGNED);
-        liveboxes.insert(op, UNASSIGNEDVIRTUAL);
+        liveboxes.insert(input.clone(), UNASSIGNED);
+        liveboxes.insert(op.clone(), UNASSIGNEDVIRTUAL);
 
-        assert_eq!(liveboxes.get(input), Some(UNASSIGNED));
-        assert_eq!(liveboxes.get(op), Some(UNASSIGNEDVIRTUAL));
+        assert_eq!(liveboxes.get(&input), Some(UNASSIGNED));
+        assert_eq!(liveboxes.get(&op), Some(UNASSIGNEDVIRTUAL));
         assert_eq!(
             liveboxes.iter().collect::<Vec<_>>(),
             vec![(input, UNASSIGNED), (op, UNASSIGNEDVIRTUAL)]
@@ -4738,6 +4785,9 @@ mod tests {
             virtuals: majit_ir::vec_set::VecSet<u32>,
             virtual_fields:
                 crate::optimizeopt::vec_assoc::VecAssoc<u32, majit_ir::VirtualFieldsInfo>,
+            box_cache: std::cell::RefCell<
+                crate::optimizeopt::vec_assoc::VecAssoc<majit_ir::OpRef, crate::r#box::BoxRef>,
+            >,
         }
 
         impl RefOnlyVirtualEnv {
@@ -4748,6 +4798,9 @@ mod tests {
                     types: crate::optimizeopt::vec_assoc::VecAssoc::new(),
                     virtuals: majit_ir::vec_set::VecSet::new(),
                     virtual_fields: crate::optimizeopt::vec_assoc::VecAssoc::new(),
+                    box_cache: std::cell::RefCell::new(
+                        crate::optimizeopt::vec_assoc::VecAssoc::new(),
+                    ),
                 }
             }
         }
@@ -4758,6 +4811,17 @@ mod tests {
                     .get(&opref.raw())
                     .copied()
                     .unwrap_or(opref)
+            }
+
+            fn get_box_replacement_boxref(&self, opref: majit_ir::OpRef) -> crate::r#box::BoxRef {
+                // #160/S11: memoize one BoxRef per replacement-walked OpRef.
+                let root = self.get_box_replacement(opref);
+                if let Some(b) = self.box_cache.borrow().get(&root) {
+                    return b.clone();
+                }
+                let b = crate::r#box::BoxRef::from_opref(root);
+                self.box_cache.borrow_mut().insert(root, b.clone());
+                b
             }
 
             fn get_box_replacement_not_const(&self, opref: majit_ir::OpRef) -> majit_ir::OpRef {

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3305,7 +3305,11 @@ impl ResumeDataLoopMemo {
     /// RPython version mutates `boxes` list:
     /// - cached: `boxes[-num - 1] = box`
     /// - new: `boxes.append(box); num = -len(boxes)`
-    pub fn assign_number_to_box(&mut self, b: &crate::r#box::BoxRef, boxes: &mut Vec<OpRef>) -> i32 {
+    pub fn assign_number_to_box(
+        &mut self,
+        b: &crate::r#box::BoxRef,
+        boxes: &mut Vec<OpRef>,
+    ) -> i32 {
         if let Some(&num) = self.cached_boxes.get(b) {
             // resume.py:268: boxes[-num - 1] = box
             let idx = (-num - 1) as usize;
@@ -4073,7 +4077,12 @@ impl ResumeDataLoopMemo {
                     && !virtual_fields.contains_key(&resolved)
                     && (env.is_virtual_ref(resolved) || env.is_virtual_raw(resolved))
                 {
-                    self.register_virtual_box(resolved, env, &numb_state.liveboxes, &mut new_liveboxes);
+                    self.register_virtual_box(
+                        resolved,
+                        env,
+                        &numb_state.liveboxes,
+                        &mut new_liveboxes,
+                    );
                     virtual_worklist.push(resolved);
                 }
             }


### PR DESCRIPTION
Part of #47

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Carries box object-identity across the short-preamble export/import boundary so a
producer resolves to the same canonical box instead of a position-only
`from_opref` placeholder, and folds in the keystone that makes the canonical box
resolver total — continuing the #47 / #9 box-identity work. Six commits (base
`origin/main`; 11 files, +119 / −36):

- **carry `same_as_source` on field `PreambleOp`** — add `same_as_source:
  Option<BoxRef>` to `field_entry::PreambleOp`, threaded from
  `ProducedShortOp.same_as_source` at the produce/export sites (produce_pure /
  produce_heap_field / produce_heap_array_item / `ImportedShortPureOp::new`), and
  collapse `ShortPreambleBuilder::add_preamble_op_from_pop` to the unconditional
  `add_preamble_op` form (shortpreamble.py:432-440): an invented-name alternate
  now reproduces `same_as(original)` from its own carried `same_as_source` instead
  of a `produced_short_boxes` lookup. The same commit resolves
  `get_box_replacement(OpRef::none())` to `BoxRef::none()` at the top of the
  resolver: the absent-operand sentinel (empty fail-arg slot, unset lazy setfield)
  is not a value-bearing position, so the `box-must-exist` assert and the
  `from_opref` fallback now apply only to value-bearing positions (byte-identical —
  `from_opref(NONE)` already round-trips to `BoxRef::none()`). A corpus probe over
  the bench + synth suite confirmed the canonical resolver (`get_box_replacement`
  → `find_producer_op`, returning the clone-stable producer `Rc`) already reaches
  every cross-phase producer, with zero non-`NONE` fallback fires — i.e. the
  box-identity re-key has no silent-miss leak.
- **resolve exported `PreambleOp.res` to the canonical slot** — derive `res` from
  `get_box_replacement(result)` (shortpreamble.py:435) so `op.pos` and `res` no
  longer diverge when Phase 1 const-folds a short-box result.
- **restore `phase1_emit_ops` on the retrace path** — the skip-Phase-1 branch
  repopulates the pool from the imported state's `partial_trace_operations`,
  making the retrace and non-retrace producer-lookup pools (`new_operations ∪
  phase1_emit_ops ∪ resop_refs`) symmetric.
- **bind inline jump args to phase-2 producers** — `ExtendedShortPreambleBuilder::
  setup` resolves an unmapped short-preamble JUMP arg through
  `get_box_replacement_box` (the registered Phase-2 producer) instead of a
  producer-less `from_opref` box, mirroring the mapped arm's `materialize_box_at`
  bind.
- **doc-only** — refresh the `Operand::Box` residual-mint doc after the object-
  carry slices (export arg-loop + inline jump-arg now 0 mints on nested_loop /
  nbody / fannkuch); dedup the triple-repeated `add_preamble_op_from_pop`
  collapse-blocker doc.

Gates: majit-metainterp lib `dynasm 1280/0` + `cranelift 1278/0`; `pyre/check.py`
`dynasm 57/57` + `cranelift 57/57` byte-exact.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal optimization tracking and identity resolution mechanisms in the JIT compiler infrastructure.
  * Improved caching performance for operation lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->