### PR TITLE
 migrate stored value/const boxes to BoxRef across metainterp, heapcache, and optimizeopt

### DIFF
--- a/majit/majit-ir/src/field_entry.rs
+++ b/majit/majit-ir/src/field_entry.rs
@@ -10,7 +10,7 @@
 //! PtrInfo move that follows can reference these types without a
 //! `majit-metainterp → majit-ir` circular dep.
 
-use crate::{Op, OpRef};
+use crate::OpRef;
 
 /// shortpreamble.py:11-49: PreambleOp
 ///
@@ -47,8 +47,11 @@ pub struct PreambleOp {
 /// Rust equivalent: typed enum instead of Python's duck-typed list.
 #[derive(Clone, Debug)]
 pub enum FieldEntry {
-    /// Normal cached field value (info.py:203 setfield).
-    Value(OpRef),
+    /// Normal cached field value (info.py:203 setfield). Stored as a
+    /// [`BoxRef`](crate::box_ref::BoxRef) so a `Const` ref is GC-walked
+    /// through `BoxRef::walk_const_ptr_refs`, never persisting a Copy
+    /// `OpRef::ConstPtr` that a moving collection cannot reach.
+    Value(crate::box_ref::BoxRef),
     /// shortpreamble.py:11 PreambleOp — sentinel stored during Phase 2 import.
     Preamble(PreambleOp),
 }
@@ -59,7 +62,7 @@ impl FieldEntry {
     /// via `force_op_from_preamble`).
     pub fn as_opref(&self) -> Option<OpRef> {
         match self {
-            FieldEntry::Value(opref) => Some(*opref),
+            FieldEntry::Value(b) => Some(b.to_opref()),
             FieldEntry::Preamble(_) => None,
         }
     }
@@ -86,7 +89,7 @@ impl FieldEntry {
     /// `get_box_replacement(PreambleOp(...))` behavior.
     pub fn as_seen_opref(&self) -> OpRef {
         match self {
-            FieldEntry::Value(opref) => *opref,
+            FieldEntry::Value(b) => b.to_opref(),
             FieldEntry::Preamble(pop) => pop.op.to_opref(),
         }
     }

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -183,7 +183,7 @@ pub struct VirtualInfo {
     pub ob_type_descr: Option<DescrRef>,
     /// Field values: `(field_descr_index, value_opref)`.
     /// **Invariant**: never contains typeptr (offset 0) — see struct-level docs.
-    pub fields: Vec<(u32, OpRef)>,
+    pub fields: Vec<(u32, BoxRef)>,
     /// info.py:91-92
     pub last_guard_pos: i32,
     /// info.py:124-128 `AbstractVirtualPtrInfo._cached_vinfo` inherited
@@ -260,7 +260,7 @@ pub struct VirtualStructInfo {
     /// The size descriptor.
     pub descr: DescrRef,
     /// Field values: (field_index, value, optional original field descriptor).
-    pub fields: Vec<(u32, OpRef)>,
+    pub fields: Vec<(u32, BoxRef)>,
     /// info.py:91-92
     pub last_guard_pos: i32,
     /// info.py `_cached_vinfo` — see AbstractVirtualPtrInfo.
@@ -277,7 +277,7 @@ pub struct VirtualArrayStructInfo {
     /// The array descriptor (arraydescr).
     pub descr: DescrRef,
     /// Per-element fields: outer Vec = elements, inner Vec = (field_descr_index, value_opref).
-    pub element_fields: Vec<Vec<(u32, OpRef)>>,
+    pub element_fields: Vec<Vec<(u32, BoxRef)>>,
     /// resume.py VArrayStructInfo.fielddescrs — InteriorFieldDescr per field.
     /// Used by _number_virtuals to extract item_size/field_offset/field_size.
     pub fielddescrs: Vec<DescrRef>,
@@ -383,13 +383,13 @@ impl VirtualRawBufferInfo {
 pub struct VirtualizableFieldState {
     /// Tracked static field values: (field_descr_index, current_value_opref).
     /// Indices correspond to VirtualizableInfo::static_fields order.
-    pub fields: Vec<(u32, OpRef)>,
+    pub fields: Vec<(u32, BoxRef)>,
     /// Original field descriptors: (field_descr_index, original_descr).
     /// Used to emit correct SetfieldRaw ops when forcing.
     pub field_descrs: Vec<(u32, DescrRef)>,
     /// Tracked array field values: (array_field_index, element_values).
     /// Indices correspond to VirtualizableInfo::array_fields order.
-    pub arrays: Vec<(u32, Vec<OpRef>)>,
+    pub arrays: Vec<(u32, Vec<BoxRef>)>,
     /// info.py:91-92
     pub last_guard_pos: i32,
 }
@@ -463,7 +463,9 @@ fn str_child_oprefs(s: &StrPtrInfo) -> Vec<OpRef> {
             .iter()
             .filter_map(|slot| slot.as_ref().map(|b| b.to_opref()))
             .collect(),
-        VStringVariant::Slice(sl) => vec![sl.s.to_opref(), sl.start.to_opref(), sl.lgtop.to_opref()],
+        VStringVariant::Slice(sl) => {
+            vec![sl.s.to_opref(), sl.start.to_opref(), sl.lgtop.to_opref()]
+        }
         VStringVariant::Concat(c) => vec![c.vleft.to_opref(), c.vright.to_opref()],
     }
 }
@@ -485,14 +487,6 @@ impl PtrInfo {
     /// in place. Pyre keeps the same structural data in Rust containers and
     /// must walk the actual `OpRef` / `GcRef` slots explicitly.
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        fn visit_opref(opref: &mut OpRef, visitor: &mut dyn FnMut(&mut GcRef)) {
-            // Forward an inline const gcref through the canonical BoxRef-Const
-            // walk; a no-op for the non-const virtual-field positions.
-            let b = BoxRef::from_opref(*opref);
-            b.walk_const_ptr_refs(visitor);
-            *opref = b.to_opref();
-        }
-
         fn visit_field(entry: &mut FieldEntry, visitor: &mut dyn FnMut(&mut GcRef)) {
             match entry {
                 FieldEntry::Value(b) => b.walk_const_ptr_refs(visitor),
@@ -523,8 +517,8 @@ impl PtrInfo {
             }
             PtrInfo::Virtual(info) => {
                 // known_class is an immortal vtable integer, not a traced ref.
-                for (_, opref) in &mut info.fields {
-                    visit_opref(opref, visitor);
+                for (_, b) in &info.fields {
+                    b.walk_const_ptr_refs(visitor);
                 }
             }
             PtrInfo::VirtualArray(info) => {
@@ -533,26 +527,26 @@ impl PtrInfo {
                 }
             }
             PtrInfo::VirtualStruct(info) => {
-                for (_, opref) in &mut info.fields {
-                    visit_opref(opref, visitor);
+                for (_, b) in &info.fields {
+                    b.walk_const_ptr_refs(visitor);
                 }
             }
             PtrInfo::VirtualArrayStruct(info) => {
-                for fields in &mut info.element_fields {
-                    for (_, opref) in fields {
-                        visit_opref(opref, visitor);
+                for fields in &info.element_fields {
+                    for (_, b) in fields {
+                        b.walk_const_ptr_refs(visitor);
                     }
                 }
             }
             PtrInfo::VirtualRawBuffer(info) => info.buffer.walk_const_ptr_refs(visitor),
             PtrInfo::VirtualRawSlice(info) => info.parent.walk_const_ptr_refs(visitor),
             PtrInfo::Virtualizable(info) => {
-                for (_, opref) in &mut info.fields {
-                    visit_opref(opref, visitor);
+                for (_, b) in &info.fields {
+                    b.walk_const_ptr_refs(visitor);
                 }
-                for (_, items) in &mut info.arrays {
-                    for opref in items {
-                        visit_opref(opref, visitor);
+                for (_, items) in &info.arrays {
+                    for b in items {
+                        b.walk_const_ptr_refs(visitor);
                     }
                 }
             }
@@ -827,20 +821,20 @@ impl PtrInfo {
             PtrInfo::Instance(v) => v.fields.iter().filter_map(|(_, e)| e.as_opref()).collect(),
             PtrInfo::Struct(v) => v.fields.iter().filter_map(|(_, e)| e.as_opref()).collect(),
             PtrInfo::Array(v) => v.items.iter().filter_map(|e| e.as_opref()).collect(),
-            PtrInfo::Virtual(v) => v.fields.iter().map(|(_, r)| *r).collect(),
+            PtrInfo::Virtual(v) => v.fields.iter().map(|(_, r)| r.to_opref()).collect(),
             PtrInfo::VirtualArray(v) => v.items.iter().map(|b| b.to_opref()).collect(),
-            PtrInfo::VirtualStruct(v) => v.fields.iter().map(|(_, r)| *r).collect(),
+            PtrInfo::VirtualStruct(v) => v.fields.iter().map(|(_, r)| r.to_opref()).collect(),
             PtrInfo::VirtualArrayStruct(v) => v
                 .element_fields
                 .iter()
-                .flat_map(|fields| fields.iter().map(|(_, r)| *r))
+                .flat_map(|fields| fields.iter().map(|(_, r)| r.to_opref()))
                 .collect(),
             PtrInfo::VirtualRawBuffer(v) => v.buffer.values(),
             PtrInfo::VirtualRawSlice(v) => vec![v.parent.to_opref()],
             PtrInfo::Virtualizable(v) => {
-                let mut refs: Vec<OpRef> = v.fields.iter().map(|(_, r)| *r).collect();
+                let mut refs: Vec<OpRef> = v.fields.iter().map(|(_, r)| r.to_opref()).collect();
                 for (_, items) in &v.arrays {
-                    refs.extend(items.iter().copied());
+                    refs.extend(items.iter().map(|b| b.to_opref()));
                 }
                 refs
             }
@@ -864,14 +858,14 @@ impl PtrInfo {
             PtrInfo::Virtual(v) => {
                 for (_, field) in &mut v.fields {
                     if !field.is_none() {
-                        *field = recurse(*field);
+                        *field = BoxRef::from_opref(recurse(field.to_opref()));
                     }
                 }
             }
             PtrInfo::VirtualStruct(v) => {
                 for (_, field) in &mut v.fields {
                     if !field.is_none() {
-                        *field = recurse(*field);
+                        *field = BoxRef::from_opref(recurse(field.to_opref()));
                     }
                 }
             }
@@ -886,7 +880,7 @@ impl PtrInfo {
                 for fields in &mut v.element_fields {
                     for (_, field) in fields {
                         if !field.is_none() {
-                            *field = recurse(*field);
+                            *field = BoxRef::from_opref(recurse(field.to_opref()));
                         }
                     }
                 }
@@ -1126,20 +1120,20 @@ impl PtrInfo {
             PtrInfo::Virtual(v) => {
                 for entry in &mut v.fields {
                     if entry.0 == field_idx {
-                        entry.1 = value;
+                        entry.1 = BoxRef::from_opref(value);
                         return;
                     }
                 }
-                v.fields.push((field_idx, value));
+                v.fields.push((field_idx, BoxRef::from_opref(value)));
             }
             PtrInfo::VirtualStruct(v) => {
                 for entry in &mut v.fields {
                     if entry.0 == field_idx {
-                        entry.1 = value;
+                        entry.1 = BoxRef::from_opref(value);
                         return;
                     }
                 }
-                v.fields.push((field_idx, value));
+                v.fields.push((field_idx, BoxRef::from_opref(value)));
             }
             _ => {}
         }
@@ -1274,12 +1268,12 @@ impl PtrInfo {
             PtrInfo::Virtual(v) => v
                 .fields
                 .iter()
-                .map(|(k, v)| (*k, FieldEntry::Value(BoxRef::from_opref(*v))))
+                .map(|(k, v)| (*k, FieldEntry::Value(v.clone())))
                 .collect(),
             PtrInfo::VirtualStruct(v) => v
                 .fields
                 .iter()
-                .map(|(k, v)| (*k, FieldEntry::Value(BoxRef::from_opref(*v))))
+                .map(|(k, v)| (*k, FieldEntry::Value(v.clone())))
                 .collect(),
             PtrInfo::Array(v) => v
                 .items
@@ -1314,12 +1308,12 @@ impl PtrInfo {
                 .fields
                 .iter()
                 .find(|(k, _)| *k == field_idx)
-                .map(|(_, v)| FieldEntry::Value(BoxRef::from_opref(*v))),
+                .map(|(_, v)| FieldEntry::Value(v.clone())),
             PtrInfo::VirtualStruct(v) => v
                 .fields
                 .iter()
                 .find(|(k, _)| *k == field_idx)
-                .map(|(_, v)| FieldEntry::Value(BoxRef::from_opref(*v))),
+                .map(|(_, v)| FieldEntry::Value(v.clone())),
             _ => None,
         }
     }
@@ -1348,10 +1342,7 @@ impl PtrInfo {
     pub fn getitem(&self, index: usize) -> Option<FieldEntry> {
         match self {
             PtrInfo::Array(v) => v.items.get(index).cloned(),
-            PtrInfo::VirtualArray(v) => v
-                .items
-                .get(index)
-                .map(|r| FieldEntry::Value(r.clone())),
+            PtrInfo::VirtualArray(v) => v.items.get(index).map(|r| FieldEntry::Value(r.clone())),
             _ => None,
         }
     }
@@ -1386,8 +1377,8 @@ impl PtrInfo {
                 }
                 v.element_fields[element_index]
                     .iter()
-                    .find(|&&(fdidx, _)| fdidx == field_descr_index)
-                    .map(|&(_, opref)| opref)
+                    .find(|(fdidx, _)| *fdidx == field_descr_index)
+                    .map(|(_, b)| b.to_opref())
             }
             _ => None,
         }
@@ -1410,9 +1401,9 @@ impl PtrInfo {
                     .iter_mut()
                     .find(|(fdidx, _)| *fdidx == field_descr_index)
                 {
-                    entry.1 = value;
+                    entry.1 = BoxRef::from_opref(value);
                 } else {
-                    fields.push((field_descr_index, value));
+                    fields.push((field_descr_index, BoxRef::from_opref(value)));
                 }
             }
             _ => {}
@@ -1439,22 +1430,22 @@ impl PtrInfo {
             result.push(Op::with_descr(opcode, &[structbox.clone()], descr));
         };
         if let PtrInfo::Virtual(v) = self {
-            for &(field_idx, value) in &v.fields {
+            for (field_idx, value) in &v.fields {
                 if !value.is_none() {
                     push_for(
                         &mut result,
-                        field_idx,
+                        *field_idx,
                         "produce_short_preamble_ops: virtual field descr missing",
                     );
                 }
             }
         }
         if let PtrInfo::VirtualStruct(v) = self {
-            for &(field_idx, value) in &v.fields {
+            for (field_idx, value) in &v.fields {
                 if !value.is_none() {
                     push_for(
                         &mut result,
-                        field_idx,
+                        *field_idx,
                         "produce_short_preamble_ops: virtual struct field descr missing",
                     );
                 }

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -304,7 +304,7 @@ pub struct VirtualRawSliceInfo {
     /// OpRef of the parent VirtualRawBuffer (or another VirtualRawSlice
     /// — `optimize_int_add` flattens chained slices when the underlying
     /// info is `VirtualRawBufferInfo`/`VirtualRawSliceInfo`).
-    pub parent: OpRef,
+    pub parent: BoxRef,
     /// info.py:91-92
     pub last_guard_pos: i32,
     /// info.py `_cached_vinfo` — see AbstractVirtualPtrInfo.
@@ -545,7 +545,7 @@ impl PtrInfo {
                     visit_opref(opref, visitor);
                 }
             }
-            PtrInfo::VirtualRawSlice(info) => visit_opref(&mut info.parent, visitor),
+            PtrInfo::VirtualRawSlice(info) => info.parent.walk_const_ptr_refs(visitor),
             PtrInfo::Virtualizable(info) => {
                 for (_, opref) in &mut info.fields {
                     visit_opref(opref, visitor);
@@ -836,7 +836,7 @@ impl PtrInfo {
                 .flat_map(|fields| fields.iter().map(|(_, r)| *r))
                 .collect(),
             PtrInfo::VirtualRawBuffer(v) => v.buffer.values().to_vec(),
-            PtrInfo::VirtualRawSlice(v) => vec![v.parent],
+            PtrInfo::VirtualRawSlice(v) => vec![v.parent.to_opref()],
             PtrInfo::Virtualizable(v) => {
                 let mut refs: Vec<OpRef> = v.fields.iter().map(|(_, r)| *r).collect();
                 for (_, items) in &v.arrays {

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -482,9 +482,11 @@ impl PtrInfo {
     /// must walk the actual `OpRef` / `GcRef` slots explicitly.
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
         fn visit_opref(opref: &mut OpRef, visitor: &mut dyn FnMut(&mut GcRef)) {
-            if let Some(slot) = opref.as_const_ptr_mut() {
-                visitor(slot);
-            }
+            // Forward an inline const gcref through the canonical BoxRef-Const
+            // walk; a no-op for the non-const virtual-field positions.
+            let b = BoxRef::from_opref(*opref);
+            b.walk_const_ptr_refs(visitor);
+            *opref = b.to_opref();
         }
 
         fn visit_field(entry: &mut FieldEntry, visitor: &mut dyn FnMut(&mut GcRef)) {

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -84,7 +84,7 @@ pub struct StrPtrInfo {
     /// vstring.py:53 self.lgtop — cached length OpRef (set by getstrlen).
     /// After force_box, this preserves the computed length so subsequent
     /// STRLEN queries reuse it instead of emitting a new STRLEN op.
-    pub lgtop: Option<OpRef>,
+    pub lgtop: Option<BoxRef>,
     /// vstring.py: self.mode — 0 = mode_string, 1 = mode_unicode.
     pub mode: u8,
     /// vstring.py: self.length — known exact length (-1 if unknown).
@@ -129,22 +129,22 @@ pub enum VStringVariant {
 /// vstring.py:142-212 `VStringPlainInfo`
 #[derive(Clone, Debug)]
 pub struct VStringPlainInfo {
-    pub _chars: Vec<Option<OpRef>>,
+    pub _chars: Vec<Option<BoxRef>>,
 }
 
 /// vstring.py:214-264 `VStringSliceInfo`
 #[derive(Clone, Debug)]
 pub struct VStringSliceInfo {
-    pub s: OpRef,
-    pub start: OpRef,
-    pub lgtop: OpRef,
+    pub s: BoxRef,
+    pub start: BoxRef,
+    pub lgtop: BoxRef,
 }
 
 /// vstring.py:266-334 `VStringConcatInfo`
 #[derive(Clone, Debug)]
 pub struct VStringConcatInfo {
-    pub vleft: OpRef,
-    pub vright: OpRef,
+    pub vleft: BoxRef,
+    pub vright: BoxRef,
     pub _is_virtual: bool,
 }
 
@@ -458,9 +458,13 @@ pub enum PtrInfo {
 fn str_child_oprefs(s: &StrPtrInfo) -> Vec<OpRef> {
     match &s.variant {
         VStringVariant::Ptr => Vec::new(),
-        VStringVariant::Plain(p) => p._chars.iter().filter_map(|slot| *slot).collect(),
-        VStringVariant::Slice(sl) => vec![sl.s, sl.start, sl.lgtop],
-        VStringVariant::Concat(c) => vec![c.vleft, c.vright],
+        VStringVariant::Plain(p) => p
+            ._chars
+            .iter()
+            .filter_map(|slot| slot.as_ref().map(|b| b.to_opref()))
+            .collect(),
+        VStringVariant::Slice(sl) => vec![sl.s.to_opref(), sl.start.to_opref(), sl.lgtop.to_opref()],
+        VStringVariant::Concat(c) => vec![c.vleft.to_opref(), c.vright.to_opref()],
     }
 }
 
@@ -553,26 +557,26 @@ impl PtrInfo {
                 }
             }
             PtrInfo::Str(info) => {
-                if let Some(opref) = info.lgtop.as_mut() {
-                    visit_opref(opref, visitor);
+                if let Some(b) = info.lgtop.as_ref() {
+                    b.walk_const_ptr_refs(visitor);
                 }
-                match &mut info.variant {
+                match &info.variant {
                     VStringVariant::Ptr => {}
                     VStringVariant::Plain(plain) => {
-                        for slot in &mut plain._chars {
-                            if let Some(opref) = slot.as_mut() {
-                                visit_opref(opref, visitor);
+                        for slot in &plain._chars {
+                            if let Some(b) = slot.as_ref() {
+                                b.walk_const_ptr_refs(visitor);
                             }
                         }
                     }
                     VStringVariant::Slice(slice) => {
-                        visit_opref(&mut slice.s, visitor);
-                        visit_opref(&mut slice.start, visitor);
-                        visit_opref(&mut slice.lgtop, visitor);
+                        slice.s.walk_const_ptr_refs(visitor);
+                        slice.start.walk_const_ptr_refs(visitor);
+                        slice.lgtop.walk_const_ptr_refs(visitor);
                     }
                     VStringVariant::Concat(concat) => {
-                        visit_opref(&mut concat.vleft, visitor);
-                        visit_opref(&mut concat.vright, visitor);
+                        concat.vleft.walk_const_ptr_refs(visitor);
+                        concat.vright.walk_const_ptr_refs(visitor);
                     }
                 }
             }
@@ -785,7 +789,7 @@ impl PtrInfo {
     /// vstring.py:112: return self.lgtop — cached length OpRef if available.
     pub fn get_cached_lgtop(&self) -> Option<OpRef> {
         match self {
-            PtrInfo::Str(info) => info.lgtop,
+            PtrInfo::Str(info) => info.lgtop.as_ref().map(|b| b.to_opref()),
             _ => None,
         }
     }

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -7,6 +7,7 @@
 //! / `BoxRef` from `majit-metainterp` live as extension traits in
 //! `metainterp::optimizeopt::info`.
 
+use crate::box_ref::BoxRef;
 use crate::field_entry::{FieldEntry, PreambleOp};
 use crate::intbound::IntBound;
 use crate::rawbuffer::{RawBuffer, RawBufferError};
@@ -488,7 +489,7 @@ impl PtrInfo {
 
         fn visit_field(entry: &mut FieldEntry, visitor: &mut dyn FnMut(&mut GcRef)) {
             match entry {
-                FieldEntry::Value(opref) => visit_opref(opref, visitor),
+                FieldEntry::Value(b) => b.walk_const_ptr_refs(visitor),
                 FieldEntry::Preamble(pop) => {
                     pop.op.walk_const_ptr_refs(visitor);
                     pop.preamble_op.walk_const_ptr_refs_mut(visitor);
@@ -1103,20 +1104,22 @@ impl PtrInfo {
             PtrInfo::Instance(v) => {
                 for entry in &mut v.fields {
                     if entry.0 == field_idx {
-                        entry.1 = FieldEntry::Value(value);
+                        entry.1 = FieldEntry::Value(BoxRef::from_opref(value));
                         return;
                     }
                 }
-                v.fields.push((field_idx, FieldEntry::Value(value)));
+                v.fields
+                    .push((field_idx, FieldEntry::Value(BoxRef::from_opref(value))));
             }
             PtrInfo::Struct(v) => {
                 for entry in &mut v.fields {
                     if entry.0 == field_idx {
-                        entry.1 = FieldEntry::Value(value);
+                        entry.1 = FieldEntry::Value(BoxRef::from_opref(value));
                         return;
                     }
                 }
-                v.fields.push((field_idx, FieldEntry::Value(value)));
+                v.fields
+                    .push((field_idx, FieldEntry::Value(BoxRef::from_opref(value))));
             }
             PtrInfo::Virtual(v) => {
                 for entry in &mut v.fields {
@@ -1168,7 +1171,7 @@ impl PtrInfo {
         assert!(!self.is_virtual(), "set_preamble_item on virtual");
         if let PtrInfo::Array(v) = self {
             if index >= v.items.len() {
-                v.items.resize(index + 1, FieldEntry::Value(OpRef::NONE));
+                v.items.resize(index + 1, FieldEntry::Value(BoxRef::none()));
             }
             v.items[index] = FieldEntry::Preamble(pop);
         }
@@ -1233,7 +1236,7 @@ impl PtrInfo {
             PtrInfo::Array(v) => {
                 if let Some(entry) = v.items.get_mut(index) {
                     if entry.is_preamble() {
-                        let taken = std::mem::replace(entry, FieldEntry::Value(OpRef::NONE));
+                        let taken = std::mem::replace(entry, FieldEntry::Value(BoxRef::none()));
                         taken.into_preamble()
                     } else {
                         None
@@ -1269,12 +1272,12 @@ impl PtrInfo {
             PtrInfo::Virtual(v) => v
                 .fields
                 .iter()
-                .map(|(k, v)| (*k, FieldEntry::Value(*v)))
+                .map(|(k, v)| (*k, FieldEntry::Value(BoxRef::from_opref(*v))))
                 .collect(),
             PtrInfo::VirtualStruct(v) => v
                 .fields
                 .iter()
-                .map(|(k, v)| (*k, FieldEntry::Value(*v)))
+                .map(|(k, v)| (*k, FieldEntry::Value(BoxRef::from_opref(*v))))
                 .collect(),
             PtrInfo::Array(v) => v
                 .items
@@ -1286,7 +1289,7 @@ impl PtrInfo {
                 .items
                 .iter()
                 .enumerate()
-                .map(|(i, val)| (i as u32, FieldEntry::Value(*val)))
+                .map(|(i, val)| (i as u32, FieldEntry::Value(BoxRef::from_opref(*val))))
                 .collect(),
             _ => Vec::new(),
         }
@@ -1309,12 +1312,12 @@ impl PtrInfo {
                 .fields
                 .iter()
                 .find(|(k, _)| *k == field_idx)
-                .map(|(_, v)| FieldEntry::Value(*v)),
+                .map(|(_, v)| FieldEntry::Value(BoxRef::from_opref(*v))),
             PtrInfo::VirtualStruct(v) => v
                 .fields
                 .iter()
                 .find(|(k, _)| *k == field_idx)
-                .map(|(_, v)| FieldEntry::Value(*v)),
+                .map(|(_, v)| FieldEntry::Value(BoxRef::from_opref(*v))),
             _ => None,
         }
     }
@@ -1324,9 +1327,9 @@ impl PtrInfo {
         match self {
             PtrInfo::Array(v) => {
                 if index >= v.items.len() {
-                    v.items.resize(index + 1, FieldEntry::Value(OpRef::NONE));
+                    v.items.resize(index + 1, FieldEntry::Value(BoxRef::none()));
                 }
-                v.items[index] = FieldEntry::Value(value);
+                v.items[index] = FieldEntry::Value(BoxRef::from_opref(value));
             }
             PtrInfo::VirtualArray(v) => {
                 // info.py:568-569 `if self.is_virtual(): return  # bogus
@@ -1343,7 +1346,10 @@ impl PtrInfo {
     pub fn getitem(&self, index: usize) -> Option<FieldEntry> {
         match self {
             PtrInfo::Array(v) => v.items.get(index).cloned(),
-            PtrInfo::VirtualArray(v) => v.items.get(index).map(|r| FieldEntry::Value(*r)),
+            PtrInfo::VirtualArray(v) => v
+                .items
+                .get(index)
+                .map(|r| FieldEntry::Value(BoxRef::from_opref(*r))),
             _ => None,
         }
     }
@@ -1353,7 +1359,7 @@ impl PtrInfo {
         match self {
             PtrInfo::Array(v) => {
                 if index < v.items.len() {
-                    v.items[index] = FieldEntry::Value(OpRef::NONE);
+                    v.items[index] = FieldEntry::Value(BoxRef::none());
                 }
             }
             PtrInfo::VirtualArray(v) => {

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -200,7 +200,7 @@ pub struct VirtualArrayInfo {
     /// Whether this was created by NewArrayClear (zero-initialized).
     pub clear: bool,
     /// Element values.
-    pub items: Vec<OpRef>,
+    pub items: Vec<BoxRef>,
     /// info.py:91-92
     pub last_guard_pos: i32,
     /// info.py `_cached_vinfo` — see AbstractVirtualPtrInfo.
@@ -524,8 +524,8 @@ impl PtrInfo {
                 }
             }
             PtrInfo::VirtualArray(info) => {
-                for opref in &mut info.items {
-                    visit_opref(opref, visitor);
+                for b in &info.items {
+                    b.walk_const_ptr_refs(visitor);
                 }
             }
             PtrInfo::VirtualStruct(info) => {
@@ -720,7 +720,7 @@ impl PtrInfo {
         PtrInfo::VirtualArray(VirtualArrayInfo {
             descr,
             clear,
-            items: vec![OpRef::NONE; length],
+            items: vec![BoxRef::none(); length],
             last_guard_pos: -1,
             avpi: AbstractVirtualPtrInfo::new(),
         })
@@ -828,7 +828,7 @@ impl PtrInfo {
             PtrInfo::Struct(v) => v.fields.iter().filter_map(|(_, e)| e.as_opref()).collect(),
             PtrInfo::Array(v) => v.items.iter().filter_map(|e| e.as_opref()).collect(),
             PtrInfo::Virtual(v) => v.fields.iter().map(|(_, r)| *r).collect(),
-            PtrInfo::VirtualArray(v) => v.items.clone(),
+            PtrInfo::VirtualArray(v) => v.items.iter().map(|b| b.to_opref()).collect(),
             PtrInfo::VirtualStruct(v) => v.fields.iter().map(|(_, r)| *r).collect(),
             PtrInfo::VirtualArrayStruct(v) => v
                 .element_fields
@@ -878,7 +878,7 @@ impl PtrInfo {
             PtrInfo::VirtualArray(v) => {
                 for item in &mut v.items {
                     if !item.is_none() {
-                        *item = recurse(*item);
+                        *item = BoxRef::from_opref(recurse(item.to_opref()));
                     }
                 }
             }
@@ -1291,7 +1291,7 @@ impl PtrInfo {
                 .items
                 .iter()
                 .enumerate()
-                .map(|(i, val)| (i as u32, FieldEntry::Value(BoxRef::from_opref(*val))))
+                .map(|(i, val)| (i as u32, FieldEntry::Value(val.clone())))
                 .collect(),
             _ => Vec::new(),
         }
@@ -1337,7 +1337,7 @@ impl PtrInfo {
                 // info.py:568-569 `if self.is_virtual(): return  # bogus
                 // setarrayitem_gc into virtual, drop the operation`.
                 if index < v.items.len() {
-                    v.items[index] = value;
+                    v.items[index] = BoxRef::from_opref(value);
                 }
             }
             _ => {}
@@ -1351,7 +1351,7 @@ impl PtrInfo {
             PtrInfo::VirtualArray(v) => v
                 .items
                 .get(index)
-                .map(|r| FieldEntry::Value(BoxRef::from_opref(*r))),
+                .map(|r| FieldEntry::Value(r.clone())),
             _ => None,
         }
     }
@@ -1366,7 +1366,7 @@ impl PtrInfo {
             }
             PtrInfo::VirtualArray(v) => {
                 if index < v.items.len() {
-                    v.items[index] = OpRef::NONE;
+                    v.items[index] = BoxRef::none();
                 }
             }
             _ => {}

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -540,11 +540,7 @@ impl PtrInfo {
                     }
                 }
             }
-            PtrInfo::VirtualRawBuffer(info) => {
-                for opref in info.buffer.values_mut() {
-                    visit_opref(opref, visitor);
-                }
-            }
+            PtrInfo::VirtualRawBuffer(info) => info.buffer.walk_const_ptr_refs(visitor),
             PtrInfo::VirtualRawSlice(info) => info.parent.walk_const_ptr_refs(visitor),
             PtrInfo::Virtualizable(info) => {
                 for (_, opref) in &mut info.fields {
@@ -835,7 +831,7 @@ impl PtrInfo {
                 .iter()
                 .flat_map(|fields| fields.iter().map(|(_, r)| *r))
                 .collect(),
-            PtrInfo::VirtualRawBuffer(v) => v.buffer.values().to_vec(),
+            PtrInfo::VirtualRawBuffer(v) => v.buffer.values(),
             PtrInfo::VirtualRawSlice(v) => vec![v.parent.to_opref()],
             PtrInfo::Virtualizable(v) => {
                 let mut refs: Vec<OpRef> = v.fields.iter().map(|(_, r)| *r).collect();

--- a/majit/majit-ir/src/rawbuffer.rs
+++ b/majit/majit-ir/src/rawbuffer.rs
@@ -3,7 +3,8 @@
 //! RPython parity target:
 //! `rpython/jit/metainterp/optimizeopt/rawbuffer.py`.
 
-use crate::{DescrRef, OpRef};
+use crate::box_ref::BoxRef;
+use crate::{DescrRef, GcRef, OpRef};
 
 /// rawbuffer.py:13 RawBuffer — 4 parallel lists: offsets, lengths, descrs, values.
 /// Sorted by offset. Invariant: offsets[i]+lengths[i] <= offsets[i+1].
@@ -20,7 +21,7 @@ pub struct RawBuffer {
     /// rawbuffer.py:16: self.descrs — per-entry ArrayDescr.
     descrs: Vec<DescrRef>,
     /// rawbuffer.py:17: self.values
-    values: Vec<OpRef>,
+    values: Vec<BoxRef>,
 }
 
 /// Error returned when a raw buffer operation violates invariants.
@@ -75,12 +76,17 @@ impl RawBuffer {
         &self.descrs
     }
 
-    pub fn values(&self) -> &[OpRef] {
-        &self.values
+    pub fn values(&self) -> Vec<OpRef> {
+        self.values.iter().map(|b| b.to_opref()).collect()
     }
 
-    pub fn values_mut(&mut self) -> &mut [OpRef] {
-        &mut self.values
+    /// Forward each stored value's inline const gcref through the canonical
+    /// BoxRef-Const walk. Replaces the old `values_mut()` round-trip used by
+    /// the PtrInfo GC walker.
+    pub fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut GcRef)) {
+        for b in &self.values {
+            b.walk_const_ptr_refs(visitor);
+        }
     }
 
     pub fn iter_entries(&self) -> impl Iterator<Item = (i64, usize, &DescrRef, OpRef)> + '_ {
@@ -89,7 +95,7 @@ impl RawBuffer {
             .copied()
             .zip(self.lengths.iter().copied())
             .zip(self.descrs.iter())
-            .zip(self.values.iter().copied())
+            .zip(self.values.iter().map(|b| b.to_opref()))
             .map(|(((offset, length), descr), value)| (offset, length, descr, value))
     }
 
@@ -106,7 +112,7 @@ impl RawBuffer {
             .zip(lengths)
             .zip(descrs)
             .zip(values)
-            .map(|(((offset, length), descr), value)| (offset, length, descr, value))
+            .map(|(((offset, length), descr), value)| (offset, length, descr, value.to_opref()))
             .collect()
     }
 
@@ -163,7 +169,7 @@ impl RawBuffer {
                     });
                 }
                 // rawbuffer.py:102: only replace value, keep existing descr.
-                self.values[i] = value;
+                self.values[i] = BoxRef::from_opref(value);
                 return Ok(());
             } else if wo > offset {
                 break;
@@ -212,7 +218,7 @@ impl RawBuffer {
         self.offsets.insert(insert_pos, offset);
         self.lengths.insert(insert_pos, length);
         self.descrs.insert(insert_pos, descr);
-        self.values.insert(insert_pos, value);
+        self.values.insert(insert_pos, BoxRef::from_opref(value));
         Ok(())
     }
 
@@ -233,7 +239,7 @@ impl RawBuffer {
                         write_length: self.lengths[i],
                     });
                 }
-                return Ok(self.values[i]);
+                return Ok(self.values[i].to_opref());
             }
         }
         Err(RawBufferError::UninitializedRead { offset, length })

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -574,7 +574,6 @@ impl OpRef {
             _ => None,
         }
     }
-
 }
 
 // `#[derive(PartialEq, Eq, Hash)]` on `OpRef` enforces RPython's

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -575,19 +575,6 @@ impl OpRef {
         }
     }
 
-    /// Mutable view of the inline `GcRef` carried by `ConstPtr`;
-    /// `None` for any other variant. Used by minor-collection root
-    /// walkers (framework.py `root_walker.walk_roots`) to forward
-    /// nursery-resident Ref constants in-place. `ConstInt` ≡ `ConstPtr`
-    /// at the AbstractValue level (history.py:227/268/314) — only the
-    /// `ConstPtr.value` slot needs GC tracing because `ConstInt.value`
-    /// is a plain integer.
-    pub fn as_const_ptr_mut(&mut self) -> Option<&mut GcRef> {
-        match self {
-            Self::ConstPtr(v) => Some(v),
-            _ => None,
-        }
-    }
 }
 
 // `#[derive(PartialEq, Eq, Hash)]` on `OpRef` enforces RPython's

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -258,7 +258,7 @@ impl CachedField {
         if let Some((lazy_obj, lazy_op)) = &self.lazy_set {
             if *lazy_obj == struct_opref {
                 return Some(crate::optimizeopt::info::FieldEntry::Value(
-                    Self::_get_rhs_from_set_op(lazy_op),
+                    BoxRef::from_opref(Self::_get_rhs_from_set_op(lazy_op)),
                 ));
             }
         }
@@ -580,7 +580,7 @@ impl ArrayCachedItem {
         if let Some((lazy_obj, lazy_op)) = &self.lazy_set {
             if *lazy_obj == array_opref {
                 return Some(crate::optimizeopt::info::FieldEntry::Value(
-                    Self::_get_rhs_from_set_op(lazy_op),
+                    BoxRef::from_opref(Self::_get_rhs_from_set_op(lazy_op)),
                 ));
             }
         }
@@ -1952,7 +1952,7 @@ impl OptHeap {
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
                                 let b_old = BoxRef::from_bound_op(op_rc);
-                                let b_cached = ctx.get_box_replacement(cached);
+                                let b_cached = ctx.get_box_replacement(cached.to_opref());
                                 ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }
@@ -2023,7 +2023,7 @@ impl OptHeap {
                     crate::optimizeopt::info::FieldEntry::Value(cached) => {
                         if !cached.is_none() {
                             let b_old = BoxRef::from_bound_op(op_rc);
-                            let b_cached = ctx.get_box_replacement(cached);
+                            let b_cached = ctx.get_box_replacement(cached.to_opref());
                             ctx.make_equal_to(&b_old, &b_cached);
                             return OptimizationResult::Remove;
                         }
@@ -2198,7 +2198,7 @@ impl OptHeap {
                 crate::optimizeopt::info::FieldEntry::Value(cached) => {
                     // heap.py:88 not cached_field.same_box(arg1)
                     // (ctx.same_box resolves both sides internally)
-                    if ctx.same_box(cached, arg1) {
+                    if ctx.same_box(cached.to_opref(), arg1) {
                         // heap.py:100 self._lazy_set = None
                         self.field_cache(descr).lazy_set = None;
                         return OptimizationResult::Remove;
@@ -2340,7 +2340,7 @@ impl OptHeap {
                 crate::optimizeopt::info::FieldEntry::Value(cached) => {
                     // heap.py:88 not cached_field.same_box(arg1)
                     // (ctx.same_box resolves both sides internally)
-                    if ctx.same_box(cached, arg1) {
+                    if ctx.same_box(cached.to_opref(), arg1) {
                         // heap.py:100 self._lazy_set = None
                         self.arrayitem_cache(descr, const_index).lazy_set = None;
                         return OptimizationResult::Remove;
@@ -2506,7 +2506,7 @@ impl OptHeap {
                             crate::optimizeopt::info::FieldEntry::Value(cached) => {
                                 if !cached.is_none() {
                                     let b_old = BoxRef::from_bound_op(op_rc);
-                                    let b_cached = ctx.get_box_replacement(cached);
+                                    let b_cached = ctx.get_box_replacement(cached.to_opref());
                                     ctx.make_equal_to(&b_old, &b_cached);
                                     return OptimizationResult::Remove;
                                 }
@@ -2587,7 +2587,7 @@ impl OptHeap {
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
                                 let b_old = BoxRef::from_bound_op(op_rc);
-                                let b_cached = ctx.get_box_replacement(cached);
+                                let b_cached = ctx.get_box_replacement(cached.to_opref());
                                 ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }
@@ -6637,7 +6637,10 @@ mod tests {
             PtrInfo::Array(ArrayPtrInfo {
                 descr: arr_descr.clone(),
                 lenbound: IntBound::from_constant(2),
-                items: vec![FieldEntry::Value(const_10), FieldEntry::Value(const_20)],
+                items: vec![
+                    FieldEntry::Value(BoxRef::from_opref(const_10)),
+                    FieldEntry::Value(BoxRef::from_opref(const_20)),
+                ],
                 last_guard_pos: -1,
             }),
         );
@@ -6646,7 +6649,10 @@ mod tests {
             PtrInfo::Array(ArrayPtrInfo {
                 descr: arr_descr,
                 lenbound: IntBound::from_constant(2),
-                items: vec![FieldEntry::Value(const_10), FieldEntry::Value(const_30)],
+                items: vec![
+                    FieldEntry::Value(BoxRef::from_opref(const_10)),
+                    FieldEntry::Value(BoxRef::from_opref(const_30)),
+                ],
                 last_guard_pos: -1,
             }),
         );

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -175,8 +175,8 @@ impl StrPtrInfoExt for StrPtrInfo {
     /// extracts a constant from lenbound directly.
     fn getstrlen(&self, ctx: &crate::optimizeopt::OptContext, mode: u8) -> Option<i64> {
         // vstring.py:112: if self.lgtop is not None: return self.lgtop
-        if let Some(lgtop) = self.lgtop {
-            return ctx.get_box_replacement_box(lgtop).and_then(|b| {
+        if let Some(lgtop) = self.lgtop.as_ref() {
+            return ctx.get_box_replacement_box(lgtop.to_opref()).and_then(|b| {
                 ctx.get_constant_int_box(&b).or_else(|| {
                     ctx.peek_intbound_box(&b)
                         .filter(|ib| ib.is_constant())
@@ -193,13 +193,13 @@ impl StrPtrInfoExt for StrPtrInfo {
             VStringVariant::Plain(info) => Some(info._chars.len() as i64),
             // vstring.py:251-253: VStringSliceInfo.getstrlen → self.lgtop
             VStringVariant::Slice(info) => {
-                let b = ctx.get_box_replacement_box(info.lgtop)?;
+                let b = ctx.get_box_replacement_box(info.lgtop.to_opref())?;
                 ctx.get_constant_int_or_bound_box(&b)
             }
             // vstring.py:281-295: VStringConcatInfo.getstrlen
             VStringVariant::Concat(info) => {
-                let vleft_box = ctx.get_box_replacement_box(info.vleft);
-                let vright_box = ctx.get_box_replacement_box(info.vright);
+                let vleft_box = ctx.get_box_replacement_box(info.vleft.to_opref());
+                let vright_box = ctx.get_box_replacement_box(info.vright.to_opref());
                 let left = vleft_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                 let right = vright_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                 let len1 = left.get_known_str_length(ctx, mode)?;
@@ -227,7 +227,7 @@ impl StrPtrInfoExt for StrPtrInfo {
             VStringVariant::Plain(info) => {
                 let mut chars = Vec::with_capacity(info._chars.len());
                 for ch in &info._chars {
-                    let ch_opref = (*ch)?;
+                    let ch_opref = ch.as_ref().map(|b| b.to_opref())?;
                     // vstring.py:179: `c.is_constant()` for Plain strings
                     // accepts only an actual ConstInt, not a synthesized
                     // ConstInt from a constant IntBound.
@@ -240,12 +240,12 @@ impl StrPtrInfoExt for StrPtrInfo {
             }
             VStringVariant::Slice(info) => {
                 // vstring.py:236-248: use getintbound().is_constant()
-                let s_box = ctx.get_box_replacement_box(info.s);
+                let s_box = ctx.get_box_replacement_box(info.s.to_opref());
                 let source = s_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                 let source_chars = source.get_constant_string_spec(ctx, mode)?;
-                let start_box = ctx.get_box_replacement_box(info.start)?;
+                let start_box = ctx.get_box_replacement_box(info.start.to_opref())?;
                 let start = usize::try_from(ctx.get_constant_int_or_bound_box(&start_box)?).ok()?;
-                let lgtop_box = ctx.get_box_replacement_box(info.lgtop)?;
+                let lgtop_box = ctx.get_box_replacement_box(info.lgtop.to_opref())?;
                 let length =
                     usize::try_from(ctx.get_constant_int_or_bound_box(&lgtop_box)?).ok()?;
                 let stop = start.checked_add(length)?;
@@ -255,8 +255,8 @@ impl StrPtrInfoExt for StrPtrInfo {
                 Some(source_chars[start..stop].to_vec())
             }
             VStringVariant::Concat(info) => {
-                let vleft_box = ctx.get_box_replacement_box(info.vleft);
-                let vright_box = ctx.get_box_replacement_box(info.vright);
+                let vleft_box = ctx.get_box_replacement_box(info.vleft.to_opref());
+                let vright_box = ctx.get_box_replacement_box(info.vright.to_opref());
                 let left = vleft_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                 let right = vright_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                 let mut chars = left.get_constant_string_spec(ctx, mode)?;
@@ -272,24 +272,28 @@ impl StrPtrInfoExt for StrPtrInfo {
         let index = usize::try_from(index).ok()?;
         match &self.variant {
             VStringVariant::Ptr => None,
-            VStringVariant::Plain(info) => info._chars.get(index).copied().flatten(),
+            VStringVariant::Plain(info) => info
+                ._chars
+                .get(index)
+                .and_then(|o| o.as_ref())
+                .map(|b| b.to_opref()),
             VStringVariant::Slice(info) => {
                 // vstring.py:491: index = _int_add(sinfo.start, index)
                 // Accept intbound-constant starts, not just literal constants.
-                let start_box = ctx.get_box_replacement_box(info.start)?;
+                let start_box = ctx.get_box_replacement_box(info.start.to_opref())?;
                 let start = ctx.get_constant_int_or_bound_box(&start_box)?;
-                let s_box = ctx.get_box_replacement_box(info.s);
+                let s_box = ctx.get_box_replacement_box(info.s.to_opref());
                 let source = s_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                 source.strgetitem(index as i64 + start, ctx)
             }
             VStringVariant::Concat(info) => {
-                let vleft_box = ctx.get_box_replacement_box(info.vleft);
+                let vleft_box = ctx.get_box_replacement_box(info.vleft.to_opref());
                 let left = vleft_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                 let left_len = usize::try_from(left.get_known_str_length(ctx, self.mode)?).ok()?;
                 if index < left_len {
                     left.strgetitem(index as i64, ctx)
                 } else {
-                    let vright_box = ctx.get_box_replacement_box(info.vright);
+                    let vright_box = ctx.get_box_replacement_box(info.vright.to_opref());
                     let right = vright_box.as_ref().and_then(|b| ctx.getptrinfo(b))?;
                     right.strgetitem((index - left_len) as i64, ctx)
                 }
@@ -1269,12 +1273,12 @@ fn force_box_impl(
             let lengthbox = match &variant {
                 VStringVariant::Plain(info) => ctx.emit_constant_int(info._chars.len() as i64),
                 VStringVariant::Slice(info) => ctx
-                    .get_box_replacement_box(info.lgtop)
+                    .get_box_replacement_box(info.lgtop.to_opref())
                     .map(|b| b.to_opref())
-                    .unwrap_or(info.lgtop),
+                    .unwrap_or(info.lgtop.to_opref()),
                 VStringVariant::Concat(info) => {
-                    let left_len = ctx.getstrlen_opref(info.vleft, mode);
-                    let right_len = ctx.getstrlen_opref(info.vright, mode);
+                    let left_len = ctx.getstrlen_opref(info.vleft.to_opref(), mode);
+                    let right_len = ctx.getstrlen_opref(info.vright.to_opref(), mode);
                     crate::optimizeopt::vstring::_int_add(left_len, right_len, ctx)
                 }
                 VStringVariant::Ptr => unreachable!(),
@@ -1297,7 +1301,7 @@ fn force_box_impl(
                     &b,
                     PtrInfo::Str(StrPtrInfo {
                         lenbound: sinfo_full.lenbound,
-                        lgtop: Some(lengthbox), // vstring.py:98 preserve computed length
+                        lgtop: Some(BoxRef::from_opref(lengthbox)), // vstring.py:98 preserve computed length
                         mode: sinfo_full.mode,
                         length: sinfo_full.length,
                         variant: VStringVariant::Ptr, // non-virtual
@@ -1328,10 +1332,11 @@ fn force_box_impl(
                     let one = ctx.emit_constant_int(1);
                     for ch in &info._chars {
                         if let Some(ch_ref) = ch {
+                            let ch_ref = ch_ref.to_opref();
                             let ch_resolved = ctx
-                                .get_box_replacement_box(*ch_ref)
+                                .get_box_replacement_box(ch_ref)
                                 .map(|b| b.to_opref())
-                                .unwrap_or(*ch_ref);
+                                .unwrap_or(ch_ref);
                             let arg_newop = ctx.materialize_box_at(newop);
                             let arg_offset = ctx.materialize_box_at(offset);
                             let arg_ch = ctx.materialize_box_at(ch_resolved);
@@ -1344,10 +1349,14 @@ fn force_box_impl(
                 VStringVariant::Concat(info) => {
                     // vstring.py:309-317 VStringConcatInfo.string_copy_parts
                     let offset = crate::optimizeopt::vstring::string_copy_parts(
-                        info.vleft, newop, zero, mode, ctx,
+                        info.vleft.to_opref(),
+                        newop,
+                        zero,
+                        mode,
+                        ctx,
                     );
                     crate::optimizeopt::vstring::string_copy_parts(
-                        info.vright,
+                        info.vright.to_opref(),
                         newop,
                         offset,
                         mode,
@@ -1357,7 +1366,14 @@ fn force_box_impl(
                 VStringVariant::Slice(info) => {
                     // vstring.py:230-233 VStringSliceInfo.string_copy_parts
                     crate::optimizeopt::vstring::copy_str_content(
-                        ctx, info.s, newop, info.start, zero, info.lgtop, mode, true,
+                        ctx,
+                        info.s.to_opref(),
+                        newop,
+                        info.start.to_opref(),
+                        zero,
+                        info.lgtop.to_opref(),
+                        mode,
+                        true,
                     );
                 }
                 VStringVariant::Ptr => unreachable!(),
@@ -1480,13 +1496,13 @@ mod tests {
 
         let slice = PtrInfo::Str(StrPtrInfo {
             lenbound: None,
-            lgtop: Some(OpRef::int_op(3)), // vstring.py:223: self.lgtop = length
+            lgtop: Some(BoxRef::from_opref(OpRef::int_op(3))), // vstring.py:223: self.lgtop = length
             mode: 0,
             length: -1,
             variant: VStringVariant::Slice(VStringSliceInfo {
-                s: OpRef::int_op(1),
-                start: OpRef::int_op(2),
-                lgtop: OpRef::int_op(3),
+                s: BoxRef::from_opref(OpRef::int_op(1)),
+                start: BoxRef::from_opref(OpRef::int_op(2)),
+                lgtop: BoxRef::from_opref(OpRef::int_op(3)),
             }),
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
@@ -1499,8 +1515,8 @@ mod tests {
             mode: 0,
             length: -1,
             variant: VStringVariant::Concat(VStringConcatInfo {
-                vleft: OpRef::int_op(4),
-                vright: OpRef::int_op(5),
+                vleft: BoxRef::from_opref(OpRef::int_op(4)),
+                vright: BoxRef::from_opref(OpRef::int_op(5)),
                 _is_virtual: true,
             }),
             last_guard_pos: -1,
@@ -1534,9 +1550,9 @@ mod tests {
             length: 3,
             variant: VStringVariant::Plain(VStringPlainInfo {
                 _chars: vec![
-                    Some(OpRef::int_op(10)),
-                    Some(OpRef::int_op(11)),
-                    Some(OpRef::int_op(12)),
+                    Some(BoxRef::from_opref(OpRef::int_op(10))),
+                    Some(BoxRef::from_opref(OpRef::int_op(11))),
+                    Some(BoxRef::from_opref(OpRef::int_op(12))),
                 ],
             }),
             last_guard_pos: -1,
@@ -1571,7 +1587,7 @@ mod tests {
             mode: 0,
             length: 1,
             variant: VStringVariant::Plain(VStringPlainInfo {
-                _chars: vec![Some(ch)],
+                _chars: vec![Some(BoxRef::from_opref(ch))],
             }),
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
@@ -1602,9 +1618,9 @@ mod tests {
                 length: 3,
                 variant: VStringVariant::Plain(VStringPlainInfo {
                     _chars: vec![
-                        Some(OpRef::int_op(10)),
-                        Some(OpRef::int_op(11)),
-                        Some(OpRef::int_op(12)),
+                        Some(BoxRef::from_opref(OpRef::int_op(10))),
+                        Some(BoxRef::from_opref(OpRef::int_op(11))),
+                        Some(BoxRef::from_opref(OpRef::int_op(12))),
                     ],
                 }),
                 last_guard_pos: -1,
@@ -1614,13 +1630,13 @@ mod tests {
 
         let slice = PtrInfo::Str(StrPtrInfo {
             lenbound: None,
-            lgtop: Some(OpRef::int_op(21)), // vstring.py:223: self.lgtop = length
+            lgtop: Some(BoxRef::from_opref(OpRef::int_op(21))), // vstring.py:223: self.lgtop = length
             mode: 0,
             length: -1,
             variant: VStringVariant::Slice(VStringSliceInfo {
-                s: source,
-                start: OpRef::int_op(20),
-                lgtop: OpRef::int_op(21),
+                s: BoxRef::from_opref(source),
+                start: BoxRef::from_opref(OpRef::int_op(20)),
+                lgtop: BoxRef::from_opref(OpRef::int_op(21)),
             }),
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
@@ -1635,8 +1651,8 @@ mod tests {
             mode: 0,
             length: -1,
             variant: VStringVariant::Concat(VStringConcatInfo {
-                vleft: source,
-                vright: OpRef::int_op(2),
+                vleft: BoxRef::from_opref(source),
+                vright: BoxRef::from_opref(OpRef::int_op(2)),
                 _is_virtual: true,
             }),
             last_guard_pos: -1,
@@ -1651,7 +1667,10 @@ mod tests {
                 mode: 0,
                 length: 2,
                 variant: VStringVariant::Plain(VStringPlainInfo {
-                    _chars: vec![Some(OpRef::int_op(11)), Some(OpRef::int_op(12))],
+                    _chars: vec![
+                        Some(BoxRef::from_opref(OpRef::int_op(11))),
+                        Some(BoxRef::from_opref(OpRef::int_op(12))),
+                    ],
                 }),
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -792,7 +792,8 @@ impl PtrInfoExt for PtrInfo {
         if fields.len() != size_descr.all_fielddescrs().len() {
             return false;
         }
-        for &(_, val) in fields {
+        for (_, val) in fields {
+            let val = val.to_opref();
             if !ctx
                 .get_box_replacement_box(val)
                 .and_then(|cb| cb.const_value())
@@ -878,7 +879,9 @@ fn force_box_impl(
                 if !ptr.is_null() {
                     // info.py:144: _force_elements_immutable
                     // Write constant field values directly to the allocated memory.
-                    for &(field_idx, val_ref) in fields.iter() {
+                    for (field_idx, val_ref) in fields.iter() {
+                        let field_idx = *field_idx;
+                        let val_ref = val_ref.to_opref();
                         if let Some(value) = ctx
                             .get_box_replacement_box(val_ref)
                             .and_then(|cb| cb.const_value())
@@ -952,7 +955,7 @@ fn force_box_impl(
                 ctx.make_equal_to(&box_, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
-                let value_ref = force_child(value_ref, ctx);
+                let value_ref = force_child(value_ref.to_opref(), ctx);
                 let descr = lookup_field_descr(&cached_fielddescrs, field_idx);
                 debug_assert!(
                     descr.is_some(),
@@ -1005,7 +1008,7 @@ fn force_box_impl(
                 ctx.make_equal_to(&box_, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
-                let value_ref = force_child(value_ref, ctx);
+                let value_ref = force_child(value_ref.to_opref(), ctx);
                 let descr = lookup_field_descr(&cached_fielddescrs, field_idx);
                 let descr = descr.expect(
                     "force_box: field_idx must resolve through descr.get_all_fielddescrs()[i]",
@@ -1123,7 +1126,7 @@ fn force_box_impl(
                     if value_ref.is_none() {
                         continue;
                     }
-                    let subbox = force_child(value_ref, ctx);
+                    let subbox = force_child(value_ref.to_opref(), ctx);
                     let arg_alloc = ctx.materialize_box_at(alloc_ref);
                     let arg_idx = ctx.materialize_box_at(idx_ref);
                     let arg_sub = ctx.materialize_box_at(subbox);

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1203,7 +1203,7 @@ fn force_box_impl(
             // Overwriting with `PtrInfo::nonnull()` would lose the
             // raw-slice identity and mis-route any later
             // `get_virtual_fields` / raw-guard path.
-            let parent_forced = force_child(slice.parent, ctx);
+            let parent_forced = force_child(slice.parent.to_opref(), ctx);
             let offset_ref = ctx.emit_constant_int(slice.offset as i64);
             let arg_parent = ctx.materialize_box_at(parent_forced);
             let arg_offset = ctx.materialize_box_at(offset_ref);
@@ -1219,7 +1219,7 @@ fn force_box_impl(
                     &b,
                     PtrInfo::VirtualRawSlice(VirtualRawSliceInfo {
                         offset: slice.offset,
-                        parent: OpRef::NONE,
+                        parent: BoxRef::none(),
                         last_guard_pos: slice.last_guard_pos,
                         avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
                     }),

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1043,6 +1043,7 @@ fn force_box_impl(
             let clear = vinfo.clear;
             let descr = vinfo.descr.clone();
             for (i, item_ref) in items.into_iter().enumerate() {
+                let item_ref = item_ref.to_opref();
                 if item_ref == OpRef::NONE {
                     continue;
                 }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5279,7 +5279,7 @@ impl OptContext {
                 let fields: Vec<(u32, FieldEntry)> = v
                     .fields
                     .iter()
-                    .map(|&(k, r)| (k, FieldEntry::Value(r)))
+                    .map(|&(k, r)| (k, FieldEntry::Value(crate::r#box::BoxRef::from_opref(r))))
                     .collect();
                 let ci = self.const_infos.entry(key).or_insert_with(|| {
                     PtrInfo::Struct(StructPtrInfo {
@@ -5298,7 +5298,7 @@ impl OptContext {
                 let fields: Vec<(u32, FieldEntry)> = v
                     .fields
                     .iter()
-                    .map(|&(k, r)| (k, FieldEntry::Value(r)))
+                    .map(|&(k, r)| (k, FieldEntry::Value(crate::r#box::BoxRef::from_opref(r))))
                     .collect();
                 let ci = self.const_infos.entry(key).or_insert_with(|| {
                     PtrInfo::Struct(StructPtrInfo {
@@ -5333,8 +5333,11 @@ impl OptContext {
             PtrInfo::VirtualArray(v) if !v.items.is_empty() => {
                 let descr = v.descr.clone();
                 let len = v.items.len() as i64;
-                let items: Vec<FieldEntry> =
-                    v.items.iter().map(|&r| FieldEntry::Value(r)).collect();
+                let items: Vec<FieldEntry> = v
+                    .items
+                    .iter()
+                    .map(|&r| FieldEntry::Value(crate::r#box::BoxRef::from_opref(r)))
+                    .collect();
                 let ci = self.const_infos.entry(key).or_insert_with(|| {
                     PtrInfo::Array(ArrayPtrInfo {
                         descr,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1107,7 +1107,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 Some(majit_ir::VirtualFieldsInfo {
                     descr: None,
                     known_class: None,
-                    field_oprefs: vec![self.ctx.get_replacement_opref(vi.parent)],
+                    field_oprefs: vec![self.ctx.get_replacement_opref(vi.parent.to_opref())],
                 })
             }
             // vstring.py:207-208 VStringPlainInfo._visitor_walk_recursive:
@@ -9430,7 +9430,7 @@ mod constant_ptr_info_tests {
             &slice_box,
             PtrInfo::VirtualRawSlice(VirtualRawSliceInfo {
                 offset: 8,
-                parent,
+                parent: crate::r#box::BoxRef::from_opref(parent),
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1134,20 +1134,21 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         ._chars
                         .iter()
                         .map(|slot| {
-                            slot.map(|r| self.ctx.get_replacement_opref(r))
+                            slot.as_ref()
+                                .map(|r| self.ctx.get_replacement_opref(r.to_opref()))
                                 .unwrap_or(OpRef::NONE)
                         })
                         .collect(),
                     // vstring.py:255-257: [self.s, self.start, self.lgtop].
                     VStringVariant::Slice(s) => vec![
-                        self.ctx.get_replacement_opref(s.s),
-                        self.ctx.get_replacement_opref(s.start),
-                        self.ctx.get_replacement_opref(s.lgtop),
+                        self.ctx.get_replacement_opref(s.s.to_opref()),
+                        self.ctx.get_replacement_opref(s.start.to_opref()),
+                        self.ctx.get_replacement_opref(s.lgtop.to_opref()),
                     ],
                     // vstring.py:319-324: [self.vleft, self.vright].
                     VStringVariant::Concat(c) => vec![
-                        self.ctx.get_replacement_opref(c.vleft),
-                        self.ctx.get_replacement_opref(c.vright),
+                        self.ctx.get_replacement_opref(c.vleft.to_opref()),
+                        self.ctx.get_replacement_opref(c.vright.to_opref()),
                     ],
                     // Non-virtual `VStringVariant::Ptr` would not reach
                     // here because of the `is_virtual()` guard above.
@@ -2291,7 +2292,7 @@ impl OptContext {
                 use crate::optimizeopt::info::VStringVariant;
                 if let PtrInfo::Str(sinfo) = info {
                     if let VStringVariant::Concat(c) = sinfo.variant {
-                        return Some((c.vleft, c.vright));
+                        return Some((c.vleft.to_opref(), c.vright.to_opref()));
                     }
                 }
                 None
@@ -2357,7 +2358,7 @@ impl OptContext {
         }
         self.with_ptr_info_mut(&resolved, |info| {
             if let PtrInfo::Str(si) = info {
-                si.lgtop = Some(lgtop);
+                si.lgtop = Some(crate::r#box::BoxRef::from_opref(lgtop));
             }
         });
     }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3579,7 +3579,7 @@ impl OptContext {
                         .iter()
                         .flat_map(|row| row.iter().map(|(_, r)| *r))
                         .collect(),
-                    PtrInfo::VirtualRawBuffer(r) => r.buffer.values().to_vec(),
+                    PtrInfo::VirtualRawBuffer(r) => r.buffer.values(),
                     _ => Vec::new(),
                 };
                 self.setinfo_from_preamble_list(&items, infos);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1055,7 +1055,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                 field_oprefs: vi
                     .items
                     .iter()
-                    .map(|vref| self.ctx.get_replacement_opref(*vref))
+                    .map(|vref| self.ctx.get_replacement_opref(vref.to_opref()))
                     .collect(),
             }),
             PtrInfo::VirtualArrayStruct(vi) => Some(majit_ir::VirtualFieldsInfo {
@@ -3572,7 +3572,7 @@ impl OptContext {
             if let Some(infos) = exported_infos {
                 let items: Vec<OpRef> = match &*preamble_info_handle.borrow() {
                     PtrInfo::Virtual(v) => v.fields.iter().map(|(_, r)| *r).collect(),
-                    PtrInfo::VirtualArray(a) => a.items.iter().copied().collect(),
+                    PtrInfo::VirtualArray(a) => a.items.iter().map(|b| b.to_opref()).collect(),
                     PtrInfo::VirtualStruct(s) => s.fields.iter().map(|(_, r)| *r).collect(),
                     PtrInfo::VirtualArrayStruct(a) => a
                         .element_fields
@@ -5336,7 +5336,7 @@ impl OptContext {
                 let items: Vec<FieldEntry> = v
                     .items
                     .iter()
-                    .map(|&r| FieldEntry::Value(crate::r#box::BoxRef::from_opref(r)))
+                    .map(|r| FieldEntry::Value(r.clone()))
                     .collect();
                 let ci = self.const_infos.entry(key).or_insert_with(|| {
                     PtrInfo::Array(ArrayPtrInfo {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1029,7 +1029,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fields
                             .iter()
                             .find(|(field_idx, _)| *field_idx == fi as u32)
-                            .map(|(_, vref)| self.ctx.get_replacement_opref(*vref))
+                            .map(|(_, vref)| self.ctx.get_replacement_opref(vref.to_opref()))
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect(),
@@ -1044,7 +1044,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fields
                             .iter()
                             .find(|(field_idx, _)| *field_idx == fi as u32)
-                            .map(|(_, vref)| self.ctx.get_replacement_opref(*vref))
+                            .map(|(_, vref)| self.ctx.get_replacement_opref(vref.to_opref()))
                             .unwrap_or(OpRef::NONE)
                     })
                     .collect(),
@@ -1068,7 +1068,7 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
                         vi.fielddescrs.iter().enumerate().map(|(fi, _)| {
                             ef.iter()
                                 .find(|(field_idx, _)| *field_idx == fi as u32)
-                                .map(|(_, vref)| self.ctx.get_replacement_opref(*vref))
+                                .map(|(_, vref)| self.ctx.get_replacement_opref(vref.to_opref()))
                                 .unwrap_or(OpRef::NONE)
                         })
                     })
@@ -3572,13 +3572,15 @@ impl OptContext {
             }
             if let Some(infos) = exported_infos {
                 let items: Vec<OpRef> = match &*preamble_info_handle.borrow() {
-                    PtrInfo::Virtual(v) => v.fields.iter().map(|(_, r)| *r).collect(),
+                    PtrInfo::Virtual(v) => v.fields.iter().map(|(_, r)| r.to_opref()).collect(),
                     PtrInfo::VirtualArray(a) => a.items.iter().map(|b| b.to_opref()).collect(),
-                    PtrInfo::VirtualStruct(s) => s.fields.iter().map(|(_, r)| *r).collect(),
+                    PtrInfo::VirtualStruct(s) => {
+                        s.fields.iter().map(|(_, r)| r.to_opref()).collect()
+                    }
                     PtrInfo::VirtualArrayStruct(a) => a
                         .element_fields
                         .iter()
-                        .flat_map(|row| row.iter().map(|(_, r)| *r))
+                        .flat_map(|row| row.iter().map(|(_, r)| r.to_opref()))
                         .collect(),
                     PtrInfo::VirtualRawBuffer(r) => r.buffer.values(),
                     _ => Vec::new(),
@@ -5280,7 +5282,7 @@ impl OptContext {
                 let fields: Vec<(u32, FieldEntry)> = v
                     .fields
                     .iter()
-                    .map(|&(k, r)| (k, FieldEntry::Value(crate::r#box::BoxRef::from_opref(r))))
+                    .map(|(k, r)| (*k, FieldEntry::Value(r.clone())))
                     .collect();
                 let ci = self.const_infos.entry(key).or_insert_with(|| {
                     PtrInfo::Struct(StructPtrInfo {
@@ -5299,7 +5301,7 @@ impl OptContext {
                 let fields: Vec<(u32, FieldEntry)> = v
                     .fields
                     .iter()
-                    .map(|&(k, r)| (k, FieldEntry::Value(crate::r#box::BoxRef::from_opref(r))))
+                    .map(|(k, r)| (*k, FieldEntry::Value(r.clone())))
                     .collect();
                 let ci = self.const_infos.entry(key).or_insert_with(|| {
                     PtrInfo::Struct(StructPtrInfo {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -6345,8 +6345,14 @@ mod tests {
         let sp = ctx
             .build_imported_short_preamble()
             .expect("forcing imported short guard arg should build short preamble");
-        assert_eq!(sp.used_boxes, vec![OpRef::int_op(14)]);
-        assert_eq!(sp.jump_args, vec![OpRef::int_op(14)]);
+        assert_eq!(
+            sp.used_boxes.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::int_op(14)]
+        );
+        assert_eq!(
+            sp.jump_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::int_op(14)]
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2292,7 +2292,7 @@ impl Optimizer {
             let targetargs: Vec<OpRef> = (0..n)
                 .map(|i| {
                     let source = typed_inputargs[i];
-                    let target = nia[i];
+                    let target = nia[i].to_opref();
                     // Constants don't participate in forwarding.
                     if ctx.get_box_replacement_box(target).and_then(|cb| cb.const_value()).is_some() {
                         return source;
@@ -3242,14 +3242,19 @@ impl Optimizer {
                         *opref = opref.with_raw(new_pos);
                     }
                 };
+                let remap_boxref = |arg: &mut crate::r#box::BoxRef| {
+                    let mut opref = arg.to_opref();
+                    remap_opref(&mut opref);
+                    *arg = crate::r#box::BoxRef::from_opref(opref);
+                };
                 for arg in &mut state.next_iteration_args {
-                    remap_opref(arg);
+                    remap_boxref(arg);
                 }
                 for arg in &mut state.end_args {
-                    remap_opref(arg);
+                    remap_boxref(arg);
                 }
                 for arg in &mut state.renamed_inputargs {
-                    remap_opref(arg);
+                    remap_boxref(arg);
                 }
                 for arg in &state.short_inputargs {
                     // Renamed-box positions track op compaction through the

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -465,7 +465,7 @@ impl Optimizer {
                     // the authoritative shape; no extra type marker is
                     // needed at the import side.
                     let _ = (field_descrs, known_class, field_idx);
-                    imported_fields.push((*field_idx, field_ref));
+                    imported_fields.push((*field_idx, BoxRef::from_opref(field_ref)));
                 }
                 let _ = field_descrs; // descr.all_fielddescrs() is authoritative
                 ctx.set_ptr_info(
@@ -510,7 +510,7 @@ impl Optimizer {
                 let mut imported_fields = Vec::new();
                 for (field_idx, field_info) in fields {
                     let field_ref = Self::import_virtual_state_value(field_info, ctx);
-                    imported_fields.push((*field_idx, field_ref));
+                    imported_fields.push((*field_idx, BoxRef::from_opref(field_ref)));
                 }
                 let _ = field_descrs; // descr.all_fielddescrs() is authoritative
                 ctx.set_ptr_info(
@@ -538,7 +538,9 @@ impl Optimizer {
                             .map(|(field_idx, field_info)| {
                                 (
                                     *field_idx,
-                                    Self::import_virtual_state_value(field_info, ctx),
+                                    BoxRef::from_opref(Self::import_virtual_state_value(
+                                        field_info, ctx,
+                                    )),
                                 )
                             })
                             .collect()
@@ -825,7 +827,11 @@ impl Optimizer {
                                     descr: entry.size_descr,
                                     known_class: *known_class,
                                     ob_type_descr: None,
-                                    fields: entry.fields,
+                                    fields: entry
+                                        .fields
+                                        .iter()
+                                        .map(|(i, r)| (*i, BoxRef::from_opref(*r)))
+                                        .collect(),
                                     last_guard_pos: -1,
                                     avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
                                 },
@@ -840,7 +846,11 @@ impl Optimizer {
                             crate::optimizeopt::info::PtrInfo::VirtualStruct(
                                 crate::optimizeopt::info::VirtualStructInfo {
                                     descr: entry.size_descr,
-                                    fields: entry.fields,
+                                    fields: entry
+                                        .fields
+                                        .iter()
+                                        .map(|(i, r)| (*i, BoxRef::from_opref(*r)))
+                                        .collect(),
                                     last_guard_pos: -1,
                                     avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
                                 },
@@ -912,7 +922,7 @@ impl Optimizer {
                 // raw pointers (info.py:865 RawBufferPtrInfo +
                 // getrawptrinfo()).
                 let opref = ctx.alloc_op_position_typed(majit_ir::Type::Ref);
-                let imported_fields: Vec<(u32, OpRef)> = fields
+                let imported_fields: Vec<(u32, BoxRef)> = fields
                     .iter()
                     .map(|(field_idx, field_info)| {
                         let field_ref = Self::import_virtual_state_from_label_args_recurse(
@@ -928,7 +938,7 @@ impl Optimizer {
                         // (`Value::Ref(class_gcref)`) from `make_constant`. The
                         // Ref-typed const forwarding is the authoritative shape.
                         let _ = (field_descrs, known_class, field_idx);
-                        (*field_idx, field_ref)
+                        (*field_idx, BoxRef::from_opref(field_ref))
                     })
                     .collect();
                 let opref_box = ctx.get_box_replacement_box(opref);
@@ -996,13 +1006,13 @@ impl Optimizer {
                     .map(|(field_idx, field_info)| {
                         (
                             *field_idx,
-                            Self::import_virtual_state_from_label_args_recurse(
+                            BoxRef::from_opref(Self::import_virtual_state_from_label_args_recurse(
                                 field_info,
                                 imported_label_args,
                                 label_slot,
                                 ctx,
                                 walk_visited,
-                            ),
+                            )),
                         )
                     })
                     .collect();
@@ -1039,12 +1049,14 @@ impl Optimizer {
                             .map(|(field_idx, field_info)| {
                                 (
                                     *field_idx,
-                                    Self::import_virtual_state_from_label_args_recurse(
-                                        field_info,
-                                        imported_label_args,
-                                        label_slot,
-                                        ctx,
-                                        walk_visited,
+                                    BoxRef::from_opref(
+                                        Self::import_virtual_state_from_label_args_recurse(
+                                            field_info,
+                                            imported_label_args,
+                                            label_slot,
+                                            ctx,
+                                            walk_visited,
+                                        ),
                                     ),
                                 )
                             })
@@ -2707,7 +2719,7 @@ impl Optimizer {
                         let fresh_info = match info {
                             crate::optimizeopt::info::PtrInfo::Virtual(mut vinfo) => {
                                 for field in &mut vinfo.fields {
-                                    let orig_field = field.1;
+                                    let orig_field = field.1.to_opref();
                                     // RPython Box type parity: the alias
                                     // inherits `box.type` from the original
                                     // field. RPython Box always carries
@@ -2727,7 +2739,7 @@ impl Optimizer {
                                     let (ff, b_ff) = ctx.reserve_virtual_box(tp);
                                     let b_orig = ctx.get_box_replacement(orig_field);
                                     ctx.make_equal_to(&b_ff, &b_orig);
-                                    field.1 = ff;
+                                    field.1 = BoxRef::from_opref(ff);
                                 }
                                 crate::optimizeopt::info::PtrInfo::Virtual(vinfo)
                             }
@@ -6209,7 +6221,7 @@ mod tests {
             &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
-                fields: vec![(1, OpRef::int_op(11))],
+                fields: vec![(1, BoxRef::from_opref(OpRef::int_op(11)))],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -6269,7 +6281,7 @@ mod tests {
             &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
-                fields: vec![(0, OpRef::int_op(11))],
+                fields: vec![(0, BoxRef::from_opref(OpRef::int_op(11)))],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -6353,11 +6365,17 @@ mod tests {
             .build_imported_short_preamble()
             .expect("forcing imported short guard arg should build short preamble");
         assert_eq!(
-            sp.used_boxes.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            sp.used_boxes
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::int_op(14)]
         );
         assert_eq!(
-            sp.jump_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            sp.jump_args
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::int_op(14)]
         );
     }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -485,7 +485,9 @@ impl Optimizer {
             VirtualStateInfo::VArray { descr, items, .. } => {
                 let imported_items = items
                     .iter()
-                    .map(|item_info| Self::import_virtual_state_value(item_info, ctx))
+                    .map(|item_info| {
+                        BoxRef::from_opref(Self::import_virtual_state_value(item_info, ctx))
+                    })
                     .collect();
                 ctx.set_ptr_info(
                     box_,
@@ -955,13 +957,13 @@ impl Optimizer {
                 let imported_items = items
                     .iter()
                     .map(|item_info| {
-                        Self::import_virtual_state_from_label_args_recurse(
+                        BoxRef::from_opref(Self::import_virtual_state_from_label_args_recurse(
                             item_info,
                             imported_label_args,
                             label_slot,
                             ctx,
                             walk_visited,
-                        )
+                        ))
                     })
                     .collect();
                 let opref_box = ctx.get_box_replacement_box(opref);

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -69,16 +69,18 @@ pub struct ShortPreamble {
     pub ops: Vec<ShortPreambleOp>,
     /// Input args of the short preamble Label.
     /// RPython stores the full short preamble as [Label(short_inputargs), ...].
-    pub inputargs: Vec<OpRef>,
+    /// Stored as [`BoxRef`] so a `Const` ref is GC-walked through
+    /// `BoxRef::walk_const_ptr_refs`; consumers read via `to_opref`.
+    pub inputargs: Vec<BoxRef>,
     /// Extra loop-header values carried by the short preamble Jump.
     /// RPython appends `sb.used_boxes` to the loop label and jumps with
     /// `args + extra`, where `extra` is the remapped version of these boxes.
-    pub used_boxes: Vec<OpRef>,
+    pub used_boxes: Vec<BoxRef>,
     /// Preamble producer results used by the short preamble's own trailing JUMP.
     /// RPython keeps this separate from `used_boxes`: the loop contract carries
     /// body boxes, while the short preamble JUMP reuses the corresponding
     /// preamble-produced values.
-    pub jump_args: Vec<OpRef>,
+    pub jump_args: Vec<BoxRef>,
     /// The exported virtual state at the loop header (from the preamble's exit).
     /// Used to check bridge compatibility and generate additional guards.
     pub exported_state: Option<VirtualState>,
@@ -99,7 +101,7 @@ pub struct ShortPreamble {
     /// inputargs (Phase 2 label_args), ops may reference Phase 1 OpRefs
     /// that aren't in the new inputargs. This field stores the original
     /// Phase 1 inputargs so inline_short_preamble can map them to jump_args.
-    pub phase1_inputargs: Option<Vec<OpRef>>,
+    pub phase1_inputargs: Option<Vec<BoxRef>>,
 }
 
 impl ShortPreamble {
@@ -128,26 +130,20 @@ impl ShortPreamble {
     }
 
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        fn visit_opref(opref: &mut OpRef, visitor: &mut dyn FnMut(&mut GcRef)) {
-            if let Some(slot) = opref.as_const_ptr_mut() {
-                visitor(slot);
-            }
-        }
-
-        fn visit_oprefs(oprefs: &mut [OpRef], visitor: &mut dyn FnMut(&mut GcRef)) {
-            for opref in oprefs {
-                visit_opref(opref, visitor);
+        fn visit_boxrefs(boxes: &[BoxRef], visitor: &mut dyn FnMut(&mut GcRef)) {
+            for b in boxes {
+                b.walk_const_ptr_refs(visitor);
             }
         }
 
         for entry in &mut self.ops {
             entry.op.walk_const_ptr_refs_mut(visitor);
         }
-        visit_oprefs(&mut self.inputargs, visitor);
-        visit_oprefs(&mut self.used_boxes, visitor);
-        visit_oprefs(&mut self.jump_args, visitor);
-        if let Some(phase1_inputargs) = self.phase1_inputargs.as_mut() {
-            visit_oprefs(phase1_inputargs, visitor);
+        visit_boxrefs(&self.inputargs, visitor);
+        visit_boxrefs(&self.used_boxes, visitor);
+        visit_boxrefs(&self.jump_args, visitor);
+        if let Some(phase1_inputargs) = self.phase1_inputargs.as_ref() {
+            visit_boxrefs(phase1_inputargs, visitor);
         }
         if let Some(exported_state) = self.exported_state.as_mut() {
             exported_state.walk_const_ptr_refs_mut(visitor);
@@ -285,7 +281,7 @@ impl CollectedShortPreambleBuilder {
 
         ShortPreamble {
             ops: entries,
-            inputargs: label_args,
+            inputargs: label_args.into_iter().map(BoxRef::from_opref).collect(),
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state,
@@ -2059,9 +2055,9 @@ fn build_short_preamble_struct_from_ops(
         crate::optimizeopt::vec_assoc::VecAssoc::new();
     ShortPreamble {
         ops: entries,
-        inputargs: short_inputargs.to_vec(),
-        used_boxes: used_boxes.to_vec(),
-        jump_args: jump_args.to_vec(),
+        inputargs: short_inputargs.iter().copied().map(BoxRef::from_opref).collect(),
+        used_boxes: used_boxes.iter().copied().map(BoxRef::from_opref).collect(),
+        jump_args: jump_args.iter().copied().map(BoxRef::from_opref).collect(),
         exported_state: None,
         constants,
         phase1_inputargs: None,
@@ -2506,11 +2502,11 @@ impl ExtendedShortPreambleBuilder {
             .iter()
             .map(|arg| {
                 self.phase1_to_inputarg
-                    .get(arg)
+                    .get(&arg.to_opref())
                     .cloned()
                     // Unmapped Phase 1 jump arg: no current-namespace
                     // producer to bind; position-only box as before.
-                    .unwrap_or_else(|| BoxRef::from_opref(*arg))
+                    .unwrap_or_else(|| arg.clone())
             })
             .collect();
         let jump_args: Vec<OpRef> = jump_args_box.iter().map(|b| b.to_opref()).collect();
@@ -2519,7 +2515,11 @@ impl ExtendedShortPreambleBuilder {
         self.extra_same_as = self.base_extra_same_as.clone();
         self.short_preamble_jump.clear();
         self.label_args = label_args.to_vec();
-        self.used_boxes = short_preamble.used_boxes.clone();
+        self.used_boxes = short_preamble
+            .used_boxes
+            .iter()
+            .map(|b| b.to_opref())
+            .collect();
         self.short_jump_args = jump_args;
         true
     }
@@ -2837,7 +2837,8 @@ impl ExtendedShortPreambleBuilder {
             &self.short_jump_args,
         );
         if inputargs != &short_inputargs {
-            sp.phase1_inputargs = Some(short_inputargs);
+            sp.phase1_inputargs =
+                Some(short_inputargs.into_iter().map(BoxRef::from_opref).collect());
         }
         sp
     }
@@ -3456,7 +3457,10 @@ mod tests {
         assert_eq!(sp.ops[0].op.opcode, OpCode::IntAdd);
         assert_eq!(sp.ops[1].op.opcode, OpCode::IntSub);
         assert_eq!(sp.ops[1].arg_mapping, vec![(1, 1)]);
-        assert_eq!(sp.inputargs, vec![OpRef::int_op(10), OpRef::int_op(11)]);
+        assert_eq!(
+            sp.inputargs.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::int_op(10), OpRef::int_op(11)]
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2314,13 +2314,13 @@ pub struct ExtendedShortPreambleBuilder {
     /// Tracks which OpRefs are already in `short` (for dedup).
     short_results: VecSet<OpRef>,
     /// Constants tracked for RPython isinstance(arg, Const) checks.
-    known_constants: VecSet<OpRef>,
+    known_constants: VecSet<BoxRef>,
     extra_same_as: Vec<Op>,
     short_preamble_jump: Vec<majit_ir::OpRc>,
     base_extra_same_as: Vec<Op>,
-    label_args: Vec<OpRef>,
-    used_boxes: Vec<OpRef>,
-    short_jump_args: Vec<OpRef>,
+    label_args: Vec<BoxRef>,
+    used_boxes: Vec<BoxRef>,
+    short_jump_args: Vec<BoxRef>,
     pub target_token: u64,
     /// RPython parity: remap Phase 1 preamble OpRefs → current inputargs.
     /// Values are the current-namespace boxes, bound to their producers at
@@ -2339,15 +2339,9 @@ pub struct ExtendedShortPreambleBuilder {
 
 impl ExtendedShortPreambleBuilder {
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        fn visit_opref(opref: &mut OpRef, visitor: &mut dyn FnMut(&mut GcRef)) {
-            if let Some(slot) = opref.as_const_ptr_mut() {
-                visitor(slot);
-            }
-        }
-
-        fn visit_oprefs(oprefs: &mut [OpRef], visitor: &mut dyn FnMut(&mut GcRef)) {
-            for opref in oprefs {
-                visit_opref(opref, visitor);
+        fn visit_boxrefs(boxes: &[BoxRef], visitor: &mut dyn FnMut(&mut GcRef)) {
+            for b in boxes {
+                b.walk_const_ptr_refs(visitor);
             }
         }
 
@@ -2361,16 +2355,12 @@ impl ExtendedShortPreambleBuilder {
         for (_, produced) in self.produced_short_boxes.iter_mut() {
             visit_produced(produced, visitor);
         }
-        for arg in &self.short_inputargs {
-            arg.walk_const_ptr_refs(visitor);
-        }
+        visit_boxrefs(&self.short_inputargs, visitor);
         for op in &mut self.short {
             op.walk_const_ptr_refs_mut(visitor);
         }
-        let known_constants = std::mem::take(&mut self.known_constants);
-        for mut opref in known_constants {
-            visit_opref(&mut opref, visitor);
-            self.known_constants.insert(opref);
+        for b in self.known_constants.iter() {
+            b.walk_const_ptr_refs(visitor);
         }
         for op in &mut self.extra_same_as {
             op.walk_const_ptr_refs_mut(visitor);
@@ -2381,19 +2371,16 @@ impl ExtendedShortPreambleBuilder {
         for op in &mut self.base_extra_same_as {
             op.walk_const_ptr_refs_mut(visitor);
         }
-        visit_oprefs(&mut self.label_args, visitor);
-        visit_oprefs(&mut self.used_boxes, visitor);
-        visit_oprefs(&mut self.short_jump_args, visitor);
-        for (source, target) in self.phase1_to_inputarg.iter_mut() {
-            let mut source_copy = *source;
-            visit_opref(&mut source_copy, visitor);
+        visit_boxrefs(&self.label_args, visitor);
+        visit_boxrefs(&self.used_boxes, visitor);
+        visit_boxrefs(&self.short_jump_args, visitor);
+        // phase1_to_inputarg keys are Phase 1 preamble OpRefs (op result
+        // positions, never Const); only the bound values carry const GcRefs.
+        for (_, target) in self.phase1_to_inputarg.iter() {
             target.walk_const_ptr_refs(visitor);
         }
-        let recorded_canonical_results = std::mem::take(&mut self.recorded_canonical_results);
-        for mut opref in recorded_canonical_results {
-            visit_opref(&mut opref, visitor);
-            self.recorded_canonical_results.insert(opref);
-        }
+        // recorded_canonical_results is keyed by `preamble_op.pos` (op result
+        // positions, never Const) — nothing to walk.
     }
 
     pub fn new(target_token: u64, sb: &ShortPreambleBuilder) -> Self {
@@ -2489,7 +2476,7 @@ impl ExtendedShortPreambleBuilder {
                     }
                     self.short.clear();
                     self.short_results.clear();
-                    self.label_args = label_args.to_vec();
+                    self.label_args = label_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
                     return false;
                 }
             }
@@ -2509,18 +2496,13 @@ impl ExtendedShortPreambleBuilder {
                     .unwrap_or_else(|| arg.clone())
             })
             .collect();
-        let jump_args: Vec<OpRef> = jump_args_box.iter().map(|b| b.to_opref()).collect();
         self.short.push(Op::new(OpCode::Jump, &jump_args_box));
         // Reset state
         self.extra_same_as = self.base_extra_same_as.clone();
         self.short_preamble_jump.clear();
-        self.label_args = label_args.to_vec();
-        self.used_boxes = short_preamble
-            .used_boxes
-            .iter()
-            .map(|b| b.to_opref())
-            .collect();
-        self.short_jump_args = jump_args;
+        self.label_args = label_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        self.used_boxes = short_preamble.used_boxes.clone();
+        self.short_jump_args = jump_args_box;
         true
     }
 
@@ -2549,7 +2531,7 @@ impl ExtendedShortPreambleBuilder {
         }
         if self.short_results.contains(&arg)
             || inputargs_set.contains(&arg)
-            || self.known_constants.contains(&arg)
+            || self.known_constants.contains(&BoxRef::from_opref(arg))
             || constants_set.contains(&arg.raw())
         {
             return true;
@@ -2671,8 +2653,9 @@ impl ExtendedShortPreambleBuilder {
                 same_as.pos.set(op);
                 self.extra_same_as.push(same_as);
             }
-            self.label_args.push(op);
-            self.short_jump_args.push(replay_op.pos.get());
+            self.label_args.push(resolved_op.clone());
+            self.short_jump_args
+                .push(BoxRef::from_opref(replay_op.pos.get()));
             self.short_preamble_jump.push(replay_op.clone());
         }
     }
@@ -2701,9 +2684,10 @@ impl ExtendedShortPreambleBuilder {
             op.pos.set(current_result);
             self.extra_same_as.push(op);
         }
-        self.label_args.push(result.to_opref());
-        self.used_boxes.push(current_result);
-        self.short_jump_args.push(produced.preamble_op.pos.get());
+        self.label_args.push(result.clone());
+        self.used_boxes.push(BoxRef::from_opref(current_result));
+        self.short_jump_args
+            .push(BoxRef::from_opref(produced.preamble_op.pos.get()));
         self.short_preamble_jump.push(produced.preamble_op.clone());
     }
 
@@ -2773,7 +2757,7 @@ impl ExtendedShortPreambleBuilder {
                 let arg = arg.to_opref();
                 if self.short_results.contains(&arg)
                     || self.short_inputargs.iter().any(|a| a.to_opref() == arg)
-                    || self.known_constants.contains(&arg)
+                    || self.known_constants.contains(&BoxRef::from_opref(arg))
                 {
                     continue;
                 }
@@ -2825,17 +2809,17 @@ impl ExtendedShortPreambleBuilder {
         // shed the boxes to their positions at this boundary.
         let short_inputargs: Vec<OpRef> =
             self.short_inputargs.iter().map(|a| a.to_opref()).collect();
-        let inputargs = if self.label_args.is_empty() {
+        let label_args: Vec<OpRef> = self.label_args.iter().map(|b| b.to_opref()).collect();
+        let used_boxes: Vec<OpRef> = self.used_boxes.iter().map(|b| b.to_opref()).collect();
+        let short_jump_args: Vec<OpRef> =
+            self.short_jump_args.iter().map(|b| b.to_opref()).collect();
+        let inputargs = if label_args.is_empty() {
             &short_inputargs
         } else {
-            &self.label_args
+            &label_args
         };
-        let mut sp = build_short_preamble_struct_from_ops(
-            inputargs,
-            &ops,
-            &self.used_boxes,
-            &self.short_jump_args,
-        );
+        let mut sp =
+            build_short_preamble_struct_from_ops(inputargs, &ops, &used_boxes, &short_jump_args);
         if inputargs != &short_inputargs {
             sp.phase1_inputargs =
                 Some(short_inputargs.into_iter().map(BoxRef::from_opref).collect());
@@ -2847,11 +2831,11 @@ impl ExtendedShortPreambleBuilder {
         &self.extra_same_as
     }
 
-    pub fn label_args(&self) -> &[OpRef] {
+    pub fn label_args(&self) -> &[BoxRef] {
         &self.label_args
     }
 
-    pub fn jump_args(&self) -> &[OpRef] {
+    pub fn jump_args(&self) -> &[BoxRef] {
         &self.short_jump_args
     }
 
@@ -3986,8 +3970,22 @@ mod tests {
 
         builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));
 
-        assert_eq!(builder.label_args(), &[OpRef::int_op(41)]);
-        assert_eq!(builder.jump_args(), &[OpRef::int_op(14)]);
+        assert_eq!(
+            builder
+                .label_args()
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
+            vec![OpRef::int_op(41)]
+        );
+        assert_eq!(
+            builder
+                .jump_args()
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
+            vec![OpRef::int_op(14)]
+        );
         let extra = builder.extra_same_as();
         assert_eq!(extra.len(), 1);
         assert_eq!(extra[0].opcode, OpCode::SameAsI);

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2055,7 +2055,11 @@ fn build_short_preamble_struct_from_ops(
         crate::optimizeopt::vec_assoc::VecAssoc::new();
     ShortPreamble {
         ops: entries,
-        inputargs: short_inputargs.iter().copied().map(BoxRef::from_opref).collect(),
+        inputargs: short_inputargs
+            .iter()
+            .copied()
+            .map(BoxRef::from_opref)
+            .collect(),
         used_boxes: used_boxes.iter().copied().map(BoxRef::from_opref).collect(),
         jump_args: jump_args.iter().copied().map(BoxRef::from_opref).collect(),
         exported_state: None,
@@ -2821,8 +2825,12 @@ impl ExtendedShortPreambleBuilder {
         let mut sp =
             build_short_preamble_struct_from_ops(inputargs, &ops, &used_boxes, &short_jump_args);
         if inputargs != &short_inputargs {
-            sp.phase1_inputargs =
-                Some(short_inputargs.into_iter().map(BoxRef::from_opref).collect());
+            sp.phase1_inputargs = Some(
+                short_inputargs
+                    .into_iter()
+                    .map(BoxRef::from_opref)
+                    .collect(),
+            );
         }
         sp
     }
@@ -3442,7 +3450,10 @@ mod tests {
         assert_eq!(sp.ops[1].op.opcode, OpCode::IntSub);
         assert_eq!(sp.ops[1].arg_mapping, vec![(1, 1)]);
         assert_eq!(
-            sp.inputargs.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            sp.inputargs
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::int_op(10), OpRef::int_op(11)]
         );
     }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1735,7 +1735,7 @@ impl ProducedShortOp {
                         if idx >= array_info.items.len() {
                             array_info.items.resize(
                                 idx + 1,
-                                crate::optimizeopt::info::FieldEntry::Value(OpRef::NONE),
+                                crate::optimizeopt::info::FieldEntry::Value(BoxRef::none()),
                             );
                         }
                         array_info.items[idx] =

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -638,7 +638,10 @@ impl UnrollOptimizer {
                         // carry the recorded JUMP args into ExportedState so the
                         // peeled-loop close passes them to generate_guards as
                         // `state.runtime_boxes` (unroll.py:153/166).
-                        state.runtime_boxes = recorded_jump_args.clone();
+                        state.runtime_boxes = recorded_jump_args
+                            .iter()
+                            .map(|&a| BoxRef::from_opref(a))
+                            .collect();
                         // end_arg_types is already populated by
                         // `Optimizer::optimize_with_constants_and_inputs_at`
                         // using the optimizer-visible `ctx.opref_type()` (see
@@ -1131,11 +1134,17 @@ impl UnrollOptimizer {
                 .expect("imported_loop_state must survive Phase 2");
             (
                 es.virtual_state.clone(),
-                es.end_args.clone(),
+                es.end_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
                 es.short_inputargs.clone(),
                 es.short_boxes.clone(),
-                es.renamed_inputargs.clone(),
-                es.runtime_boxes.clone(),
+                es.renamed_inputargs
+                    .iter()
+                    .map(|b| b.to_opref())
+                    .collect::<Vec<_>>(),
+                es.runtime_boxes
+                    .iter()
+                    .map(|b| b.to_opref())
+                    .collect::<Vec<_>>(),
             )
         };
         // RPython unroll.py:124-141 performs an extra end-of-preamble forcing
@@ -1865,9 +1874,9 @@ impl Default for UnrollOptimizer {
 #[derive(Debug)]
 pub struct ExportedState {
     /// Label args at the end of the preamble (after forcing).
-    pub end_args: Vec<OpRef>,
+    pub end_args: Vec<BoxRef>,
     /// Args for the next iteration (before forcing).
-    pub next_iteration_args: Vec<OpRef>,
+    pub next_iteration_args: Vec<BoxRef>,
     /// Types of end_args as determined by Phase 1 optimization.
     /// Used by Phase 2 import_state to propagate unboxed types.
     pub end_arg_types: Vec<Type>,
@@ -1921,7 +1930,7 @@ pub struct ExportedState {
     /// `InputArg{Int,Float,Ref}` variant carrying its `.type` intrinsically
     /// (history.py:220), so consumers read the type via `OpRef::ty()` —
     /// RPython `info.renamed_inputargs` Box parity, no parallel type array.
-    pub renamed_inputargs: Vec<OpRef>,
+    pub renamed_inputargs: Vec<BoxRef>,
     /// Short inputargs for the short preamble — the renamed inputarg box
     /// objects themselves (shortpreamble.py:430 / unroll.py:480), shared
     /// with the renamed operands inside `short_boxes`.
@@ -1930,7 +1939,7 @@ pub struct ExportedState {
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
     /// Default `Vec::new()` until the export site populates it; callers
     /// that need it write the field directly after `ExportedState::new`.
-    pub runtime_boxes: Vec<OpRef>,
+    pub runtime_boxes: Vec<BoxRef>,
     /// RPython parity: patchguardop from Phase 1's GuardFutureCondition.
     /// Phase 2's extra_guards (from virtualstate) need rd_resume_position
     /// from this patchguardop (unroll.py:333-336).
@@ -2027,8 +2036,11 @@ impl ExportedState {
                 &exported_short_boxes,
             );
         ExportedState {
-            end_args,
-            next_iteration_args,
+            end_args: end_args.iter().map(|&a| BoxRef::from_opref(a)).collect(),
+            next_iteration_args: next_iteration_args
+                .iter()
+                .map(|&a| BoxRef::from_opref(a))
+                .collect(),
             end_arg_types: Vec::new(),
             virtual_state,
             exported_infos,
@@ -2036,7 +2048,10 @@ impl ExportedState {
             short_boxes,
             short_box_const_values: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             short_preamble: None,
-            renamed_inputargs,
+            renamed_inputargs: renamed_inputargs
+                .iter()
+                .map(|&a| BoxRef::from_opref(a))
+                .collect(),
             short_inputargs,
             runtime_boxes: Vec::new(),
             patchguardop: None,
@@ -2067,9 +2082,9 @@ impl ExportedState {
             }
         }
 
-        fn visit_oprefs(oprefs: &mut [OpRef], visitor: &mut dyn FnMut(&mut GcRef)) {
-            for opref in oprefs {
-                visit_opref(opref, visitor);
+        fn visit_boxrefs(boxes: &[BoxRef], visitor: &mut dyn FnMut(&mut GcRef)) {
+            for b in boxes {
+                b.walk_const_ptr_refs(visitor);
             }
         }
 
@@ -2129,8 +2144,8 @@ impl ExportedState {
             }
         }
 
-        visit_oprefs(&mut self.end_args, visitor);
-        visit_oprefs(&mut self.next_iteration_args, visitor);
+        visit_boxrefs(&self.end_args, visitor);
+        visit_boxrefs(&self.next_iteration_args, visitor);
         self.virtual_state.walk_const_ptr_refs_mut(visitor);
         for (key, info) in self.exported_infos.iter_entries_mut() {
             visit_opref(key, visitor);
@@ -2150,11 +2165,11 @@ impl ExportedState {
         if let Some(short_preamble) = self.short_preamble.as_mut() {
             short_preamble.walk_const_ptr_refs_mut(visitor);
         }
-        visit_oprefs(&mut self.renamed_inputargs, visitor);
+        visit_boxrefs(&self.renamed_inputargs, visitor);
         for arg in &self.short_inputargs {
             arg.walk_const_ptr_refs(visitor);
         }
-        visit_oprefs(&mut self.runtime_boxes, visitor);
+        visit_boxrefs(&self.runtime_boxes, visitor);
         if let Some(patchguardop) = self.patchguardop.as_ref() {
             visit_op(patchguardop, visitor);
         }
@@ -2196,20 +2211,20 @@ impl ExportedState {
                 }
             }
         };
-        for &opref in &self.end_args {
-            visit(opref);
+        for arg in &self.end_args {
+            visit(arg.to_opref());
         }
-        for &opref in &self.next_iteration_args {
-            visit(opref);
+        for arg in &self.next_iteration_args {
+            visit(arg.to_opref());
         }
-        for &opref in &self.renamed_inputargs {
-            visit(opref);
+        for arg in &self.renamed_inputargs {
+            visit(arg.to_opref());
         }
         for arg in &self.short_inputargs {
             visit(arg.to_opref());
         }
-        for &opref in &self.runtime_boxes {
-            visit(opref);
+        for arg in &self.runtime_boxes {
+            visit(arg.to_opref());
         }
 
         for (&opref, info) in &self.exported_infos {
@@ -3841,12 +3856,13 @@ impl OptUnroll {
         );
         // for i, target in enumerate(exported_state.next_iteration_args):
         for (i, target) in exported_state.next_iteration_args.iter().enumerate() {
+            let target = target.to_opref();
             // source = targetargs[i]
             let source = targetargs[i];
             // assert source is not target — see commit log for the
             // disjoint-namespace invariant from Step 2 Commit D2 that
             // makes this hold by construction in production callers.
-            debug_assert!(source != *target, "import_state: source is target");
+            debug_assert!(source != target, "import_state: source is target");
             // source.set_forwarded(target)
             // `source` is `targetargs[i]`, produced by the caller's
             // cross-slot resolution as either a materialized inputarg or a
@@ -3861,9 +3877,9 @@ impl OptUnroll {
             // would re-materialize the unbound target internally anyway —
             // resolve-or-materialize here keeps the chain target canonical
             // from the start).
-            let b_target = match ctx.get_box_replacement_box(*target) {
+            let b_target = match ctx.get_box_replacement_box(target) {
                 Some(b) => b,
-                None => ctx.materialize_box_at(*target),
+                None => ctx.materialize_box_at(target),
             };
             ctx.make_equal_to(&b_source, &b_target);
             if crate::debug::have_debug_prints() {
@@ -3874,7 +3890,7 @@ impl OptUnroll {
             }
             // info = exported_state.exported_infos.get(target, None)
             // if info is not None:
-            if let Some(info) = exported_state.exported_infos.get(target) {
+            if let Some(info) = exported_state.exported_infos.get(&target) {
                 //     self.optimizer.setinfo_from_preamble(source, info,
                 //                                     exported_state.exported_infos)
                 self.setinfo_from_preamble(source, info, &exported_state.exported_infos, ctx);
@@ -5712,7 +5728,7 @@ mod tests {
             inputarg_infos: vec![Some(PtrInfo::Constant(old))],
             phase1_inputargs: Some(vec![BoxRef::from_opref(old_ref)]),
         });
-        state.runtime_boxes.push(old_ref);
+        state.runtime_boxes.push(BoxRef::from_opref(old_ref));
         state.patchguardop = Some(Op::new(
             OpCode::GuardNonnull,
             &[BoxRef::from_opref(old_ref)],
@@ -5724,11 +5740,11 @@ mod tests {
             }
         });
 
-        assert_eq!(state.end_args[0], new_ref);
-        assert_eq!(state.next_iteration_args[0], new_ref);
-        assert_eq!(state.renamed_inputargs[0], new_ref);
+        assert_eq!(state.end_args[0].to_opref(), new_ref);
+        assert_eq!(state.next_iteration_args[0].to_opref(), new_ref);
+        assert_eq!(state.renamed_inputargs[0].to_opref(), new_ref);
         assert_eq!(state.short_inputargs[0].to_opref(), new_ref);
-        assert_eq!(state.runtime_boxes[0], new_ref);
+        assert_eq!(state.runtime_boxes[0].to_opref(), new_ref);
         assert!(state.exported_infos.get(&new_ref).is_some());
         assert_eq!(state.exported_short_boxes[0].op.arg(0).to_opref(), new_ref);
         assert_eq!(
@@ -6418,7 +6434,10 @@ mod tests {
 
         let exported = export_state(&[OpRef::int_op(0)], &[], &mut optimizer, &mut ctx, None);
 
-        assert_eq!(exported.end_args, vec![OpRef::int_op(21)]);
+        assert_eq!(
+            exported.end_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::int_op(21)]
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1297,9 +1297,9 @@ impl UnrollOptimizer {
         // so inline_short_preamble can propagate to jump_args.
         if let Some(ref final_ctx) = opt_p2.final_ctx {
             let mut infos = Vec::with_capacity(initial_sp.inputargs.len());
-            for &inputarg in &initial_sp.inputargs {
+            for inputarg in &initial_sp.inputargs {
                 let info = final_ctx
-                    .get_box_replacement_box(inputarg)
+                    .get_box_replacement_box(inputarg.to_opref())
                     .as_ref()
                     .and_then(|b| final_ctx.peek_ptr_info(b));
                 infos.push(info);
@@ -1370,13 +1370,15 @@ impl UnrollOptimizer {
                     majit_ir::vec_set::VecSet::new();
                 let mut next_fresh = current_label_args
                     .iter()
-                    .chain(initial_sp.used_boxes.iter())
+                    .copied()
+                    .chain(initial_sp.used_boxes.iter().map(|b| b.to_opref()))
                     .map(|a| a.raw())
                     .max()
                     .unwrap_or(0)
                     .saturating_add(1)
                     .max(body_num_inputs as u32 + 100);
-                for &ub in &initial_sp.used_boxes {
+                for ub in &initial_sp.used_boxes {
+                    let ub = ub.to_opref();
                     if !seen_used.contains(&ub) {
                         seen_used.insert(ub);
                         current_label_args.push(ub);
@@ -1723,13 +1725,15 @@ impl UnrollOptimizer {
         }
 
         // ── Assembly (compile.py:310-338) ──
+        let sp_used_boxes: Vec<OpRef> = sp.used_boxes.iter().map(|b| b.to_opref()).collect();
+        let sp_jump_args: Vec<OpRef> = sp.jump_args.iter().map(|b| b.to_opref()).collect();
         let mut combined = assemble_peeled_trace_with_jump_args(
             &p1_ops,
             &body_ops,
             &label_args,
             &exported_renamed_inputargs,
-            &sp.used_boxes,
-            &sp.jump_args,
+            &sp_used_boxes,
+            &sp_jump_args,
             p2_ni,
             phase2_inputarg_base,
             jump_to_self,
@@ -2227,17 +2231,17 @@ impl ExportedState {
         }
 
         if let Some(short_preamble) = &self.short_preamble {
-            for opref in short_preamble
+            for boxref in short_preamble
                 .inputargs
                 .iter()
                 .chain(short_preamble.used_boxes.iter())
                 .chain(short_preamble.jump_args.iter())
             {
-                visit(*opref);
+                visit(boxref.to_opref());
             }
             if let Some(phase1_inputargs) = &short_preamble.phase1_inputargs {
-                for &opref in phase1_inputargs {
-                    visit(opref);
+                for boxref in phase1_inputargs {
+                    visit(boxref.to_opref());
                 }
             }
             for short_op in &short_preamble.ops {
@@ -3534,7 +3538,8 @@ impl OptUnroll {
         let mut mapping: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, OpRef> =
             crate::optimizeopt::vec_assoc::VecAssoc::new();
 
-        for (i, &short_inputarg) in short_preamble.inputargs.iter().enumerate() {
+        for (i, short_inputarg) in short_preamble.inputargs.iter().enumerate() {
+            let short_inputarg = short_inputarg.to_opref();
             if let Some(&jump_arg) = jump_args.get(i) {
                 mapping.insert(short_inputarg, jump_arg);
                 // RPython: jump_arg Box inherits info via identity.
@@ -3572,7 +3577,8 @@ impl OptUnroll {
         // In RPython, renamed inputargs are stable across compilations,
         // so this situation doesn't arise.
         if let Some(ref phase1) = short_preamble.phase1_inputargs {
-            for (i, &phase1_inputarg) in phase1.iter().enumerate() {
+            for (i, phase1_inputarg) in phase1.iter().enumerate() {
+                let phase1_inputarg = phase1_inputarg.to_opref();
                 if let Some(&jump_arg) = jump_args.get(i) {
                     if !mapping.contains_key(&phase1_inputarg) {
                         mapping.insert(phase1_inputarg, jump_arg);
@@ -3612,7 +3618,13 @@ impl OptUnroll {
             ctx.active_short_preamble_producer
                 .as_ref()
                 .map(|builder| builder.jump_args().to_vec())
-                .unwrap_or_else(|| short_preamble.jump_args.clone())
+                .unwrap_or_else(|| {
+                    short_preamble
+                        .jump_args
+                        .iter()
+                        .map(|b| b.to_opref())
+                        .collect()
+                })
         }
 
         // unroll.py:398-427: fix-point loop, runs only once in almost all cases.
@@ -5690,15 +5702,15 @@ mod tests {
                 arg_mapping: Vec::new(),
                 fail_arg_mapping: Vec::new(),
             }],
-            inputargs: vec![old_ref],
-            used_boxes: vec![old_ref],
-            jump_args: vec![old_ref],
+            inputargs: vec![BoxRef::from_opref(old_ref)],
+            used_boxes: vec![BoxRef::from_opref(old_ref)],
+            jump_args: vec![BoxRef::from_opref(old_ref)],
             exported_state: Some(VirtualState::new(vec![VirtualStateInfo::KnownClass {
                 class_ptr: old.as_usize() as i64,
             }])),
             constants,
             inputarg_infos: vec![Some(PtrInfo::Constant(old))],
-            phase1_inputargs: Some(vec![old_ref]),
+            phase1_inputargs: Some(vec![BoxRef::from_opref(old_ref)]),
         });
         state.runtime_boxes.push(old_ref);
         state.patchguardop = Some(Op::new(
@@ -5750,10 +5762,13 @@ mod tests {
         }
         let short = state.short_preamble.as_ref().unwrap();
         assert_eq!(short.ops[0].op.arg(0).to_opref(), new_ref);
-        assert_eq!(short.inputargs[0], new_ref);
-        assert_eq!(short.used_boxes[0], new_ref);
-        assert_eq!(short.jump_args[0], new_ref);
-        assert_eq!(short.phase1_inputargs.as_ref().unwrap()[0], new_ref);
+        assert_eq!(short.inputargs[0].to_opref(), new_ref);
+        assert_eq!(short.used_boxes[0].to_opref(), new_ref);
+        assert_eq!(short.jump_args[0].to_opref(), new_ref);
+        assert_eq!(
+            short.phase1_inputargs.as_ref().unwrap()[0].to_opref(),
+            new_ref
+        );
         assert_eq!(short.constants.get(&0), Some(&majit_ir::Const::Ref(new)));
     }
 
@@ -6711,8 +6726,14 @@ mod tests {
         let sp = ctx.build_imported_short_preamble().unwrap();
         // After force_box: orthodox `add_preamble_op` (shortpreamble.py:432-440)
         // populated all three lists in lock-step.
-        assert_eq!(sp.used_boxes, vec![OpRef::int_op(20)]);
-        assert_eq!(sp.jump_args, vec![OpRef::int_op(20)]);
+        assert_eq!(
+            sp.used_boxes.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::int_op(20)]
+        );
+        assert_eq!(
+            sp.jump_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::int_op(20)]
+        );
         assert!(
             !ctx.has_potential_extra_op(OpRef::int_op(20)),
             "force_box must consume the potential_extra_ops entry"
@@ -6807,8 +6828,14 @@ mod tests {
         // pop.op=19 forwards to body-visible 14 via the producer's make_equal_to,
         // so used_boxes carries the resolved body-visible OpRef while
         // jump_args carries the unresolved Phase 1 source.
-        assert_eq!(sp.used_boxes, vec![OpRef::ref_op(14)]);
-        assert_eq!(sp.jump_args, vec![OpRef::ref_op(19)]);
+        assert_eq!(
+            sp.used_boxes.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::ref_op(14)]
+        );
+        assert_eq!(
+            sp.jump_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            vec![OpRef::ref_op(19)]
+        );
         assert!(
             !ctx.has_potential_extra_op(OpRef::ref_op(19)),
             "force_box must consume the potential_extra_ops entry"

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3143,10 +3143,10 @@ impl OptUnroll {
         let opref_box = ctx.get_box_replacement_box(opref);
         let fields: Vec<OpRef> = match opref_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
             Some(crate::optimizeopt::info::PtrInfo::Virtual(v)) => {
-                v.fields.iter().map(|(_, r)| *r).collect()
+                v.fields.iter().map(|(_, r)| r.to_opref()).collect()
             }
             Some(crate::optimizeopt::info::PtrInfo::VirtualStruct(v)) => {
-                v.fields.iter().map(|(_, r)| *r).collect()
+                v.fields.iter().map(|(_, r)| r.to_opref()).collect()
             }
             Some(crate::optimizeopt::info::PtrInfo::VirtualArray(v)) => {
                 v.items.iter().map(|b| b.to_opref()).collect()
@@ -6442,7 +6442,11 @@ mod tests {
         let exported = export_state(&[OpRef::int_op(0)], &[], &mut optimizer, &mut ctx, None);
 
         assert_eq!(
-            exported.end_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            exported
+                .end_args
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::int_op(21)]
         );
     }
@@ -6753,11 +6757,17 @@ mod tests {
         // After force_box: orthodox `add_preamble_op` (shortpreamble.py:432-440)
         // populated all three lists in lock-step.
         assert_eq!(
-            sp.used_boxes.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            sp.used_boxes
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::int_op(20)]
         );
         assert_eq!(
-            sp.jump_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            sp.jump_args
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::int_op(20)]
         );
         assert!(
@@ -6855,11 +6865,17 @@ mod tests {
         // so used_boxes carries the resolved body-visible OpRef while
         // jump_args carries the unresolved Phase 1 source.
         assert_eq!(
-            sp.used_boxes.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            sp.used_boxes
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::ref_op(14)]
         );
         assert_eq!(
-            sp.jump_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+            sp.jump_args
+                .iter()
+                .map(|b| b.to_opref())
+                .collect::<Vec<_>>(),
             vec![OpRef::ref_op(19)]
         );
         assert!(

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3632,7 +3632,7 @@ impl OptUnroll {
         ) -> Vec<OpRef> {
             ctx.active_short_preamble_producer
                 .as_ref()
-                .map(|builder| builder.jump_args().to_vec())
+                .map(|builder| builder.jump_args().iter().map(|b| b.to_opref()).collect())
                 .unwrap_or_else(|| {
                     short_preamble
                         .jump_args

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2077,9 +2077,14 @@ impl ExportedState {
     /// expose their actual mutable storage.
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
         fn visit_opref(opref: &mut OpRef, visitor: &mut dyn FnMut(&mut GcRef)) {
-            if let Some(slot) = opref.as_const_ptr_mut() {
-                visitor(slot);
-            }
+            // Forward an inline const gcref through the canonical BoxRef-Const
+            // walk; a no-op for non-const positions (they carry no gcref).
+            // short_box_const_values keys are genuine const OpRefs; the other
+            // call sites (op.pos, exported_infos / short_boxes keys) are op
+            // result positions, where this resolves to nothing.
+            let b = BoxRef::from_opref(*opref);
+            b.walk_const_ptr_refs(visitor);
+            *opref = b.to_opref();
         }
 
         fn visit_boxrefs(boxes: &[BoxRef], visitor: &mut dyn FnMut(&mut GcRef)) {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3148,7 +3148,9 @@ impl OptUnroll {
             Some(crate::optimizeopt::info::PtrInfo::VirtualStruct(v)) => {
                 v.fields.iter().map(|(_, r)| *r).collect()
             }
-            Some(crate::optimizeopt::info::PtrInfo::VirtualArray(v)) => v.items.clone(),
+            Some(crate::optimizeopt::info::PtrInfo::VirtualArray(v)) => {
+                v.items.iter().map(|b| b.to_opref()).collect()
+            }
             Some(crate::optimizeopt::info::PtrInfo::Instance(v)) if !v.fields.is_empty() => {
                 v.fields.iter().map(|(_, e)| e.as_seen_opref()).collect()
             }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -219,6 +219,7 @@ impl VirtualizableTracker {
                 flat_input_idx += 1;
             }
             if !elements.is_empty() {
+                let elements: Vec<BoxRef> = elements.into_iter().map(BoxRef::from_opref).collect();
                 state.arrays.push((array_idx as u32, elements));
             }
         }
@@ -554,7 +555,7 @@ impl OptVirtualize {
                     let lgt = fielddescrs.len();
                     // info.py:648: self._items = [None] * (size * lgt)
                     let element_fields = (0..size as usize)
-                        .map(|_| (0..lgt as u32).map(|j| (j, OpRef::NONE)).collect())
+                        .map(|_| (0..lgt as u32).map(|j| (j, BoxRef::none())).collect())
                         .collect();
                     let vinfo = VirtualArrayStructInfo {
                         descr,
@@ -1587,8 +1588,11 @@ impl OptVirtualize {
         // → InstancePtrInfo(descr, known_class, is_virtual=True)
         let known_class = Some(crate::virtualref::JIT_VIRTUAL_REF_VTABLE as i64);
         let fields = vec![
-            (VREF_VIRTUAL_TOKEN_FIELD_INDEX, token_ref),
-            (VREF_FORCED_FIELD_INDEX, null_ref),
+            (
+                VREF_VIRTUAL_TOKEN_FIELD_INDEX,
+                BoxRef::from_opref(token_ref),
+            ),
+            (VREF_FORCED_FIELD_INDEX, BoxRef::from_opref(null_ref)),
         ];
         // info.py:175-188 stores no fielddescr side-list; the SizeDescr
         // (VRefSizeDescr.all_fielddescrs) is the authoritative view.
@@ -2193,14 +2197,14 @@ impl Optimization for OptVirtualize {
 
 // ── Field list helpers ──
 
-fn set_field(fields: &mut Vec<(u32, OpRef)>, field_idx: u32, value_ref: OpRef) {
+fn set_field(fields: &mut Vec<(u32, BoxRef)>, field_idx: u32, value_ref: OpRef) {
     for entry in fields.iter_mut() {
         if entry.0 == field_idx {
-            entry.1 = value_ref;
+            entry.1 = BoxRef::from_opref(value_ref);
             return;
         }
     }
-    fields.push((field_idx, value_ref));
+    fields.push((field_idx, BoxRef::from_opref(value_ref)));
 }
 
 fn set_field_descr(field_descrs: &mut Vec<(u32, DescrRef)>, field_idx: u32, descr: DescrRef) {
@@ -2220,11 +2224,11 @@ fn get_field_descr(field_descrs: &[(u32, DescrRef)], field_idx: u32) -> Option<D
         .map(|(_, descr)| descr.clone())
 }
 
-fn get_field(fields: &[(u32, OpRef)], field_idx: u32) -> Option<OpRef> {
+fn get_field(fields: &[(u32, BoxRef)], field_idx: u32) -> Option<OpRef> {
     fields
         .iter()
         .find(|(idx, _)| *idx == field_idx)
-        .map(|(_, opref)| *opref)
+        .map(|(_, b)| b.to_opref())
 }
 
 #[derive(Debug)]
@@ -2401,11 +2405,15 @@ impl majit_ir::SizeDescr for VRefSizeDescr {
 
 /// Lookup helper for `PtrInfo::Virtualizable.arrays` — returns the OpRef
 /// stored at `arrays[arr_idx][elem_idx]` if present and non-NONE.
-fn get_array_element(arrays: &[(u32, Vec<OpRef>)], arr_idx: u32, elem_idx: usize) -> Option<OpRef> {
+fn get_array_element(
+    arrays: &[(u32, Vec<BoxRef>)],
+    arr_idx: u32,
+    elem_idx: usize,
+) -> Option<OpRef> {
     arrays
         .iter()
         .find(|(i, _)| *i == arr_idx)
-        .and_then(|(_, e)| e.get(elem_idx).copied())
+        .and_then(|(_, e)| e.get(elem_idx).map(|b| b.to_opref()))
         .filter(|r| !r.is_none())
 }
 
@@ -2413,19 +2421,19 @@ fn get_array_element(arrays: &[(u32, Vec<OpRef>)], arr_idx: u32, elem_idx: usize
 /// with `OpRef::NONE` placeholders as needed, then stores `value` at
 /// `arr_idx`/`elem_idx`.
 fn set_array_element(
-    arrays: &mut Vec<(u32, Vec<OpRef>)>,
+    arrays: &mut Vec<(u32, Vec<BoxRef>)>,
     arr_idx: u32,
     elem_idx: usize,
     value: OpRef,
 ) {
     if let Some((_, elems)) = arrays.iter_mut().find(|(i, _)| *i == arr_idx) {
         if elem_idx >= elems.len() {
-            elems.resize(elem_idx + 1, OpRef::NONE);
+            elems.resize(elem_idx + 1, BoxRef::none());
         }
-        elems[elem_idx] = value;
+        elems[elem_idx] = BoxRef::from_opref(value);
     } else {
-        let mut elems = vec![OpRef::NONE; elem_idx + 1];
-        elems[elem_idx] = value;
+        let mut elems = vec![BoxRef::none(); elem_idx + 1];
+        elems[elem_idx] = BoxRef::from_opref(value);
         arrays.push((arr_idx, elems));
     }
 }
@@ -2874,7 +2882,7 @@ mod tests {
             PtrInfo::Virtualizable(VirtualizableFieldState {
                 fields: vec![],
                 field_descrs: vec![],
-                arrays: vec![(0, vec![OpRef::NONE])],
+                arrays: vec![(0, vec![BoxRef::none()])],
                 last_guard_pos: -1,
             }),
         );
@@ -3624,7 +3632,14 @@ mod tests {
         let PtrInfo::Virtual(vinfo) = info else {
             panic!("expected Virtual ptr info, got {info:?}");
         };
-        assert_eq!(vinfo.fields, vec![(0, OpRef::int_op(100))]);
+        assert_eq!(
+            vinfo
+                .fields
+                .iter()
+                .map(|(i, b)| (*i, b.to_opref()))
+                .collect::<Vec<_>>(),
+            vec![(0, OpRef::int_op(100))]
+        );
         // info.py:188 keeps no cached fielddescr list — `descr.get_all_fielddescrs()`
         // is the authoritative view. Round-trip the size descr the same way
         // production consumers (info.rs all_fielddescrs_from_descr) do.

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -566,7 +566,7 @@ impl OptVirtualize {
                     let b = BoxRef::from_bound_op(op_rc);
                     ctx.set_ptr_info(&b, PtrInfo::VirtualArrayStruct(vinfo));
                 } else {
-                    let items = vec![OpRef::NONE; size as usize];
+                    let items = vec![BoxRef::none(); size as usize];
                     let vinfo = VirtualArrayInfo {
                         descr,
                         clear: matches!(op.opcode, OpCode::NewArrayClear),
@@ -889,7 +889,7 @@ impl OptVirtualize {
                     ctx.with_ptr_info_mut(b, |info| {
                         if let PtrInfo::VirtualArray(vinfo) = info {
                             if idx < vinfo.items.len() {
-                                vinfo.items[idx] = value_ref;
+                                vinfo.items[idx] = BoxRef::from_opref(value_ref);
                                 return true;
                             }
                         }
@@ -942,7 +942,7 @@ impl OptVirtualize {
                     if index < 0 || (index as usize) >= vinfo.items.len() {
                         return OptimizationResult::InvalidLoop;
                     }
-                    let item_ref = vinfo.items[index as usize];
+                    let item_ref = vinfo.items[index as usize].to_opref();
                     if item_ref.is_none() {
                         return OptimizationResult::InvalidLoop;
                     }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -425,7 +425,7 @@ impl OptVirtualize {
     ) {
         let opinfo = crate::optimizeopt::info::VirtualRawSliceInfo {
             offset,
-            parent,
+            parent: BoxRef::from_opref(parent),
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
         };
@@ -468,7 +468,7 @@ impl OptVirtualize {
                     // signed addends is always representable. In Rust we
                     // bail on i64 overflow rather than wrap.
                     total_offset = total_offset.checked_add(slice.offset)?;
-                    current = slice.parent;
+                    current = slice.parent.to_opref();
                 }
                 Some(PtrInfo::VirtualRawBuffer(_)) => return Some((current, total_offset)),
                 _ => return None,

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -951,9 +951,11 @@ impl VirtualState {
                     .as_ref()
                     .and_then(|b| ctx.peek_ptr_info(b))
                 {
-                    Some(crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(vinfo)) => {
-                        vinfo.element_fields
-                    }
+                    Some(crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(vinfo)) => vinfo
+                        .element_fields
+                        .iter()
+                        .map(|row| row.iter().map(|(i, b)| (*i, b.to_opref())).collect())
+                        .collect(),
                     _ => return Err(()),
                 };
                 if runtime_fields.len() != element_fields.len() {
@@ -1650,7 +1652,9 @@ impl VirtualState {
                 let parent_fields =
                     Self::peek_parent_field_oprefs(state.ctx, box_opref, runtime_box, |info| {
                         match info {
-                            PtrInfo::Virtual(v) => Some(v.fields.clone()),
+                            PtrInfo::Virtual(v) => {
+                                Some(v.fields.iter().map(|(i, b)| (*i, b.to_opref())).collect())
+                            }
                             _ => None,
                         }
                     });
@@ -1695,7 +1699,9 @@ impl VirtualState {
                 let parent_fields =
                     Self::peek_parent_field_oprefs(state.ctx, box_opref, runtime_box, |info| {
                         match info {
-                            PtrInfo::VirtualStruct(s) => Some(s.fields.clone()),
+                            PtrInfo::VirtualStruct(s) => {
+                                Some(s.fields.iter().map(|(i, b)| (*i, b.to_opref())).collect())
+                            }
                             _ => None,
                         }
                     });
@@ -1839,7 +1845,9 @@ impl VirtualState {
                         Self::peek_parent_field_oprefs(state.ctx, box_opref, runtime_box, |info| {
                             match info {
                                 PtrInfo::VirtualArrayStruct(a) => {
-                                    a.element_fields.get(elem_idx).cloned()
+                                    a.element_fields.get(elem_idx).map(|row| {
+                                        row.iter().map(|(i, b)| (*i, b.to_opref())).collect()
+                                    })
                                 }
                                 _ => None,
                             }
@@ -2555,7 +2563,7 @@ fn export_single_value_inner(
                     .fields
                     .iter()
                     .map(|(field_idx, field_ref)| {
-                        let field_state = export_single_value(*field_ref, ctx, cache);
+                        let field_state = export_single_value(field_ref.to_opref(), ctx, cache);
                         (*field_idx, field_state)
                     })
                     .collect();
@@ -2585,7 +2593,7 @@ fn export_single_value_inner(
                     .fields
                     .iter()
                     .map(|(field_idx, field_ref)| {
-                        let field_state = export_single_value(*field_ref, ctx, cache);
+                        let field_state = export_single_value(field_ref.to_opref(), ctx, cache);
                         (*field_idx, field_state)
                     })
                     .collect();
@@ -2603,7 +2611,8 @@ fn export_single_value_inner(
                         fields
                             .iter()
                             .map(|(field_idx, field_ref)| {
-                                let field_state = export_single_value(*field_ref, ctx, cache);
+                                let field_state =
+                                    export_single_value(field_ref.to_opref(), ctx, cache);
                                 (*field_idx, field_state)
                             })
                             .collect()
@@ -3106,7 +3115,7 @@ mod tests {
             &outer_a_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
-                fields: vec![(0, inner_field_value)],
+                fields: vec![(0, BoxRef::from_opref(inner_field_value))],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -3115,7 +3124,7 @@ mod tests {
             &outer_b_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
-                fields: vec![(0, inner_field_value)],
+                fields: vec![(0, BoxRef::from_opref(inner_field_value))],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -3177,7 +3186,7 @@ mod tests {
             &virtual_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
-                fields: vec![(0, OpRef::NONE), (8, field_value)],
+                fields: vec![(0, BoxRef::none()), (8, BoxRef::from_opref(field_value))],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -1741,7 +1741,9 @@ impl VirtualState {
                         .get_box_replacement_box(box_opref)
                         .and_then(|b| state.ctx.getptrinfo(&b))
                         .and_then(|info| match info {
-                            PtrInfo::VirtualArray(a) => Some(a.items.clone()),
+                            PtrInfo::VirtualArray(a) => {
+                                Some(a.items.iter().map(|b| b.to_opref()).collect())
+                            }
                             _ => None,
                         })
                 } else {
@@ -2569,7 +2571,7 @@ fn export_single_value_inner(
                 let items: Vec<Rc<VirtualStateInfoNode>> = vinfo
                     .items
                     .iter()
-                    .map(|item_ref| export_single_value(*item_ref, ctx, cache))
+                    .map(|item_ref| export_single_value(item_ref.to_opref(), ctx, cache))
                     .collect();
                 let len = items.len();
                 return VirtualStateInfo::VArray {

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1581,7 +1581,10 @@ mod tests {
                 mode: 0,
                 length,
                 variant: VStringVariant::Plain(VStringPlainInfo {
-                    _chars: chars.into_iter().map(|o| o.map(BoxRef::from_opref)).collect(),
+                    _chars: chars
+                        .into_iter()
+                        .map(|o| o.map(BoxRef::from_opref))
+                        .collect(),
                 }),
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -248,15 +248,20 @@ pub fn string_copy_parts(
     let action = match resolved_box.as_ref().and_then(|b| ctx.getptrinfo(b)) {
         Some(info) => match info {
             PtrInfo::Str(sinfo) if sinfo.is_virtual() => match &sinfo.variant {
-                VStringVariant::Plain(p) => Action::Plain(p._chars.clone()),
+                VStringVariant::Plain(p) => Action::Plain(
+                    p._chars
+                        .iter()
+                        .map(|slot| slot.as_ref().map(|b| b.to_opref()))
+                        .collect(),
+                ),
                 VStringVariant::Slice(s) => Action::Slice {
-                    s: s.s,
-                    start: s.start,
-                    lgtop: s.lgtop,
+                    s: s.s.to_opref(),
+                    start: s.start.to_opref(),
+                    lgtop: s.lgtop.to_opref(),
                 },
                 VStringVariant::Concat(c) => Action::Concat {
-                    vleft: c.vleft,
-                    vright: c.vright,
+                    vleft: c.vleft.to_opref(),
+                    vright: c.vright.to_opref(),
                 },
                 VStringVariant::Ptr => Action::NonVirtual,
             },
@@ -597,7 +602,7 @@ impl OptString {
             let did_write = self
                 .with_plain_info_mut(str_ref, ctx, |info| {
                     if i < info._chars.len() {
-                        info._chars[i] = Some(char_resolved);
+                        info._chars[i] = Some(BoxRef::from_opref(char_resolved));
                         return true;
                     }
                     false
@@ -750,7 +755,7 @@ impl OptString {
                         for (index, ch_ref) in dst_chars.into_iter().enumerate() {
                             let dst_index = (dst_start as usize) + index;
                             if dst_index < info._chars.len() {
-                                info._chars[dst_index] = ch_ref;
+                                info._chars[dst_index] = ch_ref.map(BoxRef::from_opref);
                             }
                         }
                     });
@@ -909,8 +914,8 @@ impl OptString {
                     mode,
                     length: -1,
                     variant: VStringVariant::Concat(VStringConcatInfo {
-                        vleft,
-                        vright,
+                        vleft: BoxRef::from_opref(vleft),
+                        vright: BoxRef::from_opref(vright),
                         _is_virtual: true,
                     }),
                     last_guard_pos: -1,
@@ -942,8 +947,8 @@ impl OptString {
             let stop = ctx.resolve_box_box(&op.arg(3)).to_opref();
             let lgtop = self.int_sub(stop, start, ctx);
             if let Some(info) = self.get_slice_info(s, ctx) {
-                let source = info.s;
-                let source_start = info.start;
+                let source = info.s.to_opref();
+                let source_start = info.start.to_opref();
                 s = source;
                 start = _int_add(source_start, start, ctx);
             }
@@ -954,10 +959,14 @@ impl OptString {
                 &b,
                 PtrInfo::Str(StrPtrInfo {
                     lenbound: None,
-                    lgtop: Some(lgtop),
+                    lgtop: Some(BoxRef::from_opref(lgtop)),
                     mode,
                     length: -1,
-                    variant: VStringVariant::Slice(VStringSliceInfo { s, start, lgtop }),
+                    variant: VStringVariant::Slice(VStringSliceInfo {
+                        s: BoxRef::from_opref(s),
+                        start: BoxRef::from_opref(start),
+                        lgtop: BoxRef::from_opref(lgtop),
+                    }),
                     last_guard_pos: -1,
                     avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
                 }),
@@ -1114,9 +1123,9 @@ impl OptString {
                 // vstring.py:769-774: arg1 is a virtual slice, arg2 is length 1
                 let resolved1 = ctx.get_replacement_opref(arg1);
                 if let Some(info) = self.get_slice_info(resolved1, ctx) {
-                    let source = info.s;
-                    let start = info.start;
-                    let length = info.lgtop;
+                    let source = info.s.to_opref();
+                    let start = info.start.to_opref();
+                    let length = info.lgtop.to_opref();
                     if let Some(vchar) = self.strgetitem(arg2, 0, ctx) {
                         return self.generate_modified_call(
                             OopSpecIndex::StreqSliceChar,
@@ -1192,9 +1201,9 @@ impl OptString {
         // vstring.py:807-813: if arg1 is a virtual slice
         let resolved1 = ctx.get_replacement_opref(arg1);
         if let Some(info) = self.get_slice_info(resolved1, ctx) {
-            let source = info.s;
-            let start = info.start;
-            let length = info.lgtop;
+            let source = info.s.to_opref();
+            let start = info.start.to_opref();
+            let length = info.lgtop.to_opref();
             let oopspec = if self.is_known_nonnull(arg2, ctx) {
                 OopSpecIndex::StreqSliceNonnull
             } else {
@@ -1571,7 +1580,9 @@ mod tests {
                 lgtop: None,
                 mode: 0,
                 length,
-                variant: VStringVariant::Plain(VStringPlainInfo { _chars: chars }),
+                variant: VStringVariant::Plain(VStringPlainInfo {
+                    _chars: chars.into_iter().map(|o| o.map(BoxRef::from_opref)).collect(),
+                }),
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -1588,8 +1599,8 @@ mod tests {
                 mode: 0,
                 length: -1,
                 variant: VStringVariant::Concat(VStringConcatInfo {
-                    vleft,
-                    vright,
+                    vleft: BoxRef::from_opref(vleft),
+                    vright: BoxRef::from_opref(vright),
                     _is_virtual: true,
                 }),
                 last_guard_pos: -1,
@@ -1604,10 +1615,14 @@ mod tests {
             &b,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
-                lgtop: Some(lgtop), // vstring.py:223: self.lgtop = length
+                lgtop: Some(BoxRef::from_opref(lgtop)), // vstring.py:223: self.lgtop = length
                 mode: 0,
                 length: -1,
-                variant: VStringVariant::Slice(VStringSliceInfo { s, start, lgtop }),
+                variant: VStringVariant::Slice(VStringSliceInfo {
+                    s: BoxRef::from_opref(s),
+                    start: BoxRef::from_opref(start),
+                    lgtop: BoxRef::from_opref(lgtop),
+                }),
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -618,8 +618,8 @@ where
                 .ref_regs
                 .iter()
                 .zip(frame.ref_values.iter())
-                .find_map(|(opref, concrete)| {
-                    (*opref == Some(vable_opref))
+                .find_map(|(slot, concrete)| {
+                    (slot.as_ref().map(|b| b.to_opref()) == Some(vable_opref))
                         .then_some(*concrete)
                         .flatten()
                         .map(|value| value as usize as *mut u8)
@@ -1512,7 +1512,7 @@ where
                                 .return_r
                                 .expect("inline ref return missing caller destination");
                             parent.ref_regs[caller_dst] =
-                                finished_frame.ref_regs[callee_src as usize];
+                                finished_frame.ref_regs[callee_src as usize].clone();
                             parent.ref_values[caller_dst] =
                                 finished_frame.ref_values[callee_src as usize];
                         }
@@ -2583,7 +2583,11 @@ where
                             // bug.
                             let opref_opt = match slot {
                                 0 => frame.int_regs.get(reg_idx).copied().flatten(),
-                                1 => frame.ref_regs.get(reg_idx).copied().flatten(),
+                                1 => frame
+                                    .ref_regs
+                                    .get(reg_idx)
+                                    .and_then(|o| o.as_ref())
+                                    .map(|b| b.to_opref()),
                                 2 => frame.float_regs.get(reg_idx).copied().flatten(),
                                 _ => unreachable!(),
                             };
@@ -2815,7 +2819,8 @@ where
                         }
                         JitArgKind::Ref => {
                             let (value, concrete) = self.read_ref_reg(caller_src);
-                            sub_frame.ref_regs[callee_dst] = Some(value);
+                            sub_frame.ref_regs[callee_dst] =
+                                Some(crate::r#box::BoxRef::from_opref(value));
                             sub_frame.ref_values[callee_dst] = Some(concrete);
                         }
                         JitArgKind::Float => {
@@ -4718,14 +4723,17 @@ where
 
     fn set_ref_reg(&mut self, reg: usize, opref: Option<OpRef>, value: Option<i64>) {
         let frame = self.frames.current_mut();
-        frame.ref_regs[reg] = opref;
+        frame.ref_regs[reg] = opref.map(crate::r#box::BoxRef::from_opref);
         frame.ref_values[reg] = value;
     }
 
     fn read_ref_reg(&mut self, reg: usize) -> (OpRef, i64) {
         let frame = self.frames.current_mut();
         (
-            frame.ref_regs[reg].expect("jitcode ref register was uninitialized"),
+            frame.ref_regs[reg]
+                .as_ref()
+                .expect("jitcode ref register was uninitialized")
+                .to_opref(),
             frame.ref_values[reg].expect("jitcode concrete ref register was uninitialized"),
         )
     }
@@ -6934,7 +6942,7 @@ mod tests {
         sub.parent_descr_idx = 3;
         sub.int_regs[0] = Some(majit_ir::OpRef::int_op(11));
         sub.int_values[0] = Some(110);
-        sub.ref_regs[0] = Some(majit_ir::OpRef::ref_op(22));
+        sub.ref_regs[0] = Some(crate::r#box::BoxRef::from_opref(majit_ir::OpRef::ref_op(22)));
         sub.ref_values[0] = Some(220);
         sub.float_regs[0] = Some(majit_ir::OpRef::float_op(33));
         sub.float_values[0] = Some(330);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -6942,7 +6942,9 @@ mod tests {
         sub.parent_descr_idx = 3;
         sub.int_regs[0] = Some(majit_ir::OpRef::int_op(11));
         sub.int_values[0] = Some(110);
-        sub.ref_regs[0] = Some(crate::r#box::BoxRef::from_opref(majit_ir::OpRef::ref_op(22)));
+        sub.ref_regs[0] = Some(crate::r#box::BoxRef::from_opref(majit_ir::OpRef::ref_op(
+            22,
+        )));
         sub.ref_values[0] = Some(220);
         sub.float_regs[0] = Some(majit_ir::OpRef::float_op(33));
         sub.float_values[0] = Some(330);

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -9,6 +9,7 @@ use majit_ir::{OpRef, Type};
 
 use crate::jitcode::{JitArgKind, JitCode, read_u8, read_u16};
 use crate::opencoder::{Box as OpBox, TraceRecordBuffer};
+use crate::r#box::BoxRef;
 use crate::recorder::SnapshotTagged;
 
 /// Map an int register (OpRef, concrete value) to an `OpBox`.
@@ -67,7 +68,7 @@ pub struct MIFrame {
     pub code_cursor: usize,
     pub int_regs: Vec<Option<OpRef>>,
     pub int_values: Vec<Option<i64>>,
-    pub ref_regs: Vec<Option<OpRef>>,
+    pub ref_regs: Vec<Option<BoxRef>>,
     pub ref_values: Vec<Option<i64>>,
     pub float_regs: Vec<Option<OpRef>>,
     pub float_values: Vec<Option<i64>>,
@@ -402,7 +403,7 @@ impl MIFrame {
         let num_regs_r = self.jitcode.c_num_regs_r as usize;
         for (i, &value) in self.jitcode.constants_r.iter().enumerate() {
             let slot = num_regs_r + i;
-            self.ref_regs[slot] = Some(ctx.const_ref(value));
+            self.ref_regs[slot] = Some(BoxRef::from_opref(ctx.const_ref(value)));
             self.ref_values[slot] = Some(value);
         }
         let num_regs_f = self.jitcode.c_num_regs_f as usize;
@@ -497,7 +498,7 @@ impl MIFrame {
                 self.int_values[target_index] = Some(concrete);
             }
             JitArgKind::Ref => {
-                self.ref_regs[target_index] = Some(opref);
+                self.ref_regs[target_index] = Some(BoxRef::from_opref(opref));
                 self.ref_values[target_index] = Some(concrete);
             }
             JitArgKind::Float => {
@@ -593,7 +594,7 @@ impl MIFrame {
                     }
                     b'r' => {
                         let opref = OpRef::const_ptr(majit_ir::GcRef::NULL);
-                        self.ref_regs[index] = Some(opref);
+                        self.ref_regs[index] = Some(BoxRef::from_opref(opref));
                         self.ref_values[index] = Some(0);
                         (None, None, None)
                     }
@@ -691,7 +692,9 @@ impl MIFrame {
                     OpBox::ConstPtr(0)
                 } else if idx < num_regs_r {
                     let opref = self.ref_regs[idx]
-                        .expect("get_list_of_active_boxes: ref register uninitialized");
+                        .as_ref()
+                        .expect("get_list_of_active_boxes: ref register uninitialized")
+                        .to_opref();
                     let value = self.ref_values[idx]
                         .expect("get_list_of_active_boxes: ref value uninitialized");
                     register_to_box_ref(opref, value)
@@ -767,7 +770,7 @@ impl MIFrame {
                     }
                     b'r' => {
                         let opref = OpRef::const_ptr(majit_ir::GcRef::NULL);
-                        self.ref_regs[index] = Some(opref);
+                        self.ref_regs[index] = Some(BoxRef::from_opref(opref));
                         self.ref_values[index] = Some(0);
                     }
                     b'f' => {
@@ -842,7 +845,9 @@ impl MIFrame {
                     SnapshotTagged::Const(0, Type::Ref)
                 } else if idx < num_regs_r {
                     let opref = self.ref_regs[idx]
-                        .expect("get_list_of_active_snapshot_boxes: ref register uninitialized");
+                        .as_ref()
+                        .expect("get_list_of_active_snapshot_boxes: ref register uninitialized")
+                        .to_opref();
                     let value = self.ref_values[idx]
                         .expect("get_list_of_active_snapshot_boxes: ref value uninitialized");
                     if opref.is_constant() {
@@ -914,10 +919,21 @@ impl MIFrame {
     /// once via `TraceCtx::get_opref_type`. `Type::Void` panics with the
     /// upstream assertion message.
     pub fn replace_active_box_in_frame(&mut self, oldbox: OpRef, newbox: OpRef, oldbox_type: Type) {
+        // `ref_regs` stores `BoxRef`; the int/float banks stay `OpRef`. The
+        // shared replace logic compares by OpRef value (pyre's flat-OpRef
+        // adaptation of pyjitpl.py:240 `registers[i] is oldbox`), so the
+        // ref bank round-trips through `to_opref`/`from_opref`.
         let registers = match oldbox_type {
             Type::Int => &mut self.int_regs,
-            Type::Ref => &mut self.ref_regs,
             Type::Float => &mut self.float_regs,
+            Type::Ref => {
+                for slot in self.ref_regs.iter_mut() {
+                    if slot.as_ref().map(|b| b.to_opref()) == Some(oldbox) {
+                        *slot = Some(BoxRef::from_opref(newbox));
+                    }
+                }
+                return;
+            }
             // pyjitpl.py:236-244 `else: assert 0, oldbox` — RPython rejects
             // any box whose `type` attribute is not 'i' / 'r' / 'f'.
             // Mirroring that assertion strength keeps the contract: the
@@ -953,7 +969,7 @@ impl MIFrame {
                     count_i += 1;
                 }
                 JitArgKind::Ref => {
-                    self.ref_regs[count_r] = Some(*value);
+                    self.ref_regs[count_r] = Some(BoxRef::from_opref(*value));
                     self.ref_values[count_r] = Some(*concrete);
                     count_r += 1;
                 }
@@ -1050,9 +1066,15 @@ mod tests {
         assert_eq!(frame.int_values[0], Some(100));
         assert_eq!(frame.int_regs[1], Some(OpRef::int_op(11)));
         assert_eq!(frame.int_values[1], Some(101));
-        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(20)));
+        assert_eq!(
+            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
+            Some(OpRef::ref_op(20))
+        );
         assert_eq!(frame.ref_values[0], Some(200));
-        assert_eq!(frame.ref_regs[1], Some(OpRef::ref_op(21)));
+        assert_eq!(
+            frame.ref_regs[1].as_ref().map(|b| b.to_opref()),
+            Some(OpRef::ref_op(21))
+        );
         assert_eq!(frame.ref_values[1], Some(201));
         assert_eq!(frame.float_regs[0], Some(OpRef::float_op(30)));
         assert_eq!(frame.float_values[0], Some(300));
@@ -1092,7 +1114,9 @@ mod tests {
         frame.int_regs[0] = Some(OpRef::int_op(5));
         frame.int_values[0] = Some(0);
         // ref_regs[0] constant pointer addr=0xdead_beef → Box::ConstPtr.
-        frame.ref_regs[0] = Some(OpRef::const_ptr(majit_ir::GcRef(0xdead_beef)));
+        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::const_ptr(majit_ir::GcRef(
+            0xdead_beef,
+        ))));
         frame.ref_values[0] = Some(0xdead_beef);
 
         let sd = Arc::new(crate::MetaInterpStaticData::new());
@@ -1373,7 +1397,7 @@ mod tests {
         let mut frame = MIFrame::new(jitcode.clone(), 0);
         frame.int_regs[0] = Some(OpRef::int_op(1));
         frame.int_values[0] = Some(11);
-        frame.ref_regs[0] = Some(OpRef::ref_op(2));
+        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::ref_op(2)));
         frame.ref_values[0] = Some(22);
         frame.float_regs[0] = Some(OpRef::float_op(3));
         frame.float_values[0] = Some(33);
@@ -1406,7 +1430,7 @@ mod tests {
         frame.int_regs[0] = Some(OpRef::int_op(7));
         frame.int_regs[1] = Some(OpRef::int_op(8));
         frame.int_regs[2] = Some(OpRef::int_op(7)); // duplicate — must also flip.
-        frame.ref_regs[0] = Some(OpRef::ref_op(7)); // same raw u32 but different bank/variant.
+        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::ref_op(7))); // same raw u32 but different bank/variant.
         frame.float_regs[0] = Some(OpRef::float_op(7));
 
         frame.replace_active_box_in_frame(OpRef::int_op(7), OpRef::int_op(42), Type::Int);
@@ -1415,7 +1439,10 @@ mod tests {
         assert_eq!(frame.int_regs[1], Some(OpRef::int_op(8)));
         assert_eq!(frame.int_regs[2], Some(OpRef::int_op(42)));
         // Ref / float banks untouched — bank dispatch is by oldbox.type.
-        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(7)));
+        assert_eq!(
+            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
+            Some(OpRef::ref_op(7))
+        );
         assert_eq!(frame.float_regs[0], Some(OpRef::float_op(7)));
     }
 
@@ -1424,10 +1451,13 @@ mod tests {
     fn replace_active_box_in_frame_returns_early_when_bank_empty() {
         let jitcode = make_jitcode_with_regs(0, 1, 0);
         let mut frame = MIFrame::new(jitcode, 0);
-        frame.ref_regs[0] = Some(OpRef::ref_op(7));
+        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::ref_op(7)));
         frame.replace_active_box_in_frame(OpRef::int_op(7), OpRef::int_op(42), Type::Int);
         // Int bank empty — ref bank stays untouched.
-        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(7)));
+        assert_eq!(
+            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
+            Some(OpRef::ref_op(7))
+        );
     }
 
     /// Type::Void is not a valid box type (pyjitpl.py:246 `assert 0,
@@ -1455,7 +1485,10 @@ mod tests {
 
         frame.pc = 1;
         frame.make_result_of_lastop(JitArgKind::Ref, 0, OpRef::ref_op(8), 88);
-        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(8)));
+        assert_eq!(
+            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
+            Some(OpRef::ref_op(8))
+        );
         assert_eq!(frame.ref_values[0], Some(88));
 
         frame.pc = 2;

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 
 use majit_ir::{OpRef, Type};
 
+use crate::r#box::BoxRef;
 use crate::jitcode::{JitArgKind, JitCode, read_u8, read_u16};
 use crate::opencoder::{Box as OpBox, TraceRecordBuffer};
-use crate::r#box::BoxRef;
 use crate::recorder::SnapshotTagged;
 
 /// Map an int register (OpRef, concrete value) to an `OpBox`.

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1546,9 +1546,12 @@ impl<M: Clone> MetaInterp<M> {
             // compilation is paused for GC, mirroring RPython's in-place field
             // update of `ConstPtr.value`.
             let opref = unsafe { &mut *(slot_addr as *mut majit_ir::OpRef) };
-            if let Some(gcref) = opref.as_const_ptr_mut() {
-                visitor(gcref);
-            }
+            // Forward the snapshot slot's inline const gcref through the
+            // canonical BoxRef-Const walk, writing the updated ref back in
+            // place (mirroring an in-place ConstPtr.value field update).
+            let b = BoxRef::from_opref(*opref);
+            b.walk_const_ptr_refs(&mut visitor);
+            *opref = b.to_opref();
         }
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1485,12 +1485,10 @@ impl<M: Clone> MetaInterp<M> {
         // Python object graph automatically; pyre's `Vec<Option<OpRef>>`
         // storage needs an explicit walker. Independent of `self.tracing`:
         // frames are pushed for both recording and recursive-portal calls.
-        for frame in self.framestack.frames.iter_mut() {
-            for slot in frame.ref_regs.iter_mut() {
-                if let Some(opref) = slot.as_mut() {
-                    if let Some(gcref) = opref.as_const_ptr_mut() {
-                        visitor(gcref);
-                    }
+        for frame in self.framestack.frames.iter() {
+            for slot in frame.ref_regs.iter() {
+                if let Some(b) = slot.as_ref() {
+                    b.walk_const_ptr_refs(&mut visitor);
                 }
             }
         }
@@ -15272,7 +15270,10 @@ mod metainterp_static_data_tests {
         assert_eq!(f.int_values[0], Some(100));
         assert_eq!(f.int_regs[1], Some(OpRef::int_op(11)));
         assert_eq!(f.int_values[1], Some(101));
-        assert_eq!(f.ref_regs[0], Some(OpRef::ref_op(20)));
+        assert_eq!(
+            f.ref_regs[0].as_ref().map(|b| b.to_opref()),
+            Some(OpRef::ref_op(20))
+        );
         assert_eq!(f.ref_values[0], Some(200));
         assert_eq!(f.float_regs[0], Some(OpRef::float_op(30)));
         assert_eq!(f.float_values[0], Some(300));

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -1512,14 +1512,12 @@ impl<M: Clone> MetaInterp<M> {
         }
         // pyjitpl.py:3290-3306 — `initialize_virtualizable` /
         // `force_start_tracing` / `setup_tracing` snapshot inputarg
-        // constants into `initial_inputarg_consts`. Inline
-        // `ConstPtr(GcRef)` entries here live outside the op-graph
-        // and must be forwarded by the same GC walker — history.py:314
+        // constants into `initial_inputarg_consts`. Each is a
+        // `BoxKind::Const` box; a Ref entry's inline gcref is forwarded
+        // through the canonical `BoxRef::walk_const_ptr_refs` — history.py:314
         // `ConstPtr.value` is a gcref attribute of the Box.
-        for opref in trace_ctx.initial_inputarg_consts.iter_mut() {
-            if let Some(slot) = opref.as_const_ptr_mut() {
-                visitor(slot);
-            }
+        for b in trace_ctx.initial_inputarg_consts.iter() {
+            b.walk_const_ptr_refs(&mut visitor);
         }
         // heapcache.py:50-104 — the heapcache caches field values /
         // replacements / loop-invariant results as `OpRef`. With inline
@@ -2761,10 +2759,10 @@ impl<M: Clone> MetaInterp<M> {
                 .map(|value| {
                     let opref = ctx.recorder.record_input_arg(value.get_type());
                     // history.py:227/268/314 — Const{Int,Float,Ptr}.value
-                    // is inline on the Box itself; mint inline-Const
-                    // directly rather than allocating a pool index.
-                    ctx.initial_inputarg_consts
-                        .push(OpRef::const_inline_from_value(value));
+                    // is inline on the Box itself; snapshot the value into a
+                    // `BoxKind::Const` box (GC-walked once via
+                    // `BoxRef::walk_const_ptr_refs`).
+                    ctx.initial_inputarg_consts.push(BoxRef::new_const(*value));
                     opref
                 })
                 .collect()
@@ -3317,11 +3315,10 @@ impl<M: Clone> MetaInterp<M> {
                 ctx.set_trace_limit(self.warm_state.trace_limit() as usize);
                 ctx.callinfocollection = self.callinfocollection.clone();
                 // history.py:227/268/314 — Const{Int,Float,Ptr}.value
-                // is inline on the Box; mint inline-Const directly.
-                ctx.initial_inputarg_consts = live_values
-                    .iter()
-                    .map(OpRef::const_inline_from_value)
-                    .collect();
+                // is inline on the Box; snapshot each value into a
+                // `BoxKind::Const` box (GC-walked via walk_const_ptr_refs).
+                ctx.initial_inputarg_consts =
+                    live_values.iter().map(|v| BoxRef::new_const(*v)).collect();
                 if let Some(ref descriptor) = driver_descriptor {
                     ctx.set_driver_descriptor(descriptor.clone());
                 }
@@ -3531,11 +3528,9 @@ impl<M: Clone> MetaInterp<M> {
         ctx.set_trace_limit(self.warm_state.trace_limit() as usize);
         ctx.callinfocollection = self.callinfocollection.clone();
         // history.py:227/268/314 — Const{Int,Float,Ptr}.value is inline
-        // on the Box; mint inline-Const directly.
-        ctx.initial_inputarg_consts = live_values
-            .iter()
-            .map(OpRef::const_inline_from_value)
-            .collect();
+        // on the Box; snapshot each value into a `BoxKind::Const` box
+        // (GC-walked via walk_const_ptr_refs).
+        ctx.initial_inputarg_consts = live_values.iter().map(|v| BoxRef::new_const(*v)).collect();
         if let Some(ref descriptor) = driver_descriptor {
             ctx.set_driver_descriptor(descriptor.clone());
         }
@@ -4453,13 +4448,15 @@ impl<M: Clone> MetaInterp<M> {
         ctx: &TraceCtx,
         driver_descriptor: Option<&crate::jitdriver::JitDriverStaticData>,
     ) -> *const u8 {
-        // history.py:314 ConstPtr.value lives inline on the OpRef
-        // (Slice 7 inline-Const cutover).
+        // history.py:314 ConstPtr.value lives inline on the box —
+        // `orig_inpargs[idx].getref_base()` parity read.
         driver_descriptor
             .and_then(|driver| driver.virtualizable_arg_index())
-            .and_then(|idx| ctx.initial_inputarg_consts.get(idx).copied())
-            .and_then(|const_ref| const_ref.as_const_ptr())
-            .map(|gcref| gcref.0 as *const u8)
+            .and_then(|idx| ctx.initial_inputarg_consts.get(idx))
+            .and_then(|const_box| match const_box.const_value() {
+                Some(majit_ir::Value::Ref(gcref)) => Some(gcref.0 as *const u8),
+                _ => None,
+            })
             .unwrap_or(std::ptr::null())
     }
 
@@ -4741,7 +4738,16 @@ impl<M: Clone> MetaInterp<M> {
                     ctx.header_pc,
                 );
             }
-            trace.cut_trace_from_with_consts(start, original_boxes, &ctx.initial_inputarg_consts)
+            // cut_trace_from_with_consts remaps escaped original inputargs to
+            // their trace-entry Const via a transient build-time map keyed by
+            // `OpRef.raw()` — derive the inline-Const OpRef view here (not a
+            // persistent GC store, so no stale-pointer hazard).
+            let inputarg_consts: Vec<OpRef> = ctx
+                .initial_inputarg_consts
+                .iter()
+                .map(|b| b.to_opref())
+                .collect();
+            trace.cut_trace_from_with_consts(start, original_boxes, &inputarg_consts)
         } else {
             trace
         };
@@ -5949,7 +5955,13 @@ impl<M: Clone> MetaInterp<M> {
                         header_pc,
                     );
                 }
-                trace.cut_trace_from_with_consts(start, original_boxes, &initial_inputarg_consts)
+                // Inline-Const OpRef view for the transient cut_trace remap
+                // (keyed by `OpRef.raw()`; not a persistent GC store).
+                let inputarg_consts: Vec<OpRef> = initial_inputarg_consts
+                    .iter()
+                    .map(|b| b.to_opref())
+                    .collect();
+                trace.cut_trace_from_with_consts(start, original_boxes, &inputarg_consts)
             } else {
                 trace
             };

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -5046,7 +5046,8 @@ impl<M: Clone> MetaInterp<M> {
                 Some(args) => args
                     .iter()
                     .enumerate()
-                    .map(|(i, &opref)| {
+                    .map(|(i, arg)| {
+                        let opref = arg.to_opref();
                         let tp = opref.ty().unwrap_or_else(|| {
                             panic!(
                                 "renamed inputarg {:?} has no intrinsic type \
@@ -9039,10 +9040,11 @@ impl<M: Clone> MetaInterp<M> {
                 let renamed_inputargs: Vec<InputArg> = es
                     .renamed_inputargs
                     .iter()
-                    .map(|&opref| {
+                    .map(|arg| {
                         // RPython retrace passes the original typed Box list
                         // directly; each renamed inputarg OpRef carries its
                         // `.type` intrinsically (history.py:220).
+                        let opref = arg.to_opref();
                         let tp = opref.ty().unwrap_or_else(|| {
                             panic!(
                                 "renamed inputarg {:?} has no intrinsic type \
@@ -9631,7 +9633,8 @@ impl<M: Clone> MetaInterp<M> {
                 let renamed_inputargs: Vec<InputArg> = es
                     .renamed_inputargs
                     .iter()
-                    .map(|&opref| {
+                    .map(|arg| {
+                        let opref = arg.to_opref();
                         let tp = opref.ty().unwrap_or_else(|| {
                             panic!(
                                 "renamed inputarg {:?} has no intrinsic type \

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -21,6 +21,7 @@
 
 use crate::opencoder::Box as OcBox;
 use crate::recorder::Trace;
+use majit_ir::box_ref::BoxRef;
 use majit_ir::{DescrRef, GreenKey, OpCode, OpRef, Type, Value};
 use majit_trace::heapcache::HeapCache;
 
@@ -311,13 +312,14 @@ pub struct TraceCtx {
     /// pyjitpl.py:2594 frame.pc: last bytecode pc passed to trace_fn.
     /// Used by force_finish_trace segmenting to record the guard-point pc.
     pub last_traced_pc: usize,
-    /// GC-safe constant OpRefs for each initial inputarg at trace start.
-    /// Each entry is an inline `Const*` OpRef mirroring
-    /// history.py:227/268/314 (`Const*.value` lives on the box). Ref
-    /// entries are forwarded by `MetaInterp::walk_active_trace_refs`.
-    /// Used by cut_trace_from to remap escaped original inputargs to
-    /// stable inline Const OpRefs.
-    pub initial_inputarg_consts: Vec<majit_ir::OpRef>,
+    /// GC-safe constant value snapshot for each initial inputarg at trace
+    /// start. Each entry is a `BoxKind::Const` box mirroring
+    /// history.py:227/268/314 (`Const*.value` lives on the box); the inline
+    /// gcref of a Ref entry is forwarded once through the canonical
+    /// `BoxRef::walk_const_ptr_refs` by `MetaInterp::walk_active_trace_refs`.
+    /// Used by cut_trace_from to remap escaped original inputargs to their
+    /// stable Const value.
+    pub initial_inputarg_consts: Vec<BoxRef>,
     /// pyjitpl.py:1087 parity: quasi-immutable field read needs a
     /// GUARD_NOT_INVALIDATED with full snapshot at the field read's orgpc.
     /// Stores Some(orgpc) when pending.
@@ -1435,10 +1437,16 @@ impl TraceCtx {
     /// ordinary `OpRef(index)`, matching RPython's `original_boxes` list.
     pub fn initial_inputarg_argbox(&self, index: usize) -> Option<(JitArgKind, OpRef, i64)> {
         let tp = self.recorder.inputarg_types().get(index).copied()?;
-        let const_ref = self.initial_inputarg_consts.get(index).copied()?;
+        let const_box = self.initial_inputarg_consts.get(index)?;
         // history.py:227/268/314 — Const{Int,Float,Ptr}.value lives inline
-        // on the Box; `inline_const_bits` resolves it directly.
-        let bits = const_ref.inline_const_bits()?;
+        // on the Box; read it and resolve the raw bits (Int→value,
+        // Float→bit pattern, Ref→gcref address).
+        let bits = match const_box.const_value()? {
+            Value::Int(v) => v,
+            Value::Float(v) => v.to_bits() as i64,
+            Value::Ref(r) => r.0 as i64,
+            Value::Void => return None,
+        };
         let kind = match tp {
             Type::Int => JitArgKind::Int,
             Type::Ref => JitArgKind::Ref,

--- a/majit/majit-trace/src/heapcache.rs
+++ b/majit/majit-trace/src/heapcache.rs
@@ -35,6 +35,7 @@ fn vb_remove(v: &mut Vec<bool>, opref: &OpRef) -> bool {
     }
 }
 
+use majit_ir::box_ref::BoxRef;
 use majit_ir::{EffectInfo, ExtraEffect, GcRef, OpCode, OpRef, Type};
 
 /// Value-equality predicate over constant OpRefs.  Mirrors
@@ -98,11 +99,11 @@ const _HF_VERSION_MAX: u32 = HF_VERSION_MAX;
 /// call.  No separate side table.
 #[derive(Debug, Default)]
 pub(crate) struct CacheEntry {
-    cache_anything: vecset::VecMap<OpRef, OpRef>,
-    cache_seen_allocation: vecset::VecMap<OpRef, OpRef>,
+    cache_anything: vecset::VecMap<OpRef, BoxRef>,
+    cache_seen_allocation: vecset::VecMap<OpRef, BoxRef>,
     quasiimmut_seen: Option<VecSet<OpRef>>,
     quasiimmut_seen_refs: Option<VecSet<usize>>,
-    last_const_box: Option<OpRef>,
+    last_const_box: Option<BoxRef>,
 }
 
 impl CacheEntry {
@@ -136,7 +137,7 @@ impl CacheEntry {
     }
 
     /// heapcache.py:84-88 _getdict
-    pub fn _getdict(&self, seen_alloc: bool) -> &vecset::VecMap<OpRef, OpRef> {
+    pub fn _getdict(&self, seen_alloc: bool) -> &vecset::VecMap<OpRef, BoxRef> {
         if seen_alloc {
             &self.cache_seen_allocation
         } else {
@@ -146,7 +147,7 @@ impl CacheEntry {
 
     /// Pyre adapt: Python doesn't need a separate `_mut` accessor;
     /// Rust's borrow checker does.  Mirrors `_getdict`'s body.
-    pub fn _getdict_mut(&mut self, seen_alloc: bool) -> &mut vecset::VecMap<OpRef, OpRef> {
+    pub fn _getdict_mut(&mut self, seen_alloc: bool) -> &mut vecset::VecMap<OpRef, BoxRef> {
         if seen_alloc {
             &mut self.cache_seen_allocation
         } else {
@@ -165,7 +166,8 @@ impl CacheEntry {
         let ref_box = self._unique_const_heuristic(ref_box, oracle);
         let seen_alloc = self._seen_alloc(ref_box, cache);
         self._clear_cache_on_write(seen_alloc);
-        self._getdict_mut(seen_alloc).insert(ref_box, fieldbox);
+        self._getdict_mut(seen_alloc)
+            .insert(ref_box, BoxRef::from_opref(fieldbox));
     }
 
     /// heapcache.py:96-104 _unique_const_heuristic.
@@ -183,12 +185,13 @@ impl CacheEntry {
         if !(ref_box.is_constant() && ref_box.ty() == Some(Type::Ref)) {
             return ref_box;
         }
-        if let Some(last) = self.last_const_box {
+        if let Some(last) = &self.last_const_box {
+            let last = last.to_opref();
             if oracle.same_constant(last, ref_box) {
                 return last;
             }
         }
-        self.last_const_box = Some(ref_box);
+        self.last_const_box = Some(BoxRef::from_opref(ref_box));
         ref_box
     }
 
@@ -203,8 +206,7 @@ impl CacheEntry {
         let seen_alloc = self._seen_alloc(ref_box, cache);
         self._getdict(seen_alloc)
             .get(&ref_box)
-            .copied()
-            .map(|opref| cache.maybe_replace_with_const(opref))
+            .map(|fieldbox| cache.maybe_replace_with_const(fieldbox.to_opref()))
     }
 
     /// heapcache.py:116-119 read_now_known
@@ -217,7 +219,8 @@ impl CacheEntry {
     ) {
         let ref_box = self._unique_const_heuristic(ref_box, oracle);
         let seen_alloc = self._seen_alloc(ref_box, cache);
-        self._getdict_mut(seen_alloc).insert(ref_box, fieldbox);
+        self._getdict_mut(seen_alloc)
+            .insert(ref_box, BoxRef::from_opref(fieldbox));
     }
 
     /// heapcache.py:121-129 invalidate_unescaped — RPython makes this a
@@ -404,7 +407,7 @@ pub struct HeapCache {
     /// freshly-executed calls.
     loopinvariant_descr: Option<u32>,
     loopinvariant_arg0: Option<i64>,
-    loopinvariant_result: Option<OpRef>,
+    loopinvariant_result: Option<BoxRef>,
     loopinvariant_resvalue: Option<i64>,
 
     /// heapcache.py: per-box `_heapc_deps`.
@@ -413,7 +416,7 @@ pub struct HeapCache {
     /// `deps[0]` is the cached array length and `deps[1:]` are escape
     /// dependencies added by `_escape_from_write`. pyre's `OpRef` is a bare
     /// index, so the closest equivalent is a per-op side slot keyed by OpRef.
-    heapc_deps: Vec<Option<Vec<Option<OpRef>>>>,
+    heapc_deps: Vec<Option<Vec<Option<BoxRef>>>>,
 
     /// heapcache.py: oldbox.set_replaced_with_const() in replace_box().
     ///
@@ -421,7 +424,7 @@ pub struct HeapCache {
     /// carries both a position and a typed Box identity, so the key must be
     /// the full `OpRef`, not just `raw()`: `IntOp(n)` and `RefOp(n)` are
     /// different boxes upstream.
-    replaced_with_const: Vec<(OpRef, OpRef)>,
+    replaced_with_const: Vec<(OpRef, BoxRef)>,
 
     /// heapcache.py:176: need_guard_not_invalidated — set True on reset,
     /// consumed by quasi-immut field recording to decide whether to emit
@@ -467,7 +470,13 @@ impl HeapCache {
         self.replaced_with_const
             .iter()
             .rev()
-            .find_map(|(old, new)| if *old == opref { Some(*new) } else { None })
+            .find_map(|(old, new)| {
+                if *old == opref {
+                    Some(new.to_opref())
+                } else {
+                    None
+                }
+            })
             .unwrap_or(opref)
     }
 
@@ -626,7 +635,7 @@ impl HeapCache {
     }
 
     /// RPython-compatible alias.
-    pub fn _get_deps(&mut self, opref: OpRef) -> &mut Vec<Option<OpRef>> {
+    pub fn _get_deps(&mut self, opref: OpRef) -> &mut Vec<Option<BoxRef>> {
         self.update_version(opref);
         let i = opref.raw() as usize;
         if i >= self.heapc_deps.len() {
@@ -652,7 +661,7 @@ impl HeapCache {
     pub fn _escape_from_write(&mut self, r#box: OpRef, fieldbox: OpRef) {
         if self.is_unescaped(r#box) && self.is_unescaped(fieldbox) {
             let deps = self._get_deps(r#box);
-            deps.push(Some(fieldbox));
+            deps.push(Some(BoxRef::from_opref(fieldbox)));
         } else {
             // RPython's `elif fieldbox is not None` — pyre's OpRef is always
             // present (no None equivalent), so the branch always fires.
@@ -696,12 +705,12 @@ impl HeapCache {
         let deps = self.heapc_deps.get_mut(i).and_then(Option::take);
         if let Some(deps) = deps {
             if self.test_head_version(opref) {
-                let kept_len = deps.first().copied().flatten();
+                let kept_len = deps.first().cloned().flatten();
                 if let Some(length) = kept_len {
                     self.heapc_deps[i] = Some(vec![Some(length)]);
                 }
                 for dep in deps.into_iter().skip(1).flatten() {
-                    self._escape_box(dep);
+                    self._escape_box(dep.to_opref());
                 }
             }
         }
@@ -1005,9 +1014,10 @@ impl HeapCache {
                 .iter_mut()
                 .find(|(existing_old, _)| *existing_old == old)
             {
-                *existing = new;
+                *existing = BoxRef::from_opref(new);
             } else {
-                self.replaced_with_const.push((old, new));
+                self.replaced_with_const
+                    .push((old, BoxRef::from_opref(new)));
             }
         }
     }
@@ -1071,14 +1081,16 @@ impl HeapCache {
         self.known_class.get(opref.raw() as usize).and_then(|v| *v)
     }
 
-    /// Forward every inline `OpRef::ConstPtr(GcRef)` cached as a
-    /// *value* so it survives a moving minor collection. history.py:314
-    /// `ConstPtr.value` is a gcref field the Python GC traces through the
-    /// box object graph; pyre caches the inline gcref in plain `OpRef`
-    /// slots and must forward them explicitly.
+    /// Walk every cached *value* box so a `Const` ref survives a moving
+    /// minor collection. history.py:314 `ConstPtr.value` is a gcref field
+    /// the Python GC traces through the box object graph; pyre stores cached
+    /// values as [`BoxRef`] and forwards each through the canonical
+    /// `BoxRef::walk_const_ptr_refs` (the same path `Op.args` use) — a
+    /// `Const` box's inline `Value::Ref` is forwarded in place, every other
+    /// box kind is a no-op.
     ///
-    /// Only value slots are forwarded — these are returned on cache hits
-    /// and emitted into the op-graph (`replaced_with_const` /
+    /// Only value slots are walked — these are returned on cache hits and
+    /// emitted into the op-graph (`replaced_with_const` /
     /// `loopinvariant_result` / `CacheEntry` field values), so a stale one
     /// is a use-after-move. The `cache_anything` / `cache_seen_allocation`
     /// / `quasi_immut_known` *keys* are deliberately left stale: a forwarded
@@ -1086,10 +1098,8 @@ impl HeapCache {
     /// repopulates (same contract as the `call_pure_results` cache), and an
     /// in-place key rewrite would break the sorted-`VecMap` ordering.
     pub fn walk_const_ptr_refs(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        fn forward(slot: &mut OpRef, visitor: &mut dyn FnMut(&mut GcRef)) {
-            if let Some(gcref) = slot.as_const_ptr_mut() {
-                visitor(gcref);
-            }
+        fn forward(slot: &BoxRef, visitor: &mut dyn FnMut(&mut GcRef)) {
+            slot.walk_const_ptr_refs(visitor);
         }
         fn forward_entry(entry: &mut CacheEntry, visitor: &mut dyn FnMut(&mut GcRef)) {
             for value in entry.cache_anything.values_mut() {
@@ -1558,7 +1568,7 @@ impl HeapCache {
                     .and_then(|entry| {
                         let src = entry._unique_const_heuristic(source_box, oracle);
                         let dict = entry._getdict(seen_allocation_of_source);
-                        dict.get(&src).copied()
+                        dict.get(&src).cloned()
                     });
                 // heapcache.py:113 `return maybe_replace_with_const(res_box)`
                 // — follow the FO_REPLACED_WITH_CONST forwarding so callers
@@ -1566,7 +1576,8 @@ impl HeapCache {
                 // The Box identity is the OpRef; its intrinsic `value`
                 // travels with the frontend value slot, so the copy needs no
                 // explicit payload handling.
-                let value = raw_value.map(|opref| self.maybe_replace_with_const(opref));
+                let value =
+                    raw_value.map(|fieldbox| self.maybe_replace_with_const(fieldbox.to_opref()));
                 // heapcache.py:423-429: ...and write it to the dest cell.
                 if let Some(value) = value {
                     let dst_index = dststart + i;
@@ -1585,7 +1596,7 @@ impl HeapCache {
                     entry._clear_cache_on_write(seen_allocation_of_target);
                     entry
                         ._getdict_mut(seen_allocation_of_target)
-                        .insert(dst, value);
+                        .insert(dst, BoxRef::from_opref(value));
                 } else {
                     // heapcache.py:430-436: source had no cached value, so
                     // the dest's existing entry must be invalidated.
@@ -1717,8 +1728,8 @@ impl HeapCache {
         let array = entry._unique_const_heuristic(array, oracle);
         let seen_alloc = self.saw_allocation(array);
         let entry = self.heap_array_cache.get(&descr)?.get(&index_value)?;
-        let cached = entry._getdict(seen_alloc).get(&array).copied()?;
-        Some(self.maybe_replace_with_const(cached))
+        let cached = entry._getdict(seen_alloc).get(&array).cloned()?;
+        Some(self.maybe_replace_with_const(cached.to_opref()))
     }
 
     /// heapcache.py:573-585 `setarrayitem`. Non-ConstInt index (`None`
@@ -1752,7 +1763,9 @@ impl HeapCache {
         // heapcache.py:577 `indexcache.do_write_with_aliasing(box, ...)`.
         let array = entry._unique_const_heuristic(array, oracle);
         entry._clear_cache_on_write(seen_alloc);
-        entry._getdict_mut(seen_alloc).insert(array, value);
+        entry
+            ._getdict_mut(seen_alloc)
+            .insert(array, BoxRef::from_opref(value));
     }
 
     /// heapcache.py:565-568 `getarrayitem_now_known`. Same canonical
@@ -1776,7 +1789,9 @@ impl HeapCache {
             .entry(index_value)
             .or_insert_with(CacheEntry::new);
         let array = entry._unique_const_heuristic(array, oracle);
-        entry._getdict_mut(seen_alloc).insert(array, value);
+        entry
+            ._getdict_mut(seen_alloc)
+            .insert(array, BoxRef::from_opref(value));
     }
 
     /// Invalidate array caches for a specific array across every descr/index.
@@ -1878,8 +1893,8 @@ impl HeapCache {
         self.heapc_deps
             .get(array.raw() as usize)
             .and_then(|deps| deps.as_ref())
-            .and_then(|deps| deps.first().copied().flatten())
-            .map(|opref| self.maybe_replace_with_const(opref))
+            .and_then(|deps| deps.first().cloned().flatten())
+            .map(|length| self.maybe_replace_with_const(length.to_opref()))
     }
 
     /// heapcache.py:588-596 arraylen_now_known
@@ -1903,7 +1918,7 @@ impl HeapCache {
             return;
         }
         let deps = self._get_deps(array);
-        deps[0] = Some(length);
+        deps[0] = Some(BoxRef::from_opref(length));
     }
 
     // ── Likely virtual tracking (heapcache.py is_likely_virtual) ──
@@ -1964,7 +1979,7 @@ impl HeapCache {
         // would emit for a fresh call.  See `loopinvariant_resvalue` for
         // the rationale.
         Some((
-            self.loopinvariant_result?,
+            self.loopinvariant_result.as_ref()?.to_opref(),
             self.loopinvariant_resvalue.unwrap_or(0),
         ))
     }
@@ -1986,7 +2001,7 @@ impl HeapCache {
     ) {
         self.loopinvariant_descr = Some(descr_index);
         self.loopinvariant_arg0 = Some(arg0_int);
-        self.loopinvariant_result = Some(result);
+        self.loopinvariant_result = Some(BoxRef::from_opref(result));
         self.loopinvariant_resvalue = Some(resvalue);
     }
 


### PR DESCRIPTION
#108 

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal memory management system updated to improve garbage collection handling and reference tracking throughout the optimizer and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->