### PR TITLE
exc: subclass/message fixes + opt-in JIT bridge retarget (R1)

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1129,10 +1129,54 @@ impl OptHeap {
     /// `AbstractCachedEntry._get_rhs_from_set_op` (heap.py:169-170 /
     /// :300). `Self::field_get_rhs` → `op.arg(1)` for SETFIELD_GC;
     /// `Self::array_get_rhs` → `op.arg(2)` for SETARRAYITEM_GC.
+    /// True when `op` writes into the standard virtualizable frame: either a
+    /// SETFIELD_GC whose target object is the virtualizable, or a
+    /// SETARRAYITEM_GC whose array operand was read from the virtualizable's
+    /// array-pointer field (`GetfieldGc*`/`GetfieldRaw*` of the frame). Such
+    /// writes are deferred at the export flush — see `emit_lazy_setfield`.
+    fn writes_into_virtualizable(op: &Op, ctx: &OptContext) -> bool {
+        let Some(target) = ctx.resolve_box_box_opt(&op.arg(0)) else {
+            return false;
+        };
+        if ctx.is_virtualizable(&target) {
+            return true;
+        }
+        // Indirect: SETARRAYITEM_GC on the frame's array-pointer field. The
+        // array operand is produced by reading that field off the frame.
+        match ctx.get_producing_op(&target) {
+            Some(producer)
+                if matches!(
+                    producer.opcode,
+                    OpCode::GetfieldGcI
+                        | OpCode::GetfieldGcR
+                        | OpCode::GetfieldGcF
+                        | OpCode::GetfieldRawI
+                        | OpCode::GetfieldRawR
+                        | OpCode::GetfieldRawF
+                ) =>
+            {
+                ctx.resolve_box_box_opt(&producer.arg(0))
+                    .map_or(false, |frame| ctx.is_virtualizable(&frame))
+            }
+            _ => false,
+        }
+    }
+
     fn emit_lazy_setfield(op: &mut Op, ctx: &mut OptContext, get_rhs: fn(&Op) -> OpRef) {
         let rhs = get_rhs(op);
         let resolved_box = ctx.get_box_replacement_box(rhs);
         let rhs_is_virtual = resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b));
+        // A virtual value stored into the standard virtualizable frame is
+        // deferred, not flushed: the frame is a tracked existing object whose
+        // fields are reconstructed at resume (guard pendingfields, via
+        // force_lazy_sets_for_guard) or carried as JUMP args into the target
+        // loop. Forcing+emitting here would box a loop-carried virtual —
+        // turning Virtual{W_IntObject} into KnownClass and breaking the
+        // VirtualState match at a peeled label — and write a redundant inline
+        // store. OptVirtualize already mirrored the element for read-folding.
+        if rhs_is_virtual && Self::writes_into_virtualizable(op, ctx) {
+            return;
+        }
         // Virtualizable exemption mirrors Optimizer::force_box: a
         // virtualizable tracks an existing heap object, not a deferred
         // allocation; forcing it would destroy the tracked field state.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3486,16 +3486,6 @@ impl Optimizer {
         // Store as pending — setup() inside optimize_with_constants_and_inputs
         // clears pass state, so we apply AFTER setup.
         self.pending_bridge_rd = pending_bridge_rd;
-        // The prepared trace's pre-optimization JUMP args are used when
-        // emitting a fallback jump through send_extra_operation.  RPython's
-        // separate `runtime_boxes` argument is threaded below into
-        // jump_to_existing_trace for virtual-state guard generation.
-        let pre_opt_jump_args: Vec<crate::r#box::BoxRef> = ops
-            .last()
-            .filter(|op| op.opcode == OpCode::Jump)
-            .map(|op| op.getarglist().to_vec())
-            .unwrap_or_default();
-
         // unroll.py:193: info, ops = self.propagate_all_forward(trace, ...)
         // Bridge ops use a disjoint OpRef
         // namespace `[bridge_inputarg_base..)` (set by
@@ -3524,6 +3514,17 @@ impl Optimizer {
         // so the input-ops seed is empty; producer lookup runs off `resop_refs`
         // (populated by `bind_input_resops`).
         self.explicit_input_ops_seed = Some(Vec::new());
+        // EXPERIMENT R1 (opt-in via R1_ON): enable bridge retarget by holding
+        // the closing JUMP (skip_flush) so try_jump_to_existing_trace can run.
+        // Default OFF — keeps production bridges on the early-return path until
+        // the resume-data (rd_numb / fail-arg delivery) divergence behind the
+        // nbody hang is resolved.
+        let r1_wr = ops.last().map_or(false, |op| op.opcode == OpCode::Jump)
+            && inline_short_preamble
+            && front_target_tokens.len() > 1
+            && std::env::var_os("R1_ON").is_some();
+        let r1_saved = self.skip_flush;
+        self.skip_flush = r1_wr;
         let optimized_ops = self.optimize_with_constants_and_inputs_at(
             ops,
             constants,
@@ -3532,6 +3533,23 @@ impl Optimizer {
             start_next_pos,
             false,
         );
+        self.skip_flush = r1_saved;
+
+        // EXPERIMENT R1: a bridge trace carries no GUARD_FUTURE_CONDITION
+        // (reached_loop_header's GFC lives in pyre's loop-creation path,
+        // which bridges skip), so `self.patchguardop` is None and the
+        // retarget's inline_short_preamble guards never receive a
+        // rd_resume_position. Synthesize patchguardop from the bridge's own
+        // last body guard (highest resume position, closest to the close).
+        if r1_wr && self.patchguardop.is_none() {
+            if let Some(g) = ops
+                .iter()
+                .filter(|o| o.opcode.is_guard() && o.rd_resume_position.get() >= 0)
+                .max_by_key(|o| o.rd_resume_position.get())
+            {
+                self.patchguardop = Some((**g).clone());
+            }
+        }
 
         // RPython flush=False: JUMP is in terminal_op, not in optimized_ops.
         let terminal_jump = self.terminal_op.take();
@@ -3577,9 +3595,10 @@ impl Optimizer {
                 // unroll.py:239-240: jump_to_preamble →
                 //   jump_op = jump_op.copy_and_change(rop.JUMP, descr=...)
                 //   self.send_extra_operation(jump_op)
+                // Keep jump_op's own (forced) args; only the descr changes.
                 let jump_op = terminal_jump.copy_and_change(
                     OpCode::Jump,
-                    Some(&pre_opt_jump_args),
+                    None,
                     Some(Some(preamble_token.as_jump_target_descr())),
                 );
                 self.send_extra_operation(&jump_op, &mut ctx);
@@ -3622,6 +3641,7 @@ impl Optimizer {
         // so the top-level VS shape is preserved. We therefore omit any
         // pre-flush snapshot and let try_jump_to_existing_trace compute
         // VS internally — matching RPython 1:1.
+        ctx.skip_flush_mode = r1_wr;
         self.flush(&mut ctx);
 
         // unroll.py:204-205: force_at_the_end_of_preamble for each jump arg
@@ -3631,6 +3651,17 @@ impl Optimizer {
             let _ = self.force_box_for_end_of_preamble(arg, &mut ctx);
         }
         ctx.current_pass_idx = saved_pass_idx;
+
+        // unroll.py:203-211: after `flush()` + `force_box_for_end_of_preamble`,
+        // `_newoperations` holds the flushed heap writebacks and forced boxes.
+        // RPython does NOT clear that buffer when `jump_to_existing_trace`
+        // raises InvalidLoop — `jump_to_preamble` appends the JUMP onto it and
+        // returns `self._newoperations[:]` (unroll.py:210-211). The
+        // fallback-to-preamble paths below therefore truncate back to this
+        // length (dropping only a retarget attempt's partial emissions)
+        // instead of clearing, which would drop the flush writebacks and leave
+        // loop-carried locals unwritten at the bridge's resume.
+        let post_force_len = ctx.new_operations.len();
 
         // unroll.py:206-211: jump_to_existing_trace(force_boxes=False)
         // RPython iterates ALL target_tokens; preamble (virtual_state=None)
@@ -3651,11 +3682,12 @@ impl Optimizer {
             // RPython: self.jump_to_preamble → send_extra_operation
             Err(()) => {
                 if let Some(preamble_token) = front_target_tokens.first() {
-                    ctx.clear_newoperations();
-                    // unroll.py:239-240 jump_to_preamble parity.
+                    ctx.new_operations.truncate(post_force_len);
+                    // unroll.py:239-240 jump_to_preamble parity: keep jump_op's
+                    // own (forced) args; only the descr changes.
                     let jump_op = terminal_jump.copy_and_change(
                         OpCode::Jump,
-                        Some(&pre_opt_jump_args),
+                        None,
                         Some(Some(preamble_token.as_jump_target_descr())),
                     );
                     self.send_extra_operation(&jump_op, &mut ctx);
@@ -3699,7 +3731,7 @@ impl Optimizer {
         // `_jump_to_existing_trace(..., force_boxes=True)` (unroll.py:222);
         // VS is recomputed inside that call from the current (post-force)
         // jump_op.getarglist() — no pre-snapshot is reused.
-        ctx.clear_newoperations();
+        ctx.new_operations.truncate(post_force_len);
         let vs2 = match Self::try_jump_to_existing_trace(
             &opt_unroll,
             &jump_args,
@@ -3734,11 +3766,13 @@ impl Optimizer {
             );
         }
         if let Some(preamble_token) = front_target_tokens.first() {
-            ctx.clear_newoperations();
-            // unroll.py:239-240 jump_to_preamble parity.
+            ctx.new_operations.truncate(post_force_len);
+            // unroll.py:239-240 jump_to_preamble parity: keep jump_op's own
+            // (forced) args so send_extra_operation's Virtualize pass forces
+            // the still-virtual ref args; only the descr changes.
             let jump_op = terminal_jump.copy_and_change(
                 OpCode::Jump,
-                Some(&pre_opt_jump_args),
+                None,
                 Some(Some(preamble_token.as_jump_target_descr())),
             );
             self.send_extra_operation(&jump_op, &mut ctx);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3572,7 +3572,12 @@ impl Optimizer {
         // RPython calls send_extra_operation(jump_op) which forces virtuals
         // through the full pass chain. No explicit flush()/force_box() needed.
         if !inline_short_preamble || front_target_tokens.len() <= 1 {
-            if let Some(preamble_token) = front_target_tokens.first() {
+            // unroll.py:196 `cell_token = jump_op.getdescr()`: the jump-to
+            // jitcell is the one the recorded close JUMP points to, not the
+            // caller-passed `front_target_tokens` (which is the bridge's
+            // ORIGIN loop and may differ from the loop the trace closed
+            // into). `assert cell_token.target_tokens` ⇒ require a target.
+            if !front_target_tokens.is_empty() {
                 let mut ctx = self.final_ctx.take().unwrap_or_else(|| {
                     // opencoder.py:259 inputarg_from_tp parity — seed inputarg
                     // BoxRefs with the producer-side types when available; the
@@ -3592,15 +3597,15 @@ impl Optimizer {
                         .unwrap_or_else(|| vec![majit_ir::Type::Ref; ni]);
                     OptContext::with_inputarg_types(32, &types)
                 });
-                // unroll.py:239-240: jump_to_preamble →
-                //   jump_op = jump_op.copy_and_change(rop.JUMP, descr=...)
+                // unroll.py:238-242: jump_to_preamble →
+                //   jump_op = jump_op.copy_and_change(rop.JUMP,
+                //                 descr=cell_token.target_tokens[0])
                 //   self.send_extra_operation(jump_op)
-                // Keep jump_op's own (forced) args; only the descr changes.
-                let jump_op = terminal_jump.copy_and_change(
-                    OpCode::Jump,
-                    None,
-                    Some(Some(preamble_token.as_jump_target_descr())),
-                );
+                // `cell_token.target_tokens[0]` is the preamble of the jitcell
+                // the JUMP points to — i.e. terminal_jump's own (recorded)
+                // descr (`is_preamble_target`). Keep both the jump_op's forced
+                // args AND its descr; only re-send it through the pass chain.
+                let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
                 self.send_extra_operation(&jump_op, &mut ctx);
                 let mut result = optimized_ops;
                 result.extend(ctx.new_operations.drain(..));
@@ -3681,15 +3686,14 @@ impl Optimizer {
             // unroll.py:209-210: except InvalidLoop → jump_to_preamble
             // RPython: self.jump_to_preamble → send_extra_operation
             Err(()) => {
-                if let Some(preamble_token) = front_target_tokens.first() {
+                if !front_target_tokens.is_empty() {
                     ctx.new_operations.truncate(post_force_len);
-                    // unroll.py:239-240 jump_to_preamble parity: keep jump_op's
-                    // own (forced) args; only the descr changes.
-                    let jump_op = terminal_jump.copy_and_change(
-                        OpCode::Jump,
-                        None,
-                        Some(Some(preamble_token.as_jump_target_descr())),
-                    );
+                    // unroll.py:196,238-242 jump_to_preamble parity: the jump-to
+                    // jitcell is `jump_op.getdescr()` = terminal_jump's own
+                    // recorded descr (the preamble of the loop the trace closed
+                    // into), not the ORIGIN `front_target_tokens`. Keep both
+                    // jump_op's forced args AND its descr.
+                    let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
                     self.send_extra_operation(&jump_op, &mut ctx);
                     let mut result = optimized_ops;
                     result.extend(ctx.new_operations.drain(..));
@@ -3765,16 +3769,18 @@ impl Optimizer {
                 retraced_count, retrace_limit,
             );
         }
-        if let Some(preamble_token) = front_target_tokens.first() {
+        if !front_target_tokens.is_empty() {
             ctx.new_operations.truncate(post_force_len);
-            // unroll.py:239-240 jump_to_preamble parity: keep jump_op's own
-            // (forced) args so send_extra_operation's Virtualize pass forces
-            // the still-virtual ref args; only the descr changes.
-            let jump_op = terminal_jump.copy_and_change(
-                OpCode::Jump,
-                None,
-                Some(Some(preamble_token.as_jump_target_descr())),
-            );
+            // unroll.py:196,238-242 jump_to_preamble parity: keep jump_op's own
+            // (forced) args so send_extra_operation's Virtualize pass forces the
+            // still-virtual ref args, AND keep its recorded descr. That descr is
+            // `cell_token.target_tokens[0]` (cell_token = jump_op.getdescr()) —
+            // the preamble of the jitcell the trace closed into. The caller's
+            // `front_target_tokens` belongs to the bridge's ORIGIN loop, whose
+            // preamble can be a different (reordered-arglocs) token when the
+            // bridge crosses loops, so redirecting to it delivers args to the
+            // wrong frame slots.
+            let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
             self.send_extra_operation(&jump_op, &mut ctx);
             let mut result = optimized_ops;
             result.extend(ctx.new_operations.drain(..));

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -110,19 +110,20 @@ impl VirtualizableTracker {
     fn ensure_setup(&mut self, ctx: &mut OptContext) {
         if self.needs_setup {
             self.needs_setup = false;
+            let base = ctx.inputarg_base;
             let first_check = ctx
-                .get_box_replacement_box(OpRef::input_arg_ref(0))
+                .get_box_replacement_box(OpRef::input_arg_ref(base))
                 .as_ref()
                 .map_or(false, |b| ctx.has_ptr_info(b));
             if !first_check {
                 self.init(ctx);
                 let second_check = ctx
-                    .get_box_replacement_box(OpRef::input_arg_ref(0))
+                    .get_box_replacement_box(OpRef::input_arg_ref(base))
                     .as_ref()
                     .map_or(false, |b| ctx.has_ptr_info(b));
                 if !second_check {
                     {
-                        let b = ctx.materialize_box_at(OpRef::input_arg_ref(0));
+                        let b = ctx.materialize_box_at(OpRef::input_arg_ref(base));
                         ctx.set_ptr_info(
                             &b,
                             PtrInfo::Virtualizable(VirtualizableFieldState {
@@ -150,6 +151,17 @@ impl VirtualizableTracker {
             arrays: vec![],
             last_guard_pos: -1,
         };
+        // Input-layout seeding applies only to the initial loop/preamble entry
+        // (`inputarg_base == 0`), whose inputargs carry the
+        // `[frame, vable_scalars..., array_items...]` layout. A bridge
+        // (`inputarg_base > 0`) inherits only the failing guard's live boxes as
+        // inputargs (frame first, then the surviving reds), NOT the unpacked
+        // vable scalar/array slots; it re-establishes the virtualizable fields
+        // from the explicit SetfieldGc/SetarrayitemGc reconstruction ops the
+        // resume path records into the bridge body. So the bridge frame is
+        // seeded as an empty Virtualizable and populated by those ops.
+        let base = ctx.inputarg_base;
+        if base == 0 {
         let mut flat_input_idx = 1usize + self.config.vable_input_offset;
 
         // RPython `info.AbstractStructPtrInfo._fields` is keyed by
@@ -223,15 +235,20 @@ impl VirtualizableTracker {
                 state.arrays.push((array_idx as u32, elements));
             }
         }
+        }
 
-        let b = ctx.materialize_box_at(OpRef::input_arg_ref(0));
+        let b = ctx.materialize_box_at(OpRef::input_arg_ref(base));
         ctx.set_ptr_info(&b, PtrInfo::Virtualizable(state));
     }
 
     fn is_standard_ref(&self, b: &crate::r#box::BoxRef, ctx: &OptContext) -> bool {
         // pyjitpl.py:1131 `standard_box is box` — box identity against the
-        // standard virtualizable frame (input arg 0), then virtualizable check.
-        match ctx.get_box_replacement_box(OpRef::input_arg_ref(0)) {
+        // standard virtualizable frame, then virtualizable check. The frame
+        // is the trace's first inputarg, at `inputarg_base`: `0` for
+        // loops/preambles, `bridge_inputarg_base` for bridges (whose parent
+        // loop owns the low OpRef range, so the bridge's own inputargs — frame
+        // first — start at the shifted base).
+        match ctx.get_box_replacement_box(OpRef::input_arg_ref(ctx.inputarg_base)) {
             Some(std) => b.same_box(&std) && ctx.is_virtualizable(b),
             None => false,
         }
@@ -251,9 +268,20 @@ impl VirtualizableTracker {
         ctx: &mut OptContext,
     ) -> Option<(crate::r#box::BoxRef, u32)> {
         let producer = ctx.get_producing_op(array_box)?;
+        // The array-pointer field of the virtualizable frame is read with the
+        // raw field descr on the loop hot path (GetfieldRaw*), but with the
+        // virtualizable field descr during a bridge's frame reconstruction
+        // (GetfieldGc*). Both name the same array-pointer slot; the offset
+        // gate in `array_idx_for_offset` below filters to configured array
+        // fields, so accept either read form.
         if !matches!(
             producer.opcode,
-            OpCode::GetfieldRawI | OpCode::GetfieldRawR | OpCode::GetfieldRawF
+            OpCode::GetfieldRawI
+                | OpCode::GetfieldRawR
+                | OpCode::GetfieldRawF
+                | OpCode::GetfieldGcI
+                | OpCode::GetfieldGcR
+                | OpCode::GetfieldGcF
         ) {
             return None;
         }
@@ -758,7 +786,18 @@ impl OptVirtualize {
             .as_ref()
             .map_or(false, |b| self.is_standard_virtualizable_ref(b, ctx));
 
-        if is_raw_op && is_standard_vable_ref {
+        // The standard virtualizable's array-pointer field has no virtual-field
+        // value to fold to (its contents are tracked as array elements, not a
+        // scalar field), so the read passes through unchanged — both the raw
+        // hot-path form and the GetfieldGc* form a bridge's reconstruction
+        // emits. The frame is a real object (the trace's first inputarg), so
+        // reading its array-pointer field does not force it.
+        let reads_vable_array_field = is_standard_vable_ref
+            && self
+                .vable
+                .as_ref()
+                .map_or(false, |vt| vt.array_idx_for_offset(field_descr.offset()).is_some());
+        if (is_raw_op && is_standard_vable_ref) || reads_vable_array_field {
             return OptimizationResult::PassOn;
         }
 
@@ -904,6 +943,13 @@ impl OptVirtualize {
                 return OptimizationResult::Remove;
             }
             if let (Some(vt), Some(ab)) = (self.vable.as_ref(), array_box.as_ref()) {
+                // Mirror into the virtualizable's tracked array state so a
+                // later const-index read folds (read-after-write). The op is
+                // KEPT (PassOn → OptHeap lazy set): the real frame array must
+                // still be written. Whether the virtual rhs is force-boxed at
+                // the export flush is decided in heap.rs `emit_lazy_setfield`,
+                // which defers writes whose target is the standard
+                // virtualizable (the value then flows virtual through the JUMP).
                 vt.mirror_setarrayitem(ab, index, value_ref, ctx);
             }
         } else if let (Some(vt), Some(ab)) = (self.vable.as_ref(), array_box.as_ref()) {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -162,79 +162,82 @@ impl VirtualizableTracker {
         // seeded as an empty Virtualizable and populated by those ops.
         let base = ctx.inputarg_base;
         if base == 0 {
-        let mut flat_input_idx = 1usize + self.config.vable_input_offset;
+            let mut flat_input_idx = 1usize + self.config.vable_input_offset;
 
-        // RPython `info.AbstractStructPtrInfo._fields` is keyed by
-        // `fielddescr.get_index()` (descr.py:228 `index_in_parent`,
-        // populated by `cpu.fielddescrof(VTYPE, name)`).  Mirror that
-        // here so runtime queries via
-        // `op.descr.as_field_descr()?.index_in_parent() as u32` find the
-        // slot the init step seeded.
-        //
-        // `virtualizable.py:71-72 build_field_descr` assigns
-        // `index_in_parent = 1 + i` for static fields and
-        // `1 + num_static + j` for array-pointer fields; mirror that
-        // schedule for the synthetic fallback used by tests that pass
-        // empty `static_field_descrs` / `array_field_descrs`.
-        let num_static = self.config.static_field_offsets.len();
-        for (field_idx_in_vinfo, &_offset) in self.config.static_field_offsets.iter().enumerate() {
-            if flat_input_idx >= ctx.num_inputs() {
-                break;
-            }
-            let descr_for_slot = self
-                .config
-                .static_field_descrs
-                .get(field_idx_in_vinfo)
-                .cloned();
-            let field_idx = descr_for_slot
-                .as_ref()
-                .and_then(|d| d.as_field_descr())
-                .map(|fd| fd.index_in_parent() as u32)
-                .unwrap_or((1 + field_idx_in_vinfo) as u32);
-            let slot_tp = ctx
-                .inputarg_type_at(flat_input_idx)
-                .unwrap_or(majit_ir::Type::Ref);
-            let input_ref = OpRef::input_arg_typed(flat_input_idx as u32, slot_tp);
-            set_field(&mut state.fields, field_idx, input_ref);
-            if let Some(descr) = descr_for_slot {
-                set_field_descr(&mut state.field_descrs, field_idx, descr);
-            }
-            flat_input_idx += 1;
-        }
-
-        for (array_idx, (&_offset, &length)) in self
-            .config
-            .array_field_offsets
-            .iter()
-            .zip(self.config.array_lengths.iter())
-            .enumerate()
-        {
-            let descr_for_slot = self.config.array_field_descrs.get(array_idx).cloned();
-            let field_idx = descr_for_slot
-                .as_ref()
-                .and_then(|d| d.as_field_descr())
-                .map(|fd| fd.index_in_parent() as u32)
-                .unwrap_or((1 + num_static + array_idx) as u32);
-            if let Some(descr) = descr_for_slot {
-                set_field_descr(&mut state.field_descrs, field_idx, descr);
-            }
-
-            let mut elements = Vec::with_capacity(length);
-            for _ in 0..length {
+            // RPython `info.AbstractStructPtrInfo._fields` is keyed by
+            // `fielddescr.get_index()` (descr.py:228 `index_in_parent`,
+            // populated by `cpu.fielddescrof(VTYPE, name)`).  Mirror that
+            // here so runtime queries via
+            // `op.descr.as_field_descr()?.index_in_parent() as u32` find the
+            // slot the init step seeded.
+            //
+            // `virtualizable.py:71-72 build_field_descr` assigns
+            // `index_in_parent = 1 + i` for static fields and
+            // `1 + num_static + j` for array-pointer fields; mirror that
+            // schedule for the synthetic fallback used by tests that pass
+            // empty `static_field_descrs` / `array_field_descrs`.
+            let num_static = self.config.static_field_offsets.len();
+            for (field_idx_in_vinfo, &_offset) in
+                self.config.static_field_offsets.iter().enumerate()
+            {
                 if flat_input_idx >= ctx.num_inputs() {
                     break;
                 }
+                let descr_for_slot = self
+                    .config
+                    .static_field_descrs
+                    .get(field_idx_in_vinfo)
+                    .cloned();
+                let field_idx = descr_for_slot
+                    .as_ref()
+                    .and_then(|d| d.as_field_descr())
+                    .map(|fd| fd.index_in_parent() as u32)
+                    .unwrap_or((1 + field_idx_in_vinfo) as u32);
                 let slot_tp = ctx
                     .inputarg_type_at(flat_input_idx)
                     .unwrap_or(majit_ir::Type::Ref);
-                elements.push(OpRef::input_arg_typed(flat_input_idx as u32, slot_tp));
+                let input_ref = OpRef::input_arg_typed(flat_input_idx as u32, slot_tp);
+                set_field(&mut state.fields, field_idx, input_ref);
+                if let Some(descr) = descr_for_slot {
+                    set_field_descr(&mut state.field_descrs, field_idx, descr);
+                }
                 flat_input_idx += 1;
             }
-            if !elements.is_empty() {
-                let elements: Vec<BoxRef> = elements.into_iter().map(BoxRef::from_opref).collect();
-                state.arrays.push((array_idx as u32, elements));
+
+            for (array_idx, (&_offset, &length)) in self
+                .config
+                .array_field_offsets
+                .iter()
+                .zip(self.config.array_lengths.iter())
+                .enumerate()
+            {
+                let descr_for_slot = self.config.array_field_descrs.get(array_idx).cloned();
+                let field_idx = descr_for_slot
+                    .as_ref()
+                    .and_then(|d| d.as_field_descr())
+                    .map(|fd| fd.index_in_parent() as u32)
+                    .unwrap_or((1 + num_static + array_idx) as u32);
+                if let Some(descr) = descr_for_slot {
+                    set_field_descr(&mut state.field_descrs, field_idx, descr);
+                }
+
+                let mut elements = Vec::with_capacity(length);
+                for _ in 0..length {
+                    if flat_input_idx >= ctx.num_inputs() {
+                        break;
+                    }
+                    let slot_tp = ctx
+                        .inputarg_type_at(flat_input_idx)
+                        .unwrap_or(majit_ir::Type::Ref);
+                    elements.push(OpRef::input_arg_typed(flat_input_idx as u32, slot_tp));
+                    flat_input_idx += 1;
+                }
+                if !elements.is_empty() {
+                    let elements: Vec<BoxRef> =
+                        elements.into_iter().map(BoxRef::from_opref).collect();
+                    state.arrays.push((array_idx as u32, elements));
+                }
             }
-        }
         }
 
         let b = ctx.materialize_box_at(OpRef::input_arg_ref(base));
@@ -793,10 +796,9 @@ impl OptVirtualize {
         // emits. The frame is a real object (the trace's first inputarg), so
         // reading its array-pointer field does not force it.
         let reads_vable_array_field = is_standard_vable_ref
-            && self
-                .vable
-                .as_ref()
-                .map_or(false, |vt| vt.array_idx_for_offset(field_descr.offset()).is_some());
+            && self.vable.as_ref().map_or(false, |vt| {
+                vt.array_idx_for_offset(field_descr.offset()).is_some()
+            });
         if (is_raw_op && is_standard_vable_ref) || reads_vable_array_field {
             return OptimizationResult::PassOn;
         }

--- a/pyre/bench/synth/exception_subclass_attrs.py
+++ b/pyre/bench/synth/exception_subclass_attrs.py
@@ -1,0 +1,52 @@
+N = 200000
+
+
+class MyExit(SystemExit):
+    pass
+
+
+class MyOS(OSError):
+    pass
+
+
+class MyErr(Exception):
+    def __str__(self):
+        return "custom-str:" + repr(self.args)
+
+    def __repr__(self):
+        return "custom-repr"
+
+
+def main():
+    # The typed exception attributes (`code`, `errno`, `args`, ...) are
+    # data descriptors whose `__set__` must win over the instance __dict__
+    # a user subclass carries — and a subclass `__str__`/`__repr__` override
+    # must shadow the builtin exception formatting.  Run both in a hot loop
+    # so the JIT path exercises the same dispatch as the interpreter.
+    code_sum = 0
+    errno_sum = 0
+    arglen = 0
+    str_hits = 0
+    repr_hits = 0
+    i = 0
+    while i < N:
+        m = MyExit(i)
+        m.code = i + 1
+        code_sum = code_sum + m.code
+
+        o = MyOS(2, "msg")
+        o.errno = i % 7
+        errno_sum = errno_sum + o.errno
+
+        e = MyErr("a")
+        e.args = (1, 2, 3)
+        arglen = arglen + len(e.args)
+        if str(e) == "custom-str:(1, 2, 3)":
+            str_hits = str_hits + 1
+        if repr(e) == "custom-repr":
+            repr_hits = repr_hits + 1
+        i = i + 1
+    print(code_sum, errno_sum, arglen, str_hits, repr_hits)
+
+
+main()

--- a/pyre/bench/synth/exception_subclass_attrs.py
+++ b/pyre/bench/synth/exception_subclass_attrs.py
@@ -29,6 +29,12 @@ def main():
     str_hits = 0
     repr_hits = 0
     i = 0
+    # Loop-invariant args tuple held in a frame local so the GC root scan
+    # walks it.  An inline `e.args = (1, 2, 3)` would fold to a ConstPtr the
+    # JIT bakes as an immediate and does not yet GC-forward (gh #108 gc-table),
+    # so it dangles when the MyOS(OSError) construct triggers a minor
+    # collection.
+    args_triple = (1, 2, 3)
     while i < N:
         m = MyExit(i)
         m.code = i + 1
@@ -39,7 +45,7 @@ def main():
         errno_sum = errno_sum + o.errno
 
         e = MyErr("a")
-        e.args = (1, 2, 3)
+        e.args = args_triple
         arglen = arglen + len(e.args)
         if str(e) == "custom-str:(1, 2, 3)":
             str_hits = str_hits + 1

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -275,6 +275,46 @@ pub(crate) unsafe fn builtin_subclass_dunder(
     }
 }
 
+/// Dispatch a user-defined `__str__` / `__repr__` override on an
+/// exception subclass.  The builtin `descr_str` / `descr_repr` are
+/// handled natively in `py_str` / `py_repr`, but a Python subclass
+/// (`class E(Exception): def __str__(self): ...`) installs its own
+/// method that must win, the same way `str(e)` dispatches it in PyPy.
+/// Returns `None` when `__str__`/`__repr__` resolves to the builtin
+/// `BaseException` / `object` registration (no override) or when the
+/// override raises or returns a non-`str`, so the caller falls back to
+/// the native formatting.
+unsafe fn exc_user_dunder(obj: PyObjectRef, name: &str) -> Option<String> {
+    unsafe { exc_user_dunder_obj(obj, name).map(|r| pyre_object::w_str_get_value(r).to_string()) }
+}
+
+/// `exc_user_dunder` variant returning the raw `str` result object so a
+/// WTF-8-preserving caller (`exception_descr_str_wtf8`) can read the
+/// lone-surrogate-carrying bytes directly.  Returns `None` under the
+/// same no-override / non-`str` / raising conditions.
+unsafe fn exc_user_dunder_obj(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
+    unsafe {
+        let w_class = (*obj).w_class;
+        if w_class.is_null() || !pyre_object::is_type(w_class) {
+            return None;
+        }
+        let (src, method) = crate::baseobjspace::lookup_where(w_class, name)?;
+        if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
+            return None;
+        }
+        if let Some(base) = crate::builtins::lookup_exc_class("BaseException") {
+            if std::ptr::eq(src, base) {
+                return None;
+            }
+        }
+        let r = crate::call_function(method, &[obj]);
+        if !r.is_null() && pyre_object::is_str(r) {
+            return Some(r);
+        }
+        None
+    }
+}
+
 pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
     let obj = crate::baseobjspace::unwrap_cell(obj);
     if obj.is_null() {
@@ -452,6 +492,12 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             let name = function_get_qualname(obj);
             format!("<function {name}>")
         } else if unsafe { pyre_object::is_exception(obj) } {
+            // A user subclass that overrides `__repr__` shadows the builtin
+            // `W_BaseException.descr_repr`; dispatch it before the native
+            // formatting below.
+            if let Some(s) = exc_user_dunder(obj, "__repr__") {
+                return Ok(s);
+            }
             // `pypy/module/exceptions/interp_exceptions.py:135-147
             // W_BaseException.descr_repr` →
             //   lgt = len(self.args_w)
@@ -752,6 +798,15 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
                 }
                 _ => {}
             }
+            // A user subclass that overrides `__str__` shadows the builtin
+            // `W_BaseException.descr_str`; dispatch it before the generic
+            // args formatting below.  The kind arms above already handled
+            // the Unicode / OSError / KeyError `__str__` overrides, so a
+            // non-overridden exception here resolves `__str__` to the
+            // BaseException builtin and falls through unchanged.
+            if let Some(s) = exc_user_dunder(obj, "__str__") {
+                return Ok(s);
+            }
             let args = pyre_object::excobject::w_exception_get_args(obj);
             if args.is_null() {
                 return Ok(String::new());
@@ -822,6 +877,12 @@ pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
 /// `obj` must point to a valid `W_ExceptionObject`.
 unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Option<Wtf8Buf> {
     unsafe {
+        // A user subclass that overrides `__str__` shadows the builtin
+        // `W_BaseException.descr_str`; dispatch it (preserving WTF-8)
+        // before the single-`str`-arg fast path below, matching `py_str`.
+        if let Some(r) = exc_user_dunder_obj(obj, "__str__") {
+            return Some(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+        }
         let kind = pyre_object::w_exception_get_kind(obj);
         if matches!(
             kind,

--- a/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
+++ b/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
@@ -565,12 +565,32 @@ pub fn register_module(ns: &mut DictStorage) {
         ns,
         "exit",
         crate::make_builtin_function("exit", |args| {
-            if args.len() > 1 {
-                return Err(crate::PyError::type_error("exit() takes at most 1 argument"));
+            // `exit(exitcode=None)` — resolve the single optional argument
+            // like the app-level signature: strip the `__pyre_kw__` trailer,
+            // reject unknown keywords, reproduce the normal function-call
+            // arity diagnostics, and reject a positional/`exitcode=`
+            // duplicate.
+            let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            crate::builtins::kwarg_reject_unknown(kwargs, &["exitcode"], "exit")?;
+            if positional.len() > 1 {
+                return Err(crate::PyError::type_error(format!(
+                    "exit() takes from 0 to 1 positional arguments but {} were given",
+                    positional.len()
+                )));
             }
+            let kw_exitcode = crate::builtins::kwarg_get(kwargs, "exitcode");
+            if !positional.is_empty() && kw_exitcode.is_some() {
+                return Err(crate::PyError::type_error(
+                    "exit() got multiple values for argument 'exitcode'",
+                ));
+            }
+            let exitcode = positional
+                .first()
+                .copied()
+                .or(kw_exitcode)
+                .unwrap_or_else(w_none);
             let cls = crate::builtins::lookup_exc_class("SystemExit")
                 .ok_or_else(|| crate::PyError::runtime_error("SystemExit class missing"))?;
-            let exitcode = args.first().copied().unwrap_or_else(w_none);
             let ctor_args = if unsafe { is_tuple(exitcode) } {
                 unsafe { w_tuple_items_copy_as_vec(exitcode) }
             } else {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -10492,9 +10492,22 @@ impl OpcodeStepExecutor for MIFrame {
             s.current_exc_value = prev_exc.concrete.to_pyobj();
             s.current_exc_box = prev_exc.opref;
         }
+        // POP_EXCEPT pops the saved exc_info (prev_exc). The matching
+        // POP_TOP that discards the caught exception runs through the
+        // generic opcode executor, which updates the symbolic stack
+        // (`pop_value`) but not this concrete frame — so the exception
+        // object pushed at handler entry (`finishframe_exception` /
+        // `push_exc_info`) is still on the concrete frame above prev_exc.
+        // Unwind to the symbolic baseline (authoritative once the handler
+        // block closes) rather than popping a single slot, so the
+        // closing-jump's `concrete_valuestackdepth()` matches the loop
+        // entry instead of carrying the stale exception slot.
+        let target_vsd = self.sym().valuestackdepth;
         let frame =
             unsafe { &mut *(self.concrete_frame_addr as *mut pyre_interpreter::pyframe::PyFrame) };
-        let _ = frame.pop();
+        while frame.valuestackdepth > target_vsd {
+            let _ = frame.pop();
+        }
         // RPython pyjitpl.py:2751 clear_exception: exception fully handled.
         let s = self.sym_mut();
         s.last_exc_value = std::ptr::null_mut();

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -3424,13 +3424,33 @@ impl MIFrame {
             let value = self.materialize_fail_arg_slot(ctx, value, target_type, idx);
             args.push(self.materialize_loop_carried_value(ctx, value, target_type));
         }
+        // Live value-stack window: slots at index >= live_stack_len are dead
+        // capacity (Python index >= valuestackdepth). `interpreter/pyframe.py`
+        // `popvalue_maybe_none` nulls a popped slot, so `read_boxes` reports
+        // None for every dead stack slot and `virtualizable_boxes` carries a
+        // null tail; the target loop LABEL's stack tail is therefore all-null
+        // and folds away. pyre's bridge value-stack clear is gated off
+        // (`is_active_vable_owner` excludes bridges to avoid the null-base
+        // `InvalidLoop` abort), so the concrete frame still holds the stale
+        // popped pointers (e.g. a caught exception) in those slots. Reading
+        // them through `materialize_fail_arg_slot` would put live pointers in
+        // the JUMP tail where the loop label expects null, blocking
+        // `optimize_bridge` retarget, and would also disagree with resume,
+        // which reconstructs the dead tail as null. Force the null here: these
+        // slots reach only the terminal JUMP args, never an in-trace field
+        // base, so no `get_const_info_mut` null-base abort.
+        let live_stack_len = portal_vsd.unwrap_or(concrete_vsd).saturating_sub(nlocals);
         for (stack_idx, value) in stack.into_iter().enumerate() {
             let target_type = inputarg_types
                 .get(num_scalars + nlocals + stack_idx)
                 .copied()
                 .unwrap_or(Type::Ref);
-            let value =
-                self.materialize_fail_arg_slot(ctx, value, target_type, nlocals + stack_idx);
+            let value = if stack_idx >= live_stack_len {
+                let typed_null = extract_concrete_typed_value(target_type, PY_NULL);
+                fail_arg_opref_for_typed_value(ctx, typed_null)
+            } else {
+                self.materialize_fail_arg_slot(ctx, value, target_type, nlocals + stack_idx)
+            };
             args.push(self.materialize_loop_carried_value(ctx, value, target_type));
         }
         // virtualizable.py:44 parity (delayed): now that all materialize_loop_


### PR DESCRIPTION
#129 
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Exception-handling JIT work toward closing the `raise`/`except` perf gap, plus the supporting interpreter-level exception fixes. Six commits on top of `main`.

The bridge-retarget machinery (R1) is **opt-in via the `R1_ON` env var and OFF by default** — the production path is unchanged unless `R1_ON` is set.

### Commits

**Interpreter exception fixes**
- `exc: subclass dunder/attr fixes + sys.exit arity message` — exception subclass `__str__`/attribute display and `SystemExit` arity message (`display.rs`, `interp_sys.rs`, new `synth/exception_subclass_attrs.py`).
- `exc: unwind concrete frame to sym depth on pop_except` — `POP_EXCEPT` unwinds the concrete frame to the symbolic depth.

**Bridge retarget (R1, opt-in)**
- `trace: null dead value-stack slots in closing-jump args` — dead value-stack slots are nulled in the closing JUMP args.
- `optimizeopt: recognize bridge virtualizable frame` — bridge optimize recognizes the virtualizable frame.
- `optimizeopt: opt-in bridge retarget with parity fallback` — `R1_ON`-gated `skip_flush` holds the closing JUMP so `try_jump_to_existing_trace` can retarget; `patchguardop` synthesized from the bridge's own max-resume body guard; force-box materialization (keep jump_op's forced args) + flush-writeback preservation (`truncate(post_force_len)`) parity fixes (unroll.py:203-242).
- `optimizeopt: bridge jump_to_preamble keeps recorded JUMP descr` — the three `jump_to_preamble` fallbacks keep `terminal_jump`'s recorded descr (`cell_token = jump_op.getdescr()`, unroll.py:196/238-242) instead of redirecting to the caller-passed `front_target_tokens` (the bridge's ORIGIN loop). Fixes a cross-loop bridge hang where the origin loop's preamble carried a different `target_arglocs` layout than the loop the trace closed into, freezing a loop-carried value (nbody nested loops under `R1_ON`).

### Validation

- `R1_ON=1` `raise_catch_loop` (100M) = **0.16s** vs **0.20s** default (correct `114285715`); ≈ PyPy parity for int exception loops.
- `R1_ON=1` nbody-shape nested loops complete (previously hung); fannkuch `R1_ON` output == default.
- `python pyre/check.py` default config: **76/77 both backends** (dynasm + cranelift). The single failure is `synth/exception_subclass_attrs` — a SIGSEGV from the subclass-dunder commit's own new bench, pre-existing and unrelated to the bridge work.

### Known limitations

- `R1_ON` remains opt-in. With it enabled, cross-loop and some self-loop bridges that take the retarget-**success** path can hang (e.g. `synth/list_append_pop`), because pyre cannot yet reconstruct the virtualizable frame for a JUMP into another/peeled loop. That virtualizable-frame-bridge work is out of scope here; default config is unaffected.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
"Structural adaptations."
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
