### PR TITLE
majit-gc: GC-safe backend reference constants — per-loop gc_table + rgc.can_move baking guard (#108)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6333,6 +6333,16 @@ struct CompiledLoop {
     /// an immediate; holding the clone here keeps the `RwLock`
     /// allocation alive for the lifetime of the compiled code.
     cpu_attachments: CpuDescrHandle,
+    /// `assembler.py:822 gcreftracers.append(tracer)`: the per-loop
+    /// reference-constant `GcTable`, or `None` when the trace references
+    /// none. Its base address is baked into machine code by the
+    /// `LoadFromGcTable` genop, so the strong `Arc` must outlive the
+    /// compiled code. `do_compile` hands it back here; `compile_loop` /
+    /// `compile_bridge` push it onto the owning CLT's
+    /// `asmmemmgr_gcreftracers` (the authoritative keepalive, matching
+    /// `register_fail_descrs`), because a bridge's `CompiledLoop` is
+    /// consumed into `BridgeData` and would otherwise drop the table.
+    gc_table: Option<Arc<majit_gc::GcTable>>,
 }
 
 unsafe impl Send for CompiledLoop {}
@@ -7788,13 +7798,13 @@ impl CraneliftBackend {
         inputargs: &[InputArg],
         ops: &[Op],
         constants: &majit_ir::VecAssoc<u32, majit_ir::Const>,
-    ) -> Vec<Op> {
+    ) -> (Vec<Op>, Vec<GcRef>) {
         let mut normalized = normalize_ops_for_codegen_simple(inputargs, ops);
         inject_builtin_string_descrs(&mut normalized);
         if let Some(rewriter) = self.gc_rewriter() {
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
-            let (result, new_constants, _gcrefs) =
+            let (result, new_constants, gcrefs) =
                 rewriter.rewrite_for_gc_with_constants(&normalized, constants);
             // rewrite.py creates fresh ConstInt boxes for sizes, offsets
             // and helper addresses; `new_constants` is the full typed pool.
@@ -7803,9 +7813,9 @@ impl CraneliftBackend {
             for (k, c) in new_constants {
                 self.constants.entry(k).or_insert(c);
             }
-            result
+            (result, gcrefs)
         } else {
-            normalized
+            (normalized, Vec::new())
         }
     }
 
@@ -8007,8 +8017,17 @@ impl CraneliftBackend {
         caller_layout: Option<&ExitRecoveryLayout>,
     ) -> Result<CompiledLoop, BackendError> {
         validate_call_assembler_rewrite_prereqs(ops)?;
-        let prepared_ops = self.prepare_ops_for_compile(inputargs, ops, &self.constants.clone());
+        let (prepared_ops, gcrefs) =
+            self.prepare_ops_for_compile(inputargs, ops, &self.constants.clone());
         let ops = prepared_ops.as_slice();
+        // assembler.py:793-824 parity: build the per-loop gc_table from
+        // the rewrite's reference-constant list. Its base address is baked
+        // by the `LoadFromGcTable` genop; the strong `Arc` is moved into
+        // the returned `CompiledLoop` so it outlives the baked immediate,
+        // and the gc_table walker forwards its slots across collections.
+        // Empty list ⇒ no table, base stays 0.
+        let gc_table = (!gcrefs.is_empty()).then(|| majit_gc::GcTable::from_gcrefs(&gcrefs));
+        let gc_table_base = gc_table.as_ref().map_or(0usize, |t| t.base_addr());
         // RPython parity: regalloc asserts that every Box used as an
         // argument or in fail_args is bound to a register or stack
         // location before code emission begins. The pyre/Cranelift
@@ -13314,11 +13333,25 @@ impl CraneliftBackend {
                 }
 
                 // ── Load from GC table ──
+                // `assembler.py:1545` `genop_load_from_gc_table`: load the
+                // reference constant at `gc_table_base + index*WORD`.
+                // arg(0) is the `ConstInt(index)` produced by the rewrite's
+                // `remove_constptr`; the table base is baked absolute
+                // because cranelift's `JITModule` exposes no
+                // code-buffer-start reservation seam (x86-32 `MOV_rj`
+                // model, `assembler.py:1551-1552`). The slot value is
+                // GC-forwarded in place by the gc_table root walker, so
+                // each load observes the relocated object. Cranelift folds
+                // `base + (const_index << 3)` to a single address.
                 OpCode::LoadFromGcTable => {
-                    // Load a constant pointer from the GC table.
-                    // arg(0) = index into the gc table
                     let index = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    builder.def_var(var(vi), index);
+                    let base = builder.ins().iconst(cl_types::I64, gc_table_base as i64);
+                    let byte_ofs = builder.ins().ishl_imm(index, 3);
+                    let slot_addr = builder.ins().iadd(base, byte_ofs);
+                    let value = builder
+                        .ins()
+                        .load(ptr_type, MemFlags::trusted(), slot_addr, 0);
+                    builder.def_var(var(vi), value);
                 }
 
                 // ── Load effective address ──
@@ -13617,7 +13650,27 @@ impl CraneliftBackend {
             num_ref_roots: ref_root_slots.len(),
             max_output_slots,
             cpu_attachments: self.cpu_handle(),
+            gc_table,
         })
+    }
+
+    /// `assembler.py:822 gcreftracers.append(tracer)` parity for the
+    /// per-loop reference-constant `GcTable`.  The table's base address is
+    /// baked into machine code by the `LoadFromGcTable` genop, so the
+    /// strong `Arc` must outlive the compiled trace.
+    /// `clt.asmmemmgr_gcreftracers` is that lifetime root (`model.py:294`
+    /// / `llmodel.py:252-268 free_loop_and_bridges`), the same root used
+    /// by `register_fail_descrs`; when the CLT drops, the table frees and
+    /// its `Weak` in the gcreftracer registry is reaped lazily.
+    fn register_gc_table(
+        &self,
+        token: &majit_backend::JitCellToken,
+        table: Arc<majit_gc::GcTable>,
+    ) {
+        if let Some(clt) = token.compiled_loop_token.as_ref() {
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = table;
+            clt.asmmemmgr_gcreftracers.lock().push(tracer);
+        }
     }
 }
 
@@ -14655,6 +14708,9 @@ impl majit_backend::Backend for CraneliftBackend {
         }
         self.registered_call_assembler_tokens.insert(token.number);
         self.register_fail_descrs(token, &compiled.fail_descrs);
+        if let Some(table) = compiled.gc_table.clone() {
+            self.register_gc_table(token, table);
+        }
 
         // `compile.py:183-186 record_loop_or_bridge`: for each ResumeDescr
         // in the newly-compiled trace, stamp the owning CompiledLoopToken.
@@ -14864,6 +14920,12 @@ impl majit_backend::Backend for CraneliftBackend {
         // are scoped to the original loop's CLT, so the tracer batch
         // lands on `original_token`'s `asmmemmgr_gcreftracers`.
         self.register_fail_descrs(original_token, &compiled.fail_descrs);
+        // The bridge's `CompiledLoop` is consumed into `BridgeData` below,
+        // so its `gc_table` would drop with it; pin the table on the
+        // original loop's CLT (same scope as the bridge's fail descrs).
+        if let Some(table) = compiled.gc_table.clone() {
+            self.register_gc_table(original_token, table);
+        }
 
         // Attach the bridge to the original guard's fail descriptor so that
         // execute_token can dispatch to it on subsequent guard failures.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3993,6 +3993,21 @@ fn use_declared_var_or_panic(builder: &mut FunctionBuilder, opref: OpRef, what: 
     builder.use_var(var(opref.raw()))
 }
 
+/// `x86/regalloc.py:58-61` `convert_to_imm` ConstPtr guard: a non-null
+/// `ConstPtr` whose object can still move must never be baked as an
+/// immediate — `remove_constptr` (rewrite.py:1100) routes those through the
+/// gc_table. Null and non-moving (prebuilt / old-gen / no active GC)
+/// ConstPtrs are baked directly. `rgc.can_move` parity via
+/// `majit_gc::can_move`; the `we_are_translated()` clause is subsumed
+/// because `can_move` is false when no moving GC is active.
+fn guard_constptr_immediate(opref: OpRef) {
+    if let Some(g) = opref.as_const_ptr() {
+        if !g.is_null() && majit_gc::can_move(g) {
+            panic!("convert_to_imm: ConstPtr needs special care");
+        }
+    }
+}
+
 fn resolve_opref(
     builder: &mut FunctionBuilder,
     constants: &majit_ir::VecAssoc<u32, i64>,
@@ -4011,17 +4026,12 @@ fn resolve_opref(
          emitted this null OpRef must bind it (or rewrite the op) \
          instead of relying on a zero-load fallback"
     );
-    // rewrite.py:1100 post-flip invariant: `remove_constptr` routes every
-    // non-null reference constant *operand* through `LoadFromGcTable`, so
-    // a non-null `ConstPtr` must never reach op-arg resolution (which would
-    // bake an immortal, un-forwarded immediate). This path is op-arg-only;
-    // failargs resolve through `resolve_failarg_opref` and keep their
-    // constants. Null pointers stay inline and are allowed.
-    debug_assert!(
-        !opref.as_const_ptr().is_some_and(|g| !g.is_null()),
-        "cranelift resolve_opref: non-null ConstPtr {opref:?} reached op-arg \
-         resolution — remove_constptr must have replaced it with LoadFromGcTable"
-    );
+    // x86/regalloc.py:58-61: a non-null movable `ConstPtr` must never be
+    // baked as an immediate. Op-args are additionally all-rewritten to
+    // `LoadFromGcTable` (rewrite.py:1100), so in a GC-rewritten trace this
+    // never fires for op-args; the guard is the shared `convert_to_imm`
+    // parity check (null / non-moving ConstPtrs are baked directly).
+    guard_constptr_immediate(opref);
     // RPython boxes/inputargs are distinct from Consts even when pyre's
     // compact OpRef numbering collides with an entry in the constant pool.
     // Once an OpRef has a declared variable, the variable is authoritative.
@@ -4869,6 +4879,8 @@ fn resolve_opref_or_imm(
     if opref.is_none() {
         return builder.ins().iconst(cl_types::I64, 0);
     }
+    // x86/regalloc.py:58-61: refuse baking a movable non-null ConstPtr.
+    guard_constptr_immediate(opref);
     // Inline-Const fast path: history.py:227/268/314 — value lives on
     // the Box, not in a side pool.
     if let Some(c) = opref.inline_const_bits() {
@@ -4895,6 +4907,10 @@ fn resolve_failarg_opref(
     ref_root_base_ofs: i32,
     opref: OpRef,
 ) -> CValue {
+    // x86/regalloc.py:58-61: refuse baking a movable non-null ConstPtr —
+    // a fail-arg reference constant whose object can move must be reloaded
+    // through GC-forwarded resume data, not frozen as an immediate.
+    guard_constptr_immediate(opref);
     // Inline-Const fast path: history.py:227/268/314 — Const Box value
     // is inline. Stale-ref reload only applies to op-result variables
     // (regalloc-assigned slots), never to constants.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4005,6 +4005,17 @@ fn resolve_opref(
          emitted this null OpRef must bind it (or rewrite the op) \
          instead of relying on a zero-load fallback"
     );
+    // rewrite.py:1100 post-flip invariant: `remove_constptr` routes every
+    // non-null reference constant *operand* through `LoadFromGcTable`, so
+    // a non-null `ConstPtr` must never reach op-arg resolution (which would
+    // bake an immortal, un-forwarded immediate). This path is op-arg-only;
+    // failargs resolve through `resolve_failarg_opref` and keep their
+    // constants. Null pointers stay inline and are allowed.
+    debug_assert!(
+        !opref.as_const_ptr().is_some_and(|g| !g.is_null()),
+        "cranelift resolve_opref: non-null ConstPtr {opref:?} reached op-arg \
+         resolution — remove_constptr must have replaced it with LoadFromGcTable"
+    );
     // RPython boxes/inputargs are distinct from Consts even when pyre's
     // compact OpRef numbering collides with an entry in the constant pool.
     // Once an OpRef has a declared variable, the variable is authoritative.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1377,6 +1377,12 @@ fn get_actual_typeid_via_active_runtime(gcref: GcRef) -> Option<u32> {
     with_cranelift_gc(|gc| gc.get_actual_typeid(gcref)).flatten()
 }
 
+/// `majit_gc::CanMoveFn` installed by `set_gc_allocator`. Mirrors
+/// `rgc.can_move` (rpython/rlib/rgc.py:229).
+fn can_move_via_active_runtime(gcref: GcRef) -> bool {
+    with_cranelift_gc(|gc| gc.can_move(gcref)).unwrap_or(false)
+}
+
 /// `majit_gc::SubclassRangeFn` installed by `set_gc_allocator`.
 /// Resolves the codegen-time `rclass.CLASSTYPE.subclassrange_{min,max}`
 /// lookup from x86/assembler.py:1971-1974 through the GC's
@@ -7673,6 +7679,7 @@ impl CraneliftBackend {
             subclass_range: Some(subclass_range_via_active_runtime),
             typeid_subclass_range: Some(typeid_subclass_range_via_active_runtime),
             typeid_is_object: Some(typeid_is_object_via_active_runtime),
+            can_move: Some(can_move_via_active_runtime),
             supports_guard_gc_type,
         });
         majit_gc::set_active_alloc_nursery_typed(Some(alloc_nursery_typed_via_active_runtime));

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7794,7 +7794,7 @@ impl CraneliftBackend {
         if let Some(rewriter) = self.gc_rewriter() {
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
-            let (result, new_constants) =
+            let (result, new_constants, _gcrefs) =
                 rewriter.rewrite_for_gc_with_constants(&normalized, constants);
             // rewrite.py creates fresh ConstInt boxes for sizes, offsets
             // and helper addresses; `new_constants` is the full typed pool.

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2433,8 +2433,7 @@ impl<'a> AssemblerARM64<'a> {
             // The slot value is GC-forwarded in place by the gc_table
             // root walker, so each load observes the relocated object.
             OpCode::LoadFromGcTable => {
-                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) =
-                    (arglocs.first(), result_loc)
+                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
                 {
                     let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
                     self.emit_mov_imm64(dst.value as u32, slot_addr as i64);

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -312,6 +312,12 @@ pub struct AssemblerARM64<'a> {
     /// `self.cpu` attribute-access after whole-program translation,
     /// where the `cpu` object's identity is guaranteed by Python.
     cpu_handle: crate::guard::CpuDescrHandle,
+    /// `assembler.py:1545` `genop_load_from_gc_table`: base address of
+    /// this loop's per-loop `GcTable` slot array. Baked as a 64-bit
+    /// immediate by the `LoadFromGcTable` genop; 0 when the trace
+    /// references no reference constants. Set before `assemble_loop` /
+    /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
+    gc_table_base: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
@@ -448,7 +454,16 @@ impl<'a> AssemblerARM64<'a> {
             pending_force_cell: None,
             attached_descrs,
             cpu_handle,
+            gc_table_base: 0,
         }
+    }
+
+    /// `assembler.py:793-824` parity: hand the per-loop `GcTable`'s base
+    /// address to the assembler before emission, so `LoadFromGcTable`
+    /// genops bake it as the slot-array base immediate. 0 leaves the
+    /// trace with no reference constants (no `LoadFromGcTable` emitted).
+    pub(crate) fn set_gc_table_base(&mut self, base: usize) {
+        self.gc_table_base = base;
     }
 
     /// `compile.py:665` parity: heap-pinned address of `self.cpu`'s
@@ -2402,12 +2417,28 @@ impl<'a> AssemblerARM64<'a> {
             | OpCode::SameAsR
             | OpCode::SameAsF
             | OpCode::CastOpaquePtr
-            | OpCode::LoadFromGcTable
             | OpCode::VirtualRefR
             | OpCode::ConvertFloatBytesToLonglong
             | OpCode::ConvertLonglongBytesToFloat => {
                 if let (Some(src), Some(dst)) = (arglocs.first(), result_loc) {
                     self.regalloc_mov(src, dst);
+                }
+            }
+            // `assembler.py:1545` `genop_load_from_gc_table`: load the
+            // reference constant at `gc_table_base + index*WORD`. The
+            // index arrives as an immediate (the `ConstInt(index)` arg
+            // produced by `remove_constptr`); the table base is baked
+            // absolute (x86-32 `MOV_rj` model, `assembler.py:1551-1552`)
+            // because dynasm has no code-buffer-start reservation seam.
+            // The slot value is GC-forwarded in place by the gc_table
+            // root walker, so each load observes the relocated object.
+            OpCode::LoadFromGcTable => {
+                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) =
+                    (arglocs.first(), result_loc)
+                {
+                    let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
+                    self.emit_mov_imm64(dst.value as u32, slot_addr as i64);
+                    dynasm!(self.mc ; .arch aarch64 ; ldr X(dst.value), [X(dst.value)]);
                 }
             }
             // `opassembler.py:269-270 emit_op_cast_ptr_to_int =

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -1538,6 +1538,18 @@ impl RegisterManager {
     /// x86/regalloc.py:55 convert_to_imm
     pub fn convert_to_imm(&self, v: OpRef, constants: &majit_ir::VecAssoc<u32, i64>) -> Loc {
         debug_assert!(v.is_constant());
+        // x86/regalloc.py:58-61: a non-null `ConstPtr` whose object can
+        // still move must never be baked as an immediate — `remove_constptr`
+        // (rewrite.py:1100) routes those through the gc_table. Null and
+        // non-moving (prebuilt / old-gen / no active GC) ConstPtrs are baked
+        // directly. `rgc.can_move` parity via `majit_gc::can_move`; the
+        // `we_are_translated()` clause is subsumed because `can_move` is
+        // false when no moving GC is active.
+        if let Some(g) = v.as_const_ptr() {
+            if !g.is_null() && majit_gc::can_move(g) {
+                panic!("convert_to_imm: ConstPtr needs special care");
+            }
+        }
         // history.py:227/268/314 — inline-Const variants carry the value
         // directly; legacy pool-indexed Const variants look up the i64
         // raw bits via the constants snapshot.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -150,6 +150,10 @@ fn dynasm_get_actual_typeid(gcref: GcRef) -> Option<u32> {
     with_dynasm_active_gc(|gc| gc.get_actual_typeid(gcref)).flatten()
 }
 
+fn dynasm_can_move(gcref: GcRef) -> bool {
+    with_dynasm_active_gc(|gc| gc.can_move(gcref)).unwrap_or(false)
+}
+
 fn dynasm_subclass_range(classptr: usize) -> Option<(i64, i64)> {
     with_dynasm_active_gc(|gc| gc.subclass_range(classptr)).flatten()
 }
@@ -1159,6 +1163,7 @@ impl DynasmBackend {
             subclass_range: Some(dynasm_subclass_range),
             typeid_subclass_range: Some(dynasm_typeid_subclass_range),
             typeid_is_object: Some(dynasm_typeid_is_object),
+            can_move: Some(dynasm_can_move),
             supports_guard_gc_type,
         });
         majit_gc::set_active_alloc_nursery_typed(Some(dynasm_alloc_nursery_typed));

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1087,7 +1087,7 @@ impl DynasmBackend {
             use majit_gc::GcRewriter;
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
-            let (result, new_constants) =
+            let (result, new_constants, _gcrefs) =
                 rewriter.rewrite_for_gc_with_constants(&normalized, &self.constants);
             // rewrite.py creates fresh ConstInt boxes for sizes, offsets
             // and helper addresses; `new_constants` is the full typed pool.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -967,6 +967,25 @@ impl DynasmBackend {
         }
     }
 
+    /// `assembler.py:822 gcreftracers.append(tracer)` parity for the
+    /// per-loop reference-constant `GcTable`.  The table's base address
+    /// is baked into machine code by the `LoadFromGcTable` genops, so the
+    /// strong `Arc` must outlive the compiled trace.
+    /// `clt.asmmemmgr_gcreftracers` is that lifetime root (`model.py:294`
+    /// / `llmodel.py:252-268 free_loop_and_bridges`); when the CLT drops,
+    /// the table frees and its `Weak` in the gcreftracer registry is
+    /// reaped lazily, so deregistration needs no `free_loop` hook.
+    fn register_gc_table(
+        &self,
+        token: &majit_backend::JitCellToken,
+        table: Arc<majit_gc::GcTable>,
+    ) {
+        if let Some(clt) = token.compiled_loop_token.as_ref() {
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = table;
+            clt.asmmemmgr_gcreftracers.lock().push(tracer);
+        }
+    }
+
     // `set_constants_pool`, `set_next_trace_id`, and `set_next_header_pc`
     // are provided via the `Backend` trait impl below so
     // `compile_tmp_callback` and other backend-agnostic consumers can
@@ -1062,7 +1081,15 @@ impl DynasmBackend {
     }
 
     /// rewrite.py:345 parity: run GC rewriter on ops before assembly.
-    fn prepare_ops_for_compile(&mut self, inputargs: &[InputArg], ops: &[Op]) -> Vec<Op> {
+    /// Returns the rewritten ops plus the per-loop reference-constant
+    /// list (`rewrite.py:352 gcrefs_output_list`) the caller turns into a
+    /// `GcTable`. The list is empty when no rewriter is configured or the
+    /// trace references no reference constants.
+    fn prepare_ops_for_compile(
+        &mut self,
+        inputargs: &[InputArg],
+        ops: &[Op],
+    ) -> (Vec<Op>, Vec<GcRef>) {
         let num_inputs = inputargs.len() as u32;
         let mut normalized: Vec<Op> = ops
             .iter()
@@ -1087,7 +1114,7 @@ impl DynasmBackend {
             use majit_gc::GcRewriter;
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
-            let (result, new_constants, _gcrefs) =
+            let (result, new_constants, gcrefs) =
                 rewriter.rewrite_for_gc_with_constants(&normalized, &self.constants);
             // rewrite.py creates fresh ConstInt boxes for sizes, offsets
             // and helper addresses; `new_constants` is the full typed pool.
@@ -1095,9 +1122,9 @@ impl DynasmBackend {
             for (k, c) in new_constants {
                 self.constants.entry(k).or_insert(c);
             }
-            result
+            (result, gcrefs)
         } else {
-            normalized
+            (normalized, Vec::new())
         }
     }
 
@@ -1686,7 +1713,7 @@ impl Backend for DynasmBackend {
         self.next_trace_id += 1;
         let header_pc = self.next_header_pc;
         // gc.py:109 rewrite_assembler parity: run GC rewriter before regalloc.
-        let prepared_ops = self.prepare_ops_for_compile(inputargs, &ops_owned);
+        let (prepared_ops, gcrefs) = self.prepare_ops_for_compile(inputargs, &ops_owned);
         // The assembler stores the typed `Const` pool directly; each box
         // variant carries its own type (`Const::get_type`).
         let const_pool = std::mem::take(&mut self.constants);
@@ -1724,6 +1751,14 @@ impl Backend for DynasmBackend {
             inputargs,
             &prepared_ops,
         );
+        // assembler.py:793-824 parity: build the per-loop gc_table from
+        // the rewrite's reference-constant list and bake its base before
+        // emission, so `LoadFromGcTable` genops resolve their slot
+        // addresses. Empty list ⇒ no table, base stays 0.
+        let gc_table = (!gcrefs.is_empty()).then(|| majit_gc::GcTable::from_gcrefs(&gcrefs));
+        if let Some(table) = gc_table.as_ref() {
+            asm.set_gc_table_base(table.base_addr());
+        }
         asm.set_call_assembler_targets(Self::call_assembler_targets_snapshot());
         let compiled = asm.assemble_loop()?;
 
@@ -1732,6 +1767,9 @@ impl Backend for DynasmBackend {
         let frame_depth = compiled.frame_depth.load(Ordering::Acquire) as i64;
         Self::register_call_assembler_target(token, code_addr);
         self.register_fail_descrs(token, &compiled.fail_descrs);
+        if let Some(table) = gc_table {
+            self.register_gc_table(token, table);
+        }
 
         // `compile.py:183-186 record_loop_or_bridge`: for each ResumeDescr
         // in the newly-compiled trace, stamp the owning CompiledLoopToken.
@@ -1905,7 +1943,7 @@ impl Backend for DynasmBackend {
         let trace_id = self.next_trace_id;
         self.next_trace_id += 1;
 
-        let prepared_ops = self.prepare_ops_for_compile(inputargs, &ops_owned);
+        let (prepared_ops, gcrefs) = self.prepare_ops_for_compile(inputargs, &ops_owned);
         // format_trace reads raw `i64` values; the assembler stores the
         // typed `Const` pool directly (type rides on `Const::get_type`).
         let const_pool = std::mem::take(&mut self.constants);
@@ -1955,6 +1993,13 @@ impl Backend for DynasmBackend {
             inputargs,
             &prepared_ops,
         );
+        // assembler.py:793-824 parity: build the per-loop gc_table from
+        // the rewrite's reference-constant list and bake its base before
+        // emission (same as compile_loop). A bridge gets its own table.
+        let gc_table = (!gcrefs.is_empty()).then(|| majit_gc::GcTable::from_gcrefs(&gcrefs));
+        if let Some(table) = gc_table.as_ref() {
+            asm.set_gc_table_base(table.base_addr());
+        }
         asm.set_call_assembler_targets(Self::call_assembler_targets_snapshot());
 
         let _orig_compiled = Self::get_compiled(original_token);
@@ -2038,6 +2083,9 @@ impl Backend for DynasmBackend {
         // tracer batch lands on `original_token`'s
         // `asmmemmgr_gcreftracers` (`model.py:294`).
         self.register_fail_descrs(original_token, &compiled.fail_descrs);
+        if let Some(table) = gc_table {
+            self.register_gc_table(original_token, table);
+        }
 
         // `compile.py:183-186 record_loop_or_bridge`: a bridge's ResumeDescrs
         // inherit the original loop's CompiledLoopToken.  See the

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -768,6 +768,12 @@ pub struct Assembler386<'a> {
     /// passed in at construction time so the emit path bakes it as a
     /// 64-bit immediate without re-touching the backend.
     malloc_slowpath_fixed: usize,
+    /// `assembler.py:1545` `genop_load_from_gc_table`: base address of
+    /// this loop's per-loop `GcTable` slot array. Baked as a 64-bit
+    /// immediate by the `LoadFromGcTable` genop; 0 when the trace
+    /// references no reference constants. Set before `assemble_loop` /
+    /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
+    gc_table_base: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
@@ -912,7 +918,16 @@ impl<'a> Assembler386<'a> {
             frame_depth_to_patch: Vec::new(),
             jump_target_frame_depth: 0,
             malloc_slowpath_fixed,
+            gc_table_base: 0,
         }
+    }
+
+    /// `assembler.py:793-824` parity: hand the per-loop `GcTable`'s base
+    /// address to the assembler before emission, so `LoadFromGcTable`
+    /// genops bake it as the slot-array base immediate. 0 leaves the
+    /// trace with no reference constants (no `LoadFromGcTable` emitted).
+    pub(crate) fn set_gc_table_base(&mut self, base: usize) {
+        self.gc_table_base = base;
     }
 
     /// `compile.py:665` parity: heap-pinned address of `self.cpu`'s
@@ -3168,12 +3183,30 @@ impl<'a> Assembler386<'a> {
             | OpCode::SameAsR
             | OpCode::SameAsF
             | OpCode::CastOpaquePtr
-            | OpCode::LoadFromGcTable
             | OpCode::VirtualRefR
             | OpCode::ConvertFloatBytesToLonglong
             | OpCode::ConvertLonglongBytesToFloat => {
                 if let (Some(src), Some(dst)) = (arglocs.first(), result_loc) {
                     self.regalloc_mov(src, dst);
+                }
+            }
+            // `assembler.py:1545` `genop_load_from_gc_table`: load the
+            // reference constant at `gc_table_base + index*WORD`. The
+            // index arrives as an immediate (the `ConstInt(index)` arg
+            // produced by `remove_constptr`); the table base is baked
+            // absolute (x86-32 `MOV_rj` model, `assembler.py:1551-1552`)
+            // because dynasm has no code-buffer-start reservation seam.
+            // The slot value is GC-forwarded in place by the gc_table
+            // root walker, so each load observes the relocated object.
+            OpCode::LoadFromGcTable => {
+                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) =
+                    (arglocs.first(), result_loc)
+                {
+                    let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
+                    dynasm!(self.mc ; .arch x64
+                        ; mov Rq(dst.value), QWORD slot_addr as i64
+                        ; mov Rq(dst.value), [Rq(dst.value)]
+                    );
                 }
             }
             // `assembler.py:1528 genop_cast_ptr_to_int = _genop_same_as`

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -3199,8 +3199,7 @@ impl<'a> Assembler386<'a> {
             // The slot value is GC-forwarded in place by the gc_table
             // root walker, so each load observes the relocated object.
             OpCode::LoadFromGcTable => {
-                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) =
-                    (arglocs.first(), result_loc)
+                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
                 {
                     let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
                     dynasm!(self.mc ; .arch x64

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1063,12 +1063,19 @@ fn build_function(
                 // Zero-initialize array region — skip for MVP
             }
             OpCode::LoadFromGcTable => {
-                // Load from GC reference table — treat as field load
-                let vi = op.pos.get().raw();
-                if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    sink.local_set(1 + vi);
-                }
+                // `assembler.py:1545` `genop_load_from_gc_table`: this op is
+                // produced only by the GC rewrite's `remove_constptr`
+                // (`rewrite.py:1100`), whose arg is a `ConstInt(index)` into
+                // a per-loop `GcTable` whose base is baked absolute. The
+                // wasm backend does not run the GC rewrite and has no
+                // host-address gc_table model (linear memory), so this op
+                // never reaches here. Panic loudly rather than emit the old
+                // SAME_AS pass-through, which after the rewrite flip would
+                // load the raw index in place of the reference constant.
+                panic!(
+                    "wasm backend: LoadFromGcTable is unsupported (no gc_table model); \
+                     the GC rewrite must not run for wasm"
+                );
             }
 
             // ── CALL operations (via trampoline) ──

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -191,6 +191,7 @@ impl WasmBackend {
             subclass_range: Some(wasm_subclass_range),
             typeid_subclass_range: Some(wasm_typeid_subclass_range),
             typeid_is_object: Some(wasm_typeid_is_object),
+            can_move: None,
             supports_guard_gc_type,
         });
         majit_gc::set_active_alloc_nursery_typed(Some(wasm_alloc_nursery_typed));

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2293,6 +2293,18 @@ impl GcAllocator for MiniMarkGC {
         (byte & is_object_flag) != 0
     }
 
+    /// `rgc.can_move` (rpython/rlib/rgc.py:229). MiniMark mapping: an
+    /// object can still move iff it is a young (nursery) object that is
+    /// not pinned. Old-generation objects, prebuilt/foreign addresses
+    /// outside the nursery, and pinned nursery objects never move
+    /// (minimark.py keeps pinned objects in place across a minor cycle).
+    fn can_move(&self, gcref: GcRef) -> bool {
+        if gcref.is_null() {
+            return false;
+        }
+        self.is_in_nursery(gcref.0) && !self.pinned_objects.contains(&gcref.0)
+    }
+
     /// gc.py:592 `get_translated_info_for_typeinfo` parity.
     /// Returns `(type_info_group_base, shift_by, sizeof_ti)` — the
     /// base address of the materialized `type_info_group` table, the
@@ -4555,6 +4567,29 @@ mod tests {
         assert_eq!(val, 0xCAFE_BABE);
 
         gc.roots.clear();
+    }
+
+    #[test]
+    fn test_can_move_nursery_pin_and_bounds() {
+        let mut gc = test_gc(4096);
+        gc.register_type(TypeInfo::simple(16));
+
+        // rgc.py:229 — a young nursery object can still move.
+        let obj = gc.alloc_with_type(0, 16);
+        assert!(gc.is_in_nursery(obj.0));
+        assert!(gc.can_move(obj));
+
+        // A pinned nursery object will not move (rgc.py:233-235); unpin
+        // restores movability.
+        assert!(gc.pin(obj));
+        assert!(!gc.can_move(obj));
+        gc.unpin(obj);
+        assert!(gc.can_move(obj));
+
+        // Null and out-of-nursery addresses never move (rgc.py:231
+        // "with non-moving GCs, it is always False").
+        assert!(!gc.can_move(GcRef(0)));
+        assert!(!gc.can_move(GcRef(0xdead_0000)));
     }
 
     #[test]

--- a/majit/majit-gc/src/gcreftracer.rs
+++ b/majit/majit-gc/src/gcreftracer.rs
@@ -1,0 +1,189 @@
+//! Per-loop GC table for reference constants baked into compiled traces.
+//!
+//! Counterpart of `rpython/jit/backend/llsupport/gcreftracer.py`. A
+//! compiled loop/bridge that references constant GC objects must keep
+//! those references alive and up to date across moving collections.
+//! Instead of baking the raw `GcRef` value as a machine-code immediate
+//! (which a moving GC cannot find or update), the backend bakes the
+//! address of a per-loop array of reference slots and emits a
+//! `LoadFromGcTable(index)` load (`x86/assembler.py:1545`
+//! `genop_load_from_gc_table`). Each slot is a GC root: the collector
+//! forwards it in place during a stop-the-world collection, so the next
+//! load observes the relocated object.
+//!
+//! Upstream models the array with a `GCREFTRACER` `GcStruct`
+//! (`gcreftracer.py:7-11`) carrying `array_base_addr` + `array_length`,
+//! registered with the GC via a custom trace hook
+//! (`register_custom_trace_hook`, `gcreftracer.py:30`). pyre has no
+//! custom-trace-hook facility; the established equivalent is the extra
+//! root walker registry (`shadow_stack::register_extra_root_walker`,
+//! walked at `collector.rs:668` minor and `collector.rs:1185` major), so
+//! a single module walker forwards every live table's slots.
+
+use std::cell::Cell;
+use std::sync::{Arc, RwLock, Weak};
+
+use majit_ir::GcRef;
+
+/// A per-loop array of reference-constant slots.
+///
+/// `gcreftracer.py:7-11` `GCREFTRACER` stores `array_base_addr` +
+/// `array_length`; here the `Box<[Cell<GcRef>]>` *is* that array:
+/// [`base_addr`](GcTable::base_addr) is `array_base_addr` and
+/// [`len`](GcTable::len) is `array_length`. The `Box` is a stable Rust
+/// heap allocation (never relocated by the moving GC), so its base
+/// address is valid for the table's whole life — that is what the
+/// backend bakes as the `LoadFromGcTable` base immediate.
+pub struct GcTable {
+    slots: Box<[Cell<GcRef>]>,
+}
+
+// SAFETY: a `GcTable`'s slots are only mutated through `trace`, which
+// runs exclusively during a stop-the-world collection
+// (`collector.rs` `do_collect_nursery` / major), when no JIT or
+// interpreter thread is reading the slots. Construction fills the slots
+// before the `Arc` is shared, and they are never written again outside
+// `trace`. The `Cell` provides interior mutability for in-place
+// forwarding; the `Send`/`Sync` bounds let the `Arc<GcTable>` live on
+// `CompiledLoopToken.asmmemmgr_gcreftracers` and a `Weak<GcTable>` in
+// the global registry.
+unsafe impl Send for GcTable {}
+unsafe impl Sync for GcTable {}
+
+/// Live per-loop tables, walked as GC roots. The strong reference is
+/// held by `CompiledLoopToken.asmmemmgr_gcreftracers` (parity
+/// `gcreftracers.append(tracer)`, `x86/assembler.py:823`); the registry
+/// keeps only a `Weak`, so when the loop token is freed the table drops
+/// and its registry entry becomes dangling — deregistration needs no
+/// explicit `free_loop` hook (neither backend's `free_loop` clears
+/// `asmmemmgr_gcreftracers`; both rely on `Arc<CompiledLoopToken>`
+/// drop).
+static LIVE_GC_TABLES: RwLock<Vec<Weak<GcTable>>> = RwLock::new(Vec::new());
+
+impl GcTable {
+    /// Build a per-loop table from the rewrite's gcref output list and
+    /// register it for GC forwarding.
+    ///
+    /// `gcreftracer.py:26-43` `make_framework_tracer` warns that the
+    /// tracer allocation can itself trigger a GC, so it writes the
+    /// gcrefs into the raw array only afterwards. Here the
+    /// `Box<[Cell<GcRef>]>` is a plain Rust heap allocation that does not
+    /// go through the moving GC, so that hazard cannot arise; the slots
+    /// are filled before the `Arc` exists, and registration happens last,
+    /// so no collection can observe a half-filled, registered table.
+    pub fn from_gcrefs(gcrefs: &[GcRef]) -> Arc<GcTable> {
+        let slots: Box<[Cell<GcRef>]> = gcrefs.iter().map(|g| Cell::new(*g)).collect();
+        let table = Arc::new(GcTable { slots });
+        register_table(&table);
+        table
+    }
+
+    /// Raw base address of the slot array, baked by the backend genop as
+    /// the `LoadFromGcTable` base immediate. `gcreftracer.py:9`
+    /// `array_base_addr`.
+    pub fn base_addr(&self) -> usize {
+        self.slots.as_ptr() as usize
+    }
+
+    /// Number of reference-constant slots. `gcreftracer.py:10`
+    /// `array_length`.
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    /// Forward every slot in place. `gcreftracer.py:13-23`
+    /// `gcrefs_trace`: each `array_base_addr + i*WORD` slot is handed to
+    /// the GC as a root; writing back through the visitor forwards the
+    /// constant if the moving GC relocated the referenced object.
+    pub fn trace(&self, visitor: &mut dyn FnMut(&mut GcRef)) {
+        for cell in self.slots.iter() {
+            let mut r = cell.get();
+            visitor(&mut r);
+            cell.set(r);
+        }
+    }
+}
+
+/// Append a live table to the registry, sweeping out tables whose loop
+/// tokens have already been freed.
+fn register_table(table: &Arc<GcTable>) {
+    let mut guard = LIVE_GC_TABLES.write().unwrap();
+    guard.retain(|w| w.strong_count() > 0);
+    guard.push(Arc::downgrade(table));
+}
+
+/// Forward the slots of every live per-loop table. Registered once via
+/// [`install_gc_table_walker`]; fires at both the minor
+/// (`collector.rs:668`) and major (`collector.rs:1185`) collection
+/// phases.
+fn walk_all_gc_tables(visitor: &mut dyn FnMut(&mut GcRef)) {
+    // Snapshot the live tables under a read guard, then release the lock
+    // before tracing (same snapshot-then-iterate discipline as
+    // `walk_extra_roots`, `shadow_stack.rs:622`). Dead `Weak`s are
+    // filtered by `upgrade`.
+    let live: Vec<Arc<GcTable>> = {
+        let guard = LIVE_GC_TABLES.read().unwrap();
+        guard.iter().filter_map(|w| w.upgrade()).collect()
+    };
+    for table in &live {
+        table.trace(visitor);
+    }
+}
+
+/// Extra-root-walker entry point. A plain `fn` so it can be deduped by
+/// address in `register_extra_root_walker`.
+fn gc_table_extra_root_walker(visitor: &mut dyn FnMut(&mut GcRef)) {
+    walk_all_gc_tables(visitor);
+}
+
+/// Install the per-loop gc_table forwarding walker. Idempotent —
+/// `register_extra_root_walker` dedups by fn address
+/// (`shadow_stack.rs:602`). Call once at backend init.
+pub fn install_gc_table_walker() {
+    crate::shadow_stack::register_extra_root_walker(gc_table_extra_root_walker);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_forwards_slots_in_place() {
+        let table = GcTable::from_gcrefs(&[GcRef(0x1000), GcRef(0x2000)]);
+        // A moving collection relocates 0x1000 -> 0x9000.
+        table.trace(&mut |r| {
+            if r.0 == 0x1000 {
+                r.0 = 0x9000;
+            }
+        });
+        assert_eq!(table.slots[0].get(), GcRef(0x9000));
+        assert_eq!(table.slots[1].get(), GcRef(0x2000));
+        assert_eq!(table.base_addr(), table.slots.as_ptr() as usize);
+        assert_eq!(table.len(), 2);
+    }
+
+    #[test]
+    fn dropping_table_deregisters_from_walk() {
+        // A sentinel unlikely to collide with any other test's table.
+        const SENTINEL: GcRef = GcRef(0x0DEAD_BEEF);
+        let count_sentinels = || {
+            let mut n = 0usize;
+            walk_all_gc_tables(&mut |r| {
+                if *r == SENTINEL {
+                    n += 1;
+                }
+            });
+            n
+        };
+        {
+            let _table = GcTable::from_gcrefs(&[SENTINEL]);
+            assert_eq!(count_sentinels(), 1, "live table must be walked");
+        }
+        // The Arc dropped; the registry's Weak no longer upgrades.
+        assert_eq!(count_sentinels(), 0, "freed table must not be walked");
+    }
+}

--- a/majit/majit-gc/src/gcreftracer.rs
+++ b/majit/majit-gc/src/gcreftracer.rs
@@ -72,6 +72,13 @@ impl GcTable {
     /// are filled before the `Arc` exists, and registration happens last,
     /// so no collection can observe a half-filled, registered table.
     pub fn from_gcrefs(gcrefs: &[GcRef]) -> Arc<GcTable> {
+        // Ensure the forwarding walker is installed before the table can
+        // be observed by a collection. `register_extra_root_walker`
+        // dedups by fn address, so this is idempotent across every
+        // compiled loop; before the first table exists there is nothing
+        // to walk, so installing lazily here is equivalent to a one-time
+        // backend init without depending on a separate init call site.
+        install_gc_table_walker();
         let slots: Box<[Cell<GcRef>]> = gcrefs.iter().map(|g| Cell::new(*g)).collect();
         let table = Arc::new(GcTable { slots });
         register_table(&table);
@@ -151,8 +158,18 @@ pub fn install_gc_table_walker() {
 mod tests {
     use super::*;
 
+    // `LIVE_GC_TABLES` is a process-global registry; in production it is
+    // only mutated outside a collection (table build at compile time) and
+    // only read inside a stop-the-world collection, so there is never a
+    // concurrent build-vs-walk. The test harness runs tests in parallel,
+    // which would let one table-building test's registry mutation race
+    // another's global `walk_all_gc_tables` assertion. Serialize the
+    // table-touching tests against each other to model the STW invariant.
+    static TEST_REGISTRY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn trace_forwards_slots_in_place() {
+        let _serialize = TEST_REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let table = GcTable::from_gcrefs(&[GcRef(0x1000), GcRef(0x2000)]);
         // A moving collection relocates 0x1000 -> 0x9000.
         table.trace(&mut |r| {
@@ -168,6 +185,7 @@ mod tests {
 
     #[test]
     fn dropping_table_deregisters_from_walk() {
+        let _serialize = TEST_REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // A sentinel unlikely to collide with any other test's table.
         const SENTINEL: GcRef = GcRef(0x0DEAD_BEEF);
         let count_sentinels = || {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1,3 +1,4 @@
+pub use gcreftracer::{GcTable, install_gc_table_walker};
 /// GC traits and interfaces for the JIT.
 ///
 /// The GC subsystem provides:
@@ -8,7 +9,6 @@
 ///
 /// Reference: rpython/memory/gc/incminimark.py, rpython/jit/backend/llsupport/gc.py
 use majit_ir::{Const, GcRef, Op, VecAssoc};
-pub use gcreftracer::{GcTable, install_gc_table_walker};
 pub use trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout};
 
 pub mod collector;

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -415,6 +415,15 @@ pub trait GcAllocator: Send {
         false
     }
 
+    /// `rpython/rlib/rgc.py:229` `can_move(p)` — whether the GC object
+    /// `gcref` sits at an address that may still move. "With non-moving
+    /// GCs, it is always False; with moving GCs it can be True for some
+    /// time, then False once the object is sure not to move." The default
+    /// is `false`, matching a non-moving GC (and the no-GC case).
+    fn can_move(&self, _gcref: GcRef) -> bool {
+        false
+    }
+
     /// llsupport/gc.py:592 `get_translated_info_for_typeinfo`.
     /// Returns `(type_info_group_base, shift_by, sizeof_ti)`:
     ///  * `type_info_group_base` — base address of the `TYPE_INFO` table
@@ -638,12 +647,19 @@ pub type TypeidSubclassRangeFn = fn(typeid: u32) -> Option<(i64, i64)>;
 pub type TypeidIsObjectFn = fn(typeid: u32) -> Option<bool>;
 pub type ExtraRootWalkerFn = fn(&mut dyn FnMut(&mut GcRef));
 
+/// Thread-local callback that answers `rgc.can_move(gcref)`
+/// (rpython/rlib/rgc.py:229) for the currently active backend's GC. The
+/// const-baking site (`x86/regalloc.py:58-61 convert_to_imm`) consults
+/// this before baking a `ConstPtr` immediate.
+pub type CanMoveFn = fn(GcRef) -> bool;
+
 thread_local! {
     static ACTIVE_CHECK_IS_OBJECT: Cell<Option<CheckIsObjectFn>> = const { Cell::new(None) };
     static ACTIVE_GET_ACTUAL_TYPEID: Cell<Option<GetActualTypeidFn>> = const { Cell::new(None) };
     static ACTIVE_SUBCLASS_RANGE: Cell<Option<SubclassRangeFn>> = const { Cell::new(None) };
     static ACTIVE_TYPEID_SUBCLASS_RANGE: Cell<Option<TypeidSubclassRangeFn>> = const { Cell::new(None) };
     static ACTIVE_TYPEID_IS_OBJECT: Cell<Option<TypeidIsObjectFn>> = const { Cell::new(None) };
+    static ACTIVE_CAN_MOVE: Cell<Option<CanMoveFn>> = const { Cell::new(None) };
     static ACTIVE_SUPPORTS_GUARD_GC_TYPE: Cell<bool> = const { Cell::new(false) };
     static ACTIVE_EXTRA_ROOT_WALKER: Cell<Option<ExtraRootWalkerFn>> = const { Cell::new(None) };
 }
@@ -659,6 +675,7 @@ pub struct ActiveGcGuardHooks {
     pub subclass_range: Option<SubclassRangeFn>,
     pub typeid_subclass_range: Option<TypeidSubclassRangeFn>,
     pub typeid_is_object: Option<TypeidIsObjectFn>,
+    pub can_move: Option<CanMoveFn>,
     pub supports_guard_gc_type: bool,
 }
 
@@ -675,6 +692,7 @@ pub fn set_active_gc_guard_hooks(hooks: ActiveGcGuardHooks) {
     ACTIVE_SUBCLASS_RANGE.with(|c| c.set(hooks.subclass_range));
     ACTIVE_TYPEID_SUBCLASS_RANGE.with(|c| c.set(hooks.typeid_subclass_range));
     ACTIVE_TYPEID_IS_OBJECT.with(|c| c.set(hooks.typeid_is_object));
+    ACTIVE_CAN_MOVE.with(|c| c.set(hooks.can_move));
     ACTIVE_SUPPORTS_GUARD_GC_TYPE.with(|c| c.set(hooks.supports_guard_gc_type));
 }
 
@@ -718,6 +736,21 @@ pub fn get_actual_typeid(gcref: GcRef) -> Option<u32> {
     ACTIVE_GET_ACTUAL_TYPEID.with(|c| match c.get() {
         Some(f) => f(gcref),
         None => None,
+    })
+}
+
+/// `rgc.can_move(gcref)` shim (rpython/rlib/rgc.py:229). Delegates to the
+/// active backend's installed callback. Returns `false` for null pointers
+/// and when no backend is installed — i.e. a non-moving / absent GC, where
+/// every object address is stable (rgc.py:231 "with non-moving GCs, it is
+/// always False").
+pub fn can_move(gcref: GcRef) -> bool {
+    if gcref.is_null() {
+        return false;
+    }
+    ACTIVE_CAN_MOVE.with(|c| match c.get() {
+        Some(f) => f(gcref),
+        None => false,
     })
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -521,9 +521,13 @@ pub trait GcRewriter: Send {
     /// Rewrite a list of operations, inserting GC-aware code.
     fn rewrite_for_gc(&self, ops: &[Op]) -> Vec<Op>;
     /// Rewrite with access to the constant pool.
-    /// Returns (rewritten ops, merged constants). Each `Const` box carries
-    /// its own type via `Const::get_type`, so a separate type side-table is
-    /// no longer threaded through the return.
+    /// Returns (rewritten ops, merged constants, gc_table gcrefs). Each
+    /// `Const` box carries its own type via `Const::get_type`, so a separate
+    /// type side-table is no longer threaded through the return. The third
+    /// element is the per-loop reference-constant list collected by
+    /// `remove_constptr` (rewrite.py:1033-1043 `gcrefs_output_list`); the
+    /// backend builds a `GcTable` from it and bakes its base address into the
+    /// `LoadFromGcTable` loads.
     ///
     /// The default impl forwards to `rewrite_for_gc` and preserves the
     /// caller's constants verbatim. `rewrite_for_gc` may leave `Const*`
@@ -533,8 +537,8 @@ pub trait GcRewriter: Send {
         &self,
         ops: &[Op],
         constants: &VecAssoc<u32, Const>,
-    ) -> (Vec<Op>, VecAssoc<u32, Const>) {
-        (self.rewrite_for_gc(ops), constants.clone())
+    ) -> (Vec<Op>, VecAssoc<u32, Const>, Vec<GcRef>) {
+        (self.rewrite_for_gc(ops), constants.clone(), Vec::new())
     }
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -8,9 +8,11 @@
 ///
 /// Reference: rpython/memory/gc/incminimark.py, rpython/jit/backend/llsupport/gc.py
 use majit_ir::{Const, GcRef, Op, VecAssoc};
+pub use gcreftracer::{GcTable, install_gc_table_walker};
 pub use trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout};
 
 pub mod collector;
+pub mod gcreftracer;
 pub mod header;
 pub mod nursery;
 pub mod oldgen;

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -3062,6 +3062,31 @@ impl GcRewriter for GcRewriterImpl {
         // re-minting happens here. A follow-up slice flips the trait
         // to `Vec<OpRc>` and removes this clone.
         let out: Vec<Op> = st.out.iter().map(|rc| (**rc).clone()).collect();
+
+        // rewrite.py:106-116 post-condition: `remove_constptr` replaced
+        // every non-null reference-constant *operand* with a
+        // `LoadFromGcTable` result, so no raw non-null `GcRef` is left for
+        // a backend to bake as an immortal immediate. Failargs are NOT
+        // operands — they keep their constants and are forwarded by the
+        // resume path (`rd_consts`), so this scans operands only.
+        // JIT_DEBUG keeps its constants inline (rewrite.py:105). This is
+        // the "ConstPtr transient-only" invariant: any survivor is a
+        // missed emit point.
+        #[cfg(debug_assertions)]
+        for op in &out {
+            if op.opcode == OpCode::JitDebug {
+                continue;
+            }
+            for i in 0..op.num_args() {
+                debug_assert!(
+                    !matches!(op.arg(i).const_value(), Some(Value::Ref(g)) if !g.is_null()),
+                    "rewrite output {:?} still carries a non-null ConstPtr operand at \
+                     arg {i}; remove_constptr must route it through the gc_table",
+                    op.opcode
+                );
+            }
+        }
+
         (out, st.constants, st.gcrefs_output_list)
     }
 }
@@ -5237,7 +5262,10 @@ mod tests {
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // rewrite.py:109 `bool(arg.value)` — a null ConstPtr stays inline.
-        assert!(gcrefs.is_empty(), "null ConstPtr must not enter the gc_table");
+        assert!(
+            gcrefs.is_empty(),
+            "null ConstPtr must not enter the gc_table"
+        );
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::GuardNonnull);
         assert_eq!(result[0].arg(0).const_value(), Some(Value::Ref(null)));

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -473,9 +473,18 @@ struct RewriteState {
     /// rewrite.py:352 `gcrefs_output_list` — the per-loop list of
     /// reference constants pulled out of operations by `remove_constptr`.
     /// The backend builds a `GcTable` from this and emits
-    /// `LoadFromGcTable(index)` against its base. Populated only once
-    /// `remove_constptr` is wired (a later slice); empty until then.
+    /// `LoadFromGcTable(index)` against its base.
     gcrefs_output_list: Vec<GcRef>,
+    /// rewrite.py:353 `gcrefs_map` — dedup map from a reference constant
+    /// (keyed by `GcRef.0`) to its index in `gcrefs_output_list`.
+    gcrefs_map: VecAssoc<usize, u32>,
+    /// rewrite.py:354 `gcrefs_recently_loaded` — CSE cache from a gc_table
+    /// index to the `LoadFromGcTable` result box already emitted in the
+    /// current basic block. Reset at every Label (rewrite.py:1005). Reuse
+    /// across a can-collect point is sound: the load result is a Ref box,
+    /// so the register allocator keeps it in the GC map and the collector
+    /// forwards the held copy.
+    gcrefs_recently_loaded: VecAssoc<u32, BoxRef>,
 }
 
 impl RewriteState {
@@ -500,6 +509,8 @@ impl RewriteState {
             forwarded_ops: VecAssoc::new(),
             current_i: 0,
             gcrefs_output_list: Vec::new(),
+            gcrefs_map: VecAssoc::new(),
+            gcrefs_recently_loaded: VecAssoc::new(),
         }
     }
 
@@ -555,12 +566,67 @@ impl RewriteState {
         BoxRef::new_const(Value::Int(value))
     }
 
+    /// rewrite.py:1033-1043 `_gcref_index` — dedup a reference constant
+    /// into `gcrefs_output_list`, returning its stable index.
+    fn gcref_index(&mut self, gcref: GcRef) -> u32 {
+        if let Some(&index) = self.gcrefs_map.get(&gcref.0) {
+            return index;
+        }
+        let index = self.gcrefs_output_list.len() as u32;
+        self.gcrefs_map.insert(gcref.0, index);
+        self.gcrefs_output_list.push(gcref);
+        index
+    }
+
+    /// rewrite.py:1100-1115 `remove_constptr` — replace a reference
+    /// constant with the result of a `LoadFromGcTable(index)` load,
+    /// reusing one already emitted in this basic block (CSE) when
+    /// possible.
+    fn remove_constptr(&mut self, gcref: GcRef) -> BoxRef {
+        let index = self.gcref_index(gcref);
+        if let Some(load) = self.gcrefs_recently_loaded.get(&index) {
+            return load.clone();
+        }
+        let index_box = BoxRef::new_const(Value::Int(index as i64));
+        let load = self.emit(Op::new(OpCode::LoadFromGcTable, &[index_box]));
+        self.gcrefs_recently_loaded.insert(index, load.clone());
+        load
+    }
+
+    /// rewrite.py:106-116 `emit_op` arg loop — substitute each non-null
+    /// reference-constant argument with a `LoadFromGcTable` result so no
+    /// raw `GcRef` is baked into the backend. JIT_DEBUG keeps its
+    /// constants inline (rewrite.py:105 `keep`). Null pointers stay inline
+    /// (rewrite.py:109 `bool(arg.value)`). Failargs are NOT processed —
+    /// they are resolved as plain constants in `rewrite_op` (rewrite.py:121
+    /// `get_box_replacement`), matching upstream.
+    ///
+    /// rewrite.py:123-126 additionally appends the op's *descr* gcref to
+    /// the table when the descr itself is a GC object. pyre descrs are
+    /// `Arc<FailDescrCell>` pinned via the CLT keepalive
+    /// (`asmmemmgr_gcreftracers`), not moving-GC objects, so there is no
+    /// descr gcref to forward and that branch is intentionally not ported.
+    fn remove_constptrs_in(&mut self, op: &Op) {
+        if op.opcode == OpCode::JitDebug {
+            return;
+        }
+        for i in 0..op.num_args() {
+            if let Some(Value::Ref(gcref)) = op.arg(i).const_value() {
+                if !gcref.is_null() {
+                    let load = self.remove_constptr(gcref);
+                    op.setarg(i, load);
+                }
+            }
+        }
+    }
+
     /// Emit an op. Void ops do not consume a result id.
     ///
     /// The result OpRef carries its own type via the variant tag
     /// (`int_op`/`float_op`/`ref_op`) — rewrite.py:930 `v.type` parity —
     /// so no separate type table is maintained.
     fn emit(&mut self, op: Op) -> BoxRef {
+        self.remove_constptrs_in(&op);
         let rt = op.result_type();
         let pos = if rt == Type::Void {
             OpRef::NONE
@@ -590,6 +656,7 @@ impl RewriteState {
     /// The result OpRef carries its own type via the variant tag, so no
     /// separate type table is maintained — see `emit()` doc.
     fn emit_result(&mut self, op: Op, preferred_pos: OpRef) -> BoxRef {
+        self.remove_constptrs_in(&op);
         let rt = op.result_type();
         let pos = if preferred_pos.is_none() {
             let pos = OpRef::op_typed(self.next_pos, rt);
@@ -2825,6 +2892,8 @@ impl GcRewriter for GcRewriterImpl {
                 OpCode::Label => {
                     st.emitting_an_operation_that_can_collect();
                     st.known_lengths.clear();
+                    // rewrite.py:1005 emit_label resets the per-block load CSE.
+                    st.gcrefs_recently_loaded.clear();
                     let rewritten = st.rewrite_op(op);
                     st.emit_rewritten_from(op, rewritten);
                 }
@@ -5072,5 +5141,146 @@ mod tests {
             .find(|o| o.arg(2).to_opref() == guard.pos.get())
             .expect("consumer GcStore must reference the guard's result");
         assert_eq!(store.arg(0).to_opref(), result[0].pos.get());
+    }
+
+    // ── gc_table: remove_constptr / gcref dedup / load CSE ──
+    // rewrite.py:106-116 emit_op ConstPtr branch, rewrite.py:1100-1115
+    // remove_constptr, rewrite.py:1033-1043 _gcref_index, rewrite.py:1005
+    // emit_label CSE reset.
+
+    #[test]
+    fn test_remove_constptr_emits_load_and_collects_gcref() {
+        let rw = make_rewriter();
+        let r = majit_ir::GcRef(0x4000);
+        let ops = vec![Op::new(
+            OpCode::GuardNonnull,
+            &[BoxRef::new_const(Value::Ref(r))],
+        )];
+
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+
+        // The reference constant is collected at index 0.
+        assert_eq!(gcrefs, vec![r]);
+        // A LoadFromGcTable(0) is emitted before the consuming op.
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].opcode, OpCode::LoadFromGcTable);
+        assert_eq!(result[0].arg(0).const_value(), Some(Value::Int(0)));
+        // The consumer's ConstPtr arg is replaced by the load result.
+        assert_eq!(result[1].opcode, OpCode::GuardNonnull);
+        assert_eq!(result[1].arg(0).to_opref(), result[0].pos.get());
+    }
+
+    #[test]
+    fn test_remove_constptr_dedup_and_block_cse() {
+        let rw = make_rewriter();
+        let r = majit_ir::GcRef(0x4000);
+        let ops = vec![
+            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
+            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
+        ];
+
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+
+        // Same ref ⇒ one gcref entry (dedup) and one LoadFromGcTable (block CSE).
+        assert_eq!(gcrefs, vec![r]);
+        let loads = result
+            .iter()
+            .filter(|o| o.opcode == OpCode::LoadFromGcTable)
+            .count();
+        assert_eq!(loads, 1);
+        // Both consumers reference the single load result.
+        let load_pos = result
+            .iter()
+            .find(|o| o.opcode == OpCode::LoadFromGcTable)
+            .unwrap()
+            .pos
+            .get();
+        for g in result.iter().filter(|o| o.opcode == OpCode::GuardNonnull) {
+            assert_eq!(g.arg(0).to_opref(), load_pos);
+        }
+    }
+
+    #[test]
+    fn test_remove_constptr_distinct_refs() {
+        let rw = make_rewriter();
+        let r0 = majit_ir::GcRef(0x4000);
+        let r1 = majit_ir::GcRef(0x5000);
+        let ops = vec![
+            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r0))]),
+            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r1))]),
+        ];
+
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+
+        // Distinct refs occupy distinct, stable indices.
+        assert_eq!(gcrefs, vec![r0, r1]);
+        let load_indices: Vec<i64> = result
+            .iter()
+            .filter(|o| o.opcode == OpCode::LoadFromGcTable)
+            .map(|o| match o.arg(0).const_value() {
+                Some(Value::Int(i)) => i,
+                other => panic!("LoadFromGcTable index must be ConstInt, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(load_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_remove_constptr_null_stays_inline() {
+        let rw = make_rewriter();
+        let null = majit_ir::GcRef(0);
+        let ops = vec![Op::new(
+            OpCode::GuardNonnull,
+            &[BoxRef::new_const(Value::Ref(null))],
+        )];
+
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+
+        // rewrite.py:109 `bool(arg.value)` — a null ConstPtr stays inline.
+        assert!(gcrefs.is_empty(), "null ConstPtr must not enter the gc_table");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].opcode, OpCode::GuardNonnull);
+        assert_eq!(result[0].arg(0).const_value(), Some(Value::Ref(null)));
+    }
+
+    #[test]
+    fn test_remove_constptr_cse_resets_at_label() {
+        let rw = make_rewriter();
+        let r = majit_ir::GcRef(0x4000);
+        let ops = vec![
+            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
+            Op::new(OpCode::Label, &[]),
+            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
+        ];
+
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+
+        // Dedup persists across the block boundary (one gcref) ...
+        assert_eq!(gcrefs, vec![r]);
+        // ... but the load CSE resets at the Label, so the ref is reloaded.
+        let loads = result
+            .iter()
+            .filter(|o| o.opcode == OpCode::LoadFromGcTable)
+            .count();
+        assert_eq!(loads, 2);
+    }
+
+    #[test]
+    fn test_jit_debug_keeps_constptr_inline() {
+        let rw = make_rewriter();
+        let r = majit_ir::GcRef(0x4000);
+        let ops = vec![Op::new(
+            OpCode::JitDebug,
+            &[BoxRef::new_const(Value::Ref(r))],
+        )];
+
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+
+        // rewrite.py:105 `keep` — JIT_DEBUG keeps its constants inline.
+        assert!(gcrefs.is_empty(), "JIT_DEBUG keeps its constants inline");
+        assert!(
+            !result.iter().any(|o| o.opcode == OpCode::LoadFromGcTable),
+            "JIT_DEBUG must not route its ConstPtr through the gc_table"
+        );
     }
 }

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -14,7 +14,7 @@ use majit_ir::box_ref::BoxRef;
 use majit_ir::descr::{DescrRef, FieldDescr, SizeDescr};
 use majit_ir::operand::Operand;
 use majit_ir::resoperation::{Op, OpCode, OpRef};
-use majit_ir::{Const, Value, VecAssoc, VecSet};
+use majit_ir::{Const, GcRef, Value, VecAssoc, VecSet};
 
 use crate::{GcRewriter, WriteBarrierDescr};
 
@@ -469,6 +469,13 @@ struct RewriteState {
     /// Read by `set_forwarded` / `emit_maybe_forwarded` to key the
     /// `forwarded_ops` map.
     current_i: usize,
+
+    /// rewrite.py:352 `gcrefs_output_list` — the per-loop list of
+    /// reference constants pulled out of operations by `remove_constptr`.
+    /// The backend builds a `GcTable` from this and emits
+    /// `LoadFromGcTable(index)` against its base. Populated only once
+    /// `remove_constptr` is wired (a later slice); empty until then.
+    gcrefs_output_list: Vec<GcRef>,
 }
 
 impl RewriteState {
@@ -492,6 +499,7 @@ impl RewriteState {
             changed_ops: VecAssoc::new(),
             forwarded_ops: VecAssoc::new(),
             current_i: 0,
+            gcrefs_output_list: Vec::new(),
         }
     }
 
@@ -2763,7 +2771,7 @@ impl GcRewriter for GcRewriterImpl {
         &self,
         ops: &[Op],
         constants: &VecAssoc<u32, Const>,
-    ) -> (Vec<Op>, VecAssoc<u32, Const>) {
+    ) -> (Vec<Op>, VecAssoc<u32, Const>, Vec<GcRef>) {
         // rewrite.py:988-1001 remove_bridge_exception: strip a
         // SaveExcClass+SaveException+RestoreException prefix that is
         // a no-op (common in bridges).
@@ -2985,7 +2993,7 @@ impl GcRewriter for GcRewriterImpl {
         // re-minting happens here. A follow-up slice flips the trait
         // to `Vec<OpRc>` and removes this clone.
         let out: Vec<Op> = st.out.iter().map(|rc| (**rc).clone()).collect();
-        (out, st.constants)
+        (out, st.constants, st.gcrefs_output_list)
     }
 }
 
@@ -3256,7 +3264,7 @@ mod tests {
         let rw = make_rewriter();
         let ops = vec![Op::with_descr(OpCode::New, &[], size_descr(32, 7))];
 
-        let (result, constants) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // Expect: CallMallocNursery, GcStore (tid)
         assert_eq!(result.len(), 2);
@@ -3351,7 +3359,7 @@ mod tests {
         new_array.pos.set(OpRef::ref_op(0));
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
 
         assert!(
             !result
@@ -3532,7 +3540,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // Allocation header stores only (CallMallocNursery + tid GcStore) + Jump.
         // No delayed-zero NULL-pointer stores must be emitted because
@@ -3564,7 +3572,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, consts) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // Collect the NULL-pointer stores emitted by the pending-zero flush.
         let mut seen_offsets: Vec<i64> = result
@@ -3610,7 +3618,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         let null_offsets: Vec<i64> = result
             .iter()
@@ -3665,7 +3673,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], size_descr(32, 2)),
         ];
 
-        let (result, constants) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         assert!(result.iter().any(|o| o.opcode == OpCode::CallMallocNursery));
         assert!(
@@ -3837,7 +3845,7 @@ mod tests {
             vtable_descr(48, 3, 0xDEAD),
         )];
 
-        let (result, constants) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // CallMallocNursery + GcStore(tid) + GcStore(vtable)
         assert_eq!(result.len(), 3);
@@ -4098,7 +4106,7 @@ mod tests {
         guard.store_final_boxes(vec![BoxRef::from_opref(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         let same = result
             .iter()
@@ -4128,7 +4136,7 @@ mod tests {
         ]);
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         assert!(
             result.iter().all(|o| o.opcode != OpCode::GuardAlwaysFails),
@@ -4256,7 +4264,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
 
         // All indices were SET, so the in-place ZERO_ARRAY is rewritten
         // to byte_length 0 — backend treats it as a no-op.
@@ -4314,7 +4322,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
 
         let zeros: Vec<_> = result
             .iter()
@@ -4380,7 +4388,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
 
         // The ZERO_ARRAY should appear before the guard.
         let zero_idx = result.iter().position(|o| o.opcode == OpCode::ZeroArray);
@@ -4464,7 +4472,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
 
         let zeros: Vec<_> = result
             .iter()
@@ -4602,7 +4610,7 @@ mod tests {
                 ),
                 Op::new(OpCode::Finish, &[]),
             ];
-            let (result, _) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+            let (result, _, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
             let wb = result
                 .iter()
                 .filter(|o| o.opcode == OpCode::CondCallGcWb)
@@ -4741,7 +4749,7 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         assert_eq!(
             result.len(),
@@ -4818,7 +4826,7 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // Expect: LEA, LEA, INT_LSHIFT(i_len, 2), CALL_N
         assert_eq!(result.len(), 4);
@@ -4880,7 +4888,7 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // Expect (itemscale=0 so no INT_LSHIFT):
         //   i2b = int_add(p0, i0)
@@ -4947,7 +4955,7 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
 
         // Expect (itemscale=2):
         //   i0s = int_lshift(i0, 2)

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -582,7 +582,13 @@ pub fn bh_regs_depth() -> usize {
 /// root if the GC moved the referenced object.
 pub type ExtraRootWalkerFn = fn(&mut dyn FnMut(&mut GcRef));
 
-const MAX_EXTRA_ROOT_WALKERS: usize = 8;
+// Walkers registered today: eval.rs registers eight (rd_consts, partial
+// trace, active trace, compile snapshot, pyre interpreter side tables, and
+// pyre objects), plus gcreftracer.rs registers the per-loop gc_table
+// walker — nine total. Leave headroom above that so a future root source
+// does not overflow the array and poison the registry lock with a
+// "capacity exceeded" panic on first use.
+const MAX_EXTRA_ROOT_WALKERS: usize = 12;
 
 /// Registered root walkers. Each slot is either `None` or a function
 /// pointer. We cap the count to keep the set stack-allocatable and


### PR DESCRIPTION
#108
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Final functional piece of #108, plus its parity refinement.

The metainterp/optimizer half of #108 (migrating stored value/const boxes to
`BoxRef`) already landed via #132/#156/#167/#185. This PR closes the backend
half: both backends used to bake const `GcRef`s as raw machine-code immediates,
which a moving collector never walks — correctness relied on an implicit
immortality assumption that RPython does not make.

### Part 1 — `gc_table` / `GCREFTRACER` / `LOAD_FROM_GC_TABLE`

Ports `rpython/jit/backend/llsupport/gcreftracer.py`, `rewrite.py:1100`
(`remove_constptr`), and `x86/assembler.py:1545`. Every backend reference
constant is now routed through a per-loop table that is GC-forwarded in place,
loaded by `LoadFromGcTable`, and freed with the loop token.

- **Foundation** (`a39ebc39a3`) — `majit-gc/src/gcreftracer.rs`: `GcTable`
  (`Box<[Cell<GcRef>]>`) + `Weak` registry + an extra-root walker installed via
  `shadow_stack::register_extra_root_walker` (walked at minor `collector.rs:668`
  and major `collector.rs:1185`). No emission yet.
- **Thread the gcref list** (`8a2caad46c`) — the GC rewrite returns a per-loop
  `Vec<GcRef>` (empty until the flip).
- **The flip** (`081687ebce`) — `remove_constptr` (rewrite.py:1100) replaces
  non-null `ConstPtr` op-args with `LoadFromGcTable(ConstInt(index))` (dedup by
  `GcRef.0`, per-block CSE reset at `Label`); `JIT_DEBUG` and null pointers stay
  inline. Genops do a real `[base + index*8]` load (dynasm x86/aarch64 absolute
  base, cranelift `iconst(base)+ishl+iadd+load`). The table is built, registered,
  and pinned on `clt.asmmemmgr_gcreftracers` in both `compile_loop` and
  `compile_bridge`.
- **`ConstPtr` transient-only** (`3494c3aaa1`) — debug-only assertions
  (compiled out in release): the rewrite output operand scan and cranelift
  `resolve_opref` assert that no non-null `ConstPtr` survives as an op operand.

### Part 2 — `rgc.can_move` const-baking guard (parity refinement)

The Part-1 transient-only assertions were a pyre approximation, stricter than
upstream. The actual spec is `x86/regalloc.py:55-63` `convert_to_imm`: refuse a
`ConstPtr` immediate **only when it is non-null and its object can still move**
(`rgc.can_move`, `rpython/rlib/rgc.py:229`); null and immortal/non-moving
(prebuilt / old-gen) `ConstPtr`s are still baked as immediates.

- **`can_move` predicate** (`33369b241a`) — `GcAllocator::can_move`, default
  `false` ("non-moving GC ⇒ False"); the MiniMark collector returns
  `is_in_nursery(g.0) && !pinned`. Module-level `majit_gc::can_move` routes to
  the active GC via a new `ActiveGcGuardHooks.can_move` hook and returns `false`
  when no GC is active — which subsumes the `we_are_translated()` clause.
- **The guard** (`c31744efca`) — applied at the `inline_const_bits` `ConstPtr`
  baking sites: dynasm `RegisterManager::convert_to_imm` (the direct
  `x86/regalloc.py:55` analogue), and cranelift's `guard_constptr_immediate`
  helper at `resolve_opref` / `resolve_opref_or_imm` / `resolve_failarg_opref`
  (replacing the Part-1 is-null op-arg assert). A non-null movable `ConstPtr`
  reaching a baking site is now a loud `not_implemented`-parity panic instead of
  a silently-staled immediate.

**Structural adaptations** (documented in code)

- **Absolute-base addressing on 64-bit** — cites `x86/assembler.py:1551-1552`
  (`IS_X86_32` `MOV_rj`); dynasm-rs / cranelift `JITModule` lack RPython's
  code-buffer-start reservation seam, so the per-loop `Box` base is baked as an
  immediate uniformly.
- **`GcTable` = `Box<[Cell<GcRef>]>` + `Weak` registry** instead of a
  `GCREFTRACER` `GcStruct` with a custom trace hook — pyre has no
  custom-trace-hook facility; the extra-root-walker registry is the established
  equivalent. Stop-the-world collection makes in-place `Cell` slot mutation
  race-free.
- **Descrs excluded from the table** — cites `rewrite.py:123-126`; pyre descrs
  are `Arc<FailDescrCell>` pinned via the keepalive `Arc`, not moving-GC objects.

**Validation**

- aarch64 release: `check.py` dynasm 79/79 + cranelift 79/79.
- debug: `majit-gc` + `majit-metainterp` both backends all-pass (exercises the
  transient-only debug assertions; no `can_move` panic).
- x86_64 (Rosetta) release: dynasm 78/1 + cranelift 78/1 — only nbody fails
  (benign cross-arch FP); the `trace.rs:820` OOB canary is clean, no
  panic/SIGSEGV/`needs special care`.
## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced garbage collection table infrastructure to manage compiled code references, improving memory lifecycle tracking across JIT-compiled traces.

* **Refactor**
  * Enhanced garbage collection handling across multiple compiler backends for more robust reference management and improved stability during code generation and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
