### PR TITLE
pickle: protocol support and interp-level _pickle accelerator (#163)

### DIFF
--- a/pyre/check.py
+++ b/pyre/check.py
@@ -26,17 +26,21 @@ PYPY3 = os.environ.get("PYRE_CHECK_PYPY3") or (
 )
 
 
-def _detect_cpython_stdlib():
-    """Stdlib directory of the CPython baseline (`PYTHON3`).
+def _detect_pyre_stdlib():
+    """Stdlib directory to pin pyre to.
 
-    pyre's native modules (`_sre`, ...) are coupled to one CPython version,
-    and pyre's own `detect_stdlib_path` falls back to a bare `python3` on
-    PATH. When several interpreters are on PATH (e.g. CI sets up CPython
-    then PyPy, whose `python3` then shadows it) that fallback can resolve
-    to a foreign stdlib; only the regex bench — the one pure-Python stdlib
-    import in the suite — then crashes. Resolve the baseline's own stdlib
-    so `pyre_env` can pin pyre to it.
+    pyre's native modules (`_sre`, ...) are coupled to one CPython version
+    via `_sre.MAGIC`; the vendored `lib-python/3` is the version-matched
+    copy. pyre's own `detect_stdlib_path` already resolves it through
+    `find_intree_stdlib`, but a host `python3` whose `re`/`_sre` MAGIC
+    disagrees (e.g. an older CPython on the dev PATH, or a PyPy that
+    shadows CPython on the CI PATH) would mismatch if reached. Pin the
+    vendored copy explicitly so the result is independent of PATH.
+    The host `python3` stdlib is only a last resort for an out-of-tree run.
     """
+    intree = Path(__file__).resolve().parent.parent / "lib-python" / "3"
+    if intree.is_dir():
+        return str(intree)
     try:
         proc = subprocess.run(
             [PYTHON3, "-c", "import sysconfig; print(sysconfig.get_paths()['stdlib'])"],
@@ -50,7 +54,7 @@ def _detect_cpython_stdlib():
     return path if path and os.path.isdir(path) else None
 
 
-PYRE_STDLIB = _detect_cpython_stdlib()
+PYRE_STDLIB = _detect_pyre_stdlib()
 
 BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
@@ -213,9 +217,9 @@ def pyre_env():
     env = dict(os.environ)
     env["MAJIT_STRICT"] = "1"
     env["MAJIT_STATS"] = "1"
-    # Pin the stdlib to the CPython baseline so pyre never auto-detects a
-    # foreign `python3` (e.g. a PyPy that shadows CPython on the CI PATH).
-    # An explicit PYRE_STDLIB in the environment wins.
+    # Pin the vendored, `_sre.MAGIC`-matched stdlib so pyre never picks up a
+    # version-mismatched host `python3` off the PATH. An explicit PYRE_STDLIB
+    # in the environment wins.
     if PYRE_STDLIB and "PYRE_STDLIB" not in env:
         env["PYRE_STDLIB"] = PYRE_STDLIB
     return env

--- a/pyre/extra_tests/snippets/_pickle_atoms.py
+++ b/pyre/extra_tests/snippets/_pickle_atoms.py
@@ -1,0 +1,42 @@
+# Direct test of the interp-level `_pickle` accelerator (increment 1):
+# protocol 2-5 atoms via Pickler/Unpickler over io.BytesIO.
+import io
+import _pickle
+
+
+def roundtrip(obj, proto):
+    buf = io.BytesIO()
+    _pickle.Pickler(buf, proto).dump(obj)
+    buf.seek(0)
+    return _pickle.Unpickler(buf).load()
+
+
+CASES = [
+    None, True, False,
+    0, 1, -1, 255, 256, 65535, 65536,
+    2 ** 31 - 1, -(2 ** 31), 2 ** 31, 2 ** 63, 2 ** 100, -(2 ** 100),
+    3.14, -0.0, 1e308,
+    "", "a", "hello", "유니코드",
+    b"", b"abc", b"\x00\xff" * 10,
+]
+
+for proto in range(2, 6):
+    for obj in CASES:
+        got = roundtrip(obj, proto)
+        assert got == obj, (proto, repr(obj), repr(got))
+        assert type(got) is type(obj), (proto, repr(obj), type(got), type(obj))
+
+# Wire-format lock — byte-identical to CPython 3.14.
+buf = io.BytesIO()
+_pickle.Pickler(buf, 4).dump(None)
+assert buf.getvalue() == b"\x80\x04N.", buf.getvalue()
+
+buf = io.BytesIO()
+_pickle.Pickler(buf, 4).dump("a")
+assert buf.getvalue() == b"\x80\x04\x95\x05\x00\x00\x00\x00\x00\x00\x00\x8c\x01a\x94.", buf.getvalue()
+
+buf = io.BytesIO()
+_pickle.Pickler(buf, 2).dump(1)
+assert buf.getvalue() == b"\x80\x02K\x01.", buf.getvalue()
+
+print("_pickle_atoms OK")

--- a/pyre/extra_tests/snippets/_pickle_containers.py
+++ b/pyre/extra_tests/snippets/_pickle_containers.py
@@ -1,0 +1,59 @@
+# Direct test of the interp-level `_pickle` accelerator (increments 2-3):
+# memo back-references plus the tuple / list / dict containers, including
+# APPENDS / SETITEMS batching, nesting, shared references and recursion.
+import io
+import _pickle
+
+
+def dumps(obj, proto):
+    buf = io.BytesIO()
+    _pickle.Pickler(buf, proto).dump(obj)
+    return buf.getvalue()
+
+
+def loads(data):
+    return _pickle.Unpickler(io.BytesIO(data)).load()
+
+
+def roundtrip(obj, proto):
+    got = loads(dumps(obj, proto))
+    assert got == obj, (proto, repr(obj), repr(got))
+    assert type(got) is type(obj), (proto, repr(obj), type(got), type(obj))
+    return got
+
+
+CASES = [
+    (), (1,), (1, 2), (1, 2, 3), (1, 2, 3, 4), (1, 2, 3, 4, 5),
+    [], [1, 2, 3], [1, [2, 3], 4],
+    {}, {1: 2}, {1: 2, 3: 4}, {"a": 1, "b": [1, 2, 3]},
+    [(1, 2), (3, 4)], {1: {2: {3: 4}}},
+    [None, True, False, 3.5, b"xy", "uv"],
+    list(range(2500)),                 # APPENDS batching (> _BATCHSIZE)
+    {i: i * i for i in range(2500)},   # SETITEMS batching
+]
+
+for proto in range(2, 6):
+    for obj in CASES:
+        roundtrip(obj, proto)
+
+# Shared reference: the same inner list is reachable twice by identity, so
+# the second reference must be a memo GET that the unpickler restores to the
+# same object.
+inner = [1, 2]
+outer = [inner, inner]
+got = loads(dumps(outer, 4))
+assert got == outer
+assert got[0] is got[1], "shared reference identity not preserved"
+
+# Recursive list: the memo lets the unpickler close the cycle.
+rec = []
+rec.append(rec)
+got = loads(dumps(rec, 4))
+assert got[0] is got, "recursive list not reconstructed"
+
+# Wire-format locks — byte-identical to CPython 3.14.
+assert dumps((1, 2, 3), 4) == b"\x80\x04\x95\x09\x00\x00\x00\x00\x00\x00\x00K\x01K\x02K\x03\x87\x94.", dumps((1, 2, 3), 4)
+assert dumps([1, 2, 3], 2) == b"\x80\x02]q\x00(K\x01K\x02K\x03e.", dumps([1, 2, 3], 2)
+assert dumps({1: 2}, 2) == b"\x80\x02}q\x00K\x01K\x02s.", dumps({1: 2}, 2)
+
+print("_pickle_containers OK")

--- a/pyre/extra_tests/snippets/_pickle_framing.py
+++ b/pyre/extra_tests/snippets/_pickle_framing.py
@@ -1,0 +1,71 @@
+# Direct test of the interp-level `_pickle` accelerator (increment 7,
+# framing): the multi-frame framer flushes a frame once it reaches the
+# 64 KiB target, and large bytes / str / bytearray payloads are written
+# outside any frame (write_large_bytes). Output is byte-identical to
+# CPython 3.14 (cross-checked via the FNV-1a checksum printed below).
+import io
+import _pickle
+
+
+def dumps(obj, proto):
+    buf = io.BytesIO()
+    _pickle.Pickler(buf, proto).dump(obj)
+    return buf.getvalue()
+
+
+def loads(data):
+    return _pickle.Unpickler(io.BytesIO(data)).load()
+
+
+def cksum(b):
+    h = 14695981039346656037
+    for x in b:
+        h = ((h ^ x) * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return h
+
+
+def report(tag, data):
+    print(tag, len(data), data.count(b"\x95"), cksum(data))
+
+
+# A pickle large enough to cross the 64 KiB frame target produces more than
+# one frame (FRAME opcode = 0x95).
+big_list = list(range(40000))
+data = dumps(big_list, 5)
+assert loads(data) == big_list
+assert data.count(b"\x95") >= 2, data.count(b"\x95")
+report("list5", data)
+
+# Large bytes (>= 64 KiB) are written outside any frame; the surrounding
+# stream still frames the PROTO/STOP scaffolding.
+big_bytes = bytes(range(256)) * 400
+data = dumps(big_bytes, 5)
+assert loads(data) == big_bytes
+report("bytes5", data)
+
+# Large str (>= 64 KiB) likewise.
+big_str = "abcd" * 25000
+data = dumps(big_str, 5)
+assert loads(data) == big_str
+report("str5", data)
+
+# Large bytearray (proto 5 raw form) likewise.
+big_ba = bytearray(bytes(range(256)) * 400)
+data = dumps(big_ba, 5)
+assert loads(data) == big_ba
+report("bytearray5", data)
+
+# Protocol 4 frames the same way (default proto 5 vs explicit 4 differ only
+# in the bytearray raw opcode availability).
+data = dumps(big_list, 4)
+assert loads(data) == big_list
+assert data.count(b"\x95") >= 2
+report("list4", data)
+
+# A small pickle is a single frame (or none below FRAME_SIZE_MIN).
+data = dumps([1, 2, 3], 5)
+assert loads(data) == [1, 2, 3]
+assert data.count(b"\x95") == 1
+report("small5", data)
+
+print("_pickle_framing OK")

--- a/pyre/extra_tests/snippets/_pickle_legacy.py
+++ b/pyre/extra_tests/snippets/_pickle_legacy.py
@@ -45,6 +45,15 @@ assert dumps([1, 2], 0) == b"(lp0\nI1\naI2\na.", dumps([1, 2], 0)
 assert dumps((1, 2), 0) == b"(I1\nI2\ntp0\n.", dumps((1, 2), 0)
 assert dumps({"a": 1}, 0) == b"(dp0\nVa\np1\nI1\ns.", dumps({"a": 1}, 0)
 
+# bytes / bytearray at protocol < 3 reduce through `_codecs.encode`; the global
+# reference resolves the encode function's `__module__` (`_codecs`), so the wire
+# is byte-identical to CPython 3.14.
+assert dumps(b"abc", 0) == b"c_codecs\nencode\np0\n(Vabc\np1\nVlatin1\np2\ntp3\nRp4\n.", dumps(b"abc", 0)
+assert dumps(b"abc", 1) == b"c_codecs\nencode\nq\x00(X\x03\x00\x00\x00abcq\x01X\x06\x00\x00\x00latin1q\x02tq\x03Rq\x04.", dumps(b"abc", 1)
+assert dumps(b"abc", 2) == b"\x80\x02c_codecs\nencode\nq\x00X\x03\x00\x00\x00abcq\x01X\x06\x00\x00\x00latin1q\x02\x86q\x03Rq\x04.", dumps(b"abc", 2)
+assert dumps(bytearray(b"abc"), 0) == b"c__builtin__\nbytearray\np0\n(c_codecs\nencode\np1\n(Vabc\np2\nVlatin1\np3\ntp4\nRp5\ntp6\nRp7\n.", dumps(bytearray(b"abc"), 0)
+assert dumps(bytearray(b"abc"), 2) == b"\x80\x02c__builtin__\nbytearray\nq\x00c_codecs\nencode\nq\x01X\x03\x00\x00\x00abcq\x02X\x06\x00\x00\x00latin1q\x03\x86q\x04Rq\x05\x85q\x06Rq\x07.", dumps(bytearray(b"abc"), 2)
+
 # fix_imports: at protocol < 3, range maps to the Python 2 __builtin__.xrange
 # global; protocol 3 keeps the canonical name. Both round-trip.
 assert dumps(range(5), 2) == (

--- a/pyre/extra_tests/snippets/_pickle_legacy.py
+++ b/pyre/extra_tests/snippets/_pickle_legacy.py
@@ -1,0 +1,86 @@
+# Direct test of the interp-level `_pickle` accelerator (increment 6):
+# protocol 0 / 1 legacy text opcodes (INT / LONG / FLOAT / UNICODE plus the
+# MARK-based LIST / DICT / TUPLE and text PUT / GET), persistent_id, and the
+# `_compat_pickle` fix_imports name mapping at protocol < 3.
+import io
+import _pickle
+
+
+def dumps(obj, proto):
+    buf = io.BytesIO()
+    _pickle.Pickler(buf, proto).dump(obj)
+    return buf.getvalue()
+
+
+def loads(data):
+    return _pickle.Unpickler(io.BytesIO(data)).load()
+
+
+def roundtrip(obj, proto):
+    got = loads(dumps(obj, proto))
+    assert got == obj, (proto, repr(obj), repr(got))
+    assert type(got) is type(obj), (proto, type(obj), type(got))
+    return got
+
+
+# Protocol 0 (text) and 1 (binary) atoms + containers round-trip.
+for proto in (0, 1):
+    for obj in [
+        None, True, False,
+        0, 1, -1, 255, 256, -256, 2 ** 31, -(2 ** 31), 2 ** 70, -(2 ** 70),
+        3.14, -2.5, 0.0, 1e300,
+        "", "abc", "héllo", "ünïcödé\n\ttab", "with\\backslash", "null\0byte",
+        [], [1, 2, 3], ["a", "b"],
+        (), (1,), (1, 2, 3), (1, 2, 3, 4),
+        {}, {"k": "v", "n": 1}, [[1, 2], [3, 4]], {"d": {"e": 1}},
+    ]:
+        roundtrip(obj, proto)
+
+# Protocol 0 wire is byte-identical to CPython 3.14 for these.
+assert dumps(1, 0) == b"I1\n.", dumps(1, 0)
+assert dumps(2 ** 70, 0) == b"L1180591620717411303424L\n.", dumps(2 ** 70, 0)
+assert dumps(2.5, 0) == b"F2.5\n.", dumps(2.5, 0)
+assert dumps("ab", 0) == b"Vab\np0\n.", dumps("ab", 0)
+assert dumps([1, 2], 0) == b"(lp0\nI1\naI2\na.", dumps([1, 2], 0)
+assert dumps((1, 2), 0) == b"(I1\nI2\ntp0\n.", dumps((1, 2), 0)
+assert dumps({"a": 1}, 0) == b"(dp0\nVa\np1\nI1\ns.", dumps({"a": 1}, 0)
+
+# fix_imports: at protocol < 3, range maps to the Python 2 __builtin__.xrange
+# global; protocol 3 keeps the canonical name. Both round-trip.
+assert dumps(range(5), 2) == (
+    b"\x80\x02c__builtin__\nxrange\nq\x00K\x00K\x05K\x01\x87q\x01Rq\x02."
+), dumps(range(5), 2)
+for proto in range(0, 6):
+    assert roundtrip(range(2, 10, 3), proto) == range(2, 10, 3)
+
+# Loading the Python 2 names directly also resolves through fix_imports.
+assert loads(b"\x80\x02c__builtin__\nxrange\nK\x00K\x03K\x01\x87R.") == range(3)
+
+
+# persistent_id / persistent_load via subclassing.
+_registry = {"shared": ["one", "two"]}
+
+
+class IdPickler(_pickle.Pickler):
+    def persistent_id(self, obj):
+        for key, value in _registry.items():
+            if value is obj:
+                return key
+        return None
+
+
+class IdUnpickler(_pickle.Unpickler):
+    def persistent_load(self, pid):
+        return _registry[pid]
+
+
+for proto in (0, 2, 5):
+    buf = io.BytesIO()
+    shared = _registry["shared"]
+    IdPickler(buf, proto).dump([shared, shared, "tail"])
+    got = IdUnpickler(io.BytesIO(buf.getvalue())).load()
+    assert got[0] is shared, (proto, "persistent_load object identity")
+    assert got[0] is got[1], (proto, "shared persistent reference")
+    assert got[2] == "tail", proto
+
+print("_pickle_legacy OK")

--- a/pyre/extra_tests/snippets/_pickle_memo.py
+++ b/pyre/extra_tests/snippets/_pickle_memo.py
@@ -1,0 +1,37 @@
+# A reused Pickler keeps its memo across dump() calls (until clear_memo),
+# so a second dump of the same object emits a back-reference rather than a
+# fresh copy, and the two unpickled objects share identity. clear_memo()
+# resets that. The Unpickler memo persists symmetrically across load() calls.
+import io
+import _pickle
+import pickle
+
+for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
+    shared = ["x", "y"]
+    buf = io.BytesIO()
+    p = _pickle.Pickler(buf, proto)
+    p.dump(shared)
+    len1 = buf.tell()
+    p.dump(shared)  # second dump should reference the memoized list
+    len2 = buf.tell() - len1
+    # The back-referenced second pickle is much smaller than the first.
+    assert len2 < len1, (proto, len1, len2)
+
+    # Load both from the same stream; identity is preserved across dumps.
+    buf.seek(0)
+    up = _pickle.Unpickler(buf)
+    a = up.load()
+    b = up.load()
+    assert a is b, (proto, "cross-dump identity lost")
+    assert a == ["x", "y"], (proto, a)
+
+    # clear_memo() makes the next dump independent (full copy again).
+    buf2 = io.BytesIO()
+    p2 = _pickle.Pickler(buf2, proto)
+    p2.dump(shared)
+    n1 = buf2.tell()
+    p2.clear_memo()
+    p2.dump(shared)
+    n2 = buf2.tell() - n1
+    # After clear_memo the object is serialized in full again.
+    assert n2 == n1, (proto, n1, n2)

--- a/pyre/extra_tests/snippets/_pickle_module.py
+++ b/pyre/extra_tests/snippets/_pickle_module.py
@@ -1,0 +1,88 @@
+# Increment 8 (THE FLIP): the top-level `pickle` module resolves
+# Pickler / Unpickler / dump / dumps / load / loads and the three error
+# classes from the interp-level `_pickle` accelerator. This exercises the
+# public `pickle` API end-to-end and cross-validates against CPython 3.14.
+import io
+
+try:
+    import pickle
+except (ImportError, AssertionError):
+    # `import pickle` pulls in `re`, whose `_sre.MAGIC` is asserted against
+    # the stdlib version. When PYRE_STDLIB is not pinned to the bundled 3.14
+    # stdlib (e.g. the bare extra_tests runner falling back to the host's
+    # older stdlib), that assertion fails before pickle loads. That is the
+    # same coupling as synth/sre_pattern_methods, not a pickle defect, so
+    # skip here; run with PYRE_STDLIB=lib-python/3 for the full check.
+    print("_pickle_module SKIP (stdlib re/_sre MAGIC mismatch)")
+    raise SystemExit(0)
+
+
+# All nine names come from the accelerator.
+for name in ("Pickler", "Unpickler", "dump", "dumps", "load", "loads"):
+    assert hasattr(pickle, name), name
+assert pickle.Pickler.__module__ == "_pickle", pickle.Pickler.__module__
+assert pickle.Unpickler.__module__ == "_pickle", pickle.Unpickler.__module__
+
+# The exception hierarchy: PicklingError / UnpicklingError subclass PickleError.
+assert issubclass(pickle.PicklingError, pickle.PickleError)
+assert issubclass(pickle.UnpicklingError, pickle.PickleError)
+assert issubclass(pickle.PickleError, Exception)
+
+# HIGHEST_PROTOCOL is 5 since 3.8; DEFAULT_PROTOCOL is 4 (<=3.13) or 5
+# (3.14). pyre and the 3.14 target use 5; the cross-check runner may run an
+# older host, so accept either rather than pinning the host version.
+assert pickle.HIGHEST_PROTOCOL == 5, pickle.HIGHEST_PROTOCOL
+assert pickle.DEFAULT_PROTOCOL in (4, 5), pickle.DEFAULT_PROTOCOL
+
+
+def roundtrip(obj, proto):
+    got = pickle.loads(pickle.dumps(obj, proto))
+    assert got == obj, (proto, repr(obj), repr(got))
+    assert type(got) is type(obj), (proto, type(obj), type(got))
+    return got
+
+
+samples = [
+    None, True, False, 0, 1, -1, 255, 2 ** 70, -(2 ** 70),
+    3.14, -0.0, 1e300,
+    "", "abc", "ünïcödé", b"", b"\x00\xff\x80",
+    [], [1, "two", 3.0], (), (1, 2, 3),
+    {}, {"k": "v", 1: [2, 3]},
+    bytearray(b"\x00\x01\x02"),
+]
+for proto in range(0, 6):
+    for obj in samples:
+        roundtrip(obj, proto)
+
+# dump / load through a file object (io.BytesIO).
+buf = io.BytesIO()
+pickle.dump({"x": [1, 2], "y": (3, 4)}, buf, 5)
+buf.seek(0)
+assert pickle.load(buf) == {"x": [1, 2], "y": (3, 4)}
+
+# Default protocol round-trips.
+assert pickle.loads(pickle.dumps(["default", 1, 2])) == ["default", 1, 2]
+
+# Shared-reference identity survives the public API.
+shared = [1, 2, 3]
+g = pickle.loads(pickle.dumps([shared, shared], 5))
+assert g[0] is g[1]
+
+# Protocol-0 wire is byte-identical to CPython 3.14 via the public API.
+assert pickle.dumps(1, 0) == b"I1\n.", pickle.dumps(1, 0)
+assert pickle.dumps([1, 2], 0) == b"(lp0\nI1\naI2\na.", pickle.dumps([1, 2], 0)
+
+# An invalid opcode raises UnpicklingError.
+try:
+    pickle.loads(b"\xff.")
+    raise AssertionError("expected UnpicklingError")
+except pickle.UnpicklingError:
+    pass
+
+# A buffer_callback that is never invoked (no PickleBuffer values present)
+# leaves pickling unchanged, exactly as in CPython.
+calls = []
+assert pickle.loads(pickle.dumps(b"data", 5, buffer_callback=calls.append)) == b"data"
+assert calls == []
+
+print("_pickle_module OK")

--- a/pyre/extra_tests/snippets/_pickle_module.py
+++ b/pyre/extra_tests/snippets/_pickle_module.py
@@ -85,4 +85,16 @@ calls = []
 assert pickle.loads(pickle.dumps(b"data", 5, buffer_callback=calls.append)) == b"data"
 assert calls == []
 
+# Protocol-5 out-of-band buffers via the public API: PickleBuffer resolves
+# from the accelerator and round-trips through buffer_callback / buffers.
+assert pickle._HAVE_PICKLE_BUFFER
+assert pickle.PickleBuffer is not None
+bufs = []
+pb_data = pickle.dumps(pickle.PickleBuffer(b"oob payload"), 5,
+                       buffer_callback=lambda b: bufs.append(b) or False)
+assert len(bufs) == 1
+restored = pickle.loads(pb_data, buffers=[b"oob payload"])
+restored = restored if isinstance(restored, (bytes, bytearray)) else restored.tobytes()
+assert restored == b"oob payload", restored
+
 print("_pickle_module OK")

--- a/pyre/extra_tests/snippets/_pickle_objects.py
+++ b/pyre/extra_tests/snippets/_pickle_objects.py
@@ -1,0 +1,112 @@
+# Direct test of the interp-level `_pickle` accelerator (increment 5):
+# the reduce protocol — arbitrary objects (`__dict__`, `__slots__`,
+# `__getstate__` / `__setstate__`, `__reduce__`), classes by reference,
+# shared-instance identity, and the protocol < 3 `codecs.encode` bytes
+# reduce. Instance pickles are not byte-identical to CPython (string
+# interning of qualnames differs), so this asserts roundtrip + type, not
+# the wire.
+import io
+import _pickle
+
+
+def dumps(obj, proto):
+    buf = io.BytesIO()
+    _pickle.Pickler(buf, proto).dump(obj)
+    return buf.getvalue()
+
+
+def loads(data):
+    return _pickle.Unpickler(io.BytesIO(data)).load()
+
+
+def roundtrip(obj, proto):
+    got = loads(dumps(obj, proto))
+    assert got == obj, (proto, repr(obj), repr(got))
+    assert type(got) is type(obj), (proto, type(obj), type(got))
+    return got
+
+
+class Plain:
+    def __init__(self, x=0, y=0):
+        self.x = x
+        self.y = y
+
+    def __eq__(self, o):
+        return type(self) is type(o) and self.__dict__ == o.__dict__
+
+
+class Slotted:
+    __slots__ = ("a", "b")
+
+    def __init__(self, a=0, b=0):
+        self.a = a
+        self.b = b
+
+    def __eq__(self, o):
+        return type(self) is type(o) and self.a == o.a and self.b == o.b
+
+
+class Mixed:
+    __slots__ = ("s", "__dict__")
+
+    def __init__(self, s=0, d=0):
+        self.s = s
+        self.d = d
+
+    def __eq__(self, o):
+        return type(self) is type(o) and self.s == o.s and self.d == o.d
+
+
+class WithState:
+    def __init__(self, v=0):
+        self.v = v
+        self.cache = None
+
+    def __getstate__(self):
+        return {"v": self.v}
+
+    def __setstate__(self, st):
+        self.v = st["v"]
+        self.cache = "rebuilt"
+
+    def __eq__(self, o):
+        return type(self) is type(o) and self.v == o.v
+
+
+class WithReduce:
+    def __init__(self, n):
+        self.n = n
+
+    def __reduce__(self):
+        return (WithReduce, (self.n,))
+
+    def __eq__(self, o):
+        return type(self) is type(o) and self.n == o.n
+
+
+for proto in range(2, 6):
+    roundtrip(Plain(1, 2), proto)
+    roundtrip(Slotted(3, 4), proto)
+    roundtrip(Mixed(5, 6), proto)
+    roundtrip(WithReduce(9), proto)
+
+    # __setstate__ side-effect runs on load.
+    g = roundtrip(WithState(7), proto)
+    assert g.cache == "rebuilt", (proto, g.cache)
+
+    # classes pickle by reference.
+    assert loads(dumps(Plain, proto)) is Plain, proto
+
+    # nested containers + shared-instance identity.
+    pt = Plain(3, 4)
+    g = roundtrip([pt, pt, {"k": Slotted(5, 6)}], proto)
+    assert g[0] is g[1], (proto, "shared identity lost")
+
+# protocol 2 routes bytes through the `codecs.encode(s, 'latin1')` reduce.
+assert loads(dumps(b"\x00\xff\x80", 2)) == b"\x00\xff\x80"
+
+# range reduces to `range(start, stop, step)` and roundtrips at all protos.
+for proto in range(2, 6):
+    assert roundtrip(range(2, 10, 3), proto) == range(2, 10, 3)
+
+print("_pickle_objects OK")

--- a/pyre/extra_tests/snippets/_pickle_objects.py
+++ b/pyre/extra_tests/snippets/_pickle_objects.py
@@ -109,4 +109,33 @@ assert loads(dumps(b"\x00\xff\x80", 2)) == b"\x00\xff\x80"
 for proto in range(2, 6):
     assert roundtrip(range(2, 10, 3), proto) == range(2, 10, 3)
 
+
+# __getnewargs_ex__ with keyword args forces NEWOBJ_EX (proto >= 4) carrying
+# a non-empty kwargs dict; the unpickler must call cls.__new__(cls, *a, **kw).
+# A class-level sink records what __new__ received (the __dict__ state then
+# overwrites the instance attrs, so the sink is the only witness of kwargs).
+class NewArgsEx:
+    seen = []
+
+    def __new__(cls, *args, **kwargs):
+        cls.seen.append((args, dict(kwargs)))
+        return super().__new__(cls)
+
+    def __init__(self, a=0, b=0):
+        self.a = a
+        self.b = b
+
+    def __getnewargs_ex__(self):
+        return ((self.a,), {"b": self.b})
+
+    def __eq__(self, o):
+        return type(self) is type(o) and self.a == o.a and self.b == o.b
+
+
+for proto in range(4, 6):
+    NewArgsEx.seen.clear()
+    roundtrip(NewArgsEx(1, 2), proto)
+    # The load-time __new__ got the keyword arg from __getnewargs_ex__.
+    assert ((1,), {"b": 2}) in NewArgsEx.seen, (proto, NewArgsEx.seen)
+
 print("_pickle_objects OK")

--- a/pyre/extra_tests/snippets/_pickle_objects.py
+++ b/pyre/extra_tests/snippets/_pickle_objects.py
@@ -110,10 +110,12 @@ for proto in range(2, 6):
     assert roundtrip(range(2, 10, 3), proto) == range(2, 10, 3)
 
 
-# __getnewargs_ex__ with keyword args forces NEWOBJ_EX (proto >= 4) carrying
-# a non-empty kwargs dict; the unpickler must call cls.__new__(cls, *a, **kw).
-# A class-level sink records what __new__ received (the __dict__ state then
-# overwrites the instance attrs, so the sink is the only witness of kwargs).
+# __getnewargs_ex__ with keyword args: protocol >= 4 emits NEWOBJ_EX with a
+# non-empty kwargs dict; protocols 2/3 encode the constructor as
+# partial(cls.__new__, cls, *args, **kwargs). Either way the unpickler must end
+# up calling cls.__new__(cls, *a, **kw). A class-level sink records what __new__
+# received (the __dict__ state then overwrites the instance attrs, so the sink
+# is the only witness of kwargs).
 class NewArgsEx:
     seen = []
 
@@ -132,7 +134,7 @@ class NewArgsEx:
         return type(self) is type(o) and self.a == o.a and self.b == o.b
 
 
-for proto in range(4, 6):
+for proto in range(2, 6):
     NewArgsEx.seen.clear()
     roundtrip(NewArgsEx(1, 2), proto)
     # The load-time __new__ got the keyword arg from __getnewargs_ex__.

--- a/pyre/extra_tests/snippets/_pickle_oob.py
+++ b/pyre/extra_tests/snippets/_pickle_oob.py
@@ -1,0 +1,111 @@
+# Increment 7b: protocol-5 out-of-band buffers. A `PickleBuffer` wrapping a
+# bytes-like object serializes in-band by default (BINBYTES for a read-only
+# buffer, BYTEARRAY8 for a mutable one, both memoized) and out-of-band when a
+# `buffer_callback` returns a false value (NEXT_BUFFER, plus READONLY_BUFFER
+# for a read-only buffer). The wire format is byte-identical to CPython 3.14.
+import io
+
+# pyre exposes PickleBuffer through `__pypy__` and the accelerator as
+# `_pickle`; avoid `import pickle` here so the test does not depend on the
+# bundled stdlib (re/_sre) being pinned. CPython has neither `__pypy__` nor a
+# stdlib-free `_pickle.PickleBuffer`, so fall back to the public `pickle`.
+try:
+    from __pypy__ import PickleBuffer
+    import _pickle as P
+except ImportError:
+    import pickle as P
+    PickleBuffer = P.PickleBuffer
+
+Pickler, Unpickler = P.Pickler, P.Unpickler
+
+
+def dumps(obj, proto, **kw):
+    b = io.BytesIO()
+    Pickler(b, proto, **kw).dump(obj)
+    return b.getvalue()
+
+
+def loads(data, **kw):
+    return Unpickler(io.BytesIO(data), **kw).load()
+
+
+def as_bytes(x):
+    if isinstance(x, (bytes, bytearray)):
+        return bytes(x)
+    return x.tobytes()  # memoryview
+
+
+# In-band read-only buffer round-trips through BINBYTES (no NEXT_BUFFER).
+d = dumps(PickleBuffer(b"hello readonly"), 5)
+assert 0x97 not in d
+assert as_bytes(loads(d)) == b"hello readonly"
+
+# In-band mutable buffer round-trips through BYTEARRAY8.
+d = dumps(PickleBuffer(bytearray(b"hello mutable")), 5)
+assert 0x97 not in d
+r = loads(d)
+assert isinstance(r, bytearray) and as_bytes(r) == b"hello mutable"
+
+# Out-of-band read-only: callback returns a false value -> NEXT_BUFFER and
+# READONLY_BUFFER, callback invoked exactly once, data not in the stream.
+collected = []
+orig = b"out of band readonly data"
+d = dumps(PickleBuffer(orig), 5, buffer_callback=lambda b: collected.append(b) or False)
+assert 0x97 in d and 0x98 in d
+assert len(collected) == 1
+assert as_bytes(loads(d, buffers=[orig])) == orig
+
+# Out-of-band mutable: NEXT_BUFFER without READONLY_BUFFER.
+collected = []
+orig_m = bytearray(b"out of band mutable data")
+d = dumps(PickleBuffer(orig_m), 5, buffer_callback=lambda b: collected.append(b) or False)
+assert 0x97 in d and 0x98 not in d
+assert as_bytes(loads(d, buffers=[orig_m])) == bytes(orig_m)
+
+# A callback returning a true value keeps the buffer in-band.
+collected = []
+d = dumps(PickleBuffer(b"inband via callback"), 5, buffer_callback=lambda b: collected.append(b) or True)
+assert 0x97 not in d
+assert len(collected) == 1
+assert as_bytes(loads(d)) == b"inband via callback"
+
+# Shared identity: a PickleBuffer saved in-band twice memoizes (GET back-ref).
+pb = PickleBuffer(b"shared")
+g = loads(dumps([pb, pb], 5))
+assert as_bytes(g[0]) == b"shared" and as_bytes(g[1]) == b"shared"
+assert g[0] is g[1]
+
+# PickleBuffer requires protocol >= 5.
+try:
+    dumps(PickleBuffer(b"x"), 4)
+    raise AssertionError("expected error for protocol < 5")
+except Exception as e:
+    assert "protocol >= 5" in str(e), str(e)
+
+# buffer_callback requires protocol >= 5.
+try:
+    dumps(b"x", 4, buffer_callback=lambda b: None)
+    raise AssertionError("expected ValueError for buffer_callback < proto 5")
+except ValueError as e:
+    assert "protocol >= 5" in str(e), str(e)
+
+# An out-of-band stream cannot be loaded without a *buffers* argument.
+collected = []
+d = dumps(PickleBuffer(b"needs buffers"), 5, buffer_callback=lambda b: collected.append(b) or False)
+try:
+    loads(d)
+    raise AssertionError("expected error for missing buffers")
+except Exception as e:
+    assert "out-of-band" in str(e), str(e)
+
+# raw() exposes a memoryview onto the wrapped buffer; release() invalidates it.
+pb = PickleBuffer(b"raw bytes")
+assert as_bytes(pb.raw()) == b"raw bytes"
+pb.release()
+try:
+    pb.raw()
+    raise AssertionError("expected error after release")
+except (ValueError, Exception):
+    pass
+
+print("_pickle_oob OK")

--- a/pyre/extra_tests/snippets/_pickle_sets.py
+++ b/pyre/extra_tests/snippets/_pickle_sets.py
@@ -1,0 +1,41 @@
+# Direct test of the interp-level `_pickle` accelerator (increment 4):
+# set / frozenset (protocol >= 4) and bytearray (protocol >= 5).
+import io
+import _pickle
+
+
+def dumps(obj, proto):
+    buf = io.BytesIO()
+    _pickle.Pickler(buf, proto).dump(obj)
+    return buf.getvalue()
+
+
+def loads(data):
+    return _pickle.Unpickler(io.BytesIO(data)).load()
+
+
+def roundtrip(obj, proto):
+    got = loads(dumps(obj, proto))
+    assert got == obj, (proto, repr(obj), repr(got))
+    assert type(got) is type(obj), (proto, repr(obj), type(got), type(obj))
+    return got
+
+
+for proto in (4, 5):
+    for obj in [
+        set(), {1}, {1, 2, 3}, {1, 2, 3, "x", "y"},
+        frozenset(), frozenset({1, 2, 3}), frozenset({(1, 2), (3, 4)}),
+        set(range(2500)),                  # ADDITEMS batching (> _BATCHSIZE)
+        [{1, 2}, {3, 4}], {"s": {1, 2, 3}},
+    ]:
+        roundtrip(obj, proto)
+
+# bytearray is ordered, so its protocol-5 form is byte-identical to CPython.
+for obj in [bytearray(b""), bytearray(b"hello\x00\xff"), bytearray(range(256))]:
+    roundtrip(obj, 5)
+
+assert dumps(bytearray(b"hi"), 5) == (
+    b"\x80\x05\x95\x0d\x00\x00\x00\x00\x00\x00\x00\x96\x02\x00\x00\x00\x00\x00\x00\x00hi\x94."
+), dumps(bytearray(b"hi"), 5)
+
+print("_pickle_sets OK")

--- a/pyre/extra_tests/snippets/builtin_bytes_truthiness.py
+++ b/pyre/extra_tests/snippets/builtin_bytes_truthiness.py
@@ -1,0 +1,23 @@
+assert bool(b"") is False
+assert bool(bytearray()) is False
+assert bool(b"x") is True
+assert bool(bytearray(b"x")) is True
+assert (not b"") is True
+assert (not bytearray()) is True
+# used in conditionals (exercise the JIT conditional-jump path too)
+def f(x):
+    if x:
+        return "truthy"
+    return "falsy"
+assert f(b"") == "falsy"
+assert f(bytearray()) == "falsy"
+assert f(b"ab") == "truthy"
+# while-loop consume (Unpickler-style): truthiness drives loop exit at empty
+buf = bytearray(b"abc"); seen = []
+while buf:
+    seen.append(buf.pop(0))
+assert seen == [97, 98, 99], seen
+# regression: other empties stay correct
+for v in ["", [], (), {}, set(), 0, 0.0]:
+    assert bool(v) is False, v
+print("builtin_bytes_truthiness OK")

--- a/pyre/extra_tests/snippets/module_type.py
+++ b/pyre/extra_tests/snippets/module_type.py
@@ -1,0 +1,51 @@
+# The `module` type is a real, registered type object: `type(m)` is a
+# class (not the bare name string), instances carry `object`-inherited
+# introspection, `module(name)` builds a working module, and pickling a
+# module is refused at every protocol (its native name/dict payload
+# cannot be reconstructed via `__newobj__`).
+import sys
+import types
+import pickle
+
+m = sys.modules["sys"]
+M = type(m)
+
+# A real type, not a string.
+assert M is types.ModuleType, M
+assert type(M) is type, type(M)
+assert M.__name__ == "module", M.__name__
+assert isinstance(m, object)
+assert m.__class__ is M
+
+# `module` defines its own `__new__` (its tp_new is not object's).
+assert M.__new__ is not object.__new__
+
+# Inherited object introspection resolves.
+assert hasattr(m, "__reduce_ex__")
+assert hasattr(m, "__dict__")
+assert not (M.__flags__ & (1 << 7))  # module is instantiable, not DISALLOW
+
+# Attribute access on a live module still works.
+assert m.path is sys.path
+
+# `module(name, doc=None)` builds a real, usable module.
+fresh = M("fresh", "the docstring")
+assert type(fresh) is M
+assert fresh.__name__ == "fresh"
+assert fresh.__doc__ == "the docstring"
+assert fresh.__spec__ is None
+assert repr(fresh) == "<module 'fresh'>", repr(fresh)
+fresh.value = 42
+assert fresh.value == 42
+assert vars(fresh)["value"] == 42
+
+# A module cannot be pickled at any protocol.
+for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+    try:
+        pickle.dumps(m, proto)
+    except TypeError as e:
+        assert str(e) == "cannot pickle 'module' object", str(e)
+    else:
+        raise AssertionError(("module should not pickle", proto))
+
+print("module_type OK")

--- a/pyre/extra_tests/snippets/pickle_dictiter.py
+++ b/pyre/extra_tests/snippets/pickle_dictiter.py
@@ -1,0 +1,13 @@
+d = {"a": 1, "b": 2, "c": 3}
+assert iter(d.keys()).__reduce__() == (iter, (["a", "b", "c"],)), iter(d.keys()).__reduce__()
+assert iter(d.keys()).__length_hint__() == 3
+ki = iter(d.keys())
+next(ki)
+assert ki.__reduce__() == (iter, (["b", "c"],))
+assert iter(d.values()).__reduce__() == (iter, ([1, 2, 3],))
+assert iter(d.items()).__reduce__() == (iter, ([("a", 1), ("b", 2), ("c", 3)],))
+import pickle
+ki = iter(d.keys())
+next(ki)
+assert list(pickle.loads(pickle.dumps(ki))) == ["b", "c"]
+print("pickle_dictiter OK")

--- a/pyre/extra_tests/snippets/pickle_disallow.py
+++ b/pyre/extra_tests/snippets/pickle_disallow.py
@@ -1,0 +1,70 @@
+# `Py_TPFLAGS_DISALLOW_INSTANTIATION` (1 << 7): a generator's type has a
+# NULL `tp_new`, so `generator()` raises `cannot create 'generator'
+# instances` and pickling raises `cannot pickle 'generator' object` at
+# every protocol.  A generator is only ever produced by calling a
+# generator function.
+import io
+import pickle
+import _pickle
+
+DISALLOW = 1 << 7
+
+
+def gen():
+    yield 1
+
+
+g = gen()
+G = type(g)
+
+# The flag is exposed through `__flags__`.
+assert G.__flags__ & DISALLOW, hex(G.__flags__)
+
+# Direct instantiation is refused.
+try:
+    G()
+except TypeError as e:
+    assert str(e) == "cannot create 'generator' instances", str(e)
+else:
+    raise AssertionError("generator() should raise")
+
+# Pickling is refused at every protocol, through both the bound
+# `__reduce_ex__` and the full pickler paths.
+for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+    try:
+        gen().__reduce_ex__(proto)
+    except TypeError as e:
+        assert str(e) == "cannot pickle 'generator' object", str(e)
+    else:
+        raise AssertionError(("__reduce_ex__ should raise", proto))
+
+try:
+    pickle.dumps(gen())
+except TypeError as e:
+    assert str(e) == "cannot pickle 'generator' object", str(e)
+else:
+    raise AssertionError("pickle.dumps(gen) should raise")
+
+try:
+    buf = io.BytesIO()
+    _pickle.Pickler(buf, 2).dump(gen())
+except TypeError as e:
+    assert str(e) == "cannot pickle 'generator' object", str(e)
+else:
+    raise AssertionError("_pickle.Pickler.dump(gen) should raise")
+
+# The flag does not leak: a generator still iterates, and ordinary
+# classes remain instantiable and picklable.
+assert list(gen()) == [1]
+
+
+class C:
+    def __init__(self):
+        self.x = 1
+
+
+assert not (C.__flags__ & DISALLOW)
+assert C().x == 1
+assert pickle.loads(pickle.dumps(C())).x == 1
+
+print("pickle_disallow OK")

--- a/pyre/extra_tests/snippets/pickle_enumerate.py
+++ b/pyre/extra_tests/snippets/pickle_enumerate.py
@@ -1,0 +1,13 @@
+e = enumerate([10, 20, 30])
+r = e.__reduce__()
+assert r[0] is enumerate and r[1][1] == 0 and list(r[1][0]) == [10, 20, 30], r
+e = enumerate([10, 20, 30])
+next(e)
+assert e.__reduce__()[1][1] == 1
+import pickle
+e = enumerate([10, 20, 30])
+next(e)
+assert list(pickle.loads(pickle.dumps(e))) == [(1, 20), (2, 30)]
+e = enumerate([10, 20], start=5)
+assert e.__reduce__()[1][1] == 5
+print("pickle_enumerate OK")

--- a/pyre/extra_tests/snippets/pickle_import.py
+++ b/pyre/extra_tests/snippets/pickle_import.py
@@ -1,0 +1,12 @@
+# C1: stdlib copyreg.py is visible and pickle imports.
+import copyreg
+assert hasattr(copyreg, "_extension_registry"), "copyreg._extension_registry missing"
+assert hasattr(copyreg, "_inverted_registry"), "copyreg._inverted_registry missing"
+assert hasattr(copyreg, "_extension_cache"), "copyreg._extension_cache missing"
+assert hasattr(copyreg, "__newobj__"), "copyreg.__newobj__ missing"
+assert hasattr(copyreg, "_reconstructor"), "copyreg._reconstructor missing"
+assert callable(copyreg._reduce_ex), "copyreg._reduce_ex missing"
+
+import pickle
+assert hasattr(pickle, "dumps") and hasattr(pickle, "loads")
+print("pickle_import OK")

--- a/pyre/extra_tests/snippets/pickle_instances.py
+++ b/pyre/extra_tests/snippets/pickle_instances.py
@@ -1,0 +1,18 @@
+import pickle
+class C:
+    def __init__(self, x): self.x = x
+    def __eq__(self, o): return type(self) is type(o) and self.x == o.x
+class S:
+    __slots__ = ("a",)
+    def __init__(self, a): self.a = a
+    def __eq__(self, o): return type(self) is type(o) and self.a == o.a
+for proto in range(0, 6):
+    assert pickle.loads(pickle.dumps(C(42), proto)) == C(42)
+    assert pickle.loads(pickle.dumps(C([1,2]), proto)) == C([1,2])
+    nested = C(C(C(1)))
+    assert pickle.loads(pickle.dumps(nested, proto)).x.x.x == 1
+# A __slots__ class without a custom __getstate__ can only be pickled at
+# protocol >= 2 (copyreg._reduce_ex raises for protocols 0 and 1).
+for proto in range(2, 6):
+    assert pickle.loads(pickle.dumps(S(7), proto)) == S(7)
+print("pickle_instances OK")

--- a/pyre/extra_tests/snippets/pickle_io_prereq.py
+++ b/pyre/extra_tests/snippets/pickle_io_prereq.py
@@ -1,0 +1,48 @@
+import io
+
+# io.UnsupportedOperation is a real (OSError, ValueError) exception class
+# with a settable __module__ (io.py:78 assigns it), usable in raise/except.
+assert isinstance(io.UnsupportedOperation, type), io.UnsupportedOperation
+assert issubclass(io.UnsupportedOperation, OSError)
+assert issubclass(io.UnsupportedOperation, ValueError)
+assert io.UnsupportedOperation.__module__ == "io", io.UnsupportedOperation.__module__
+try:
+    raise io.UnsupportedOperation("nope")
+except ValueError as e:
+    assert isinstance(e, io.UnsupportedOperation)
+    assert isinstance(e, OSError)
+
+# io.BlockingIOError resolves to the builtin BlockingIOError.
+assert io.BlockingIOError is BlockingIOError
+
+# io.BytesIO is a working in-memory binary stream.
+b = io.BytesIO()
+b.write(b"hello"); b.write(b" world")
+assert b.getvalue() == b"hello world", b.getvalue()
+assert b.tell() == 11
+b.seek(0)
+assert b.read(5) == b"hello"
+assert b.readline() == b" world"
+b2 = io.BytesIO(b"abc")
+assert b2.read() == b"abc"
+assert b2.read() == b""
+b3 = io.BytesIO()
+b3.write(b"line1\nline2\n")
+b3.seek(0)
+assert list(b3) == [b"line1\n", b"line2\n"]
+
+# Negative-bound slice assignment (STORE_SLICE) — used by pickle's
+# _Unpickler.load_tuple3 (`self.stack[-3:] = [...]`).
+lst = [1, 2, 3, 4, 5]
+lst[-3:] = [(lst[-3], lst[-2], lst[-1])]
+assert lst == [1, 2, (3, 4, 5)], lst
+lst2 = [1, 2, 3, 4, 5]
+lst2[-3:-1] = [9]
+assert lst2 == [1, 2, 9, 5], lst2
+
+# import pickle (pure-Python module) now succeeds: the _io exception
+# fixes let `import io` import, and the chain through `import re` works.
+import pickle
+assert pickle is not None
+
+print("pickle_io_prereq OK")

--- a/pyre/extra_tests/snippets/pickle_iterators_roundtrip.py
+++ b/pyre/extra_tests/snippets/pickle_iterators_roundtrip.py
@@ -1,0 +1,31 @@
+# Protocol-sweep round-trip for the iterator reducers: every iterator
+# family is advanced past its first element(s), pickled, and unpickled at
+# each protocol 0-5, then must resume at the saved position.  Complements
+# pickle_roundtrip.py (which pins the exact reduce shapes at the default
+# protocol) by exercising the full protocol range, including the text
+# protocols 0/1 that route through copyreg._reduce_ex.
+import pickle
+from itertools import islice
+
+
+def resume(make, advance, proto):
+    it = make()
+    for _ in range(advance):
+        next(it)
+    return pickle.loads(pickle.dumps(it, proto))
+
+
+# every finite iterator family resumes at its saved position across protocols
+for proto in range(0, 6):
+    assert list(resume(lambda: iter([1, 2, 3, 4]), 2, proto)) == [3, 4], proto
+    assert list(resume(lambda: iter((1, 2, 3, 4)), 1, proto)) == [2, 3, 4], proto
+    assert list(resume(lambda: iter("abcd"), 3, proto)) == ["d"], proto
+    assert list(resume(lambda: iter(range(5)), 2, proto)) == [2, 3, 4], proto
+    assert list(resume(lambda: iter({"a": 1, "b": 2}.keys()), 1, proto)) == ["b"], proto
+    assert list(resume(lambda: enumerate([10, 20, 30]), 1, proto)) == [(1, 20), (2, 30)], proto
+    # long-range iterator: a 10**30-element range stays lazy, so take the
+    # first few with islice rather than materialising the whole thing.
+    big = resume(lambda: iter(range(10 ** 30)), 2, proto)
+    assert list(islice(big, 3)) == [2, 3, 4], proto
+
+print("pickle_iterators_roundtrip OK")

--- a/pyre/extra_tests/snippets/pickle_pypy_module.py
+++ b/pyre/extra_tests/snippets/pickle_pypy_module.py
@@ -1,0 +1,22 @@
+from __pypy__ import identity_dict
+from __pypy__.builders import BytesBuilder
+d = identity_dict()
+a = [1, 2]; b = [1, 2]          # equal but distinct objects
+d[a] = ("idx_a", a)
+assert a in d and b not in d     # identity, not equality
+assert d.get(a)[0] == "idx_a"
+assert len(d) == 1
+bb = BytesBuilder(); bb.append(b"ab"); bb.append(b"cd")
+assert bb.build() == b"abcd" and len(bb) == 4
+
+import pickle
+for proto in range(0, 6):
+    for x in [[1, [2, 3]], {"a": 1, "b": [2]}, {1, 2, 3},
+              (1, [2], {3: 4}), [[], {}, ()], {"self": None}]:
+        got = pickle.loads(pickle.dumps(x, proto))
+        assert got == x, f"proto={proto} {x!r} -> {got!r}"
+# recursive structure (memo must handle cycles by identity)
+lst = [1]; lst.append(lst)
+out = pickle.loads(pickle.dumps(lst))
+assert out[0] == 1 and out[1] is out
+print("pickle_pypy_module OK")

--- a/pyre/extra_tests/snippets/pickle_rangeiter.py
+++ b/pyre/extra_tests/snippets/pickle_rangeiter.py
@@ -1,0 +1,17 @@
+assert iter(range(3)).__reduce__() == (iter, (range(0, 3),), None)
+assert iter(range(3)).__length_hint__() == 3
+it = iter(range(10))
+next(it)
+next(it)
+next(it)
+assert it.__reduce__() == (iter, (range(3, 10),), None), it.__reduce__()
+assert it.__length_hint__() == 7
+big = 10 ** 30
+assert iter(range(big)).__reduce__() == (iter, (range(0, big),), None)
+assert iter(range(big)).__length_hint__() == big
+assert reversed(range(3)).__reduce__() == (iter, (range(2, -1, -1),), None)
+import pickle
+it = iter(range(5))
+next(it)
+assert list(pickle.loads(pickle.dumps(it))) == [1, 2, 3, 4]
+print("pickle_rangeiter OK")

--- a/pyre/extra_tests/snippets/pickle_reduce.py
+++ b/pyre/extra_tests/snippets/pickle_reduce.py
@@ -1,0 +1,23 @@
+import copyreg, pickle
+class C:
+    def __init__(self): self.x = 1
+r = C().__reduce_ex__(2)
+assert r[0] is copyreg.__newobj__ and r[1] == (C,) and r[2] == {"x": 1} and r[3] is None and r[4] is None, r
+r = (1, 2).__reduce_ex__(2)
+assert r[0] is copyreg.__newobj__ and r[1] == (tuple, (1, 2)) and r[2] is None, r
+r = C().__reduce_ex__(0)
+assert r[0] is copyreg._reconstructor and r[1] == (C, object, None) and r[2] == {"x": 1}, r
+assert C().__reduce__()[0] is copyreg._reconstructor
+assert C().__getstate__() == {"x": 1}
+class Empty: pass
+assert Empty().__getstate__() is None and object().__getstate__() is None
+class S:
+    __slots__ = ("a", "b")
+    def __init__(self): self.a = 1; self.b = 2
+assert S().__reduce_ex__(2)[2] == (None, {"a": 1, "b": 2}), S().__reduce_ex__(2)
+assert (1,2).__getnewargs__() == ((1,2),) and (5).__getnewargs__() == (5,) and "ab".__getnewargs__() == ("ab",)
+try:
+    (1, 2).__reduce_ex__(0); raise AssertionError("expected TypeError")
+except TypeError as e:
+    assert "cannot pickle" in str(e), e
+print("pickle_reduce OK")

--- a/pyre/extra_tests/snippets/pickle_roundtrip.py
+++ b/pyre/extra_tests/snippets/pickle_roundtrip.py
@@ -1,0 +1,88 @@
+# Consolidated pickle round-trip verification for the iterator reducers.
+# Non-divergent iterators reconstruct to the exact CPython 3.14 shape;
+# map/filter/zip/set/reversed-of-sequence materialise to list_iterator
+# (a documented divergence) but still round-trip their remaining items.
+#
+# Each object is round-tripped once at the default protocol (plus the big
+# int at protocol 0, which exercises the text LONG opcode).  The exact
+# reduce shapes are pinned by pickle_{seqiter,rangeiter,dictiter,enumerate}.
+import pickle
+
+
+def _double(x):
+    return x * 2
+
+
+def _is_even(x):
+    return x % 2 == 0
+
+
+def rt(obj):
+    return pickle.loads(pickle.dumps(obj))
+
+
+# --- sequence iterators (list / tuple / str / bytes) ---
+for seq in ([1, 2, 3, 4], (10, 20, 30), "abcd", b"wxyz"):
+    it = iter(seq)
+    next(it)
+    assert list(rt(it)) == list(seq)[1:], seq
+
+# --- range iterator (small) ---
+it = iter(range(10))
+for _ in range(3):
+    next(it)
+assert list(rt(it)) == list(range(3, 10))
+
+# --- long-range iterator + the proto-0 text LONG path for big ints ---
+big = 10 ** 40
+it = iter(range(big))
+next(it)
+next(it)
+r = rt(it)
+assert next(r) == 2 and next(r) == 3
+assert pickle.loads(pickle.dumps(big, 0)) == big
+assert pickle.loads(pickle.dumps(-big, 0)) == -big
+
+# --- dict view iterators ---
+d = {"a": 1, "b": 2, "c": 3}
+ki = iter(d.keys()); next(ki)
+assert list(rt(ki)) == ["b", "c"]
+vi = iter(d.values()); next(vi)
+assert list(rt(vi)) == [2, 3]
+ii = iter(d.items()); next(ii)
+assert list(rt(ii)) == [("b", 2), ("c", 3)]
+
+# --- enumerate (default start, list source) ---
+e = enumerate([10, 20, 30])
+next(e)
+assert list(rt(e)) == [(1, 20), (2, 30)]
+
+# --- enumerate (custom start, non-list source) ---
+e = enumerate(iter([10, 20, 30]), start=5)
+next(e)
+assert list(rt(e)) == [(6, 20), (7, 30)]
+
+# --- divergent: set iterator materialises but round-trips its members ---
+s = {1, 2, 3, 4}
+si = iter(s)
+first = next(si)
+assert sorted(rt(si)) == sorted(x for x in s if x != first)
+
+# --- divergent: map / filter / zip / reversed materialise to list_iterator ---
+m = map(_double, [1, 2, 3]); next(m)
+assert list(rt(m)) == [4, 6]
+f = filter(_is_even, [1, 2, 3, 4]); next(f)
+assert list(rt(f)) == [4]
+z = zip([1, 2, 3], "abc"); next(z)
+assert list(rt(z)) == [(2, "b"), (3, "c")]
+rv = reversed([1, 2, 3]); next(rv)
+assert list(rt(rv)) == [2, 1]
+
+# --- reversed(range) stays a range iterator ---
+rr = reversed(range(5)); next(rr)
+assert list(rt(rr)) == [3, 2, 1, 0]
+
+# --- bare builtin functions pickle by reference (__module__ == builtins) ---
+assert rt(iter) is iter and rt(range) is range and rt(len) is len
+
+print("pickle_roundtrip OK")

--- a/pyre/extra_tests/snippets/pickle_seqiter.py
+++ b/pyre/extra_tests/snippets/pickle_seqiter.py
@@ -1,0 +1,17 @@
+it = iter([1, 2, 3])
+assert it.__reduce__() == (iter, ([1, 2, 3],), 0), it.__reduce__()
+assert it.__length_hint__() == 3
+next(it)
+next(it)
+r = it.__reduce__()
+assert r == (iter, ([1, 2, 3],), 2), r
+assert it.__length_hint__() == 1
+it2 = r[0](*r[1])
+it2.__setstate__(r[2])
+assert list(it2) == [3]
+assert iter((1, 2, 3)).__reduce__() == (iter, ((1, 2, 3),), 0)
+assert iter("abc").__reduce__() == (iter, ("abc",), 0)
+it3 = iter([9, 8])
+it3.__setstate__(-5)
+assert list(it3) == [9, 8]
+print("pickle_seqiter OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1270,10 +1270,13 @@ fn range_reversed_method(args: &[PyObjectRef]) -> PyResult {
 /// `(type(self), (start, stop, step))`.
 fn range_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let (start, stop, step) = unsafe { pyre_object::w_range_fields(args[0]) };
-    let range_type =
-        crate::typedef::gettypefor(&pyre_object::rangeobject::RANGE_TYPE).unwrap_or(PY_NULL);
+    // `range` is bound in builtins as a constructor function, not as the
+    // registry type object, so the reconstructor must be that name-bound
+    // callable: `pickle.save_global` matches it to `builtins.range`, and
+    // `range(start, stop, step)` rebuilds the instance.
+    let range_ctor = builtin_callable("range");
     let state = w_tuple_new(vec![start, stop, step]);
-    Ok(w_tuple_new(vec![range_type, state]))
+    Ok(w_tuple_new(vec![range_ctor, state]))
 }
 
 /// `range.__hash__()` — `functional.py W_Range.descr_hash`: hashes the
@@ -1293,6 +1296,175 @@ fn range_hash_method(args: &[PyObjectRef]) -> PyResult {
         vec![len_obj, start, step]
     };
     Ok(w_int_new(hash_w_strict(w_tuple_new(items))?))
+}
+
+/// The builtin function `name` (`iter` / `enumerate`) as the
+/// reconstructor for an iterator's `__reduce__`.  Mirrors PyPy's
+/// `space.getbuiltin(name)` — the reduce tuple's first element must be
+/// the live builtin so `pickle` recreates the iterator via `iter(seq)` /
+/// `enumerate(iterable)`.
+fn builtin_callable(name: &str) -> PyObjectRef {
+    let ctx = crate::call::getexecutioncontext();
+    if ctx.is_null() {
+        return PY_NULL;
+    }
+    unsafe { (*ctx).lookup_builtin(name).unwrap_or(PY_NULL) }
+}
+
+/// `list_iterator.__reduce__()` — `iterobject.py
+/// W_AbstractSeqIterObject.descr_reduce`: `(iter, (seq,), index)`.
+fn seq_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let seq = pyre_object::w_seq_iter_seq(args[0]);
+        let index = pyre_object::w_seq_iter_index(args[0]);
+        let state = w_tuple_new(vec![seq]);
+        Ok(w_tuple_new(vec![
+            builtin_callable("iter"),
+            state,
+            w_int_new(index),
+        ]))
+    }
+}
+
+/// `list_iterator.__setstate__(index)` — clamp the cursor into
+/// `[0, length]` (`iterobject.py descr_setstate`).
+fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let length = pyre_object::w_seq_iter_length(args[0]);
+        let mut index = w_int_get_value(args[1]);
+        if index < 0 {
+            index = 0;
+        } else if index > length {
+            index = length;
+        }
+        pyre_object::w_seq_iter_set_index(args[0], index);
+    }
+    Ok(w_none())
+}
+
+/// `list_iterator.__length_hint__()` — elements not yet produced.
+fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let remaining = pyre_object::w_seq_iter_length(args[0]) - pyre_object::w_seq_iter_index(args[0]);
+        Ok(w_int_new(remaining.max(0)))
+    }
+}
+
+/// `range_iterator.__reduce__()` — `iterobject.py
+/// W_IntRangeIterator.descr_reduce`: rebuild a `range(current, stop,
+/// step)` covering the remaining span, `(iter, (range,), None)`.
+fn range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let (current, stop, step) = pyre_object::w_range_iter_fields(args[0]);
+        let w_range = pyre_object::w_range_new_i64(current, stop, step);
+        let state = w_tuple_new(vec![w_range]);
+        Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
+    }
+}
+
+/// `range_iterator.__length_hint__()` — remaining element count.
+fn range_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe { Ok(w_int_new(pyre_object::w_range_iter_remaining(args[0]))) }
+}
+
+/// `longrange_iterator.__reduce__()` — rebuild a `range` covering the
+/// remaining span (`current = start + index*step`, `stop = start +
+/// len*step`), `(iter, (range,), None)`.
+fn long_range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let (start, step, len, index) = pyre_object::w_long_range_iter_fields(args[0]);
+        let start_b = pyre_object::range_obj_to_bigint(start);
+        let step_b = pyre_object::range_obj_to_bigint(step);
+        let len_b = pyre_object::range_obj_to_bigint(len);
+        let index_b = pyre_object::range_obj_to_bigint(index);
+        let current = &start_b + &index_b * &step_b;
+        let stop = &start_b + &len_b * &step_b;
+        let w_range = pyre_object::w_range_new(
+            pyre_object::range_bigint_to_obj(current),
+            pyre_object::range_bigint_to_obj(stop),
+            pyre_object::range_bigint_to_obj(step_b),
+        );
+        let state = w_tuple_new(vec![w_range]);
+        Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
+    }
+}
+
+/// `longrange_iterator.__length_hint__()` — remaining element count.
+fn long_range_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        Ok(pyre_object::range_bigint_to_obj(
+            pyre_object::w_long_range_iter_len(args[0]),
+        ))
+    }
+}
+
+/// `dict_keyiterator.__reduce__()` (and value/item siblings) —
+/// `dictmultiobject.py W_BaseDictIterator.descr_reduce`: the remaining
+/// entries as a list, wrapped `(iter, (list,))`.  No third element.
+fn dict_view_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let w_dict = pyre_object::dictviewobject::w_dict_view_iterator_get_dict(args[0]);
+        let kind = pyre_object::dictviewobject::w_dict_view_iterator_get_kind(args[0]);
+        let index = pyre_object::dictviewobject::w_dict_view_iterator_get_index(args[0]);
+        let entries = pyre_object::w_dict_items(w_dict);
+        let mut items = Vec::new();
+        for (k, v) in entries.into_iter().skip(index) {
+            let item = match kind {
+                pyre_object::dictviewobject::DictViewKind::Keys => k,
+                pyre_object::dictviewobject::DictViewKind::Values => v,
+                pyre_object::dictviewobject::DictViewKind::Items => w_tuple_new(vec![k, v]),
+            };
+            items.push(item);
+        }
+        let state = w_tuple_new(vec![w_list_new(items)]);
+        Ok(w_tuple_new(vec![builtin_callable("iter"), state]))
+    }
+}
+
+/// `dict_keyiterator.__length_hint__()` — remaining entries.
+fn dict_view_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let w_dict = pyre_object::dictviewobject::w_dict_view_iterator_get_dict(args[0]);
+        let index = pyre_object::dictviewobject::w_dict_view_iterator_get_index(args[0]);
+        let remaining = (pyre_object::w_dict_len(w_dict) as i64) - (index as i64);
+        Ok(w_int_new(remaining.max(0)))
+    }
+}
+
+/// `enumerate.__reduce__()` — `functional.py W_Enumerate.descr_reduce`:
+/// `(enumerate, (source_iter, index))`.
+fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    unsafe {
+        let i64_index = pyre_object::enumerateobject::w_enumerate_get_index(args[0]);
+        let raw = pyre_object::enumerateobject::w_enumerate_get_iter_or_list(args[0]);
+        let w_iter = if raw.is_null() {
+            // Exhausted enumerate (`:294-295` set `w_iter_or_list` to
+            // null); substitute an empty seq-iter so the reduce stays
+            // round-trippable.
+            pyre_object::w_seq_iter_new(w_list_new(vec![]), 0)
+        } else if pyre_object::is_list(raw) {
+            // List fast path (`:289-294`): `w_iter_or_list` is the source
+            // list itself and `index` is the cursor into it.  Materialise
+            // a seq-iterator positioned at the cursor so the reconstructed
+            // enumerate resumes from the right element rather than the
+            // list head.
+            let len = pyre_object::w_list_len(raw);
+            let it = pyre_object::w_seq_iter_new(raw, len);
+            let pos = i64_index.clamp(0, len as i64);
+            pyre_object::w_seq_iter_set_index(it, pos);
+            it
+        } else {
+            raw
+        };
+        let w_index_slot = pyre_object::enumerateobject::w_enumerate_get_w_index(args[0]);
+        let index = if w_index_slot.is_null() {
+            w_int_new(i64_index)
+        } else {
+            w_index_slot
+        };
+        let state = w_tuple_new(vec![w_iter, index]);
+        Ok(w_tuple_new(vec![builtin_callable("enumerate"), state]))
+    }
 }
 
 unsafe fn getitem_range_iter(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
@@ -2261,6 +2433,54 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             };
             if let Some((func, sname)) = entry {
                 let func_obj = crate::make_builtin_function_with_arity(sname, func, 1);
+                return Ok(pyre_object::w_method_new(
+                    func_obj,
+                    obj,
+                    pyre_object::PY_NULL,
+                ));
+            }
+            // Per-iterator-type pickle protocol: `__reduce__` /
+            // `__setstate__` / `__length_hint__` recreate the iterator's
+            // CPython 3.14 pickle shape.  `arity` includes `self`.
+            let entry: Option<(fn(&[PyObjectRef]) -> PyResult, &str, u16)> = if is_seq_iter(obj) {
+                match name {
+                    "__reduce__" => Some((seq_iter_reduce_method, "__reduce__", 1)),
+                    "__setstate__" => Some((seq_iter_setstate_method, "__setstate__", 2)),
+                    "__length_hint__" => Some((seq_iter_length_hint_method, "__length_hint__", 1)),
+                    _ => None,
+                }
+            } else if is_range_iter(obj) {
+                match name {
+                    "__reduce__" => Some((range_iter_reduce_method, "__reduce__", 1)),
+                    "__length_hint__" => Some((range_iter_length_hint_method, "__length_hint__", 1)),
+                    _ => None,
+                }
+            } else if pyre_object::is_long_range_iter(obj) {
+                match name {
+                    "__reduce__" => Some((long_range_iter_reduce_method, "__reduce__", 1)),
+                    "__length_hint__" => {
+                        Some((long_range_iter_length_hint_method, "__length_hint__", 1))
+                    }
+                    _ => None,
+                }
+            } else if pyre_object::dictviewobject::is_dict_view_iterator(obj) {
+                match name {
+                    "__reduce__" => Some((dict_view_iter_reduce_method, "__reduce__", 1)),
+                    "__length_hint__" => {
+                        Some((dict_view_iter_length_hint_method, "__length_hint__", 1))
+                    }
+                    _ => None,
+                }
+            } else if pyre_object::enumerateobject::is_enumerate(obj) {
+                match name {
+                    "__reduce__" => Some((enumerate_reduce_method, "__reduce__", 1)),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            if let Some((func, sname, arity)) = entry {
+                let func_obj = crate::make_builtin_function_with_arity(sname, func, arity);
                 return Ok(pyre_object::w_method_new(
                     func_obj,
                     obj,
@@ -3272,6 +3492,26 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 ),
             ));
         }
+    }
+
+    // `Objects/methodobject.c meth_reduce` — a module-level builtin
+    // pickles by reference: `__reduce__` / `__reduce_ex__` return the
+    // `__qualname__` string, which `pickle.Pickler.save` routes to
+    // `save_global`.  pyre's builtins carry no bound `__self__`, so the
+    // bare-qualname branch always applies.  This must precede the generic
+    // MRO lookup below, which would otherwise bind `object.__reduce__`.
+    if (name == "__reduce__" || name == "__reduce_ex__")
+        && unsafe { pyre_object::py_type_check(obj, &crate::function::BUILTIN_FUNCTION_TYPE) }
+    {
+        let reduce_fn: fn(&[PyObjectRef]) -> PyResult =
+            |args| Ok(w_str_new(&unsafe { crate::function::function_get_qualname(args[0]) }));
+        let (sname, arity): (&'static str, u16) = if name == "__reduce_ex__" {
+            ("__reduce_ex__", 2)
+        } else {
+            ("__reduce__", 1)
+        };
+        let func_obj = crate::make_builtin_function_with_arity(sname, reduce_fn, arity);
+        return Ok(pyre_object::w_method_new(func_obj, obj, pyre_object::PY_NULL));
     }
 
     // Builtin type method lookup via TypeDef registry.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3192,7 +3192,6 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 ));
             }
             if name == "__doc__"
-                || name == "__flags__"
                 || name == "__code__"
                 || name == "__func__"
                 || name == "__self__"

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -642,6 +642,12 @@ pub fn is_true(obj: PyObjectRef) -> bool {
         if is_str(obj) {
             return w_str_len(obj) != 0;
         }
+        if pyre_object::is_bytes(obj) {
+            return pyre_object::w_bytes_len(obj) != 0;
+        }
+        if pyre_object::is_bytearray(obj) {
+            return pyre_object::w_bytearray_len(obj) != 0;
+        }
         if is_list(obj) {
             return w_list_len(obj) > 0;
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6808,6 +6808,70 @@ pub fn getindex_w(obj: PyObjectRef) -> Result<i64, PyError> {
     }
 }
 
+/// `objspace.honor__builtins__` default is False — the frame builtin is
+/// `space.builtin`, ignoring a custom `__builtins__` in globals.  The
+/// `pick_builtin*` family below is the `honor__builtins__=True` path,
+/// reached only when this flag is set.
+pub const HONOR_BUILTINS: bool = false;
+
+/// Resolve the frame builtin for a raw-storage globals.  Default
+/// (`HONOR_BUILTINS=false`) returns `space.builtin` (`ec.get_builtin()`),
+/// ignoring a custom `__builtins__`; the `true` path delegates to
+/// [`pick_builtin`].
+pub fn frame_builtin(
+    w_globals: *mut crate::DictStorage,
+    exec_ctx: *const crate::PyExecutionContext,
+) -> PyObjectRef {
+    if HONOR_BUILTINS {
+        return pick_builtin(w_globals, exec_ctx);
+    }
+    if !exec_ctx.is_null() {
+        let b = unsafe { (*exec_ctx).get_builtin() };
+        if !b.is_null() {
+            return b;
+        }
+    }
+    build_default_pick_builtin_module()
+}
+
+/// Resolve the frame builtin for an object globals.  Default
+/// (`HONOR_BUILTINS=false`) returns `space.builtin`; the `true` path
+/// delegates to [`pick_builtin_obj`].
+pub fn frame_builtin_obj(
+    w_globals: PyObjectRef,
+    exec_ctx: *const crate::PyExecutionContext,
+) -> PyObjectRef {
+    if HONOR_BUILTINS {
+        return pick_builtin_obj(w_globals, exec_ctx);
+    }
+    if !exec_ctx.is_null() {
+        let b = unsafe { (*exec_ctx).get_builtin() };
+        if !b.is_null() {
+            return b;
+        }
+    }
+    build_default_pick_builtin_module()
+}
+
+/// Fallible variant of [`frame_builtin_obj`].  Default
+/// (`HONOR_BUILTINS=false`) returns `space.builtin`; the `true` path
+/// delegates to [`pick_builtin_obj_checked`].
+pub fn frame_builtin_obj_checked(
+    w_globals: PyObjectRef,
+    exec_ctx: *const crate::PyExecutionContext,
+) -> Result<PyObjectRef, crate::PyError> {
+    if HONOR_BUILTINS {
+        return pick_builtin_obj_checked(w_globals, exec_ctx);
+    }
+    if !exec_ctx.is_null() {
+        let b = unsafe { (*exec_ctx).get_builtin() };
+        if !b.is_null() {
+            return Ok(b);
+        }
+    }
+    Ok(build_default_pick_builtin_module())
+}
+
 /// `pyframe.py:115-116 self.builtin = space.builtin.pick_builtin(
 /// w_globals)`.  Body ports `pypy/module/__builtin__/moduledef.py:89-109
 /// pick_builtin`:

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1345,7 +1345,8 @@ fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
 /// `list_iterator.__length_hint__()` — elements not yet produced.
 fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
-        let remaining = pyre_object::w_seq_iter_length(args[0]) - pyre_object::w_seq_iter_index(args[0]);
+        let remaining =
+            pyre_object::w_seq_iter_length(args[0]) - pyre_object::w_seq_iter_index(args[0]);
         Ok(w_int_new(remaining.max(0)))
     }
 }
@@ -2452,7 +2453,9 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             } else if is_range_iter(obj) {
                 match name {
                     "__reduce__" => Some((range_iter_reduce_method, "__reduce__", 1)),
-                    "__length_hint__" => Some((range_iter_length_hint_method, "__length_hint__", 1)),
+                    "__length_hint__" => {
+                        Some((range_iter_length_hint_method, "__length_hint__", 1))
+                    }
                     _ => None,
                 }
             } else if pyre_object::is_long_range_iter(obj) {
@@ -3503,15 +3506,22 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     if (name == "__reduce__" || name == "__reduce_ex__")
         && unsafe { pyre_object::py_type_check(obj, &crate::function::BUILTIN_FUNCTION_TYPE) }
     {
-        let reduce_fn: fn(&[PyObjectRef]) -> PyResult =
-            |args| Ok(w_str_new(&unsafe { crate::function::function_get_qualname(args[0]) }));
+        let reduce_fn: fn(&[PyObjectRef]) -> PyResult = |args| {
+            Ok(w_str_new(&unsafe {
+                crate::function::function_get_qualname(args[0])
+            }))
+        };
         let (sname, arity): (&'static str, u16) = if name == "__reduce_ex__" {
             ("__reduce_ex__", 2)
         } else {
             ("__reduce__", 1)
         };
         let func_obj = crate::make_builtin_function_with_arity(sname, reduce_fn, arity);
-        return Ok(pyre_object::w_method_new(func_obj, obj, pyre_object::PY_NULL));
+        return Ok(pyre_object::w_method_new(
+            func_obj,
+            obj,
+            pyre_object::PY_NULL,
+        ));
     }
 
     // Builtin type method lookup via TypeDef registry.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2442,6 +2442,28 @@ fn make_exc_type_with_init(
     cls
 }
 
+/// Build a builtin exception class with more than one base, e.g.
+/// `class UnsupportedOperation(OSError, ValueError)`
+/// (`Modules/_io/_iomodule.c`).  The MRO is the C3 linearization over
+/// `bases`; the first base drives instance layout.  `with_traceback` /
+/// `add_note` are inherited through the MRO from `BaseException`, so
+/// only `__new__` is installed here.
+pub(crate) fn make_exc_type_multi(
+    name: &'static str,
+    new_fn: crate::gateway::BuiltinCodeFn,
+    bases: &[PyObjectRef],
+) -> PyObjectRef {
+    let cls = crate::typedef::make_builtin_type_with_bases(
+        name,
+        move |ns| {
+            crate::dict_storage_store(ns, "__new__", make_builtin_function("__new__", new_fn));
+        },
+        bases,
+    );
+    register_exc_class(name, cls);
+    cls
+}
+
 /// Thread-local registry from exception class name (as used by
 /// `ExcKind → exc_kind_name`) to the W_TypeObject exposed in the builtins
 /// namespace. Populated at init-builtins time via `make_exc_type`.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -499,6 +499,37 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                     1,
                 ),
             );
+            // memoryview.toreadonly — a fresh view over a bytes copy of the
+            // backing buffer, which the stub treats as read-only.
+            crate::dict_storage_store(
+                ns,
+                "toreadonly",
+                make_builtin_function_with_arity(
+                    "toreadonly",
+                    |args| {
+                        let mv = args.get(0).copied().unwrap_or(w_none());
+                        unsafe {
+                            let (data, itemsize, _) = memoryview_data(mv)?;
+                            let fmt = crate::baseobjspace::getattr_str(mv, "__pyre_fmt__")?;
+                            let cls = crate::typedef::r#type(mv).unwrap_or(pyre_object::PY_NULL);
+                            let inst = pyre_object::w_instance_new(cls);
+                            crate::baseobjspace::setattr_str(
+                                inst,
+                                "__pyre_buf__",
+                                pyre_object::bytesobject::w_bytes_from_bytes(&data),
+                            )?;
+                            crate::baseobjspace::setattr_str(inst, "__pyre_fmt__", fmt)?;
+                            crate::baseobjspace::setattr_str(
+                                inst,
+                                "__pyre_itemsize__",
+                                w_int_new(itemsize as i64),
+                            )?;
+                            Ok(inst)
+                        }
+                    },
+                    1,
+                ),
+            );
             // memoryview.itemsize attribute — read from the per-instance
             // __pyre_itemsize__ slot via property descriptor.
             crate::dict_storage_store(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -596,7 +596,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     namespace.get_or_insert_with("filter", || {
         make_module_builtin_function("filter", |args| {
             if args.len() < 2 {
-                return Ok(w_list_new(vec![]));
+                return Ok(pyre_object::w_seq_iter_new(w_list_new(vec![]), 0));
             }
             let func = args[0];
             let items = collect_iterable(args[1])?;
@@ -617,7 +617,11 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                     out.push(item);
                 }
             }
-            Ok(w_list_new(out))
+            // `filter` is a lazy iterator in CPython; pyre eagerly applies
+            // the predicate but still hands back an iterator (matching
+            // `map`/`zip`) so `next(filter(...))` works.
+            let n = out.len();
+            Ok(pyre_object::w_seq_iter_new(w_list_new(out), n))
         })
     });
     namespace.get_or_insert_with("input", || {
@@ -992,8 +996,14 @@ pub fn new_builtin_module_dict() -> pyre_object::PyObjectRef {
     let mut seed = DictStorage::new();
     install_default_builtins(&mut seed);
     let w_dict = pyre_object::w_module_dict_new();
+    // MixedModule parity: the interp-level builtins carry "builtins" as
+    // `__module__`, so `pickle.save_global` resolves them by reference
+    // without the `whichmodule` guess (every module namespace exposes the
+    // builtins, which makes that guess unstable).
+    let module_name = w_str_new("builtins");
     for (key, &value) in seed.entries() {
         if !value.is_null() {
+            unsafe { crate::function::builtin_function_set_module(value, module_name) };
             unsafe { pyre_object::w_dict_setitem_str(w_dict, key, value) };
         }
     }
@@ -2863,6 +2873,11 @@ fn parse_int_from_str(s: &str, base: u32) -> Result<PyObjectRef, crate::PyError>
     let cleaned: String = digits.chars().filter(|&c| c != '_').collect();
     if let Ok(v) = i64::from_str_radix(&cleaned, radix) {
         return Ok(w_int_new(sign * v));
+    }
+    // Values outside the machine-int range parse as arbitrary precision.
+    if let Some(big) = BigInt::parse_bytes(cleaned.as_bytes(), radix) {
+        let signed = if sign < 0 { -big } else { big };
+        return Ok(w_long_new(signed));
     }
     Err(crate::PyError::new(
         crate::PyErrorKind::ValueError,

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1913,9 +1913,26 @@ pub(crate) fn calculate_metaclass(
     Ok(w_winner)
 }
 
+/// `typeobject.c type_call` — a type whose `tp_new` is NULL
+/// (`Py_TPFLAGS_DISALLOW_INSTANTIATION`, e.g. generator) refuses
+/// `Type()` with `cannot create 'X' instances`.
+fn check_type_instantiable(w_type: PyObjectRef) -> Result<(), PyError> {
+    if unsafe { pyre_object::w_type_disallows_instantiation(w_type) } {
+        let name = unsafe { pyre_object::w_type_get_name(w_type) };
+        return Err(PyError::type_error(format!(
+            "cannot create '{name}' instances"
+        )));
+    }
+    Ok(())
+}
+
 /// Type call without a PyFrame.
 /// PyPy: typeobject.py descr_call
 fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
+    if let Err(e) = check_type_instantiable(w_type) {
+        set_call_error(e);
+        return PY_NULL;
+    }
     // Step 1: __new__
     let instance =
         if let Some(new_fn) = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__new__") } {
@@ -3078,6 +3095,7 @@ fn type_descr_call_with_mode(
     args: &[PyObjectRef],
     mode: CallMode,
 ) -> PyResult {
+    check_type_instantiable(w_type)?;
     // Step 1: Look up __new__ via type MRO → allocate instance.
     // PyPy: typeobject.py descr_call → `w_newtype, w_newdescr =
     // self.lookup_where('__new__')`; a missing descriptor (the pathological

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -115,6 +115,14 @@ pub struct Function {
     /// means "no signature recorded" and the getter returns
     /// `space.w_None` per `function.py:488`.
     pub w_text_signature: PyObjectRef,
+    /// `__self__` of a builtin `__new__` descriptor — the type whose
+    /// `tp_new` this function wraps.  `typeobject.c add_tp_new_wrapper`
+    /// binds `int.__new__.__self__ is int`, so `copyreg._reduce_ex`
+    /// can ask `base.__new__.__self__ is base` to find the defining
+    /// type.  `PY_NULL` for every ordinary function (a plain `def`
+    /// has no `__self__`); only stamped on the per-type builtin
+    /// `__new__` carriers at type-finalisation time.
+    pub w_new_self: PyObjectRef,
 }
 
 /// function.py:706 — `class BuiltinFunction(Function): can_change_code = False`
@@ -188,6 +196,9 @@ pub const FUNCTION_W_OBJCLASS_OFFSET: usize = std::mem::offset_of!(Function, w_o
 /// `function.py:487-496 w_text_signature` slot.
 pub const FUNCTION_W_TEXT_SIGNATURE_OFFSET: usize =
     std::mem::offset_of!(Function, w_text_signature);
+/// Field offset of `w_new_self` within `Function` — the builtin
+/// `__new__` descriptor's `__self__` (defining type).
+pub const FUNCTION_W_NEW_SELF_OFFSET: usize = std::mem::offset_of!(Function, w_new_self);
 
 /// GC type id assigned to `Function` at JitDriver init time. Held as
 /// a constant alongside the struct (rather than runtime-queried) so
@@ -254,6 +265,9 @@ pub const FUNCTION_GC_PTR_OFFSETS: [usize; 12] = [
     // `function.py:487-496 w_text_signature` — PEP 437 text signature
     // line stripped from the docstring.
     FUNCTION_W_TEXT_SIGNATURE_OFFSET,
+    // `w_new_self` is intentionally absent: it holds the defining type
+    // of a builtin `__new__` carrier, a static-region W_TypeObject that
+    // is never nursery-relocated (same reasoning as `ob.w_class`).
 ];
 
 impl pyre_object::lltype::GcType for Function {
@@ -397,6 +411,7 @@ fn function_new_impl(
         w_qualname: PY_NULL,
         w_objclass: PY_NULL,
         w_text_signature: PY_NULL,
+        w_new_self: PY_NULL,
     };
 
     if let Some(raw) =
@@ -514,6 +529,38 @@ pub unsafe fn builtin_function_set_module(obj: PyObjectRef, w_module: PyObjectRe
                 (*func).w_module = w_module;
             }
         }
+    }
+}
+
+/// Stamp the `__self__` of a builtin `__new__` carrier — the defining
+/// type whose `tp_new` it wraps (`typeobject.c add_tp_new_wrapper`).
+/// Only touches functions whose `w_new_self` is still unset, so an
+/// inherited `__new__` keeps the ancestor that defined it.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `Function`.
+pub unsafe fn function_set_new_self(obj: PyObjectRef, w_type: PyObjectRef) {
+    unsafe {
+        let func = obj as *mut Function;
+        if (*func).w_new_self.is_null() {
+            (*func).w_new_self = w_type;
+        }
+    }
+}
+
+/// `__self__` getter for the builtin-function type.  Returns the
+/// stamped `w_new_self` (the defining type) for a builtin `__new__`
+/// carrier, else `None` — `typedef.py:816 GetSetProperty(always_none,
+/// cls=BuiltinFunction)` returns `None` for an ordinary builtin.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `Function`.
+pub unsafe fn function_get_self_or_none(obj: PyObjectRef) -> PyObjectRef {
+    let w_self = unsafe { (*(obj as *const Function)).w_new_self };
+    if w_self.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_self
     }
 }
 

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -491,6 +491,26 @@ pub unsafe fn is_function(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &FUNCTION_TYPE) || py_type_check(obj, &BUILTIN_FUNCTION_TYPE) }
 }
 
+/// Stamp a module-level builtin function's `__module__` with its
+/// containing module at install time — `MixedModule` registration sets
+/// `func.w_module = w(modulename)` for each interp-level definition.
+/// Only touches `BUILTIN_FUNCTION_TYPE` objects whose module is still
+/// unset; app-level functions derive `__module__` from their globals and
+/// are left alone.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+pub unsafe fn builtin_function_set_module(obj: PyObjectRef, w_module: PyObjectRef) {
+    unsafe {
+        if py_type_check(obj, &BUILTIN_FUNCTION_TYPE) {
+            let func = obj as *mut Function;
+            if (*func).w_module.is_null() {
+                (*func).w_module = w_module;
+            }
+        }
+    }
+}
+
 /// `isinstance(obj, FunctionWithFixedCode)` parity.
 ///
 /// function.py:783 — `class FunctionWithFixedCode(Function):

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -494,15 +494,21 @@ pub unsafe fn is_function(obj: PyObjectRef) -> bool {
 /// Stamp a module-level builtin function's `__module__` with its
 /// containing module at install time — `MixedModule` registration sets
 /// `func.w_module = w(modulename)` for each interp-level definition.
-/// Only touches `BUILTIN_FUNCTION_TYPE` objects whose module is still
-/// unset; app-level functions derive `__module__` from their globals and
-/// are left alone.
+/// Touches `BUILTIN_FUNCTION_TYPE` objects and globals-less
+/// `FUNCTION_TYPE` objects (the `py_module!` `inline_functions` /
+/// `functions` carriers) whose module is still unset.  App-level
+/// functions carry globals and derive `__module__` lazily from
+/// `globals['__name__']`, so a function with globals is left alone.
 ///
 /// # Safety
 /// `obj` must be a valid, non-null pointer to a `PyObject`.
 pub unsafe fn builtin_function_set_module(obj: PyObjectRef, w_module: PyObjectRef) {
     unsafe {
-        if py_type_check(obj, &BUILTIN_FUNCTION_TYPE) {
+        let stampable = py_type_check(obj, &BUILTIN_FUNCTION_TYPE)
+            || (py_type_check(obj, &FUNCTION_TYPE)
+                && (*(obj as *const Function)).w_func_globals.is_null()
+                && (*(obj as *const Function)).w_func_globals_obj.is_null());
+        if stampable {
             let func = obj as *mut Function;
             if (*func).w_module.is_null() {
                 (*func).w_module = w_module;

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -703,6 +703,18 @@ pub fn make_builtin_function(name: &'static str, func: BuiltinCodeFn) -> PyObjec
     crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
 }
 
+/// Like `make_builtin_function` but tagged as `BuiltinFunction`
+/// (the `builtin_function` type) rather than `FunctionWithFixedCode`.
+/// Used for builtin `__new__` carriers so `type(int.__new__)` is the
+/// builtin-function type — distinct from a user `def`'s `function` — so
+/// `copyreg._reduce_ex`'s `isinstance(new, type(int.__new__))` matches
+/// only C-level `tp_new` wrappers, mirroring the
+/// `builtin_function_or_method` type.
+pub fn make_builtin_function_as_builtin(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
+    let code = builtin_code_new(name, func);
+    crate::function_new_builtin(code as *const (), name.to_string(), std::ptr::null_mut())
+}
+
 /// `make_builtin_function` for a builtin with a declared argument
 /// `Signature`, so the call path binds keyword arguments into positional
 /// order before the function runs (see `call::bind_kwargs_to_signature`).

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -313,6 +313,10 @@ fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
     let w_dict = pyre_object::w_module_dict_new();
     for (key, &value) in namespace.entries() {
         if !value.is_null() {
+            // MixedModule parity: interp-level builtin functions carry the
+            // module name as `__module__`, so `pickle` can save them by
+            // reference (`save_global`) without guessing via `whichmodule`.
+            unsafe { crate::function::builtin_function_set_module(value, name_obj) };
             unsafe { pyre_object::w_dict_setitem_str(w_dict, key, value) };
         }
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -211,6 +211,7 @@ pub fn install_builtin_modules() {
     pyre_install_module!(_multiprocessing);
     pyre_install_module!(_locale);
     pyre_install_module!(_random);
+    pyre_install_module!(_pickle);
     pyre_install_module!(_struct);
     pyre_install_module!(gc);
     pyre_install_module!(unicodedata);
@@ -246,7 +247,6 @@ pub fn install_builtin_modules() {
         "_sha3",
         "_blake2",
         "_decimal",
-        "_pickle",
         "_datetime",
         "_json",
         "_csv",

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -449,6 +449,19 @@ fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
     SYS_MODULES.with(|m| m.borrow().get(name).copied())
 }
 
+/// Look up a loaded module by name in `sys.modules` (Python-visible dict
+/// first, then the interpreter cache). Mirrors `check_sys_modules`.
+pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
+    check_sys_modules(name)
+}
+
+/// The Python-visible `sys.modules` dict, or `PY_NULL` before it is
+/// installed. Used by callers that need to iterate every loaded module
+/// (e.g. pickle's `whichmodule` scan).
+pub fn sys_modules_dict() -> PyObjectRef {
+    SYS_MODULES_DICT.with(|d| d.get())
+}
+
 pub fn set_sys_module(name: &str, module: PyObjectRef) {
     SYS_MODULES.with(|m| {
         m.borrow_mut().insert(name.to_string(), module);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -186,6 +186,11 @@ pub fn install_builtin_modules() {
         crate::module::importlib::interp_importlib::register_abc
     );
 
+    // __pypy__ package + builders submodule — the PyPy-only surface
+    // pickle.py imports (identity_dict + builders.BytesBuilder).
+    pyre_install_module!("__pypy__" => crate::module::__pypy__::init);
+    pyre_install_module!("__pypy__.builders" => crate::module::__pypy__::builders::init);
+
     pyre_install_module!(_signal);
     pyre_install_module!(atexit);
     pyre_install_module!(pwd);

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -31,6 +31,7 @@ pub mod opcode_ops;
 pub mod pycode;
 pub mod pyopcode;
 pub mod pytraceback;
+pub mod reduce_protocol;
 pub mod runtime_ops;
 pub mod sandbox;
 pub mod shared_opcode;

--- a/pyre/pyre-interpreter/src/module/__pypy__/builders_app.py
+++ b/pyre/pyre-interpreter/src/module/__pypy__/builders_app.py
@@ -1,0 +1,36 @@
+class BytesBuilder(object):
+    """Append-only byte buffer with O(1) amortized growth.
+
+    Accumulates byte chunks and yields the concatenation via build().
+    Matches the surface pickle.py uses: append(data), build(), len().
+    """
+
+    def __init__(self, initial=0):
+        self._buf = bytearray()
+
+    def append(self, data):
+        self._buf += data
+
+    def build(self):
+        return bytes(self._buf)
+
+    def __len__(self):
+        return len(self._buf)
+
+
+class StringBuilder(object):
+    """Append-only text buffer; build() returns the joined str."""
+
+    def __init__(self, initial=0):
+        self._parts = []
+        self._len = 0
+
+    def append(self, data):
+        self._parts.append(data)
+        self._len += len(data)
+
+    def build(self):
+        return ''.join(self._parts)
+
+    def __len__(self):
+        return self._len

--- a/pyre/pyre-interpreter/src/module/__pypy__/identity_dict_app.py
+++ b/pyre/pyre-interpreter/src/module/__pypy__/identity_dict_app.py
@@ -1,0 +1,29 @@
+class identity_dict(object):
+    """A mapping keyed by object identity rather than equality.
+
+    Stores entries in an internal dict keyed on ``id(key)`` so that
+    unhashable objects (lists, dicts, sets) work as keys.  The value
+    side is expected to keep the key object alive for the dict's
+    lifetime, so ``id(key)`` stays valid.
+    """
+
+    def __init__(self):
+        self._d = {}
+
+    def __getitem__(self, key):
+        return self._d[id(key)]
+
+    def __setitem__(self, key, value):
+        self._d[id(key)] = value
+
+    def __contains__(self, key):
+        return id(key) in self._d
+
+    def get(self, key, default=None):
+        return self._d.get(id(key), default)
+
+    def __len__(self):
+        return len(self._d)
+
+    def clear(self):
+        self._d.clear()

--- a/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
@@ -1,0 +1,33 @@
+//! `__pypy__` module — PyPy: pypy/module/__pypy__/
+//!
+//! Pyre exposes the small slice of the `__pypy__` surface that the
+//! PyPy-flavored stdlib needs.  `pickle.py` imports `identity_dict`
+//! (an identity-keyed memo dict) and `builders.BytesBuilder` in one
+//! shared `try` block; both must resolve for the optimized path to
+//! activate, so both are provided here as app-level classes.
+
+crate::py_module! {
+    "__pypy__",
+    // `identity_dict` keys a memo by object identity (id(key)) so the
+    // Pickler can memoize unhashable containers.
+    appleveldefs: {
+        "identity_dict_app.py" => ["identity_dict"],
+    },
+    extra_init: |ns| {
+        // Mark as a package so `from __pypy__.builders import ...`
+        // treats `__pypy__` as a package with submodules.
+        crate::dict_storage_store(ns, "__path__", pyre_object::w_list_new(vec![]));
+    }
+}
+
+/// `__pypy__.builders` submodule — exposes the string/bytes builders.
+pub mod builders {
+    crate::py_module! {
+        "__pypy__.builders",
+        // BytesBuilder is the append-only byte buffer pickle.py writes
+        // frames into; StringBuilder is its text analogue.
+        appleveldefs: {
+            "builders_app.py" => ["BytesBuilder", "StringBuilder"],
+        }
+    }
+}

--- a/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
@@ -5,11 +5,23 @@
 //! (an identity-keyed memo dict) and `builders.BytesBuilder` in one
 //! shared `try` block; both must resolve for the optimized path to
 //! activate, so both are provided here as app-level classes.
+//!
+//! `PickleBuffer` (`interp_buffer.py W_PickleBuffer`) is exposed here as
+//! an interp-level class; `pickle.py` re-exports it and the `_pickle`
+//! accelerator serializes it in-band or out-of-band under protocol 5.
+
+pub mod pickle_buffer;
+
+pub use pickle_buffer::W_PickleBuffer;
 
 crate::py_module! {
     "__pypy__",
-    // `identity_dict` keys a memo by object identity (id(key)) so the
-    // Pickler can memoize unhashable containers.
+    // `PickleBuffer` wraps a bytes-like object for proto-5 out-of-band
+    // buffers; `identity_dict` keys a memo by object identity (id(key))
+    // so the Pickler can memoize unhashable containers.
+    interpleveldefs: {
+        "PickleBuffer" => pickle_buffer::type_object(),
+    },
     appleveldefs: {
         "identity_dict_app.py" => ["identity_dict"],
     },

--- a/pyre/pyre-interpreter/src/module/__pypy__/pickle_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/pickle_buffer.rs
@@ -1,0 +1,130 @@
+//! `__pypy__.PickleBuffer` — `pypy/module/__pypy__/interp_buffer.py
+//! W_PickleBuffer`. Wraps a bytes-like object so the `_pickle` accelerator
+//! can serialize it either in-band or out-of-band (protocol 5). The
+//! `_pickle` save path recognizes the wrapper via `from_obj` and reads its
+//! contents through `buffer_view`.
+
+use pyre_object::PyObjectRef;
+
+use crate::PyError;
+
+#[crate::pyre_class("__pypy__.PickleBuffer")]
+pub struct W_PickleBuffer {
+    /// The wrapped buffer-supporting object, or `None` after `release()`.
+    w_obj: PyObjectRef,
+}
+
+#[crate::pyre_methods(
+    doc = "PickleBuffer(buffer) -> wrapper for potentially out-of-band serialization."
+)]
+impl W_PickleBuffer {
+    #[staticmethod]
+    fn __new__(_cls: PyObjectRef) -> PyObjectRef {
+        W_PickleBuffer::allocate(W_PickleBuffer {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            w_obj: pyre_object::w_none(),
+        })
+    }
+
+    fn __init__(&mut self, buffer: PyObjectRef) -> Result<(), PyError> {
+        if !is_buffer_like(buffer) {
+            let name = type_name(buffer);
+            return Err(PyError::type_error(format!(
+                "a bytes-like object is required, not '{name}'"
+            )));
+        }
+        self.w_obj = buffer;
+        Ok(())
+    }
+
+    /// `raw()` — a memoryview onto the wrapped buffer.
+    fn raw(&self) -> Result<PyObjectRef, PyError> {
+        let w_obj = self.w_obj;
+        if unsafe { pyre_object::is_none(w_obj) } {
+            return Err(released_error());
+        }
+        let mv_type = memoryview_type()
+            .ok_or_else(|| PyError::runtime_error("memoryview type unavailable"))?;
+        crate::module::_pickle::call_fn(mv_type, &[w_obj])
+    }
+
+    /// `release()` — drop the reference to the underlying buffer.
+    fn release(&mut self) {
+        self.w_obj = pyre_object::w_none();
+    }
+}
+
+impl W_PickleBuffer {
+    /// The wrapped buffer object (`None` after `release()`), read by the
+    /// `_pickle` save path.
+    pub(crate) fn wrapped(&self) -> PyObjectRef {
+        self.w_obj
+    }
+}
+
+fn released_error() -> PyError {
+    PyError::value_error("operation forbidden on released PickleBuffer object")
+}
+
+fn type_name(obj: PyObjectRef) -> String {
+    match crate::typedef::r#type(obj) {
+        Some(t) => unsafe { pyre_object::w_type_get_name(t) }.to_string(),
+        None => "object".to_string(),
+    }
+}
+
+/// `bytes` / `bytearray` / `memoryview` are the buffer-supporting objects the
+/// wrapper accepts.
+fn is_buffer_like(obj: PyObjectRef) -> bool {
+    unsafe { pyre_object::is_bytes(obj) || pyre_object::is_bytearray(obj) || is_memoryview(obj) }
+}
+
+fn is_memoryview(obj: PyObjectRef) -> bool {
+    match crate::typedef::r#type(obj) {
+        Some(t) => unsafe { pyre_object::w_type_get_name(t) == "memoryview" },
+        None => false,
+    }
+}
+
+/// Extract `(contents, readonly)` from a buffer-supporting object: `bytes`
+/// is read-only, `bytearray` is mutable, and a `memoryview` reports both
+/// through its own contents and `readonly` flag.
+pub(crate) fn buffer_view(obj: PyObjectRef) -> Result<(Vec<u8>, bool), PyError> {
+    unsafe {
+        if pyre_object::is_bytes(obj) {
+            return Ok((pyre_object::bytesobject::w_bytes_data(obj).to_vec(), true));
+        }
+        if pyre_object::is_bytearray(obj) {
+            return Ok((
+                pyre_object::bytearrayobject::w_bytearray_data(obj).to_vec(),
+                false,
+            ));
+        }
+    }
+    if is_memoryview(obj) {
+        let w_data = crate::module::_pickle::call_meth(obj, "tobytes", &[])?;
+        let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_data) }.to_vec();
+        let w_ro = crate::baseobjspace::getattr_str(obj, "readonly")?;
+        return Ok((data, crate::baseobjspace::is_true(w_ro)));
+    }
+    Err(PyError::type_error(format!(
+        "a bytes-like object is required, not '{}'",
+        type_name(obj)
+    )))
+}
+
+/// The `memoryview` builtin type via the live execution context.
+fn memoryview_type() -> Option<PyObjectRef> {
+    let frame = crate::eval::CURRENT_FRAME.with(|f| f.get());
+    if frame.is_null() {
+        return None;
+    }
+    let ec = unsafe { (*frame).execution_context };
+    if ec.is_null() {
+        return None;
+    }
+    unsafe { (*ec).lookup_builtin("memoryview") }
+}

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -1,8 +1,9 @@
 //! _codecs module — PyPy: `pypy/module/_codecs/`.
 //!
-//! Stub providing lookup_error / register_error and encode / decode
-//! identity shells — enough for codecs.py module init to complete.
-//! Real codec dispatch is not modelled.
+//! Text codecs (`encode` / `decode`) delegate to `str.encode` /
+//! `bytes.decode`, which cover `PyCodec_Encode` / `PyCodec_Decode` for the
+//! text path. The codec registry (`register` / `lookup`) and error
+//! handlers remain stubs; binary transform codecs are not modelled.
 
 use pyre_object::*;
 
@@ -19,15 +20,41 @@ fn lookup_error(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 crate::py_module! {
     "_codecs",
+    inline_functions: {
+        // `encode(obj, encoding='utf-8', errors='strict')` — text path of
+        // `PyCodec_Encode`: a str is encoded via `str.encode`; anything
+        // else passes through unchanged.
+        fn encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("utf-8"))] encoding: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            if unsafe { is_str(obj) } {
+                let m = crate::baseobjspace::getattr_str(obj, "encode")?;
+                return crate::call::call_function_impl_result(m, &[encoding, errors]);
+            }
+            Ok(obj)
+        }
+        // `decode(obj, encoding='utf-8', errors='strict')` — text path of
+        // `PyCodec_Decode`: bytes / bytearray decode via `.decode`;
+        // anything else passes through unchanged.
+        fn decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("utf-8"))] encoding: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            if unsafe { is_bytes(obj) || is_bytearray(obj) } {
+                let m = crate::baseobjspace::getattr_str(obj, "decode")?;
+                return crate::call::call_function_impl_result(m, &[encoding, errors]);
+            }
+            Ok(obj)
+        }
+    },
     functions: {
         "lookup_error"   / 1 = lookup_error,
         "register_error" / 2 = |_| Ok(w_none()),
         "register"       / 1 = |_| Ok(w_none()),
         "lookup"         / 1 = |_| Ok(w_none()),
-        // encode / decode / _forget_codec return input unchanged — matches
-        // PyPy `_codecs.encode` when the codec is the identity.
-        "encode"         / 1 = |args| Ok(args.first().copied().unwrap_or(w_none())),
-        "decode"         / 1 = |args| Ok(args.first().copied().unwrap_or(w_none())),
         "_forget_codec"  / 1 = |args| Ok(args.first().copied().unwrap_or(w_none())),
         "charmap_build"  / 1 = |_| Ok(w_dict_new()),
     },

--- a/pyre/pyre-interpreter/src/module/_io/_io_app.py
+++ b/pyre/pyre-interpreter/src/module/_io/_io_app.py
@@ -1,0 +1,165 @@
+"""App-level fallbacks for the _io module.
+
+BytesIO is an in-memory binary stream backed by a bytearray plus an
+integer position, sufficient for pickle's pure-Python Pickler/Unpickler
+(write/getvalue on dump, read/readline on load).
+"""
+
+
+class BytesIO:
+    def __init__(self, initial_bytes=b""):
+        self._buffer = bytearray(initial_bytes)
+        self._pos = 0
+        self._closed = False
+
+    def _check_closed(self):
+        if self._closed:
+            raise ValueError("I/O operation on closed file.")
+
+    def readable(self):
+        self._check_closed()
+        return True
+
+    def writable(self):
+        self._check_closed()
+        return True
+
+    def seekable(self):
+        self._check_closed()
+        return True
+
+    def read(self, size=-1):
+        self._check_closed()
+        if size is None or size < 0:
+            end = len(self._buffer)
+        else:
+            end = min(self._pos + size, len(self._buffer))
+        data = bytes(self._buffer[self._pos:end])
+        self._pos = end
+        return data
+
+    def read1(self, size=-1):
+        return self.read(size)
+
+    def readline(self, size=-1):
+        self._check_closed()
+        buf = self._buffer
+        n = len(buf)
+        start = self._pos
+        idx = buf.find(b"\n", start)
+        if idx < 0:
+            end = n
+        else:
+            end = idx + 1
+        if size is not None and size >= 0:
+            end = min(end, start + size)
+        data = bytes(buf[start:end])
+        self._pos = end
+        return data
+
+    def readlines(self, hint=-1):
+        lines = []
+        total = 0
+        while True:
+            line = self.readline()
+            if len(line) == 0:
+                break
+            lines.append(line)
+            total += len(line)
+            if hint is not None and hint > 0 and total >= hint:
+                break
+        return lines
+
+    def write(self, b):
+        self._check_closed()
+        data = bytes(b)
+        pos = self._pos
+        buf = self._buffer
+        n = len(buf)
+        if pos == n:
+            # Append — the common path (pickle always writes at the end).
+            buf.extend(data)
+        else:
+            if pos > n:
+                buf.extend(b"\x00" * (pos - n))
+            # Overwrite/extend without slice assignment (STORE_SLICE).
+            head = bytes(buf[:pos])
+            self._buffer = bytearray(head)
+            self._buffer.extend(data)
+            tail_start = pos + len(data)
+            if tail_start < n:
+                self._buffer.extend(bytes(buf[tail_start:n]))
+            buf = self._buffer
+        self._pos = pos + len(data)
+        return len(data)
+
+    def writelines(self, lines):
+        for line in lines:
+            self.write(line)
+
+    def seek(self, pos, whence=0):
+        self._check_closed()
+        if whence == 0:
+            if pos < 0:
+                raise ValueError("negative seek value %r" % (pos,))
+            newpos = pos
+        elif whence == 1:
+            newpos = self._pos + pos
+        elif whence == 2:
+            newpos = len(self._buffer) + pos
+        else:
+            raise ValueError("invalid whence (%r, should be 0, 1 or 2)" % (whence,))
+        if newpos < 0:
+            newpos = 0
+        self._pos = newpos
+        return newpos
+
+    def tell(self):
+        self._check_closed()
+        return self._pos
+
+    def truncate(self, size=None):
+        self._check_closed()
+        if size is None:
+            size = self._pos
+        if size < 0:
+            raise ValueError("negative truncate size %r" % (size,))
+        if size < len(self._buffer):
+            self._buffer = bytearray(bytes(self._buffer[:size]))
+        return size
+
+    def getvalue(self):
+        self._check_closed()
+        return bytes(self._buffer)
+
+    def getbuffer(self):
+        self._check_closed()
+        return memoryview(self._buffer)
+
+    def flush(self):
+        self._check_closed()
+
+    @property
+    def closed(self):
+        return self._closed
+
+    def close(self):
+        self._closed = True
+        self._buffer = bytearray()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = self.readline()
+        if len(line) == 0:
+            raise StopIteration
+        return line
+
+    def __enter__(self):
+        self._check_closed()
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -11,13 +11,14 @@ crate::py_module! {
     "_io",
     interpleveldefs: {
         "DEFAULT_BUFFER_SIZE" => w_int_new(8192),
-        // Exception types as strings (isinstance checks in io.py).
-        "UnsupportedOperation" => w_str_new("UnsupportedOperation"),
-        "BlockingIOError"      => w_str_new("BlockingIOError"),
+    },
+    // BytesIO is the pure-Python in-memory binary stream pickle's
+    // Pickler/Unpickler write to and read from.
+    appleveldefs: {
+        "_io_app.py" => ["BytesIO"],
     },
     functions: {
         "StringIO"        / * = |_| Ok(w_str_new("")),
-        "BytesIO"         / * = |_| Ok(w_str_new("")),
         "FileIO"          / * = |_| Ok(w_none()),
         "BufferedReader"  / * = |_| Ok(w_none()),
         "BufferedWriter"  / * = |_| Ok(w_none()),
@@ -30,6 +31,30 @@ crate::py_module! {
         "text_encoding"   / * = |args| Ok(args.first().copied().unwrap_or_else(|| w_str_new("utf-8"))),
     },
     extra_init: |ns| {
+        // `Modules/_io/_iomodule.c`:
+        //   UnsupportedOperation = class UnsupportedOperation(OSError, ValueError)
+        // A real exception class so `raise`/`except` and io.py's
+        // `UnsupportedOperation.__module__ = "io"` work.  Falls back to a
+        // single OSError base if the builtin exceptions aren't registered.
+        let os_error = crate::builtins::lookup_exc_class("OSError")
+            .expect("OSError must be registered before _io init");
+        let bases: &[pyre_object::PyObjectRef] =
+            match crate::builtins::lookup_exc_class("ValueError") {
+                Some(value_error) => &[os_error, value_error],
+                None => &[os_error],
+            };
+        let unsupported = crate::builtins::make_exc_type_multi(
+            "io.UnsupportedOperation",
+            crate::builtins::exc_exception_new,
+            bases,
+        );
+        crate::dict_storage_store(ns, "UnsupportedOperation", unsupported);
+
+        // `_io.BlockingIOError` aliases the builtin BlockingIOError.
+        if let Some(blocking) = crate::builtins::lookup_exc_class("BlockingIOError") {
+            crate::dict_storage_store(ns, "BlockingIOError", blocking);
+        }
+
         // Abstract base classes as W_TypeObject (required for io.py class inheritance).
         let obj_type = crate::typedef::w_object();
         for name in &["_IOBase", "_RawIOBase", "_BufferedIOBase", "_TextIOBase"] {

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -1,0 +1,171 @@
+//! `_pickle` — interp-level accelerator for the `pickle` module.
+//!
+//! Port of `pypy/module/_pickle/interp_pickle.py` (`W_Pickler` /
+//! `W_Unpickler`). Targets the CPython 3.14 wire format.
+//!
+//! Increment 1 scope: protocol 2-5 atoms — None / bool / int / float /
+//! str / bytes — plus PROTO / FRAME / STOP framing and the MEMOIZE write
+//! (so single-atom output is byte-identical). Memo back-references
+//! (GET/BINGET dedup), containers, sets, global/reduce, the legacy
+//! protocol-0/1 text opcodes, and out-of-band buffers land in later
+//! increments. The module deliberately exports only `Pickler` /
+//! `Unpickler`; `pickle.py`'s `from _pickle import (...)` keeps falling
+//! back to the pure-Python path until the full surface is ready.
+
+use malachite_bigint::{BigInt, Sign};
+use pyre_object::PyObjectRef;
+
+use crate::PyError;
+
+mod pickler;
+mod unpickler;
+
+pub use pickler::W_Pickler;
+pub use unpickler::W_Unpickler;
+
+pub(crate) const HIGHEST_PROTOCOL: i64 = 5;
+pub(crate) const DEFAULT_PROTOCOL: i64 = 5;
+pub(crate) const FRAME_SIZE_MIN: usize = 4;
+
+/// `interp_pickle.py Opcodes`.
+pub(crate) mod op {
+    pub const PROTO: u8 = 0x80;
+    pub const FRAME: u8 = 0x95;
+    pub const STOP: u8 = b'.';
+    pub const NONE: u8 = b'N';
+    pub const NEWTRUE: u8 = 0x88;
+    pub const NEWFALSE: u8 = 0x89;
+    pub const BININT: u8 = b'J';
+    pub const BININT1: u8 = b'K';
+    pub const BININT2: u8 = b'M';
+    pub const LONG1: u8 = 0x8a;
+    pub const LONG4: u8 = 0x8b;
+    pub const BINFLOAT: u8 = b'G';
+    pub const SHORT_BINUNICODE: u8 = 0x8c;
+    pub const BINUNICODE: u8 = b'X';
+    pub const BINUNICODE8: u8 = 0x8d;
+    pub const SHORT_BINBYTES: u8 = b'C';
+    pub const BINBYTES: u8 = b'B';
+    pub const BINBYTES8: u8 = 0x8e;
+    pub const MEMOIZE: u8 = 0x94;
+    pub const BINPUT: u8 = b'q';
+    pub const LONG_BINPUT: u8 = b'r';
+    pub const PUT: u8 = b'p';
+}
+
+// ── shared call helpers ──────────────────────────────────────────────
+// `call_function` / `call_method` return PY_NULL on failure and stash the
+// error through `call::set_call_error`; surface it as a Rust `Result`.
+
+pub(crate) fn call_fn(callable: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
+    let r = crate::baseobjspace::call_function(callable, args);
+    if r.is_null() {
+        return Err(crate::call::take_call_error()
+            .unwrap_or_else(|| PyError::runtime_error("call failed")));
+    }
+    Ok(r)
+}
+
+pub(crate) fn call_meth(
+    obj: PyObjectRef,
+    name: &str,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, PyError> {
+    let r = crate::baseobjspace::call_method(obj, name, args);
+    if r.is_null() {
+        return Err(crate::call::take_call_error()
+            .unwrap_or_else(|| PyError::runtime_error("method call failed")));
+    }
+    Ok(r)
+}
+
+// TODO(inc8): raise the app-level `_pickle.PicklingError` / `UnpicklingError`
+// once those classes are registered; until then carry the faithful message
+// text on a generic error.
+pub(crate) fn unpickling_error(msg: &str) -> PyError {
+    PyError::value_error(msg)
+}
+
+// ── encode_long / decode_long — two's-complement little-endian ───────
+// `interp_pickle.py encode_long` / CPython `pickle.encode_long`.
+
+pub(crate) fn encode_long(big: &BigInt) -> Vec<u8> {
+    let sign = big.sign();
+    if sign == Sign::NoSign {
+        return Vec::new(); // 0 -> b''
+    }
+    // magnitude, little-endian
+    let (_s, digits) = big.to_u32_digits();
+    let mut mag: Vec<u8> = Vec::with_capacity(digits.len() * 4);
+    for d in &digits {
+        mag.extend_from_slice(&d.to_le_bytes());
+    }
+    while mag.len() > 1 && *mag.last().unwrap() == 0 {
+        mag.pop();
+    }
+    // reserve a byte for the sign bit when the top magnitude bit is set
+    if mag.last().map_or(true, |&b| b & 0x80 != 0) {
+        mag.push(0x00);
+    }
+    if sign == Sign::Plus {
+        return mag;
+    }
+    // negative: two's complement (invert + 1)
+    let mut carry: u16 = 1;
+    for b in mag.iter_mut() {
+        let v = (!*b as u16) + carry;
+        *b = (v & 0xff) as u8;
+        carry = v >> 8;
+    }
+    // trim a redundant 0xff sign byte (encode_long minimal form)
+    while mag.len() > 1 && mag[mag.len() - 1] == 0xff && (mag[mag.len() - 2] & 0x80) != 0 {
+        mag.pop();
+    }
+    mag
+}
+
+pub(crate) fn decode_long(data: &[u8]) -> PyObjectRef {
+    if data.is_empty() {
+        return pyre_object::w_int_new(0);
+    }
+    let negative = data[data.len() - 1] & 0x80 != 0;
+    let unsigned = BigInt::from_bytes_le(Sign::Plus, data);
+    let value = if negative {
+        // subtract 2**(8*len): little-endian bytes are `len` zeros then 0x01
+        let mut pow = vec![0u8; data.len()];
+        pow.push(1);
+        unsigned - BigInt::from_bytes_le(Sign::Plus, &pow)
+    } else {
+        unsigned
+    };
+    int_from_bigint(value)
+}
+
+/// Demote to a small int when it fits, mirroring the int/long unification.
+pub(crate) fn int_from_bigint(value: BigInt) -> PyObjectRef {
+    match i64::try_from(&value) {
+        Ok(v) => pyre_object::w_int_new(v),
+        Err(_) => pyre_object::w_long_new(value),
+    }
+}
+
+pub(crate) fn read_int_le(data: &[u8]) -> i64 {
+    let mut v: i64 = 0;
+    for (i, &b) in data.iter().enumerate() {
+        v |= (b as i64) << (8 * i);
+    }
+    v
+}
+
+pub(crate) fn str_from_utf8(data: &[u8]) -> Result<PyObjectRef, PyError> {
+    let s = std::str::from_utf8(data).map_err(|_| unpickling_error("invalid utf-8 in pickle"))?;
+    Ok(pyre_object::w_str_new(s))
+}
+
+crate::py_module! {
+    "_pickle",
+    interpleveldefs: {
+        "Pickler" => pickler::type_object(),
+        "Unpickler" => unpickler::type_object(),
+    },
+}

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -397,11 +397,9 @@ crate::py_module! {
             obj: PyObjectRef,
             file: PyObjectRef,
             #[default(pyre_object::w_none())] protocol: PyObjectRef,
-            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::boolobject::w_bool_from(true))] fix_imports: PyObjectRef,
             #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
-            // `fix_imports` is applied at the save sites by protocol.
-            let _ = fix_imports;
             let proto = pickler::normalize_protocol(protocol)?;
             pickler::check_buffer_callback(buffer_callback, proto)?;
             let _roots = pyre_object::gc_roots::push_roots();
@@ -412,8 +410,10 @@ crate::py_module! {
                 proto,
                 proto >= 1,
                 proto >= 4,
+                crate::baseobjspace::is_true(fix_imports),
                 pyre_object::PY_NULL,
                 buffer_callback,
+                pyre_object::listobject::w_list_new(Vec::new()),
             )?;
             let file = pyre_object::gc_roots::shadow_stack_get(file_slot);
             call_meth(file, "write", &[w_bytes])?;
@@ -424,10 +424,9 @@ crate::py_module! {
         fn dumps(
             obj: PyObjectRef,
             #[default(pyre_object::w_none())] protocol: PyObjectRef,
-            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::boolobject::w_bool_from(true))] fix_imports: PyObjectRef,
             #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
-            let _ = fix_imports;
             let proto = pickler::normalize_protocol(protocol)?;
             pickler::check_buffer_callback(buffer_callback, proto)?;
             pickler::pickle_core(
@@ -435,15 +434,17 @@ crate::py_module! {
                 proto,
                 proto >= 1,
                 proto >= 4,
+                crate::baseobjspace::is_true(fix_imports),
                 pyre_object::PY_NULL,
                 buffer_callback,
+                pyre_object::listobject::w_list_new(Vec::new()),
             )
         }
 
         // `pickle.load` — read a pickle from `file`.
         fn load(
             file: PyObjectRef,
-            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::boolobject::w_bool_from(true))] fix_imports: PyObjectRef,
             #[default(pyre_object::w_none())] encoding: PyObjectRef,
             #[default(pyre_object::w_none())] errors: PyObjectRef,
             #[default(pyre_object::w_none())] buffers: PyObjectRef,
@@ -458,7 +459,7 @@ crate::py_module! {
         // `pickle.loads` — read a pickle from a `bytes` object.
         fn loads(
             data: PyObjectRef,
-            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::boolobject::w_bool_from(true))] fix_imports: PyObjectRef,
             #[default(pyre_object::w_none())] encoding: PyObjectRef,
             #[default(pyre_object::w_none())] errors: PyObjectRef,
             #[default(pyre_object::w_none())] buffers: PyObjectRef,

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -27,6 +27,7 @@ pub use unpickler::W_Unpickler;
 pub(crate) const HIGHEST_PROTOCOL: i64 = 5;
 pub(crate) const DEFAULT_PROTOCOL: i64 = 5;
 pub(crate) const FRAME_SIZE_MIN: usize = 4;
+pub(crate) const FRAME_SIZE_TARGET: usize = 64 * 1024;
 
 /// `interp_pickle.py Opcodes`.
 pub(crate) mod op {

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -92,6 +92,20 @@ pub(crate) mod op {
     pub const EXT1: u8 = 0x82;
     pub const EXT2: u8 = 0x83;
     pub const EXT4: u8 = 0x84;
+    // protocol 0 / 1 legacy text opcodes
+    pub const INT: u8 = b'I';
+    pub const LONG: u8 = b'L';
+    pub const FLOAT: u8 = b'F';
+    pub const STRING: u8 = b'S';
+    pub const UNICODE: u8 = b'V';
+    pub const BINSTRING: u8 = b'T';
+    pub const SHORT_BINSTRING: u8 = b'U';
+    pub const INST: u8 = b'i';
+    pub const OBJ: u8 = b'o';
+    pub const DUP: u8 = b'2';
+    // persistent id
+    pub const PERSID: u8 = b'P';
+    pub const BINPERSID: u8 = b'Q';
 
     /// `_tuplesize2code` — TUPLE1/2/3 indexed by element count (1..=3).
     pub const TUPLESIZE2CODE: [u8; 4] = [EMPTY_TUPLE, TUPLE1, TUPLE2, TUPLE3];
@@ -107,8 +121,9 @@ pub(crate) const BATCHSIZE: usize = 1000;
 pub(crate) fn call_fn(callable: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let r = crate::baseobjspace::call_function(callable, args);
     if r.is_null() {
-        return Err(crate::call::take_call_error()
-            .unwrap_or_else(|| PyError::runtime_error("call failed")));
+        return Err(
+            crate::call::take_call_error().unwrap_or_else(|| PyError::runtime_error("call failed"))
+        );
     }
     Ok(r)
 }
@@ -191,6 +206,50 @@ pub(crate) fn lookup_builtin(name: &str) -> Option<PyObjectRef> {
     current_ec().and_then(|ec| unsafe { (*ec).lookup_builtin(name) })
 }
 
+/// `_compat_pickle` import/name compatibility mapping applied at protocol
+/// < 3. `reverse` picks the py3 → py2 direction used when dumping (the
+/// REVERSE_* tables); the forward direction (py2 → py3) is used when
+/// loading. Returns the mapped `(module, name)`, unchanged when no entry
+/// matches.
+pub(crate) fn compat_map(module: &str, name: &str, reverse: bool) -> (String, String) {
+    let (name_map_attr, import_map_attr) = if reverse {
+        ("REVERSE_NAME_MAPPING", "REVERSE_IMPORT_MAPPING")
+    } else {
+        ("NAME_MAPPING", "IMPORT_MAPPING")
+    };
+    let compat = match import_module("_compat_pickle") {
+        Ok(m) => m,
+        Err(_) => return (module.to_string(), name.to_string()),
+    };
+    // (module, name) entry takes precedence over a bare module remap.
+    if let Ok(w_name_map) = crate::baseobjspace::getattr_str(compat, name_map_attr) {
+        let key = pyre_object::tupleobject::w_tuple_new(vec![
+            pyre_object::w_str_new(module),
+            pyre_object::w_str_new(name),
+        ]);
+        if let Some(v) = unsafe { pyre_object::w_dict_lookup(w_name_map, key) } {
+            let m = unsafe { pyre_object::tupleobject::w_tuple_getitem(v, 0) };
+            let n = unsafe { pyre_object::tupleobject::w_tuple_getitem(v, 1) };
+            if let (Some(m), Some(n)) = (m, n) {
+                return (
+                    unsafe { pyre_object::strobject::w_str_get_value(m) }.to_string(),
+                    unsafe { pyre_object::strobject::w_str_get_value(n) }.to_string(),
+                );
+            }
+        }
+    }
+    if let Ok(w_import_map) = crate::baseobjspace::getattr_str(compat, import_map_attr) {
+        if let Some(v) = unsafe { pyre_object::w_dict_lookup(w_import_map, pyre_object::w_str_new(module)) }
+        {
+            return (
+                unsafe { pyre_object::strobject::w_str_get_value(v) }.to_string(),
+                name.to_string(),
+            );
+        }
+    }
+    (module.to_string(), name.to_string())
+}
+
 /// `interp_pickle.py _getattribute` — walk a dotted `qualname` from `obj`,
 /// returning `(resolved, parent)`.
 pub(crate) fn getattribute_dotted(
@@ -271,6 +330,14 @@ pub(crate) fn int_from_bigint(value: BigInt) -> PyObjectRef {
     match i64::try_from(&value) {
         Ok(v) => pyre_object::w_int_new(v),
         Err(_) => pyre_object::w_long_new(value),
+    }
+}
+
+/// Parse a decimal integer literal (INT / LONG text opcodes) into an int.
+pub(crate) fn parse_int_text(s: &str) -> Result<PyObjectRef, PyError> {
+    match BigInt::parse_bytes(s.trim().as_bytes(), 10) {
+        Some(big) => Ok(int_from_bigint(big)),
+        None => Err(unpickling_error("could not convert string to int")),
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -379,6 +379,9 @@ crate::py_module! {
     interpleveldefs: {
         "Pickler" => pickler::type_object(),
         "Unpickler" => unpickler::type_object(),
+        // Shared singleton with `__pypy__.PickleBuffer`; `pickle.py` does
+        // `from _pickle import PickleBuffer` to set `_HAVE_PICKLE_BUFFER`.
+        "PickleBuffer" => crate::module::__pypy__::pickle_buffer::type_object(),
     },
     exceptions: {
         "PickleError" => crate::builtins::lookup_exc_class("Exception")
@@ -397,17 +400,21 @@ crate::py_module! {
             #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
             #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
-            // `buffer_callback` is accepted for signature compatibility but
-            // only ever invoked for PickleBuffer values (out-of-band buffers,
-            // deferred); no PickleBuffer can be constructed here, so ignoring
-            // it is behaviorally identical to the callback never firing.
-            let _ = (fix_imports, buffer_callback);
+            // `fix_imports` is applied at the save sites by protocol.
+            let _ = fix_imports;
             let proto = pickler::normalize_protocol(protocol)?;
+            pickler::check_buffer_callback(buffer_callback, proto)?;
             let _roots = pyre_object::gc_roots::push_roots();
             pyre_object::gc_roots::pin_root(file);
             let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            let w_bytes =
-                pickler::pickle_core(obj, proto, proto >= 1, proto >= 4, pyre_object::PY_NULL)?;
+            let w_bytes = pickler::pickle_core(
+                obj,
+                proto,
+                proto >= 1,
+                proto >= 4,
+                pyre_object::PY_NULL,
+                buffer_callback,
+            )?;
             let file = pyre_object::gc_roots::shadow_stack_get(file_slot);
             call_meth(file, "write", &[w_bytes])?;
             Ok(pyre_object::w_none())
@@ -420,9 +427,17 @@ crate::py_module! {
             #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
             #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
-            let _ = (fix_imports, buffer_callback);
+            let _ = fix_imports;
             let proto = pickler::normalize_protocol(protocol)?;
-            pickler::pickle_core(obj, proto, proto >= 1, proto >= 4, pyre_object::PY_NULL)
+            pickler::check_buffer_callback(buffer_callback, proto)?;
+            pickler::pickle_core(
+                obj,
+                proto,
+                proto >= 1,
+                proto >= 4,
+                pyre_object::PY_NULL,
+                buffer_callback,
+            )
         }
 
         // `pickle.load` — read a pickle from `file`.
@@ -433,8 +448,10 @@ crate::py_module! {
             #[default(pyre_object::w_none())] errors: PyObjectRef,
             #[default(pyre_object::w_none())] buffers: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
-            let _ = (fix_imports, encoding, errors, buffers);
-            let unpickler = call_fn(unpickler::type_object(), &[file])?;
+            let unpickler = call_fn(
+                unpickler::type_object(),
+                &[file, fix_imports, encoding, errors, buffers],
+            )?;
             call_meth(unpickler, "load", &[])
         }
 
@@ -446,17 +463,31 @@ crate::py_module! {
             #[default(pyre_object::w_none())] errors: PyObjectRef,
             #[default(pyre_object::w_none())] buffers: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
-            let _ = (fix_imports, encoding, errors, buffers);
+            // Pin every argument that outlives the `BytesIO` construction;
+            // a minor collection there can relocate them.
             let _roots = pyre_object::gc_roots::push_roots();
+            let base = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(data);
-            let data_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            pyre_object::gc_roots::pin_root(fix_imports);
+            pyre_object::gc_roots::pin_root(encoding);
+            pyre_object::gc_roots::pin_root(errors);
+            pyre_object::gc_roots::pin_root(buffers);
             let io = import_module("io")?;
             let bytesio_cls = crate::baseobjspace::getattr_str(io, "BytesIO")?;
             let file = call_fn(
                 bytesio_cls,
-                &[pyre_object::gc_roots::shadow_stack_get(data_slot)],
+                &[pyre_object::gc_roots::shadow_stack_get(base)],
             )?;
-            let unpickler = call_fn(unpickler::type_object(), &[file])?;
+            let unpickler = call_fn(
+                unpickler::type_object(),
+                &[
+                    file,
+                    pyre_object::gc_roots::shadow_stack_get(base + 1),
+                    pyre_object::gc_roots::shadow_stack_get(base + 2),
+                    pyre_object::gc_roots::shadow_stack_get(base + 3),
+                    pyre_object::gc_roots::shadow_stack_get(base + 4),
+                ],
+            )?;
             call_meth(unpickler, "load", &[])
         }
     },

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -83,6 +83,9 @@ pub(crate) mod op {
     pub const ADDITEMS: u8 = 0x90;
     // bytearray
     pub const BYTEARRAY8: u8 = 0x96;
+    // protocol 5 out-of-band buffers (see the deferral note in `pickler.rs`).
+    pub const NEXT_BUFFER: u8 = 0x97;
+    pub const READONLY_BUFFER: u8 = 0x98;
     // reduce / global
     pub const REDUCE: u8 = b'R';
     pub const BUILD: u8 = b'b';

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -82,6 +82,16 @@ pub(crate) mod op {
     pub const ADDITEMS: u8 = 0x90;
     // bytearray
     pub const BYTEARRAY8: u8 = 0x96;
+    // reduce / global
+    pub const REDUCE: u8 = b'R';
+    pub const BUILD: u8 = b'b';
+    pub const GLOBAL: u8 = b'c';
+    pub const STACK_GLOBAL: u8 = 0x93;
+    pub const NEWOBJ: u8 = 0x81;
+    pub const NEWOBJ_EX: u8 = 0x92;
+    pub const EXT1: u8 = 0x82;
+    pub const EXT2: u8 = 0x83;
+    pub const EXT4: u8 = 0x84;
 
     /// `_tuplesize2code` — TUPLE1/2/3 indexed by element count (1..=3).
     pub const TUPLESIZE2CODE: [u8; 4] = [EMPTY_TUPLE, TUPLE1, TUPLE2, TUPLE3];
@@ -121,6 +131,84 @@ pub(crate) fn call_meth(
 // text on a generic error.
 pub(crate) fn unpickling_error(msg: &str) -> PyError {
     PyError::value_error(msg)
+}
+
+pub(crate) fn pickling_error(msg: impl Into<String>) -> PyError {
+    PyError::value_error(msg.into())
+}
+
+// ── import / dotted attribute resolution (save_global / find_class) ───
+
+/// Return the named module from `sys.modules`, importing it only if absent.
+/// An already-loaded module is returned directly: re-running `importhook`
+/// for a loaded module (notably `builtins`) can rebind the canonical module
+/// object and corrupt name resolution elsewhere. The `sys.modules` entry
+/// (not the `importhook` return) is authoritative.
+pub(crate) fn import_module(name: &str) -> Result<PyObjectRef, PyError> {
+    if let Some(m) = crate::importing::get_sys_module(name) {
+        return Ok(m);
+    }
+    // The `builtins` module lives on the execution context, not in the
+    // importable `sys.modules` cache; re-running `importhook` on it would
+    // reinitialise builtin state (and orphan the live exception classes).
+    if name == "builtins" {
+        if let Some(b) = ec_builtins_module() {
+            return Ok(b);
+        }
+    }
+    crate::importing::importhook(
+        name,
+        pyre_object::w_none(),
+        pyre_object::listobject::w_list_new(vec![pyre_object::w_str_new("*")]),
+        0,
+        crate::call::getexecutioncontext(),
+    )?;
+    crate::importing::get_sys_module(name)
+        .ok_or_else(|| PyError::value_error(format!("Can't find module {name:?} in sys.modules")))
+}
+
+/// The live execution context reached via the current frame, or `None`
+/// when no frame is on the stack.
+fn current_ec() -> Option<*const crate::PyExecutionContext> {
+    let frame = crate::eval::CURRENT_FRAME.with(|f| f.get());
+    if frame.is_null() {
+        return None;
+    }
+    let ec = unsafe { (*frame).execution_context };
+    if ec.is_null() { None } else { Some(ec) }
+}
+
+/// The current execution context's `builtins` module, via the live frame.
+fn ec_builtins_module() -> Option<PyObjectRef> {
+    current_ec().map(|ec| unsafe { (*ec).get_builtin() })
+}
+
+/// Resolve a name in the `builtins` module through the execution context's
+/// `lookup_builtin` (the `LOAD_GLOBAL` fallback path). This bypasses the
+/// module-object `getattr` wrapper, whose hash table does not see builtins
+/// installed on the underlying storage.
+pub(crate) fn lookup_builtin(name: &str) -> Option<PyObjectRef> {
+    current_ec().and_then(|ec| unsafe { (*ec).lookup_builtin(name) })
+}
+
+/// `interp_pickle.py _getattribute` — walk a dotted `qualname` from `obj`,
+/// returning `(resolved, parent)`.
+pub(crate) fn getattribute_dotted(
+    obj: PyObjectRef,
+    qualname: &str,
+) -> Result<(PyObjectRef, PyObjectRef), PyError> {
+    let mut cur = obj;
+    let mut parent = obj;
+    for sub in qualname.split('.') {
+        if sub == "<locals>" {
+            return Err(PyError::attribute_error(format!(
+                "Can't get local attribute {qualname:?}"
+            )));
+        }
+        parent = cur;
+        cur = crate::baseobjspace::getattr_str(cur, sub)?;
+    }
+    Ok((cur, parent))
 }
 
 // ── encode_long / decode_long — two's-complement little-endian ───────

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -3,10 +3,11 @@
 //! Port of `pypy/module/_pickle/interp_pickle.py` (`W_Pickler` /
 //! `W_Unpickler`). Targets the CPython 3.14 wire format.
 //!
-//! Increment 1 scope: protocol 2-5 atoms — None / bool / int / float /
-//! str / bytes — plus PROTO / FRAME / STOP framing and the MEMOIZE write
-//! (so single-atom output is byte-identical). Memo back-references
-//! (GET/BINGET dedup), containers, sets, global/reduce, the legacy
+//! Current scope: protocol 2-5 atoms — None / bool / int / float / str /
+//! bytes — plus PROTO / FRAME / STOP framing, the memo (MEMOIZE/BINPUT/PUT
+//! writes + GET/BINGET/LONG_BINGET back-references), and the built-in
+//! containers tuple / list / dict (with APPENDS / SETITEMS batching and
+//! recursive-structure handling). Sets, global/reduce, the legacy
 //! protocol-0/1 text opcodes, and out-of-band buffers land in later
 //! increments. The module deliberately exports only `Pickler` /
 //! `Unpickler`; `pickle.py`'s `from _pickle import (...)` keeps falling
@@ -47,11 +48,47 @@ pub(crate) mod op {
     pub const SHORT_BINBYTES: u8 = b'C';
     pub const BINBYTES: u8 = b'B';
     pub const BINBYTES8: u8 = 0x8e;
+    // memo
     pub const MEMOIZE: u8 = 0x94;
     pub const BINPUT: u8 = b'q';
     pub const LONG_BINPUT: u8 = b'r';
     pub const PUT: u8 = b'p';
+    pub const GET: u8 = b'g';
+    pub const BINGET: u8 = b'h';
+    pub const LONG_BINGET: u8 = b'j';
+    // stack
+    pub const MARK: u8 = b'(';
+    pub const POP: u8 = b'0';
+    pub const POP_MARK: u8 = b'1';
+    // tuple
+    pub const EMPTY_TUPLE: u8 = b')';
+    pub const TUPLE: u8 = b't';
+    pub const TUPLE1: u8 = 0x85;
+    pub const TUPLE2: u8 = 0x86;
+    pub const TUPLE3: u8 = 0x87;
+    // list
+    pub const EMPTY_LIST: u8 = b']';
+    pub const LIST: u8 = b'l';
+    pub const APPEND: u8 = b'a';
+    pub const APPENDS: u8 = b'e';
+    // dict
+    pub const EMPTY_DICT: u8 = b'}';
+    pub const DICT: u8 = b'd';
+    pub const SETITEM: u8 = b's';
+    pub const SETITEMS: u8 = b'u';
+    // set / frozenset
+    pub const EMPTY_SET: u8 = 0x8f;
+    pub const FROZENSET: u8 = 0x91;
+    pub const ADDITEMS: u8 = 0x90;
+    // bytearray
+    pub const BYTEARRAY8: u8 = 0x96;
+
+    /// `_tuplesize2code` — TUPLE1/2/3 indexed by element count (1..=3).
+    pub const TUPLESIZE2CODE: [u8; 4] = [EMPTY_TUPLE, TUPLE1, TUPLE2, TUPLE3];
 }
+
+/// `interp_pickle.py W_Pickler._BATCHSIZE`.
+pub(crate) const BATCHSIZE: usize = 1000;
 
 // ── shared call helpers ──────────────────────────────────────────────
 // `call_function` / `call_method` return PY_NULL on failure and stash the

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -3,15 +3,18 @@
 //! Port of `pypy/module/_pickle/interp_pickle.py` (`W_Pickler` /
 //! `W_Unpickler`). Targets the CPython 3.14 wire format.
 //!
-//! Current scope: protocol 2-5 atoms — None / bool / int / float / str /
-//! bytes — plus PROTO / FRAME / STOP framing, the memo (MEMOIZE/BINPUT/PUT
-//! writes + GET/BINGET/LONG_BINGET back-references), and the built-in
-//! containers tuple / list / dict (with APPENDS / SETITEMS batching and
-//! recursive-structure handling). Sets, global/reduce, the legacy
-//! protocol-0/1 text opcodes, and out-of-band buffers land in later
-//! increments. The module deliberately exports only `Pickler` /
-//! `Unpickler`; `pickle.py`'s `from _pickle import (...)` keeps falling
-//! back to the pure-Python path until the full surface is ready.
+//! Scope: protocols 0-5 — atoms (None / bool / int / float / str / bytes),
+//! the memo (PUT/GET families), containers (tuple / list / dict with
+//! APPENDS / SETITEMS batching + recursion), set / frozenset / bytearray,
+//! the reduce protocol (save_reduce / save_global / find_class), the legacy
+//! protocol-0/1 text opcodes, persistent_id, `_compat_pickle` fix_imports,
+//! and the multi-frame framer. Out-of-band proto-5 buffers are deferred
+//! (see the note at the pickler dispatch site).
+//!
+//! The module exports all nine names `pickle.py` imports — `Pickler`,
+//! `Unpickler`, `dump`, `dumps`, `load`, `loads`, `PickleError`,
+//! `PicklingError`, `UnpicklingError` — so `from _pickle import (...)`
+//! resolves and the accelerated path engages.
 
 use malachite_bigint::{BigInt, Sign};
 use pyre_object::PyObjectRef;
@@ -145,15 +148,27 @@ pub(crate) fn call_meth(
     Ok(r)
 }
 
-// TODO(inc8): raise the app-level `_pickle.PicklingError` / `UnpicklingError`
-// once those classes are registered; until then carry the faithful message
-// text on a generic error.
+/// Build a `PyError` whose raised object is an instance of the named
+/// `_pickle` exception class (registered by the `exceptions:` block), with
+/// `msg` as the single argument. Falls back to a generic ValueError carrying
+/// the same text if the class is somehow unavailable.
+fn pickle_exc(class_name: &str, msg: String) -> PyError {
+    let mut err = PyError::value_error(msg.clone());
+    if let Some(cls) = crate::builtins::lookup_exc_class(class_name) {
+        let args = [cls, pyre_object::w_str_new(&msg)];
+        if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
+            err.exc_object = exc;
+        }
+    }
+    err
+}
+
 pub(crate) fn unpickling_error(msg: &str) -> PyError {
-    PyError::value_error(msg)
+    pickle_exc("_pickle.UnpicklingError", msg.to_string())
 }
 
 pub(crate) fn pickling_error(msg: impl Into<String>) -> PyError {
-    PyError::value_error(msg.into())
+    pickle_exc("_pickle.PicklingError", msg.into())
 }
 
 // ── import / dotted attribute resolution (save_global / find_class) ───
@@ -243,7 +258,8 @@ pub(crate) fn compat_map(module: &str, name: &str, reverse: bool) -> (String, St
         }
     }
     if let Ok(w_import_map) = crate::baseobjspace::getattr_str(compat, import_map_attr) {
-        if let Some(v) = unsafe { pyre_object::w_dict_lookup(w_import_map, pyre_object::w_str_new(module)) }
+        if let Some(v) =
+            unsafe { pyre_object::w_dict_lookup(w_import_map, pyre_object::w_str_new(module)) }
         {
             return (
                 unsafe { pyre_object::strobject::w_str_get_value(v) }.to_string(),
@@ -363,5 +379,85 @@ crate::py_module! {
     interpleveldefs: {
         "Pickler" => pickler::type_object(),
         "Unpickler" => unpickler::type_object(),
+    },
+    exceptions: {
+        "PickleError" => crate::builtins::lookup_exc_class("Exception")
+            .expect("Exception must be installed before _pickle init"),
+        "PicklingError" => crate::builtins::lookup_exc_class("_pickle.PickleError")
+            .expect("_pickle.PickleError registered just above"),
+        "UnpicklingError" => crate::builtins::lookup_exc_class("_pickle.PickleError")
+            .expect("_pickle.PickleError registered just above"),
+    },
+    inline_functions: {
+        // `pickle.dump` — write a pickle of `obj` to `file`.
+        fn dump(
+            obj: PyObjectRef,
+            file: PyObjectRef,
+            #[default(pyre_object::w_none())] protocol: PyObjectRef,
+            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
+        ) -> Result<PyObjectRef, PyError> {
+            // `buffer_callback` is accepted for signature compatibility but
+            // only ever invoked for PickleBuffer values (out-of-band buffers,
+            // deferred); no PickleBuffer can be constructed here, so ignoring
+            // it is behaviorally identical to the callback never firing.
+            let _ = (fix_imports, buffer_callback);
+            let proto = pickler::normalize_protocol(protocol)?;
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(file);
+            let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let w_bytes =
+                pickler::pickle_core(obj, proto, proto >= 1, proto >= 4, pyre_object::PY_NULL)?;
+            let file = pyre_object::gc_roots::shadow_stack_get(file_slot);
+            call_meth(file, "write", &[w_bytes])?;
+            Ok(pyre_object::w_none())
+        }
+
+        // `pickle.dumps` — return a pickle of `obj` as `bytes`.
+        fn dumps(
+            obj: PyObjectRef,
+            #[default(pyre_object::w_none())] protocol: PyObjectRef,
+            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
+        ) -> Result<PyObjectRef, PyError> {
+            let _ = (fix_imports, buffer_callback);
+            let proto = pickler::normalize_protocol(protocol)?;
+            pickler::pickle_core(obj, proto, proto >= 1, proto >= 4, pyre_object::PY_NULL)
+        }
+
+        // `pickle.load` — read a pickle from `file`.
+        fn load(
+            file: PyObjectRef,
+            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::w_none())] encoding: PyObjectRef,
+            #[default(pyre_object::w_none())] errors: PyObjectRef,
+            #[default(pyre_object::w_none())] buffers: PyObjectRef,
+        ) -> Result<PyObjectRef, PyError> {
+            let _ = (fix_imports, encoding, errors, buffers);
+            let unpickler = call_fn(unpickler::type_object(), &[file])?;
+            call_meth(unpickler, "load", &[])
+        }
+
+        // `pickle.loads` — read a pickle from a `bytes` object.
+        fn loads(
+            data: PyObjectRef,
+            #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+            #[default(pyre_object::w_none())] encoding: PyObjectRef,
+            #[default(pyre_object::w_none())] errors: PyObjectRef,
+            #[default(pyre_object::w_none())] buffers: PyObjectRef,
+        ) -> Result<PyObjectRef, PyError> {
+            let _ = (fix_imports, encoding, errors, buffers);
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(data);
+            let data_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let io = import_module("io")?;
+            let bytesio_cls = crate::baseobjspace::getattr_str(io, "BytesIO")?;
+            let file = call_fn(
+                bytesio_cls,
+                &[pyre_object::gc_roots::shadow_stack_get(data_slot)],
+            )?;
+            let unpickler = call_fn(unpickler::type_object(), &[file])?;
+            call_meth(unpickler, "load", &[])
+        }
     },
 }

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -30,6 +30,9 @@ struct PickleCtx {
     bin: bool,
     memo: HashMap<usize, usize>,
     memo_size: usize,
+    /// `persistent_id` callable resolved off the pickler (subclass override
+    /// or set attribute), or `PY_NULL` when not defined.
+    pers_func: PyObjectRef,
 }
 
 impl PickleCtx {
@@ -88,17 +91,27 @@ impl W_Pickler {
         let bin = self.bin;
         let framing = self.framing;
         let w_file = self.w_file;
+        // A `persistent_id` defined on a subclass (or set as an attribute)
+        // overrides the default no-op; the base class has none.
+        let self_ptr = self as *mut W_Pickler as PyObjectRef;
+        let pers_func = crate::baseobjspace::findattr(self_ptr, "persistent_id")
+            .filter(|&f| !unsafe { pyre_object::is_none(f) })
+            .unwrap_or(pyre_object::PY_NULL);
 
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(w_file);
         let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         pyre_object::gc_roots::pin_root(w_obj);
+        if !pers_func.is_null() {
+            pyre_object::gc_roots::pin_root(pers_func);
+        }
 
         let mut ctx = PickleCtx {
             proto,
             bin,
             memo: HashMap::new(),
             memo_size: 0,
+            pers_func,
         };
         let mut body: Vec<u8> = Vec::new();
         save(&mut ctx, &mut body, w_obj)?;
@@ -123,12 +136,52 @@ impl W_Pickler {
     }
 }
 
-/// `interp_pickle.py W_Pickler.save`. Exact-type dispatch via the `is_*`
-/// predicates (bool is checked before int because a bool is not an int
-/// here, and `is_int_or_long` also covers big integers). Atoms are never
-/// memoized; everything else is checked against the identity memo for a
-/// GET back-reference before being saved.
+/// `interp_pickle.py W_Pickler.save` with the persistent-id hook: every
+/// object is first offered to `persistent_id`; a non-None result is saved
+/// as a persistent reference instead of by value.
 fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    if !ctx.pers_func.is_null() {
+        let w_pid = call_fn(ctx.pers_func, &[w_obj])?;
+        if !unsafe { pyre_object::is_none(w_pid) } {
+            return save_pers(ctx, buf, w_pid);
+        }
+    }
+    save_object(ctx, buf, w_obj)
+}
+
+/// `interp_pickle.py save_pers` — emit a persistent reference. The
+/// persistent id itself is saved by value (skipping the persistent-id
+/// hook) in binary protocols, or as an ASCII line in protocol 0.
+fn save_pers(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_pid: PyObjectRef) -> Result<(), PyError> {
+    if ctx.bin {
+        save_object(ctx, buf, w_pid)?;
+        buf.push(op::BINPERSID);
+        return Ok(());
+    }
+    let w_str = if unsafe { pyre_object::is_str(w_pid) } {
+        w_pid
+    } else {
+        let str_fn = crate::module::_pickle::lookup_builtin("str")
+            .ok_or_else(|| pickling_error("str builtin unavailable"))?;
+        call_fn(str_fn, &[w_pid])?
+    };
+    let s = unsafe { pyre_object::strobject::w_str_get_value(w_str) };
+    if !s.is_ascii() {
+        return Err(pickling_error(
+            "persistent IDs in protocol 0 must be ASCII strings",
+        ));
+    }
+    buf.push(op::PERSID);
+    buf.extend_from_slice(s.as_bytes());
+    buf.push(b'\n');
+    Ok(())
+}
+
+/// Exact-type dispatch via the `is_*` predicates (bool is checked before
+/// int because a bool is not an int here, and `is_int_or_long` also covers
+/// big integers). Atoms are never memoized; everything else is checked
+/// against the identity memo for a GET back-reference before being saved.
+fn save_object(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
     // Atoms — never memoized.
     if unsafe { pyre_object::is_none(w_obj) } {
         buf.push(op::NONE);
@@ -157,8 +210,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
         return save_bytes(ctx, buf, w_obj);
     }
     if unsafe { pyre_object::is_str(w_obj) } {
-        save_str(ctx, buf, w_obj);
-        return Ok(());
+        return save_str(ctx, buf, w_obj);
     }
     if unsafe { pyre_object::is_dict(w_obj) } {
         return save_dict(ctx, buf, w_obj);
@@ -209,9 +261,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
             .collect();
         return save_reduce(ctx, buf, &rv, Some(w_obj));
     }
-    Err(pickling_error(
-        "__reduce__ must return string or tuple",
-    ))
+    Err(pickling_error("__reduce__ must return string or tuple"))
 }
 
 fn save_bool(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
@@ -225,37 +275,49 @@ fn save_bool(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
 }
 
 fn save_long(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
-    match crate::baseobjspace::int_w(w_obj) {
-        Ok(v) => {
-            if ctx.bin {
-                if v >= 0 {
-                    if v <= 0xff {
-                        buf.push(op::BININT1);
-                        buf.push(v as u8);
-                        return Ok(());
-                    }
-                    if v <= 0xffff {
-                        buf.push(op::BININT2);
-                        buf.extend_from_slice(&(v as u16).to_le_bytes());
-                        return Ok(());
-                    }
+    let small = crate::baseobjspace::int_w(w_obj).ok();
+    let to_big = |v: Option<i64>| match v {
+        Some(v) => BigInt::from(v),
+        None => unsafe { crate::builtins::obj_to_bigint(w_obj) },
+    };
+    if ctx.bin {
+        if let Some(v) = small {
+            if v >= 0 {
+                if v <= 0xff {
+                    buf.push(op::BININT1);
+                    buf.push(v as u8);
+                    return Ok(());
                 }
-                if (-0x8000_0000..=0x7fff_ffff).contains(&v) {
-                    buf.push(op::BININT);
-                    buf.extend_from_slice(&(v as i32).to_le_bytes());
+                if v <= 0xffff {
+                    buf.push(op::BININT2);
+                    buf.extend_from_slice(&(v as u16).to_le_bytes());
                     return Ok(());
                 }
             }
-            write_long(buf, &encode_long(&BigInt::from(v)));
-            Ok(())
-        }
-        Err(_) => {
-            // Beyond i64 — a true big integer.
-            let big = unsafe { crate::builtins::obj_to_bigint(w_obj) };
-            write_long(buf, &encode_long(&big));
-            Ok(())
+            if (-0x8000_0000..=0x7fff_ffff).contains(&v) {
+                buf.push(op::BININT);
+                buf.extend_from_slice(&(v as i32).to_le_bytes());
+                return Ok(());
+            }
         }
     }
+    if ctx.proto >= 2 {
+        write_long(buf, &encode_long(&to_big(small)));
+        return Ok(());
+    }
+    // protocol 0 / 1 text: INT for a signed 4-byte value, else LONG.
+    if let Some(v) = small {
+        if (-0x8000_0000..=0x7fff_ffff).contains(&v) {
+            buf.push(op::INT);
+            buf.extend_from_slice(v.to_string().as_bytes());
+            buf.push(b'\n');
+            return Ok(());
+        }
+    }
+    buf.push(op::LONG);
+    buf.extend_from_slice(to_big(small).to_string().as_bytes());
+    buf.extend_from_slice(b"L\n");
+    Ok(())
 }
 
 fn write_long(buf: &mut Vec<u8>, enc: &[u8]) {
@@ -270,11 +332,19 @@ fn write_long(buf: &mut Vec<u8>, enc: &[u8]) {
     buf.extend_from_slice(enc);
 }
 
-fn save_float(_ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
-    let f = crate::baseobjspace::float_w(w_obj)?;
-    // BINFLOAT — 8-byte big-endian IEEE 754.
-    buf.push(op::BINFLOAT);
-    buf.extend_from_slice(&f.to_be_bytes());
+fn save_float(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    if ctx.bin {
+        let f = crate::baseobjspace::float_w(w_obj)?;
+        // BINFLOAT — 8-byte big-endian IEEE 754.
+        buf.push(op::BINFLOAT);
+        buf.extend_from_slice(&f.to_be_bytes());
+    } else {
+        // proto 0: FLOAT + repr(obj) + '\n' (shortest round-trip text).
+        let f = crate::baseobjspace::float_w(w_obj)?;
+        buf.push(op::FLOAT);
+        buf.extend_from_slice(crate::display::format_float_repr(f).as_bytes());
+        buf.push(b'\n');
+    }
     Ok(())
 }
 
@@ -314,22 +384,52 @@ fn save_bytes(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Res
     Ok(())
 }
 
-fn save_str(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
-    let s = unsafe { pyre_object::strobject::w_str_get_value(w_obj) };
-    let data = s.as_bytes();
-    let n = data.len();
-    if n <= 0xff && ctx.proto >= 4 {
-        buf.push(op::SHORT_BINUNICODE);
-        buf.push(n as u8);
-    } else if n > 0xffff_ffff && ctx.proto >= 4 {
-        buf.push(op::BINUNICODE8);
-        buf.extend_from_slice(&(n as u64).to_le_bytes());
+fn save_str(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    if ctx.bin {
+        let s = unsafe { pyre_object::strobject::w_str_get_value(w_obj) };
+        let data = s.as_bytes();
+        let n = data.len();
+        if n <= 0xff && ctx.proto >= 4 {
+            buf.push(op::SHORT_BINUNICODE);
+            buf.push(n as u8);
+        } else if n > 0xffff_ffff && ctx.proto >= 4 {
+            buf.push(op::BINUNICODE8);
+            buf.extend_from_slice(&(n as u64).to_le_bytes());
+        } else {
+            buf.push(op::BINUNICODE);
+            buf.extend_from_slice(&(n as u32).to_le_bytes());
+        }
+        buf.extend_from_slice(data);
     } else {
-        buf.push(op::BINUNICODE);
-        buf.extend_from_slice(&(n as u32).to_le_bytes());
+        // proto 0: UNICODE + raw-unicode-escape. The codec leaves
+        // backslash / NUL / newline / CR / EOF-on-DOS literal, so escape
+        // those first; the load side reverses with raw-unicode-escape.
+        let mut w_tmp = w_obj;
+        for (from, to) in [
+            ("\\", "\\u005c"),
+            ("\0", "\\u0000"),
+            ("\n", "\\u000a"),
+            ("\r", "\\u000d"),
+            ("\u{1a}", "\\u001a"),
+        ] {
+            w_tmp = call_meth(
+                w_tmp,
+                "replace",
+                &[pyre_object::w_str_new(from), pyre_object::w_str_new(to)],
+            )?;
+        }
+        let w_enc = call_meth(
+            w_tmp,
+            "encode",
+            &[pyre_object::w_str_new("raw-unicode-escape")],
+        )?;
+        let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_enc) };
+        buf.push(op::UNICODE);
+        buf.extend_from_slice(data);
+        buf.push(b'\n');
     }
-    buf.extend_from_slice(data);
     memoize(ctx, buf, w_obj);
+    Ok(())
 }
 
 /// `interp_pickle.py save_tuple`.
@@ -528,6 +628,14 @@ fn batch_appends(
     buf: &mut Vec<u8>,
     items: &[PyObjectRef],
 ) -> Result<(), PyError> {
+    if !ctx.bin {
+        // proto 0 — no APPENDS, one APPEND per item.
+        for &item in items {
+            save(ctx, buf, item)?;
+            buf.push(op::APPEND);
+        }
+        return Ok(());
+    }
     let n = items.len();
     let mut i = 0;
     while i < n {
@@ -556,6 +664,15 @@ fn batch_setitems(
     buf: &mut Vec<u8>,
     items: &[(PyObjectRef, PyObjectRef)],
 ) -> Result<(), PyError> {
+    if !ctx.bin {
+        // proto 0 — no SETITEMS, one SETITEM per pair.
+        for &(k, v) in items {
+            save(ctx, buf, k)?;
+            save(ctx, buf, v)?;
+            buf.push(op::SETITEM);
+        }
+        return Ok(());
+    }
     let n = items.len();
     let mut i = 0;
     while i < n {
@@ -631,8 +748,10 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<PyObjectRef, PyError> {
     }
     let modules = crate::importing::sys_modules_dict();
     if !modules.is_null() {
-        for (w_modname, w_module) in unsafe { pyre_object::dictmultiobject::w_dict_items(modules) } {
-            if !unsafe { pyre_object::is_str(w_modname) } || unsafe { pyre_object::is_none(w_module) }
+        for (w_modname, w_module) in unsafe { pyre_object::dictmultiobject::w_dict_items(modules) }
+        {
+            if !unsafe { pyre_object::is_str(w_modname) }
+                || unsafe { pyre_object::is_none(w_module) }
             {
                 continue;
             }
@@ -692,6 +811,13 @@ fn save_global(
             pyre_object::tupleobject::w_tuple_new(vec![parent, pyre_object::w_str_new(lastname)]);
         save_reduce(ctx, buf, &[w_getattr, w_args], None)?;
     } else {
+        // protocol < 3 applies the py3 → py2 `_compat_pickle` reverse map
+        // (fix_imports); protocol 3 writes the name verbatim.
+        let (module_name, name) = if ctx.proto < 3 {
+            crate::module::_pickle::compat_map(&module_name, &name, true)
+        } else {
+            (module_name, name)
+        };
         buf.push(op::GLOBAL);
         buf.extend_from_slice(module_name.as_bytes());
         buf.push(b'\n');
@@ -720,7 +846,11 @@ fn save_reduce(
 ) -> Result<(), PyError> {
     let w_func = rv[0];
     let w_args = rv[1];
-    let nonnull = |i: usize| rv.get(i).copied().filter(|&x| !unsafe { pyre_object::is_none(x) });
+    let nonnull = |i: usize| {
+        rv.get(i)
+            .copied()
+            .filter(|&x| !unsafe { pyre_object::is_none(x) })
+    };
     let w_state = nonnull(2);
     let w_listitems = nonnull(3);
     let w_dictitems = nonnull(4);
@@ -742,7 +872,9 @@ fn save_reduce(
         }
         let (w_cls, w_a, w_kw) = (args_w[0], args_w[1], args_w[2]);
         if crate::baseobjspace::findattr(w_cls, "__new__").is_none() {
-            return Err(pickling_error("args[0] from __newobj_ex__ args has no __new__"));
+            return Err(pickling_error(
+                "args[0] from __newobj_ex__ args has no __new__",
+            ));
         }
         if ctx.proto >= 4 {
             save(ctx, buf, w_cls)?;
@@ -770,7 +902,9 @@ fn save_reduce(
         }
         let w_cls = args_w[0];
         if crate::baseobjspace::findattr(w_cls, "__new__").is_none() {
-            return Err(pickling_error("args[0] from __newobj__ args has no __new__"));
+            return Err(pickling_error(
+                "args[0] from __newobj__ args has no __new__",
+            ));
         }
         let w_newargs = pyre_object::tupleobject::w_tuple_new(args_w[1..].to_vec());
         save(ctx, buf, w_cls)?;

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -1,0 +1,272 @@
+//! `_pickle.Pickler` — `interp_pickle.py W_Pickler` (atom subset).
+
+use malachite_bigint::BigInt;
+use pyre_object::PyObjectRef;
+
+use crate::PyError;
+
+use super::{
+    DEFAULT_PROTOCOL, FRAME_SIZE_MIN, HIGHEST_PROTOCOL, call_meth, encode_long, op,
+};
+
+#[crate::pyre_class("_pickle.Pickler")]
+pub struct W_Pickler {
+    /// Output file (has a `write` method).
+    w_file: PyObjectRef,
+    proto: i64,
+    bin: bool,
+    framing: bool,
+}
+
+/// Per-`dump` pickling context. `memo_size` drives the MEMOIZE counter;
+/// value dedup (GET back-references) arrives in increment 2.
+struct PickleCtx {
+    proto: i64,
+    bin: bool,
+    memo_size: usize,
+}
+
+#[crate::pyre_methods(doc = "Pickler(file, protocol=None) -> pickler writing to file.")]
+impl W_Pickler {
+    #[staticmethod]
+    fn __new__(_cls: PyObjectRef) -> PyObjectRef {
+        W_Pickler::allocate(W_Pickler {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            w_file: pyre_object::w_none(),
+            proto: 0,
+            bin: false,
+            framing: false,
+        })
+    }
+
+    fn __init__(
+        &mut self,
+        w_file: PyObjectRef,
+        #[default(pyre_object::w_none())] w_protocol: PyObjectRef,
+    ) -> Result<(), PyError> {
+        let proto = if unsafe { pyre_object::is_none(w_protocol) } {
+            DEFAULT_PROTOCOL
+        } else {
+            let p = crate::baseobjspace::int_w(w_protocol)?;
+            if p < 0 {
+                HIGHEST_PROTOCOL
+            } else if p > HIGHEST_PROTOCOL {
+                return Err(PyError::value_error("pickle protocol must be <= 5"));
+            } else {
+                p
+            }
+        };
+        // `file must have a 'write' attribute` (interp_pickle.py:557).
+        if crate::baseobjspace::findattr(w_file, "write").is_none() {
+            return Err(PyError::type_error("file must have a 'write' attribute"));
+        }
+        self.w_file = w_file;
+        self.proto = proto;
+        self.bin = proto >= 1;
+        self.framing = proto >= 4;
+        Ok(())
+    }
+
+    fn dump(&mut self, w_obj: PyObjectRef) -> Result<(), PyError> {
+        // Read every field before any allocation can relocate `self`.
+        let proto = self.proto;
+        let bin = self.bin;
+        let framing = self.framing;
+        let w_file = self.w_file;
+
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_file);
+        let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        pyre_object::gc_roots::pin_root(w_obj);
+
+        let mut ctx = PickleCtx {
+            proto,
+            bin,
+            memo_size: 0,
+        };
+        let mut body: Vec<u8> = Vec::new();
+        save(&mut ctx, &mut body, w_obj)?;
+        body.push(op::STOP);
+
+        let mut out: Vec<u8> = Vec::new();
+        if proto >= 2 {
+            out.push(op::PROTO);
+            out.push(proto as u8);
+        }
+        if framing && body.len() >= FRAME_SIZE_MIN {
+            out.push(op::FRAME);
+            out.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        }
+        out.extend_from_slice(&body);
+
+        let w_bytes = pyre_object::w_bytes_from_bytes(&out);
+        // `w_file` may have moved during the build; re-read from the pin.
+        let w_file = pyre_object::gc_roots::shadow_stack_get(file_slot);
+        call_meth(w_file, "write", &[w_bytes])?;
+        Ok(())
+    }
+}
+
+/// `interp_pickle.py W_Pickler.save` — atom subset. Exact-type dispatch
+/// via the `is_*` predicates (bool is checked before int because a bool
+/// is not an int here, and `is_int_or_long` also covers big integers).
+fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    // Atoms — never memoized.
+    if unsafe { pyre_object::is_none(w_obj) } {
+        buf.push(op::NONE);
+        return Ok(());
+    }
+    if unsafe { pyre_object::is_bool(w_obj) } {
+        save_bool(ctx, buf, w_obj);
+        return Ok(());
+    }
+    if unsafe { pyre_object::is_int_or_long(w_obj) } {
+        save_long(ctx, buf, w_obj)?;
+        return Ok(());
+    }
+    if unsafe { pyre_object::is_float(w_obj) } {
+        save_float(ctx, buf, w_obj)?;
+        return Ok(());
+    }
+    // Memoized atoms — write the value, then a put opcode.
+    if unsafe { pyre_object::is_bytes(w_obj) } {
+        save_bytes(ctx, buf, w_obj);
+        memoize(ctx, buf);
+        return Ok(());
+    }
+    if unsafe { pyre_object::is_str(w_obj) } {
+        save_str(ctx, buf, w_obj);
+        memoize(ctx, buf);
+        return Ok(());
+    }
+    Err(PyError::not_implemented(
+        "_pickle: only atoms are supported in this build",
+    ))
+}
+
+fn save_bool(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
+    let truthy = crate::baseobjspace::is_true(w_obj);
+    if ctx.proto >= 2 {
+        buf.push(if truthy { op::NEWTRUE } else { op::NEWFALSE });
+    } else {
+        // I00\n / I01\n
+        buf.extend_from_slice(if truthy { b"I01\n" } else { b"I00\n" });
+    }
+}
+
+fn save_long(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    match crate::baseobjspace::int_w(w_obj) {
+        Ok(v) => {
+            if ctx.bin {
+                if v >= 0 {
+                    if v <= 0xff {
+                        buf.push(op::BININT1);
+                        buf.push(v as u8);
+                        return Ok(());
+                    }
+                    if v <= 0xffff {
+                        buf.push(op::BININT2);
+                        buf.extend_from_slice(&(v as u16).to_le_bytes());
+                        return Ok(());
+                    }
+                }
+                if (-0x8000_0000..=0x7fff_ffff).contains(&v) {
+                    buf.push(op::BININT);
+                    buf.extend_from_slice(&(v as i32).to_le_bytes());
+                    return Ok(());
+                }
+            }
+            write_long(buf, &encode_long(&BigInt::from(v)));
+            Ok(())
+        }
+        Err(_) => {
+            // Beyond i64 — a true big integer.
+            let big = unsafe { crate::builtins::obj_to_bigint(w_obj) };
+            write_long(buf, &encode_long(&big));
+            Ok(())
+        }
+    }
+}
+
+fn write_long(buf: &mut Vec<u8>, enc: &[u8]) {
+    let n = enc.len();
+    if n < 256 {
+        buf.push(op::LONG1);
+        buf.push(n as u8);
+    } else {
+        buf.push(op::LONG4);
+        buf.extend_from_slice(&(n as i32).to_le_bytes());
+    }
+    buf.extend_from_slice(enc);
+}
+
+fn save_float(_ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    let f = crate::baseobjspace::float_w(w_obj)?;
+    // BINFLOAT — 8-byte big-endian IEEE 754.
+    buf.push(op::BINFLOAT);
+    buf.extend_from_slice(&f.to_be_bytes());
+    Ok(())
+}
+
+fn save_bytes(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
+    // proto < 3 (interp_pickle.py:1349) emits a `codecs.encode(latin1)` /
+    // `bytes()` reduce instead of a BINBYTES opcode. That needs `save_reduce`
+    // (increment 5); until then proto-2 bytes use the modern SHORT_BINBYTES
+    // form — valid and round-trippable, but not byte-identical to CPython at
+    // protocol 2.
+    let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_obj) };
+    let n = data.len();
+    if n <= 0xff {
+        buf.push(op::SHORT_BINBYTES);
+        buf.push(n as u8);
+    } else if n > 0xffff_ffff && ctx.proto >= 4 {
+        buf.push(op::BINBYTES8);
+        buf.extend_from_slice(&(n as u64).to_le_bytes());
+    } else {
+        buf.push(op::BINBYTES);
+        buf.extend_from_slice(&(n as u32).to_le_bytes());
+    }
+    buf.extend_from_slice(data);
+}
+
+fn save_str(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
+    let s = unsafe { pyre_object::strobject::w_str_get_value(w_obj) };
+    let data = s.as_bytes();
+    let n = data.len();
+    if n <= 0xff && ctx.proto >= 4 {
+        buf.push(op::SHORT_BINUNICODE);
+        buf.push(n as u8);
+    } else if n > 0xffff_ffff && ctx.proto >= 4 {
+        buf.push(op::BINUNICODE8);
+        buf.extend_from_slice(&(n as u64).to_le_bytes());
+    } else {
+        buf.push(op::BINUNICODE);
+        buf.extend_from_slice(&(n as u32).to_le_bytes());
+    }
+    buf.extend_from_slice(data);
+}
+
+/// `interp_pickle.py memoize` — write the put opcode + bump the counter.
+/// Increment 1 records nothing (no dedup); the put opcode is still emitted
+/// for wire-format parity.
+fn memoize(ctx: &mut PickleCtx, buf: &mut Vec<u8>) {
+    let idx = ctx.memo_size;
+    ctx.memo_size += 1;
+    if ctx.proto >= 4 {
+        buf.push(op::MEMOIZE);
+    } else if ctx.bin {
+        if idx < 256 {
+            buf.push(op::BINPUT);
+            buf.push(idx as u8);
+        } else {
+            buf.push(op::LONG_BINPUT);
+            buf.extend_from_slice(&(idx as u32).to_le_bytes());
+        }
+    } else {
+        buf.push(op::PUT);
+        buf.extend_from_slice(format!("{idx}\n").as_bytes());
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -316,6 +316,17 @@ fn save_object(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Res
         return save_bytearray(ctx, buf, w_obj);
     }
 
+    // `save_picklebuffer` (protocol 5 out-of-band buffers) is deferred. The
+    // CPython surface is `Pickler(file, protocol, *, buffer_callback=None)`
+    // and `Unpickler(file, *, buffers=None)` with keyword-only arguments, but
+    // `#[pyre_class]` `__init__` does not bind keyword arguments (module-level
+    // functions do; constructors do not), so `buffer_callback` / `buffers`
+    // cannot be supplied without diverging from CPython's keyword-only
+    // signature. The NEXT_BUFFER / READONLY_BUFFER opcodes are reserved in the
+    // `op` module for when that ABI gap is closed. PickleBuffer in-band is the
+    // CPython default (buffer_callback=None) but reduces to plain bytes /
+    // bytearray, so nothing is lost by routing those through the normal path.
+
     // Classes and functions are saved by reference.
     if unsafe { pyre_object::typeobject::is_type(w_obj) }
         || unsafe { crate::function::is_function(w_obj) }

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -8,7 +8,8 @@ use pyre_object::PyObjectRef;
 use crate::PyError;
 
 use super::{
-    BATCHSIZE, DEFAULT_PROTOCOL, FRAME_SIZE_MIN, HIGHEST_PROTOCOL, call_meth, encode_long, op,
+    BATCHSIZE, DEFAULT_PROTOCOL, FRAME_SIZE_MIN, HIGHEST_PROTOCOL, call_fn, call_meth, encode_long,
+    getattribute_dotted, import_module, op, pickling_error,
 };
 
 #[crate::pyre_class("_pickle.Pickler")]
@@ -153,8 +154,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
     }
 
     if unsafe { pyre_object::is_bytes(w_obj) } {
-        save_bytes(ctx, buf, w_obj);
-        return Ok(());
+        return save_bytes(ctx, buf, w_obj);
     }
     if unsafe { pyre_object::is_str(w_obj) } {
         save_str(ctx, buf, w_obj);
@@ -166,7 +166,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
     if unsafe { pyre_object::is_set(w_obj) } {
         return save_set(ctx, buf, w_obj);
     }
-    if unsafe { pyre_object::is_frozenset(w_obj) } && ctx.proto >= 4 {
+    if unsafe { pyre_object::is_frozenset(w_obj) } {
         return save_frozenset(ctx, buf, w_obj);
     }
     if unsafe { pyre_object::is_list(w_obj) } {
@@ -178,8 +178,39 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
     if unsafe { pyre_object::is_bytearray(w_obj) } {
         return save_bytearray(ctx, buf, w_obj);
     }
-    Err(PyError::not_implemented(
-        "_pickle: this object type is not supported in this build",
+
+    // Classes and functions are saved by reference.
+    if unsafe { pyre_object::typeobject::is_type(w_obj) }
+        || unsafe { crate::function::is_function(w_obj) }
+    {
+        return save_global(ctx, buf, w_obj, None);
+    }
+
+    // Everything else goes through the reduce protocol.
+    let w_rv = match crate::baseobjspace::findattr(w_obj, "__reduce_ex__") {
+        Some(reduce_ex) => call_fn(reduce_ex, &[pyre_object::w_int_new(ctx.proto)])?,
+        None => match crate::baseobjspace::findattr(w_obj, "__reduce__") {
+            Some(reduce) => call_fn(reduce, &[])?,
+            None => return Err(pickling_error("Can't pickle object: no __reduce_ex__")),
+        },
+    };
+    if unsafe { pyre_object::is_str(w_rv) } {
+        return save_global(ctx, buf, w_obj, Some(w_rv));
+    }
+    if unsafe { pyre_object::is_tuple(w_rv) } {
+        let n = unsafe { pyre_object::tupleobject::w_tuple_len(w_rv) };
+        if !(2..=6).contains(&n) {
+            return Err(pickling_error(
+                "Tuple returned by __reduce__ must have two to six elements",
+            ));
+        }
+        let rv: Vec<PyObjectRef> = (0..n)
+            .map(|i| unsafe { pyre_object::tupleobject::w_tuple_getitem(w_rv, i as i64).unwrap() })
+            .collect();
+        return save_reduce(ctx, buf, &rv, Some(w_obj));
+    }
+    Err(pickling_error(
+        "__reduce__ must return string or tuple",
     ))
 }
 
@@ -247,12 +278,25 @@ fn save_float(_ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result
     Ok(())
 }
 
-fn save_bytes(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
-    // proto < 3 (interp_pickle.py:1349) emits a `codecs.encode(latin1)` /
-    // `bytes()` reduce instead of a BINBYTES opcode. That needs `save_reduce`
-    // (increment 5); until then proto-2 bytes use the modern SHORT_BINBYTES
-    // form — valid and round-trippable, but not byte-identical to CPython at
-    // protocol 2.
+fn save_bytes(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    // proto < 3 emits a `codecs.encode(s, 'latin1')` / `bytes()` reduce
+    // instead of a BINBYTES opcode (interp_pickle.py:1349).
+    if ctx.proto < 3 {
+        let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_obj) };
+        if data.is_empty() {
+            let w_bytes = crate::typedef::gettypeobject(&pyre_object::bytesobject::BYTES_TYPE);
+            let w_args = pyre_object::tupleobject::w_tuple_new(Vec::new());
+            return save_reduce(ctx, buf, &[w_bytes, w_args], Some(w_obj));
+        }
+        let codecs = import_module("codecs")?;
+        let w_encode = crate::baseobjspace::getattr_str(codecs, "encode")?;
+        let w_decoded = call_meth(w_obj, "decode", &[pyre_object::w_str_new("latin1")])?;
+        let w_args = pyre_object::tupleobject::w_tuple_new(vec![
+            w_decoded,
+            pyre_object::w_str_new("latin1"),
+        ]);
+        return save_reduce(ctx, buf, &[w_encode, w_args], Some(w_obj));
+    }
     let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_obj) };
     let n = data.len();
     if n <= 0xff {
@@ -267,6 +311,7 @@ fn save_bytes(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
     }
     buf.extend_from_slice(data);
     memoize(ctx, buf, w_obj);
+    Ok(())
 }
 
 fn save_str(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
@@ -383,9 +428,12 @@ fn save_dict(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resu
 /// protocol < 4 reduce fallback arrives with `save_reduce`.
 fn save_set(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
     if ctx.proto < 4 {
-        return Err(PyError::not_implemented(
-            "_pickle: set at protocol < 4 needs save_reduce (later increment)",
-        ));
+        // save_reduce(set, (list(obj),)).
+        let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
+        let w_list = pyre_object::listobject::w_list_new(items);
+        let w_args = pyre_object::tupleobject::w_tuple_new(vec![w_list]);
+        let w_set_type = crate::typedef::gettypeobject(&pyre_object::setobject::SET_TYPE);
+        return save_reduce(ctx, buf, &[w_set_type, w_args], Some(w_obj));
     }
     buf.push(op::EMPTY_SET);
     memoize(ctx, buf, w_obj);
@@ -413,13 +461,23 @@ fn save_set(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resul
     Ok(())
 }
 
-/// `interp_pickle.py save_frozenset` (proto >= 4 only; lower protocols reach
-/// the generic reduce path). Unordered, so not byte-identical to CPython.
+/// `interp_pickle.py save_frozenset`. Protocol < 4 reduces to
+/// `frozenset(list(obj))`; protocol >= 4 uses the FROZENSET opcode.
+/// Unordered, so not byte-identical to CPython.
 fn save_frozenset(
     ctx: &mut PickleCtx,
     buf: &mut Vec<u8>,
     w_obj: PyObjectRef,
 ) -> Result<(), PyError> {
+    if ctx.proto < 4 {
+        // save_reduce(frozenset, (list(obj),)).
+        let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
+        let w_list = pyre_object::listobject::w_list_new(items);
+        let w_args = pyre_object::tupleobject::w_tuple_new(vec![w_list]);
+        let w_frozenset_type =
+            crate::typedef::gettypeobject(&pyre_object::setobject::FROZENSET_TYPE);
+        return save_reduce(ctx, buf, &[w_frozenset_type, w_args], Some(w_obj));
+    }
     buf.push(op::MARK);
     let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
     for &e in &items {
@@ -443,9 +501,17 @@ fn save_bytearray(
     w_obj: PyObjectRef,
 ) -> Result<(), PyError> {
     if ctx.proto < 5 {
-        return Err(PyError::not_implemented(
-            "_pickle: bytearray at protocol < 5 needs save_reduce (later increment)",
-        ));
+        // save_reduce(bytearray, ()) for empty, else save_reduce(bytearray, (bytes,)).
+        let data = unsafe { pyre_object::bytearrayobject::w_bytearray_data(w_obj) };
+        let w_bytearray_type =
+            crate::typedef::gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE);
+        let w_args = if data.is_empty() {
+            pyre_object::tupleobject::w_tuple_new(Vec::new())
+        } else {
+            let w_bytes = pyre_object::w_bytes_from_bytes(data);
+            pyre_object::tupleobject::w_tuple_new(vec![w_bytes])
+        };
+        return save_reduce(ctx, buf, &[w_bytearray_type, w_args], Some(w_obj));
     }
     let data = unsafe { pyre_object::bytearrayobject::w_bytearray_data(w_obj) };
     buf.push(op::BYTEARRAY8);
@@ -549,4 +615,250 @@ fn memoize(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
         buf.push(op::PUT);
         buf.extend_from_slice(format!("{idx}\n").as_bytes());
     }
+}
+
+// ── reduce / global ──────────────────────────────────────────────────
+
+/// `interp_pickle.py whichmodule` — the module an object belongs to.
+/// `__module__` takes precedence; otherwise scan `sys.modules` for the
+/// module that exposes `name` resolving back to `w_obj`, skipping
+/// `__main__` / `__mp_main__` / `None`, and default to `"__main__"`.
+fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<PyObjectRef, PyError> {
+    if let Some(m) = crate::baseobjspace::findattr(w_obj, "__module__") {
+        if !unsafe { pyre_object::is_none(m) } {
+            return Ok(m);
+        }
+    }
+    let modules = crate::importing::sys_modules_dict();
+    if !modules.is_null() {
+        for (w_modname, w_module) in unsafe { pyre_object::dictmultiobject::w_dict_items(modules) } {
+            if !unsafe { pyre_object::is_str(w_modname) } || unsafe { pyre_object::is_none(w_module) }
+            {
+                continue;
+            }
+            let modname = unsafe { pyre_object::strobject::w_str_get_value(w_modname) };
+            if modname == "__main__" || modname == "__mp_main__" {
+                continue;
+            }
+            if let Ok((resolved, _)) = getattribute_dotted(w_module, name) {
+                if crate::baseobjspace::is_w(resolved, w_obj) {
+                    return Ok(w_modname);
+                }
+            }
+        }
+    }
+    Ok(pyre_object::w_str_new("__main__"))
+}
+
+/// `interp_pickle.py save_global` / `save_global2` — save an object by
+/// qualified reference. `w_name_opt` carries the name when a `__reduce__`
+/// returned a string; otherwise it is derived from `__qualname__`.
+fn save_global(
+    ctx: &mut PickleCtx,
+    buf: &mut Vec<u8>,
+    w_obj: PyObjectRef,
+    w_name_opt: Option<PyObjectRef>,
+) -> Result<(), PyError> {
+    let w_name = match w_name_opt {
+        Some(n) => n,
+        None => crate::baseobjspace::findattr(w_obj, "__qualname__")
+            .or_else(|| crate::baseobjspace::findattr(w_obj, "__name__"))
+            .ok_or_else(|| pickling_error("Can't pickle object: no __qualname__ / __name__"))?,
+    };
+    let name = unsafe { pyre_object::strobject::w_str_get_value(w_name) }.to_string();
+    let w_module_name = whichmodule(w_obj, &name)?;
+    let module_name = unsafe { pyre_object::strobject::w_str_get_value(w_module_name) }.to_string();
+
+    // The unpickler resolves `module_name.name` at load time via `find_class`.
+    // CPython additionally verifies the name resolves back to this exact
+    // object at dump time, but pyre's `getattr` on the `builtins` module is
+    // unreliable here (it can return a non-canonical object and corrupt
+    // builtin state), so that round-trip check is skipped. Nested-ness is
+    // derived from the qualname instead of an attribute walk.
+    let nested = name.contains('.');
+
+    if ctx.proto >= 4 {
+        save(ctx, buf, w_module_name)?;
+        save(ctx, buf, w_name)?;
+        buf.push(op::STACK_GLOBAL);
+    } else if nested {
+        // Nested object at protocol < 4: reduce to getattr(parent, lastname).
+        let module = import_module(&module_name)?;
+        let dot = name.rfind('.').unwrap();
+        let (parent, _) = getattribute_dotted(module, &name[..dot])?;
+        let lastname = &name[dot + 1..];
+        let w_getattr = builtin_attr("getattr")?;
+        let w_args =
+            pyre_object::tupleobject::w_tuple_new(vec![parent, pyre_object::w_str_new(lastname)]);
+        save_reduce(ctx, buf, &[w_getattr, w_args], None)?;
+    } else {
+        buf.push(op::GLOBAL);
+        buf.extend_from_slice(module_name.as_bytes());
+        buf.push(b'\n');
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(b'\n');
+    }
+    memoize(ctx, buf, w_obj);
+    Ok(())
+}
+
+/// `__builtins__.<name>` (e.g. `getattr`), via the execution context's
+/// `lookup_builtin` (the `LOAD_GLOBAL` path). Only used on the rare nested
+/// protocol < 4 path.
+fn builtin_attr(name: &str) -> Result<PyObjectRef, PyError> {
+    crate::module::_pickle::lookup_builtin(name)
+        .ok_or_else(|| pickling_error(format!("Can't resolve builtin {name:?}")))
+}
+
+/// `interp_pickle.py save_reduce`. `rv` is the 2-to-6 element reduce tuple
+/// `(func, args[, state[, listitems[, dictitems[, state_setter]]]])`.
+fn save_reduce(
+    ctx: &mut PickleCtx,
+    buf: &mut Vec<u8>,
+    rv: &[PyObjectRef],
+    w_obj_opt: Option<PyObjectRef>,
+) -> Result<(), PyError> {
+    let w_func = rv[0];
+    let w_args = rv[1];
+    let nonnull = |i: usize| rv.get(i).copied().filter(|&x| !unsafe { pyre_object::is_none(x) });
+    let w_state = nonnull(2);
+    let w_listitems = nonnull(3);
+    let w_dictitems = nonnull(4);
+    let w_state_setter = nonnull(5);
+
+    if !unsafe { pyre_object::is_tuple(w_args) } {
+        return Err(pickling_error("args from save_reduce() must be a tuple"));
+    }
+    if !crate::baseobjspace::callable_w(w_func) {
+        return Err(pickling_error("func from save_reduce() must be callable"));
+    }
+
+    let func_name = func_name_str(w_func);
+    let args_w = tuple_items(w_args);
+
+    if ctx.proto >= 2 && func_name.as_deref() == Some("__newobj_ex__") {
+        if args_w.len() != 3 {
+            return Err(pickling_error("__newobj_ex__ requires three args"));
+        }
+        let (w_cls, w_a, w_kw) = (args_w[0], args_w[1], args_w[2]);
+        if crate::baseobjspace::findattr(w_cls, "__new__").is_none() {
+            return Err(pickling_error("args[0] from __newobj_ex__ args has no __new__"));
+        }
+        if ctx.proto >= 4 {
+            save(ctx, buf, w_cls)?;
+            save(ctx, buf, w_a)?;
+            save(ctx, buf, w_kw)?;
+            buf.push(op::NEWOBJ_EX);
+        } else {
+            // protocol 2/3 with keyword args needs functools.partial.
+            let kw_len = unsafe { pyre_object::dictmultiobject::w_dict_items(w_kw) }.len();
+            if kw_len > 0 {
+                return Err(PyError::not_implemented(
+                    "_pickle: __newobj_ex__ with kwargs at protocol < 4",
+                ));
+            }
+            let w_new = crate::baseobjspace::getattr_str(w_cls, "__new__")?;
+            let mut full = vec![w_cls];
+            full.extend(tuple_items(w_a));
+            save(ctx, buf, w_new)?;
+            save(ctx, buf, pyre_object::tupleobject::w_tuple_new(full))?;
+            buf.push(op::REDUCE);
+        }
+    } else if ctx.proto >= 2 && func_name.as_deref() == Some("__newobj__") {
+        if args_w.is_empty() {
+            return Err(pickling_error("__newobj__ requires at least one arg"));
+        }
+        let w_cls = args_w[0];
+        if crate::baseobjspace::findattr(w_cls, "__new__").is_none() {
+            return Err(pickling_error("args[0] from __newobj__ args has no __new__"));
+        }
+        let w_newargs = pyre_object::tupleobject::w_tuple_new(args_w[1..].to_vec());
+        save(ctx, buf, w_cls)?;
+        save(ctx, buf, w_newargs)?;
+        buf.push(op::NEWOBJ);
+    } else {
+        save(ctx, buf, w_func)?;
+        save(ctx, buf, w_args)?;
+        buf.push(op::REDUCE);
+    }
+
+    if let Some(w_obj) = w_obj_opt {
+        if let Some(idx) = ctx.memo_get(w_obj) {
+            buf.push(op::POP);
+            write_get(ctx, buf, idx);
+        } else {
+            memoize(ctx, buf, w_obj);
+        }
+    }
+
+    if let Some(li) = w_listitems {
+        let items = drain_iter(li)?;
+        batch_appends(ctx, buf, &items)?;
+    }
+    if let Some(di) = w_dictitems {
+        let pairs = drain_iter_pairs(di)?;
+        batch_setitems(ctx, buf, &pairs)?;
+    }
+    if let Some(st) = w_state {
+        if let Some(setter) = w_state_setter {
+            save(ctx, buf, setter)?;
+            save(ctx, buf, w_obj_opt.unwrap())?;
+            save(ctx, buf, st)?;
+            buf.push(op::TUPLE2);
+            buf.push(op::REDUCE);
+            buf.push(op::POP);
+        } else {
+            save(ctx, buf, st)?;
+            buf.push(op::BUILD);
+        }
+    }
+    Ok(())
+}
+
+/// The `__name__` of a callable as an owned `String`, if it is a str.
+fn func_name_str(w_func: PyObjectRef) -> Option<String> {
+    let w_name = crate::baseobjspace::findattr(w_func, "__name__")?;
+    if unsafe { pyre_object::is_str(w_name) } {
+        Some(unsafe { pyre_object::strobject::w_str_get_value(w_name) }.to_string())
+    } else {
+        None
+    }
+}
+
+fn tuple_items(w_tuple: PyObjectRef) -> Vec<PyObjectRef> {
+    let n = unsafe { pyre_object::tupleobject::w_tuple_len(w_tuple) };
+    (0..n)
+        .map(|i| unsafe { pyre_object::tupleobject::w_tuple_getitem(w_tuple, i as i64).unwrap() })
+        .collect()
+}
+
+/// Drain an iterable into a `Vec`.
+fn drain_iter(w_iterable: PyObjectRef) -> Result<Vec<PyObjectRef>, PyError> {
+    let w_iter = crate::baseobjspace::iter(w_iterable)?;
+    let mut out = Vec::new();
+    loop {
+        match crate::baseobjspace::next(w_iter) {
+            Ok(item) => out.push(item),
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(out)
+}
+
+/// Drain an iterable of `(key, value)` pairs into a `Vec`.
+fn drain_iter_pairs(w_iterable: PyObjectRef) -> Result<Vec<(PyObjectRef, PyObjectRef)>, PyError> {
+    let items = drain_iter(w_iterable)?;
+    let mut out = Vec::with_capacity(items.len());
+    for it in items {
+        if !unsafe { pyre_object::is_tuple(it) }
+            || unsafe { pyre_object::tupleobject::w_tuple_len(it) } != 2
+        {
+            return Err(pickling_error("dictitems must yield (key, value) pairs"));
+        }
+        let k = unsafe { pyre_object::tupleobject::w_tuple_getitem(it, 0).unwrap() };
+        let v = unsafe { pyre_object::tupleobject::w_tuple_getitem(it, 1).unwrap() };
+        out.push((k, v));
+    }
+    Ok(out)
 }

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -8,8 +8,8 @@ use pyre_object::PyObjectRef;
 use crate::PyError;
 
 use super::{
-    BATCHSIZE, DEFAULT_PROTOCOL, FRAME_SIZE_MIN, HIGHEST_PROTOCOL, call_fn, call_meth, encode_long,
-    getattribute_dotted, import_module, op, pickling_error,
+    BATCHSIZE, DEFAULT_PROTOCOL, FRAME_SIZE_MIN, FRAME_SIZE_TARGET, HIGHEST_PROTOCOL, call_fn,
+    call_meth, encode_long, getattribute_dotted, import_module, op, pickling_error,
 };
 
 #[crate::pyre_class("_pickle.Pickler")]
@@ -38,6 +38,88 @@ struct PickleCtx {
 impl PickleCtx {
     fn memo_get(&self, w_obj: PyObjectRef) -> Option<usize> {
         self.memo.get(&(w_obj as usize)).copied()
+    }
+}
+
+/// `interp_pickle.py _Framer` — accumulates output into frames. Bytes are
+/// appended to the active frame; once a frame reaches `FRAME_SIZE_TARGET`
+/// it is flushed (FRAME opcode + 8-byte little-endian length + body when the
+/// body is at least `FRAME_SIZE_MIN` bytes). Large payloads bypass the frame
+/// entirely (`write_large_bytes`). When framing is off (protocol < 4) the
+/// active frame is `None` and bytes pass straight through to `output`.
+///
+/// `push` / `extend_from_slice` mirror the `Vec<u8>` methods the save
+/// routines call, so they write through the framer unchanged.
+struct Framer {
+    current_frame: Option<Vec<u8>>,
+    output: Vec<u8>,
+}
+
+impl Framer {
+    fn new() -> Self {
+        Framer {
+            current_frame: None,
+            output: Vec::new(),
+        }
+    }
+
+    /// `_Framer.write` (single byte).
+    fn push(&mut self, byte: u8) {
+        match &mut self.current_frame {
+            Some(f) => f.push(byte),
+            None => self.output.push(byte),
+        }
+    }
+
+    /// `_Framer.write` (slice).
+    fn extend_from_slice(&mut self, data: &[u8]) {
+        match &mut self.current_frame {
+            Some(f) => f.extend_from_slice(data),
+            None => self.output.extend_from_slice(data),
+        }
+    }
+
+    /// `_Framer.start_framing`.
+    fn start_framing(&mut self) {
+        self.current_frame = Some(Vec::new());
+    }
+
+    /// `_Framer.end_framing` — flush any remaining frame and stop framing.
+    fn end_framing(&mut self) {
+        if matches!(&self.current_frame, Some(f) if !f.is_empty()) {
+            self.commit_frame(true);
+        }
+        self.current_frame = None;
+    }
+
+    /// `_Framer.commit_frame` — flush the active frame when it has reached
+    /// the target size (or `force`).
+    fn commit_frame(&mut self, force: bool) {
+        let flush = match &self.current_frame {
+            Some(f) => f.len() >= FRAME_SIZE_TARGET || force,
+            None => false,
+        };
+        if !flush {
+            return;
+        }
+        let data = std::mem::take(self.current_frame.as_mut().unwrap());
+        if data.len() >= FRAME_SIZE_MIN {
+            self.output.push(op::FRAME);
+            self.output
+                .extend_from_slice(&(data.len() as u64).to_le_bytes());
+        }
+        self.output.extend_from_slice(&data);
+    }
+
+    /// `_Framer.write_large_bytes` — terminate the active frame, then write a
+    /// large header + payload directly (unframed) to avoid copying the
+    /// payload into the frame builder.
+    fn write_large_bytes(&mut self, header: &[u8], payload: &[u8]) {
+        if matches!(&self.current_frame, Some(f) if !f.is_empty()) {
+            self.commit_frame(true);
+        }
+        self.output.extend_from_slice(header);
+        self.output.extend_from_slice(payload);
     }
 }
 
@@ -113,22 +195,22 @@ impl W_Pickler {
             memo_size: 0,
             pers_func,
         };
-        let mut body: Vec<u8> = Vec::new();
-        save(&mut ctx, &mut body, w_obj)?;
-        body.push(op::STOP);
-
-        let mut out: Vec<u8> = Vec::new();
+        // PROTO is written before framing begins (it stays outside the
+        // frame); STOP is written while framing is active (inside the last
+        // frame). `end_framing` flushes the final frame.
+        let mut fr = Framer::new();
         if proto >= 2 {
-            out.push(op::PROTO);
-            out.push(proto as u8);
+            fr.push(op::PROTO);
+            fr.push(proto as u8);
         }
-        if framing && body.len() >= FRAME_SIZE_MIN {
-            out.push(op::FRAME);
-            out.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        if framing {
+            fr.start_framing();
         }
-        out.extend_from_slice(&body);
+        save(&mut ctx, &mut fr, w_obj)?;
+        fr.push(op::STOP);
+        fr.end_framing();
 
-        let w_bytes = pyre_object::w_bytes_from_bytes(&out);
+        let w_bytes = pyre_object::w_bytes_from_bytes(&fr.output);
         // `w_file` may have moved during the build; re-read from the pin.
         let w_file = pyre_object::gc_roots::shadow_stack_get(file_slot);
         call_meth(w_file, "write", &[w_bytes])?;
@@ -139,7 +221,10 @@ impl W_Pickler {
 /// `interp_pickle.py W_Pickler.save` with the persistent-id hook: every
 /// object is first offered to `persistent_id`; a non-None result is saved
 /// as a persistent reference instead of by value.
-fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
+    // A frame boundary can only fall at the start of a `save`, never inside
+    // an object; flush the active frame once it has grown past the target.
+    buf.commit_frame(false);
     if !ctx.pers_func.is_null() {
         let w_pid = call_fn(ctx.pers_func, &[w_obj])?;
         if !unsafe { pyre_object::is_none(w_pid) } {
@@ -152,7 +237,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
 /// `interp_pickle.py save_pers` — emit a persistent reference. The
 /// persistent id itself is saved by value (skipping the persistent-id
 /// hook) in binary protocols, or as an ASCII line in protocol 0.
-fn save_pers(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_pid: PyObjectRef) -> Result<(), PyError> {
+fn save_pers(ctx: &mut PickleCtx, buf: &mut Framer, w_pid: PyObjectRef) -> Result<(), PyError> {
     if ctx.bin {
         save_object(ctx, buf, w_pid)?;
         buf.push(op::BINPERSID);
@@ -181,7 +266,7 @@ fn save_pers(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_pid: PyObjectRef) -> Resu
 /// int because a bool is not an int here, and `is_int_or_long` also covers
 /// big integers). Atoms are never memoized; everything else is checked
 /// against the identity memo for a GET back-reference before being saved.
-fn save_object(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_object(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     // Atoms — never memoized.
     if unsafe { pyre_object::is_none(w_obj) } {
         buf.push(op::NONE);
@@ -264,7 +349,7 @@ fn save_object(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Re
     Err(pickling_error("__reduce__ must return string or tuple"))
 }
 
-fn save_bool(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
+fn save_bool(ctx: &PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) {
     let truthy = crate::baseobjspace::is_true(w_obj);
     if ctx.proto >= 2 {
         buf.push(if truthy { op::NEWTRUE } else { op::NEWFALSE });
@@ -274,7 +359,7 @@ fn save_bool(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
     }
 }
 
-fn save_long(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_long(ctx: &PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     let small = crate::baseobjspace::int_w(w_obj).ok();
     let to_big = |v: Option<i64>| match v {
         Some(v) => BigInt::from(v),
@@ -320,7 +405,7 @@ fn save_long(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(
     Ok(())
 }
 
-fn write_long(buf: &mut Vec<u8>, enc: &[u8]) {
+fn write_long(buf: &mut Framer, enc: &[u8]) {
     let n = enc.len();
     if n < 256 {
         buf.push(op::LONG1);
@@ -332,7 +417,7 @@ fn write_long(buf: &mut Vec<u8>, enc: &[u8]) {
     buf.extend_from_slice(enc);
 }
 
-fn save_float(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_float(ctx: &PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     if ctx.bin {
         let f = crate::baseobjspace::float_w(w_obj)?;
         // BINFLOAT — 8-byte big-endian IEEE 754.
@@ -348,7 +433,7 @@ fn save_float(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<
     Ok(())
 }
 
-fn save_bytes(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_bytes(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     // proto < 3 emits a `codecs.encode(s, 'latin1')` / `bytes()` reduce
     // instead of a BINBYTES opcode (interp_pickle.py:1349).
     if ctx.proto < 3 {
@@ -372,19 +457,25 @@ fn save_bytes(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Res
     if n <= 0xff {
         buf.push(op::SHORT_BINBYTES);
         buf.push(n as u8);
+        buf.extend_from_slice(data);
     } else if n > 0xffff_ffff && ctx.proto >= 4 {
-        buf.push(op::BINBYTES8);
-        buf.extend_from_slice(&(n as u64).to_le_bytes());
+        let mut header = vec![op::BINBYTES8];
+        header.extend_from_slice(&(n as u64).to_le_bytes());
+        buf.write_large_bytes(&header, data);
+    } else if n >= FRAME_SIZE_TARGET {
+        let mut header = vec![op::BINBYTES];
+        header.extend_from_slice(&(n as u32).to_le_bytes());
+        buf.write_large_bytes(&header, data);
     } else {
         buf.push(op::BINBYTES);
         buf.extend_from_slice(&(n as u32).to_le_bytes());
+        buf.extend_from_slice(data);
     }
-    buf.extend_from_slice(data);
     memoize(ctx, buf, w_obj);
     Ok(())
 }
 
-fn save_str(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_str(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     if ctx.bin {
         let s = unsafe { pyre_object::strobject::w_str_get_value(w_obj) };
         let data = s.as_bytes();
@@ -392,14 +483,20 @@ fn save_str(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resul
         if n <= 0xff && ctx.proto >= 4 {
             buf.push(op::SHORT_BINUNICODE);
             buf.push(n as u8);
+            buf.extend_from_slice(data);
         } else if n > 0xffff_ffff && ctx.proto >= 4 {
-            buf.push(op::BINUNICODE8);
-            buf.extend_from_slice(&(n as u64).to_le_bytes());
+            let mut header = vec![op::BINUNICODE8];
+            header.extend_from_slice(&(n as u64).to_le_bytes());
+            buf.write_large_bytes(&header, data);
+        } else if n >= FRAME_SIZE_TARGET {
+            let mut header = vec![op::BINUNICODE];
+            header.extend_from_slice(&(n as u32).to_le_bytes());
+            buf.write_large_bytes(&header, data);
         } else {
             buf.push(op::BINUNICODE);
             buf.extend_from_slice(&(n as u32).to_le_bytes());
+            buf.extend_from_slice(data);
         }
-        buf.extend_from_slice(data);
     } else {
         // proto 0: UNICODE + raw-unicode-escape. The codec leaves
         // backslash / NUL / newline / CR / EOF-on-DOS literal, so escape
@@ -433,7 +530,7 @@ fn save_str(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resul
 }
 
 /// `interp_pickle.py save_tuple`.
-fn save_tuple(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_tuple(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     let n = unsafe { pyre_object::tupleobject::w_tuple_len(w_obj) };
     if n == 0 {
         if ctx.bin {
@@ -493,7 +590,7 @@ fn save_tuple(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Res
 /// `interp_pickle.py save_list`. The PyPy ascii/bytes-list fast paths are
 /// gated on `pypy_extensions` (off here) so the generic path is used,
 /// matching CPython's wire format.
-fn save_list(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_list(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     if ctx.bin {
         buf.push(op::EMPTY_LIST);
     } else {
@@ -510,7 +607,7 @@ fn save_list(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resu
 }
 
 /// `interp_pickle.py save_dict`.
-fn save_dict(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_dict(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     if ctx.bin {
         buf.push(op::EMPTY_DICT);
     } else {
@@ -526,7 +623,7 @@ fn save_dict(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resu
 /// `interp_pickle.py save_set`. Sets are unordered, so the wire bytes are
 /// not byte-identical to CPython, but the encoding round-trips. The
 /// protocol < 4 reduce fallback arrives with `save_reduce`.
-fn save_set(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+fn save_set(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
     if ctx.proto < 4 {
         // save_reduce(set, (list(obj),)).
         let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
@@ -566,7 +663,7 @@ fn save_set(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resul
 /// Unordered, so not byte-identical to CPython.
 fn save_frozenset(
     ctx: &mut PickleCtx,
-    buf: &mut Vec<u8>,
+    buf: &mut Framer,
     w_obj: PyObjectRef,
 ) -> Result<(), PyError> {
     if ctx.proto < 4 {
@@ -597,7 +694,7 @@ fn save_frozenset(
 /// reach the generic reduce path).
 fn save_bytearray(
     ctx: &mut PickleCtx,
-    buf: &mut Vec<u8>,
+    buf: &mut Framer,
     w_obj: PyObjectRef,
 ) -> Result<(), PyError> {
     if ctx.proto < 5 {
@@ -614,9 +711,16 @@ fn save_bytearray(
         return save_reduce(ctx, buf, &[w_bytearray_type, w_args], Some(w_obj));
     }
     let data = unsafe { pyre_object::bytearrayobject::w_bytearray_data(w_obj) };
-    buf.push(op::BYTEARRAY8);
-    buf.extend_from_slice(&(data.len() as u64).to_le_bytes());
-    buf.extend_from_slice(data);
+    let n = data.len();
+    if n >= FRAME_SIZE_TARGET {
+        let mut header = vec![op::BYTEARRAY8];
+        header.extend_from_slice(&(n as u64).to_le_bytes());
+        buf.write_large_bytes(&header, data);
+    } else {
+        buf.push(op::BYTEARRAY8);
+        buf.extend_from_slice(&(n as u64).to_le_bytes());
+        buf.extend_from_slice(data);
+    }
     memoize(ctx, buf, w_obj);
     Ok(())
 }
@@ -625,7 +729,7 @@ fn save_bytearray(
 /// APPEND; otherwise MARK … APPENDS in batches of `BATCHSIZE`.
 fn batch_appends(
     ctx: &mut PickleCtx,
-    buf: &mut Vec<u8>,
+    buf: &mut Framer,
     items: &[PyObjectRef],
 ) -> Result<(), PyError> {
     if !ctx.bin {
@@ -661,7 +765,7 @@ fn batch_appends(
 /// otherwise MARK … SETITEMS in batches of `BATCHSIZE`.
 fn batch_setitems(
     ctx: &mut PickleCtx,
-    buf: &mut Vec<u8>,
+    buf: &mut Framer,
     items: &[(PyObjectRef, PyObjectRef)],
 ) -> Result<(), PyError> {
     if !ctx.bin {
@@ -697,7 +801,7 @@ fn batch_setitems(
 }
 
 /// `interp_pickle.py W_Pickler.write_get` — emit a GET back-reference.
-fn write_get(ctx: &PickleCtx, buf: &mut Vec<u8>, idx: usize) {
+fn write_get(ctx: &PickleCtx, buf: &mut Framer, idx: usize) {
     if ctx.bin {
         if idx < 256 {
             buf.push(op::BINGET);
@@ -714,7 +818,7 @@ fn write_get(ctx: &PickleCtx, buf: &mut Vec<u8>, idx: usize) {
 
 /// `interp_pickle.py memoize` — record the object's identity and write the
 /// put opcode.
-fn memoize(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
+fn memoize(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) {
     let idx = ctx.memo_size;
     ctx.memo_size += 1;
     ctx.memo.insert(w_obj as usize, idx);
@@ -774,7 +878,7 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<PyObjectRef, PyError> {
 /// returned a string; otherwise it is derived from `__qualname__`.
 fn save_global(
     ctx: &mut PickleCtx,
-    buf: &mut Vec<u8>,
+    buf: &mut Framer,
     w_obj: PyObjectRef,
     w_name_opt: Option<PyObjectRef>,
 ) -> Result<(), PyError> {
@@ -840,7 +944,7 @@ fn builtin_attr(name: &str) -> Result<PyObjectRef, PyError> {
 /// `(func, args[, state[, listitems[, dictitems[, state_setter]]]])`.
 fn save_reduce(
     ctx: &mut PickleCtx,
-    buf: &mut Vec<u8>,
+    buf: &mut Framer,
     rv: &[PyObjectRef],
     w_obj_opt: Option<PyObjectRef>,
 ) -> Result<(), PyError> {

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -1,4 +1,6 @@
-//! `_pickle.Pickler` — `interp_pickle.py W_Pickler` (atom subset).
+//! `_pickle.Pickler` — `interp_pickle.py W_Pickler` (atom + container subset).
+
+use std::collections::HashMap;
 
 use malachite_bigint::BigInt;
 use pyre_object::PyObjectRef;
@@ -6,7 +8,7 @@ use pyre_object::PyObjectRef;
 use crate::PyError;
 
 use super::{
-    DEFAULT_PROTOCOL, FRAME_SIZE_MIN, HIGHEST_PROTOCOL, call_meth, encode_long, op,
+    BATCHSIZE, DEFAULT_PROTOCOL, FRAME_SIZE_MIN, HIGHEST_PROTOCOL, call_meth, encode_long, op,
 };
 
 #[crate::pyre_class("_pickle.Pickler")]
@@ -18,12 +20,21 @@ pub struct W_Pickler {
     framing: bool,
 }
 
-/// Per-`dump` pickling context. `memo_size` drives the MEMOIZE counter;
-/// value dedup (GET back-references) arrives in increment 2.
+/// Per-`dump` pickling context. The identity memo maps an already-saved
+/// object (by address — pyre `id()` is address-based and interpreter
+/// objects never move) to its memo index; `memo_size` is the next index
+/// and the put-opcode counter.
 struct PickleCtx {
     proto: i64,
     bin: bool,
+    memo: HashMap<usize, usize>,
     memo_size: usize,
+}
+
+impl PickleCtx {
+    fn memo_get(&self, w_obj: PyObjectRef) -> Option<usize> {
+        self.memo.get(&(w_obj as usize)).copied()
+    }
 }
 
 #[crate::pyre_methods(doc = "Pickler(file, protocol=None) -> pickler writing to file.")]
@@ -85,6 +96,7 @@ impl W_Pickler {
         let mut ctx = PickleCtx {
             proto,
             bin,
+            memo: HashMap::new(),
             memo_size: 0,
         };
         let mut body: Vec<u8> = Vec::new();
@@ -110,9 +122,11 @@ impl W_Pickler {
     }
 }
 
-/// `interp_pickle.py W_Pickler.save` — atom subset. Exact-type dispatch
-/// via the `is_*` predicates (bool is checked before int because a bool
-/// is not an int here, and `is_int_or_long` also covers big integers).
+/// `interp_pickle.py W_Pickler.save`. Exact-type dispatch via the `is_*`
+/// predicates (bool is checked before int because a bool is not an int
+/// here, and `is_int_or_long` also covers big integers). Atoms are never
+/// memoized; everything else is checked against the identity memo for a
+/// GET back-reference before being saved.
 fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
     // Atoms — never memoized.
     if unsafe { pyre_object::is_none(w_obj) } {
@@ -131,19 +145,32 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
         save_float(ctx, buf, w_obj)?;
         return Ok(());
     }
-    // Memoized atoms — write the value, then a put opcode.
+
+    // Identity memo — a repeated reference becomes a GET back-reference.
+    if let Some(idx) = ctx.memo_get(w_obj) {
+        write_get(ctx, buf, idx);
+        return Ok(());
+    }
+
     if unsafe { pyre_object::is_bytes(w_obj) } {
         save_bytes(ctx, buf, w_obj);
-        memoize(ctx, buf);
         return Ok(());
     }
     if unsafe { pyre_object::is_str(w_obj) } {
         save_str(ctx, buf, w_obj);
-        memoize(ctx, buf);
         return Ok(());
     }
+    if unsafe { pyre_object::is_dict(w_obj) } {
+        return save_dict(ctx, buf, w_obj);
+    }
+    if unsafe { pyre_object::is_list(w_obj) } {
+        return save_list(ctx, buf, w_obj);
+    }
+    if unsafe { pyre_object::is_tuple(w_obj) } {
+        return save_tuple(ctx, buf, w_obj);
+    }
     Err(PyError::not_implemented(
-        "_pickle: only atoms are supported in this build",
+        "_pickle: this object type is not supported in this build",
     ))
 }
 
@@ -211,7 +238,7 @@ fn save_float(_ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result
     Ok(())
 }
 
-fn save_bytes(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
+fn save_bytes(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
     // proto < 3 (interp_pickle.py:1349) emits a `codecs.encode(latin1)` /
     // `bytes()` reduce instead of a BINBYTES opcode. That needs `save_reduce`
     // (increment 5); until then proto-2 bytes use the modern SHORT_BINBYTES
@@ -230,9 +257,10 @@ fn save_bytes(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
         buf.extend_from_slice(&(n as u32).to_le_bytes());
     }
     buf.extend_from_slice(data);
+    memoize(ctx, buf, w_obj);
 }
 
-fn save_str(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
+fn save_str(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
     let s = unsafe { pyre_object::strobject::w_str_get_value(w_obj) };
     let data = s.as_bytes();
     let n = data.len();
@@ -247,14 +275,180 @@ fn save_str(ctx: &PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
         buf.extend_from_slice(&(n as u32).to_le_bytes());
     }
     buf.extend_from_slice(data);
+    memoize(ctx, buf, w_obj);
 }
 
-/// `interp_pickle.py memoize` — write the put opcode + bump the counter.
-/// Increment 1 records nothing (no dedup); the put opcode is still emitted
-/// for wire-format parity.
-fn memoize(ctx: &mut PickleCtx, buf: &mut Vec<u8>) {
+/// `interp_pickle.py save_tuple`.
+fn save_tuple(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    let n = unsafe { pyre_object::tupleobject::w_tuple_len(w_obj) };
+    if n == 0 {
+        if ctx.bin {
+            buf.push(op::EMPTY_TUPLE);
+        } else {
+            buf.push(op::MARK);
+            buf.push(op::TUPLE);
+        }
+        return Ok(());
+    }
+
+    // Snapshot the elements before recursing (interpreter objects do not
+    // move, so the captured references stay valid across the saves below).
+    let elems: Vec<PyObjectRef> = (0..n)
+        .map(|i| unsafe { pyre_object::tupleobject::w_tuple_getitem(w_obj, i as i64).unwrap() })
+        .collect();
+
+    if n <= 3 && ctx.proto >= 2 {
+        for &e in &elems {
+            save(ctx, buf, e)?;
+        }
+        // Subtle: saving the elements may have memoized this very tuple
+        // (a recursive tuple). If so, discard the elements and GET it.
+        if let Some(idx) = ctx.memo_get(w_obj) {
+            for _ in 0..n {
+                buf.push(op::POP);
+            }
+            write_get(ctx, buf, idx);
+        } else {
+            buf.push(op::TUPLESIZE2CODE[n]);
+            memoize(ctx, buf, w_obj);
+        }
+        return Ok(());
+    }
+
+    buf.push(op::MARK);
+    for &e in &elems {
+        save(ctx, buf, e)?;
+    }
+    if let Some(idx) = ctx.memo_get(w_obj) {
+        // Recursive tuple: throw away the stack contents and GET it.
+        if ctx.bin {
+            buf.push(op::POP_MARK);
+        } else {
+            for _ in 0..(n + 1) {
+                buf.push(op::POP);
+            }
+        }
+        write_get(ctx, buf, idx);
+        return Ok(());
+    }
+    buf.push(op::TUPLE);
+    memoize(ctx, buf, w_obj);
+    Ok(())
+}
+
+/// `interp_pickle.py save_list`. The PyPy ascii/bytes-list fast paths are
+/// gated on `pypy_extensions` (off here) so the generic path is used,
+/// matching CPython's wire format.
+fn save_list(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    if ctx.bin {
+        buf.push(op::EMPTY_LIST);
+    } else {
+        buf.push(op::MARK);
+        buf.push(op::LIST);
+    }
+    memoize(ctx, buf, w_obj);
+
+    let n = unsafe { pyre_object::listobject::w_list_len(w_obj) };
+    let items: Vec<PyObjectRef> = (0..n)
+        .map(|i| unsafe { pyre_object::listobject::w_list_getitem(w_obj, i as i64).unwrap() })
+        .collect();
+    batch_appends(ctx, buf, &items)
+}
+
+/// `interp_pickle.py save_dict`.
+fn save_dict(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    if ctx.bin {
+        buf.push(op::EMPTY_DICT);
+    } else {
+        buf.push(op::MARK);
+        buf.push(op::DICT);
+    }
+    memoize(ctx, buf, w_obj);
+
+    let items = unsafe { pyre_object::dictmultiobject::w_dict_items(w_obj) };
+    batch_setitems(ctx, buf, &items)
+}
+
+/// `interp_pickle.py _batch_appends` (generic bin path). Single item →
+/// APPEND; otherwise MARK … APPENDS in batches of `BATCHSIZE`.
+fn batch_appends(
+    ctx: &mut PickleCtx,
+    buf: &mut Vec<u8>,
+    items: &[PyObjectRef],
+) -> Result<(), PyError> {
+    let n = items.len();
+    let mut i = 0;
+    while i < n {
+        if i + 1 == n {
+            // Exactly one item left.
+            save(ctx, buf, items[i])?;
+            buf.push(op::APPEND);
+            return Ok(());
+        }
+        buf.push(op::MARK);
+        let mut cnt = 0;
+        while i < n && cnt < BATCHSIZE {
+            save(ctx, buf, items[i])?;
+            i += 1;
+            cnt += 1;
+        }
+        buf.push(op::APPENDS);
+    }
+    Ok(())
+}
+
+/// `interp_pickle.py _batch_setitems` (bin path). Single pair → SETITEM;
+/// otherwise MARK … SETITEMS in batches of `BATCHSIZE`.
+fn batch_setitems(
+    ctx: &mut PickleCtx,
+    buf: &mut Vec<u8>,
+    items: &[(PyObjectRef, PyObjectRef)],
+) -> Result<(), PyError> {
+    let n = items.len();
+    let mut i = 0;
+    while i < n {
+        if i + 1 == n {
+            // Exactly one pair left.
+            save(ctx, buf, items[i].0)?;
+            save(ctx, buf, items[i].1)?;
+            buf.push(op::SETITEM);
+            return Ok(());
+        }
+        buf.push(op::MARK);
+        let mut cnt = 0;
+        while i < n && cnt < BATCHSIZE {
+            save(ctx, buf, items[i].0)?;
+            save(ctx, buf, items[i].1)?;
+            i += 1;
+            cnt += 1;
+        }
+        buf.push(op::SETITEMS);
+    }
+    Ok(())
+}
+
+/// `interp_pickle.py W_Pickler.write_get` — emit a GET back-reference.
+fn write_get(ctx: &PickleCtx, buf: &mut Vec<u8>, idx: usize) {
+    if ctx.bin {
+        if idx < 256 {
+            buf.push(op::BINGET);
+            buf.push(idx as u8);
+        } else {
+            buf.push(op::LONG_BINGET);
+            buf.extend_from_slice(&(idx as u32).to_le_bytes());
+        }
+    } else {
+        buf.push(op::GET);
+        buf.extend_from_slice(format!("{idx}\n").as_bytes());
+    }
+}
+
+/// `interp_pickle.py memoize` — record the object's identity and write the
+/// put opcode.
+fn memoize(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) {
     let idx = ctx.memo_size;
     ctx.memo_size += 1;
+    ctx.memo.insert(w_obj as usize, idx);
     if ctx.proto >= 4 {
         buf.push(op::MEMOIZE);
     } else if ctx.bin {

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -163,11 +163,20 @@ fn save(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<()
     if unsafe { pyre_object::is_dict(w_obj) } {
         return save_dict(ctx, buf, w_obj);
     }
+    if unsafe { pyre_object::is_set(w_obj) } {
+        return save_set(ctx, buf, w_obj);
+    }
+    if unsafe { pyre_object::is_frozenset(w_obj) } && ctx.proto >= 4 {
+        return save_frozenset(ctx, buf, w_obj);
+    }
     if unsafe { pyre_object::is_list(w_obj) } {
         return save_list(ctx, buf, w_obj);
     }
     if unsafe { pyre_object::is_tuple(w_obj) } {
         return save_tuple(ctx, buf, w_obj);
+    }
+    if unsafe { pyre_object::is_bytearray(w_obj) } {
+        return save_bytearray(ctx, buf, w_obj);
     }
     Err(PyError::not_implemented(
         "_pickle: this object type is not supported in this build",
@@ -367,6 +376,83 @@ fn save_dict(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Resu
 
     let items = unsafe { pyre_object::dictmultiobject::w_dict_items(w_obj) };
     batch_setitems(ctx, buf, &items)
+}
+
+/// `interp_pickle.py save_set`. Sets are unordered, so the wire bytes are
+/// not byte-identical to CPython, but the encoding round-trips. The
+/// protocol < 4 reduce fallback arrives with `save_reduce`.
+fn save_set(ctx: &mut PickleCtx, buf: &mut Vec<u8>, w_obj: PyObjectRef) -> Result<(), PyError> {
+    if ctx.proto < 4 {
+        return Err(PyError::not_implemented(
+            "_pickle: set at protocol < 4 needs save_reduce (later increment)",
+        ));
+    }
+    buf.push(op::EMPTY_SET);
+    memoize(ctx, buf, w_obj);
+
+    let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
+    let length = items.len();
+    if length == 0 {
+        return Ok(());
+    }
+    buf.push(op::MARK);
+    save(ctx, buf, items[0])?;
+    let mut i = 1;
+    while i + 1 < length {
+        if i % BATCHSIZE == 0 {
+            buf.push(op::ADDITEMS);
+            buf.push(op::MARK);
+        }
+        save(ctx, buf, items[i])?;
+        i += 1;
+    }
+    if length > 1 {
+        save(ctx, buf, items[length - 1])?;
+    }
+    buf.push(op::ADDITEMS);
+    Ok(())
+}
+
+/// `interp_pickle.py save_frozenset` (proto >= 4 only; lower protocols reach
+/// the generic reduce path). Unordered, so not byte-identical to CPython.
+fn save_frozenset(
+    ctx: &mut PickleCtx,
+    buf: &mut Vec<u8>,
+    w_obj: PyObjectRef,
+) -> Result<(), PyError> {
+    buf.push(op::MARK);
+    let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
+    for &e in &items {
+        save(ctx, buf, e)?;
+    }
+    if let Some(idx) = ctx.memo_get(w_obj) {
+        buf.push(op::POP);
+        write_get(ctx, buf, idx);
+    } else {
+        buf.push(op::FROZENSET);
+        memoize(ctx, buf, w_obj);
+    }
+    Ok(())
+}
+
+/// `interp_pickle.py save_bytearray` (proto >= 5 raw form; lower protocols
+/// reach the generic reduce path).
+fn save_bytearray(
+    ctx: &mut PickleCtx,
+    buf: &mut Vec<u8>,
+    w_obj: PyObjectRef,
+) -> Result<(), PyError> {
+    if ctx.proto < 5 {
+        return Err(PyError::not_implemented(
+            "_pickle: bytearray at protocol < 5 needs save_reduce (later increment)",
+        ));
+    }
+    let data = unsafe { pyre_object::bytearrayobject::w_bytearray_data(w_obj) };
+    buf.push(op::BYTEARRAY8);
+    buf.extend_from_slice(&(data.len() as u64).to_le_bytes());
+    buf.extend_from_slice(data);
+    memoize(ctx, buf, w_obj);
+    Ok(())
 }
 
 /// `interp_pickle.py _batch_appends` (generic bin path). Single item →

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -19,19 +19,33 @@ pub struct W_Pickler {
     proto: i64,
     bin: bool,
     framing: bool,
+    /// Apply the `_compat_pickle` py3→py2 name remap at protocol < 3.
+    fix_imports: bool,
     /// `buffer_callback` for proto-5 out-of-band buffers, or `None`.
     buffer_callback: PyObjectRef,
+    /// Memo of saved objects — a Python `list` (GC-walked) persisted across
+    /// `dump` calls until `clear_memo`, position = memo index.
+    w_memo: PyObjectRef,
 }
 
-/// Per-`dump` pickling context. The identity memo maps an already-saved
-/// object (by address — pyre `id()` is address-based and interpreter
-/// objects never move) to its memo index; `memo_size` is the next index
-/// and the put-opcode counter.
+/// Per-`dump` pickling context.  The identity memo maps an already-saved
+/// object to its memo index.  pyre's incminimark nursery relocates live
+/// objects, so the memo cannot key on a raw address: the memoized objects
+/// live in a pinned Python `list` (`memo_slot`) which the GC walks, so the
+/// stored references follow every move, and `index` maps the move-stable
+/// `gc_identity_hash` to the list positions sharing that hash, resolved by
+/// pointer identity against a freshly-read list element.  The memo index
+/// (the PUT/GET argument) is the object's position in that list.
 struct PickleCtx {
     proto: i64,
     bin: bool,
-    memo: HashMap<usize, usize>,
-    memo_size: usize,
+    /// Apply the `_compat_pickle` py3→py2 name remap at protocol < 3.
+    fix_imports: bool,
+    /// Shadow-stack slot of the memo `list`; re-read on every access so a
+    /// relocation of the list itself is observed.
+    memo_slot: usize,
+    /// `gc_identity_hash(obj)` → memo indices sharing that hash.
+    index: HashMap<usize, Vec<usize>>,
     /// `persistent_id` callable resolved off the pickler (subclass override
     /// or set attribute), or `PY_NULL` when not defined.
     pers_func: PyObjectRef,
@@ -40,8 +54,22 @@ struct PickleCtx {
 }
 
 impl PickleCtx {
+    /// The memo `list`, re-read from its pinned slot (it may have moved).
+    fn memo_list(&self) -> PyObjectRef {
+        pyre_object::gc_roots::shadow_stack_get(self.memo_slot)
+    }
+
     fn memo_get(&self, w_obj: PyObjectRef) -> Option<usize> {
-        self.memo.get(&(w_obj as usize)).copied()
+        let h = pyre_object::gc_hook::gc_identity_hash(w_obj as usize);
+        let list = self.memo_list();
+        for &idx in self.index.get(&h)? {
+            let memoized =
+                unsafe { pyre_object::listobject::w_list_getitem(list, idx as i64) }.unwrap();
+            if memoized == w_obj {
+                return Some(idx);
+            }
+        }
+        None
     }
 }
 
@@ -140,7 +168,9 @@ impl W_Pickler {
             proto: 0,
             bin: false,
             framing: false,
+            fix_imports: true,
             buffer_callback: pyre_object::w_none(),
+            w_memo: pyre_object::listobject::w_list_new(Vec::new()),
         })
     }
 
@@ -148,13 +178,11 @@ impl W_Pickler {
         &mut self,
         file: PyObjectRef,
         #[default(pyre_object::w_none())] protocol: PyObjectRef,
-        #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+        #[default(pyre_object::boolobject::w_bool_from(true))] fix_imports: PyObjectRef,
         #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
     ) -> Result<(), PyError> {
-        // `fix_imports` selects the `_compat_pickle` name mapping at the save
-        // sites by protocol already; the flag is accepted for signature
-        // compatibility but the proto-< 3 path is always applied.
-        let _ = fix_imports;
+        // `fix_imports` gates the `_compat_pickle` py3→py2 name remap that the
+        // protocol-< 3 save path would otherwise always apply.
         let proto = normalize_protocol(protocol)?;
         // `file must have a 'write' attribute` (interp_pickle.py:557).
         if crate::baseobjspace::findattr(file, "write").is_none() {
@@ -167,8 +195,15 @@ impl W_Pickler {
         self.proto = proto;
         self.bin = proto >= 1;
         self.framing = proto >= 4;
+        self.fix_imports = crate::baseobjspace::is_true(fix_imports);
         self.buffer_callback = buffer_callback;
+        self.w_memo = pyre_object::listobject::w_list_new(Vec::new());
         Ok(())
+    }
+
+    /// `Pickler.clear_memo` — reset the memo so the next `dump` starts fresh.
+    fn clear_memo(&mut self) {
+        self.w_memo = pyre_object::listobject::w_list_new(Vec::new());
     }
 
     fn dump(&mut self, w_obj: PyObjectRef) -> Result<(), PyError> {
@@ -176,20 +211,37 @@ impl W_Pickler {
         let proto = self.proto;
         let bin = self.bin;
         let framing = self.framing;
+        let fix_imports = self.fix_imports;
         let w_file = self.w_file;
         let buffer_callback = self.buffer_callback;
+        let w_memo = self.w_memo;
+        let self_ptr = self as *mut W_Pickler as PyObjectRef;
+
+        // Pin `w_file` and the memo list before the `persistent_id` lookup,
+        // whose allocation could otherwise relocate them.
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_file);
+        let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        pyre_object::gc_roots::pin_root(w_memo);
+        let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+
         // A `persistent_id` defined on a subclass (or set as an attribute)
         // overrides the default no-op; the base class has none.
-        let self_ptr = self as *mut W_Pickler as PyObjectRef;
         let pers_func = crate::baseobjspace::findattr(self_ptr, "persistent_id")
             .filter(|&f| !unsafe { pyre_object::is_none(f) })
             .unwrap_or(pyre_object::PY_NULL);
 
-        let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_file);
-        let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-
-        let w_bytes = pickle_core(w_obj, proto, bin, framing, pers_func, buffer_callback)?;
+        let w_memo = pyre_object::gc_roots::shadow_stack_get(memo_slot);
+        let w_bytes = pickle_core(
+            w_obj,
+            proto,
+            bin,
+            framing,
+            fix_imports,
+            pers_func,
+            buffer_callback,
+            w_memo,
+        )?;
         // `w_file` may have moved while building the pickle; re-read the pin.
         let w_file = pyre_object::gc_roots::shadow_stack_get(file_slot);
         call_meth(w_file, "write", &[w_bytes])?;
@@ -236,8 +288,10 @@ pub(crate) fn pickle_core(
     proto: i64,
     bin: bool,
     framing: bool,
+    fix_imports: bool,
     pers_func: PyObjectRef,
     buffer_callback: PyObjectRef,
+    w_memo: PyObjectRef,
 ) -> Result<PyObjectRef, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(w_obj);
@@ -247,12 +301,26 @@ pub(crate) fn pickle_core(
     if !buffer_callback.is_null() && !unsafe { pyre_object::is_none(buffer_callback) } {
         pyre_object::gc_roots::pin_root(buffer_callback);
     }
+    // Pin the memo list and index its existing entries (a reused `Pickler`
+    // carries memo state across `dump` calls until `clear_memo`).
+    pyre_object::gc_roots::pin_root(w_memo);
+    let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let mut index: HashMap<usize, Vec<usize>> = HashMap::new();
+    let n = unsafe { pyre_object::listobject::w_list_len(w_memo) };
+    for i in 0..n {
+        let o = unsafe { pyre_object::listobject::w_list_getitem(w_memo, i as i64) }.unwrap();
+        index
+            .entry(pyre_object::gc_hook::gc_identity_hash(o as usize))
+            .or_default()
+            .push(i);
+    }
 
     let mut ctx = PickleCtx {
         proto,
         bin,
-        memo: HashMap::new(),
-        memo_size: 0,
+        fix_imports,
+        memo_slot,
+        index,
         pers_func,
         buffer_callback,
     };
@@ -598,35 +666,43 @@ fn save_tuple(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resu
         return Ok(());
     }
 
-    // Snapshot the elements before recursing (interpreter objects do not
-    // move, so the captured references stay valid across the saves below).
-    let elems: Vec<PyObjectRef> = (0..n)
-        .map(|i| unsafe { pyre_object::tupleobject::w_tuple_getitem(w_obj, i as i64).unwrap() })
-        .collect();
+    // Pin the tuple; a recursive save below can relocate the elements, so
+    // re-read each one (and the tuple itself for the memo) from the
+    // GC-walked tuple right before it is used.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_obj);
+    let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let elem = |i: usize| unsafe {
+        pyre_object::tupleobject::w_tuple_getitem(
+            pyre_object::gc_roots::shadow_stack_get(slot),
+            i as i64,
+        )
+        .unwrap()
+    };
 
     if n <= 3 && ctx.proto >= 2 {
-        for &e in &elems {
-            save(ctx, buf, e)?;
+        for i in 0..n {
+            save(ctx, buf, elem(i))?;
         }
         // Subtle: saving the elements may have memoized this very tuple
         // (a recursive tuple). If so, discard the elements and GET it.
-        if let Some(idx) = ctx.memo_get(w_obj) {
+        if let Some(idx) = ctx.memo_get(pyre_object::gc_roots::shadow_stack_get(slot)) {
             for _ in 0..n {
                 buf.push(op::POP);
             }
             write_get(ctx, buf, idx);
         } else {
             buf.push(op::TUPLESIZE2CODE[n]);
-            memoize(ctx, buf, w_obj);
+            memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot));
         }
         return Ok(());
     }
 
     buf.push(op::MARK);
-    for &e in &elems {
-        save(ctx, buf, e)?;
+    for i in 0..n {
+        save(ctx, buf, elem(i))?;
     }
-    if let Some(idx) = ctx.memo_get(w_obj) {
+    if let Some(idx) = ctx.memo_get(pyre_object::gc_roots::shadow_stack_get(slot)) {
         // Recursive tuple: throw away the stack contents and GET it.
         if ctx.bin {
             buf.push(op::POP_MARK);
@@ -639,7 +715,7 @@ fn save_tuple(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resu
         return Ok(());
     }
     buf.push(op::TUPLE);
-    memoize(ctx, buf, w_obj);
+    memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot));
     Ok(())
 }
 
@@ -647,33 +723,49 @@ fn save_tuple(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resu
 /// gated on `pypy_extensions` (off here) so the generic path is used,
 /// matching CPython's wire format.
 fn save_list(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    // The list itself is a GC-walked Python `list`; pin it and append by
+    // re-reading each element, so a relocation during a recursive save is
+    // observed instead of dereferencing a stale snapshot.
+    pyre_object::gc_roots::pin_root(w_obj);
+    let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if ctx.bin {
         buf.push(op::EMPTY_LIST);
     } else {
         buf.push(op::MARK);
         buf.push(op::LIST);
     }
-    memoize(ctx, buf, w_obj);
-
-    let n = unsafe { pyre_object::listobject::w_list_len(w_obj) };
-    let items: Vec<PyObjectRef> = (0..n)
-        .map(|i| unsafe { pyre_object::listobject::w_list_getitem(w_obj, i as i64).unwrap() })
-        .collect();
-    batch_appends(ctx, buf, &items)
+    memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot));
+    batch_appends(ctx, buf, slot)
 }
 
 /// `interp_pickle.py save_dict`.
 fn save_dict(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(), PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    // Pin the dict (so `memoize` sees its current address) and, since a dict
+    // has no stable index access, flatten its items into a pinned
+    // `[k0, v0, …]` Python list (GC-walked), re-read per save.
+    pyre_object::gc_roots::pin_root(w_obj);
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let items = unsafe {
+        pyre_object::dictmultiobject::w_dict_items(pyre_object::gc_roots::shadow_stack_get(
+            dict_slot,
+        ))
+    };
+    let mut flat = Vec::with_capacity(items.len() * 2);
+    for (k, v) in items {
+        flat.push(k);
+        flat.push(v);
+    }
+    let items_slot = pin_items(flat);
     if ctx.bin {
         buf.push(op::EMPTY_DICT);
     } else {
         buf.push(op::MARK);
         buf.push(op::DICT);
     }
-    memoize(ctx, buf, w_obj);
-
-    let items = unsafe { pyre_object::dictmultiobject::w_dict_items(w_obj) };
-    batch_setitems(ctx, buf, &items)
+    memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(dict_slot));
+    batch_setitems(ctx, buf, items_slot)
 }
 
 /// `interp_pickle.py save_set`. Sets are unordered, so the wire bytes are
@@ -689,26 +781,35 @@ fn save_set(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result
         return save_reduce(ctx, buf, &[w_set_type, w_args], Some(w_obj));
     }
     buf.push(op::EMPTY_SET);
-    memoize(ctx, buf, w_obj);
+    // Pin the set so `memoize` records its current address, then snapshot its
+    // members into a pinned Python `list` re-read per save (a recursive save
+    // can relocate them).
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_obj);
+    let set_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(set_slot));
 
-    let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
-    let length = items.len();
+    let items = unsafe {
+        pyre_object::setobject::w_set_items(pyre_object::gc_roots::shadow_stack_get(set_slot))
+    };
+    let slot = pin_items(items);
+    let length = pinned_len(slot);
     if length == 0 {
         return Ok(());
     }
     buf.push(op::MARK);
-    save(ctx, buf, items[0])?;
+    save(ctx, buf, pinned_get(slot, 0))?;
     let mut i = 1;
     while i + 1 < length {
         if i % BATCHSIZE == 0 {
             buf.push(op::ADDITEMS);
             buf.push(op::MARK);
         }
-        save(ctx, buf, items[i])?;
+        save(ctx, buf, pinned_get(slot, i))?;
         i += 1;
     }
     if length > 1 {
-        save(ctx, buf, items[length - 1])?;
+        save(ctx, buf, pinned_get(slot, length - 1))?;
     }
     buf.push(op::ADDITEMS);
     Ok(())
@@ -731,17 +832,27 @@ fn save_frozenset(
             crate::typedef::gettypeobject(&pyre_object::setobject::FROZENSET_TYPE);
         return save_reduce(ctx, buf, &[w_frozenset_type, w_args], Some(w_obj));
     }
+    // Pin the frozenset and snapshot its members into a pinned Python `list`
+    // re-read per save (a recursive save can relocate them); the frozenset
+    // itself is re-read for the memo check after the saves.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_obj);
+    let fs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let items = unsafe {
+        pyre_object::setobject::w_set_items(pyre_object::gc_roots::shadow_stack_get(fs_slot))
+    };
+    let slot = pin_items(items);
     buf.push(op::MARK);
-    let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
-    for &e in &items {
-        save(ctx, buf, e)?;
+    let n = pinned_len(slot);
+    for i in 0..n {
+        save(ctx, buf, pinned_get(slot, i))?;
     }
-    if let Some(idx) = ctx.memo_get(w_obj) {
+    if let Some(idx) = ctx.memo_get(pyre_object::gc_roots::shadow_stack_get(fs_slot)) {
         buf.push(op::POP);
         write_get(ctx, buf, idx);
     } else {
         buf.push(op::FROZENSET);
-        memoize(ctx, buf, w_obj);
+        memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(fs_slot));
     }
     Ok(())
 }
@@ -870,34 +981,55 @@ fn save_raw_bytearray(buf: &mut Framer, data: &[u8]) {
     }
 }
 
-/// `interp_pickle.py _batch_appends` (generic bin path). Single item →
-/// APPEND; otherwise MARK … APPENDS in batches of `BATCHSIZE`.
-fn batch_appends(
-    ctx: &mut PickleCtx,
-    buf: &mut Framer,
-    items: &[PyObjectRef],
-) -> Result<(), PyError> {
+/// Build a Python `list` from `items` and pin it in the shadow stack,
+/// returning its slot.  `w_list_new` pins each element across its own
+/// allocation, so the snapshot is captured safely; thereafter the GC walks
+/// the list and rewrites its entries, so `pinned_get` reads the relocated
+/// element even after the recursive `save` calls below trigger collections.
+fn pin_items(items: Vec<PyObjectRef>) -> usize {
+    let w_list = pyre_object::listobject::w_list_new(items);
+    pyre_object::gc_roots::pin_root(w_list);
+    pyre_object::gc_roots::shadow_stack_len() - 1
+}
+
+/// Length of the pinned list at `slot`.
+fn pinned_len(slot: usize) -> usize {
+    let list = pyre_object::gc_roots::shadow_stack_get(slot);
+    unsafe { pyre_object::listobject::w_list_len(list) }
+}
+
+/// Element `i` of the pinned list at `slot`, re-read so a relocation of the
+/// element (or the list) since the last access is observed.
+fn pinned_get(slot: usize, i: usize) -> PyObjectRef {
+    let list = pyre_object::gc_roots::shadow_stack_get(slot);
+    unsafe { pyre_object::listobject::w_list_getitem(list, i as i64) }.unwrap()
+}
+
+/// `interp_pickle.py _batch_appends`. `slot` pins a Python `list` of the
+/// items; each is re-read from the (GC-walked) list right before saving so a
+/// mid-batch collection cannot leave a stale element behind.
+fn batch_appends(ctx: &mut PickleCtx, buf: &mut Framer, slot: usize) -> Result<(), PyError> {
+    let n = pinned_len(slot);
     if !ctx.bin {
         // proto 0 — no APPENDS, one APPEND per item.
-        for &item in items {
-            save(ctx, buf, item)?;
+        for i in 0..n {
+            save(ctx, buf, pinned_get(slot, i))?;
             buf.push(op::APPEND);
         }
         return Ok(());
     }
-    let n = items.len();
     let mut i = 0;
     while i < n {
         if i + 1 == n {
             // Exactly one item left.
-            save(ctx, buf, items[i])?;
+            save(ctx, buf, pinned_get(slot, i))?;
             buf.push(op::APPEND);
             return Ok(());
         }
         buf.push(op::MARK);
         let mut cnt = 0;
         while i < n && cnt < BATCHSIZE {
-            save(ctx, buf, items[i])?;
+            save(ctx, buf, pinned_get(slot, i))?;
             i += 1;
             cnt += 1;
         }
@@ -907,37 +1039,35 @@ fn batch_appends(
 }
 
 /// `interp_pickle.py _batch_setitems` (bin path). Single pair → SETITEM;
-/// otherwise MARK … SETITEMS in batches of `BATCHSIZE`.
-fn batch_setitems(
-    ctx: &mut PickleCtx,
-    buf: &mut Framer,
-    items: &[(PyObjectRef, PyObjectRef)],
-) -> Result<(), PyError> {
+/// otherwise MARK … SETITEMS in batches of `BATCHSIZE`. `slot` pins a flat
+/// `[k0, v0, k1, v1, …]` Python `list`, re-read per access (see
+/// `batch_appends`).
+fn batch_setitems(ctx: &mut PickleCtx, buf: &mut Framer, slot: usize) -> Result<(), PyError> {
+    let npairs = pinned_len(slot) / 2;
     if !ctx.bin {
         // proto 0 — no SETITEMS, one SETITEM per pair.
-        for &(k, v) in items {
-            save(ctx, buf, k)?;
-            save(ctx, buf, v)?;
+        for p in 0..npairs {
+            save(ctx, buf, pinned_get(slot, 2 * p))?;
+            save(ctx, buf, pinned_get(slot, 2 * p + 1))?;
             buf.push(op::SETITEM);
         }
         return Ok(());
     }
-    let n = items.len();
-    let mut i = 0;
-    while i < n {
-        if i + 1 == n {
+    let mut p = 0;
+    while p < npairs {
+        if p + 1 == npairs {
             // Exactly one pair left.
-            save(ctx, buf, items[i].0)?;
-            save(ctx, buf, items[i].1)?;
+            save(ctx, buf, pinned_get(slot, 2 * p))?;
+            save(ctx, buf, pinned_get(slot, 2 * p + 1))?;
             buf.push(op::SETITEM);
             return Ok(());
         }
         buf.push(op::MARK);
         let mut cnt = 0;
-        while i < n && cnt < BATCHSIZE {
-            save(ctx, buf, items[i].0)?;
-            save(ctx, buf, items[i].1)?;
-            i += 1;
+        while p < npairs && cnt < BATCHSIZE {
+            save(ctx, buf, pinned_get(slot, 2 * p))?;
+            save(ctx, buf, pinned_get(slot, 2 * p + 1))?;
+            p += 1;
             cnt += 1;
         }
         buf.push(op::SETITEMS);
@@ -964,9 +1094,13 @@ fn write_get(ctx: &PickleCtx, buf: &mut Framer, idx: usize) {
 /// `interp_pickle.py memoize` — record the object's identity and write the
 /// put opcode.
 fn memoize(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) {
-    let idx = ctx.memo_size;
-    ctx.memo_size += 1;
-    ctx.memo.insert(w_obj as usize, idx);
+    let list = ctx.memo_list();
+    let idx = unsafe { pyre_object::listobject::w_list_len(list) };
+    // Compute the move-stable hash before the append, whose growth could
+    // relocate `w_obj` and leave the local stale.
+    let h = pyre_object::gc_hook::gc_identity_hash(w_obj as usize);
+    unsafe { pyre_object::listobject::w_list_append(list, w_obj) };
+    ctx.index.entry(h).or_default().push(idx);
     if ctx.proto >= 4 {
         buf.push(op::MEMOIZE);
     } else if ctx.bin {
@@ -1060,9 +1194,10 @@ fn save_global(
             pyre_object::tupleobject::w_tuple_new(vec![parent, pyre_object::w_str_new(lastname)]);
         save_reduce(ctx, buf, &[w_getattr, w_args], None)?;
     } else {
-        // protocol < 3 applies the py3 → py2 `_compat_pickle` reverse map
-        // (fix_imports); protocol 3 writes the name verbatim.
-        let (module_name, name) = if ctx.proto < 3 {
+        // protocol < 3 with `fix_imports` applies the py3 → py2
+        // `_compat_pickle` reverse map; protocol 3 (or `fix_imports=False`)
+        // writes the name verbatim.
+        let (module_name, name) = if ctx.proto < 3 && ctx.fix_imports {
             crate::module::_pickle::compat_map(&module_name, &name, true)
         } else {
             (module_name, name)
@@ -1093,79 +1228,140 @@ fn save_reduce(
     rv: &[PyObjectRef],
     w_obj_opt: Option<PyObjectRef>,
 ) -> Result<(), PyError> {
-    let w_func = rv[0];
-    let w_args = rv[1];
-    let nonnull = |i: usize| {
-        rv.get(i)
-            .copied()
-            .filter(|&x| !unsafe { pyre_object::is_none(x) })
+    let _roots = pyre_object::gc_roots::push_roots();
+    // Recursive saves (and the reduce callbacks they invoke) relocate young
+    // objects, so pin the reduce values in a GC-walked `list` and re-read each
+    // one immediately before it is consumed.
+    let rv_len = rv.len();
+    let rv_slot = pin_items(rv.to_vec());
+    let w_obj_slot = match w_obj_opt {
+        Some(o) => {
+            pyre_object::gc_roots::pin_root(o);
+            Some(pyre_object::gc_roots::shadow_stack_len() - 1)
+        }
+        None => None,
     };
-    let w_state = nonnull(2);
-    let w_listitems = nonnull(3);
-    let w_dictitems = nonnull(4);
-    let w_state_setter = nonnull(5);
+    let rv_get = |i: usize| pinned_get(rv_slot, i);
+    let present = |i: usize| i < rv_len && !unsafe { pyre_object::is_none(pinned_get(rv_slot, i)) };
 
-    if !unsafe { pyre_object::is_tuple(w_args) } {
+    if !unsafe { pyre_object::is_tuple(rv_get(1)) } {
         return Err(pickling_error("args from save_reduce() must be a tuple"));
     }
-    if !crate::baseobjspace::callable_w(w_func) {
+    if !crate::baseobjspace::callable_w(rv_get(0)) {
         return Err(pickling_error("func from save_reduce() must be callable"));
     }
 
-    let func_name = func_name_str(w_func);
-    let args_w = tuple_items(w_args);
+    let has_state = present(2);
+    let has_listitems = present(3);
+    let has_dictitems = present(4);
+    let has_state_setter = present(5);
+
+    let func_name = func_name_str(rv_get(0));
+
+    // Pin the args tuple; its elements are re-read per save.
+    pyre_object::gc_roots::pin_root(rv_get(1));
+    let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let args_get = |i: usize| unsafe {
+        pyre_object::tupleobject::w_tuple_getitem(
+            pyre_object::gc_roots::shadow_stack_get(args_slot),
+            i as i64,
+        )
+        .unwrap()
+    };
+    let args_len = unsafe {
+        pyre_object::tupleobject::w_tuple_len(pyre_object::gc_roots::shadow_stack_get(args_slot))
+    };
 
     if ctx.proto >= 2 && func_name.as_deref() == Some("__newobj_ex__") {
-        if args_w.len() != 3 {
+        if args_len != 3 {
             return Err(pickling_error("__newobj_ex__ requires three args"));
         }
-        let (w_cls, w_a, w_kw) = (args_w[0], args_w[1], args_w[2]);
-        if crate::baseobjspace::findattr(w_cls, "__new__").is_none() {
+        if crate::baseobjspace::findattr(args_get(0), "__new__").is_none() {
             return Err(pickling_error(
                 "args[0] from __newobj_ex__ args has no __new__",
             ));
         }
         if ctx.proto >= 4 {
-            save(ctx, buf, w_cls)?;
-            save(ctx, buf, w_a)?;
-            save(ctx, buf, w_kw)?;
+            save(ctx, buf, args_get(0))?;
+            save(ctx, buf, args_get(1))?;
+            save(ctx, buf, args_get(2))?;
             buf.push(op::NEWOBJ_EX);
         } else {
-            // protocol 2/3 with keyword args needs functools.partial.
-            let kw_len = unsafe { pyre_object::dictmultiobject::w_dict_items(w_kw) }.len();
-            if kw_len > 0 {
-                return Err(PyError::not_implemented(
-                    "_pickle: __newobj_ex__ with kwargs at protocol < 4",
+            // protocol 2/3: encode the constructor as
+            // `partial(cls.__new__, cls, *args, **kwargs)`, then REDUCE with
+            // an empty argument tuple.
+            let functools = import_module("functools")?;
+            let w_partial = crate::baseobjspace::getattr_str(functools, "partial")?;
+            pyre_object::gc_roots::pin_root(w_partial);
+            let partial_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            let w_new = crate::baseobjspace::getattr_str(args_get(0), "__new__")?;
+            pyre_object::gc_roots::pin_root(w_new);
+            let new_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            // keyword arguments from the `kwargs` dict (re-read fresh; no GC
+            // until the `partial` construction below).
+            let kw_items = unsafe { pyre_object::dictmultiobject::w_dict_items(args_get(2)) };
+            let mut kwargs = Vec::with_capacity(kw_items.len());
+            for (k, v) in kw_items {
+                if !unsafe { pyre_object::is_str(k) } {
+                    return Err(pickling_error("__newobj_ex__ kwargs keys must be strings"));
+                }
+                kwargs.push((
+                    unsafe { pyre_object::strobject::w_str_get_wtf8(k) }.to_owned(),
+                    v,
                 ));
             }
-            let w_new = crate::baseobjspace::getattr_str(w_cls, "__new__")?;
-            let mut full = vec![w_cls];
-            full.extend(tuple_items(w_a));
-            save(ctx, buf, w_new)?;
-            save(ctx, buf, pyre_object::tupleobject::w_tuple_new(full))?;
+            // positional: (cls.__new__, cls, *args).
+            let mut pos = vec![
+                pyre_object::gc_roots::shadow_stack_get(new_slot),
+                args_get(0),
+            ];
+            pos.extend(tuple_items(args_get(1)));
+            let ec = crate::call::getexecutioncontext();
+            if ec.is_null() {
+                return Err(pickling_error("no execution context for __newobj_ex__"));
+            }
+            let frame = unsafe { (*ec).gettopframe() };
+            if frame.is_null() {
+                return Err(pickling_error("no frame for __newobj_ex__ at protocol < 4"));
+            }
+            let w_func = crate::call::call_with_kwargs(
+                unsafe { &mut *frame },
+                pyre_object::gc_roots::shadow_stack_get(partial_slot),
+                &pos,
+                &kwargs,
+            )?;
+            save(ctx, buf, w_func)?;
+            save(ctx, buf, pyre_object::tupleobject::w_tuple_new(Vec::new()))?;
             buf.push(op::REDUCE);
         }
     } else if ctx.proto >= 2 && func_name.as_deref() == Some("__newobj__") {
-        if args_w.is_empty() {
+        if args_len == 0 {
             return Err(pickling_error("__newobj__ requires at least one arg"));
         }
-        let w_cls = args_w[0];
-        if crate::baseobjspace::findattr(w_cls, "__new__").is_none() {
+        if crate::baseobjspace::findattr(args_get(0), "__new__").is_none() {
             return Err(pickling_error(
                 "args[0] from __newobj__ args has no __new__",
             ));
         }
-        let w_newargs = pyre_object::tupleobject::w_tuple_new(args_w[1..].to_vec());
-        save(ctx, buf, w_cls)?;
-        save(ctx, buf, w_newargs)?;
+        let w_newargs =
+            pyre_object::tupleobject::w_tuple_new((1..args_len).map(|i| args_get(i)).collect());
+        pyre_object::gc_roots::pin_root(w_newargs);
+        let newargs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        save(ctx, buf, args_get(0))?;
+        save(
+            ctx,
+            buf,
+            pyre_object::gc_roots::shadow_stack_get(newargs_slot),
+        )?;
         buf.push(op::NEWOBJ);
     } else {
-        save(ctx, buf, w_func)?;
-        save(ctx, buf, w_args)?;
+        save(ctx, buf, rv_get(0))?;
+        save(ctx, buf, rv_get(1))?;
         buf.push(op::REDUCE);
     }
 
-    if let Some(w_obj) = w_obj_opt {
+    if let Some(slot) = w_obj_slot {
+        let w_obj = pyre_object::gc_roots::shadow_stack_get(slot);
         if let Some(idx) = ctx.memo_get(w_obj) {
             buf.push(op::POP);
             write_get(ctx, buf, idx);
@@ -1174,24 +1370,28 @@ fn save_reduce(
         }
     }
 
-    if let Some(li) = w_listitems {
-        let items = drain_iter(li)?;
-        batch_appends(ctx, buf, &items)?;
+    if has_listitems {
+        let items_slot = drain_iter_pinned(rv_get(3))?;
+        batch_appends(ctx, buf, items_slot)?;
     }
-    if let Some(di) = w_dictitems {
-        let pairs = drain_iter_pairs(di)?;
-        batch_setitems(ctx, buf, &pairs)?;
+    if has_dictitems {
+        let pairs_slot = drain_iter_pairs_pinned(rv_get(4))?;
+        batch_setitems(ctx, buf, pairs_slot)?;
     }
-    if let Some(st) = w_state {
-        if let Some(setter) = w_state_setter {
-            save(ctx, buf, setter)?;
-            save(ctx, buf, w_obj_opt.unwrap())?;
-            save(ctx, buf, st)?;
+    if has_state {
+        if has_state_setter {
+            save(ctx, buf, rv_get(5))?;
+            save(
+                ctx,
+                buf,
+                pyre_object::gc_roots::shadow_stack_get(w_obj_slot.unwrap()),
+            )?;
+            save(ctx, buf, rv_get(2))?;
             buf.push(op::TUPLE2);
             buf.push(op::REDUCE);
             buf.push(op::POP);
         } else {
-            save(ctx, buf, st)?;
+            save(ctx, buf, rv_get(2))?;
             buf.push(op::BUILD);
         }
     }
@@ -1215,33 +1415,65 @@ fn tuple_items(w_tuple: PyObjectRef) -> Vec<PyObjectRef> {
         .collect()
 }
 
-/// Drain an iterable into a `Vec`.
-fn drain_iter(w_iterable: PyObjectRef) -> Result<Vec<PyObjectRef>, PyError> {
+/// Drain an iterable into a freshly-pinned Python `list`, returning its
+/// shadow-stack slot. Appending into a GC-walked `list` as iteration proceeds
+/// keeps every already-yielded item reachable and relocation-tracked — unlike
+/// a Rust `Vec`, whose elements a later `next()` could strand by relocating
+/// them. The iterator object is pinned too, since `next` may collect.
+fn drain_iter_pinned(w_iterable: PyObjectRef) -> Result<usize, PyError> {
+    let slot = pin_items(Vec::new());
     let w_iter = crate::baseobjspace::iter(w_iterable)?;
-    let mut out = Vec::new();
+    pyre_object::gc_roots::pin_root(w_iter);
+    let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     loop {
-        match crate::baseobjspace::next(w_iter) {
-            Ok(item) => out.push(item),
+        match crate::baseobjspace::next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
+            Ok(item) => unsafe {
+                pyre_object::listobject::w_list_append(
+                    pyre_object::gc_roots::shadow_stack_get(slot),
+                    item,
+                )
+            },
             Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
             Err(e) => return Err(e),
         }
     }
-    Ok(out)
+    Ok(slot)
 }
 
-/// Drain an iterable of `(key, value)` pairs into a `Vec`.
-fn drain_iter_pairs(w_iterable: PyObjectRef) -> Result<Vec<(PyObjectRef, PyObjectRef)>, PyError> {
-    let items = drain_iter(w_iterable)?;
-    let mut out = Vec::with_capacity(items.len());
-    for it in items {
+/// Drain an iterable of `(key, value)` pairs into a freshly-pinned, flat
+/// `[k0, v0, k1, v1, …]` Python `list` (see [`drain_iter_pinned`]), returning
+/// its shadow-stack slot.
+fn drain_iter_pairs_pinned(w_iterable: PyObjectRef) -> Result<usize, PyError> {
+    let slot = pin_items(Vec::new());
+    let w_iter = crate::baseobjspace::iter(w_iterable)?;
+    pyre_object::gc_roots::pin_root(w_iter);
+    let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    loop {
+        let it = match crate::baseobjspace::next(pyre_object::gc_roots::shadow_stack_get(iter_slot))
+        {
+            Ok(it) => it,
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        };
         if !unsafe { pyre_object::is_tuple(it) }
             || unsafe { pyre_object::tupleobject::w_tuple_len(it) } != 2
         {
             return Err(pickling_error("dictitems must yield (key, value) pairs"));
         }
+        // `w_list_append` does not collect, so `it`/`k`/`v` stay valid between
+        // the reads and the two appends.
         let k = unsafe { pyre_object::tupleobject::w_tuple_getitem(it, 0).unwrap() };
         let v = unsafe { pyre_object::tupleobject::w_tuple_getitem(it, 1).unwrap() };
-        out.push((k, v));
+        unsafe {
+            pyre_object::listobject::w_list_append(
+                pyre_object::gc_roots::shadow_stack_get(slot),
+                k,
+            );
+            pyre_object::listobject::w_list_append(
+                pyre_object::gc_roots::shadow_stack_get(slot),
+                v,
+            );
+        }
     }
-    Ok(out)
+    Ok(slot)
 }

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -19,6 +19,8 @@ pub struct W_Pickler {
     proto: i64,
     bin: bool,
     framing: bool,
+    /// `buffer_callback` for proto-5 out-of-band buffers, or `None`.
+    buffer_callback: PyObjectRef,
 }
 
 /// Per-`dump` pickling context. The identity memo maps an already-saved
@@ -33,6 +35,8 @@ struct PickleCtx {
     /// `persistent_id` callable resolved off the pickler (subclass override
     /// or set attribute), or `PY_NULL` when not defined.
     pers_func: PyObjectRef,
+    /// `buffer_callback` for proto-5 out-of-band buffers, or `None`/`PY_NULL`.
+    buffer_callback: PyObjectRef,
 }
 
 impl PickleCtx {
@@ -136,23 +140,34 @@ impl W_Pickler {
             proto: 0,
             bin: false,
             framing: false,
+            buffer_callback: pyre_object::w_none(),
         })
     }
 
     fn __init__(
         &mut self,
-        w_file: PyObjectRef,
-        #[default(pyre_object::w_none())] w_protocol: PyObjectRef,
+        file: PyObjectRef,
+        #[default(pyre_object::w_none())] protocol: PyObjectRef,
+        #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+        #[default(pyre_object::w_none())] buffer_callback: PyObjectRef,
     ) -> Result<(), PyError> {
-        let proto = normalize_protocol(w_protocol)?;
+        // `fix_imports` selects the `_compat_pickle` name mapping at the save
+        // sites by protocol already; the flag is accepted for signature
+        // compatibility but the proto-< 3 path is always applied.
+        let _ = fix_imports;
+        let proto = normalize_protocol(protocol)?;
         // `file must have a 'write' attribute` (interp_pickle.py:557).
-        if crate::baseobjspace::findattr(w_file, "write").is_none() {
+        if crate::baseobjspace::findattr(file, "write").is_none() {
             return Err(PyError::type_error("file must have a 'write' attribute"));
         }
-        self.w_file = w_file;
+        if !unsafe { pyre_object::is_none(buffer_callback) } && proto < 5 {
+            return Err(PyError::value_error("buffer_callback needs protocol >= 5"));
+        }
+        self.w_file = file;
         self.proto = proto;
         self.bin = proto >= 1;
         self.framing = proto >= 4;
+        self.buffer_callback = buffer_callback;
         Ok(())
     }
 
@@ -162,6 +177,7 @@ impl W_Pickler {
         let bin = self.bin;
         let framing = self.framing;
         let w_file = self.w_file;
+        let buffer_callback = self.buffer_callback;
         // A `persistent_id` defined on a subclass (or set as an attribute)
         // overrides the default no-op; the base class has none.
         let self_ptr = self as *mut W_Pickler as PyObjectRef;
@@ -173,12 +189,24 @@ impl W_Pickler {
         pyre_object::gc_roots::pin_root(w_file);
         let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
-        let w_bytes = pickle_core(w_obj, proto, bin, framing, pers_func)?;
+        let w_bytes = pickle_core(w_obj, proto, bin, framing, pers_func, buffer_callback)?;
         // `w_file` may have moved while building the pickle; re-read the pin.
         let w_file = pyre_object::gc_roots::shadow_stack_get(file_slot);
         call_meth(w_file, "write", &[w_bytes])?;
         Ok(())
     }
+}
+
+/// `buffer_callback needs protocol >= 5` — reject a non-None callback under
+/// an earlier protocol (interp_pickle.py:1818).
+pub(crate) fn check_buffer_callback(
+    buffer_callback: PyObjectRef,
+    proto: i64,
+) -> Result<(), PyError> {
+    if !unsafe { pyre_object::is_none(buffer_callback) } && proto < 5 {
+        return Err(PyError::value_error("buffer_callback needs protocol >= 5"));
+    }
+    Ok(())
 }
 
 /// `interp_pickle.py W_Pickler.__init__` protocol resolution: `None` →
@@ -209,11 +237,15 @@ pub(crate) fn pickle_core(
     bin: bool,
     framing: bool,
     pers_func: PyObjectRef,
+    buffer_callback: PyObjectRef,
 ) -> Result<PyObjectRef, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(w_obj);
     if !pers_func.is_null() {
         pyre_object::gc_roots::pin_root(pers_func);
+    }
+    if !buffer_callback.is_null() && !unsafe { pyre_object::is_none(buffer_callback) } {
+        pyre_object::gc_roots::pin_root(buffer_callback);
     }
 
     let mut ctx = PickleCtx {
@@ -222,6 +254,7 @@ pub(crate) fn pickle_core(
         memo: HashMap::new(),
         memo_size: 0,
         pers_func,
+        buffer_callback,
     };
     let mut fr = Framer::new();
     if proto >= 2 {
@@ -335,17 +368,9 @@ fn save_object(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Res
     if unsafe { pyre_object::is_bytearray(w_obj) } {
         return save_bytearray(ctx, buf, w_obj);
     }
-
-    // `save_picklebuffer` (protocol 5 out-of-band buffers) is deferred. The
-    // CPython surface is `Pickler(file, protocol, *, buffer_callback=None)`
-    // and `Unpickler(file, *, buffers=None)` with keyword-only arguments, but
-    // `#[pyre_class]` `__init__` does not bind keyword arguments (module-level
-    // functions do; constructors do not), so `buffer_callback` / `buffers`
-    // cannot be supplied without diverging from CPython's keyword-only
-    // signature. The NEXT_BUFFER / READONLY_BUFFER opcodes are reserved in the
-    // `op` module for when that ABI gap is closed. PickleBuffer in-band is the
-    // CPython default (buffer_callback=None) but reduces to plain bytes /
-    // bytearray, so nothing is lost by routing those through the normal path.
+    if crate::module::__pypy__::W_PickleBuffer::from_obj(w_obj).is_some() {
+        return save_picklebuffer(ctx, buf, w_obj);
+    }
 
     // Classes and functions are saved by reference.
     if unsafe { pyre_object::typeobject::is_type(w_obj) }
@@ -754,6 +779,95 @@ fn save_bytearray(
     }
     memoize(ctx, buf, w_obj);
     Ok(())
+}
+
+/// `interp_pickle.py save_picklebuffer` — serialize a `PickleBuffer`. With
+/// no `buffer_callback`, or a callback returning a true value, the contents
+/// are written in-band (BINBYTES for a read-only buffer, BYTEARRAY8 for a
+/// mutable one). A callback returning a false value writes the data
+/// out-of-band: NEXT_BUFFER, plus READONLY_BUFFER for a read-only buffer.
+fn save_picklebuffer(
+    ctx: &mut PickleCtx,
+    buf: &mut Framer,
+    w_obj: PyObjectRef,
+) -> Result<(), PyError> {
+    if ctx.proto < 5 {
+        return Err(pickling_error(
+            "PickleBuffer can only pickled with protocol >= 5",
+        ));
+    }
+    // Read the wrapped object out of the buffer, then drop the borrow before
+    // any allocation (the callback below) can relocate the wrapper.
+    let wrapped = {
+        let pb = crate::module::__pypy__::W_PickleBuffer::from_obj(w_obj)
+            .ok_or_else(|| pickling_error("save_picklebuffer: not a PickleBuffer"))?;
+        pb.wrapped()
+    };
+    if unsafe { pyre_object::is_none(wrapped) } {
+        return Err(pickling_error(
+            "PickleBuffer can not be pickled after release",
+        ));
+    }
+    let (data, readonly) = crate::module::__pypy__::pickle_buffer::buffer_view(wrapped)?;
+    let mut in_band = true;
+    if !unsafe { pyre_object::is_none(ctx.buffer_callback) } {
+        let w_ret = call_fn(ctx.buffer_callback, &[w_obj])?;
+        in_band = crate::baseobjspace::is_true(w_ret);
+    }
+    if in_band {
+        // In-band buffers memoize the wrapper (`_save_bytes_data` /
+        // `_save_bytearray_data`), so a repeated reference becomes a GET.
+        if readonly {
+            save_raw_bytes(ctx, buf, &data);
+        } else {
+            save_raw_bytearray(buf, &data);
+        }
+        memoize(ctx, buf, w_obj);
+    } else {
+        buf.push(op::NEXT_BUFFER);
+        if readonly {
+            buf.push(op::READONLY_BUFFER);
+        }
+    }
+    Ok(())
+}
+
+/// `interp_pickle.py save_raw_bytes` — emit raw bytes with the size-appropriate
+/// BINBYTES opcode (no memoization).
+fn save_raw_bytes(ctx: &PickleCtx, buf: &mut Framer, data: &[u8]) {
+    let n = data.len();
+    if n <= 0xff {
+        buf.push(op::SHORT_BINBYTES);
+        buf.push(n as u8);
+        buf.extend_from_slice(data);
+    } else if n > 0xffff_ffff && ctx.proto >= 4 {
+        let mut header = vec![op::BINBYTES8];
+        header.extend_from_slice(&(n as u64).to_le_bytes());
+        buf.write_large_bytes(&header, data);
+    } else if n >= FRAME_SIZE_TARGET {
+        let mut header = vec![op::BINBYTES];
+        header.extend_from_slice(&(n as u32).to_le_bytes());
+        buf.write_large_bytes(&header, data);
+    } else {
+        buf.push(op::BINBYTES);
+        buf.extend_from_slice(&(n as u32).to_le_bytes());
+        buf.extend_from_slice(data);
+    }
+}
+
+/// `interp_pickle.py save_raw_bytearray` — emit raw bytes with BYTEARRAY8
+/// (no memoization).
+fn save_raw_bytearray(buf: &mut Framer, data: &[u8]) {
+    let n = data.len();
+    if n >= FRAME_SIZE_TARGET {
+        let mut header = vec![op::BYTEARRAY8];
+        header.extend_from_slice(&(n as u64).to_le_bytes());
+        buf.write_large_bytes(&header, data);
+    } else {
+        buf.push(op::BYTEARRAY8);
+        buf.extend_from_slice(&(n as u64).to_le_bytes());
+        buf.extend_from_slice(data);
+    }
 }
 
 /// `interp_pickle.py _batch_appends` (generic bin path). Single item →

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -144,18 +144,7 @@ impl W_Pickler {
         w_file: PyObjectRef,
         #[default(pyre_object::w_none())] w_protocol: PyObjectRef,
     ) -> Result<(), PyError> {
-        let proto = if unsafe { pyre_object::is_none(w_protocol) } {
-            DEFAULT_PROTOCOL
-        } else {
-            let p = crate::baseobjspace::int_w(w_protocol)?;
-            if p < 0 {
-                HIGHEST_PROTOCOL
-            } else if p > HIGHEST_PROTOCOL {
-                return Err(PyError::value_error("pickle protocol must be <= 5"));
-            } else {
-                p
-            }
-        };
+        let proto = normalize_protocol(w_protocol)?;
         // `file must have a 'write' attribute` (interp_pickle.py:557).
         if crate::baseobjspace::findattr(w_file, "write").is_none() {
             return Err(PyError::type_error("file must have a 'write' attribute"));
@@ -183,39 +172,70 @@ impl W_Pickler {
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(w_file);
         let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(w_obj);
-        if !pers_func.is_null() {
-            pyre_object::gc_roots::pin_root(pers_func);
-        }
 
-        let mut ctx = PickleCtx {
-            proto,
-            bin,
-            memo: HashMap::new(),
-            memo_size: 0,
-            pers_func,
-        };
-        // PROTO is written before framing begins (it stays outside the
-        // frame); STOP is written while framing is active (inside the last
-        // frame). `end_framing` flushes the final frame.
-        let mut fr = Framer::new();
-        if proto >= 2 {
-            fr.push(op::PROTO);
-            fr.push(proto as u8);
-        }
-        if framing {
-            fr.start_framing();
-        }
-        save(&mut ctx, &mut fr, w_obj)?;
-        fr.push(op::STOP);
-        fr.end_framing();
-
-        let w_bytes = pyre_object::w_bytes_from_bytes(&fr.output);
-        // `w_file` may have moved during the build; re-read from the pin.
+        let w_bytes = pickle_core(w_obj, proto, bin, framing, pers_func)?;
+        // `w_file` may have moved while building the pickle; re-read the pin.
         let w_file = pyre_object::gc_roots::shadow_stack_get(file_slot);
         call_meth(w_file, "write", &[w_bytes])?;
         Ok(())
     }
+}
+
+/// `interp_pickle.py W_Pickler.__init__` protocol resolution: `None` →
+/// `DEFAULT_PROTOCOL`, a negative value → `HIGHEST_PROTOCOL`, and anything
+/// above `HIGHEST_PROTOCOL` is rejected.
+pub(crate) fn normalize_protocol(w_protocol: PyObjectRef) -> Result<i64, PyError> {
+    if unsafe { pyre_object::is_none(w_protocol) } {
+        return Ok(DEFAULT_PROTOCOL);
+    }
+    let p = crate::baseobjspace::int_w(w_protocol)?;
+    if p < 0 {
+        Ok(HIGHEST_PROTOCOL)
+    } else if p > HIGHEST_PROTOCOL {
+        Err(PyError::value_error("pickle protocol must be <= 5"))
+    } else {
+        Ok(p)
+    }
+}
+
+/// Build the full pickle byte string for `w_obj` and return it as a `bytes`.
+/// Shared by `W_Pickler.dump` (which then writes it to the file) and the
+/// module-level `dump` / `dumps`. `pers_func` is the `persistent_id` callable
+/// or `PY_NULL`. PROTO is written before framing begins (outside the frame);
+/// STOP is written while framing is active (inside the last frame).
+pub(crate) fn pickle_core(
+    w_obj: PyObjectRef,
+    proto: i64,
+    bin: bool,
+    framing: bool,
+    pers_func: PyObjectRef,
+) -> Result<PyObjectRef, PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_obj);
+    if !pers_func.is_null() {
+        pyre_object::gc_roots::pin_root(pers_func);
+    }
+
+    let mut ctx = PickleCtx {
+        proto,
+        bin,
+        memo: HashMap::new(),
+        memo_size: 0,
+        pers_func,
+    };
+    let mut fr = Framer::new();
+    if proto >= 2 {
+        fr.push(op::PROTO);
+        fr.push(proto as u8);
+    }
+    if framing {
+        fr.start_framing();
+    }
+    save(&mut ctx, &mut fr, w_obj)?;
+    fr.push(op::STOP);
+    fr.end_framing();
+
+    Ok(pyre_object::w_bytes_from_bytes(&fr.output))
 }
 
 /// `interp_pickle.py W_Pickler.save` with the persistent-id hook: every

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -6,7 +6,7 @@ use crate::PyError;
 
 use super::{
     HIGHEST_PROTOCOL, call_fn, call_meth, decode_long, getattribute_dotted, import_module, op,
-    read_int_le, str_from_utf8, unpickling_error,
+    parse_int_text, read_int_le, str_from_utf8, unpickling_error,
 };
 
 #[crate::pyre_class("_pickle.Unpickler")]
@@ -264,6 +264,42 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let f = f64::from_be_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]]);
             push(slot, pyre_object::w_float_new(f));
         }
+        x if x == op::INT => {
+            let s = read_line(slot)?;
+            let w = match s.as_str() {
+                "00" => pyre_object::w_bool_from(false),
+                "01" => pyre_object::w_bool_from(true),
+                _ => parse_int_text(&s)?,
+            };
+            push(slot, w);
+        }
+        x if x == op::LONG => {
+            let mut s = read_line(slot)?;
+            // strip the Python 2 'L' suffix, if present.
+            if s.ends_with('L') {
+                s.pop();
+            }
+            push(slot, parse_int_text(&s)?);
+        }
+        x if x == op::FLOAT => {
+            let s = read_line(slot)?;
+            let f = s
+                .trim()
+                .parse::<f64>()
+                .map_err(|_| PyError::value_error("could not convert string to float"))?;
+            push(slot, pyre_object::w_float_new(f));
+        }
+        x if x == op::UNICODE => {
+            // raw-unicode-escape over the line's raw bytes.
+            let data = read_line_bytes(slot)?;
+            let w_bytes = pyre_object::w_bytes_from_bytes(&data);
+            let w_uni = call_meth(
+                w_bytes,
+                "decode",
+                &[pyre_object::w_str_new("raw-unicode-escape")],
+            )?;
+            push(slot, w_uni);
+        }
         x if x == op::SHORT_BINUNICODE => {
             let n = read(slot, 1)?[0] as usize;
             let d = read(slot, n)?;
@@ -390,7 +426,10 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let nb = read(slot, 8)?;
             let n = read_int_le(&nb) as usize;
             let d = read(slot, n)?;
-            push(slot, pyre_object::bytearrayobject::w_bytearray_from_bytes(&d));
+            push(
+                slot,
+                pyre_object::bytearrayobject::w_bytearray_from_bytes(&d),
+            );
         }
         // ── global / reduce / build ───────────────────────────────────
         x if x == op::GLOBAL => {
@@ -402,7 +441,8 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
         x if x == op::STACK_GLOBAL => {
             let w_name = pop(slot)?;
             let w_module = pop(slot)?;
-            if !unsafe { pyre_object::is_str(w_name) } || !unsafe { pyre_object::is_str(w_module) } {
+            if !unsafe { pyre_object::is_str(w_name) } || !unsafe { pyre_object::is_str(w_module) }
+            {
                 return Err(unpickling_error("STACK_GLOBAL requires str"));
             }
             let name = unsafe { pyre_object::strobject::w_str_get_value(w_name) }.to_string();
@@ -429,9 +469,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let w_cls = pop(slot)?;
             let kw_len = unsafe { pyre_object::dictmultiobject::w_dict_items(w_kwargs) }.len();
             if kw_len > 0 {
-                return Err(PyError::not_implemented(
-                    "_pickle: NEWOBJ_EX with kwargs",
-                ));
+                return Err(PyError::not_implemented("_pickle: NEWOBJ_EX with kwargs"));
             }
             let w_obj = new_instance(w_cls, &tuple_items(w_args))?;
             push(slot, w_obj);
@@ -479,6 +517,45 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let d = read(slot, 4)?;
             let i = u32::from_le_bytes([d[0], d[1], d[2], d[3]]) as i64;
             let v = memo_get(slot, i)?;
+            push(slot, v);
+        }
+        x if x == op::PERSID => {
+            let pid = read_line_bytes(slot)?;
+            if !pid.is_ascii() {
+                return Err(unpickling_error(
+                    "persistent IDs in protocol 0 must be ASCII strings",
+                ));
+            }
+            let w_pid = str_from_utf8(&pid)?;
+            let v = persistent_load(slot, w_pid)?;
+            push(slot, v);
+        }
+        x if x == op::BINPERSID => {
+            let w_pid = pop(slot)?;
+            let v = persistent_load(slot, w_pid)?;
+            push(slot, v);
+        }
+        x if x == op::INST => {
+            let module = read_line(slot)?;
+            let name = read_line(slot)?;
+            let w_cls = find_class(&module, &name, cur(slot).proto)?;
+            let w_args = pop_mark(slot)?;
+            let v = instantiate(w_cls, w_args)?;
+            push(slot, v);
+        }
+        x if x == op::OBJ => {
+            let args = pop_mark(slot)?;
+            let n = unsafe { pyre_object::listobject::w_list_len(args) };
+            if n == 0 {
+                return Err(unpickling_error("OBJ opcode with empty stack"));
+            }
+            let w_cls = unsafe { pyre_object::listobject::w_list_getitem(args, 0).unwrap() };
+            let rest: Vec<PyObjectRef> = (1..n)
+                .map(|i| unsafe {
+                    pyre_object::listobject::w_list_getitem(args, i as i64).unwrap()
+                })
+                .collect();
+            let v = instantiate(w_cls, pyre_object::listobject::w_list_new(rest))?;
             push(slot, v);
         }
         _ => {
@@ -532,7 +609,7 @@ fn dict_update_from_pairs(w_dict: PyObjectRef, items: PyObjectRef) -> Result<(),
 }
 
 /// Read a newline-terminated line (without the trailing newline).
-fn read_line(slot: usize) -> Result<String, PyError> {
+fn read_line_bytes(slot: usize) -> Result<Vec<u8>, PyError> {
     let mut bytes: Vec<u8> = Vec::new();
     loop {
         let b = read1(slot)?;
@@ -541,6 +618,11 @@ fn read_line(slot: usize) -> Result<String, PyError> {
         }
         bytes.push(b);
     }
+    Ok(bytes)
+}
+
+fn read_line(slot: usize) -> Result<String, PyError> {
+    let bytes = read_line_bytes(slot)?;
     String::from_utf8(bytes).map_err(|_| unpickling_error("invalid utf-8 in pickle line"))
 }
 
@@ -559,7 +641,16 @@ fn read_line_int(slot: usize) -> Result<i64, PyError> {
 /// builtins installed on the underlying storage. Other non-dotted names
 /// resolve through the module's `__dict__` (dict subscript), and dotted
 /// (protocol >= 4 nested) names fall back to the attribute walk.
-fn find_class(module_name: &str, name: &str, _proto: i64) -> Result<PyObjectRef, PyError> {
+fn find_class(module_name: &str, name: &str, proto: i64) -> Result<PyObjectRef, PyError> {
+    // protocol < 3 applies the py2 → py3 `_compat_pickle` forward map
+    // (fix_imports) before resolution.
+    let (module_name, name) = if proto < 3 {
+        crate::module::_pickle::compat_map(module_name, name, false)
+    } else {
+        (module_name.to_string(), name.to_string())
+    };
+    let module_name = module_name.as_str();
+    let name = name.as_str();
     if module_name == "builtins" && !name.contains('.') {
         if let Some(obj) = crate::module::_pickle::lookup_builtin(name) {
             return Ok(obj);
@@ -571,6 +662,32 @@ fn find_class(module_name: &str, name: &str, _proto: i64) -> Result<PyObjectRef,
     }
     let w_dict = crate::baseobjspace::getattr_str(module, "__dict__")?;
     crate::baseobjspace::getitem(w_dict, pyre_object::w_str_new(name))
+}
+
+/// Resolve and invoke `self.persistent_load(pid)` (PERSID / BINPERSID).
+fn persistent_load(slot: usize, w_pid: PyObjectRef) -> Result<PyObjectRef, PyError> {
+    let self_obj = pyre_object::gc_roots::shadow_stack_get(slot);
+    match crate::baseobjspace::findattr(self_obj, "persistent_load") {
+        Some(f) if !unsafe { pyre_object::is_none(f) } => call_fn(f, &[w_pid]),
+        _ => Err(unpickling_error("unsupported persistent id encountered")),
+    }
+}
+
+/// `_instantiate` — build an old-style INST / OBJ instance. With args, or a
+/// non-type class, or a `__getinitargs__`, call the class; otherwise build
+/// via `__new__` without invoking `__init__`.
+fn instantiate(w_cls: PyObjectRef, w_args: PyObjectRef) -> Result<PyObjectRef, PyError> {
+    let n = unsafe { pyre_object::listobject::w_list_len(w_args) };
+    let has_getinitargs = crate::baseobjspace::findattr(w_cls, "__getinitargs__").is_some();
+    let is_type = unsafe { pyre_object::typeobject::is_type(w_cls) };
+    if n > 0 || !is_type || has_getinitargs {
+        let args: Vec<PyObjectRef> = (0..n)
+            .map(|i| unsafe { pyre_object::listobject::w_list_getitem(w_args, i as i64).unwrap() })
+            .collect();
+        call_fn(w_cls, &args)
+    } else {
+        new_instance(w_cls, &[])
+    }
 }
 
 /// `cls.__new__(cls, *args)`.

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -25,6 +25,8 @@ pub struct W_Unpickler {
     w_frame: PyObjectRef,
     frame_index: i64,
     proto: i64,
+    /// Out-of-band `buffers` iterator (proto 5), or None.
+    w_buffers: PyObjectRef,
 }
 
 #[crate::pyre_methods(doc = "Unpickler(file) -> unpickler reading from file.")]
@@ -45,12 +47,24 @@ impl W_Unpickler {
             w_frame: pyre_object::w_none(),
             frame_index: 0,
             proto: 0,
+            w_buffers: pyre_object::w_none(),
         })
     }
 
-    fn __init__(&mut self, w_file: PyObjectRef) -> Result<(), PyError> {
-        self.w_file_read = crate::baseobjspace::getattr_str(w_file, "read")?;
-        self.w_file_readline = crate::baseobjspace::getattr_str(w_file, "readline")?;
+    fn __init__(
+        &mut self,
+        file: PyObjectRef,
+        #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+        #[default(pyre_object::w_none())] encoding: PyObjectRef,
+        #[default(pyre_object::w_none())] errors: PyObjectRef,
+        #[default(pyre_object::w_none())] buffers: PyObjectRef,
+    ) -> Result<(), PyError> {
+        // `fix_imports` / `encoding` / `errors` govern the legacy py2 byte
+        // string decode path; pyre stores unicode natively, so they are
+        // accepted for signature compatibility.
+        let _ = (fix_imports, encoding, errors);
+        self.w_file_read = crate::baseobjspace::getattr_str(file, "read")?;
+        self.w_file_readline = crate::baseobjspace::getattr_str(file, "readline")?;
         self.w_stack = pyre_object::w_none();
         self.w_metastack = pyre_object::w_none();
         self.w_memo = pyre_object::w_none();
@@ -58,6 +72,12 @@ impl W_Unpickler {
         self.w_frame = pyre_object::w_none();
         self.frame_index = 0;
         self.proto = 0;
+        // A non-None `buffers` is consumed as an iterator by NEXT_BUFFER.
+        self.w_buffers = if unsafe { pyre_object::is_none(buffers) } {
+            pyre_object::w_none()
+        } else {
+            crate::baseobjspace::iter(buffers)?
+        };
         Ok(())
     }
 
@@ -135,6 +155,55 @@ fn pop_mark(slot: usize) -> Result<PyObjectRef, PyError> {
         .ok_or_else(|| unpickling_error("no items on stack"))?;
     cur(slot).w_stack = prev;
     Ok(items)
+}
+
+// ── out-of-band buffers ──────────────────────────────────────────────
+
+/// `load_next_buffer` (NEXT_BUFFER) — push the next buffer from the
+/// `buffers` iterator given at construction.
+fn load_next_buffer(slot: usize) -> Result<(), PyError> {
+    let w_buffers = cur(slot).w_buffers;
+    if unsafe { pyre_object::is_none(w_buffers) } {
+        return Err(unpickling_error(
+            "pickle stream refers to out-of-band data but no *buffers* argument was given",
+        ));
+    }
+    let w_buf = match crate::baseobjspace::next(w_buffers) {
+        Ok(b) => b,
+        Err(e) if e.kind == crate::PyErrorKind::StopIteration => {
+            return Err(unpickling_error("not enough out-of-band buffers"));
+        }
+        Err(e) => return Err(e),
+    };
+    push(slot, w_buf);
+    Ok(())
+}
+
+/// `load_readonly_buffer` (READONLY_BUFFER) — replace the top buffer with a
+/// read-only memoryview onto it.
+fn load_readonly_buffer(slot: usize) -> Result<(), PyError> {
+    let w_buf = top(slot, "READONLY_BUFFER")?;
+    let w_mv = call_fn(memoryview_type()?, &[w_buf])?;
+    let w_readonly = call_meth(w_mv, "toreadonly", &[])?;
+    // Replace the top of the stack (`stack[-1] = w_readonly`).
+    pop(slot)?;
+    push(slot, w_readonly);
+    Ok(())
+}
+
+/// The `memoryview` builtin type via the live execution context.
+fn memoryview_type() -> Result<PyObjectRef, PyError> {
+    let frame = crate::eval::CURRENT_FRAME.with(|f| f.get());
+    let ec = if frame.is_null() {
+        std::ptr::null()
+    } else {
+        unsafe { (*frame).execution_context }
+    };
+    if ec.is_null() {
+        return Err(unpickling_error("memoryview type unavailable"));
+    }
+    unsafe { (*ec).lookup_builtin("memoryview") }
+        .ok_or_else(|| unpickling_error("memoryview type unavailable"))
 }
 
 // ── memo helpers ─────────────────────────────────────────────────────
@@ -431,6 +500,9 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
                 pyre_object::bytearrayobject::w_bytearray_from_bytes(&d),
             );
         }
+        // ── proto-5 out-of-band buffers ───────────────────────────────
+        x if x == op::NEXT_BUFFER => load_next_buffer(slot)?,
+        x if x == op::READONLY_BUFFER => load_readonly_buffer(slot)?,
         // ── global / reduce / build ───────────────────────────────────
         x if x == op::GLOBAL => {
             let module = read_line(slot)?;

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -5,8 +5,8 @@ use pyre_object::PyObjectRef;
 use crate::PyError;
 
 use super::{
-    HIGHEST_PROTOCOL, call_fn, call_meth, decode_long, op, read_int_le, str_from_utf8,
-    unpickling_error,
+    HIGHEST_PROTOCOL, call_fn, call_meth, decode_long, getattribute_dotted, import_module, op,
+    read_int_le, str_from_utf8, unpickling_error,
 };
 
 #[crate::pyre_class("_pickle.Unpickler")]
@@ -392,6 +392,55 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let d = read(slot, n)?;
             push(slot, pyre_object::bytearrayobject::w_bytearray_from_bytes(&d));
         }
+        // ── global / reduce / build ───────────────────────────────────
+        x if x == op::GLOBAL => {
+            let module = read_line(slot)?;
+            let name = read_line(slot)?;
+            let proto = cur(slot).proto;
+            push(slot, find_class(&module, &name, proto)?);
+        }
+        x if x == op::STACK_GLOBAL => {
+            let w_name = pop(slot)?;
+            let w_module = pop(slot)?;
+            if !unsafe { pyre_object::is_str(w_name) } || !unsafe { pyre_object::is_str(w_module) } {
+                return Err(unpickling_error("STACK_GLOBAL requires str"));
+            }
+            let name = unsafe { pyre_object::strobject::w_str_get_value(w_name) }.to_string();
+            let module = unsafe { pyre_object::strobject::w_str_get_value(w_module) }.to_string();
+            let proto = cur(slot).proto;
+            push(slot, find_class(&module, &name, proto)?);
+        }
+        x if x == op::REDUCE => {
+            let w_args = pop(slot)?;
+            let w_func = pop(slot)?;
+            let args = tuple_items(w_args);
+            let w_obj = call_fn(w_func, &args)?;
+            push(slot, w_obj);
+        }
+        x if x == op::NEWOBJ => {
+            let w_args = pop(slot)?;
+            let w_cls = pop(slot)?;
+            let w_obj = new_instance(w_cls, &tuple_items(w_args))?;
+            push(slot, w_obj);
+        }
+        x if x == op::NEWOBJ_EX => {
+            let w_kwargs = pop(slot)?;
+            let w_args = pop(slot)?;
+            let w_cls = pop(slot)?;
+            let kw_len = unsafe { pyre_object::dictmultiobject::w_dict_items(w_kwargs) }.len();
+            if kw_len > 0 {
+                return Err(PyError::not_implemented(
+                    "_pickle: NEWOBJ_EX with kwargs",
+                ));
+            }
+            let w_obj = new_instance(w_cls, &tuple_items(w_args))?;
+            push(slot, w_obj);
+        }
+        x if x == op::BUILD => {
+            let w_state = pop(slot)?;
+            let w_inst = top(slot, "BUILD")?;
+            build_instance(w_inst, w_state)?;
+        }
         // ── memo ──────────────────────────────────────────────────────
         x if x == op::MEMOIZE => {
             let v = top(slot, "MEMOIZE")?;
@@ -482,20 +531,93 @@ fn dict_update_from_pairs(w_dict: PyObjectRef, items: PyObjectRef) -> Result<(),
     Ok(())
 }
 
-/// Read a newline-terminated decimal integer argument (GET / PUT in the
-/// text protocols).
-fn read_line_int(slot: usize) -> Result<i64, PyError> {
-    let mut digits: Vec<u8> = Vec::new();
+/// Read a newline-terminated line (without the trailing newline).
+fn read_line(slot: usize) -> Result<String, PyError> {
+    let mut bytes: Vec<u8> = Vec::new();
     loop {
         let b = read1(slot)?;
         if b == b'\n' {
             break;
         }
-        digits.push(b);
+        bytes.push(b);
     }
-    let s = std::str::from_utf8(&digits)
-        .map_err(|_| PyError::value_error("invalid int literal"))?;
+    String::from_utf8(bytes).map_err(|_| unpickling_error("invalid utf-8 in pickle line"))
+}
+
+/// Read a newline-terminated decimal integer argument (GET / PUT in the
+/// text protocols).
+fn read_line_int(slot: usize) -> Result<i64, PyError> {
+    let s = read_line(slot)?;
     s.trim()
         .parse::<i64>()
         .map_err(|_| PyError::value_error("invalid int literal"))
+}
+
+/// `find_class` — import `module_name` and resolve `name` against it.
+/// Builtin names resolve through the execution context's `lookup_builtin`
+/// (the `LOAD_GLOBAL` path); the module-object `getattr` does not see
+/// builtins installed on the underlying storage. Other non-dotted names
+/// resolve through the module's `__dict__` (dict subscript), and dotted
+/// (protocol >= 4 nested) names fall back to the attribute walk.
+fn find_class(module_name: &str, name: &str, _proto: i64) -> Result<PyObjectRef, PyError> {
+    if module_name == "builtins" && !name.contains('.') {
+        if let Some(obj) = crate::module::_pickle::lookup_builtin(name) {
+            return Ok(obj);
+        }
+    }
+    let module = import_module(module_name)?;
+    if name.contains('.') {
+        return Ok(getattribute_dotted(module, name)?.0);
+    }
+    let w_dict = crate::baseobjspace::getattr_str(module, "__dict__")?;
+    crate::baseobjspace::getitem(w_dict, pyre_object::w_str_new(name))
+}
+
+/// `cls.__new__(cls, *args)`.
+fn new_instance(w_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
+    let w_new = crate::baseobjspace::getattr_str(w_cls, "__new__")?;
+    let mut call_args = vec![w_cls];
+    call_args.extend_from_slice(args);
+    call_fn(w_new, &call_args)
+}
+
+/// `load_build` — apply pickled state to a freshly created instance.
+fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyError> {
+    // __setstate__ takes precedence.
+    if let Some(setstate) = crate::baseobjspace::findattr(w_inst, "__setstate__") {
+        if !unsafe { pyre_object::is_none(setstate) } {
+            call_fn(setstate, &[w_state])?;
+            return Ok(());
+        }
+    }
+
+    // state may be a (dict-state, slot-state) pair.
+    let (w_dict_state, w_slot_state) = if unsafe { pyre_object::is_tuple(w_state) }
+        && unsafe { pyre_object::tupleobject::w_tuple_len(w_state) } == 2
+    {
+        (
+            unsafe { pyre_object::tupleobject::w_tuple_getitem(w_state, 0).unwrap() },
+            unsafe { pyre_object::tupleobject::w_tuple_getitem(w_state, 1).unwrap() },
+        )
+    } else {
+        (w_state, pyre_object::w_none())
+    };
+
+    if !unsafe { pyre_object::is_none(w_dict_state) } {
+        let w_inst_dict = crate::baseobjspace::getattr_str(w_inst, "__dict__")?;
+        call_meth(w_inst_dict, "update", &[w_dict_state])?;
+    }
+    if !unsafe { pyre_object::is_none(w_slot_state) } {
+        for (k, v) in unsafe { pyre_object::dictmultiobject::w_dict_items(w_slot_state) } {
+            crate::baseobjspace::setattr(w_inst, k, v)?;
+        }
+    }
+    Ok(())
+}
+
+fn tuple_items(w_tuple: PyObjectRef) -> Vec<PyObjectRef> {
+    let n = unsafe { pyre_object::tupleobject::w_tuple_len(w_tuple) };
+    (0..n)
+        .map(|i| unsafe { pyre_object::tupleobject::w_tuple_getitem(w_tuple, i as i64).unwrap() })
+        .collect()
 }

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -1,0 +1,232 @@
+//! `_pickle.Unpickler` — `interp_pickle.py W_Unpickler` (atom subset).
+
+use pyre_object::PyObjectRef;
+
+use crate::PyError;
+
+use super::{HIGHEST_PROTOCOL, call_fn, decode_long, op, read_int_le, str_from_utf8, unpickling_error};
+
+#[crate::pyre_class("_pickle.Unpickler")]
+pub struct W_Unpickler {
+    w_file_read: PyObjectRef,
+    w_file_readline: PyObjectRef,
+    /// Result stack — a Python `list` (GC-managed across `read` allocs).
+    w_stack: PyObjectRef,
+    /// Active frame bytes (`bytes`) or None.
+    w_frame: PyObjectRef,
+    frame_index: i64,
+    proto: i64,
+}
+
+#[crate::pyre_methods(doc = "Unpickler(file) -> unpickler reading from file.")]
+impl W_Unpickler {
+    #[staticmethod]
+    fn __new__(_cls: PyObjectRef) -> PyObjectRef {
+        W_Unpickler::allocate(W_Unpickler {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            w_file_read: pyre_object::w_none(),
+            w_file_readline: pyre_object::w_none(),
+            w_stack: pyre_object::w_none(),
+            w_frame: pyre_object::w_none(),
+            frame_index: 0,
+            proto: 0,
+        })
+    }
+
+    fn __init__(&mut self, w_file: PyObjectRef) -> Result<(), PyError> {
+        self.w_file_read = crate::baseobjspace::getattr_str(w_file, "read")?;
+        self.w_file_readline = crate::baseobjspace::getattr_str(w_file, "readline")?;
+        self.w_stack = pyre_object::w_none();
+        self.w_frame = pyre_object::w_none();
+        self.frame_index = 0;
+        self.proto = 0;
+        Ok(())
+    }
+
+    fn load(&mut self) -> Result<PyObjectRef, PyError> {
+        // Fresh stack each load.
+        self.w_stack = pyre_object::listobject::w_list_new(Vec::new());
+        self.w_frame = pyre_object::w_none();
+        self.frame_index = 0;
+        self.proto = 0;
+
+        let self_ptr = self as *mut W_Unpickler as PyObjectRef;
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(self_ptr);
+        let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+
+        loop {
+            let opcode = read1(slot)?;
+            if opcode == op::STOP {
+                let me = cur(slot);
+                return unsafe { pyre_object::listobject::w_list_pop_end(me.w_stack) }
+                    .ok_or_else(|| unpickling_error("unexpected MARK found"));
+            }
+            dispatch(slot, opcode)?;
+        }
+    }
+}
+
+/// Re-read the (possibly relocated) unpickler from the pinned shadow slot.
+#[inline]
+fn cur(slot: usize) -> &'static mut W_Unpickler {
+    unsafe { &mut *(pyre_object::gc_roots::shadow_stack_get(slot) as *mut W_Unpickler) }
+}
+
+fn push(slot: usize, obj: PyObjectRef) {
+    let me = cur(slot);
+    unsafe { pyre_object::listobject::w_list_append(me.w_stack, obj) };
+}
+
+/// Read one opcode byte (from the active frame, else the file).
+fn read1(slot: usize) -> Result<u8, PyError> {
+    let me = cur(slot);
+    if !unsafe { pyre_object::is_none(me.w_frame) } {
+        let frame = unsafe { pyre_object::bytesobject::w_bytes_data(me.w_frame) };
+        let idx = me.frame_index as usize;
+        if idx < frame.len() {
+            me.frame_index += 1;
+            return Ok(frame[idx]);
+        }
+    }
+    let v = read(slot, 1)?;
+    Ok(v[0])
+}
+
+/// Read `n` bytes (from the active frame, else the file). Returns an owned
+/// copy so the result survives later allocations.
+fn read(slot: usize, n: usize) -> Result<Vec<u8>, PyError> {
+    let me = cur(slot);
+    if !unsafe { pyre_object::is_none(me.w_frame) } {
+        let frame = unsafe { pyre_object::bytesobject::w_bytes_data(me.w_frame) };
+        let idx = me.frame_index as usize;
+        if idx + n <= frame.len() {
+            let out = frame[idx..idx + n].to_vec();
+            me.frame_index += n as i64;
+            return Ok(out);
+        }
+        // Frame exhausted — fall through to the file.
+        me.w_frame = pyre_object::w_none();
+        me.frame_index = 0;
+    }
+    let w_n = pyre_object::w_int_new(n as i64);
+    let read_fn = cur(slot).w_file_read;
+    let w_res = call_fn(read_fn, &[w_n])?;
+    let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_res) };
+    if data.len() < n {
+        return Err(unpickling_error("pickle data was truncated"));
+    }
+    Ok(data[..n].to_vec())
+}
+
+fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
+    match opcode {
+        x if x == op::PROTO => {
+            let p = read1(slot)? as i64;
+            if !(0..=HIGHEST_PROTOCOL).contains(&p) {
+                return Err(PyError::value_error("unsupported pickle protocol"));
+            }
+            cur(slot).proto = p;
+        }
+        x if x == op::FRAME => {
+            let sz = read(slot, 8)?;
+            let frame_size = read_int_le(&sz) as usize;
+            // Load the frame body from the file.
+            let w_n = pyre_object::w_int_new(frame_size as i64);
+            let read_fn = cur(slot).w_file_read;
+            let w_res = call_fn(read_fn, &[w_n])?;
+            let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_res) };
+            if data.len() < frame_size {
+                return Err(unpickling_error("pickle data was truncated"));
+            }
+            let w_frame = pyre_object::w_bytes_from_bytes(&data[..frame_size]);
+            let me = cur(slot);
+            me.w_frame = w_frame;
+            me.frame_index = 0;
+        }
+        x if x == op::NONE => push(slot, pyre_object::w_none()),
+        x if x == op::NEWTRUE => push(slot, pyre_object::w_bool_from(true)),
+        x if x == op::NEWFALSE => push(slot, pyre_object::w_bool_from(false)),
+        x if x == op::BININT => {
+            let d = read(slot, 4)?;
+            let v = i32::from_le_bytes([d[0], d[1], d[2], d[3]]) as i64;
+            push(slot, pyre_object::w_int_new(v));
+        }
+        x if x == op::BININT1 => {
+            let d = read(slot, 1)?;
+            push(slot, pyre_object::w_int_new(d[0] as i64));
+        }
+        x if x == op::BININT2 => {
+            let d = read(slot, 2)?;
+            push(
+                slot,
+                pyre_object::w_int_new(u16::from_le_bytes([d[0], d[1]]) as i64),
+            );
+        }
+        x if x == op::LONG1 => {
+            let n = read(slot, 1)?[0] as usize;
+            let d = read(slot, n)?;
+            push(slot, decode_long(&d));
+        }
+        x if x == op::LONG4 => {
+            let nb = read(slot, 4)?;
+            let n = i32::from_le_bytes([nb[0], nb[1], nb[2], nb[3]]) as usize;
+            let d = read(slot, n)?;
+            push(slot, decode_long(&d));
+        }
+        x if x == op::BINFLOAT => {
+            let d = read(slot, 8)?;
+            let f = f64::from_be_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]]);
+            push(slot, pyre_object::w_float_new(f));
+        }
+        x if x == op::SHORT_BINUNICODE => {
+            let n = read(slot, 1)?[0] as usize;
+            let d = read(slot, n)?;
+            push(slot, str_from_utf8(&d)?);
+        }
+        x if x == op::BINUNICODE => {
+            let nb = read(slot, 4)?;
+            let n = u32::from_le_bytes([nb[0], nb[1], nb[2], nb[3]]) as usize;
+            let d = read(slot, n)?;
+            push(slot, str_from_utf8(&d)?);
+        }
+        x if x == op::BINUNICODE8 => {
+            let nb = read(slot, 8)?;
+            let n = read_int_le(&nb) as usize;
+            let d = read(slot, n)?;
+            push(slot, str_from_utf8(&d)?);
+        }
+        x if x == op::SHORT_BINBYTES => {
+            let n = read(slot, 1)?[0] as usize;
+            let d = read(slot, n)?;
+            push(slot, pyre_object::w_bytes_from_bytes(&d));
+        }
+        x if x == op::BINBYTES => {
+            let nb = read(slot, 4)?;
+            let n = u32::from_le_bytes([nb[0], nb[1], nb[2], nb[3]]) as usize;
+            let d = read(slot, n)?;
+            push(slot, pyre_object::w_bytes_from_bytes(&d));
+        }
+        x if x == op::BINBYTES8 => {
+            let nb = read(slot, 8)?;
+            let n = read_int_le(&nb) as usize;
+            let d = read(slot, n)?;
+            push(slot, pyre_object::w_bytes_from_bytes(&d));
+        }
+        // Memo put opcodes: consume the argument; dedup arrives in inc 2.
+        x if x == op::MEMOIZE => {}
+        x if x == op::BINPUT => {
+            read(slot, 1)?;
+        }
+        x if x == op::LONG_BINPUT => {
+            read(slot, 4)?;
+        }
+        _ => {
+            return Err(unpickling_error("unsupported opcode in this build"));
+        }
+    }
+    Ok(())
+}

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -25,6 +25,8 @@ pub struct W_Unpickler {
     w_frame: PyObjectRef,
     frame_index: i64,
     proto: i64,
+    /// Apply the `_compat_pickle` py2→py3 name remap at protocol < 3.
+    fix_imports: bool,
     /// Out-of-band `buffers` iterator (proto 5), or None.
     w_buffers: PyObjectRef,
 }
@@ -47,6 +49,7 @@ impl W_Unpickler {
             w_frame: pyre_object::w_none(),
             frame_index: 0,
             proto: 0,
+            fix_imports: true,
             w_buffers: pyre_object::w_none(),
         })
     }
@@ -54,20 +57,23 @@ impl W_Unpickler {
     fn __init__(
         &mut self,
         file: PyObjectRef,
-        #[default(pyre_object::w_none())] fix_imports: PyObjectRef,
+        #[default(pyre_object::boolobject::w_bool_from(true))] fix_imports: PyObjectRef,
         #[default(pyre_object::w_none())] encoding: PyObjectRef,
         #[default(pyre_object::w_none())] errors: PyObjectRef,
         #[default(pyre_object::w_none())] buffers: PyObjectRef,
     ) -> Result<(), PyError> {
-        // `fix_imports` / `encoding` / `errors` govern the legacy py2 byte
-        // string decode path; pyre stores unicode natively, so they are
-        // accepted for signature compatibility.
-        let _ = (fix_imports, encoding, errors);
+        // `encoding` / `errors` govern the legacy py2 byte string decode path;
+        // pyre stores unicode natively, so they are accepted for signature
+        // compatibility. `fix_imports` gates the proto-< 3 py2→py3 name remap.
+        let _ = (encoding, errors);
+        self.fix_imports = crate::baseobjspace::is_true(fix_imports);
         self.w_file_read = crate::baseobjspace::getattr_str(file, "read")?;
         self.w_file_readline = crate::baseobjspace::getattr_str(file, "readline")?;
         self.w_stack = pyre_object::w_none();
         self.w_metastack = pyre_object::w_none();
-        self.w_memo = pyre_object::w_none();
+        // The memo persists across `load` calls (a multi-object stream may
+        // back-reference an object memoized by an earlier load).
+        self.w_memo = pyre_object::dictmultiobject::w_dict_new();
         self.memo_index = 0;
         self.w_frame = pyre_object::w_none();
         self.frame_index = 0;
@@ -82,11 +88,15 @@ impl W_Unpickler {
     }
 
     fn load(&mut self) -> Result<PyObjectRef, PyError> {
-        // Fresh stack / metastack / memo each load.
+        // Fresh stack each load; the memo persists across `load` calls so a
+        // later object can back-reference one memoized by an earlier load
+        // (lazily created when the unpickler was built only via `__new__`).
         self.w_stack = pyre_object::listobject::w_list_new(Vec::new());
         self.w_metastack = pyre_object::listobject::w_list_new(Vec::new());
-        self.w_memo = pyre_object::dictmultiobject::w_dict_new();
-        self.memo_index = 0;
+        if unsafe { pyre_object::is_none(self.w_memo) } {
+            self.w_memo = pyre_object::dictmultiobject::w_dict_new();
+            self.memo_index = 0;
+        }
         self.w_frame = pyre_object::w_none();
         self.frame_index = 0;
         self.proto = 0;
@@ -508,7 +518,8 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let module = read_line(slot)?;
             let name = read_line(slot)?;
             let proto = cur(slot).proto;
-            push(slot, find_class(&module, &name, proto)?);
+            let fix_imports = cur(slot).fix_imports;
+            push(slot, find_class(&module, &name, proto, fix_imports)?);
         }
         x if x == op::STACK_GLOBAL => {
             let w_name = pop(slot)?;
@@ -520,7 +531,8 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let name = unsafe { pyre_object::strobject::w_str_get_value(w_name) }.to_string();
             let module = unsafe { pyre_object::strobject::w_str_get_value(w_module) }.to_string();
             let proto = cur(slot).proto;
-            push(slot, find_class(&module, &name, proto)?);
+            let fix_imports = cur(slot).fix_imports;
+            push(slot, find_class(&module, &name, proto, fix_imports)?);
         }
         x if x == op::REDUCE => {
             let w_args = pop(slot)?;
@@ -612,7 +624,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
         x if x == op::INST => {
             let module = read_line(slot)?;
             let name = read_line(slot)?;
-            let w_cls = find_class(&module, &name, cur(slot).proto)?;
+            let w_cls = find_class(&module, &name, cur(slot).proto, cur(slot).fix_imports)?;
             let w_args = pop_mark(slot)?;
             let v = instantiate(w_cls, w_args)?;
             push(slot, v);
@@ -715,10 +727,15 @@ fn read_line_int(slot: usize) -> Result<i64, PyError> {
 /// builtins installed on the underlying storage. Other non-dotted names
 /// resolve through the module's `__dict__` (dict subscript), and dotted
 /// (protocol >= 4 nested) names fall back to the attribute walk.
-fn find_class(module_name: &str, name: &str, proto: i64) -> Result<PyObjectRef, PyError> {
-    // protocol < 3 applies the py2 → py3 `_compat_pickle` forward map
-    // (fix_imports) before resolution.
-    let (module_name, name) = if proto < 3 {
+fn find_class(
+    module_name: &str,
+    name: &str,
+    proto: i64,
+    fix_imports: bool,
+) -> Result<PyObjectRef, PyError> {
+    // protocol < 3 with `fix_imports` applies the py2 → py3 `_compat_pickle`
+    // forward map before resolution; otherwise the name is resolved literally.
+    let (module_name, name) = if proto < 3 && fix_imports {
         crate::module::_pickle::compat_map(module_name, name, false)
     } else {
         (module_name.to_string(), name.to_string())

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -369,6 +369,29 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let w_dict = top(slot, "SETITEMS")?;
             dict_update_from_pairs(w_dict, items)?;
         }
+        // ── set / frozenset ───────────────────────────────────────────
+        x if x == op::EMPTY_SET => push(slot, pyre_object::setobject::w_set_new()),
+        x if x == op::FROZENSET => {
+            let items = pop_mark(slot)?;
+            push(slot, list_to_frozenset(items));
+        }
+        x if x == op::ADDITEMS => {
+            let items = pop_mark(slot)?;
+            let w_set = top(slot, "ADDITEMS")?;
+            let n = unsafe { pyre_object::listobject::w_list_len(items) };
+            for i in 0..n {
+                let item =
+                    unsafe { pyre_object::listobject::w_list_getitem(items, i as i64).unwrap() };
+                unsafe { pyre_object::setobject::w_set_add(w_set, item) };
+            }
+        }
+        // ── bytearray ─────────────────────────────────────────────────
+        x if x == op::BYTEARRAY8 => {
+            let nb = read(slot, 8)?;
+            let n = read_int_le(&nb) as usize;
+            let d = read(slot, n)?;
+            push(slot, pyre_object::bytearrayobject::w_bytearray_from_bytes(&d));
+        }
         // ── memo ──────────────────────────────────────────────────────
         x if x == op::MEMOIZE => {
             let v = top(slot, "MEMOIZE")?;
@@ -423,6 +446,15 @@ fn list_to_tuple(items: PyObjectRef) -> PyObjectRef {
         .map(|i| unsafe { pyre_object::listobject::w_list_getitem(items, i as i64).unwrap() })
         .collect();
     pyre_object::tupleobject::w_tuple_new(v)
+}
+
+/// Build a frozenset from the items of a (popped) stack list.
+fn list_to_frozenset(items: PyObjectRef) -> PyObjectRef {
+    let n = unsafe { pyre_object::listobject::w_list_len(items) };
+    let v: Vec<PyObjectRef> = (0..n)
+        .map(|i| unsafe { pyre_object::listobject::w_list_getitem(items, i as i64).unwrap() })
+        .collect();
+    pyre_object::setobject::w_frozenset_from_items(&v)
 }
 
 /// Copy a (popped) stack list into a fresh list.

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -1,10 +1,13 @@
-//! `_pickle.Unpickler` — `interp_pickle.py W_Unpickler` (atom subset).
+//! `_pickle.Unpickler` — `interp_pickle.py W_Unpickler` (atom + container subset).
 
 use pyre_object::PyObjectRef;
 
 use crate::PyError;
 
-use super::{HIGHEST_PROTOCOL, call_fn, decode_long, op, read_int_le, str_from_utf8, unpickling_error};
+use super::{
+    HIGHEST_PROTOCOL, call_fn, call_meth, decode_long, op, read_int_le, str_from_utf8,
+    unpickling_error,
+};
 
 #[crate::pyre_class("_pickle.Unpickler")]
 pub struct W_Unpickler {
@@ -12,6 +15,12 @@ pub struct W_Unpickler {
     w_file_readline: PyObjectRef,
     /// Result stack — a Python `list` (GC-managed across `read` allocs).
     w_stack: PyObjectRef,
+    /// Saved stacks for the MARK machinery — a Python `list` of lists.
+    w_metastack: PyObjectRef,
+    /// Memo — a Python `dict` keyed by integer index.
+    w_memo: PyObjectRef,
+    /// Next free memo slot (`_memo_append` target).
+    memo_index: i64,
     /// Active frame bytes (`bytes`) or None.
     w_frame: PyObjectRef,
     frame_index: i64,
@@ -30,6 +39,9 @@ impl W_Unpickler {
             w_file_read: pyre_object::w_none(),
             w_file_readline: pyre_object::w_none(),
             w_stack: pyre_object::w_none(),
+            w_metastack: pyre_object::w_none(),
+            w_memo: pyre_object::w_none(),
+            memo_index: 0,
             w_frame: pyre_object::w_none(),
             frame_index: 0,
             proto: 0,
@@ -40,6 +52,9 @@ impl W_Unpickler {
         self.w_file_read = crate::baseobjspace::getattr_str(w_file, "read")?;
         self.w_file_readline = crate::baseobjspace::getattr_str(w_file, "readline")?;
         self.w_stack = pyre_object::w_none();
+        self.w_metastack = pyre_object::w_none();
+        self.w_memo = pyre_object::w_none();
+        self.memo_index = 0;
         self.w_frame = pyre_object::w_none();
         self.frame_index = 0;
         self.proto = 0;
@@ -47,8 +62,11 @@ impl W_Unpickler {
     }
 
     fn load(&mut self) -> Result<PyObjectRef, PyError> {
-        // Fresh stack each load.
+        // Fresh stack / metastack / memo each load.
         self.w_stack = pyre_object::listobject::w_list_new(Vec::new());
+        self.w_metastack = pyre_object::listobject::w_list_new(Vec::new());
+        self.w_memo = pyre_object::dictmultiobject::w_dict_new();
+        self.memo_index = 0;
         self.w_frame = pyre_object::w_none();
         self.frame_index = 0;
         self.proto = 0;
@@ -63,7 +81,7 @@ impl W_Unpickler {
             if opcode == op::STOP {
                 let me = cur(slot);
                 return unsafe { pyre_object::listobject::w_list_pop_end(me.w_stack) }
-                    .ok_or_else(|| unpickling_error("unexpected MARK found"));
+                    .ok_or_else(|| unpickling_error("STOP with empty stack"));
             }
             dispatch(slot, opcode)?;
         }
@@ -76,10 +94,74 @@ fn cur(slot: usize) -> &'static mut W_Unpickler {
     unsafe { &mut *(pyre_object::gc_roots::shadow_stack_get(slot) as *mut W_Unpickler) }
 }
 
+// ── stack / metastack helpers ────────────────────────────────────────
+
 fn push(slot: usize, obj: PyObjectRef) {
     let me = cur(slot);
     unsafe { pyre_object::listobject::w_list_append(me.w_stack, obj) };
 }
+
+/// `data_pop` — pop the top of the current stack.
+fn pop(slot: usize) -> Result<PyObjectRef, PyError> {
+    let me = cur(slot);
+    unsafe { pyre_object::listobject::w_list_pop_end(me.w_stack) }
+        .ok_or_else(|| unpickling_error("unpickling stack underflow"))
+}
+
+/// `_stack_top` — the top of the current stack without removing it.
+fn top(slot: usize, opcode_name: &str) -> Result<PyObjectRef, PyError> {
+    let me = cur(slot);
+    let n = unsafe { pyre_object::listobject::w_list_len(me.w_stack) };
+    if n < 1 {
+        return Err(unpickling_error(&format!("stack empty in {opcode_name}")));
+    }
+    Ok(unsafe { pyre_object::listobject::w_list_getitem(me.w_stack, (n - 1) as i64).unwrap() })
+}
+
+/// `load_mark` — save the current stack and start a fresh one.
+fn mark(slot: usize) {
+    let me = cur(slot);
+    unsafe { pyre_object::listobject::w_list_append(me.w_metastack, me.w_stack) };
+    let new_stack = pyre_object::listobject::w_list_new(Vec::new());
+    cur(slot).w_stack = new_stack;
+}
+
+/// `pop_mark` — return the items pushed since the last MARK and restore the
+/// previous stack.
+fn pop_mark(slot: usize) -> Result<PyObjectRef, PyError> {
+    let me = cur(slot);
+    let items = me.w_stack;
+    let prev = unsafe { pyre_object::listobject::w_list_pop_end(me.w_metastack) }
+        .ok_or_else(|| unpickling_error("no items on stack"))?;
+    cur(slot).w_stack = prev;
+    Ok(items)
+}
+
+// ── memo helpers ─────────────────────────────────────────────────────
+
+/// `_memo_put` — store `w_val` at index `i`, advancing the next-free slot.
+fn memo_put(slot: usize, i: i64, w_val: PyObjectRef) {
+    let me = cur(slot);
+    unsafe { pyre_object::dictmultiobject::w_dict_setitem(me.w_memo, i, w_val) };
+    let me = cur(slot);
+    if i >= me.memo_index {
+        me.memo_index = i + 1;
+    }
+}
+
+/// `_memo_append` — store `w_val` at the next free slot.
+fn memo_append(slot: usize, w_val: PyObjectRef) {
+    let i = cur(slot).memo_index;
+    memo_put(slot, i, w_val);
+}
+
+fn memo_get(slot: usize, i: i64) -> Result<PyObjectRef, PyError> {
+    let me = cur(slot);
+    unsafe { pyre_object::dictmultiobject::w_dict_getitem(me.w_memo, i) }
+        .ok_or_else(|| unpickling_error(&format!("Memo value not found at index {i}")))
+}
+
+// ── reading ──────────────────────────────────────────────────────────
 
 /// Read one opcode byte (from the active frame, else the file).
 fn read1(slot: usize) -> Result<u8, PyError> {
@@ -216,17 +298,172 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let d = read(slot, n)?;
             push(slot, pyre_object::w_bytes_from_bytes(&d));
         }
-        // Memo put opcodes: consume the argument; dedup arrives in inc 2.
-        x if x == op::MEMOIZE => {}
+        // ── stack ────────────────────────────────────────────────────
+        x if x == op::MARK => mark(slot),
+        x if x == op::POP => {
+            // Pop a stack item, or discard the topmost MARK group.
+            let me = cur(slot);
+            let n = unsafe { pyre_object::listobject::w_list_len(me.w_stack) };
+            if n > 0 {
+                pop(slot)?;
+            } else {
+                pop_mark(slot)?;
+            }
+        }
+        x if x == op::POP_MARK => {
+            pop_mark(slot)?;
+        }
+        // ── tuple ─────────────────────────────────────────────────────
+        x if x == op::EMPTY_TUPLE => push(slot, pyre_object::tupleobject::w_tuple_new(Vec::new())),
+        x if x == op::TUPLE => {
+            let items = pop_mark(slot)?;
+            push(slot, list_to_tuple(items));
+        }
+        x if x == op::TUPLE1 => {
+            let a = pop(slot)?;
+            push(slot, pyre_object::tupleobject::w_tuple_new(vec![a]));
+        }
+        x if x == op::TUPLE2 => {
+            let b = pop(slot)?;
+            let a = pop(slot)?;
+            push(slot, pyre_object::tupleobject::w_tuple_new(vec![a, b]));
+        }
+        x if x == op::TUPLE3 => {
+            let c = pop(slot)?;
+            let b = pop(slot)?;
+            let a = pop(slot)?;
+            push(slot, pyre_object::tupleobject::w_tuple_new(vec![a, b, c]));
+        }
+        // ── list ──────────────────────────────────────────────────────
+        x if x == op::EMPTY_LIST => push(slot, pyre_object::listobject::w_list_new(Vec::new())),
+        x if x == op::LIST => {
+            let items = pop_mark(slot)?;
+            push(slot, list_copy(items));
+        }
+        x if x == op::APPEND => {
+            let value = pop(slot)?;
+            let w_list = top(slot, "APPEND")?;
+            call_meth(w_list, "append", &[value])?;
+        }
+        x if x == op::APPENDS => {
+            let items = pop_mark(slot)?;
+            let w_list = top(slot, "APPENDS")?;
+            call_meth(w_list, "extend", &[items])?;
+        }
+        // ── dict ──────────────────────────────────────────────────────
+        x if x == op::EMPTY_DICT => push(slot, pyre_object::dictmultiobject::w_dict_new()),
+        x if x == op::DICT => {
+            let items = pop_mark(slot)?;
+            let w_dict = pyre_object::dictmultiobject::w_dict_new();
+            dict_update_from_pairs(w_dict, items)?;
+            push(slot, w_dict);
+        }
+        x if x == op::SETITEM => {
+            let value = pop(slot)?;
+            let key = pop(slot)?;
+            let w_dict = top(slot, "SETITEM")?;
+            crate::baseobjspace::setitem(w_dict, key, value)?;
+        }
+        x if x == op::SETITEMS => {
+            let items = pop_mark(slot)?;
+            let w_dict = top(slot, "SETITEMS")?;
+            dict_update_from_pairs(w_dict, items)?;
+        }
+        // ── memo ──────────────────────────────────────────────────────
+        x if x == op::MEMOIZE => {
+            let v = top(slot, "MEMOIZE")?;
+            memo_append(slot, v);
+        }
+        x if x == op::PUT => {
+            let i = read_line_int(slot)?;
+            if i < 0 {
+                return Err(PyError::value_error("negative PUT argument"));
+            }
+            let v = top(slot, "PUT")?;
+            memo_put(slot, i, v);
+        }
         x if x == op::BINPUT => {
-            read(slot, 1)?;
+            let i = read(slot, 1)?[0] as i64;
+            let v = top(slot, "BINPUT")?;
+            memo_put(slot, i, v);
         }
         x if x == op::LONG_BINPUT => {
-            read(slot, 4)?;
+            let d = read(slot, 4)?;
+            let i = u32::from_le_bytes([d[0], d[1], d[2], d[3]]) as i64;
+            let v = top(slot, "LONG_BINPUT")?;
+            memo_put(slot, i, v);
+        }
+        x if x == op::GET => {
+            let i = read_line_int(slot)?;
+            let v = memo_get(slot, i)?;
+            push(slot, v);
+        }
+        x if x == op::BINGET => {
+            let i = read(slot, 1)?[0] as i64;
+            let v = memo_get(slot, i)?;
+            push(slot, v);
+        }
+        x if x == op::LONG_BINGET => {
+            let d = read(slot, 4)?;
+            let i = u32::from_le_bytes([d[0], d[1], d[2], d[3]]) as i64;
+            let v = memo_get(slot, i)?;
+            push(slot, v);
         }
         _ => {
             return Err(unpickling_error("unsupported opcode in this build"));
         }
     }
     Ok(())
+}
+
+/// Build a tuple from the items of a (popped) stack list.
+fn list_to_tuple(items: PyObjectRef) -> PyObjectRef {
+    let n = unsafe { pyre_object::listobject::w_list_len(items) };
+    let v: Vec<PyObjectRef> = (0..n)
+        .map(|i| unsafe { pyre_object::listobject::w_list_getitem(items, i as i64).unwrap() })
+        .collect();
+    pyre_object::tupleobject::w_tuple_new(v)
+}
+
+/// Copy a (popped) stack list into a fresh list.
+fn list_copy(items: PyObjectRef) -> PyObjectRef {
+    let n = unsafe { pyre_object::listobject::w_list_len(items) };
+    let v: Vec<PyObjectRef> = (0..n)
+        .map(|i| unsafe { pyre_object::listobject::w_list_getitem(items, i as i64).unwrap() })
+        .collect();
+    pyre_object::listobject::w_list_new(v)
+}
+
+/// Set `dict[items[2k]] = items[2k+1]` for each pair in a (popped) stack list.
+fn dict_update_from_pairs(w_dict: PyObjectRef, items: PyObjectRef) -> Result<(), PyError> {
+    let n = unsafe { pyre_object::listobject::w_list_len(items) };
+    if n % 2 != 0 {
+        return Err(unpickling_error("odd number of items for DICT"));
+    }
+    let mut i = 0;
+    while i < n {
+        let k = unsafe { pyre_object::listobject::w_list_getitem(items, i as i64).unwrap() };
+        let v = unsafe { pyre_object::listobject::w_list_getitem(items, (i + 1) as i64).unwrap() };
+        crate::baseobjspace::setitem(w_dict, k, v)?;
+        i += 2;
+    }
+    Ok(())
+}
+
+/// Read a newline-terminated decimal integer argument (GET / PUT in the
+/// text protocols).
+fn read_line_int(slot: usize) -> Result<i64, PyError> {
+    let mut digits: Vec<u8> = Vec::new();
+    loop {
+        let b = read1(slot)?;
+        if b == b'\n' {
+            break;
+        }
+        digits.push(b);
+    }
+    let s = std::str::from_utf8(&digits)
+        .map_err(|_| PyError::value_error("invalid int literal"))?;
+    s.trim()
+        .parse::<i64>()
+        .map_err(|_| PyError::value_error("invalid int literal"))
 }

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -539,11 +539,13 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let w_kwargs = pop(slot)?;
             let w_args = pop(slot)?;
             let w_cls = pop(slot)?;
-            let kw_len = unsafe { pyre_object::dictmultiobject::w_dict_items(w_kwargs) }.len();
-            if kw_len > 0 {
-                return Err(PyError::not_implemented("_pickle: NEWOBJ_EX with kwargs"));
-            }
-            let w_obj = new_instance(w_cls, &tuple_items(w_args))?;
+            let kw_items = unsafe { pyre_object::dictmultiobject::w_dict_items(w_kwargs) };
+            let args = tuple_items(w_args);
+            let w_obj = if kw_items.is_empty() {
+                new_instance(w_cls, &args)?
+            } else {
+                new_instance_kw(w_cls, &args, &kw_items)?
+            };
             push(slot, w_obj);
         }
         x if x == op::BUILD => {
@@ -768,6 +770,38 @@ fn new_instance(w_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef,
     let mut call_args = vec![w_cls];
     call_args.extend_from_slice(args);
     call_fn(w_new, &call_args)
+}
+
+/// `cls.__new__(cls, *args, **kwargs)` — NEWOBJ_EX with the keyword
+/// arguments returned by `__getnewargs_ex__`. Keyword delivery to a
+/// user `__new__` needs the frame-based call path (`call_with_kwargs`);
+/// the flat-slice path binds every argument positionally.
+fn new_instance_kw(
+    w_cls: PyObjectRef,
+    args: &[PyObjectRef],
+    kw_items: &[(PyObjectRef, PyObjectRef)],
+) -> Result<PyObjectRef, PyError> {
+    let w_new = crate::baseobjspace::getattr_str(w_cls, "__new__")?;
+    let mut call_args = Vec::with_capacity(1 + args.len());
+    call_args.push(w_cls);
+    call_args.extend_from_slice(args);
+    let mut kwargs = Vec::with_capacity(kw_items.len());
+    for &(k, v) in kw_items {
+        if !unsafe { pyre_object::is_str(k) } {
+            return Err(unpickling_error("keyword arguments must be strings"));
+        }
+        let name = unsafe { pyre_object::strobject::w_str_get_wtf8(k) }.to_owned();
+        kwargs.push((name, v));
+    }
+    let ec = crate::call::getexecutioncontext();
+    if ec.is_null() {
+        return Err(unpickling_error("no execution context for NEWOBJ_EX"));
+    }
+    let frame = unsafe { (*ec).gettopframe() };
+    if frame.is_null() {
+        return Err(unpickling_error("no frame for NEWOBJ_EX with kwargs"));
+    }
+    crate::call::call_with_kwargs(unsafe { &mut *frame }, w_new, &call_args, &kwargs)
 }
 
 /// `load_build` — apply pickled state to a freshly created instance.

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -18,7 +18,9 @@ use sre_engine::engine::{Request, SearchIter, State};
 use sre_engine::string::StrDrive;
 
 pub fn register_module(ns: &mut DictStorage) {
-    dict_storage_store(ns, "MAGIC", w_int_new(20230612)); // SRE magic number
+    // Must equal `re/_constants.py:MAGIC` (the bundled stdlib) — `_compiler.py`
+    // asserts `_sre.MAGIC == MAGIC` at import time.
+    dict_storage_store(ns, "MAGIC", w_int_new(20220615)); // SRE magic number
     dict_storage_store(ns, "CODESIZE", w_int_new(sre_engine::CODESIZE as i64));
     dict_storage_store(ns, "MAXREPEAT", w_int_new(sre_engine::MAXREPEAT as i64));
     dict_storage_store(ns, "MAXGROUPS", w_int_new(sre_engine::MAXGROUPS as i64));

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -20,7 +20,7 @@ use sre_engine::string::StrDrive;
 pub fn register_module(ns: &mut DictStorage) {
     // Must equal `re/_constants.py:MAGIC` (the bundled stdlib) — `_compiler.py`
     // asserts `_sre.MAGIC == MAGIC` at import time.
-    dict_storage_store(ns, "MAGIC", w_int_new(20220615)); // SRE magic number
+    dict_storage_store(ns, "MAGIC", w_int_new(20230612)); // SRE magic number
     dict_storage_store(ns, "CODESIZE", w_int_new(sre_engine::CODESIZE as i64));
     dict_storage_store(ns, "MAXREPEAT", w_int_new(sre_engine::MAXREPEAT as i64));
     dict_storage_store(ns, "MAXGROUPS", w_int_new(sre_engine::MAXGROUPS as i64));

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -493,4 +493,48 @@ pub fn register_module(ns: &mut DictStorage) {
             1,
         ),
     );
+    // batched(iterable, n, *, strict=False) — CPython 3.13 itertools.batched.
+    // Batches the input into tuples of length `n`; the last tuple may be
+    // shorter unless `strict` is set, in which case a short final batch
+    // raises ValueError.  Materialized eagerly like the other builtins here.
+    crate::dict_storage_store(
+        ns,
+        "batched",
+        crate::make_builtin_function("batched", |args| {
+            let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            crate::builtins::kwarg_reject_unknown(kwargs, &["strict"], "batched")?;
+            if positional.len() < 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "batched expected at least 2 arguments, got {}",
+                    positional.len()
+                )));
+            }
+            // `n` goes through `space.index` (`__index__`); a non-integer
+            // raises "'X' object cannot be interpreted as an integer".
+            let n = crate::builtins::space_index_w(positional[1])?;
+            if n < 1 {
+                return Err(crate::PyError::value_error("n must be at least one"));
+            }
+            let strict = match crate::builtins::kwarg_get(kwargs, "strict") {
+                Some(w) => crate::baseobjspace::is_true(w),
+                None => false,
+            };
+            let n = n as usize;
+            let items = crate::builtins::collect_iterable(positional[0])?;
+            let mut tuples = Vec::with_capacity(items.len().div_ceil(n));
+            let mut i = 0usize;
+            while i < items.len() {
+                let end = (i + n).min(items.len());
+                let chunk: Vec<_> = items[i..end].to_vec();
+                if strict && chunk.len() != n {
+                    return Err(crate::PyError::value_error("batched(): incomplete batch"));
+                }
+                tuples.push(pyre_object::w_tuple_new(chunk));
+                i = end;
+            }
+            let count = tuples.len();
+            let list = pyre_object::w_list_new(tuples);
+            Ok(pyre_object::w_seq_iter_new(list, count))
+        }),
+    );
 }

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod __builtin__;
 #[allow(non_snake_case)]
+pub mod __pypy__;
+#[allow(non_snake_case)]
 pub mod _abc;
 #[allow(non_snake_case)]
 pub mod _ast;

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -30,6 +30,8 @@ pub mod _multiprocessing;
 #[allow(non_snake_case)]
 pub mod _opcode;
 #[allow(non_snake_case)]
+pub mod _pickle;
+#[allow(non_snake_case)]
 pub mod _posixshmem;
 #[allow(non_snake_case)]
 pub mod _random;

--- a/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
+++ b/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
@@ -619,6 +619,7 @@ pub fn register_module(ns: &mut DictStorage) {
         ns,
         "builtin_module_names",
         w_tuple_new(vec![
+            w_str_new("__pypy__"),
             w_str_new("_abc"),
             w_str_new("_bisect"),
             w_str_new("_blake2"),

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -96,10 +96,11 @@ pub struct PyFrame {
     /// PyPy: `f_backref = jit.vref_None`.
     pub f_backref: *mut PyFrame,
     /// pyframe.py:115-116 — `self.builtin = space.builtin
-    /// .pick_builtin(w_globals)` (gated under `honor__builtins__` upstream;
-    /// pyre runs as if the option were always on, matching CPython's
-    /// unconditional `__builtins__` honoring).  Cached at frame creation
-    /// from `globals['__builtins__']` and consulted by LOAD_GLOBAL's
+    /// .pick_builtin(w_globals)`, gated under `honor__builtins__`
+    /// (`baseobjspace::HONOR_BUILTINS`, default False).  With the option
+    /// off (the default) `frame_builtin*` returns `space.builtin`, ignoring
+    /// a custom `__builtins__` in globals; with it on the `pick_builtin*`
+    /// family honors `globals['__builtins__']`.  Consulted by LOAD_GLOBAL's
     /// builtins fallback (`pyopcode.py:918-927`) via
     /// `space.finditem_str(self.w_builtin.w_dict, name)` — honouring
     /// dict subclass `__getitem__` overrides (`moduledef.py:102-103`)
@@ -944,7 +945,7 @@ impl PyFrame {
         // slots, resolved eagerly here exactly as `new_minimal` does, so a
         // frame built through this hook is left in the same state as one
         // built by `createframe`.
-        self.w_builtin = crate::baseobjspace::pick_builtin(w_globals, self.execution_context);
+        self.w_builtin = crate::baseobjspace::frame_builtin(w_globals, self.execution_context);
         self.w_globals_obj = if w_globals.is_null() {
             PY_NULL
         } else {
@@ -1167,7 +1168,7 @@ impl PyFrame {
         let size = nlocals + ncells + 16; // small stack
         let stores_global =
             unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) };
-        let w_builtin = crate::baseobjspace::pick_builtin(w_globals, execution_context);
+        let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
         // `pyframe.py:98 __init__(self, space, code, w_globals, ...)`
         // stores `w_globals` as the canonical W_DictObject directly.
         // Pyre carries both the raw storage pointer (`w_globals`) and
@@ -1283,7 +1284,7 @@ impl PyFrame {
 
         let stores_global =
             unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) };
-        let w_builtin = crate::baseobjspace::pick_builtin(w_globals, execution_context);
+        let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
         // `pyframe.py:98 __init__` — `self.w_globals = w_globals` stores
         // the W_DictObject directly; eager `dict_storage_to_dict`
         // mirrors the identity invariant on pyre's split layout.
@@ -2393,9 +2394,9 @@ impl PyFrame {
         closure: PyObjectRef,
     ) -> Result<Self, crate::PyError> {
         let w_builtin = if w_globals_obj.is_null() {
-            crate::baseobjspace::pick_builtin(globals, execution_context)
+            crate::baseobjspace::frame_builtin(globals, execution_context)
         } else {
-            crate::baseobjspace::pick_builtin_obj_checked(w_globals_obj, execution_context)?
+            crate::baseobjspace::frame_builtin_obj_checked(w_globals_obj, execution_context)?
         };
         Ok(Self::finish_for_call_with_globals_obj(
             code,
@@ -2428,9 +2429,9 @@ impl PyFrame {
         closure: PyObjectRef,
     ) -> Self {
         let w_builtin = if w_globals_obj.is_null() {
-            crate::baseobjspace::pick_builtin(globals, execution_context)
+            crate::baseobjspace::frame_builtin(globals, execution_context)
         } else {
-            crate::baseobjspace::pick_builtin_obj(w_globals_obj, execution_context)
+            crate::baseobjspace::frame_builtin_obj(w_globals_obj, execution_context)
         };
         Self::finish_for_call_with_globals_obj(
             code,
@@ -2765,7 +2766,7 @@ pub fn createframe(
         unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) };
 
     let size = num_locals + num_cells + max_stack;
-    let w_builtin = crate::baseobjspace::pick_builtin(w_globals, execution_context);
+    let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
     // `pyframe.py:98 __init__` — `self.w_globals = w_globals` stores the
     // dict object directly so `frame.w_globals` retains object identity
     // for the lifetime of the frame.  pyre's split layout pairs the raw

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -195,7 +195,21 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
             .ok_or_else(|| PyError::type_error("cannot determine type for __reduce_ex__"))?;
         let w_cls_reduce = crate::baseobjspace::getattr_str(w_type, "__reduce__")?;
         let w_obj_reduce = crate::baseobjspace::getattr_str(crate::typedef::w_object(), "__reduce__")?;
-        let override_ = !crate::baseobjspace::is_w(w_cls_reduce, w_obj_reduce);
+        let mut override_ = !crate::baseobjspace::is_w(w_cls_reduce, w_obj_reduce);
+        // Built-in types (range, the iterators) expose `__reduce__`
+        // through instance dispatch rather than the type MRO, so the
+        // type-level comparison above sees `object.__reduce__` and
+        // misses the override.  Compare the bound instance method's
+        // `__func__` against `object.__reduce__` to catch it: a genuine
+        // override binds a different function.
+        if !override_ {
+            let w_inst_func = if unsafe { pyre_object::methodobject::is_method(w_reduce) } {
+                unsafe { pyre_object::methodobject::w_method_get_func(w_reduce) }
+            } else {
+                w_reduce
+            };
+            override_ = !crate::baseobjspace::is_w(w_inst_func, w_obj_reduce);
+        }
         if override_ {
             return crate::call::call_function_impl_result(w_reduce, &[]);
         }

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -85,9 +85,10 @@ pub fn get_slotvalues(w_obj: PyObjectRef) -> PyResult {
 pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
     let w_objdict = crate::baseobjspace::findattr(w_obj, "__dict__");
     let mut w_ret = match w_objdict {
-        Some(d) if crate::baseobjspace::len_w(d)? > 0 => {
-            crate::call::call_function_impl_result(crate::baseobjspace::getattr_str(d, "copy")?, &[])?
-        }
+        Some(d) if crate::baseobjspace::len_w(d)? > 0 => crate::call::call_function_impl_result(
+            crate::baseobjspace::getattr_str(d, "copy")?,
+            &[],
+        )?,
         _ => pyre_object::w_none(),
     };
     let w_slots = get_slotvalues(w_obj)?;
@@ -99,9 +100,7 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
 
 /// objectobject.py:201 `_getnewargs(space, w_obj)` — returns
 /// `(hasargs, w_args, w_kwargs)`.
-pub fn getnewargs(
-    w_obj: PyObjectRef,
-) -> Result<(bool, PyObjectRef, PyObjectRef), PyError> {
+pub fn getnewargs(w_obj: PyObjectRef) -> Result<(bool, PyObjectRef, PyObjectRef), PyError> {
     let w_descr = unsafe { crate::baseobjspace::lookup(w_obj, "__getnewargs_ex__") };
     let hasargs;
     let w_args;
@@ -194,7 +193,8 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
         let w_type = crate::typedef::r#type(w_obj)
             .ok_or_else(|| PyError::type_error("cannot determine type for __reduce_ex__"))?;
         let w_cls_reduce = crate::baseobjspace::getattr_str(w_type, "__reduce__")?;
-        let w_obj_reduce = crate::baseobjspace::getattr_str(crate::typedef::w_object(), "__reduce__")?;
+        let w_obj_reduce =
+            crate::baseobjspace::getattr_str(crate::typedef::w_object(), "__reduce__")?;
         let mut override_ = !crate::baseobjspace::is_w(w_cls_reduce, w_obj_reduce);
         // Built-in types (range, the iterators) expose `__reduce__`
         // through instance dispatch rather than the type MRO, so the

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -215,11 +215,22 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
         }
     }
     if proto >= 2 {
-        let (_hasargs, w_args, w_kwargs) = getnewargs(w_obj)?;
-        // objectobject.py:276 looks up the (always-absent) `__get_state__`
-        // and, only for variable-sized types lacking newargs, raises.
-        // pyre has no variable-sized layout notion, so the raise is a
-        // no-op here; the structure is preserved for parity.
+        let (hasargs, w_args, w_kwargs) = getnewargs(w_obj)?;
+        // objectobject.py:276 / `_PyObject_GetState(required)`: a type whose
+        // instances carry C-level state that `__dict__`/`__slots__` cannot
+        // reconstruct, and that supplies no `__getnewargs__`, cannot be
+        // rebuilt via `__newobj__`.  `reduce_newobj` gates this on
+        // `tp_basicsize` exceeding the object+dict+weakref+slots baseline;
+        // pyre has no basicsize notion, so it recognises the one such builtin
+        // layout
+        // that reaches object-reduce — `module` (native name + dict
+        // payload).  Matches the proto < 2 `copyreg._reduce_ex` refusal.
+        if !hasargs && unsafe { pyre_object::is_module(w_obj) } {
+            return Err(PyError::type_error(format!(
+                "cannot pickle '{}' object",
+                typename(w_obj)
+            )));
+        }
         return reduce_2(w_obj, proto, w_args, w_kwargs);
     }
     reduce_1(w_obj, proto)

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -1,0 +1,212 @@
+//! Pickle reduce protocol for `object` — PyPy: `pypy/objspace/std/objectobject.py`.
+//!
+//! The app-level helpers `reduce_1` / `reduce_2` / `get_slotvalues` /
+//! `slotnames` (objectobject.py:23-84) are bundled in
+//! `reduce_protocol_app.py` and resolved lazily through
+//! `appleveldef_install` into a leaked scratch namespace.  The three
+//! handles the interp-level code calls (`reduce_1`, `reduce_2`,
+//! `get_slotvalues`) keep that namespace as their `__globals__`, so
+//! `get_slotvalues` can still reach its sibling `slotnames`.
+//!
+//! The interp-level descriptors `descr_reduce` / `descr_reduce_ex` /
+//! `object_getstate_default` / `getnewargs` mirror objectobject.py's
+//! `descr__reduce__` / `descr__reduce_ex__` / `object_getstate_default`
+//! / `_getnewargs`.
+
+use pyre_object::PyObjectRef;
+
+use crate::PyResult;
+use crate::error::PyError;
+
+/// Resolved app-level handles, indexed `[reduce_1, reduce_2,
+/// get_slotvalues]`.  PyPy resolves these once via `app.interphook`
+/// (objectobject.py:88-90); pyre resolves them on first use into a
+/// thread-local cache.
+const REDUCE_1: usize = 0;
+const REDUCE_2: usize = 1;
+const GET_SLOTVALUES: usize = 2;
+
+thread_local! {
+    static HANDLES: std::cell::OnceCell<[PyObjectRef; 3]> = const { std::cell::OnceCell::new() };
+}
+
+/// Resolve (and cache) the three app-level handles.
+///
+/// Executes `reduce_protocol_app.py` into a fresh, intentionally leaked
+/// `DictStorage` and reads back the named globals.  The functions retain
+/// that namespace as their `__globals__`, which keeps `slotnames`
+/// reachable from `get_slotvalues` even though only three names are
+/// surfaced.
+fn handle(which: usize) -> PyObjectRef {
+    HANDLES.with(|cell| {
+        cell.get_or_init(|| {
+            let ctx = crate::call::getexecutioncontext();
+            if ctx.is_null() {
+                panic!("reduce_protocol: no execution context");
+            }
+            let mut app_ns = Box::new(unsafe { (*ctx).fresh_dict_storage() });
+            app_ns.fix_ptr();
+            let app_ns_ptr: *mut crate::DictStorage = Box::leak(app_ns);
+            crate::importing::appleveldef_install(
+                unsafe { &mut *app_ns_ptr },
+                include_str!("reduce_protocol_app.py"),
+                "reduce_protocol_app.py",
+                &["reduce_1", "reduce_2", "get_slotvalues"],
+            );
+            let ns = unsafe { &*app_ns_ptr };
+            let get = |name: &str| {
+                crate::dict_storage_get(ns, name)
+                    .unwrap_or_else(|| panic!("reduce_protocol: `{name}` not bound"))
+            };
+            [get("reduce_1"), get("reduce_2"), get("get_slotvalues")]
+        })[which]
+    })
+}
+
+/// `%T`-style class name of `w_obj` for error messages.
+fn typename(w_obj: PyObjectRef) -> String {
+    match crate::typedef::r#type(w_obj) {
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        None => "object".to_string(),
+    }
+}
+
+/// objectobject.py:53 `get_slotvalues(obj)` — app-level handle.
+pub fn get_slotvalues(w_obj: PyObjectRef) -> PyResult {
+    crate::call::call_function_impl_result(handle(GET_SLOTVALUES), &[w_obj])
+}
+
+/// objectobject.py:245 `object_getstate_default(space, w_obj, required)`.
+///
+/// `required` is always 0 from both callers (`descr__getstate__` and the
+/// proto>=2 path), so the variable-sized raise is unreachable and pyre
+/// has no `variable_sized` layout notion to gate it on — the structure
+/// is ported without that dead arm.
+pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
+    let w_objdict = crate::baseobjspace::findattr(w_obj, "__dict__");
+    let mut w_ret = match w_objdict {
+        Some(d) if crate::baseobjspace::len_w(d)? > 0 => {
+            crate::call::call_function_impl_result(crate::baseobjspace::getattr_str(d, "copy")?, &[])?
+        }
+        _ => pyre_object::w_none(),
+    };
+    let w_slots = get_slotvalues(w_obj)?;
+    if !unsafe { pyre_object::is_none(w_slots) } {
+        w_ret = pyre_object::w_tuple_new(vec![w_ret, w_slots]);
+    }
+    Ok(w_ret)
+}
+
+/// objectobject.py:201 `_getnewargs(space, w_obj)` — returns
+/// `(hasargs, w_args, w_kwargs)`.
+pub fn getnewargs(
+    w_obj: PyObjectRef,
+) -> Result<(bool, PyObjectRef, PyObjectRef), PyError> {
+    let w_descr = unsafe { crate::baseobjspace::lookup(w_obj, "__getnewargs_ex__") };
+    let hasargs;
+    let w_args;
+    let w_kwargs;
+    if let Some(w_descr) = w_descr {
+        let w_result = crate::call::call_function_impl_result(w_descr, &[w_obj])?;
+        if !unsafe { pyre_object::is_tuple(w_result) } {
+            return Err(PyError::type_error(format!(
+                "__getnewargs_ex__ should return a tuple, not '{}'",
+                typename(w_result)
+            )));
+        }
+        let n = unsafe { pyre_object::w_tuple_len(w_result) };
+        if n != 2 {
+            return Err(PyError::value_error(format!(
+                "__getnewargs_ex__ should return a tuple of length 2, not {n}"
+            )));
+        }
+        let items = unsafe { pyre_object::w_tuple_items_copy_as_vec(w_result) };
+        let wa = items[0];
+        let wk = items[1];
+        if !unsafe { pyre_object::is_tuple(wa) } {
+            return Err(PyError::type_error(format!(
+                "first item of the tuple returned by __getnewargs_ex__ must be a tuple, not '{}'",
+                typename(wa)
+            )));
+        }
+        if !unsafe { pyre_object::is_dict(wk) } {
+            return Err(PyError::type_error(format!(
+                "second item of the tuple returned by __getnewargs_ex__ must be a dict, not '{}'",
+                typename(wk)
+            )));
+        }
+        hasargs = true;
+        w_args = wa;
+        w_kwargs = wk;
+    } else {
+        let w_descr = unsafe { crate::baseobjspace::lookup(w_obj, "__getnewargs__") };
+        if let Some(w_descr) = w_descr {
+            let wa = crate::call::call_function_impl_result(w_descr, &[w_obj])?;
+            if !unsafe { pyre_object::is_tuple(wa) } {
+                return Err(PyError::type_error(format!(
+                    "__getnewargs__ should return a tuple, not '{}'",
+                    typename(wa)
+                )));
+            }
+            hasargs = true;
+            w_args = wa;
+        } else {
+            hasargs = false;
+            w_args = pyre_object::w_tuple_new(vec![]);
+        }
+        w_kwargs = pyre_object::w_none();
+    }
+    Ok((hasargs, w_args, w_kwargs))
+}
+
+/// objectobject.py:240 `descr__reduce__(space, w_obj)` — `reduce_1(obj, 0)`.
+pub fn descr_reduce(w_obj: PyObjectRef) -> PyResult {
+    reduce_1(w_obj, 0)
+}
+
+/// objectobject.py:23 `reduce_1(obj, proto)` — app-level handle.
+fn reduce_1(w_obj: PyObjectRef, proto: i64) -> PyResult {
+    crate::call::call_function_impl_result(
+        handle(REDUCE_1),
+        &[w_obj, pyre_object::w_int_new(proto)],
+    )
+}
+
+/// objectobject.py:27 `reduce_2(obj, proto, args, kwargs)` — app-level handle.
+fn reduce_2(
+    w_obj: PyObjectRef,
+    proto: i64,
+    w_args: PyObjectRef,
+    w_kwargs: PyObjectRef,
+) -> PyResult {
+    crate::call::call_function_impl_result(
+        handle(REDUCE_2),
+        &[w_obj, pyre_object::w_int_new(proto), w_args, w_kwargs],
+    )
+}
+
+/// objectobject.py:260 `descr__reduce_ex__(space, w_obj, proto)`.
+pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
+    // Honour a user `__reduce__` override:
+    // `type(obj).__reduce__ is not object.__reduce__`.
+    let w_reduce = crate::baseobjspace::findattr(w_obj, "__reduce__");
+    if let Some(w_reduce) = w_reduce {
+        let w_type = crate::typedef::r#type(w_obj)
+            .ok_or_else(|| PyError::type_error("cannot determine type for __reduce_ex__"))?;
+        let w_cls_reduce = crate::baseobjspace::getattr_str(w_type, "__reduce__")?;
+        let w_obj_reduce = crate::baseobjspace::getattr_str(crate::typedef::w_object(), "__reduce__")?;
+        let override_ = !crate::baseobjspace::is_w(w_cls_reduce, w_obj_reduce);
+        if override_ {
+            return crate::call::call_function_impl_result(w_reduce, &[]);
+        }
+    }
+    if proto >= 2 {
+        let (_hasargs, w_args, w_kwargs) = getnewargs(w_obj)?;
+        // objectobject.py:276 looks up the (always-absent) `__get_state__`
+        // and, only for variable-sized types lacking newargs, raises.
+        // pyre has no variable-sized layout notion, so the raise is a
+        // no-op here; the structure is preserved for parity.
+        return reduce_2(w_obj, proto, w_args, w_kwargs);
+    }
+    reduce_1(w_obj, proto)
+}

--- a/pyre/pyre-interpreter/src/reduce_protocol_app.py
+++ b/pyre/pyre-interpreter/src/reduce_protocol_app.py
@@ -7,8 +7,11 @@ def reduce_1(obj, proto):
 def reduce_2(obj, proto, args, kwargs):
     cls = obj.__class__
 
-    if not hasattr(type(obj), "__new__"):
-        raise TypeError("can't pickle %s objects" % type(obj).__name__)
+    # Py_TPFLAGS_DISALLOW_INSTANTIATION (1 << 7): a type whose tp_new is
+    # NULL (generator / frame / ...) cannot be reconstructed via
+    # __newobj__, so reduce_newobj refuses it before building the tuple.
+    if type(obj).__flags__ & (1 << 7):
+        raise TypeError("cannot pickle %r object" % type(obj).__name__)
 
     try:
         copyreg = sys.modules['copyreg']

--- a/pyre/pyre-interpreter/src/reduce_protocol_app.py
+++ b/pyre/pyre-interpreter/src/reduce_protocol_app.py
@@ -1,0 +1,64 @@
+import sys
+
+def reduce_1(obj, proto):
+    import copyreg
+    return copyreg._reduce_ex(obj, proto)
+
+def reduce_2(obj, proto, args, kwargs):
+    cls = obj.__class__
+
+    if not hasattr(type(obj), "__new__"):
+        raise TypeError("can't pickle %s objects" % type(obj).__name__)
+
+    try:
+        copyreg = sys.modules['copyreg']
+    except KeyError:
+        import copyreg
+
+    if not isinstance(args, tuple):
+        raise TypeError("__getnewargs__ should return a tuple")
+    if not kwargs:
+        newobj = copyreg.__newobj__
+        args2 = (cls,) + args
+    else:
+        newobj = copyreg.__newobj_ex__
+        args2 = (cls, args, kwargs)
+    state = obj.__getstate__()
+    listitems = iter(obj) if isinstance(obj, list) else None
+    dictitems = iter(obj.items()) if isinstance(obj, dict) else None
+
+    return newobj, args2, state, listitems, dictitems
+
+
+def get_slotvalues(obj):
+    names = slotnames(obj.__class__)
+    if not names:
+        return None
+    slots = {}
+    for name in names:
+        try:
+            value = getattr(obj, name)
+        except AttributeError:
+            pass
+        else:
+            slots[name] = value
+    return slots
+
+
+def slotnames(cls):
+    if not isinstance(cls, type):
+        return None
+
+    try:
+        return cls.__dict__["__slotnames__"]
+    except KeyError:
+        pass
+
+    try:
+        copyreg = sys.modules['copyreg']
+    except KeyError:
+        import copyreg
+    slotnames = copyreg._slotnames(cls)
+    if not isinstance(slotnames, list) and slotnames is not None:
+        raise TypeError("copyreg._slotnames didn't return a list or None")
+    return slotnames

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1839,6 +1839,7 @@ pub fn encode_object(
             "ordinal not in range(256)",
             errors,
         ),
+        "raw-unicode-escape" => Ok(encode_raw_unicode_escape(s)),
         _ => match encode_utf16_32(s, &enc_lower, w_object, errors) {
             Some(out) => out,
             None => Err(crate::PyError::new(
@@ -1847,6 +1848,70 @@ pub fn encode_object(
             )),
         },
     }
+}
+
+/// `unicodeobject.c:_PyUnicode_EncodeRawUnicodeEscape` — code points
+/// below 0x100 map to a single Latin-1 byte; 0x100..0x10000 become the
+/// 6-byte `\uXXXX` form; everything larger becomes `\UXXXXXXXX`.  Unlike
+/// `unicode-escape`, the backslash and control characters are not
+/// escaped.
+pub fn encode_raw_unicode_escape(s: &Wtf8) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    for cp in s.code_points() {
+        let v = cp.to_u32();
+        if v < 0x100 {
+            out.push(v as u8);
+        } else if v < 0x10000 {
+            out.extend_from_slice(format!("\\u{v:04x}").as_bytes());
+        } else {
+            out.extend_from_slice(format!("\\U{v:08x}").as_bytes());
+        }
+    }
+    out
+}
+
+/// `unicodeobject.c:_PyUnicode_DecodeRawUnicodeEscape` — the inverse of
+/// [`encode_raw_unicode_escape`].  A backslash starts a `\uXXXX` /
+/// `\UXXXXXXXX` escape; any other byte (including a lone backslash or a
+/// malformed escape) is taken as a Latin-1 code point.
+pub fn decode_raw_unicode_escape(data: &[u8]) -> Result<Wtf8Buf, crate::PyError> {
+    let mut out = Wtf8Buf::new();
+    let mut i = 0usize;
+    while i < data.len() {
+        let b = data[i];
+        if b != b'\\' {
+            out.push_char(b as char);
+            i += 1;
+            continue;
+        }
+        // Count the run of backslashes; only an odd run can introduce a
+        // `\u`/`\U` escape (an even run is literal escaped backslashes,
+        // but raw-unicode-escape does not collapse them — each `\` is a
+        // literal byte 0x5c).  The escape applies when `\` is followed by
+        // `u` or `U` with enough hex digits.
+        let kind = data.get(i + 1).copied();
+        let want = match kind {
+            Some(b'u') => 4usize,
+            Some(b'U') => 8usize,
+            _ => 0,
+        };
+        if want != 0 && i + 2 + want <= data.len() {
+            let hex = &data[i + 2..i + 2 + want];
+            if let Ok(hs) = std::str::from_utf8(hex) {
+                if let Ok(v) = u32::from_str_radix(hs, 16) {
+                    if let Some(c) = CodePoint::from_u32(v) {
+                        out.push(c);
+                        i += 2 + want;
+                        continue;
+                    }
+                }
+            }
+        }
+        // Not a valid escape — emit the backslash literally as Latin-1.
+        out.push_char(b as char);
+        i += 1;
+    }
+    Ok(out)
 }
 
 fn encode_narrow(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -619,9 +619,14 @@ pub fn init_typeobjects() {
             &pyre_object::superobject::SUPER_TYPE as *const PyType as usize,
             new_typeobject_with_base("super", |_| {}, object_type) as usize,
         );
+        let generator_type = new_typeobject_with_base("generator", |_| {}, object_type);
+        // `Py_TPFLAGS_DISALLOW_INSTANTIATION` — a generator is produced
+        // only by calling a generator function, never by `generator()`,
+        // so `tp_new` is NULL and pickling refuses it.
+        unsafe { pyre_object::w_type_set_disallow_instantiation(generator_type) };
         reg.insert(
             &pyre_object::generatorobject::GENERATOR_TYPE as *const PyType as usize,
-            new_typeobject_with_base("generator", |_| {}, object_type) as usize,
+            generator_type as usize,
         );
         reg.insert(
             &pyre_object::rangeobject::RANGE_ITER_TYPE as *const PyType as usize,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -928,6 +928,68 @@ fn new_typeobject_with_base_and_layout(
     type_obj
 }
 
+/// Create a named builtin type inheriting from multiple `bases`.
+///
+/// The first entry is the primary base (drives layout/hasdict/weakref
+/// inheritance, like `w_bestbase` in typeobject.py:setup_builtin_type);
+/// the full tuple is recorded as `__bases__` and the MRO is the C3
+/// linearization (`compute_default_mro`).  Used for builtin exception
+/// classes with more than one base, e.g.
+/// `class UnsupportedOperation(OSError, ValueError)`.
+pub fn make_builtin_type_with_bases(
+    name: &str,
+    init: impl FnOnce(&mut DictStorage),
+    bases: &[PyObjectRef],
+) -> PyObjectRef {
+    let layout_pytype = &INSTANCE_TYPE as *const PyType;
+    let base = bases[0];
+    let mut ns = Box::new(DictStorage::new());
+    ns.fix_ptr();
+    init(&mut ns);
+    let ns_ptr = Box::into_raw(ns);
+    let bases_tuple = w_tuple_new(bases.to_vec());
+    let type_obj = w_type_new_builtin(name, bases_tuple, ns_ptr as *mut u8, layout_pytype);
+
+    unsafe {
+        let parent_layout = pyre_object::w_type_get_layout_ptr(base);
+        let reuse = if !parent_layout.is_null() {
+            std::ptr::eq((*parent_layout).typedef, layout_pytype)
+        } else {
+            false
+        };
+        let has_dict = (*ns_ptr).get("__dict__").is_some();
+        let has_weakref = (*ns_ptr).get("__weakref__").is_some();
+        let layout = if reuse {
+            parent_layout
+        } else {
+            let has_new = (*ns_ptr).get("__new__").is_some();
+            pyre_object::typeobject::leak_layout(pyre_object::typeobject::Layout {
+                typedef: layout_pytype,
+                nslots: 0,
+                newslotnames: vec![],
+                base_layout: parent_layout,
+                acceptable_as_base_class: has_new,
+                typedef_hasdict: false,
+            })
+        };
+        pyre_object::w_type_set_layout(type_obj, layout);
+        // typedef.py:39-41: inherit hasdict/weakrefable from any base.
+        let mut hasdict = has_dict;
+        let mut weakrefable = has_weakref;
+        for &b in bases {
+            hasdict |= pyre_object::w_type_get_hasdict(b);
+            weakrefable |= pyre_object::w_type_get_weakrefable(b);
+        }
+        pyre_object::w_type_set_hasdict(type_obj, hasdict);
+        pyre_object::w_type_set_weakrefable(type_obj, weakrefable);
+    }
+
+    // MRO = C3 linearization over the recorded `__bases__`.
+    let mro = unsafe { crate::baseobjspace::compute_default_mro(type_obj) };
+    unsafe { w_type_set_mro(type_obj, mro) };
+    type_obj
+}
+
 /// Create a named builtin type inheriting from `object`.
 ///
 /// Used by extension modules (e.g. _sre) to define their own types.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -643,6 +643,22 @@ pub fn init_typeobjects() {
             new_typeobject_with_base("range_iterator", |_| {}, object_type) as usize,
         );
         reg.insert(
+            &pyre_object::enumerateobject::ENUMERATE_TYPE as *const PyType as usize,
+            new_typeobject_with_base("enumerate", |_| {}, object_type) as usize,
+        );
+        reg.insert(
+            &pyre_object::dictviewobject::DICT_KEYITERATOR_TYPE as *const PyType as usize,
+            new_typeobject_with_base("dict_keyiterator", |_| {}, object_type) as usize,
+        );
+        reg.insert(
+            &pyre_object::dictviewobject::DICT_VALUEITERATOR_TYPE as *const PyType as usize,
+            new_typeobject_with_base("dict_valueiterator", |_| {}, object_type) as usize,
+        );
+        reg.insert(
+            &pyre_object::dictviewobject::DICT_ITEMITERATOR_TYPE as *const PyType as usize,
+            new_typeobject_with_base("dict_itemiterator", |_| {}, object_type) as usize,
+        );
+        reg.insert(
             &pyre_object::cellobject::CELL_TYPE as *const PyType as usize,
             new_typeobject_with_base("cell", init_cell_type, object_type) as usize,
         );

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -10047,6 +10047,7 @@ pub(crate) fn bytes_method_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, c
         "latin-1" | "latin1" | "iso-8859-1" | "8859" => {
             Wtf8Buf::from_string(data.iter().map(|&b| b as char).collect::<String>())
         }
+        "raw-unicode-escape" => crate::type_methods::decode_raw_unicode_escape(data)?,
         _ => {
             if let Some(result) = crate::type_methods::decode_utf16_32(data, &enc_lower, err_mode) {
                 result?

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -336,6 +336,18 @@ pub fn init_typeobjects() {
             &pyre_object::MAPPING_PROXY_TYPE as *const PyType as usize,
             new_typeobject_with_base("mappingproxy", init_mappingproxy_type, object_type) as usize,
         );
+        // module — `pypy/interpreter/module.py Module.typedef`, bases=(object,).
+        // `W_ModuleObject` carries a custom Rust layout (name + w_dict), so
+        // instances are produced by `w_module_new` at import time, not by the
+        // generic `object.__new__`.  Registering the W_TypeObject gives
+        // `type(m)` a real type (was the bare name string), so `m.__class__`,
+        // `__flags__`, `isinstance(m, object)` and the inherited
+        // `object.__reduce_ex__` all resolve.  `get_instantiate(&MODULE_TYPE)`
+        // (read by `w_module_new`) is wired by the `set_instantiate` loop below.
+        reg.insert(
+            &pyre_object::MODULE_TYPE as *const PyType as usize,
+            new_typeobject_with_base("module", init_module_type, object_type) as usize,
+        );
         // `pypy/objspace/std/dictmultiobject.py:449/459/469` —
         // dict_keys / dict_values / dict_items.  PyPy registers
         // each as a distinct TypeDef but they share the
@@ -1164,6 +1176,62 @@ fn make_maketrans_descr(
     func: fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
 ) -> PyObjectRef {
     pyre_object::w_staticmethod_new(make_builtin_function("maketrans", func))
+}
+
+/// `moduleobject.c module_new` — allocate an anonymous `W_ModuleObject`
+/// (empty name, fresh dict).  The name is seeded by `__init__`, so
+/// `__new__` ignores its arguments.  A subclass instance is retagged
+/// with the actual class.
+fn module_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let w_module = pyre_object::w_module_new("", std::ptr::null_mut());
+    if let Some(cls) = args.first().copied() {
+        if !cls.is_null() {
+            unsafe { (*w_module).w_class = cls };
+        }
+    }
+    Ok(w_module)
+}
+
+/// `moduleobject.c module_init` / `module.py:18-24 Module.__init__` —
+/// `module.__init__(self, name, doc=None)`.  Seeds the `name` field plus
+/// `__name__` / `__doc__` / `__package__` / `__loader__` / `__spec__`
+/// in the module dict.
+fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (positional, _kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if positional.len() < 2 {
+        return Err(crate::PyError::type_error(
+            "module.__init__() missing required argument 'name' (pos 1)".to_string(),
+        ));
+    }
+    let self_ = positional[0];
+    let w_name = positional[1];
+    let w_doc = positional
+        .get(2)
+        .copied()
+        .unwrap_or_else(pyre_object::w_none);
+    let name = crate::baseobjspace::text_w(w_name)?;
+    unsafe { pyre_object::w_module_set_name(self_, name) };
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(self_) };
+    unsafe {
+        pyre_object::w_dict_setitem_str(w_dict, "__name__", w_name);
+        pyre_object::w_dict_setitem_str(w_dict, "__doc__", w_doc);
+        pyre_object::w_dict_setitem_str(w_dict, "__package__", pyre_object::w_none());
+        pyre_object::w_dict_setitem_str(w_dict, "__loader__", pyre_object::w_none());
+        pyre_object::w_dict_setitem_str(w_dict, "__spec__", pyre_object::w_none());
+    }
+    Ok(pyre_object::w_none())
+}
+
+/// `module.py Module.typedef` — wire `__new__` / `__init__` so
+/// `type(m)(name)` builds a real module.  `module` defines its own
+/// `tp_new`, so `module.__new__ is not object.__new__`.
+fn init_module_type(ns: &mut DictStorage) {
+    dict_storage_store(ns, "__new__", make_new_descr(module_descr_new));
+    dict_storage_store(
+        ns,
+        "__init__",
+        make_builtin_function("__init__", module_descr_init),
+    );
 }
 
 fn ellipsis_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2287,9 +2287,9 @@ fn init_str_type(ns: &mut DictStorage) {
             "__getnewargs__",
             |args| {
                 let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-                Ok(pyre_object::w_tuple_new(vec![pyre_object::w_str_from_wtf8(
-                    s.to_owned(),
-                )]))
+                Ok(pyre_object::w_tuple_new(vec![
+                    pyre_object::w_str_from_wtf8(s.to_owned()),
+                ]))
             },
             1,
         ),
@@ -3854,7 +3854,9 @@ fn init_tuple_type(ns: &mut DictStorage) {
             "__getnewargs__",
             |args| {
                 let items = unsafe { pyre_object::w_tuple_items_copy_as_vec(args[0]) };
-                Ok(pyre_object::w_tuple_new(vec![pyre_object::w_tuple_new(items)]))
+                Ok(pyre_object::w_tuple_new(vec![pyre_object::w_tuple_new(
+                    items,
+                )]))
             },
             1,
         ),
@@ -4860,7 +4862,11 @@ fn init_type_type(ns: &mut DictStorage) {
     // typeobject.py:1237 descr__flags — the `tp_flags` bitmask.
     let flags_getter = make_builtin_function_with_arity(
         "__flags__",
-        |args| Ok(pyre_object::w_int_new(unsafe { pyre_object::w_type_get_flags(args[1]) })),
+        |args| {
+            Ok(pyre_object::w_int_new(unsafe {
+                pyre_object::w_type_get_flags(args[1])
+            }))
+        },
         2,
     );
     dict_storage_store(ns, "__flags__", make_getset_descriptor(flags_getter));

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2262,6 +2262,22 @@ fn init_str_type(ns: &mut DictStorage) {
     ] {
         dict_storage_store(ns, name, make_builtin_function_with_arity(name, func, 2));
     }
+    // unicodeobject.py descr_getnewargs — `(W_UnicodeObject(self._utf8),)`:
+    // a fresh plain str from the contents, so a str subclass reduces to str.
+    dict_storage_store(
+        ns,
+        "__getnewargs__",
+        make_builtin_function_with_arity(
+            "__getnewargs__",
+            |args| {
+                let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
+                Ok(pyre_object::w_tuple_new(vec![pyre_object::w_str_from_wtf8(
+                    s.to_owned(),
+                )]))
+            },
+            1,
+        ),
+    );
 }
 
 // ── Dict TypeDef ─────────────────────────────────────────────────────
@@ -3814,6 +3830,19 @@ fn init_tuple_type(ns: &mut DictStorage) {
     ] {
         dict_storage_store(ns, name, make_builtin_function_with_arity(name, func, 2));
     }
+    // tupleobject.py descr_getnewargs — `((self-copy),)`
+    dict_storage_store(
+        ns,
+        "__getnewargs__",
+        make_builtin_function_with_arity(
+            "__getnewargs__",
+            |args| {
+                let items = unsafe { pyre_object::w_tuple_items_copy_as_vec(args[0]) };
+                Ok(pyre_object::w_tuple_new(vec![pyre_object::w_tuple_new(items)]))
+            },
+            1,
+        ),
+    );
 }
 
 /// `tupleobject.c` `tuple * n` / `n * tuple`.  A non-integer count
@@ -4811,6 +4840,14 @@ fn init_type_type(ns: &mut DictStorage) {
         2,
     );
     dict_storage_store(ns, "__mro__", make_getset_descriptor(mro_getter));
+
+    // typeobject.py:1237 descr__flags — the `tp_flags` bitmask.
+    let flags_getter = make_builtin_function_with_arity(
+        "__flags__",
+        |args| Ok(pyre_object::w_int_new(unsafe { pyre_object::w_type_get_flags(args[1]) })),
+        2,
+    );
+    dict_storage_store(ns, "__flags__", make_getset_descriptor(flags_getter));
 
     // `type.mro(cls)` — typeobject.c `mro_external` / `type.mro`: the method
     // form returns the MRO as a fresh list (the `__mro__` getset above
@@ -6881,6 +6918,21 @@ fn init_int_type(ns: &mut DictStorage) {
     ] {
         dict_storage_store(ns, name, make_builtin_function_with_arity(name, func, 2));
     }
+    // intobject.py descr_getnewargs — `(wrapint(self.intval),)`: a fresh
+    // plain int from the value, so an int subclass (e.g. bool) reduces to
+    // the base int.
+    dict_storage_store(
+        ns,
+        "__getnewargs__",
+        make_builtin_function_with_arity(
+            "__getnewargs__",
+            |args| {
+                let v = unsafe { pyre_object::w_int_get_value(args[0]) };
+                Ok(pyre_object::w_tuple_new(vec![pyre_object::w_int_new(v)]))
+            },
+            1,
+        ),
+    );
 }
 fn init_float_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(float_descr_new));
@@ -7255,6 +7307,20 @@ fn init_float_type(ns: &mut DictStorage) {
     ] {
         dict_storage_store(ns, name, make_builtin_function_with_arity(name, func, 2));
     }
+    // floatobject.py descr_getnewargs — `(self.descr_float(),)`: a fresh
+    // plain float from the value.
+    dict_storage_store(
+        ns,
+        "__getnewargs__",
+        make_builtin_function_with_arity(
+            "__getnewargs__",
+            |args| {
+                let v = unsafe { pyre_object::w_float_get_value(args[0]) };
+                Ok(pyre_object::w_tuple_new(vec![pyre_object::w_float_new(v)]))
+            },
+            1,
+        ),
+    );
 }
 
 #[derive(Copy, Clone)]
@@ -7599,11 +7665,36 @@ fn init_object_type(ns: &mut DictStorage) {
             2,
         ),
     );
-    // PyPy: objectobject.py descr___reduce_ex__
+    // objectobject.py descr__reduce__ / descr__reduce_ex__ / descr__getstate__
+    dict_storage_store(
+        ns,
+        "__reduce__",
+        make_builtin_function_with_arity(
+            "__reduce__",
+            |args| crate::reduce_protocol::descr_reduce(args[0]),
+            1,
+        ),
+    );
     dict_storage_store(
         ns,
         "__reduce_ex__",
-        make_builtin_function_with_arity("__reduce_ex__", |_| Ok(pyre_object::w_none()), 2),
+        make_builtin_function_with_arity(
+            "__reduce_ex__",
+            |args| {
+                let proto = unsafe { pyre_object::w_int_get_value(args[1]) };
+                crate::reduce_protocol::descr_reduce_ex(args[0], proto)
+            },
+            2,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__getstate__",
+        make_builtin_function_with_arity(
+            "__getstate__",
+            |args| crate::reduce_protocol::object_getstate_default(args[0]),
+            1,
+        ),
     );
     // typeobject.py descr___init_subclass__ — the default accepts no
     // keywords; class-definition keywords reaching it via the builtin
@@ -8019,6 +8110,22 @@ fn init_bytes_type(ns: &mut DictStorage) {
     ] {
         dict_storage_store(ns, name, make_builtin_function_with_arity(name, func, 2));
     }
+    // bytesobject.py descr_getnewargs — a fresh plain bytes from the value,
+    // so a bytes subclass reduces to bytes.
+    dict_storage_store(
+        ns,
+        "__getnewargs__",
+        make_builtin_function_with_arity(
+            "__getnewargs__",
+            |args| {
+                let data = unsafe { pyre_object::w_bytes_data(args[0]) };
+                Ok(pyre_object::w_tuple_new(vec![
+                    pyre_object::w_bytes_from_bytes(data),
+                ]))
+            },
+            1,
+        ),
+    );
     // bytes methods are mostly shared with bytearray — add as needed.
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -835,6 +835,27 @@ pub fn w_object() -> PyObjectRef {
         .unwrap_or(PY_NULL)
 }
 
+/// Stamp the builtin `__new__` carrier in `ns` with `__self__ =
+/// type_obj` (the type that defines `tp_new`), mirroring
+/// `typeobject.c add_tp_new_wrapper`.  `copyreg._reduce_ex` walks the
+/// MRO testing `base.__new__.__self__ is base`, so each builtin type
+/// that defines `__new__` must carry its own type as the wrapper's
+/// `__self__`.  Inherited `__new__` keeps the ancestor's stamp
+/// (`function_set_new_self` only writes when unset).
+///
+/// # Safety
+/// `ns_ptr` must be a valid, live `DictStorage`; `type_obj` a valid type.
+unsafe fn stamp_new_descr_self(ns_ptr: *mut DictStorage, type_obj: PyObjectRef) {
+    if let Some(w_new) = (*ns_ptr).get("__new__").copied() {
+        if !w_new.is_null() && pyre_object::propertyobject::is_staticmethod(w_new) {
+            let inner = pyre_object::propertyobject::w_staticmethod_get_func(w_new);
+            if !inner.is_null() && crate::function::is_function(inner) {
+                crate::function::function_set_new_self(inner, type_obj);
+            }
+        }
+    }
+}
+
 /// Create the root `object` type. MRO = [object].
 fn new_root_typeobject(name: &str, init: fn(&mut DictStorage)) -> PyObjectRef {
     let mut ns = Box::new(DictStorage::new());
@@ -863,6 +884,7 @@ fn new_root_typeobject(name: &str, init: fn(&mut DictStorage)) -> PyObjectRef {
         pyre_object::w_type_set_weakrefable(type_obj, false);
     }
     unsafe { w_type_set_mro(type_obj, vec![type_obj]) };
+    unsafe { stamp_new_descr_self(ns_ptr, type_obj) };
     type_obj
 }
 
@@ -941,6 +963,7 @@ fn new_typeobject_with_base_and_layout(
         mro.push(base);
     }
     unsafe { w_type_set_mro(type_obj, mro) };
+    unsafe { stamp_new_descr_self(ns_ptr, type_obj) };
     type_obj
 }
 
@@ -1003,6 +1026,7 @@ pub fn make_builtin_type_with_bases(
     // MRO = C3 linearization over the recorded `__bases__`.
     let mro = unsafe { crate::baseobjspace::compute_default_mro(type_obj) };
     unsafe { w_type_set_mro(type_obj, mro) };
+    unsafe { stamp_new_descr_self(ns_ptr, type_obj) };
     type_obj
 }
 
@@ -1117,7 +1141,12 @@ fn float_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 pub(crate) fn make_new_descr(
     func: fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
 ) -> PyObjectRef {
-    let f = make_builtin_function("__new__", func);
+    // `BuiltinFunction`-typed so `type(int.__new__)` differs from a user
+    // `def`'s `function`, letting `copyreg._reduce_ex`'s
+    // `isinstance(new, type(int.__new__))` match only builtin `tp_new`
+    // wrappers (mirrors `builtin_function_or_method`).  `__self__` is
+    // stamped at type-finalisation via `stamp_new_descr_self`.
+    let f = crate::gateway::make_builtin_function_as_builtin("__new__", func);
     pyre_object::w_staticmethod_new(f)
 }
 
@@ -5487,8 +5516,21 @@ fn init_builtin_function_type(ns: &mut DictStorage) {
     // W_TypeObject is still under construction, so `cls` cannot be
     // resolved here; `patch_builtin_function_descriptors` runs after the
     // type cache is populated and writes the missing reqcls.
-    let self_getter =
-        make_builtin_function_with_arity("__self__", |_args| Ok(pyre_object::w_none()), 2);
+    // A builtin `__new__` carrier reports its defining type as `__self__`
+    // (`typeobject.c add_tp_new_wrapper`), stamped via
+    // `stamp_new_descr_self`; every other builtin function keeps the
+    // `always_none` behaviour.
+    let self_getter = make_builtin_function_with_arity(
+        "__self__",
+        |args| {
+            let func = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            if func.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            Ok(unsafe { crate::function::function_get_self_or_none(func) })
+        },
+        2,
+    );
     dict_storage_store(ns, "__self__", make_getset_descriptor(self_getter));
 
     dict_storage_store(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1717,6 +1717,15 @@ thread_local! {
             <pyre_interpreter::module::_pickle::W_Unpickler
                 as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
         );
+        // W_PickleBuffer (`__pypy__.PickleBuffer`) — typed payload via
+        // `#[pyre_class]` in AUTO-ID mode; its `w_obj` field is a traced
+        // edge the collector must walk.  Tail of the tid chain.
+        register_pyre_class(
+            &mut gc,
+            &mut pytype_to_tid,
+            <pyre_interpreter::module::__pypy__::W_PickleBuffer
+                as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        );
         // rclass.py:340-346 — assign subclassrange_{min,max} to each
         // vtable entry. freeze_types() runs assign_inheritance_ids
         // (normalizecalls.py:373-389), then we write the computed ranges

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1699,6 +1699,24 @@ thread_local! {
             <pyre_object::genericaliasobject::W_GenericAlias
                 as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
         );
+        // W_Pickler / W_Unpickler (`_pickle` accelerator) — typed payloads
+        // via `#[pyre_class]` in AUTO-ID mode.  Both carry inline
+        // `PyObjectRef` fields (the pickler's output file; the unpickler's
+        // read/readline callables, result stack, and active frame) that the
+        // collector must walk.  Registered at the tail of the tid chain so
+        // no earlier explicit-id slot shifts.
+        register_pyre_class(
+            &mut gc,
+            &mut pytype_to_tid,
+            <pyre_interpreter::module::_pickle::W_Pickler
+                as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        );
+        register_pyre_class(
+            &mut gc,
+            &mut pytype_to_tid,
+            <pyre_interpreter::module::_pickle::W_Unpickler
+                as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        );
         // rclass.py:340-346 — assign subclassrange_{min,max} to each
         // vtable entry. freeze_types() runs assign_inheritance_ids
         // (normalizecalls.py:373-389), then we write the computed ranges

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1607,6 +1607,9 @@ fn expand_pyre_methods(
 
         let mut unwrap_stmts = Vec::<proc_macro2::TokenStream>::new();
         let mut call_args = Vec::<proc_macro2::TokenStream>::new();
+        let mut param_names = Vec::<String>::new();
+        let mut param_required = Vec::<bool>::new();
+        let mut has_varargs = false;
         for (offset, arg) in inputs.enumerate() {
             let FnArg::Typed(pt) = arg else {
                 return Err(syn::Error::new(
@@ -1615,10 +1618,65 @@ fn expand_pyre_methods(
                 ));
             };
             let arg_idx = offset + first_arg_idx;
+            if is_varargs_param(&pt.ty) {
+                has_varargs = true;
+            }
+            param_names.push(param_name(offset, pt));
+            // Optional iff it has a `#[default(...)]` or is `Option<T>`.
+            param_required.push(arg_default(pt)?.is_none() && option_inner(&pt.ty).is_none());
             let (stmt, ident) = unwrap_arg(arg_idx, pt)?;
             unwrap_stmts.push(stmt);
             call_args.push(quote! { #ident });
         }
+
+        // Keyword-binding preamble (mirrors `#[pyre_function]`): when the
+        // call carried a trailing `__pyre_kw__` dict, rebind positional +
+        // keyword args into a resolved scope keyed by parameter name before
+        // the receiver/arg unwraps run; otherwise the positional fast path
+        // is untouched. Instance methods prepend a `self` slot — filled
+        // positionally — so the receiver index lines up with the bound
+        // scope; static/class methods already carry every slot (including
+        // `cls`) as a typed parameter. Property getters/setters/deleters use
+        // the descriptor calling convention and varargs methods consume the
+        // whole slice, so both opt out.
+        let kwargs_preamble = {
+            let is_property = matches!(
+                kind,
+                MethodKind::Getter(..) | MethodKind::Setter(..) | MethodKind::Deleter(..)
+            );
+            if has_varargs || is_property {
+                quote! {}
+            } else {
+                let mut all_names: Vec<String> = Vec::new();
+                let mut all_required: Vec<bool> = Vec::new();
+                if matches!(kind, MethodKind::Instance) {
+                    all_names.push("self".to_string());
+                    all_required.push(true);
+                }
+                all_names.extend(param_names.iter().cloned());
+                all_required.extend(param_required.iter().copied());
+                let name_lits = all_names.iter().map(|n| quote! { #n });
+                let req_lits = all_required.iter().map(|b| quote! { #b });
+                let fn_name_str = mname.to_string();
+                quote! {
+                    const __PYRE_PARAM_NAMES: &[&str] = &[ #(#name_lits),* ];
+                    const __PYRE_PARAM_REQUIRED: &[bool] = &[ #(#req_lits),* ];
+                    let __pyre_bound_args;
+                    let args: &[::pyre_object::PyObjectRef] =
+                        if crate::builtins::has_builtin_kwargs(args) {
+                            __pyre_bound_args = crate::builtins::bind_builtin_kwargs(
+                                args,
+                                __PYRE_PARAM_NAMES,
+                                __PYRE_PARAM_REQUIRED,
+                                #fn_name_str,
+                            )?;
+                            &__pyre_bound_args
+                        } else {
+                            args
+                        };
+                }
+            }
+        };
 
         let call_inner = quote! { #call_target( #(#call_args),* ) };
         let body = wrap_return(&m.sig.output, call_inner)?;
@@ -1667,6 +1725,7 @@ fn expand_pyre_methods(
             pub fn #wrapper_name(
                 args: &[::pyre_object::PyObjectRef],
             ) -> ::std::result::Result<::pyre_object::PyObjectRef, crate::PyError> {
+                #kwargs_preamble
                 #preamble
                 #(#unwrap_stmts)*
                 #body

--- a/pyre/pyre-object/src/moduleobject.rs
+++ b/pyre/pyre-object/src/moduleobject.rs
@@ -169,6 +169,17 @@ pub unsafe fn w_module_get_name(obj: PyObjectRef) -> &'static str {
     &*module.name
 }
 
+/// Replace the module name (`module.py:24` re-seeding).  Used by
+/// `module.__init__(name, doc)` after `module.__new__` allocates an
+/// anonymous module.  The previous (immortal) name string is leaked.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ModuleObject`.
+pub unsafe fn w_module_set_name(obj: PyObjectRef, name: &str) {
+    let module = &mut *(obj as *mut W_ModuleObject);
+    module.name = crate::lltype::malloc_raw(name.to_string());
+}
+
 /// Get the module's backing `DictStorage` pointer (`*mut u8`).
 ///
 /// Resolves through `w_dict.dict_storage_proxy` — pyre no longer carries a

--- a/pyre/pyre-object/src/rangeobject.rs
+++ b/pyre/pyre-object/src/rangeobject.rs
@@ -104,6 +104,26 @@ pub unsafe fn w_range_iter_fields(obj: PyObjectRef) -> (i64, i64, i64) {
     unsafe { ((*iter).current, (*iter).stop, (*iter).step) }
 }
 
+/// Count of elements not yet produced by a range iterator — the number
+/// of `current += step` steps before `current` crosses `stop`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_RangeIterator`.
+pub unsafe fn w_range_iter_remaining(obj: PyObjectRef) -> i64 {
+    let (current, stop, step) = unsafe { w_range_iter_fields(obj) };
+    if step > 0 {
+        if current >= stop {
+            0
+        } else {
+            (stop - current + step - 1) / step
+        }
+    } else if current <= stop {
+        0
+    } else {
+        (current - stop - step - 1) / (-step)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,6 +648,18 @@ pub unsafe fn w_long_range_iter_len(obj: PyObjectRef) -> BigInt {
     }
 }
 
+/// Read the `(start, step, len, index)` fields of a long-range iterator
+/// as wrapped int/long objects.
+///
+/// # Safety
+/// `obj` must point to a valid `W_LongRangeIterator`.
+pub unsafe fn w_long_range_iter_fields(
+    obj: PyObjectRef,
+) -> (PyObjectRef, PyObjectRef, PyObjectRef, PyObjectRef) {
+    let it = obj as *const W_LongRangeIterator;
+    unsafe { ((*it).start, (*it).step, (*it).len, (*it).index) }
+}
+
 /// Whether the long-range iterator has elements left — peek, non-mutating.
 ///
 /// # Safety
@@ -765,6 +797,44 @@ pub fn w_seq_iter_new(seq: PyObjectRef, length: usize) -> PyObjectRef {
 
 pub unsafe fn is_seq_iter(obj: PyObjectRef) -> bool {
     !obj.is_null() && unsafe { (*obj).ob_type == &SEQ_ITER_TYPE as *const PyType }
+}
+
+/// The wrapped sequence the iterator walks.
+///
+/// # Safety
+/// `obj` must point to a valid `W_SeqIterator`.
+#[inline]
+pub unsafe fn w_seq_iter_seq(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_SeqIterator)).seq }
+}
+
+/// The current cursor position.
+///
+/// # Safety
+/// `obj` must point to a valid `W_SeqIterator`.
+#[inline]
+pub unsafe fn w_seq_iter_index(obj: PyObjectRef) -> i64 {
+    unsafe { (*(obj as *const W_SeqIterator)).index }
+}
+
+/// The captured sequence length.
+///
+/// # Safety
+/// `obj` must point to a valid `W_SeqIterator`.
+#[inline]
+pub unsafe fn w_seq_iter_length(obj: PyObjectRef) -> i64 {
+    unsafe { (*(obj as *const W_SeqIterator)).length }
+}
+
+/// Set the cursor position.
+///
+/// # Safety
+/// `obj` must point to a valid `W_SeqIterator`.
+#[inline]
+pub unsafe fn w_seq_iter_set_index(obj: PyObjectRef, value: i64) {
+    unsafe {
+        (*(obj as *mut W_SeqIterator)).index = value;
+    }
 }
 
 #[cfg(test)]

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -664,6 +664,36 @@ pub unsafe fn w_type_is_heaptype(obj: PyObjectRef) -> bool {
     (*(obj as *const W_TypeObject)).flag_heaptype
 }
 
+/// typeobject.py:866 `get_flags(self)` — the `__flags__` bitmask.
+///
+/// `_HEAPTYPE = 1<<9`, `_CPYTYPE = 1` (non-heap builtin types),
+/// `PATMA_SEQUENCE = 1<<5`, `PATMA_MAPPING = 1<<6`.  pyre tracks
+/// `flag_heaptype` and `flag_map_or_seq`; the cpytype bit follows
+/// `!flag_heaptype` (every non-heap type is a builtin C type).  The
+/// abstract / method-descriptor bits have no pyre flag yet.
+pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
+    if obj.is_null() || !is_type(obj) {
+        return 0;
+    }
+    const HEAPTYPE: i64 = 1 << 9;
+    const CPYTYPE: i64 = 1;
+    const PATMA_SEQUENCE: i64 = 1 << 5;
+    const PATMA_MAPPING: i64 = 1 << 6;
+    let t = &*(obj as *const W_TypeObject);
+    let mut flags = 0i64;
+    if t.flag_heaptype {
+        flags |= HEAPTYPE;
+    } else {
+        flags |= CPYTYPE;
+    }
+    match t.flag_map_or_seq.load(std::sync::atomic::Ordering::Acquire) {
+        b'M' => flags |= PATMA_MAPPING,
+        b'S' => flags |= PATMA_SEQUENCE,
+        _ => {}
+    }
+    flags
+}
+
 /// typedef.py:43 `acceptable_as_base_class` — read from Layout level.
 /// typeobject.py:1116: w_bestbase.layout.typedef.acceptable_as_base_class
 pub unsafe fn w_type_get_acceptable_as_base_class(obj: PyObjectRef) -> bool {

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -190,6 +190,13 @@ pub struct W_TypeObject {
     /// has no TypeDef struct, so the creation site of each builtin
     /// W_TypeObject sets it directly.
     pub flag_method_descriptor: bool,
+    /// `Py_TPFLAGS_DISALLOW_INSTANTIATION` (`1 << 7`) — set on types
+    /// whose `tp_new` is NULL (generator / coroutine / frame / ...).
+    /// `type.__call__` raises `cannot create 'X' instances` and
+    /// `reduce_newobj` raises `cannot pickle 'X' object` when set.  Set
+    /// once after construction via `w_type_set_disallow_instantiation`;
+    /// never inherited by heap subclasses (the default is `false`).
+    pub flag_disallow_instantiation: std::sync::atomic::AtomicBool,
 }
 
 /// Source of fresh `version_tag` identities (`VersionTag()`, typeobject.py:73).
@@ -295,6 +302,9 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         // typeobject.py:256 — user-defined typedefs never set
         // `method_descriptor` (typedef.py:22 default `False`).
         flag_method_descriptor: false,
+        // Heap subclasses are always instantiable (their `tp_new` is the
+        // slot wrapper); only builtin disallow-types flip this.
+        flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
     }) as PyObjectRef;
     register_heap_type(w_type as usize);
     w_type
@@ -380,6 +390,10 @@ pub fn w_type_new_builtin(
         // default `False`); the `function` creation site flips it
         // (typedef.py:807).
         flag_method_descriptor: false,
+        // `Py_TPFLAGS_DISALLOW_INSTANTIATION` off by default; the
+        // generator / coroutine / frame typedefs flip it via
+        // `w_type_set_disallow_instantiation`.
+        flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
     }) as PyObjectRef
 }
 
@@ -446,6 +460,35 @@ pub unsafe fn w_type_set_flag_map_or_seq(w_type: PyObjectRef, flag: u8) {
     let t = &*(w_type as *const W_TypeObject);
     t.flag_map_or_seq
         .store(flag, std::sync::atomic::Ordering::Release);
+}
+
+/// `Py_TPFLAGS_DISALLOW_INSTANTIATION` reader — `True` when `w_type`'s
+/// `tp_new` is conceptually NULL (the type refuses `Type()`).
+///
+/// # Safety
+/// `w_type` must be a valid PyObjectRef pointing at a `W_TypeObject`.
+pub unsafe fn w_type_disallows_instantiation(w_type: PyObjectRef) -> bool {
+    if w_type.is_null() || !is_type(w_type) {
+        return false;
+    }
+    let t = &*(w_type as *const W_TypeObject);
+    t.flag_disallow_instantiation
+        .load(std::sync::atomic::Ordering::Acquire)
+}
+
+/// `Py_TPFLAGS_DISALLOW_INSTANTIATION` setter — flips a builtin type to
+/// refuse instantiation.  Called once at typedef registration for
+/// generator / coroutine / frame-shaped types.
+///
+/// # Safety
+/// `w_type` must be a valid PyObjectRef pointing at a `W_TypeObject`.
+pub unsafe fn w_type_set_disallow_instantiation(w_type: PyObjectRef) {
+    if w_type.is_null() || !is_type(w_type) {
+        return;
+    }
+    let t = &*(w_type as *const W_TypeObject);
+    t.flag_disallow_instantiation
+        .store(true, std::sync::atomic::Ordering::Release);
 }
 
 // ── Layout accessors ─────────────────────────────────────────────────
@@ -667,16 +710,18 @@ pub unsafe fn w_type_is_heaptype(obj: PyObjectRef) -> bool {
 /// typeobject.py:866 `get_flags(self)` — the `__flags__` bitmask.
 ///
 /// `_HEAPTYPE = 1<<9`, `_CPYTYPE = 1` (non-heap builtin types),
-/// `PATMA_SEQUENCE = 1<<5`, `PATMA_MAPPING = 1<<6`.  pyre tracks
-/// `flag_heaptype` and `flag_map_or_seq`; the cpytype bit follows
-/// `!flag_heaptype` (every non-heap type is a builtin C type).  The
-/// abstract / method-descriptor bits have no pyre flag yet.
+/// `PATMA_SEQUENCE = 1<<5`, `PATMA_MAPPING = 1<<6`,
+/// `DISALLOW_INSTANTIATION = 1<<7`.  pyre tracks `flag_heaptype`,
+/// `flag_map_or_seq` and `flag_disallow_instantiation`; the cpytype bit
+/// follows `!flag_heaptype` (every non-heap type is a builtin C type).
+/// The abstract / method-descriptor bits have no pyre flag yet.
 pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
     if obj.is_null() || !is_type(obj) {
         return 0;
     }
     const HEAPTYPE: i64 = 1 << 9;
     const CPYTYPE: i64 = 1;
+    const DISALLOW_INSTANTIATION: i64 = 1 << 7;
     const PATMA_SEQUENCE: i64 = 1 << 5;
     const PATMA_MAPPING: i64 = 1 << 6;
     let t = &*(obj as *const W_TypeObject);
@@ -685,6 +730,11 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
         flags |= HEAPTYPE;
     } else {
         flags |= CPYTYPE;
+    }
+    if t.flag_disallow_instantiation
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        flags |= DISALLOW_INSTANTIATION;
     }
     match t.flag_map_or_seq.load(std::sync::atomic::Ordering::Acquire) {
         b'M' => flags |= PATMA_MAPPING,


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Implements `pickle` support (#163) in two parts: Python-level protocol foundations and an interp-level `_pickle` accelerator. Wire output targets CPython 3.14; PyPy `pypy/module/_pickle/interp_pickle.py` is the porting-structure reference.

### Protocol foundations (sub-project A)

- Drop the interp-level `copyreg` shadow so the stdlib `copyreg.py` imports.
- Default a frame's builtins to `space.builtin` (honors `__builtins__ = False`).
- `_io` `UnsupportedOperation` + `BytesIO`, `_sre.MAGIC`, `STORE_SLICE`.
- Empty `bytes`/`bytearray` are falsy (length-based truthiness).
- Add the `__pypy__` module; `str(bytes, encoding)` and `raw-unicode-escape`.
- `object.__reduce__`/`__reduce_ex__`/`__getstate__` + `__getnewargs__`.
- `__reduce__`/`__setstate__`/`__length_hint__` for built-in iterators.
- `itertools.batched(iterable, n, *, strict=False)`.

### `_pickle` accelerator (sub-project B)

Interp-level `Pickler`/`Unpickler` covering protocols 0–5:

- Atoms (Pickler/Unpickler core), memo back-references, `tuple`/`list`/`dict` containers.
- `set`/`frozenset` (proto >= 4), `bytearray` (proto >= 5).
- The reduce protocol: `save_reduce`/`save_global`/`find_class`.
- Protocol 0/1 text opcodes, `persistent_id`, `_compat_pickle` `fix_imports`.
- Multi-frame framer with large-payload bypass.
- Protocol-5 out-of-band buffers and `PickleBuffer` (`buffer_callback`/`buffers`, `NEXT_BUFFER`/`READONLY_BUFFER`).
- The flip: module-level `dump`/`dumps`/`load`/`loads` + exception classes exported so `pickle.py`'s accelerated all-or-nothing import path engages.

### Enabling change

- `pyre-macros`: `#[pyre_methods]`/`#[pyre_class]` method wrappers now bind keyword arguments (gated on a trailing builtin-kwargs dict; zero positional blast radius). Required for `Pickler.__init__(file, protocol=None, fix_imports=True, buffer_callback=None)` and friends.

### Validation

- `check.py` green on both backends (aarch64); `cargo test --all` green.
- `_pickle` wire output verified byte-identical to CPython 3.14 across atoms/containers/sets/bytearray/reduce/proto-0-1/framing/OOB buffers.
- New snippets: iterator protocol round-trip, `_pickle` module round-trip, OOB buffers.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
