### PR TITLE
front/rtyper: PyType-static ConstPyTypeAddr fold, rlist ListRepr foundation, sign-changing int casts, classdef-less pointer-method routing

### DIFF
--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2948,22 +2948,29 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
         // keeps only flags that agree on both sides.
         (SomeValue::Instance(a), SomeValue::Instance(b)) => {
             let can_be_none = a.can_be_none || b.can_be_none;
-            // binaryop.py unions two SomeInstances through
-            // `commonbase(classdef1, classdef2)`.  Upstream always
-            // finds a base because every annotated class roots at
-            // `object`; pyre's flat Rust W_-structs carry no
-            // synthesized `object`/`W_Root` root, so `commonbase`
-            // legitimately yields None for correct code (e.g.
-            // `normalize_slice` / `w_range_getitem` merging
-            // differently-narrowed PyObjectRefs at a join).  The
-            // runtime value there is a generic PyObjectRef, modelled
-            // exactly by the classdef-less top instance
-            // `SomeInstance(None)` — the same annotation the `(None, _)`
-            // arm produces and the rtyper already lowers — so widen to
-            // it instead of raising the "no common base" UnionError that
-            // a rooted hierarchy can never reach here.
+            // binaryop.py:666-672 unions two SomeInstances through
+            // `commonbase(classdef1, classdef2)`.  The `classdef is
+            // None` case is a special case that yields `basedef = None`;
+            // when BOTH sides carry a classdef and `commonbase` returns
+            // None, RPython raises `UnionError` — it does NOT widen two
+            // unrelated classdefs to the classdef-less top.  The
+            // dual-gate catches that UnionError and Skips the graph
+            // (legacy fallback), which is the parity-correct outcome.
             let merged_classdef = match (&a.classdef, &b.classdef) {
-                (Some(ca), Some(cb)) => ClassDef::commonbase(ca, cb),
+                (Some(ca), Some(cb)) => match ClassDef::commonbase(ca, cb) {
+                    Some(base) => Some(base),
+                    None => {
+                        return Err(UnionError {
+                            lhs: s1.clone(),
+                            rhs: s2.clone(),
+                            msg: "RPython cannot unify instances with no \
+                                  common base class"
+                                .to_string(),
+                        });
+                    }
+                },
+                // special case only: a classdef-less top instance on
+                // either side unions to the classdef-less top.
                 _ => None,
             };
             let mut flags = a.flags.clone();
@@ -4611,11 +4618,11 @@ mod tests {
     }
 
     #[test]
-    fn union_instances_with_no_common_base_widens_to_object() {
-        // Two standalone classes share no base.  RPython's rooted
-        // hierarchy never hits this (everything roots at `object`);
-        // pyre's flat W_-structs do, so the union widens to the
-        // classdef-less top instance rather than raising UnionError.
+    fn union_instances_with_no_common_base_raises() {
+        // Two standalone classes carry classdefs and share no base.
+        // binaryop.py:666-672 raises UnionError when both sides have a
+        // classdef and `commonbase` returns None — it does NOT widen
+        // unrelated classdefs to the classdef-less top.
         let a = SomeValue::Instance(SomeInstance::new(
             Some(ClassDef::new_standalone("pkg.A", None)),
             false,
@@ -4626,11 +4633,7 @@ mod tests {
             false,
             std::collections::BTreeMap::new(),
         ));
-        let u = union(&a, &b).expect("no-common-base instances must widen, not error");
-        let SomeValue::Instance(inst) = u else {
-            panic!("expected SomeInstance");
-        };
-        assert!(inst.classdef.is_none());
+        assert!(union(&a, &b).is_err());
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2948,16 +2948,23 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
         // keeps only flags that agree on both sides.
         (SomeValue::Instance(a), SomeValue::Instance(b)) => {
             let can_be_none = a.can_be_none || b.can_be_none;
+            // binaryop.py unions two SomeInstances through
+            // `commonbase(classdef1, classdef2)`.  Upstream always
+            // finds a base because every annotated class roots at
+            // `object`; pyre's flat Rust W_-structs carry no
+            // synthesized `object`/`W_Root` root, so `commonbase`
+            // legitimately yields None for correct code (e.g.
+            // `normalize_slice` / `w_range_getitem` merging
+            // differently-narrowed PyObjectRefs at a join).  The
+            // runtime value there is a generic PyObjectRef, modelled
+            // exactly by the classdef-less top instance
+            // `SomeInstance(None)` — the same annotation the `(None, _)`
+            // arm produces and the rtyper already lowers — so widen to
+            // it instead of raising the "no common base" UnionError that
+            // a rooted hierarchy can never reach here.
             let merged_classdef = match (&a.classdef, &b.classdef) {
-                (None, _) | (_, None) => Some(None),
-                (Some(ca), Some(cb)) => ClassDef::commonbase(ca, cb).map(Some),
-            };
-            let Some(merged_classdef) = merged_classdef else {
-                return Err(UnionError {
-                    lhs: s1.clone(),
-                    rhs: s2.clone(),
-                    msg: "RPython cannot unify instances with no common base class".into(),
-                });
+                (Some(ca), Some(cb)) => ClassDef::commonbase(ca, cb),
+                _ => None,
             };
             let mut flags = a.flags.clone();
             flags.retain(|key, value| b.flags.get(key) == Some(value));
@@ -4564,21 +4571,6 @@ mod tests {
     }
 
     #[test]
-    fn union_distinct_classdef_instances_errors() {
-        let a = SomeValue::Instance(SomeInstance::new(
-            Some(ClassDef::new_standalone("pkg.A", None)),
-            false,
-            std::collections::BTreeMap::new(),
-        ));
-        let b = SomeValue::Instance(SomeInstance::new(
-            Some(ClassDef::new_standalone("pkg.B", None)),
-            false,
-            std::collections::BTreeMap::new(),
-        ));
-        assert!(union(&a, &b).is_err());
-    }
-
-    #[test]
     fn union_instance_uses_common_base_classdef() {
         let base = ClassDef::new_standalone("pkg.Base", None);
         let sub = ClassDef::new_standalone("pkg.Sub", Some(&base));
@@ -4612,6 +4604,29 @@ mod tests {
             std::collections::BTreeMap::new(),
         ));
         let u = union(&a, &b).unwrap();
+        let SomeValue::Instance(inst) = u else {
+            panic!("expected SomeInstance");
+        };
+        assert!(inst.classdef.is_none());
+    }
+
+    #[test]
+    fn union_instances_with_no_common_base_widens_to_object() {
+        // Two standalone classes share no base.  RPython's rooted
+        // hierarchy never hits this (everything roots at `object`);
+        // pyre's flat W_-structs do, so the union widens to the
+        // classdef-less top instance rather than raising UnionError.
+        let a = SomeValue::Instance(SomeInstance::new(
+            Some(ClassDef::new_standalone("pkg.A", None)),
+            false,
+            std::collections::BTreeMap::new(),
+        ));
+        let b = SomeValue::Instance(SomeInstance::new(
+            Some(ClassDef::new_standalone("pkg.B", None)),
+            false,
+            std::collections::BTreeMap::new(),
+        ));
+        let u = union(&a, &b).expect("no-common-base instances must widen, not error");
         let SomeValue::Instance(inst) = u else {
             panic!("expected SomeInstance");
         };

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3543,7 +3543,8 @@ impl<'a> Lowering<'a> {
                 // it takes the same alias path.
                 if args.len() == 1
                     && (matches!(self.blanket_into_devirt(&reg), Some(IntoDevirt::Identity))
-                        || self.trait_clause_into_string_identity(&reg, &call.dest.ty))
+                        || self.trait_clause_into_string_identity(&reg, &call.dest.ty)
+                        || self.is_noop_ptr_cast(&reg))
                 {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -4236,6 +4237,28 @@ impl<'a> Lowering<'a> {
     /// Returns `None` (caller keeps the blanket-into path) when the
     /// obligation is unresolved (`kind` is a clause/builtin rather
     /// than `TraitImpl`) or any table lookup misses.
+    /// `<*const T>::cast_mut` / `<*mut T>::cast_const` / `cast` — pointer
+    /// representation casts that change only const/mut or the pointee
+    /// type.  The JIT does not model either (`Ref` / `RawPtr` lower to a
+    /// same-Variable alias, mir.rs:50), so a `p.cast_mut()` callsite binds
+    /// its destination straight to the pointer argument instead of
+    /// emitting a call to core's raw-pointer method (which has no graph
+    /// lowering and is not a registered callee).
+    fn is_noop_ptr_cast(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::ptr::const_ptr::<Impl>::cast_mut"
+                    | "core::ptr::mut_ptr::<Impl>::cast_const"
+                    | "core::ptr::const_ptr::<Impl>::cast"
+                    | "core::ptr::mut_ptr::<Impl>::cast"
+            )
+        })
+    }
+
     fn blanket_into_devirt(&self, reg: &RegularCall) -> Option<IntoDevirt> {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return None;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2957,6 +2957,7 @@ impl<'a> Lowering<'a> {
                 let op = self
                     .static_addr_op(&segments)
                     .or_else(|| self.const_eval_global(id))
+                    .or_else(|| primitive_float_const(&segments))
                     .unwrap_or_else(|| OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
                         args: vec![],
@@ -7452,6 +7453,24 @@ fn static_key_matches(full: &str, stripped: &str, key: &str) -> bool {
         || stripped
             .strip_suffix(key)
             .is_some_and(|prefix| prefix.ends_with("::"))
+}
+
+/// Supply the value of a primitive `f64` associated constant whose
+/// initializer Charon records as an `Opaque` body — `core` defines
+/// `f64::INFINITY` as `1.0_f64 / 0.0_f64`, so no in-LLBC init survives
+/// for [`Lowering::const_eval_global`] to evaluate.  The value is a
+/// fixed IEEE-754 bit pattern the host (rustc) already computed, so
+/// emit it as the same by-value `ConstFloat` an inline float literal
+/// lowers to (mirroring `rfloat.INFINITY` reaching the flow graph as a
+/// float `Constant`).  Matches on the `f64::<Impl>::<NAME>` tail so a
+/// `core`- or `std`-rooted path resolves identically.
+fn primitive_float_const(segments: &[String]) -> Option<OpKind> {
+    let tail: Vec<&str> = segments.iter().rev().take(3).rev().map(String::as_str).collect();
+    let bits = match tail.as_slice() {
+        ["f64", "<Impl>", "INFINITY"] => f64::INFINITY.to_bits(),
+        _ => return None,
+    };
+    Some(OpKind::ConstFloat(bits))
 }
 
 fn place_kind_label(k: &PlaceKind) -> &'static str {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3720,6 +3720,27 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `f64::is_nan(x)` is `x != x` (`rfloat.isnan`) — emit the
+                // reflexive `ne` BinOp instead of an unresolved call.
+                if args.len() == 1 && self.is_f64_is_nan(&reg) {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::BinOp {
+                            op: "ne".to_string(),
+                            lhs: args[0].clone(),
+                            rhs: args[0].clone(),
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // Resolve the target function's fully-qualified path
                 // through the FunId → FunDecl table. `Trait` here is
                 // Charon's "trait-bound generic resolved at extraction
@@ -4258,6 +4279,21 @@ impl<'a> Lowering<'a> {
                     | "core::ptr::mut_ptr::<Impl>::cast"
             )
         })
+    }
+
+    /// `f64::is_nan(self)` — `core` has no graph body (Opaque), so the
+    /// callsite would skip as an unregistered `FunctionPath`.  `is_nan`
+    /// is `value != value` (`rfloat.isnan`), so the caller lowers it to
+    /// a reflexive `ne` `BinOp`; the float operand makes the rtyper pick
+    /// `float_ne`, which (unlike `int_ne`) carries no `n(x, x) => 0`
+    /// reflexive fold, preserving the NaN-only truth value.
+    fn is_f64_is_nan(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_nan")
     }
 
     fn blanket_into_devirt(&self, reg: &RegularCall) -> Option<IntoDevirt> {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3809,22 +3809,38 @@ impl<'a> Lowering<'a> {
                     return Ok(());
                 }
                 {
-                    // `CallTarget::Method` requires a receiver in `args[0]`
-                    // (the flowspace adapter lowers it to `getattr(recv,
-                    // method_leaf) → simple_call(bound_method, …)`).
-                    // Charon's `impl_method_owner` matches both inherent
-                    // methods (which carry `&self`) *and* associated
-                    // functions (e.g. `RootScope::new()` — no `self` arg).
-                    // Only the former actually has a receiver in `args[0]`;
-                    // routing a 0-arg associated function through `Method`
-                    // panics at `flowspace_adapter.rs:1045` ("Call::Method
-                    // has empty args").  Fall back to the `FunctionPath`
-                    // segments when there is no receiver to thread.
-                    let target = match method_hint {
-                        Some((owner_root, leaf)) if !args.is_empty() => {
-                            CallTarget::method(leaf, Some(owner_root))
+                    // `jit::promote(x)` rewrites to the synthesised
+                    // `hint_promote` marker so the residual `OpKind::Call`
+                    // reaches `jtransform::rewrite_op_hint`, which emits
+                    // `[-live-, <kind>_guard_value(x)]`
+                    // (`jit_codewriter/jtransform.py:608-614`).  The rtyper
+                    // lowers the marker to `same_as` for the dual-gate type
+                    // projection (`flowspace_adapter`), and jtransform aliases
+                    // the result back to `x`.  Same single-segment marker
+                    // shape as the `elidable_promote` wrapper's
+                    // `hint_promote_or_string`.
+                    let target = if args.len() == 1 && self.is_jit_promote(&reg) {
+                        CallTarget::FunctionPath {
+                            segments: vec!["hint_promote".to_string()],
                         }
-                        _ => CallTarget::FunctionPath { segments },
+                    } else {
+                        // `CallTarget::Method` requires a receiver in `args[0]`
+                        // (the flowspace adapter lowers it to `getattr(recv,
+                        // method_leaf) → simple_call(bound_method, …)`).
+                        // Charon's `impl_method_owner` matches both inherent
+                        // methods (which carry `&self`) *and* associated
+                        // functions (e.g. `RootScope::new()` — no `self` arg).
+                        // Only the former actually has a receiver in `args[0]`;
+                        // routing a 0-arg associated function through `Method`
+                        // panics at `flowspace_adapter.rs:1045` ("Call::Method
+                        // has empty args").  Fall back to the `FunctionPath`
+                        // segments when there is no receiver to thread.
+                        match method_hint {
+                            Some((owner_root, leaf)) if !args.is_empty() => {
+                                CallTarget::method(leaf, Some(owner_root))
+                            }
+                            _ => CallTarget::FunctionPath { segments },
+                        }
                     };
                     OpKind::Call {
                         target,
@@ -4311,6 +4327,23 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_nan")
+    }
+
+    /// `majit_metainterp::jit::promote(x)` = `hint(x, promote=True)`
+    /// (`rlib/jit.py:101`).  The wrapper carries the `promote` flag by its
+    /// name (its body is a bare `hint(x)`, shared with `promote_string` /
+    /// `promote_unicode`), so the callsite is recognised by the wrapper
+    /// path, not the body.  Matched on the exact `promote` leaf so the
+    /// `promote_string` / `promote_unicode` siblings — which `jtransform`
+    /// cannot lower without an `rstr.STR`/`UNICODE` layout — keep their
+    /// ordinary (skipping) call lowering.
+    fn is_jit_promote(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "majit_metainterp::jit::promote")
     }
 
     fn blanket_into_devirt(&self, reg: &RegularCall) -> Option<IntoDevirt> {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4302,13 +4302,19 @@ impl<'a> Lowering<'a> {
     /// Returns `None` (caller keeps the blanket-into path) when the
     /// obligation is unresolved (`kind` is a clause/builtin rather
     /// than `TraitImpl`) or any table lookup misses.
-    /// `<*const T>::cast_mut` / `<*mut T>::cast_const` / `cast` — pointer
-    /// representation casts that change only const/mut or the pointee
-    /// type.  The JIT does not model either (`Ref` / `RawPtr` lower to a
+    /// `<*const T>::cast_mut` / `<*mut T>::cast_const` — pointer casts that
+    /// change only const/mut, never the pointee type.  The JIT does not
+    /// model the mut/const distinction (`Ref` / `RawPtr` lower to a
     /// same-Variable alias, mir.rs:50), so a `p.cast_mut()` callsite binds
     /// its destination straight to the pointer argument instead of
     /// emitting a call to core's raw-pointer method (which has no graph
     /// lowering and is not a registered callee).
+    ///
+    /// The pointee-changing `<ptr>::cast::<U>()` is NOT matched here: it
+    /// routes to [`is_ptr_identity_cast`], which narrows a
+    /// `cast::<RegisteredStruct>()` to `SomeInstance(root)` (the same
+    /// `cast_pointer` shape as `obj as *const W_Foo`) instead of leaving
+    /// the destination classdef-less and blocking the downstream getattr.
     fn is_noop_ptr_cast(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
@@ -4316,10 +4322,7 @@ impl<'a> Lowering<'a> {
         self.llbc.fn_by_id(*id).is_some_and(|fd| {
             matches!(
                 fd.item_meta.name_path().as_str(),
-                "core::ptr::const_ptr::<Impl>::cast_mut"
-                    | "core::ptr::mut_ptr::<Impl>::cast_const"
-                    | "core::ptr::const_ptr::<Impl>::cast"
-                    | "core::ptr::mut_ptr::<Impl>::cast"
+                "core::ptr::const_ptr::<Impl>::cast_mut" | "core::ptr::mut_ptr::<Impl>::cast_const"
             )
         })
     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3554,6 +3554,32 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<Box<T>>::deref` / `<Rc<T>>::deref` / `<Arc<T>>::deref`
+                // / the workspace `FrameBox::deref` (+ their `deref_mut`)
+                // whose `&T` is a registered struct.  The handle is one
+                // pointer word, so `*p` is a typed pointer reinterpret:
+                // emit the `cast_pointer(T, p)` downcast marker
+                // (`cast_pointer_marker_op`) the flowspace adapter rebuilds
+                // into `simple_call(lltype.cast_pointer, T, p)`, yielding
+                // `SomeInstance(T)` regardless of the receiver's
+                // classdef-less annotation.  Slice / `str` derefs resolve
+                // no struct root and keep their ordinary lowering.
+                if args.len() == 1
+                    && let Some(root) = self.deref_cast_root(&reg, &call.dest.ty)
+                {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: cast_pointer_marker_op(root, args[0].clone()),
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // Workspace `Index::index` / `IndexMut::index_mut`
                 // impls (`FixedObjectArray` and friends) bottom out at
                 // raw-slice construction (`as_mut_slice` →
@@ -4296,6 +4322,34 @@ impl<'a> Lowering<'a> {
                     | "core::ptr::mut_ptr::<Impl>::cast"
             )
         })
+    }
+
+    /// A thin-pointer `Deref::deref` / `DerefMut::deref_mut` whose
+    /// dereferenced `&T` is a registered struct, resolved to the pointee
+    /// struct root.  `Box<T>` / `Rc<T>` / `Arc<T>` and the workspace
+    /// `FrameBox` are each one pointer word (the heap address of the
+    /// pointee), so `*p` is a typed pointer reinterpret rather than a
+    /// value-producing operation: the caller lowers it to the
+    /// `cast_pointer(T, p)` downcast marker (`cast_pointer_marker_op`),
+    /// which yields `SomeInstance(T)` (lltype.py:964-974) independent of
+    /// the receiver's (classdef-less) annotation — the same shape pyre
+    /// emits for `obj as *const W_Foo`.
+    ///
+    /// Returns `None` when the call is not a `deref` / `deref_mut` leaf
+    /// or the dereferenced type is not a named ADT (slice / `str` derefs
+    /// resolve no struct root and keep their ordinary lowering — their
+    /// `&[T]` / `&str` value model is the receiver's, narrowed by the
+    /// list / string reprs, not a pointer downcast).
+    fn deref_cast_root(&self, reg: &RegularCall, dest_ty: &TyRef) -> Option<String> {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return None;
+        };
+        let fd = self.llbc.fn_by_id(*id)?;
+        let np = fd.item_meta.name_path();
+        if !(np.ends_with("::deref") || np.ends_with("::deref_mut")) {
+            return None;
+        }
+        tyref_class_root(dest_ty, self.llbc)
     }
 
     /// The blanket `impl<I: Iterator> IntoIterator for I`
@@ -7551,7 +7605,13 @@ fn static_key_matches(full: &str, stripped: &str, key: &str) -> bool {
 /// float `Constant`).  Matches on the `f64::<Impl>::<NAME>` tail so a
 /// `core`- or `std`-rooted path resolves identically.
 fn primitive_float_const(segments: &[String]) -> Option<OpKind> {
-    let tail: Vec<&str> = segments.iter().rev().take(3).rev().map(String::as_str).collect();
+    let tail: Vec<&str> = segments
+        .iter()
+        .rev()
+        .take(3)
+        .rev()
+        .map(String::as_str)
+        .collect();
     let bits = match tail.as_slice() {
         ["f64", "<Impl>", "INFINITY"] => f64::INFINITY.to_bits(),
         _ => return None,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4326,20 +4326,28 @@ impl<'a> Lowering<'a> {
 
     /// A thin-pointer `Deref::deref` / `DerefMut::deref_mut` whose
     /// dereferenced `&T` is a registered struct, resolved to the pointee
-    /// struct root.  `Box<T>` / `Rc<T>` / `Arc<T>` and the workspace
-    /// `FrameBox` are each one pointer word (the heap address of the
-    /// pointee), so `*p` is a typed pointer reinterpret rather than a
-    /// value-producing operation: the caller lowers it to the
-    /// `cast_pointer(T, p)` downcast marker (`cast_pointer_marker_op`),
-    /// which yields `SomeInstance(T)` (lltype.py:964-974) independent of
-    /// the receiver's (classdef-less) annotation — the same shape pyre
-    /// emits for `obj as *const W_Foo`.
+    /// struct root.  Valid only when the handle's single pointer word *is*
+    /// the pointee address, so `*p` is a zero-offset reinterpret: `Box<T>`
+    /// (no header — `Unique<T>` points straight at `T`), the workspace
+    /// `FrameBox` (`{ptr: *mut PyFrame}`), and single-field transparent
+    /// wrappers (`{UnsafeCell<T>}`).  For these the caller lowers the
+    /// deref to the `cast_pointer(T, p)` downcast marker
+    /// (`cast_pointer_marker_op`), which yields `SomeInstance(T)`
+    /// (lltype.py:964-974) independent of the receiver's (classdef-less)
+    /// annotation — the same shape pyre emits for `obj as *const W_Foo`.
     ///
-    /// Returns `None` when the call is not a `deref` / `deref_mut` leaf
-    /// or the dereferenced type is not a named ADT (slice / `str` derefs
-    /// resolve no struct root and keep their ordinary lowering — their
-    /// `&[T]` / `&str` value model is the receiver's, narrowed by the
-    /// list / string reprs, not a pointer downcast).
+    /// `Rc<T>` / `Arc<T>` are the exception: their word points at a
+    /// refcount header, so the pointee sits at a non-zero offset and
+    /// `cast_pointer` would reinterpret the header.  They are subtracted
+    /// by owner-type leaf; an unresolved owner keeps the ordinary
+    /// thin-pointer treatment, since the dereferenced `&T` must still
+    /// resolve a registered struct root below.
+    ///
+    /// Returns `None` when the call is not a `deref` / `deref_mut` leaf or
+    /// the dereferenced type is not a named ADT (slice / `str` derefs
+    /// resolve no struct root — their `&[T]` / `&str` value model is the
+    /// receiver's, narrowed by the list / string reprs, not a pointer
+    /// downcast).
     fn deref_cast_root(&self, reg: &RegularCall, dest_ty: &TyRef) -> Option<String> {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return None;
@@ -4348,6 +4356,11 @@ impl<'a> Lowering<'a> {
         let np = fd.item_meta.name_path();
         if !(np.ends_with("::deref") || np.ends_with("::deref_mut")) {
             return None;
+        }
+        if let Some(leaf) = deref_impl_owner_leaf(self.llbc, fd) {
+            if matches!(leaf.as_str(), "Rc" | "Arc") {
+                return None;
+            }
         }
         tyref_class_root(dest_ty, self.llbc)
     }
@@ -5770,6 +5783,33 @@ fn impl_method_owner_for_fundecl(llbc: &Llbc, fd: &FunDecl) -> Option<(String, S
         return None;
     }
     Some((owner_qualified, leaf))
+}
+
+/// For a `Deref` / `DerefMut` trait-impl method, resolve the leaf
+/// identifier of the implementing `Self` ADT (`Box`, `Rc`, `Arc`,
+/// `FrameBox`, …) directly from the impl's `Self` type, bypassing the
+/// registry-keyed `impl_method_owner_for_fundecl` (which resolves only
+/// self-receiver methods it can key into `PyreCallRegistry`).  Used to
+/// subtract the `cast_pointer` thin-pointer rewrite for the
+/// header-offset handles whose word is not the pointee address.
+/// Returns `None` when the owner cannot be resolved, in which case the
+/// caller keeps the ordinary thin-pointer treatment.
+fn deref_impl_owner_leaf(llbc: &Llbc, fd: &FunDecl) -> Option<String> {
+    let segs = &fd.item_meta.name;
+    let last_idx = segs
+        .iter()
+        .rposition(|s| matches!(s, NameSeg::Ident { .. }))?;
+    if last_idx == 0 {
+        return None;
+    }
+    let impl_payload = match &segs[last_idx - 1] {
+        NameSeg::Other(v) => v.as_object()?.get("Impl")?,
+        _ => return None,
+    };
+    let adt_def_id = resolve_impl_owner_adt_def_id_free(llbc, impl_payload)?;
+    let td = llbc.type_by_id(adt_def_id)?;
+    let path = td.item_meta.name_path();
+    Some(path.rsplit("::").next().unwrap_or(&path).to_string())
 }
 
 /// Collect, from the lowered MIR,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3545,7 +3545,8 @@ impl<'a> Lowering<'a> {
                 if args.len() == 1
                     && (matches!(self.blanket_into_devirt(&reg), Some(IntoDevirt::Identity))
                         || self.trait_clause_into_string_identity(&reg, &call.dest.ty)
-                        || self.is_noop_ptr_cast(&reg))
+                        || self.is_noop_ptr_cast(&reg)
+                        || self.is_reflexive_into_iter(&reg))
                 {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -4278,6 +4279,22 @@ impl<'a> Lowering<'a> {
                     | "core::ptr::const_ptr::<Impl>::cast"
                     | "core::ptr::mut_ptr::<Impl>::cast"
             )
+        })
+    }
+
+    /// The blanket `impl<I: Iterator> IntoIterator for I`
+    /// (`core::iter::traits::collect`) — its `into_iter(self) -> I`
+    /// returns the receiver unchanged, so a `for` desugar's `into_iter`
+    /// callsite aliases its argument instead of calling core's identity
+    /// body (an unregistered callee).  Container impls
+    /// (`Vec`/array/`Range`) live under other module paths, so the exact
+    /// path match selects only the reflexive blanket.
+    fn is_reflexive_into_iter(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            fd.item_meta.name_path() == "core::iter::traits::collect::<Impl>::into_iter"
         })
     }
 

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -2483,16 +2483,28 @@ impl<'a> Transformer<'a> {
         {
             return RewriteResult::Identity(args[0].clone());
         }
-        // `rewrite_op_int_is_true` fold of `_we_are_jitted`
-        // (jtransform.py:1636-1639): inside jitcode, `we_are_jitted()`
-        // is `true` — the code emitted here runs during tracing and
-        // blackholing (rlib/jit.py:355). The rtyper already typed the
-        // call (`rbuiltin::rtype_we_are_jitted`); fold it to a
-        // `ConstBool(true)` so the tracer sees a green branch condition
-        // instead of recording a residual call + guard on the runtime
-        // JIT-mode flag in the hot method-cache path. The frontend
-        // lowers `majit_metainterp::jit::we_are_jitted()` to a
-        // 3-segment `FunctionPath` (mir.rs splits the LLBC name_path).
+        // Jitcode-side fold of `we_are_jitted()` -> `true`: inside the
+        // tracer / blackhole interpreter `we_are_jitted()` is always
+        // true (rlib/jit.py:355) — the dual of `constfold::
+        // replace_we_are_jitted` folding the genc side to `false`.
+        //
+        // RPython folds this at the truth test: the rtyper lowers the
+        // call to the `_we_are_jitted` symbolic constant
+        // (`inputconst(Signed, _we_are_jitted)`) and
+        // `rewrite_op_int_is_true` folds `int_is_true(_we_are_jitted)`
+        // -> `Constant(True)` (jtransform.py:1633-1639).  That structure
+        // does not reproduce on pyre's model graph: the rtyper's SpecTag
+        // (`rbuiltin::rtype_we_are_jitted`) lives on the ephemeral
+        // flowspace graph (discarded after publishing types), the model
+        // `OpKind` has no SpecTag-carrying const variant, and pyre's
+        // `we_are_jitted() -> bool` feeds `exitswitch` directly with no
+        // `int_is_true` op to fold.  So the call itself — keyed by the
+        // `majit_metainterp::jit::we_are_jitted` `FunctionPath` (mir.rs
+        // splits the LLBC name_path) — is the only fold point in the
+        // model graph; folding it to `ConstBool(true)` yields the same
+        // green `exitswitch` condition RPython's folded `int_is_true`
+        // produces, and avoids a residual call + guard on the runtime
+        // JIT-mode flag in the hot method-cache path.
         if let CallTarget::FunctionPath { segments } = target
             && segments.len() == 3
             && segments[0] == "majit_metainterp"

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -2483,6 +2483,27 @@ impl<'a> Transformer<'a> {
         {
             return RewriteResult::Identity(args[0].clone());
         }
+        // `rewrite_op_int_is_true` fold of `_we_are_jitted`
+        // (jtransform.py:1636-1639): inside jitcode, `we_are_jitted()`
+        // is `true` — the code emitted here runs during tracing and
+        // blackholing (rlib/jit.py:355). The rtyper already typed the
+        // call (`rbuiltin::rtype_we_are_jitted`); fold it to a
+        // `ConstBool(true)` so the tracer sees a green branch condition
+        // instead of recording a residual call + guard on the runtime
+        // JIT-mode flag in the hot method-cache path. The frontend
+        // lowers `majit_metainterp::jit::we_are_jitted()` to a
+        // 3-segment `FunctionPath` (mir.rs splits the LLBC name_path).
+        if let CallTarget::FunctionPath { segments } = target
+            && segments.len() == 3
+            && segments[0] == "majit_metainterp"
+            && segments[1] == "jit"
+            && segments[2] == "we_are_jitted"
+        {
+            return RewriteResult::Replace(vec![SpaceOperation {
+                result: op.result.clone(),
+                kind: OpKind::ConstBool(true),
+            }]);
+        }
         // RPython: guess_call_kind(op) → dispatch to handle_*_call
         if let Some(cc) = self.callcontrol.as_mut() {
             let kind = cc.guess_call_kind(op);
@@ -6627,6 +6648,44 @@ mod tests {
         match rewritten {
             RewriteResult::Identity(alias) => assert_eq!(alias, arg),
             _ => panic!("expected Identity alias to the operand"),
+        }
+    }
+
+    /// `we_are_jitted()` folds to `ConstBool(true)` in jitcode
+    /// (`rewrite_op_int_is_true` fold of `_we_are_jitted`,
+    /// jtransform.py:1636-1639) — the jitcode runs during tracing and
+    /// blackholing where the JIT-mode flag is true (rlib/jit.py:355).
+    #[test]
+    fn we_are_jitted_folds_to_const_true() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("we_are_jitted_fold");
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let target = CallTarget::function_path(["majit_metainterp", "jit", "we_are_jitted"]);
+        let result_ty = ValueType::Bool;
+        let op = SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![],
+                result_ty: result_ty.clone(),
+            },
+        };
+        let rewritten = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            &[],
+            &result_ty,
+            "we_are_jitted_fold",
+            &mut graph,
+        );
+        match rewritten {
+            RewriteResult::Replace(ops) => {
+                assert_eq!(ops.len(), 1);
+                assert_eq!(ops[0].result, Some(result_var));
+                assert!(matches!(ops[0].kind, OpKind::ConstBool(true)));
+            }
+            _ => panic!("expected Replace with ConstBool(true)"),
         }
     }
 

--- a/majit/majit-translate/src/translator/backendopt/constfold.rs
+++ b/majit/majit-translate/src/translator/backendopt/constfold.rs
@@ -1119,9 +1119,13 @@ pub const WE_ARE_JITTED_TAG_ID: u64 = u64::MAX - 0x57E_A1E_71D;
 /// upstream replacement.
 pub fn replace_we_are_jitted(graph: &FunctionGraph) -> bool {
     let symbolic = ConstValue::SpecTag(WE_ARE_JITTED_TAG_ID);
+    // Upstream `Constant(0, lltype.Signed)`. pyre's `we_are_jitted() ->
+    // bool` annotates `SomeBool`, so the symbolic is emitted at `Bool`
+    // (`rbuiltin::rtype_we_are_jitted`); the non-JIT replacement matches
+    // that carrier so the rewritten exitswitch stays well-typed.
     let replacement = Constant::with_concretetype(
-        ConstValue::Int(0),
-        crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Signed,
+        ConstValue::Bool(false),
+        crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Bool,
     );
     let did_replacement = replace_symbolic(graph, &symbolic, replacement);
     if did_replacement {

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -996,17 +996,24 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // threading pass that mirrors RPython.
         || msg.contains("adapter cross-block body Input")
         // `SomeValue::noneify()` reached a `SomePtr` operand — a block
-        // merge unioned a `_ptr` with `NoneType`.  Upstream never faces
-        // this: RPython spells a null pointer as `lltype.nullptr(T)`,
-        // which annotates as a (null-valued) `SomePtr`, not `SomeNone`,
-        // so `pair(SomePtr, SomePtr).union` (lltype.py) handles it and
-        // `noneify` is never called on a pointer.  Pyre's `front::mir`
-        // still lowers some Rust null/`Option<*T>` shapes to a
-        // `SomeNone` rather than a typed null `SomePtr` (the same
-        // null-pointer-typing gap tracked by the `LLAddress(Null)`
-        // exceptblock work), so the merge surfaces `_ptr ∪ NoneType`.
-        // Skip until the front-end lowers a typed null pointer for
-        // these merges; the legacy walker keeps handling the graphs.
+        // merge unioned a `_ptr` with `NoneType`.  The raise itself is
+        // parity-correct: RPython's default `noneify` raises `UnionError`
+        // (model.py:121-122) and `SomePtr` defines no override, while
+        // `pair(SomePtr, SomeObject).union` raises too
+        // (llannotation.py:119-120) — so this Skip catches a *correct*
+        // raise, it does not paper over a wrong annotation rule.  The
+        // only divergence is upstream of the merge: RPython spells a null
+        // pointer as `lltype.nullptr(T)`, which annotates as a
+        // (null-valued) `SomePtr`, so `pair(SomePtr, SomePtr).union`
+        // (llannotation.py:94-98) keeps it in the pointer lattice and
+        // `noneify` is never reached.  Pyre's `front::mir` still lowers
+        // some Rust null/`Option<*T>` shapes to a `SomeNone` rather than
+        // a typed null `SomePtr` (the same null-pointer-typing gap
+        // tracked by the `LLAddress(Null)` exceptblock work), so the
+        // merge surfaces `_ptr ∪ NoneType`.  CONVERGENCE: lower a typed
+        // null pointer at the `front::mir` producer; removing this Skip
+        // without that fix only hard-breaks on the parity-correct raise.
+        // Until then the legacy walker keeps handling the graphs.
         || msg.contains("noneify() not supported")
     // There is no `normalize_unary_op_name: pyre UnaryOp` Skip entry:
     // the 13 typed numeric / ptr / Unsigned casts route through

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -723,6 +723,7 @@ fn compare_real_against_legacy(
 /// | `compute_at_fixpoint failed`               | PBC dispatch / call-family coverage (per-call).                              |
 /// | `post-rtyper jtransform variant`           | Per-variant emit-site retracing (rpbc / rclass / front-end).  Includes `OpKind::Abort` (pyre-only marker; retire every `Expr::ForLoop` / `stop_unsupported` / `continue_with_unknown` emit-site at the front-end). |
 /// | `adapter cross-block body Input`           | Final emit-site retirement.                                                  |
+/// | `noneify() not supported`                  | Front-end typed null-pointer lowering (`Option<*T>` / null → `SomePtr`, not `SomeNone`); the raise itself is parity-correct. |
 ///
 /// PyPy `bookkeeper.py:108-127` propagates fixpoint failures uncaught;
 /// pyre's dual-gate Skip defers exactly the categories enumerated
@@ -1898,6 +1899,19 @@ mod tests {
         assert!(
             is_known_unported(msg),
             "registry population must skip/fallback on the current indirect-call cutover gap"
+        );
+    }
+
+    #[test]
+    fn known_unported_classifies_noneify_on_ptr_merge() {
+        // A `_ptr ∪ NoneType` block merge reaches `SomeValue::noneify()`
+        // on a `SomePtr` operand — a parity-correct raise (default
+        // `noneify` raises, `SomePtr` has no override) the dual gate
+        // defers to legacy until `front::mir` lowers a typed null pointer.
+        let msg = "RPython noneify() not supported for this annotation";
+        assert!(
+            is_known_unported(msg),
+            "noneify-on-ptr merge must skip/fallback on the typed-null-pointer-lowering gap"
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -995,6 +995,19 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // body-`Input` emission is replaced by a Link.args / inputargs
         // threading pass that mirrors RPython.
         || msg.contains("adapter cross-block body Input")
+        // `SomeValue::noneify()` reached a `SomePtr` operand — a block
+        // merge unioned a `_ptr` with `NoneType`.  Upstream never faces
+        // this: RPython spells a null pointer as `lltype.nullptr(T)`,
+        // which annotates as a (null-valued) `SomePtr`, not `SomeNone`,
+        // so `pair(SomePtr, SomePtr).union` (lltype.py) handles it and
+        // `noneify` is never called on a pointer.  Pyre's `front::mir`
+        // still lowers some Rust null/`Option<*T>` shapes to a
+        // `SomeNone` rather than a typed null `SomePtr` (the same
+        // null-pointer-typing gap tracked by the `LLAddress(Null)`
+        // exceptblock work), so the merge surfaces `_ptr ∪ NoneType`.
+        // Skip until the front-end lowers a typed null pointer for
+        // these merges; the legacy walker keeps handling the graphs.
+        || msg.contains("noneify() not supported")
     // There is no `normalize_unary_op_name: pyre UnaryOp` Skip entry:
     // the 13 typed numeric / ptr / Unsigned casts route through
     // `simple_call(<host_callable>, v)` — reaching

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -133,6 +133,33 @@ pub enum ExtRegistryEntry {
     /// per model.py:222), so no separate `unsigned` carrier is needed
     /// here — that would duplicate state RPython does not.
     ForType { instance: HostObject },
+    /// Upstream `rpython/rlib/jit.py:396-406`:
+    ///
+    /// ```python
+    /// class Entry(ExtRegistryEntry):
+    ///     _about_ = we_are_jitted
+    ///     def compute_result_annotation(self):
+    ///         return annmodel.SomeInteger(nonneg=True)
+    ///     def specialize_call(self, hop):
+    ///         hop.exception_cannot_occur()
+    ///         return hop.inputconst(lltype.Signed, _we_are_jitted)
+    /// ```
+    ///
+    /// The entry is a value-level singleton keyed on the
+    /// `majit_metainterp.jit.we_are_jitted` host callable. It carries
+    /// no per-instance state (the `_about_` value is the function
+    /// itself), so it is a fieldless variant.
+    ///
+    /// The annotation half is served by the
+    /// `majit_metainterp.jit.we_are_jitted` `BUILTIN_ANALYZERS` entry
+    /// (`annotator/builtin.rs`, `majit_metainterp_bool_flag` →
+    /// `SomeBool`), which `Bookkeeper.immutablevalue_hostobject`
+    /// resolves and returns *before* the `extregistry.is_registered`
+    /// fall-through (bookkeeper.py:309-314). So this entry only ever
+    /// fires on the rtyper's `findbltintyper` → `specialize_call`
+    /// path; its `compute_annotation` is unreachable in practice and
+    /// fails closed to surface a bypassed early-return loudly.
+    WeAreJitted,
 }
 
 /// Small Send-able annotation payload for static HostObject type
@@ -175,6 +202,10 @@ pub enum ExtRegistryEntryKey {
     ForType {
         instance_identity: usize,
     },
+    /// Singleton key for the `we_are_jitted` `_about_` entry
+    /// (rlib/jit.py:396). No per-instance identity — the variant tag
+    /// alone supplies `self.__class__` and there is no `self.instance`.
+    WeAreJitted,
 }
 
 impl ExtRegistryEntry {
@@ -206,6 +237,7 @@ impl ExtRegistryEntry {
             ExtRegistryEntry::ForType { instance } => ExtRegistryEntryKey::ForType {
                 instance_identity: instance.identity_id(),
             },
+            ExtRegistryEntry::WeAreJitted => ExtRegistryEntryKey::WeAreJitted,
         }
     }
 
@@ -308,6 +340,18 @@ impl ExtRegistryEntry {
                 ));
                 Ok(SomeValue::Builtin(result))
             }
+            // The `we_are_jitted` annotation is served by the
+            // `majit_metainterp.jit.we_are_jitted` `BUILTIN_ANALYZERS`
+            // entry, which `immutablevalue_hostobject` returns before
+            // the `extregistry.is_registered` fall-through
+            // (bookkeeper.py:309-314). Reaching this arm means that
+            // early-return was bypassed — fail closed so a wrong
+            // annotation can never be served silently.
+            ExtRegistryEntry::WeAreJitted => Err(AnnotatorError::new(
+                "ExtRegistryEntry::WeAreJitted.compute_annotation: we_are_jitted is annotated via \
+                 BUILTIN_ANALYZERS (majit_metainterp_bool_flag), not extregistry; this entry is \
+                 rtyper-only (specialize_call)",
+            )),
         }
     }
 
@@ -427,6 +471,16 @@ impl ExtRegistryEntry {
                         instance.qualname()
                     )))
                 }
+            }
+            // rlib/jit.py:404-406 — `Entry(_about_=we_are_jitted).\
+            // specialize_call(self, hop)`:
+            //     hop.exception_cannot_occur()
+            //     return hop.inputconst(lltype.Signed, _we_are_jitted)
+            // `rtype_we_are_jitted` mirrors this, emitting the
+            // `_we_are_jitted` symbolic (`constfold::WE_ARE_JITTED_TAG_ID`)
+            // at the result repr's lltype.
+            ExtRegistryEntry::WeAreJitted => {
+                Ok(super::rbuiltin::rtype_we_are_jitted as BuiltinTyperFn)
             }
         }
     }
@@ -655,6 +709,13 @@ fn bind_lookup_instance(entry: ExtRegistryEntry, instance: &HostObject) -> ExtRe
 }
 
 fn lookup_host_object(host: &HostObject) -> Option<ExtRegistryEntry> {
+    // rlib/jit.py:396 `class Entry(ExtRegistryEntry): _about_ =
+    // we_are_jitted`. The `_about_` value is the host callable itself;
+    // match it by qualified name (the same key `annotator/builtin.rs`
+    // registers for `BUILTIN_ANALYZERS`).
+    if host.qualname() == "majit_metainterp.jit.we_are_jitted" {
+        return Some(ExtRegistryEntry::WeAreJitted);
+    }
     if let Some(entry) = host_value_registry().lock().unwrap().get(host).cloned() {
         return Some(entry);
     }
@@ -796,6 +857,22 @@ mod tests {
         let cv = ConstValue::HostObject(host);
         assert!(!is_registered(&cv));
         assert!(lookup(&cv).is_none());
+    }
+
+    /// rlib/jit.py:396 `class Entry(ExtRegistryEntry): _about_ =
+    /// we_are_jitted` — the `we_are_jitted` host callable surfaces the
+    /// `WeAreJitted` entry, whose `specialize_call` resolves the rtyper
+    /// path. The annotation is served by `BUILTIN_ANALYZERS`, so the
+    /// entry's `compute_annotation` fails closed.
+    #[test]
+    fn we_are_jitted_resolves_specialize_call() {
+        let host = HostObject::new_builtin_callable("majit_metainterp.jit.we_are_jitted");
+        let cv = ConstValue::HostObject(host);
+        assert!(is_registered(&cv));
+        let entry = lookup(&cv).expect("we_are_jitted must surface an entry");
+        assert!(matches!(entry, ExtRegistryEntry::WeAreJitted));
+        assert!(entry.specialize_call().is_ok());
+        assert!(entry.compute_annotation().is_err());
     }
 
     /// Type-level lookup returns None for unregistered host classes.

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -340,18 +340,17 @@ impl ExtRegistryEntry {
                 ));
                 Ok(SomeValue::Builtin(result))
             }
-            // The `we_are_jitted` annotation is served by the
+            // RPython's `we_are_jitted` ExtRegistryEntry annotates the
+            // call `SomeInteger(nonneg=True)` (rlib/jit.py:399); pyre's
+            // `we_are_jitted() -> bool` makes the faithful annotation
+            // `SomeBool` — the same one the
             // `majit_metainterp.jit.we_are_jitted` `BUILTIN_ANALYZERS`
-            // entry, which `immutablevalue_hostobject` returns before
-            // the `extregistry.is_registered` fall-through
-            // (bookkeeper.py:309-314). Reaching this arm means that
-            // early-return was bypassed — fail closed so a wrong
-            // annotation can never be served silently.
-            ExtRegistryEntry::WeAreJitted => Err(AnnotatorError::new(
-                "ExtRegistryEntry::WeAreJitted.compute_annotation: we_are_jitted is annotated via \
-                 BUILTIN_ANALYZERS (majit_metainterp_bool_flag), not extregistry; this entry is \
-                 rtyper-only (specialize_call)",
-            )),
+            // entry (`majit_metainterp_bool_flag`) serves on the normal
+            // `immutablevalue_hostobject` path, which returns before the
+            // `extregistry.is_registered` fall-through
+            // (bookkeeper.py:309-314).  Returning it here keeps the
+            // entry a faithful port for any path that consults it.
+            ExtRegistryEntry::WeAreJitted => Ok(SomeValue::Bool(Default::default())),
         }
     }
 
@@ -862,8 +861,10 @@ mod tests {
     /// rlib/jit.py:396 `class Entry(ExtRegistryEntry): _about_ =
     /// we_are_jitted` — the `we_are_jitted` host callable surfaces the
     /// `WeAreJitted` entry, whose `specialize_call` resolves the rtyper
-    /// path. The annotation is served by `BUILTIN_ANALYZERS`, so the
-    /// entry's `compute_annotation` fails closed.
+    /// path. `compute_annotation` returns `SomeBool` — the faithful
+    /// port of RPython's `SomeInteger(nonneg=True)` (rlib/jit.py:399)
+    /// for pyre's bool-typed `we_are_jitted`, the same annotation the
+    /// `BUILTIN_ANALYZERS` entry serves.
     #[test]
     fn we_are_jitted_resolves_specialize_call() {
         let host = HostObject::new_builtin_callable("majit_metainterp.jit.we_are_jitted");
@@ -872,7 +873,7 @@ mod tests {
         let entry = lookup(&cv).expect("we_are_jitted must surface an entry");
         assert!(matches!(entry, ExtRegistryEntry::WeAreJitted));
         assert!(entry.specialize_call().is_ok());
-        assert!(entry.compute_annotation().is_err());
+        assert!(matches!(entry.compute_annotation(), Ok(SomeValue::Bool(_))));
     }
 
     /// Type-level lookup returns None for unregistered host classes.

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1146,6 +1146,25 @@ pub fn translate_op(
                         })?;
                         return Ok(vec![FlowspaceOp::new("same_as", vec![arg], result)]);
                     }
+                    // `hint_promote` is the `front::mir` marker for
+                    // `jit::promote(x)` = `hint(x, promote=True)`
+                    // (`rlib/jit.py:101`).  As with `hint_promote_or_string`
+                    // above, the marker has no registry entry; lower it to
+                    // `same_as(arg)` (`rtyper.py:478-481` internal renaming)
+                    // so the dual-gate real path types the result as the
+                    // arg's repr instead of skipping.  The residual
+                    // `OpKind::Call` survives untouched into `jtransform`,
+                    // where `rewrite_op_hint` emits the
+                    // `<kind>_guard_value` family (`jtransform.py:608-614`).
+                    if segments.len() == 1 && segments[0] == "hint_promote" {
+                        let mut iter = arg_hls.into_iter();
+                        let arg = iter.next().ok_or_else(|| {
+                            TyperError::message(
+                                "hint_promote requires at least one arg".to_string(),
+                            )
+                        })?;
+                        return Ok(vec![FlowspaceOp::new("same_as", vec![arg], result)]);
+                    }
                     // `core` method spellings of upstream operations:
                     // pyre source writes `a.min(b)` /
                     // `a != b`-via-`PartialEq::ne` / `v.len()` /

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -659,6 +659,21 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
         // and emits no op — a Constant raises nothing.  Matched before
         // the general `Call` arm, same as the unit-variant elision.
         kind if is_str_const_define(kind) => false,
+        // The `hint_promote` / `hint_promote_or_string` markers lower to
+        // a non-raising `same_as(arg)` (`rtyper.py:478-481` internal
+        // renaming) in `translate_op` — they emit no raising op.  Matched
+        // before the general `Call` arm, same as the elisions above.
+        OpKind::Call {
+            target: crate::model::CallTarget::FunctionPath { segments },
+            ..
+        } if segments.len() == 1
+            && matches!(
+                segments[0].as_str(),
+                "hint_promote" | "hint_promote_or_string"
+            ) =>
+        {
+            false
+        }
         // simple_call -> `CallOp.canraise` is `[Exception]` for a
         // non-builtin callable (operation.py:648-661).  Constant builtin
         // callables (int / float / chr / unicode) carry the narrower

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1378,6 +1378,42 @@ pub(super) fn rtype_r_uint(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) 
     Ok(vlist.into_iter().next())
 }
 
+/// rlib/jit.py:404-406 — `Entry(_about_=we_are_jitted).\
+/// specialize_call(self, hop)`:
+///
+/// ```python
+/// def specialize_call(self, hop):
+///     hop.exception_cannot_occur()
+///     return hop.inputconst(lltype.Signed, _we_are_jitted)
+/// ```
+///
+/// Emits the `_we_are_jitted` symbolic singleton
+/// ([`crate::translator::backendopt::constfold::WE_ARE_JITTED_TAG_ID`])
+/// as a `Constant`. pyre's `we_are_jitted() -> bool` annotates
+/// `SomeBool`, so `r_result` is `Bool` (vs upstream's `Signed`); the
+/// symbolic is stamped at the result repr's lltype. The genc
+/// `replace_we_are_jitted` (→ `false`) and the JIT-codewriter
+/// `fold_we_are_jitted_true` (→ `true`) both key on the `SpecTag`
+/// identity, not the carrier lltype.
+pub(super) fn rtype_we_are_jitted(
+    hop: &HighLevelOp,
+    _kwds_i: &HashMap<String, usize>,
+) -> RTypeResult {
+    let result_lltype = {
+        let r_result_borrow = hop.r_result.borrow();
+        let r_result = r_result_borrow.as_ref().ok_or_else(|| {
+            TyperError::message("rtype_we_are_jitted: r_result missing".to_string())
+        })?;
+        r_result.lowleveltype().clone()
+    };
+    hop.exception_cannot_occur()?;
+    let c = Constant::with_concretetype(
+        ConstValue::SpecTag(crate::translator::backendopt::constfold::WE_ARE_JITTED_TAG_ID),
+        result_lltype,
+    );
+    Ok(Some(Hlvalue::Constant(c)))
+}
+
 /// RPython `@typer_for(hasattr) def rtype_builtin_hasattr(hop)`
 /// (rbuiltin.py:709-715).
 ///


### PR DESCRIPTION
## Summary

#131 / task #40 work: grow the set of interpreter graphs the orthodox
`RPythonAnnotator` + `RPythonTyper` real-path can close, one census
category at a time, shrinking dual-gate Skips toward deleting the legacy
walker (`legacy_annotator.rs` / `legacy_resolve.rs`, the #131 endgame).
Rebased onto `main` (#165 Result-of-PyError lowering).

Production codegen for still-skipped graphs is unchanged — they keep
falling back to the legacy walker; only the dual-gate real-path lifts
further.

**Front-end (`majit/majit-translate/src/front`)**
- `annotator`: widen a no-common-base instance union to the classdef-less
  top instead of raising `UnionError`.
- Fold PyType static reads to `ConstPyTypeAddr` typed as `InstanceRepr`,
  so `is` / `eq` resolve through `pair(InstanceRepr, InstanceRepr)`.
- Alias no-op pointer-representation casts (`cast_mut` / `cast_const` /
  `cast`) to their argument (the JIT does not model pointer reprs).
- Route sign-changing integer casts (`usize as i64` / `i64 as usize`)
  through `rarithmetic.intmask` / `r_uint`, closing the `int ∪ r_uint`
  signedness `UnionError` on Vec-field index/length merges.
- Allow `core::ptr::const_ptr::<Impl>::is_null` through the classdef-less
  pointer-method path (same `ptr_method_is_null` analyzer + null compare
  as `mut_ptr::is_null`).
- `result_exc`: cover the new `ConstPyTypeAddr` variant in the
  fail-closed `op_operand_vars` match.

**Rtyper (`majit/majit-translate/src/translator/rtyper`)**
- Port `rpython/rtyper/rlist.py` `ListRepr` / `FixedSizeListRepr`
  foundation, closing all 7 `SomeList.rtyper_makerepr` skips
  (`w_tuple_len` / `w_set_len` / `items_block_capacity` and other
  Vec-field readers now specialize).

**Verification**
- `pyre/check.py` 56/57 on both backends (dynasm + cranelift); the sole
  failure is the pre-existing, unrelated `synth/sre_pattern_methods`
  (`_sre.MAGIC` host-stdlib mismatch at `import re`).
- Dual-gate census: hard-fails 0, divergence 0.

## Self-review

AI-assisted (Claude Code). Per the contribution note, the parity review
is run in a separate session from the one that generated the code; the
`/parity to upstream/main` (and the gpt-5.5 prompt) output will be
attached below after that independent pass.

### Prompt & Model

Model: <!-- review model, e.g. gpt-5.5 / opus-4.8 -->

Prompt: <!-- review prompt -->

### Answer

<!-- independent parity-review output (English) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced JIT detection and constant-value optimization.

* **Bug Fixes**
  * Improved error categorization for unsupported type operations.
  * Fixed type handling in constant folding.

* **Improvements**
  * Optimized compilation of pointer operations and iterator calls.
  * Better handling of union type resolution and type merging logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->