### PR TITLE
M4 walker cutover: entry-hook opcode flips, GUARD_CLASS record parity, blackhole array-build wiring

### DIFF
--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1033,14 +1033,21 @@ fn catch_and_rewrap(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Result
     let e_exc_value_in = e_inputs[nonr_args.len() + 1].clone();
     let e_shell: Option<Variable> = if has_r {
         // `PyError::from_exc_object(exc_value)` is an associated fn (no
-        // `self`), yet it is spelled as a `Method` target with the caught
-        // exception value as `args[0]`.  This is correct here: a
-        // `CallTarget::Method` is a *static* impl-resolution hint
-        // (`call.rs resolve_method` → `for_impl_method(receiver, name)`),
-        // not a runtime `getattr(args[0], name)` dispatch, so args map
-        // positionally to the graph's params — `obj ← exc_value` — exactly
-        // as for the inherent `&self` `to_exc_object` above.  A
-        // `FunctionPath(["PyError", "from_exc_object"])` would instead
+        // `self`), yet it is spelled as a `Method` target with `receiver_root
+        // = "PyError"` and the caught exception value as `args[0]`.  The
+        // codewriter resolves the recorded call statically, not by a runtime
+        // dispatch on the exception object: `call.rs::resolve_method` keys the
+        // `getfunctionptr(graph)` identity on
+        // `CallPath::for_impl_method(receiver_root, name)` →
+        // `for_impl_method("PyError", "from_exc_object")` and never on the
+        // runtime receiver's class, so `exc_value` flows positionally into
+        // the callee's first param (`obj`) — the same way the inherent
+        // `&self` `to_exc_object` above threads its receiver positionally.
+        // (The rtyper's annotator-facing lowering in `flowspace_adapter.rs`
+        // does turn every `Method` into `getattr(args[0], leaf) →
+        // simple_call`; that view drives type inference only — the
+        // codewriter's static `resolve_method` above mints the actual call.)
+        // A `FunctionPath(["PyError", "from_exc_object"])` would instead
         // resolve to that bare two-segment path, which misses the
         // module-qualified impl-method registration and falls back to a
         // symbolic address.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9316,7 +9316,7 @@ fn try_walker_specialize_subscr(
     if !list_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(list_op) {
         let type_const = ctx.trace_ctx.const_int(list_type_addr);
         ctx.trace_ctx
-            .record_guard(OpCode::GuardNonnullClass, &[list_op, type_const], 0);
+            .record_guard(OpCode::GuardClass, &[list_op, type_const], 0);
         walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
     }
     ctx.trace_ctx
@@ -9484,7 +9484,7 @@ fn try_walker_specialize_store_subscr(
     if !list_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(list_op) {
         let type_const = ctx.trace_ctx.const_int(list_type_addr);
         ctx.trace_ctx
-            .record_guard(OpCode::GuardNonnullClass, &[list_op, type_const], 0);
+            .record_guard(OpCode::GuardClass, &[list_op, type_const], 0);
         walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
     }
     ctx.trace_ctx

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -9994,6 +9994,106 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "PyreSym::new_uninit hits the Phase X-1 skeleton-panic since the \
+                debug-only fallback was removed; needs a populated-jitcode harness."]
+    fn test_guard_class_uses_guard_nonnull_class() {
+        let mut ctx = TraceCtx::for_test(1);
+        // registers_r[i] tracks locals_cells_stack_w[*] — W_Root array, Type::Ref.
+        let obj = OpRef::input_arg_ref(0);
+        let mut sym = PyreSym::new_uninit(OpRef::NONE);
+        sym.registers_r = vec![obj];
+        sym.symbolic_local_types = vec![Type::Ref];
+        sym.nlocals = 1;
+
+        let mut state = MIFrame {
+            ctx: &mut ctx,
+            sym: &mut sym,
+            fallthrough_pc: 0,
+            parent_frames: Vec::new(),
+            pending_result_stack_idx: None,
+            pending_result_type: None,
+            pending_inline_frame: None,
+            residual_call_pc: None,
+            orgpc: 0,
+            concrete_frame_addr: 0,
+            pre_opcode_registers_r: None,
+            pre_opcode_semantic_depth: None,
+        };
+
+        state.with_ctx(|this, ctx| {
+            this.guard_class(ctx, obj, &INT_TYPE as *const PyType);
+        });
+
+        let tree_loop = ctx.into_tree_loop();
+        let op = tree_loop.ops.last().expect("guard op should be present");
+        assert_eq!(op.opcode, OpCode::GuardClass);
+        assert_eq!(op.arg(0).to_opref(), obj);
+    }
+
+    #[test]
+    #[ignore = "PyreSym::new_uninit hits the Phase X-1 skeleton-panic since the \
+                debug-only fallback was removed; needs a populated-jitcode harness."]
+    fn test_trace_guarded_int_payload_uses_guard_nonnull_class_and_pure_payload() {
+        // value_type is read from the recorder's inputarg type (Phase α/β: Box.type
+        // intrinsic parity, history.py:220) so the inputarg must be Ref for
+        // trace_guarded_int_payload to take the fast path rather than short-circuit.
+        let mut ctx = TraceCtx::for_test_types(&[Type::Ref]);
+        // value_type is Ref per the comment above; registers_r[0] = inputarg slot 0.
+        let int_obj = OpRef::input_arg_ref(0);
+        let mut sym = PyreSym::new_uninit(OpRef::NONE);
+        sym.registers_r = vec![int_obj];
+        sym.symbolic_local_types = vec![Type::Ref];
+        sym.nlocals = 1;
+
+        let mut state = MIFrame {
+            ctx: &mut ctx,
+            sym: &mut sym,
+            fallthrough_pc: 0,
+            parent_frames: Vec::new(),
+            pending_result_stack_idx: None,
+            pending_result_type: None,
+            pending_inline_frame: None,
+            residual_call_pc: None,
+            orgpc: 0,
+            concrete_frame_addr: 0,
+            pre_opcode_registers_r: None,
+            pre_opcode_semantic_depth: None,
+        };
+
+        let _ = state.with_ctx(|this, ctx| this.trace_guarded_int_payload(ctx, int_obj));
+
+        let recorder = ctx.into_recorder();
+        let mut saw_guard_nonnull_class = false;
+        let mut saw_pure_payload = false;
+        for pos in 1..(1 + recorder.num_ops() as u32) {
+            let Some(op) = recorder.get_op_by_raw_pos(pos) else {
+                continue;
+            };
+            if op.opcode == OpCode::GuardClass {
+                saw_guard_nonnull_class = true;
+            }
+            if op.opcode == OpCode::GetfieldGcPureI
+                && op
+                    .getarglist()
+                    .iter()
+                    .map(|a| a.to_opref())
+                    .collect::<Vec<_>>()
+                    == vec![int_obj]
+            {
+                saw_pure_payload = true;
+            }
+        }
+        assert!(
+            saw_guard_nonnull_class,
+            "int payload fast path should guard object class via GuardClass"
+        );
+        assert!(
+            saw_pure_payload,
+            "int payload fast path should read the immutable payload with GetfieldGcPureI"
+        );
+    }
+
+    #[test]
     fn test_trace_unbox_int_with_resume_skips_guard_for_constant_object() {
         let mut ctx = TraceCtx::for_test(0);
         let int_obj = ctx.const_ref(w_int_new(7) as i64);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8918,6 +8918,73 @@ mod tests {
         assert!(stack_color_map.contains(&5));
     }
 
+    /// Encode<->decode resume-symmetry round trip over a NON-IDENTITY,
+    /// coalesced color map shaped exactly as the codewriter publishes it
+    /// (`stack_slot_color_map` built at codewriter.rs:10000-10006,
+    /// `pyre_color_for_semantic_local` at codewriter.rs:10018-10044). The
+    /// forward map assigns one post-regalloc Ref color per semantic slot;
+    /// chordal coalescing legitimately reuses a color across slots that are
+    /// never simultaneously live, so the shared inverse
+    /// `semantic_ref_slot_for_reg_color` — called by the encode side
+    /// (collect_outer_active_boxes) and both decode sides
+    /// (restore_guard_failure_values / setup_bridge_sym) — must disambiguate
+    /// by the live window: the live stack prefix first, then the live locals.
+    ///
+    /// Layout: nlocals=2, max_stackdepth=3, live stack depth 2 (stack_only=2).
+    ///   local 0 -> color 5, local 1 -> color 6
+    ///   stack 0 -> color 6 (shared with live local 1)
+    ///   stack 1 -> color 7
+    ///   stack 2 -> color 5 (shared with live local 0; DEAD, index >= stack_only)
+    ///
+    /// Expected inverses are DERIVED from the published maps, so this asserts
+    /// a true publish<->inverse identity rather than ad-hoc literals. The
+    /// non-identity local map ([5,6] not [0,1]) defeats the identity fallback
+    /// (state.rs:1649), which is why the only existing end-to-end decode test
+    /// (skeleton jitcode, empty maps) never exercises this path.
+    #[test]
+    fn resume_symmetry_roundtrip_coalesced_color_map() {
+        let nlocals = 2usize;
+        // live stack depth = valuestackdepth - nlocals; the published stack map
+        // is the FULL max_stackdepth (3), but only the live prefix is in window.
+        let stack_only = 2usize;
+        let local_map = [5u16, 6u16];
+        let stack_map = [6u16, 7u16, 5u16];
+        let live_locals = [0usize, 1usize];
+
+        let invert = |reg: u16| {
+            semantic_ref_slot_for_reg_color(
+                nlocals,
+                stack_only,
+                &local_map,
+                &stack_map,
+                &live_locals,
+                reg as usize,
+            )
+        };
+
+        // Round-trip closure: every LIVE stack slot's published color inverts
+        // back to its own semantic slot (nlocals + d) — the stack map is its
+        // own inverse over the live prefix.
+        for d in 0..stack_only {
+            assert_eq!(invert(stack_map[d]), Some(nlocals + d));
+        }
+
+        // Color 6 is shared by live local 1 and live stack slot 0. The decoder
+        // scans the live stack prefix first, so it MUST resolve to the stack
+        // slot (Some(2)), never the local (Some(1)). This is the kept-stack /
+        // local coalescing case the guard-failure deopt depends on.
+        assert_eq!(invert(stack_map[0]), Some(2));
+        assert_eq!(invert(local_map[1]), Some(2));
+
+        // Color 5 is shared by live local 0 and the DEAD stack slot 2 (index
+        // >= stack_only, outside the live window). It must route to the live
+        // local, not the dead stack slot.
+        assert_eq!(invert(local_map[0]), Some(0));
+
+        // The dead stack slot's color must never recover as that slot.
+        assert_ne!(invert(stack_map[2]), Some(nlocals + 2));
+    }
+
     fn empty_meta() -> PyreMeta {
         PyreMeta {
             num_locals: 0,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5412,7 +5412,15 @@ impl MIFrame {
             return;
         }
         let expected_type_const = ctx.const_int(expected_type as usize as i64);
-        self.generate_guard(ctx, OpCode::GuardNonnullClass, &[obj, expected_type_const]);
+        // pyjitpl.py:1521 records GUARD_CLASS. The obj is non-null by
+        // construction here (every caller passes a value-stack operand or a
+        // freshly read object, the same invariant under which the codewriter
+        // emits guard_class at jtransform.py:1004-1010 handle_getfield_typeptr).
+        // A genuinely null-fed class-guarded slot is rejected structurally by
+        // the cross-loop-CUT abort in compile_loop_body, not by the guard form.
+        // The optimizer strengthens a separately-recorded preceding GUARD_NONNULL
+        // into GUARD_NONNULL_CLASS (rewrite.py:408-444 / optimize_guard_class).
+        self.generate_guard(ctx, OpCode::GuardClass, &[obj, expected_type_const]);
         // heapcache.py:470-473: class_now_known sets class + nullity.
         ctx.heap_cache_mut()
             .class_now_known(obj, expected_type as usize as i64);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8170,6 +8170,30 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // LOAD_NAME / STORE_NAME walker activation via trait-path delegation.
+        //
+        // Module-level namespace ops whose name operand is an oparg-derived
+        // index into `code.names` — the r0-only arm entry leaves that payload
+        // register unbound (ResidualCallArgUnbound), the same gap the single
+        // LoadFast hook handles.  Resolve the name here and delegate to the
+        // existing `OpcodeStepExecutor::load_name` / `store_name` (the methods
+        // `execute_load_name` / `execute_store_name` call on the trait leg),
+        // whose MIFrame impls record the live namespace lookup/store IR and
+        // advance the vsd shadow via push_value / pop_value — so the early
+        // return bypasses `apply_walker_stack_effect`.
+        if let Instruction::LoadName { namei } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let idx = namei.get(op_arg) as usize;
+            OpcodeStepExecutor::load_name(self, code.names[idx].as_ref(), idx)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+        if let Instruction::StoreName { namei } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let idx = namei.get(op_arg) as usize;
+            OpcodeStepExecutor::store_name(self, code.names[idx].as_ref(), idx)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_FAST walker activation via trait-path delegation.
         //
         // Same oparg-payload shape as LoadFast (the var_num local index is
@@ -9638,15 +9662,17 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::DictMerge { .. }
             | Instruction::SetFunctionAttribute { .. }
             | Instruction::UnpackEx { .. }
-            // Instruction::LoadName / StoreName excluded: the trait
-            // handlers (`load_name_value` / `store_name_value`) carry the
-            // celldict ModuleDictStrategy fast path (LOAD_GLOBAL_cached
-            // celldict.py:285-322: QUASIIMMUT_FIELD version dep + elidable
-            // cell fold; STORE_GLOBAL_cached celldict.py:328-333:
-            // layout-agnostic setitem_str). The walker's jitcode arm for
-            // these aborts with ResidualCallArgUnbound on the &str name
-            // argument — it was never exercised before module-level frames
-            // became portals.
+            // LoadName / StoreName handled by the
+            // dispatch_via_walker_for_opcode entry hook: it resolves the
+            // &str name from `code.names[idx]` and delegates to the trait
+            // `load_name` / `store_name` (celldict ModuleDictStrategy fast
+            // path — LOAD_GLOBAL_cached celldict.py:285-322; STORE_GLOBAL_cached
+            // celldict.py:328-333). The auto-gen arm walk aborts on the
+            // oparg-derived &str name argument (ResidualCallArgUnbound); the
+            // hook pre-resolves it, the same gap the single LoadFast hook
+            // handles.
+            | Instruction::LoadName { .. }
+            | Instruction::StoreName { .. }
             | Instruction::StoreGlobal { .. }
             | Instruction::DeleteAttr { .. }
             | Instruction::ImportName { .. }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8357,6 +8357,29 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // COPY walker activation via trait-path delegation.
+        //
+        // The auto-gen arm jitcode for `Copy` lowers `opcode_copy_value`
+        // (`peek_at` + `push_value`), whose `Result<(), PyError>` Ok/Err
+        // discriminant the arm walk cannot make concrete
+        // (`Copy|SwitchValueNotConcrete`); the result-shell scope does not
+        // drain it because `copy_value` forwards to the shared
+        // `peek_at`/`push_value` stack ops (a whole-program lowering, not a
+        // per-opcode slice).  The blocker is arm-walk-only: `COPY i`
+        // duplicates the stack slot at `peek_at(i)` and pushes it — a pure
+        // symbolic stack manipulation that records no IR op (the duplicated
+        // `FrontendOp` flows to consumers directly, like the `PushNull`
+        // constant slot).  Delegate to `OpcodeStepExecutor::copy_value`
+        // exactly as `execute_copy` (pyopcode.rs:1989) does;
+        // `peek_at`/`push_value` keep the symbolic + concrete-shadow stacks
+        // + vsd shadow coherent, so this bypasses `apply_walker_stack_effect`.
+        // Same delegation pattern as the PopTop / PushNull hooks above.
+        if let Instruction::Copy { i } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::copy_value(self, i.get(op_arg) as usize)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         Ok(None)
     }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8314,6 +8314,41 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // POP_TOP / PUSH_EXC_INFO / POP_EXCEPT — the exception-handler trio.
+        //
+        // The auto-gen arm jitcodes recurse through `inline_call` into the
+        // exc-info-stack helper jitcodes whose `PyFrame::pop` is concrete-
+        // executed by `try_execute_residual_call_via_executor` against the live
+        // frame and underflows (`pyframe.rs:1320`, raise_catch_loop /
+        // exception_inlined_callee_caught) — the same live-frame-pop hazard the
+        // StoreFastStoreFast / StoreSubscr hooks above avoid.  Delegate to the
+        // shared symbolic handlers the trait leg already runs: `opcode_pop_top`
+        // (`pop_value`), `OpcodeStepExecutor::push_exc_info` /
+        // `pop_except` (vable-only `pop_value`/`push_value` for the stack
+        // effect plus the EC `sys_exc_value` save/restore GETFIELD_GC /
+        // SETFIELD_GC).  `pop_value`/`push_value` keep the symbolic + vable
+        // shadow + vsd coherent, so this bypasses `apply_walker_stack_effect`
+        // (the early `return` skips both the arm walk and the post-walk
+        // resync).  Same delegation pattern as the hooks above.
+        if matches!(instruction, Instruction::PopTop) {
+            use pyre_interpreter::SharedOpcodeHandler;
+            let _ = op_arg;
+            let _ = SharedOpcodeHandler::pop_value(self)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+        if matches!(instruction, Instruction::PushExcInfo) {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let _ = op_arg;
+            OpcodeStepExecutor::push_exc_info(self)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+        if matches!(instruction, Instruction::PopExcept) {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let _ = op_arg;
+            OpcodeStepExecutor::pop_except(self)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         Ok(None)
     }
 
@@ -9548,36 +9583,21 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // only r0.  Re-enable once arm-entry operand seeding (#405)
             // lands on dispatch_via_miframe_at_opcode_entry.
             | Instruction::StoreSubscr // handled by dispatch_via_walker_for_opcode entry hook
-            // Instruction::PopExcept excluded: same bridge-tracing
-            // rationale as PushExcInfo below — its arm manages the
-            // exception-info stack via impure helper jitcodes the walker
-            // cannot execute concretely, so on the bridge leg the handler's
-            // stack is left inflated and the loop-back `Jump` carries the
-            // wrong arg count.  Trait dispatch executes it concretely.
-            // Instruction::PushExcInfo excluded: its codewriter arm
-            // `inline_call`s the exception-info-stack helper jitcodes,
-            // which branch on the concrete result of an impure /
-            // may-raise `residual_call`.  The production walker only folds
-            // the concrete result of *pure* calls
-            // (`try_fold_pure_call_via_executor`), so the helper's
-            // post-call `goto_if_not` reads a `Null` concrete and mis-routes
-            // into the helper's `raise/r` tail — surfacing a spurious
-            // `SubRaise { exc_concrete: Null }` that aborts every bridge
-            // trace of an exception handler.  The walker path was never
-            // exercised before (the main loop only traces the no-exception
-            // path; the bridge that reaches the handler never compiled
-            // until the exc-value threading fix landed).  Keep PUSH_EXC_INFO
-            // on trait dispatch — which executes the opcode concretely — the
-            // same rationale that excludes `Reraise` above, until the walker
-            // can execute impure residual calls during tracing.
-            // Instruction::PopTop excluded: in the exception-handler
-            // region it pops the matched exception value off the stack the
-            // PUSH_EXC_INFO / POP_EXCEPT helpers manage.  Leaving it on the
-            // walker while those are trait-dispatched desyncs the bridge's
-            // handler-region stack, producing a loop-back `Jump` with the
-            // wrong arg count (bridge fails to compile) and a backend
-            // regalloc panic.  Keep the whole handler region on one concrete
-            // (trait) leg so the bridge's framestate matches the loop entry.
+            // PopExcept / PushExcInfo / PopTop — the exception-handler trio —
+            // handled by the dispatch_via_walker_for_opcode entry hook
+            // (try_walker_direct_opcode_dispatch), NOT the generic arm-jitcode
+            // walk.  The arm walk recurses through `inline_call` into the
+            // exc-info-stack helper jitcodes whose `PyFrame::pop` is
+            // concrete-executed by `try_execute_residual_call_via_executor`
+            // against the live frame and underflows (`pyframe.rs:1320`); the
+            // hook instead delegates to the shared symbolic
+            // `opcode_pop_top`/`push_exc_info`/`pop_except` (vable-only
+            // `pop_value`/`push_value` for the stack effect), exactly as the
+            // StoreSubscr / StoreFastStoreFast hooks avoid the same
+            // live-frame-pop hazard.
+            | Instruction::PopExcept
+            | Instruction::PushExcInfo
+            | Instruction::PopTop
             // PushNull is handled by the dispatch_via_walker_for_opcode
             // entry hook (direct const-NULL symbolic push): its auto-gen
             // arm is an inert residual wrapper (`opcode_push_null` is not

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8213,7 +8213,12 @@ impl MIFrame {
             let raw = namei.get(op_arg) as usize;
             let name_idx = raw >> 1;
             let push_null = (raw & 1) != 0;
-            OpcodeStepExecutor::load_global(self, code.names[name_idx].as_ref(), name_idx, push_null)?;
+            OpcodeStepExecutor::load_global(
+                self,
+                code.names[name_idx].as_ref(),
+                name_idx,
+                push_null,
+            )?;
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
@@ -8582,6 +8587,55 @@ impl MIFrame {
             use pyre_interpreter::OpcodeStepExecutor;
             let _ = op_arg;
             let step = OpcodeStepExecutor::return_value(self)?;
+            return Ok(Some(step));
+        }
+
+        // JUMP_BACKWARD — the loop back-edge.  It CANNOT route through the
+        // arm walk, whose `ref_return/r`-style terminator surfaces as
+        // `DispatchOutcome::SubReturn` and whose top-level outcomes are
+        // rejected; the loop close needs `StepResult::CloseLoop`, which only
+        // the entry hook can propagate.  Delegate to the same pub
+        // `execute_jump_backward` the trait dispatch arm calls
+        // (pyopcode.rs:2942), with `next_instr = self.orgpc + 1` — identical
+        // to the trait leg's `pc + 1`, since `set_orgpc(pc)` ran before the
+        // gate and `close_loop_args_at`'s loop-header override of `orgpc` has
+        // not happened yet.  `jump_backward` returns `StepResult::CloseLoop`,
+        // which `dispatch_via_walker_for_opcode` propagates verbatim and
+        // `trace_step_result_to_action` maps to `CloseLoopWithArgs` — the
+        // identical mapping the trait leg uses.  Unlike PopJumpIf (two
+        // divergent recording paths), JumpBackward has a SINGLE shared
+        // `close_loop_args_at` reached identically by both legs, and is absent
+        // from `apply_walker_stack_effect` (zero net stack delta) and
+        // `instruction_needs_pre_opcode_snapshot`, so the GuardFutureCondition
+        // snapshot reads the same pre-gate orgpc / vable shadow / registers_r
+        // on either leg.  The dispatch gate keeps inline-frame JumpBackward on
+        // the trait leg.
+        if matches!(instruction, Instruction::JumpBackward { .. }) {
+            let next_instr = self.orgpc + 1;
+            let step = pyre_interpreter::execute_jump_backward(
+                self,
+                code,
+                *instruction,
+                op_arg,
+                next_instr,
+            )?;
+            return Ok(Some(step));
+        }
+
+        // JUMP_BACKWARD_NO_INTERRUPT — no guard, no loop close: just
+        // `set_next_instr(next_instr - delta)`, returns Continue.  Delegate to
+        // the same pub `execute_jump_backward_no_interrupt` the trait arm
+        // calls (pyopcode.rs:3096); it subtracts the delta from `next_instr`
+        // directly (no `skip_caches`), so `next_instr = self.orgpc + 1` (==
+        // the trait leg's `pc + 1`) is required for the identical target.
+        if matches!(instruction, Instruction::JumpBackwardNoInterrupt { .. }) {
+            let next_instr = self.orgpc + 1;
+            let step = pyre_interpreter::execute_jump_backward_no_interrupt(
+                self,
+                *instruction,
+                op_arg,
+                next_instr,
+            )?;
             return Ok(Some(step));
         }
 
@@ -9902,6 +9956,17 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // no guard; the dispatch gate keeps inline-frame ReturnValue on
             // the trait leg, so only the root exit is flipped.
             | Instruction::ReturnValue
+            // JumpBackward / JumpBackwardNoInterrupt — the loop back-edge,
+            // handled by the entry hook (NOT the arm walk, which surfaces
+            // SubReturn / rejects the top-level CloseLoop outcome).  The hook
+            // delegates to the same pub execute_jump_backward(_no_interrupt)
+            // the trait dispatch arms call, propagating StepResult::CloseLoop
+            // verbatim.  Unlike PopJumpIf, JumpBackward has a single shared
+            // close_loop_args_at reached identically by both legs (no
+            // leg-dependent kept-stack snapshot); the gate keeps inline-frame
+            // JumpBackward on the trait leg.
+            | Instruction::JumpBackward { .. }
+            | Instruction::JumpBackwardNoInterrupt { .. }
             // StoreFastStoreFast handled by the
             // dispatch_via_walker_for_opcode entry hook, delegating to the
             // symbolic `OpcodeStepExecutor::store_fast_store_fast` (the arm

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8378,6 +8378,25 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // RAISE_VARARGS walker activation via trait-path delegation.
+        //
+        // Structural twin of the Reraise hook above: `raise_varargs` always
+        // returns `Err(PyError)` (it raises), seeding `last_exc_box` /
+        // `last_exc_value` on the valid-raise path before returning.  The `?`
+        // propagates that `Err` out as the dispatch `step_result`, exactly as
+        // `execute_raise_varargs` does on the trait leg; `trace_code_step`'s
+        // post-dispatch handling is keyed on the instruction type
+        // (`Instruction::RaiseVarargs` → `handle_raise_varargs` when
+        // `last_exc_box != NONE`, else `handle_possible_exception`), so it
+        // runs identically on either dispatch leg.  Unlike a branch guard
+        // this records no kept-stack snapshot, so the #124 resume gap does
+        // not apply.
+        if let Instruction::RaiseVarargs { argc } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::raise_varargs(self, u32::from(argc.get(op_arg)) as usize)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // BUILD_TUPLE / UNPACK_SEQUENCE walker activation via trait-path
         // delegation.
         //
@@ -9763,6 +9782,7 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::MakeCell { .. }
             | Instruction::ConvertValue { .. }
             | Instruction::Reraise { .. } // walker hook in dispatch_via_walker_for_opcode delegates to MIFrame::reraise which returns Err(PyError) with reraise_lasti seeded — `step_result.err().map(|e| e.reraise_lasti)` extraction works the same on either leg
+            | Instruction::RaiseVarargs { .. } // walker hook delegates to MIFrame::raise_varargs (always Err, seeds last_exc_box); trace_code_step's RaiseVarargs post-dispatch handler (handle_raise_varargs) is keyed on the instruction type, so it runs identically on either leg
             | Instruction::PopJumpIfNone { .. }
             | Instruction::PopJumpIfNotNone { .. }
             | Instruction::ForIter { .. }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8292,6 +8292,26 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // BUILD_MAP walker activation via trait-path delegation.
+        //
+        // The auto-gen arm jitcode for `BuildMap` inlines the interpreter's
+        // `SharedOpcodeHandler::build_map` (`build_map_from_refs`, eval.rs:1267)
+        // and switches on its `Result<_, PyError>` Ok/Err discriminant — which
+        // the arm walk cannot make concrete (`BuildMap|SwitchValueNotConcrete`).
+        // The entry-hook instead dispatches `OpcodeStepExecutor::build_map`,
+        // resolving to MIFrame's trace-aware override (`trace_build_map` emits
+        // the BUILD_MAP IR + maintains the concrete dict shadow, exactly like
+        // `build_tuple`), bypassing the concrete `build_map_from_refs` the arm
+        // walk inlines.  `pop_n` (count*2) / `push_value` keep the symbolic +
+        // concrete-shadow stacks + vsd shadow coherent, so this bypasses
+        // `apply_walker_stack_effect`.  Same delegation pattern as the
+        // BuildTuple / UnpackSequence hooks above.
+        if let Instruction::BuildMap { count } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::build_map(self, count.get(op_arg) as usize)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_FAST_STORE_FAST walker activation via trait-path delegation.
         //
         // The auto-gen arm jitcode lowers to a chain of `residual_call` ops

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8561,6 +8561,30 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // RETURN_VALUE — the root portal exit.  Unlike every hook above it
+        // propagates a control-flow `StepResult::Return`, NOT `Continue`.
+        // The opcode records no IR itself: `return_value` (the default
+        // `OpcodeStepExecutor::return_value`, which MIFrame does not override)
+        // is `pop_value` + `finish_value` -> `StepResult::Return(value)`; the
+        // `Finish` + `ensure_boxed_for_ca` + `store_token_in_vable` are
+        // emitted post-dispatch in `trace_step_result_to_action`'s Return
+        // arm, reached identically by both legs.  It CANNOT go via the arm
+        // walk: the arm's `ref_return/r` surfaces as
+        // `DispatchOutcome::SubReturn` (`is_top_level=false`), the wrong shape
+        // for a root return.  The entry hook propagates the Return verbatim
+        // (`dispatch_via_walker_for_opcode` returns it unchanged).  It records
+        // no guard and is in neither `instruction_may_raise` nor
+        // `instruction_needs_pre_opcode_snapshot`, so there is no
+        // dispatch-leg-dependent snapshot; the dispatch gate routes
+        // inline-frame ReturnValue to the trait leg, so only the root
+        // portal-exit case is flipped.
+        if matches!(instruction, Instruction::ReturnValue) {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let _ = op_arg;
+            let step = OpcodeStepExecutor::return_value(self)?;
+            return Ok(Some(step));
+        }
+
         Ok(None)
     }
 
@@ -9869,6 +9893,15 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // `InlineCallArityMismatch` on inlined tuples.
             | Instruction::BuildTuple { .. }
             | Instruction::UnpackSequence { .. }
+            // ReturnValue — the root portal exit, handled by the entry hook
+            // (NOT the arm walk, whose ref_return/r surfaces as SubReturn,
+            // the wrong shape for a root return).  The hook propagates the
+            // default OpcodeStepExecutor::return_value's StepResult::Return
+            // verbatim; the Finish is emitted post-dispatch in
+            // trace_step_result_to_action's Return arm on both legs.  Records
+            // no guard; the dispatch gate keeps inline-frame ReturnValue on
+            // the trait leg, so only the root exit is flipped.
+            | Instruction::ReturnValue
             // StoreFastStoreFast handled by the
             // dispatch_via_walker_for_opcode entry hook, delegating to the
             // symbolic `OpcodeStepExecutor::store_fast_store_fast` (the arm

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8233,6 +8233,26 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // COMPARE_OP walker activation via trait-path delegation (non-fused).
+        //
+        // The fused COMPARE_OP + POP_JUMP_IF_* path is handled earlier by
+        // `try_fused_compare_goto_if_not` (pyjitpl.py:541-556 parity), which
+        // returns before this dispatch — so this hook only sees the
+        // standalone (result-materialised) CompareOp the fusion declined.
+        // Same MAY-RAISE shape as BinaryOp: delegate to
+        // `OpcodeStepExecutor::compare_op` (the method `execute_compare_op`
+        // calls on the trait leg), which pops the two operands, emits the
+        // typed comparison IR (IntLt/FloatLt behind class guards) or the
+        // generic `compare_value` residual, and pushes the boxed bool.  The
+        // following PopJumpIf* / consumer reads that bool exactly as on the
+        // trait leg.  `pop_value` / `push_value` handle vsd; early return
+        // bypasses `apply_walker_stack_effect`.
+        if let Instruction::CompareOp { opname } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::compare_op(self, opname.get(op_arg))?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_SUBSCR walker activation via trait-path delegation.
         //
         // The auto-gen arm jitcode for `StoreSubscr` is
@@ -9612,6 +9632,12 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // ×2 + specialised arithmetic IR + push_value).  May-raise; the
             // Err propagates to trace_code_step like the trait leg.
             | Instruction::BinaryOp { .. }
+            // CompareOp (non-fused) handled by the entry hook: delegates to
+            // OpcodeStepExecutor::compare_op (typed comparison IR or generic
+            // compare_value residual + push bool). May-raise; Err propagates
+            // like the trait leg. The fused compare+branch path is handled
+            // earlier by try_fused_compare_goto_if_not and never reaches here.
+            | Instruction::CompareOp { .. }
             | Instruction::ExtendedArg
             | Instruction::Resume { .. }
             | Instruction::Cache

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8152,6 +8152,24 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // TO_BOOL walker activation via trait-path delegation.
+        //
+        // The compiler only emits TO_BOOL ahead of a truthiness consumer
+        // (POP_JUMP_IF_TRUE/FALSE or UNARY_NOT), each of which re-evaluates
+        // the operand's truthiness through its own guard.  The MIFrame
+        // `to_bool` override is therefore a stack-neutral no-op (the explicit
+        // bool materialisation is redundant under tracing), matching exactly
+        // what the trait leg's `execute_to_bool` already records.  An entry
+        // hook delegating to the same no-op preserves that — routing through
+        // the auto-gen arm walk instead would emit the arm's bool-conversion
+        // residual and diverge.  Early return bypasses
+        // `apply_walker_stack_effect` (net-zero effect, nothing to record).
+        if let Instruction::ToBool = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::to_bool(self)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_FAST walker activation via trait-path delegation.
         //
         // Same oparg-payload shape as LoadFast (the var_num local index is
@@ -9578,6 +9596,13 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::EndFor
             | Instruction::UnaryNot
             | Instruction::UnaryInvert
+            // ToBool handled by the dispatch_via_walker_for_opcode entry hook:
+            // delegates to the stack-neutral no-op `to_bool` (truthiness is
+            // re-evaluated by the following branch / UnaryNot guard, so the
+            // bool materialisation is redundant under tracing).  Early return,
+            // so no apply_walker_stack_effect arm — unlike UnaryNot/UnaryInvert
+            // above, which arm-walk.
+            | Instruction::ToBool
             | Instruction::GetIter
             | Instruction::MatchMapping
             | Instruction::MatchSequence

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8117,6 +8117,41 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // LOAD_FAST_LOAD_FAST / LOAD_FAST_BORROW_LOAD_FAST_BORROW walker
+        // activation via trait-path delegation.
+        //
+        // The load-side superinstruction siblings of StoreFastStoreFast: two
+        // packed var_num local indices the r0-only arm entry leaves unbound
+        // (ResidualCallArgUnbound), the same payload-seed gap as the single
+        // LoadFast hook above.  Resolve both indices + names from the code
+        // pool and delegate to `OpcodeStepExecutor::load_fast_pair_checked`,
+        // whose MIFrame override is two trace-aware `load_local_value` +
+        // `push_value` pairs — i.e. exactly two single-LoadFast pushes.  The
+        // borrow / non-borrow distinction collapses at the trace level (the
+        // single LoadFast / LoadFastBorrow hook above already routes both
+        // through `load_fast_checked`), so both superinstructions share the
+        // one pair recorder.  `push_value` advances vsd, so this bypasses
+        // `apply_walker_stack_effect` via the early return.
+        if let Instruction::LoadFastLoadFast { var_nums }
+        | Instruction::LoadFastBorrowLoadFastBorrow { var_nums } = instruction
+        {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let idx1 = pyre_interpreter::var_nums_to_first_index(*var_nums, op_arg);
+            let idx2 = pyre_interpreter::var_nums_to_second_index(*var_nums, op_arg);
+            let name1 = if idx1 < pyre_interpreter::code_varnames_len(code) {
+                code.varnames[idx1].as_ref()
+            } else {
+                "<cell>"
+            };
+            let name2 = if idx2 < pyre_interpreter::code_varnames_len(code) {
+                code.varnames[idx2].as_ref()
+            } else {
+                "<cell>"
+            };
+            OpcodeStepExecutor::load_fast_pair_checked(self, idx1, name1, idx2, name2)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_FAST walker activation via trait-path delegation.
         //
         // Same oparg-payload shape as LoadFast (the var_num local index is
@@ -9515,6 +9550,15 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // a register the r0-only arm entry leaves unbound.
             | Instruction::LoadFast { .. }
             | Instruction::LoadFastBorrow { .. }
+            // LoadFastLoadFast / LoadFastBorrowLoadFastBorrow handled by the
+            // dispatch_via_walker_for_opcode entry hook: resolves both packed
+            // var_num local indices + names and delegates to
+            // OpcodeStepExecutor::load_fast_pair_checked (two trace-aware
+            // load_local_value + push_value pairs).  The auto-gen arm reads
+            // the packed var_nums oparg payload from a register the r0-only
+            // arm entry leaves unbound — same gap as the single LoadFast.
+            | Instruction::LoadFastLoadFast { .. }
+            | Instruction::LoadFastBorrowLoadFastBorrow { .. }
             // StoreFast handled by the dispatch_via_walker_for_opcode entry
             // hook: delegates to OpcodeStepExecutor::store_fast (pop_value
             // advances vsd, setarrayitem_vable_r writes the local).

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8250,6 +8250,40 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // BUILD_TUPLE / UNPACK_SEQUENCE walker activation via trait-path
+        // delegation.
+        //
+        // These two opcodes carry a specialised, virtualization-aware
+        // recorder (`MIFrame::trace_build_tuple_value` /
+        // `unpack_sequence_value`): the arity-2 int/float build emits
+        // `NewWithVtable` + inline `value0`/`value1` `SetfieldGc` + paired
+        // `w_class` guards so `OptVirtualize` can elide a tuple that is
+        // built only to be immediately unpacked (`makespecialisedtuple2`
+        // parity).  The auto-gen arm jitcode records the OPAQUE
+        // `bh_build_tuple` residual instead, which OptVirtualize cannot see
+        // through (it also aborts `InlineCallArityMismatch` when the tuple
+        // flows through an inlined call).  Routing through the generic arm
+        // walk would therefore both lose the virtualization and abort on
+        // inlined tuples — so dispatch them here, reusing the exact shared
+        // opcode functions the trait leg runs
+        // (`OpcodeStepExecutor::build_tuple` → `opcode_build_tuple` →
+        // `pop_n` + `SharedOpcodeHandler::build_tuple` + `push_value`).
+        // `pop_n`/`pop_value`/`push_value` update the symbolic + concrete-
+        // shadow stacks + vsd shadow, so this bypasses
+        // `apply_walker_stack_effect` (the early `return` below skips both
+        // the arm walk and the post-walk resync).  Same delegation pattern
+        // as the StoreSubscr / PushNull / Reraise hooks above.
+        if let Instruction::BuildTuple { count } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::build_tuple(self, count.get(op_arg) as usize)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+        if let Instruction::UnpackSequence { count } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::unpack_sequence(self, count.get(op_arg) as usize)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         Ok(None)
     }
 
@@ -9323,15 +9357,18 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
     // through `ref_copy/r>r` (`assembler.rs::emit_const_r`), so arms
     // decode without residual-call wrappers around unit variants.
     //
-    // BuildTuple / UnpackSequence are intentionally NOT in this set: the
-    // trait-dispatch handlers (`trace_build_tuple_value`,
-    // `unpack_sequence_value`) carry the specialised arity-2 tuple
-    // build/unpack fast paths, and the walker's jitcode dispatch cannot
-    // yet express them (it aborts with `InlineCallArityMismatch` when the
-    // tuple flows through an inlined call). Keep them on the trait path
-    // until the walker can encode the specialised tuple layout.
+    // BuildTuple / UnpackSequence are walker-handled via the
+    // `try_walker_direct_opcode_dispatch` entry hook (NOT the auto-gen arm
+    // jitcode): the hook delegates to `OpcodeStepExecutor::build_tuple` /
+    // `unpack_sequence`, which run the specialised arity-2 tuple
+    // build/unpack fast paths (`trace_build_tuple_value` /
+    // `unpack_sequence_value`).  The generic arm jitcode CANNOT express
+    // those (it records the opaque `bh_build_tuple` residual and aborts
+    // `InlineCallArityMismatch` when the tuple flows through an inlined
+    // call), so the direct hook is the orthodox dispatch — the same shape
+    // as the StoreSubscr / PushNull / Reraise hooks.
     //
-    // StoreFastStoreFast is also excluded: its codewriter arm lowers to a
+    // StoreFastStoreFast is still excluded: its codewriter arm lowers to a
     // chain of `residual_call` ops whose funcptr `constants_i` entries are
     // unresolved placeholders (not patched by `patch_constants_i_fnaddrs`,
     // which only rewrites build→runtime fnaddr pairs). The walker reads one
@@ -9518,6 +9555,15 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // vsd-resync route loses the push and underflows the
             // following CALL.
             | Instruction::PushNull
+            // BuildTuple / UnpackSequence handled by the
+            // dispatch_via_walker_for_opcode entry hook, delegating to the
+            // specialised `OpcodeStepExecutor::build_tuple` /
+            // `unpack_sequence` recorders (see the hook comment): the
+            // generic arm records an opaque residual that loses
+            // OptVirtualize's build→unpack elision and aborts
+            // `InlineCallArityMismatch` on inlined tuples.
+            | Instruction::BuildTuple { .. }
+            | Instruction::UnpackSequence { .. }
     )
 }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8194,6 +8194,29 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // LOAD_GLOBAL walker activation via trait-path delegation.
+        //
+        // The oparg packs the name index (>> 1) and the PUSH_NULL flag (& 1).
+        // Resolve both and delegate to the existing
+        // `OpcodeStepExecutor::load_global` (the method `execute_load_global`
+        // calls on the trait leg) → `load_name_value`, the shared celldict
+        // ModuleDictStrategy live lookup both legs already use (the auto-gen
+        // arm aborts on the oparg-derived &str name argument).  This
+        // delegation is the LIVE lookup, not the EffectInfo-residual cell fold
+        // (`try_walker_load_global_cell_fold`, jitcode_dispatch.rs) — the
+        // early return bypasses the arm walk where that fold lives, so the
+        // moving-GC const-fold hazard it guards against (#336, fixed by the
+        // can_move skip) is not on this path.  push_value (+ the optional
+        // PUSH_NULL push) advances vsd.
+        if let Instruction::LoadGlobal { namei } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let raw = namei.get(op_arg) as usize;
+            let name_idx = raw >> 1;
+            let push_null = (raw & 1) != 0;
+            OpcodeStepExecutor::load_global(self, code.names[name_idx].as_ref(), name_idx, push_null)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_FAST walker activation via trait-path delegation.
         //
         // Same oparg-payload shape as LoadFast (the var_num local index is
@@ -9699,6 +9722,14 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // handles.
             | Instruction::LoadName { .. }
             | Instruction::StoreName { .. }
+            // LoadGlobal handled by the dispatch_via_walker_for_opcode entry
+            // hook: resolves the name index + PUSH_NULL flag and delegates to
+            // the trait load_global → load_name_value (shared celldict live
+            // lookup). The early return bypasses the arm walk + the
+            // EffectInfo-residual cell fold (try_walker_load_global_cell_fold),
+            // so the #336 moving-GC const-fold hazard is off this path. Same
+            // oparg-derived &str name gap as LoadName.
+            | Instruction::LoadGlobal { .. }
             | Instruction::StoreGlobal { .. }
             | Instruction::DeleteAttr { .. }
             | Instruction::ImportName { .. }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8284,6 +8284,36 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // STORE_FAST_STORE_FAST walker activation via trait-path delegation.
+        //
+        // The auto-gen arm jitcode lowers to a chain of `residual_call` ops
+        // whose funcptr `constants_i` entries are unresolved symbolic-hash
+        // placeholders (not patched by `patch_constants_i_fnaddrs`); the arm
+        // walk would `blr` an unmapped address, and its authoritative
+        // `try_execute_residual_call_via_executor` would concretely run the
+        // real `PyFrame::store_fast_store_fast`, popping the LIVE frame's
+        // value stack — which the trace walk never populates (only symbolic
+        // `pop_value` / vsd advance), underflowing `PyFrame::pop`.
+        //
+        // Both hazards are arm-walk-only.  Delegate to
+        // `OpcodeStepExecutor::store_fast_store_fast` (→ `pop_value` ×2 +
+        // `store_local_value` ×2) exactly as trait dispatch does: `pop_value`
+        // is the symbolic pop and `store_local_value` records the
+        // `setarrayitem_vable` write into the virtualizable locals (the
+        // frame is forced on deopt), so there is no live-frame pop and no
+        // unresolved residual.  `var_nums_to_first_index` /
+        // `var_nums_to_second_index` fold the paired local indices from
+        // `op_arg` (the same `#[elidable_cannot_raise]` helpers the seam
+        // uses).  Same delegation pattern as the BuildTuple / UnpackSequence
+        // hooks above; bypasses `apply_walker_stack_effect`.
+        if let Instruction::StoreFastStoreFast { var_nums } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let idx1 = pyre_interpreter::var_nums_to_first_index(*var_nums, op_arg);
+            let idx2 = pyre_interpreter::var_nums_to_second_index(*var_nums, op_arg);
+            OpcodeStepExecutor::store_fast_store_fast(self, idx1, idx2)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         Ok(None)
     }
 
@@ -9368,14 +9398,14 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
     // call), so the direct hook is the orthodox dispatch — the same shape
     // as the StoreSubscr / PushNull / Reraise hooks.
     //
-    // StoreFastStoreFast is still excluded: its codewriter arm lowers to a
-    // chain of `residual_call` ops whose funcptr `constants_i` entries are
-    // unresolved placeholders (not patched by `patch_constants_i_fnaddrs`,
-    // which only rewrites build→runtime fnaddr pairs). The walker reads one
-    // of those placeholders as the call target and branches to it (`blr`),
-    // faulting on an unmapped address. Route it through the trait handler
-    // (`opcode_store_fast_store_fast`) until the arm's helper fnaddrs are
-    // resolved.
+    // StoreFastStoreFast is walker-handled via the
+    // `try_walker_direct_opcode_dispatch` entry hook (NOT the auto-gen arm
+    // jitcode): the hook delegates to
+    // `OpcodeStepExecutor::store_fast_store_fast`, whose symbolic
+    // `pop_value` + `store_local_value` (`setarrayitem_vable`) avoid both
+    // arm-walk hazards — the unresolved placeholder funcptrs the arm `blr`s
+    // and the concrete live-frame `PyFrame::pop` underflow.  See the hook
+    // comment for detail.
     matches!(
         instruction,
         Instruction::Nop
@@ -9564,6 +9594,12 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // `InlineCallArityMismatch` on inlined tuples.
             | Instruction::BuildTuple { .. }
             | Instruction::UnpackSequence { .. }
+            // StoreFastStoreFast handled by the
+            // dispatch_via_walker_for_opcode entry hook, delegating to the
+            // symbolic `OpcodeStepExecutor::store_fast_store_fast` (the arm
+            // jitcode carries unresolved placeholder funcptrs and would pop
+            // the live frame; see the hook comment).
+            | Instruction::StoreFastStoreFast { .. }
     )
 }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8516,6 +8516,28 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // CHECK_EXC_MATCH — same exception-handler family, same two
+        // arm-walk hazards the trio above avoids.  The auto-gen arm inlines
+        // the concrete `eval::check_exc_match` whose `pop`/`peek` run against
+        // the live frame via `try_execute_residual_call_via_executor`
+        // (live-frame-pop underflow), and `validate_check_exc_match_class`'s
+        // `Result` Ok/Err is a `SwitchValueNotConcrete` arm-walk abort.  The
+        // `MIFrame::check_exc_match` override records complete leg-independent
+        // IR — symbolic `pop_value` of the match type, a read of the
+        // raise-seeded `sym.last_exc_value`, and a `push_value` of a
+        // `const_ref` bool (the immortal TRUE/FALSE singleton); it records no
+        // guard and is in neither `instruction_may_raise` nor
+        // `instruction_needs_pre_opcode_snapshot`, so there is no
+        // dispatch-leg-dependent snapshot.  The class-mismatch `TypeError`
+        // `?`-propagates as a trace Abort identically on either leg.  Same
+        // delegation pattern as the PopTop / PushExcInfo / PopExcept hooks.
+        if matches!(instruction, Instruction::CheckExcMatch) {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let _ = op_arg;
+            OpcodeStepExecutor::check_exc_match(self)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // COPY walker activation via trait-path delegation.
         //
         // The auto-gen arm jitcode for `Copy` lowers `opcode_copy_value`
@@ -9821,6 +9843,16 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::PopExcept
             | Instruction::PushExcInfo
             | Instruction::PopTop
+            // CheckExcMatch — same exception-handler family, handled by the
+            // entry hook (NOT the arm walk): the arm inlines the concrete
+            // `eval::check_exc_match` (live-frame pop underflow) and a
+            // `validate_check_exc_match_class` Result the walk cannot make
+            // concrete (`SwitchValueNotConcrete`).  The hook delegates to the
+            // `MIFrame::check_exc_match` override (symbolic `pop_value` +
+            // raise-seeded `sym.last_exc_value` read + `const_ref` bool push,
+            // no guard), exactly as the PopTop / PushExcInfo / PopExcept hooks
+            // avoid the same live-frame-pop hazard.
+            | Instruction::CheckExcMatch
             // PushNull is handled by the dispatch_via_walker_for_opcode
             // entry hook (direct const-NULL symbolic push): its auto-gen
             // arm is an inert residual wrapper (`opcode_push_null` is not

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -109,8 +109,13 @@ pub trait WalkerFrameOps {
     /// `pyjitpl.py:1518-1523` `opimpl_guard_class` parity.  Skips the
     /// guard when the heapcache already knows the class or the OpRef
     /// is constant (the runtime type is already pinned).  Otherwise
-    /// records `GUARD_NONNULL_CLASS` with `expected_type_const` and
-    /// updates the heapcache's class+nullity record.
+    /// records `GUARD_CLASS` with `expected_type_const` and updates the
+    /// heapcache's class+nullity record.  The obj is non-null by
+    /// construction (a value-stack operand, the same invariant under
+    /// which the codewriter emits guard_class at
+    /// jtransform.py:1004-1010 handle_getfield_typeptr); the optimizer
+    /// strengthens a preceding `GUARD_NONNULL` into `GUARD_NONNULL_CLASS`
+    /// (rewrite.py:408-444).
     fn guard_class(&mut self, obj: OpRef, expected_type: *const PyType) {
         if self.ctx().heap_cache().is_class_known(obj) {
             return;
@@ -129,7 +134,7 @@ pub trait WalkerFrameOps {
             return;
         }
         let expected_type_const = self.ctx_mut().const_int(expected_type as usize as i64);
-        self.generate_guard(OpCode::GuardNonnullClass, &[obj, expected_type_const]);
+        self.generate_guard(OpCode::GuardClass, &[obj, expected_type_const]);
         // heapcache.py:470-473 `class_now_known` parity.
         self.ctx_mut()
             .heap_cache_mut()

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7984,7 +7984,7 @@ mod tests {
 
         let recorder = ctx.into_recorder();
         let op = recorder.ops().last().expect("guard op should be present");
-        assert_eq!(op.opcode, OpCode::GuardNonnullClass);
+        assert_eq!(op.opcode, OpCode::GuardClass);
         assert_eq!(op.arg(0).to_opref(), obj);
     }
 
@@ -8064,7 +8064,7 @@ mod tests {
             })
             .collect();
         for op in recorder.ops() {
-            if op.opcode == OpCode::GuardNonnullClass {
+            if op.opcode == OpCode::GuardClass {
                 saw_guard_nonnull_class = true;
             }
             if op.opcode == OpCode::GetfieldGcPureI
@@ -8080,7 +8080,7 @@ mod tests {
         }
         assert!(
             saw_guard_nonnull_class,
-            "int payload fast path should guard object class via GuardNonnullClass: {:?}",
+            "int payload fast path should guard object class via GuardClass: {:?}",
             recorded_ops
         );
         assert!(
@@ -8515,7 +8515,7 @@ mod tests {
             recorder
                 .ops()
                 .iter()
-                .all(|op| op.opcode != majit_ir::OpCode::GuardNonnullClass),
+                .all(|op| op.opcode != majit_ir::OpCode::GuardClass),
             "typed-int index should not guard object class for an unbox fast path: {:?}",
             recorder.ops()
         );
@@ -8982,7 +8982,7 @@ r = acc",
     /// RPython portal return type is always REF (warmspot.py:449).
     /// The self-recursive call uses CALL_ASSEMBLER_R, FINISH records with
     /// done_with_this_frame_descr_ref, and the caller unboxes via
-    /// GuardNonnullClass + GetfieldGcPureI (pyjitpl.py:3198-3220).
+    /// GuardClass + GetfieldGcPureI (pyjitpl.py:3198-3220).
     ///
     /// A previous bug used CALL_ASSEMBLER_I + FINISH(Int) + forced unbox
     /// at the blackhole boundary, causing pointer-like-integer corruption


### PR DESCRIPTION
follow-up #122

## Summary

Continues the #141 M4 walker cutover — moving opcodes off the trait-dispatch tracer leg onto the walker leg via the direct entry-hook in `try_walker_direct_opcode_dispatch` — plus two adjacent fixes surfaced along the way.

### Walker entry-hook opcode flips (#141 M4.Cutover)

The entry-hook bypasses the auto-generated arm-jitcode walk and delegates straight to `MIFrame`'s trace-aware `OpcodeStepExecutor` impl, so the opcode records IR / produces concrete values exactly as the trait leg did, without the arm-walk's `ResidualCallArgUnbound` (arm-entry seed gap) or `SwitchValueNotConcrete` (Result-shell) blockers. Flipped this round:

- `BUILD_TUPLE` / `UNPACK_SEQUENCE`
- `STORE_FAST_STORE_FAST`
- exception-handler trio `POP_EXCEPT` / `PUSH_EXC_INFO` / `POP_TOP`
- `COPY` — `copy_value`, a pure stack-dup that records no IR (like `PUSH_NULL`)
- `BUILD_MAP` — `trace_build_map` IR + concrete dict shadow, same shape as the already-hooked `BUILD_TUPLE`

Each keeps the symbolic stack, the concrete-shadow stack, and the vsd shadow coherent.

### GUARD_CLASS record-time parity

`opimpl_guard_class` records a bare `GUARD_CLASS`; `GUARD_NONNULL_CLASS` arises only in the optimizer when a genuinely-preceding `GUARD_NONNULL` is fused (that fusion is already ported). The codewriter emits guard_class only immediately before a typeptr read, so every record site passes a non-null value-stack operand and must record bare `GUARD_CLASS` too. The divergence was opcode-only — the helper already calls `class_now_known`, which sets the known-nullity heapcache flag. Flipped the trait-leg helper, the walker-leg helper, the two walker-native list getitem/setitem sites, and updated the tests.

### Blackhole resume builder: GC array-build family

`build_inline_call_only_bh_builder` wired the residual_call and vable-array families but not the GC array-build ops (`new_array_clear` + `setarrayitem_gc_r`) that `BUILD_TUPLE` / `BUILD_LIST` / `BUILD_MAP` / `BUILD_SET` / `BUILD_STRING` lower to. A guard-failure resume into a jitcode whose forward path builds a container after the hot loop — reached only via the loop-exit deopt — walked the `new_array_clear` byte and hit `dispatch_step`'s unwired-opcode panic (`opcode 0xd8 = BC_NEW_ARRAY_CLEAR_C`). Registered the four opname variants (`new_array_clear/{cd>r,id>r}`, `setarrayitem_gc_r/{rcrd,rird}`; handlers were already wired in `wire_bhimpl_handlers`) and added a synth regression bench that builds each container type after a hot loop.

### Verification

`check.py` green on both backends — dynasm 80/80 + cranelift 80/80 over the full synth corpus.

## Self-review

### Prompt & Model

Model: opus-4.8

Prompt: <!-- Self-review delegated to a separate Codex review session per project convention. -->

### Answer

<!-- Pending post-session Codex review. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced JIT bytecode opcode dispatch and handling for improved compilation efficiency across multiple instruction types.
  * Optimized guard code generation to better handle class type checks.

* **Tests**
  * Expanded test coverage for guard behavior, bytecode dispatch, and roundtrip compilation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->