### PR TITLE
CPython regression-suite test infra + import-gateway interpreter fixes

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -269,7 +269,11 @@ jobs:
 
   cpython-tests:
     name: CPython suite (gate)
-    runs-on: ubuntu-24.04
+    # aarch64: the baseline is recorded on darwin-aarch64 and the JIT codegen is
+    # arch-specific, so the gate runs where the baseline was observed.
+    # macos-latest is the only aarch64 OS in prepare-charon-llbc's matrix, so its
+    # Charon/LLBC caches (keyed by runner.os-runner.arch) are already prepared.
+    runs-on: macos-latest
     needs: prepare-charon-llbc
     if: ${{ always() }}
     timeout-minutes: 30

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -8,6 +8,7 @@ on:
       - "Cargo.lock"
       - "majit/**/*"
       - "pyre/**/*"
+      - "lib-python/**"
       - "scripts/install-charon.py"
       - "scripts/extract-llbc.py"
       - ".github/workflows/pyre-ci.yml"
@@ -18,6 +19,7 @@ on:
       - "Cargo.lock"
       - "majit/**/*"
       - "pyre/**/*"
+      - "lib-python/**"
       - "scripts/install-charon.py"
       - "scripts/extract-llbc.py"
       - ".github/workflows/pyre-ci.yml"
@@ -264,3 +266,73 @@ jobs:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
         PYRE_CHECK_PYPY3: ${{ steps.pypy.outputs.python-path }}
       run: ${{ steps.cpython.outputs.python-path }} pyre/check.py
+
+  cpython-tests:
+    name: CPython suite (gate)
+    runs-on: ubuntu-24.04
+    needs: prepare-charon-llbc
+    if: ${{ always() }}
+    timeout-minutes: 30
+    env:
+      # See prepare-charon-llbc: restore the shared build dir into the
+      # workspace and use the same Charon pin/cache key.
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+    steps:
+    - name: Check prepare-charon-llbc result
+      if: ${{ needs.prepare-charon-llbc.result != 'success' }}
+      shell: bash
+      run: |
+        echo "prepare-charon-llbc did not succeed: ${{ needs.prepare-charon-llbc.result }}" >&2
+        exit 1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - name: Set up CPython
+      id: cpython
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.14"
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-bin: false
+    - name: Compute LLBC fingerprint
+      id: llbc-fingerprint
+      shell: bash
+      run: |
+        value="$(scripts/extract-llbc.py --fingerprint pyre-object pyre-interpreter pyre-jit)"
+        echo "value=${value}" >> "$GITHUB_OUTPUT"
+    - name: Restore Charon binary
+      id: restore-charon
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          .pyre-build/charon
+          .pyre-build/charon-src
+        key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
+    - name: Restore LLBC
+      id: restore-llbc
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: build/llbc
+        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
+    - name: Check prepared cache hits
+      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' || steps.restore-llbc.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        echo "cache miss from prepare-charon-llbc" >&2
+        echo "Charon cache hit: ${{ steps.restore-charon.outputs.cache-hit }}" >&2
+        echo "LLBC cache hit: ${{ steps.restore-llbc.outputs.cache-hit }}" >&2
+        exit 1
+    - name: Verify prepared Charon/LLBC
+      shell: bash
+      run: |
+        test -d .pyre-build/charon
+        test -s build/llbc/pyre-object.ullbc
+        test -s build/llbc/pyre-interpreter.ullbc
+        test -s build/llbc/pyre-jit.ullbc
+    - name: Build pyre-dynasm
+      run: cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm
+    - name: Run CPython suite (gate regressions, JIT on)
+      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 4 --timeout 120

--- a/.github/workflows/pyre-cpython-nightly.yml
+++ b/.github/workflows/pyre-cpython-nightly.yml
@@ -23,8 +23,11 @@ permissions:
 
 jobs:
   full-suite:
-    name: full CPython suite (ubuntu)
-    runs-on: ubuntu-24.04
+    name: full CPython suite (macos)
+    # aarch64: the gate's baseline is darwin-aarch64 and the JIT codegen is
+    # arch-specific, so the exploratory reports (incl. the JIT-divergence
+    # signal) are produced on the same arch as the gate.
+    runs-on: macos-latest
     timeout-minutes: 120
     env:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build

--- a/.github/workflows/pyre-cpython-nightly.yml
+++ b/.github/workflows/pyre-cpython-nightly.yml
@@ -1,0 +1,90 @@
+name: pyre CPython suite (nightly)
+
+# Non-gating exploratory run of the FULL CPython regression suite (every
+# module, including ones that fail today) across three lanes:
+#   * dynasm, JIT on   — the gating backend, full picture
+#   * dynasm, JIT off  — interpreter baseline; a module that passes here but
+#     not under JIT is a JIT correctness divergence
+#   * cranelift, JIT on
+# Reports are uploaded as artifacts so coverage growth and JIT divergence can
+# be tracked over time. This never gates a PR (`--full` always exits 0).
+
+on:
+  schedule:
+    - cron: "0 7 * * *"  # 07:00 UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: pyre-cpython-nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  full-suite:
+    name: full CPython suite (ubuntu)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - name: Set up CPython
+      id: cpython
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.14"
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-bin: false
+    - name: Cache Charon binary
+      id: charon-cache
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          .pyre-build/charon
+          .pyre-build/charon-src
+        key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
+        restore-keys: |
+          charon-bin-${{ runner.os }}-${{ runner.arch }}-
+    - name: Install Charon
+      if: steps.charon-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: scripts/install-charon.py
+    - name: Compute LLBC fingerprint
+      id: llbc-fingerprint
+      shell: bash
+      run: |
+        value="$(scripts/extract-llbc.py --fingerprint pyre-object pyre-interpreter pyre-jit)"
+        echo "value=${value}" >> "$GITHUB_OUTPUT"
+    - name: Cache LLBC
+      id: llbc-cache
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: build/llbc
+        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
+    - name: Extract LLBC
+      if: steps.llbc-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: scripts/extract-llbc.py pyre-object pyre-interpreter pyre-jit
+    - name: Build backends
+      run: |
+        cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm
+        cargo build --release -p pyrex --bin pyre-cranelift --no-default-features --features cranelift
+    - name: dynasm (JIT on)
+      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --full --backend dynasm --jobs 4 --timeout 120 --report reports/dynasm-jit.json
+    - name: dynasm (JIT off)
+      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --full --backend dynasm --no-jit --jobs 4 --timeout 120 --report reports/dynasm-nojit.json
+    - name: cranelift (JIT on)
+      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --full --backend cranelift --jobs 4 --timeout 120 --report reports/cranelift-jit.json
+    - name: Upload reports
+      if: ${{ always() }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: cpython-suite-reports
+        path: reports/

--- a/pyre/bench/synth/comprehension_module_scope.py
+++ b/pyre/bench/synth/comprehension_module_scope.py
@@ -4,7 +4,7 @@
 # fast<->locals sync must skip the hidden slot, otherwise the next global
 # store erases the just-bound name and reading it raises NameError.
 
-squares = [n for n in range(5)]   # `n` is a module-scope hidden fast local
+squares = [n for n in range(5)]   # noqa: C416 - `n` is a module-scope hidden fast local (comprehension form is the point)
 n = 100                           # rebind `n` as a real global
 total = 0                         # a second global store must not erase `n`
 

--- a/pyre/bench/synth/comprehension_module_scope.py
+++ b/pyre/bench/synth/comprehension_module_scope.py
@@ -1,0 +1,16 @@
+# PEP 709 inlines comprehensions into their enclosing scope. At module
+# scope the iteration variable becomes a CO_FAST_HIDDEN local, yet a later
+# top-level binding of the same name is a normal global (STORE_NAME). The
+# fast<->locals sync must skip the hidden slot, otherwise the next global
+# store erases the just-bound name and reading it raises NameError.
+
+squares = [n for n in range(5)]   # `n` is a module-scope hidden fast local
+n = 100                           # rebind `n` as a real global
+total = 0                         # a second global store must not erase `n`
+
+i = 0
+while i < 300000:
+    total = total + n
+    i = i + 1
+
+print(squares[-1], n, total)

--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -1,0 +1,124 @@
+# CPython regression suite for pyre
+
+Runs the vendored CPython 3.14 regression suite (`lib-python/3/test/`) against
+a built pyre interpreter and gates on regressions. This is the analog of
+PyPy's `lib-python/conftest.py` and RustPython's `-m test` CI, adapted to
+pyre's plain-Python runner convention (no pytest / RPython dependency).
+
+## Design
+
+- **Per-module subprocess.** Each test module runs in its own subprocess of
+  the built interpreter, exactly like PyPy launches `pypy3-c -m test <module>`.
+  Test pollution can't leak between modules.
+- **Pristine vendored tests.** `lib-python/3/test/` stays an unmodified copy
+  of CPython's `Lib/test`. Every skip / expected-status decision lives in the
+  external `baseline.json` — we never edit test files (so stdlib upgrades stay
+  a clean drop-in; see `lib-python/stdlib-upgrade.txt`).
+- **External baseline.** `baseline.json` records the expected status of every
+  module per backend. A module recorded `PASS` that stops passing is a
+  regression and fails CI; a newly-passing module is reported (run
+  `--update-baseline` to record it) but does not fail the run.
+
+## Usage
+
+```sh
+# build the interpreter first
+cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm
+
+# gate against the baseline (default: dynasm, JIT on, script mode)
+python3 pyre/cpython_tests/run.py
+
+# explore the whole suite without gating, write a JSON report
+python3 pyre/cpython_tests/run.py --full --report /tmp/report.json
+
+# focus on one module / list selection / regenerate the baseline
+python3 pyre/cpython_tests/run.py --filter test_json
+python3 pyre/cpython_tests/run.py --list
+python3 pyre/cpython_tests/run.py --full --update-baseline
+```
+
+Key flags: `--backend dynasm|cranelift`, `--no-jit` (`PYRE_NO_JIT=1`),
+`--mode script|module|regrtest`, `--jobs N`, `--timeout S`, `--filter SUB`,
+`--baseline PATH`, `--update-baseline`, `--strict-baseline`, `--full`,
+`--report PATH`.
+
+### Run modes
+
+- `script` (default): `pyre <path>/test_xxx.py` — runs the file directly as
+  `__main__`, firing its `unittest.main()`. The most robust mode today; it
+  bypasses `runpy` / `importlib.util.find_spec`.
+- `module`: `pyre -m test.<module>` — same entry via `runpy`. Blocked until
+  `importlib.util.find_spec` is wired to pyre's importer (see backlog).
+- `regrtest`: `pyre -m test -v <module>` — CPython's libregrtest, the
+  PyPy/RustPython form, for once libregrtest imports cleanly.
+
+## Result classes
+
+`PASS` (rc 0) · `FAIL` (unittest ran but failed) · `IMPORTERROR` (module could
+not even be imported/run — an interpreter or stdlib-compat gap) · `CRASH`
+(rust panic / nonzero `internal_compile_panics` / signal) · `TIMEOUT` ·
+`SKIP` (curated out in the baseline / `KNOWN_SKIPS`).
+
+## CI
+
+- `.github/workflows/pyre-ci.yml` job `cpython-tests` — gates PRs on the
+  baseline-`PASS` subset, dynasm with **JIT on** (`MAJIT_STRICT=1`), ubuntu.
+- `.github/workflows/pyre-cpython-nightly.yml` — non-gating nightly `--full`
+  across three lanes (dynasm JIT-on, dynasm JIT-off, cranelift) with reports
+  uploaded as artifacts. A module that passes JIT-off but not JIT-on is a JIT
+  correctness divergence.
+
+## Current state and backlog (Phase 0)
+
+The baseline currently records **32 `PASS`**, 381 `IMPORTERROR`, 20 `SKIP`,
+1 `CRASH` (434 modules, stdlib 3.14.6). The `PASS` set grows as the gaps
+below are closed; the rest still hit an interpreter or stdlib-compat gap
+before their tests can run. (It was 0 `PASS` / 414 `IMPORTERROR` before the
+`-m`/`STORE_SLICE`/submodule-binding/`_ast`/PEP-709-hidden-locals fixes
+below.)
+
+Building this infra already surfaced and fixed five interpreter gaps:
+
+- **`-m module`** support (`pyrex/src/lib.rs` — `runpy._run_module_as_main`).
+- **`STORE_SLICE`** (`obj[i:j] = v`) — `eval.rs` / `runtime_ops.rs`.
+- **submodule attribute binding** — `import a.b` now binds `b` on `a`
+  (`importing.rs::absolute_import`, the `_find_and_load` step). Fixes
+  `import xml.etree.ElementTree`, `importlib.util`, and a broad class of
+  stdlib imports.
+- **`_ast` node types are now heap types** (`module/_ast/interp_ast.rs`,
+  built via `type(name, bases, {})` along the ASDL hierarchy). `ast.py` can
+  monkeypatch / subclass them. Fixes `import ast` and, transitively,
+  `collections`, `json`, `functools`, `enum`, `textwrap`, `argparse`, …
+- **PEP 709 hidden comprehension locals at module scope** (`eval.rs`
+  `store_name_value` + `pyframe.rs` fast↔locals sync). A module-level inlined
+  comprehension makes its iteration variable a `CO_FAST_HIDDEN` fast local
+  whose binding lives in the module dict (via `STORE_NAME`), not the NULL
+  fast slot. Two parity fixes: **(a)** `STORE_NAME` now writes straight to
+  `w_locals` (PyPy `pyopcode.py:855` `space.setitem_str(getorcreatedebug().
+  w_locals, …)`) instead of via `getdictscope()` — the old path ran
+  `fast2locals` on every store, which deleted the hidden name from the dict
+  (the module's `w_locals` *is* its globals). **(b)** `fast2locals` /
+  `locals2fast` skip `CO_FAST_HIDDEN` slots (CPython `frameobject.c`; PyPy
+  has no PEP 709) so an explicit `locals()`/`vars()` can't erase them either.
+  This was **the gateway**: it unblocks `import dis` → `inspect` →
+  `unittest`. Repro: `y=[op for op in range(2)]; op=5; i=6; print(op)`
+  (byte-identical to CPython 3.14 after the fix).
+
+Known remaining blockers (the backlog the suite tracks), highest-leverage
+first:
+
+1. **`from package import submodule` fallback.** `from test import support`
+   fails when `support` isn't already an attribute; IMPORT_FROM must fall back
+   to importing the submodule. Also `from unittest import mock`
+   (`unittest.mock` submodule).
+2. **`importlib.util.find_spec` returns `None`.** pyre's native importer is
+   not wired into importlib's `meta_path`, so `runpy` (`-m`) can't locate
+   modules. Blocks `--mode module`/`regrtest`.
+3. **Compiler gap (external `rustpython-codegen`): `class_decorator` symbol
+   missing from the symbol table** — `compile error: the symbol
+   'class_decorator' must be present in the symbol table` (hit by
+   `test_grammar`). Lives in the git-pinned compiler dependency, not pyre's
+   tree.
+4. **Assorted stdlib-compat gaps** surfaced per module (e.g. `datetime.date`,
+   `genericpath._splitext`, `typing`'s `_idfunc`, complex `re` patterns). Run
+   `--full --report` to enumerate the current set.

--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -62,7 +62,10 @@ not even be imported/run — an interpreter or stdlib-compat gap) · `CRASH`
 ## CI
 
 - `.github/workflows/pyre-ci.yml` job `cpython-tests` — gates PRs on the
-  baseline-`PASS` subset, dynasm with **JIT on** (`MAJIT_STRICT=1`), ubuntu.
+  baseline-`PASS` subset, dynasm with **JIT on** (`MAJIT_STRICT=1`), on
+  `macos-latest` (aarch64). The baseline is recorded on darwin-aarch64 and the
+  JIT codegen is architecture-specific, so the gate runs on the same arch the
+  baseline was observed on (x86_64 JIT-on is a separate, unstable surface).
 - `.github/workflows/pyre-cpython-nightly.yml` — non-gating nightly `--full`
   across three lanes (dynasm JIT-on, dynasm JIT-off, cranelift) with reports
   uploaded as artifacts. A module that passes JIT-off but not JIT-on is a JIT

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -1,0 +1,1327 @@
+{
+  "modules": {
+    "test.test___all__": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test__colorize": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test__interpchannels": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test__interpreters": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test__locale": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test__opcode": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test__osx_support": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_abc": {
+      "dynasm": "CRASH"
+    },
+    "test.test_abstract_numbers": {
+      "dynasm": "PASS"
+    },
+    "test.test_android": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_annotationlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_apple": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_argparse": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_array": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_asdl_parser": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ast": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_asyncgen": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_asyncio": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_atexit": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_audit": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_augassign": {
+      "dynasm": "PASS"
+    },
+    "test.test_base64": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_baseexception": {
+      "dynasm": "PASS"
+    },
+    "test.test_bdb": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_bigaddrspace": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_bigmem": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_binascii": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_binop": {
+      "dynasm": "PASS"
+    },
+    "test.test_bisect": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_bool": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_buffer": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_bufio": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_build_details": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_builtin": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_bytes": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_bz2": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_c_locale_coercion": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_calendar": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_call": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_capi": {
+      "dynasm": "SKIP",
+      "reason": "needs C-API"
+    },
+    "test.test_cext": {
+      "dynasm": "SKIP",
+      "reason": "needs C compiler / C-API"
+    },
+    "test.test_charmapcodec": {
+      "dynasm": "PASS"
+    },
+    "test.test_class": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_clinic": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_cmath": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_cmd": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_cmd_line": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_cmd_line_script": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_code": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_code_module": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codeccallbacks": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecencodings_cn": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecencodings_hk": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecencodings_iso2022": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecencodings_jp": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecencodings_kr": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecencodings_tw": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecmaps_cn": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecmaps_hk": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecmaps_jp": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecmaps_kr": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecmaps_tw": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codecs": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_codeop": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_collections": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_colorsys": {
+      "dynasm": "PASS"
+    },
+    "test.test_compare": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_compile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_compileall": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_compiler_assemble": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_compiler_codegen": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_complex": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_concurrent_futures": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_configparser": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_contains": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_context": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_contextlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_contextlib_async": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_copy": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_copyreg": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_coroutines": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_cppext": {
+      "dynasm": "SKIP",
+      "reason": "needs C compiler / C-API"
+    },
+    "test.test_cprofile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_crossinterp": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_csv": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ctypes": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_curses": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dataclasses": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_datetime": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dbm": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dbm_dumb": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dbm_gnu": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dbm_ndbm": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dbm_sqlite3": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_decimal": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_decorators": {
+      "dynasm": "PASS"
+    },
+    "test.test_defaultdict": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_deque": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_descr": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_descrtut": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_devpoll": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dict": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dictcomps": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dictviews": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_difflib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dis": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_doctest": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_docxmlrpc": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dtrace": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dynamic": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_dynamicclassattribute": {
+      "dynasm": "PASS"
+    },
+    "test.test_eintr": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_email": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_embed": {
+      "dynasm": "SKIP",
+      "reason": "needs embedded CPython"
+    },
+    "test.test_ensurepip": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_enum": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_enumerate": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_eof": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_epoll": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_errno": {
+      "dynasm": "PASS"
+    },
+    "test.test_except_star": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_exception_group": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_exception_hierarchy": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_exception_variations": {
+      "dynasm": "PASS"
+    },
+    "test.test_exceptions": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_extcall": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_external_inspection": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_faulthandler": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_fcntl": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_file": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_file_eintr": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_filecmp": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_fileinput": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_fileio": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_fileutils": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_finalization": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_float": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_flufl": {
+      "dynasm": "PASS"
+    },
+    "test.test_fnmatch": {
+      "dynasm": "PASS"
+    },
+    "test.test_fork1": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_format": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_fractions": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_frame": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_free_threading": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_frozen": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_fstring": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ftplib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_funcattrs": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_functools": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_future_stmt": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_gc": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_gdb": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_generated_cases": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_generator_stop": {
+      "dynasm": "PASS"
+    },
+    "test.test_generators": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_genericalias": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_genericclass": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_genericpath": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_genexps": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_getopt": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_getpass": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_getpath": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_gettext": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_glob": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_global": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_grammar": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_graphlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_grp": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_gzip": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_hash": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_hashlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_heapq": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_hmac": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_html": {
+      "dynasm": "PASS"
+    },
+    "test.test_htmlparser": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_http_cookiejar": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_http_cookies": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_httplib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_httpservers": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_idle": {
+      "dynasm": "SKIP",
+      "reason": "needs display"
+    },
+    "test.test_imaplib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_import": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_importlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_index": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_inspect": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_int": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_int_literal": {
+      "dynasm": "PASS"
+    },
+    "test.test_interpreters": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_io": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ioctl": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ipaddress": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_isinstance": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_iter": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_iterlen": {
+      "dynasm": "PASS"
+    },
+    "test.test_itertools": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_json": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_keyword": {
+      "dynasm": "PASS"
+    },
+    "test.test_keywordonlyarg": {
+      "dynasm": "PASS"
+    },
+    "test.test_kqueue": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_largefile": {
+      "dynasm": "SKIP",
+      "reason": "demands too many resources"
+    },
+    "test.test_launcher": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_linecache": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_list": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_listcomps": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_lltrace": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_locale": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_logging": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_long": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_longexp": {
+      "dynasm": "PASS"
+    },
+    "test.test_lzma": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_mailbox": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_marshal": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_math": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_math_property": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_memoryio": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_memoryview": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_metaclass": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_mimetypes": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_minidom": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_mmap": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_module": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_modulefinder": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_monitoring": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_msvcrt": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_multibytecodec": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_multiprocessing_fork": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_multiprocessing_forkserver": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_multiprocessing_main_handling": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_multiprocessing_spawn": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_named_expressions": {
+      "dynasm": "PASS"
+    },
+    "test.test_netrc": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ntpath": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_nturl2path": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_numeric_tower": {
+      "dynasm": "PASS"
+    },
+    "test.test_opcache": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_opcodes": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_openpty": {
+      "dynasm": "PASS"
+    },
+    "test.test_operator": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_optimizer": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_optparse": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ordered_dict": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_os": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_osx_env": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pathlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_patma": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pdb": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_peepholer": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_peg_generator": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pep646_syntax": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_perf_profiler": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_perfmaps": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pickle": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_picklebuffer": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pickletools": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pkg": {
+      "dynasm": "PASS"
+    },
+    "test.test_pkgutil": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_platform": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_plistlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_poll": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_popen": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_poplib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_positional_only_arg": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_posix": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_posixpath": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pow": {
+      "dynasm": "PASS"
+    },
+    "test.test_pprint": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_print": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_profile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_property": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pstats": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pty": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pulldom": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pwd": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_py_compile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pyclbr": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pydoc": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pyexpat": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_pyrepl": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_queue": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_quopri": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_raise": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_random": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_range": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_re": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_readline": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_regrtest": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_remote_pdb": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_repl": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_reprlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_resource": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_richcmp": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_rlcompleter": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_robotparser": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_runpy": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_sax": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_sched": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_scope": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_script_helper": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_secrets": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_select": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_selectors": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_set": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_setcomps": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_shelve": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_shlex": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_shutil": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_signal": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_site": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_slice": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_smtplib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_smtpnet": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_socket": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_socketserver": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_sort": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_source_encoding": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_sqlite3": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ssl": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_stable_abi_ctypes": {
+      "dynasm": "SKIP",
+      "reason": "needs ctypes.pythonapi"
+    },
+    "test.test_startfile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_stat": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_statistics": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_str": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_strftime": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_string": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_string_literals": {
+      "dynasm": "PASS"
+    },
+    "test.test_stringprep": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_strptime": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_strtod": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_struct": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_structseq": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_subclassinit": {
+      "dynasm": "PASS"
+    },
+    "test.test_subprocess": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_sundry": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_super": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_support": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_symtable": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_syntax": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_sys": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_sys_setprofile": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_sys_settrace": {
+      "dynasm": "SKIP",
+      "reason": "implementation detail"
+    },
+    "test.test_sysconfig": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_syslog": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tabnanny": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tarfile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tcl": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tempfile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_termios": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_textwrap": {
+      "dynasm": "PASS"
+    },
+    "test.test_thread": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_thread_local_bytecode": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_threadedtempfile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_threading": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_threading_local": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_threadsignals": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_time": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_timeit": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_timeout": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tkinter": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tokenize": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tomllib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tools": {
+      "dynasm": "SKIP",
+      "reason": "CPython internal build details"
+    },
+    "test.test_trace": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_traceback": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tracemalloc": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tstring": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ttk": {
+      "dynasm": "SKIP",
+      "reason": "needs display"
+    },
+    "test.test_ttk_textonly": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tty": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_tuple": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_turtle": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_type_aliases": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_type_annotations": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_type_cache": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_type_comments": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_type_params": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_typechecks": {
+      "dynasm": "PASS"
+    },
+    "test.test_types": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_typing": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_ucn": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_unary": {
+      "dynasm": "PASS"
+    },
+    "test.test_unicode_file": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_unicode_file_functions": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_unicode_identifiers": {
+      "dynasm": "PASS"
+    },
+    "test.test_unicodedata": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_unittest": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_univnewlines": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_unpack": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_unpack_ex": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_unparse": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_urllib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_urllib2": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_urllib2_localnet": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_urllib2net": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_urllib_response": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_urllibnet": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_urlparse": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_userdict": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_userlist": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_userstring": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_utf8_mode": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_utf8source": {
+      "dynasm": "PASS"
+    },
+    "test.test_uuid": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_venv": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_wait3": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_wait4": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_warnings": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_wave": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_weakref": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_weakset": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_webbrowser": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_winapi": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_winconsoleio": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_winreg": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_winsound": {
+      "dynasm": "SKIP",
+      "reason": "needs audio hardware"
+    },
+    "test.test_with": {
+      "dynasm": "PASS"
+    },
+    "test.test_wmi": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_wsgiref": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xml_dom_minicompat": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xml_dom_xmlbuilder": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xml_etree": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xml_etree_c": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xmlrpc": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xpickle": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xxlimited": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_xxtestfuzz": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_yield_from": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_zipapp": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_zipfile": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_zipfile64": {
+      "dynasm": "SKIP",
+      "reason": "demands too many resources"
+    },
+    "test.test_zipimport": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_zipimport_support": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_zlib": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_zoneinfo": {
+      "dynasm": "IMPORTERROR"
+    },
+    "test.test_zstd": {
+      "dynasm": "IMPORTERROR"
+    }
+  },
+  "stdlib_version": "3.14.6"
+}

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Run the vendored CPython regression suite against a pyre binary.
+
+This mirrors PyPy's `lib-python/conftest.py` mechanism: each CPython test
+module is run in its OWN subprocess of the built interpreter, the vendored
+test files stay pristine, and every expected-status / skip decision lives in
+an EXTERNAL baseline (`baseline.json`) — never as edits to the test files.
+
+Each module is launched one of three ways, selectable with `--mode`:
+
+  * script (default): `pyre <path>/test_xxx.py` — runs the test file directly
+    as `__main__` so its `if __name__ == "__main__": unittest.main()` block
+    fires. Needs only `unittest` plus the module's own imports; bypasses
+    `runpy` / `importlib.util.find_spec` (which pyre's native importer does
+    not yet feed), so it is the most robust mode today.
+  * module: `pyre -m test.<module>` — same unittest entry but via `runpy`
+    (currently blocked until `importlib.util.find_spec` is wired to pyre's
+    importer).
+  * regrtest: `pyre -m test -v <module>` — CPython's own libregrtest, the
+    PyPy/RustPython form (used once libregrtest imports cleanly).
+
+A (module, backend) result is classified as:
+
+  PASS        rc 0 (unittest printed OK)
+  FAIL        clean nonzero exit (test failures/errors)
+  CRASH       rust panic / nonzero internal_compile_panics / signal
+  TIMEOUT     exceeded --timeout
+  IMPORTERROR module could not even be imported (an interpreter/stdlib gap;
+              this is the Phase-0 backlog the suite self-populates)
+
+Gating (default): a module recorded PASS in the baseline that no longer
+passes is a REGRESSION and makes the run exit nonzero. A module that newly
+passes is reported as an improvement but does not fail the run (run with
+`--update-baseline` to record it). `SKIP` baseline entries are not run.
+
+Usage:
+    python3 pyre/cpython_tests/run.py [--backend dynasm|cranelift]
+        [--no-jit] [--mode unittest|regrtest] [--jobs N]
+        [--timeout SECONDS] [--filter SUBSTR] [--list]
+        [--baseline PATH] [--update-baseline] [--strict-baseline] [--full]
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+TARGET_RELEASE = ROOT / "target" / "release"
+TESTDIR = ROOT / "lib-python" / "3" / "test"
+STDLIB_VERSION_FILE = ROOT / "lib-python" / "stdlib-version.txt"
+DEFAULT_BASELINE = HERE / "baseline.json"
+
+EXE = ".exe" if sys.platform == "win32" else ""
+BIN_NAME = {"dynasm": "pyre-dynasm", "cranelift": "pyre-cranelift"}
+
+STATUSES = ("PASS", "FAIL", "CRASH", "TIMEOUT", "IMPORTERROR", "SKIP")
+
+# Modules deliberately not run, ported from PyPy's lib-python/conftest.py
+# `testmap` skip reasons. These are CPython implementation-detail or
+# environment-specific tests that are never expected to pass on an
+# alternative interpreter; keep them out of the gate regardless of state.
+KNOWN_SKIPS = {
+    "test.test_dis": "implementation detail",
+    "test.test_dict_version": "implementation detail",
+    "test.test_gc": "implementation detail",
+    "test.test_frozen": "implementation detail",
+    "test.test_frame": "implementation detail",
+    "test.test_sys_setprofile": "implementation detail",
+    "test.test_sys_settrace": "implementation detail",
+    "test.test_bytecode_helper": "implementation detail",
+    "test.test_code": "implementation detail",
+    "test.test_peepholer": "implementation detail",
+    "test.test_opcache": "implementation detail",
+    "test.test_refcounting": "implementation detail (refcount semantics)",
+    "test.test_capi": "needs C-API",
+    "test.test_cppext": "needs C compiler / C-API",
+    "test.test_cext": "needs C compiler / C-API",
+    "test.test_stable_abi_ctypes": "needs ctypes.pythonapi",
+    "test.test_ossaudiodev": "needs low level audio",
+    "test.test_winsound": "needs audio hardware",
+    "test.test_tk": "needs display",
+    "test.test_ttk": "needs display",
+    "test.test_idle": "needs display",
+    "test.test_tools": "CPython internal build details",
+    "test.test_zipfile64": "demands too many resources",
+    "test.test_largefile": "demands too many resources",
+    "test.test_embed": "needs embedded CPython",
+}
+
+# ── classification ───────────────────────────────────────────────────
+
+def jit_panic_reason(stderr: str) -> str | None:
+    """A JIT-level rust panic or nonzero internal_compile_panics, else None.
+
+    Mirrors check.py `_jit_panic_reason`: pyre's panic hook suppresses
+    legitimate trace-abandon panics, so anything here is a real crash.
+    """
+    if not stderr:
+        return None
+    if "panicked" in stderr:
+        for line in stderr.splitlines():
+            if "panicked" in line:
+                return f"rust panic: {line.strip()[:80]}"
+        return "rust panic"
+    for line in stderr.splitlines():
+        if line.startswith("[jit-stats]") and "internal_compile_panics=" in line:
+            field = line.split("internal_compile_panics=", 1)[1].split()[0]
+            try:
+                if int(field) > 0:
+                    return f"internal_compile_panics={field}"
+            except ValueError:
+                pass
+    return None
+
+
+def classify(rc: int, out: str, err: str) -> tuple[str, str]:
+    """Map a finished run to (status, detail).
+
+    The FAIL vs IMPORTERROR split keys on whether unittest actually ran:
+    a `Ran N tests` / `FAILED (` line means the module imported and the test
+    framework executed (a genuine test FAIL), while its absence means the
+    module could not even be loaded — an interpreter/stdlib gap, which is the
+    Phase-0 backlog this suite is meant to surface.
+    """
+    panic = jit_panic_reason(err)
+    if panic:
+        return "CRASH", panic
+    if rc < 0 or rc > 128:
+        return "CRASH", f"signal/abort rc={rc}"
+    if rc == 0:
+        return "PASS", ""
+    last = ""
+    for line in reversed(err.splitlines()):
+        if line.strip():
+            last = line.strip()
+            break
+    ran = "Ran " in out or "Ran " in err or "FAILED (" in out or "FAILED (" in err
+    status = "FAIL" if ran else "IMPORTERROR"
+    return status, f"rc={rc} {last}"[:120]
+
+
+# ── discovery ────────────────────────────────────────────────────────
+
+def discover_modules(filter_substring: str | None) -> list[str]:
+    """Dotted names (`test.test_xxx`) for every CPython test module/package."""
+    names: list[str] = []
+    for p in sorted(TESTDIR.glob("test_*.py")):
+        names.append(f"test.{p.stem}")
+    for d in sorted(TESTDIR.glob("test_*")):
+        if d.is_dir() and (d / "__init__.py").exists():
+            names.append(f"test.{d.name}")
+    names = sorted(set(names))
+    if filter_substring:
+        names = [n for n in names if filter_substring in n]
+    return names
+
+
+# ── execution ────────────────────────────────────────────────────────
+
+def module_path(module: str) -> Path:
+    """Filesystem path to run a dotted `test.<name>` module as a script:
+    a `test_xxx.py` file, or a package's `__main__.py`."""
+    name = module.split(".", 1)[1]
+    pyfile = TESTDIR / f"{name}.py"
+    if pyfile.exists():
+        return pyfile
+    return TESTDIR / name / "__main__.py"
+
+
+def build_cmd(binary: Path, module: str, mode: str) -> list[str]:
+    if mode == "regrtest":
+        # CPython libregrtest; <module> is the bare basename (test_xxx).
+        return [str(binary), "-m", "test", "-v", module.split(".", 1)[1]]
+    if mode == "module":
+        return [str(binary), "-m", module]
+    # script (default): run the file directly as __main__.
+    return [str(binary), str(module_path(module))]
+
+
+def run_module(binary: Path, module: str, mode: str, timeout: int,
+               env: dict) -> tuple[str, str]:
+    cmd = build_cmd(binary, module, mode)
+    # Run in a throwaway cwd so a test writing into '.' never touches the
+    # repo (the stdlib is resolved relative to the executable, not cwd).
+    with tempfile.TemporaryDirectory(prefix="pyre-cpytest-") as cwd:
+        try:
+            proc = subprocess.run(
+                cmd, cwd=cwd, env=env, capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return "TIMEOUT", f"timeout {timeout}s"
+    return classify(proc.returncode, proc.stdout or "", proc.stderr or "")
+
+
+# ── baseline ─────────────────────────────────────────────────────────
+
+def stdlib_version() -> str:
+    try:
+        text = STDLIB_VERSION_FILE.read_text(encoding="utf-8")
+    except OSError:
+        return "unknown"
+    for token in text.split():
+        if token.startswith("v") and token[1:2].isdigit():
+            return token.lstrip("v")
+    return "unknown"
+
+
+def load_baseline(path: Path) -> dict:
+    if not path.exists():
+        return {"stdlib_version": stdlib_version(), "modules": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def expected_status(baseline: dict, module: str, backend: str) -> str | None:
+    entry = baseline.get("modules", {}).get(module)
+    if entry is None:
+        return None
+    return entry.get(backend) or entry.get("dynasm")
+
+
+# ── main ─────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--backend", choices=("dynasm", "cranelift"), default="dynasm")
+    ap.add_argument("--binary", help="explicit interpreter path (overrides --backend)")
+    ap.add_argument("--no-jit", action="store_true", help="set PYRE_NO_JIT=1")
+    ap.add_argument("--mode", choices=("script", "module", "regrtest"), default="script")
+    ap.add_argument("--jobs", type=int, default=os.cpu_count() or 4)
+    ap.add_argument("--timeout", type=int, default=300)
+    ap.add_argument("--filter", help="only modules whose dotted name contains this")
+    ap.add_argument("--list", action="store_true", help="list selected modules and exit")
+    ap.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    ap.add_argument("--update-baseline", action="store_true",
+                    help="rewrite the baseline from observed results (non-gating)")
+    ap.add_argument("--strict-baseline", action="store_true",
+                    help="also fail on newly-passing modules not recorded as PASS")
+    ap.add_argument("--full", action="store_true",
+                    help="run every module and only report (never gate, never skip)")
+    ap.add_argument("--report", type=Path,
+                    help="write the per-module results as JSON to this path")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    binary = Path(args.binary) if args.binary else TARGET_RELEASE / f"{BIN_NAME[args.backend]}{EXE}"
+    binary = binary.resolve()
+    if not args.list and not binary.exists():
+        print(f"error: interpreter not found: {binary}", file=sys.stderr)
+        print("       build it with: cargo build --release -p pyrex --bin "
+              f"{BIN_NAME[args.backend]} --no-default-features --features {args.backend}",
+              file=sys.stderr)
+        return 2
+
+    if not TESTDIR.is_dir():
+        print(f"error: CPython test suite not found: {TESTDIR}", file=sys.stderr)
+        return 2
+
+    baseline = load_baseline(args.baseline)
+    modules = discover_modules(args.filter)
+
+    if args.list:
+        for m in modules:
+            print(m)
+        print(f"\n{len(modules)} modules", file=sys.stderr)
+        return 0
+
+    env = dict(os.environ)
+    env["MAJIT_STRICT"] = "1"
+    env["MAJIT_STATS"] = "1"
+    if args.no_jit:
+        env["PYRE_NO_JIT"] = "1"
+
+    # Decide which modules to actually run.
+    to_run: list[str] = []
+    skipped: list[str] = []
+    for m in modules:
+        exp = expected_status(baseline, m, args.backend)
+        is_skip = (exp == "SKIP") or (m in KNOWN_SKIPS)
+        if is_skip and not args.full and not args.update_baseline:
+            skipped.append(m)
+            continue
+        to_run.append(m)
+
+    print(f"pyre CPython suite — backend={args.backend} mode={args.mode} "
+          f"jit={'off' if args.no_jit else 'on'} jobs={args.jobs}")
+    print(f"binary: {binary}")
+    print(f"{len(to_run)} to run, {len(skipped)} skipped, timeout={args.timeout}s\n")
+
+    results: dict[str, tuple[str, str]] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        futs = {pool.submit(run_module, binary, m, args.mode, args.timeout, env): m
+                for m in to_run}
+        done = 0
+        for fut in concurrent.futures.as_completed(futs):
+            m = futs[fut]
+            status, detail = fut.result()
+            results[m] = (status, detail)
+            done += 1
+            mark = {"PASS": "·", "FAIL": "F", "CRASH": "C",
+                    "TIMEOUT": "T", "IMPORTERROR": "i"}.get(status, "?")
+            sys.stdout.write(mark)
+            sys.stdout.flush()
+            if done % 80 == 0:
+                sys.stdout.write(f" {done}/{len(to_run)}\n")
+    print()
+
+    # Summary by status.
+    counts = {s: 0 for s in STATUSES}
+    for status, _ in results.values():
+        counts[status] = counts.get(status, 0) + 1
+    counts["SKIP"] = len(skipped)
+    print("\n── summary ──")
+    for s in STATUSES:
+        print(f"  {s:12s} {counts[s]}")
+
+    # Regression / improvement analysis vs baseline.
+    regressions: list[str] = []
+    improvements: list[str] = []
+    for m, (status, detail) in sorted(results.items()):
+        exp = expected_status(baseline, m, args.backend)
+        if exp == "PASS" and status != "PASS":
+            regressions.append(f"{m}: PASS -> {status}  {detail}")
+        elif exp != "PASS" and status == "PASS":
+            improvements.append(f"{m}: {exp or 'new'} -> PASS")
+
+    if improvements:
+        print(f"\n── improvements ({len(improvements)}) ──")
+        for line in improvements:
+            print(f"  + {line}")
+
+    if args.report:
+        report = {
+            "backend": args.backend,
+            "mode": args.mode,
+            "jit": not args.no_jit,
+            "stdlib_version": stdlib_version(),
+            "counts": counts,
+            "modules": {m: {"status": s, "detail": d}
+                        for m, (s, d) in sorted(results.items())},
+        }
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n",
+                               encoding="utf-8")
+        print(f"\nreport written: {args.report}")
+
+    if args.update_baseline:
+        write_baseline(args.baseline, baseline, results, args.backend)
+        print(f"\nbaseline written: {args.baseline} "
+              f"({sum(1 for s, _ in results.values() if s == 'PASS')} PASS recorded)")
+        return 0
+
+    if regressions:
+        print(f"\n── REGRESSIONS ({len(regressions)}) ──")
+        for line in regressions:
+            print(f"  - {line}")
+        return 1
+
+    if args.strict_baseline and improvements:
+        print("\nstrict: newly-passing modules must be recorded "
+              "(run --update-baseline)")
+        return 1
+
+    print("\nno regressions")
+    return 0
+
+
+def write_baseline(path: Path, baseline: dict, results: dict, backend: str) -> None:
+    modules = baseline.setdefault("modules", {})
+    baseline["stdlib_version"] = stdlib_version()
+    for m, (status, _detail) in results.items():
+        entry = modules.setdefault(m, {})
+        # A curated KNOWN_SKIP stays SKIP regardless of what the run observed
+        # (it is a "do not run" decision, not a result). Modules absent from
+        # `results` (phantom skips that no longer exist) are simply not added.
+        if m in KNOWN_SKIPS:
+            entry[backend] = "SKIP"
+            entry.setdefault("reason", KNOWN_SKIPS[m])
+        else:
+            entry[backend] = status
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -35,7 +35,7 @@ passes is reported as an improvement but does not fail the run (run with
 
 Usage:
     python3 pyre/cpython_tests/run.py [--backend dynasm|cranelift]
-        [--no-jit] [--mode unittest|regrtest] [--jobs N]
+        [--no-jit] [--mode script|module|regrtest] [--jobs N]
         [--timeout SECONDS] [--filter SUBSTR] [--list]
         [--baseline PATH] [--update-baseline] [--strict-baseline] [--full]
 """
@@ -229,6 +229,13 @@ def expected_status(baseline: dict, module: str, backend: str) -> str | None:
 
 # ── main ─────────────────────────────────────────────────────────────
 
+def positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return ivalue
+
+
 def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -236,8 +243,8 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--binary", help="explicit interpreter path (overrides --backend)")
     ap.add_argument("--no-jit", action="store_true", help="set PYRE_NO_JIT=1")
     ap.add_argument("--mode", choices=("script", "module", "regrtest"), default="script")
-    ap.add_argument("--jobs", type=int, default=os.cpu_count() or 4)
-    ap.add_argument("--timeout", type=int, default=300)
+    ap.add_argument("--jobs", type=positive_int, default=os.cpu_count() or 4)
+    ap.add_argument("--timeout", type=positive_int, default=300)
     ap.add_argument("--filter", help="only modules whose dotted name contains this")
     ap.add_argument("--list", action="store_true", help="list selected modules and exit")
     ap.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
@@ -366,14 +373,17 @@ def main() -> int:
         print(f"\n── REGRESSIONS ({len(regressions)}) ──")
         for line in regressions:
             print(f"  - {line}")
-        return 1
+        # `--full` is report-only (the nightly exploratory lanes rely on it);
+        # never let a current PASS regression fail an exploratory run.
+        if not args.full:
+            return 1
 
-    if args.strict_baseline and improvements:
+    if args.strict_baseline and improvements and not args.full:
         print("\nstrict: newly-passing modules must be recorded "
               "(run --update-baseline)")
         return 1
 
-    print("\nno regressions")
+    print("\nno regressions" if not regressions else "\n(--full: regressions reported, not gated)")
     return 0
 
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1366,11 +1366,14 @@ impl NamespaceOpcodeHandler for PyFrame {
         self.load_global_value(name, nameindex)
     }
 
-    /// PyPy: STORE_NAME writes to locals (class body) or globals.
+    /// pyopcode.py:855-859 STORE_NAME —
+    /// `space.setitem_str(self.getorcreatedebug().w_locals, varname, w_value)`.
     ///
-    /// Non-dict mapping locals route through
-    /// `space.setitem(w_locals_object, name, value)` matching
-    /// `pyopcode.py:STORE_NAME` `space.setitem(w_locals, ...)`.
+    /// Writes straight to `w_locals` (the class namespace, or — at module
+    /// scope — the globals dict). It must NOT route through `getdictscope`:
+    /// that runs `fast2locals`, which would erase a module frame's
+    /// `CO_FAST_HIDDEN` inlined-comprehension locals (their fast slot is NULL,
+    /// the binding lives in `w_locals` via STORE_NAME) on every store.
     fn store_name_value(
         &mut self,
         name: &str,
@@ -1383,7 +1386,7 @@ impl NamespaceOpcodeHandler for PyFrame {
             crate::baseobjspace::setitem(w_locals_object, key, value)?;
             return Ok(());
         }
-        let ns = unsafe { &mut *self.getdictscope()? };
+        let ns = unsafe { &mut *self.get_or_create_w_locals() };
         dict_storage_store(ns, name, value);
         Ok(())
     }
@@ -3673,9 +3676,13 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     // ── StoreSlice (a[b:c] = d) ──
+    // Stack (bottom→top): value, container, start, stop.
     fn store_slice(&mut self) -> Result<(), PyError> {
-        // Stub — rarely used in hot loops
-        Err(PyError::type_error("STORE_SLICE not yet implemented"))
+        let stop = self.pop();
+        let start = self.pop();
+        let container = self.pop();
+        let value = self.pop();
+        crate::runtime_ops::store_slice_values(container, start, stop, value)
     }
 
     // ── BuildString (f-string concatenation) ──

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -982,6 +982,7 @@ fn absolute_import(
 ) -> Result<PyObjectRef, crate::PyError> {
     let parts: Vec<&str> = modulename.split('.').collect();
     let mut first: Option<PyObjectRef> = None;
+    let mut parent: Option<PyObjectRef> = None;
     let mut prefix = Vec::new();
 
     for (level, &part) in parts.iter().enumerate() {
@@ -994,9 +995,16 @@ fn absolute_import(
                 format!("No module named '{modulename}'"),
             ));
         };
+        // _bootstrap._find_and_load: bind the submodule as an attribute of
+        // its parent package, so `import a.b` makes `a.b` reachable. A
+        // parent that refuses attribute assignment is ignored, as in CPython.
+        if let Some(parent_mod) = parent {
+            let _ = crate::setattr_str(parent_mod, part, module);
+        }
         if level == 0 {
             first = Some(module);
         }
+        parent = Some(module);
     }
 
     // PyPy: if w_fromlist is not None, return the leaf module.

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -995,11 +995,23 @@ fn absolute_import(
                 format!("No module named '{modulename}'"),
             ));
         };
-        // _bootstrap._find_and_load: bind the submodule as an attribute of
-        // its parent package, so `import a.b` makes `a.b` reachable. A
-        // parent that refuses attribute assignment is ignored, as in CPython.
+        // _bootstrap._find_and_load (_bootstrap.py:1346-1352): bind the
+        // submodule as an attribute of its parent package so `import a.b`
+        // makes `a.b` reachable. Only an AttributeError is swallowed (with an
+        // ImportWarning); any other exception propagates.
         if let Some(parent_mod) = parent {
-            let _ = crate::setattr_str(parent_mod, part, module);
+            if let Err(err) = crate::setattr_str(parent_mod, part, module) {
+                if err.kind != crate::PyErrorKind::AttributeError {
+                    return Err(err);
+                }
+                let parent_name = parts[..level].join(".");
+                crate::warn::warn(
+                    &format!(
+                        "Cannot set an attribute on '{parent_name}' for child module '{part}'"
+                    ),
+                    "ImportWarning",
+                );
+            }
         }
         if level == 0 {
             first = Some(module);

--- a/pyre/pyre-interpreter/src/module/_ast/interp_ast.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/interp_ast.rs
@@ -14,10 +14,12 @@ use pyre_object::PyObjectRef;
 /// matching CPython where `_ast` types are heap types. Actual AST node
 /// construction is not supported because pyre uses RustPython's compiler.
 pub fn register_module(ns: &mut DictStorage) {
-    // `type(name, (base,), {"__module__": "_ast"})` — a fresh heap type.
+    // `type(name, (base,), {"__module__": "ast"})` — a fresh heap type. The
+    // generated AST types report `__module__ == "ast"` (astcompiler/ast.py:150;
+    // the host `_ast.Module.__module__` is likewise `'ast'`).
     let make = |name: &str, base: PyObjectRef| -> PyObjectRef {
         let dict = pyre_object::w_dict_new();
-        crate::baseobjspace::setitem(dict, pyre_object::w_str_new("__module__"), pyre_object::w_str_new("_ast"))
+        crate::baseobjspace::setitem(dict, pyre_object::w_str_new("__module__"), pyre_object::w_str_new("ast"))
             .expect("set __module__ on _ast type namespace");
         let args = [
             pyre_object::w_str_new(name),

--- a/pyre/pyre-interpreter/src/module/_ast/interp_ast.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/interp_ast.rs
@@ -3,161 +3,104 @@
 //! Verbatim move of the inline block previously in importing.rs.
 
 use crate::DictStorage;
+use pyre_object::PyObjectRef;
 
 /// _ast stub — PyPy: pypy/module/_ast/
 ///
-/// Exposes the AST node type hierarchy as plain type stubs. Our stubs are
-/// enough to satisfy `from _ast import *` in `ast.py` and class body
-/// references like `class slice(AST)`. Actual AST construction is not
-/// supported because pyre uses RustPython's compiler.
+/// Exposes the AST node type hierarchy. The node types are created as **heap
+/// types** (via `type(name, bases, {})`) following the ASDL hierarchy
+/// (`AST` → abstract group → concrete node), so `ast.py` can subclass them
+/// (`class Suite(mod)`) and monkeypatch them (`Tuple.dims = property(...)`),
+/// matching CPython where `_ast` types are heap types. Actual AST node
+/// construction is not supported because pyre uses RustPython's compiler.
 pub fn register_module(ns: &mut DictStorage) {
-    let ast_names: &[&str] = &[
-        "AST",
-        "mod",
-        "Module",
-        "Interactive",
-        "Expression",
-        "FunctionType",
-        "stmt",
-        "FunctionDef",
-        "AsyncFunctionDef",
-        "ClassDef",
-        "Return",
-        "Delete",
-        "Assign",
-        "TypeAlias",
-        "AugAssign",
-        "AnnAssign",
-        "For",
-        "AsyncFor",
-        "While",
-        "If",
-        "With",
-        "AsyncWith",
-        "Match",
-        "Raise",
-        "Try",
-        "TryStar",
-        "Assert",
-        "Import",
-        "ImportFrom",
-        "Global",
-        "Nonlocal",
-        "Expr",
-        "Pass",
-        "Break",
-        "Continue",
-        "expr",
-        "BoolOp",
-        "NamedExpr",
-        "BinOp",
-        "UnaryOp",
-        "Lambda",
-        "IfExp",
-        "Dict",
-        "Set",
-        "ListComp",
-        "SetComp",
-        "DictComp",
-        "GeneratorExp",
-        "Await",
-        "Yield",
-        "YieldFrom",
-        "Compare",
-        "Call",
-        "FormattedValue",
-        "JoinedStr",
-        "Constant",
-        "Attribute",
-        "Subscript",
-        "Starred",
-        "Name",
-        "List",
-        "Tuple",
-        "Slice",
-        "expr_context",
-        "Load",
-        "Store",
-        "Del",
-        "boolop",
-        "And",
-        "Or",
-        "operator",
-        "Add",
-        "Sub",
-        "Mult",
-        "MatMult",
-        "Div",
-        "Mod",
-        "Pow",
-        "LShift",
-        "RShift",
-        "BitOr",
-        "BitXor",
-        "BitAnd",
-        "FloorDiv",
-        "unaryop",
-        "Invert",
-        "Not",
-        "UAdd",
-        "USub",
-        "cmpop",
-        "Eq",
-        "NotEq",
-        "Lt",
-        "LtE",
-        "Gt",
-        "GtE",
-        "Is",
-        "IsNot",
-        "In",
-        "NotIn",
-        "comprehension",
-        "excepthandler",
-        "ExceptHandler",
-        "arguments",
-        "arg",
-        "keyword",
-        "alias",
-        "withitem",
-        "match_case",
-        "pattern",
-        "MatchValue",
-        "MatchSingleton",
-        "MatchSequence",
-        "MatchMapping",
-        "MatchClass",
-        "MatchStar",
-        "MatchAs",
-        "MatchOr",
-        "type_ignore",
-        "TypeIgnore",
-        "type_param",
-        "TypeVar",
-        "ParamSpec",
-        "TypeVarTuple",
-        // Flags used by ast.parse()
-        "PyCF_ONLY_AST",
-        "PyCF_OPTIMIZED_AST",
-        "PyCF_TYPE_COMMENTS",
-        "PyCF_ALLOW_TOP_LEVEL_AWAIT",
+    // `type(name, (base,), {"__module__": "_ast"})` — a fresh heap type.
+    let make = |name: &str, base: PyObjectRef| -> PyObjectRef {
+        let dict = pyre_object::w_dict_new();
+        crate::baseobjspace::setitem(dict, pyre_object::w_str_new("__module__"), pyre_object::w_str_new("_ast"))
+            .expect("set __module__ on _ast type namespace");
+        let args = [
+            pyre_object::w_str_new(name),
+            pyre_object::w_tuple_new(vec![base]),
+            dict,
+        ];
+        crate::builtins::type_descr_new(&args).expect("_ast heap type creation")
+    };
+
+    // Root: AST(object).
+    let ast = make("AST", crate::typedef::w_object());
+    crate::dict_storage_store(ns, "AST", ast);
+
+    // Abstract groups (direct AST subclasses) and their concrete members,
+    // per the ASDL grammar.
+    let groups: &[(&str, &[&str])] = &[
+        ("mod", &["Module", "Interactive", "Expression", "FunctionType"]),
+        (
+            "stmt",
+            &[
+                "FunctionDef", "AsyncFunctionDef", "ClassDef", "Return", "Delete", "Assign",
+                "TypeAlias", "AugAssign", "AnnAssign", "For", "AsyncFor", "While", "If", "With",
+                "AsyncWith", "Match", "Raise", "Try", "TryStar", "Assert", "Import", "ImportFrom",
+                "Global", "Nonlocal", "Expr", "Pass", "Break", "Continue",
+            ],
+        ),
+        (
+            "expr",
+            &[
+                "BoolOp", "NamedExpr", "BinOp", "UnaryOp", "Lambda", "IfExp", "Dict", "Set",
+                "ListComp", "SetComp", "DictComp", "GeneratorExp", "Await", "Yield", "YieldFrom",
+                "Compare", "Call", "FormattedValue", "JoinedStr", "Constant", "Attribute",
+                "Subscript", "Starred", "Name", "List", "Tuple", "Slice",
+            ],
+        ),
+        ("expr_context", &["Load", "Store", "Del"]),
+        ("boolop", &["And", "Or"]),
+        (
+            "operator",
+            &[
+                "Add", "Sub", "Mult", "MatMult", "Div", "Mod", "Pow", "LShift", "RShift", "BitOr",
+                "BitXor", "BitAnd", "FloorDiv",
+            ],
+        ),
+        ("unaryop", &["Invert", "Not", "UAdd", "USub"]),
+        ("cmpop", &["Eq", "NotEq", "Lt", "LtE", "Gt", "GtE", "Is", "IsNot", "In", "NotIn"]),
+        ("excepthandler", &["ExceptHandler"]),
+        (
+            "pattern",
+            &[
+                "MatchValue", "MatchSingleton", "MatchSequence", "MatchMapping", "MatchClass",
+                "MatchStar", "MatchAs", "MatchOr",
+            ],
+        ),
+        ("type_ignore", &["TypeIgnore"]),
+        ("type_param", &["TypeVar", "ParamSpec", "TypeVarTuple"]),
     ];
-    // `pypy/interpreter/astcompiler/consts.py` — `compile()` /
-    // `ast.parse()` flag bitmasks, used by `lib-python/3/ast.py`
-    // (`flags = PyCF_ONLY_AST; flags |= PyCF_TYPE_COMMENTS`).
-    for name in ast_names {
-        if name.starts_with("PyCF") {
-            // Values mirror `pypy/interpreter/astcompiler/consts.py:33-42`.
-            let value: i64 = match *name {
-                "PyCF_ONLY_AST" => 0x0400,
-                "PyCF_ALLOW_TOP_LEVEL_AWAIT" => 0x2000,
-                "PyCF_TYPE_COMMENTS" => 0x40000000,
-                "PyCF_OPTIMIZED_AST" => 0x8000,
-                _ => 0,
-            };
-            crate::dict_storage_store(ns, name, pyre_object::w_int_new(value));
-        } else {
-            crate::dict_storage_store(ns, name, crate::typedef::make_builtin_type(name, |_| {}));
+    for (group, members) in groups {
+        let g = make(group, ast);
+        crate::dict_storage_store(ns, group, g);
+        for m in *members {
+            let t = make(m, g);
+            crate::dict_storage_store(ns, m, t);
         }
+    }
+
+    // Leaf node types that are direct AST subclasses (no further subclasses).
+    for name in &[
+        "comprehension", "arguments", "arg", "keyword", "alias", "withitem", "match_case",
+    ] {
+        let t = make(name, ast);
+        crate::dict_storage_store(ns, name, t);
+    }
+
+    // `compile()` / `ast.parse()` flag bitmasks, used by `lib-python/3/ast.py`
+    // (`flags = PyCF_ONLY_AST; flags |= PyCF_TYPE_COMMENTS`). Values mirror
+    // `pypy/interpreter/astcompiler/consts.py:33-42`.
+    for (name, value) in &[
+        ("PyCF_ONLY_AST", 0x0400i64),
+        ("PyCF_ALLOW_TOP_LEVEL_AWAIT", 0x2000),
+        ("PyCF_TYPE_COMMENTS", 0x4000_0000),
+        ("PyCF_OPTIMIZED_AST", 0x8000),
+    ] {
+        crate::dict_storage_store(ns, name, pyre_object::w_int_new(*value));
     }
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -701,6 +701,17 @@ pub fn ncells(code: &CodeObject) -> usize {
     npure_cellvars(code) + code.freevars.len()
 }
 
+/// True when localsplus slot `idx` carries `CO_FAST_HIDDEN`, i.e. an inlined
+/// comprehension's iteration variable (PEP 709). These slots are workspace
+/// only and stay invisible to `locals()` / the fast↔locals sync.
+#[inline]
+#[majit_macros::elidable_cannot_raise]
+pub fn hidden_local(code: &CodeObject, idx: usize) -> bool {
+    code.localspluskinds
+        .get(idx)
+        .is_some_and(|&kind| kind & crate::bytecode::CO_FAST_HIDDEN != 0)
+}
+
 /// `LOAD_DEREF` unbound-variable error for the unified deref slot `idx`,
 /// shared by the interpreter (`load_deref`) and the JIT residual
 /// (`bh_load_deref_value_fn`).
@@ -877,6 +888,20 @@ impl PyFrame {
     pub fn getdictscope(&mut self) -> Result<*mut DictStorage, crate::PyError> {
         self.fast2locals()?;
         Ok(self.get_w_locals())
+    }
+
+    /// `getorcreatedebug().w_locals` — the STORE_NAME / DELETE_NAME target
+    /// (`pyopcode.py:855-865`): the class namespace, or the globals dict at
+    /// module scope. Lazily allocates an empty dict if the frame has none.
+    /// Unlike `getdictscope` it performs no `fast2locals` materialization, so
+    /// it never disturbs `CO_FAST_HIDDEN` slots.
+    #[inline]
+    pub fn get_or_create_w_locals(&mut self) -> *mut DictStorage {
+        let data = self.getorcreate_debug_data(-1);
+        if data.w_locals.is_null() {
+            data.w_locals = pyre_object::lltype::malloc_raw(DictStorage::new());
+        }
+        data.w_locals
     }
 
     /// PyPy-compatible `__init__` hook.
@@ -1940,6 +1965,12 @@ impl PyFrame {
         // pyframe.py:609-615: copy locals from dict to fast slots
         let mut new_fastlocals_w = vec![PY_NULL; numlocals];
         for i in 0..numlocals {
+            // CO_FAST_HIDDEN slots are not reflected in the locals mapping —
+            // preserve the current fast value instead of clearing it.
+            if hidden_local(code, i) {
+                new_fastlocals_w[i] = self.locals_w()[i];
+                continue;
+            }
             let name = &code.varnames[i];
             if let Some(&w_value) = w_locals_ref.get(name.as_ref()) {
                 new_fastlocals_w[i] = w_value;
@@ -2008,6 +2039,12 @@ impl PyFrame {
 
         let mut new_fastlocals_w = vec![PY_NULL; numlocals];
         for i in 0..numlocals {
+            // CO_FAST_HIDDEN slots are not reflected in the locals mapping —
+            // preserve the current fast value instead of clearing it.
+            if hidden_local(code, i) {
+                new_fastlocals_w[i] = self.locals_w()[i];
+                continue;
+            }
             let name = &code.varnames[i];
             if let Some(w_value) = finditem_str_object(w_locals_object, name)? {
                 new_fastlocals_w[i] = w_value;
@@ -2091,6 +2128,17 @@ impl PyFrame {
 
         // pyframe.py:564-575: copy local variables
         for i in 0..numlocals {
+            // CO_FAST_HIDDEN slots — an inlined comprehension's iteration
+            // variable at module/class scope — are not user-visible and must
+            // not be synced to the locals mapping. For a module frame whose
+            // `w_locals` is its globals dict, the slot stays NULL (the name is
+            // bound by STORE_NAME in the dict, not the fast array), so the
+            // delitem branch below would otherwise erase the binding on every
+            // getdictscope. frameobject.c skips CO_FAST_HIDDEN in both
+            // directions.
+            if hidden_local(code, i) {
+                continue;
+            }
             let name = &varnames[i];
             let w_value = self.locals_w()[i];
             if !w_value.is_null() {
@@ -2171,6 +2219,10 @@ impl PyFrame {
         let numlocals = varnames.len();
 
         for i in 0..numlocals {
+            // CO_FAST_HIDDEN slots are not user-visible — see fast2locals.
+            if hidden_local(code, i) {
+                continue;
+            }
             let name = &varnames[i];
             let w_value = self.locals_w()[i];
             if !w_value.is_null() {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -621,6 +621,20 @@ pub fn format_value(value: PyObjectRef, spec: PyObjectRef) -> Result<PyObjectRef
     Ok(pyre_object::w_str_from_wtf8(s))
 }
 
+/// STORE_SLICE evaluation (`obj[start:stop] = value`): builds a `slice`
+/// object and dispatches through `setitem`, mirroring `PyObject_SetItem`
+/// with a slice key. The dual of `binary_slice_values`; a `None` step.
+pub fn store_slice_values(
+    obj: PyObjectRef,
+    start: PyObjectRef,
+    stop: PyObjectRef,
+    value: PyObjectRef,
+) -> Result<(), PyError> {
+    let slice = pyre_object::w_slice_new(start, stop, pyre_object::w_none());
+    crate::baseobjspace::setitem(obj, slice, value)?;
+    Ok(())
+}
+
 /// BINARY_SLICE evaluation, shared by the interpreter (`binary_slice`)
 /// and the JIT residual (`bh_binary_slice_fn`): returns `obj[start:stop]`.
 /// `list` / `str` / `tuple` slice on element (code-point for `str`)

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -20,6 +20,7 @@ mod repl_readline;
 enum RunMode {
     Script(String),
     Command(String),
+    Module(String),
     Repl,
 }
 
@@ -29,6 +30,7 @@ fn usage(binary_name: &str) -> String {
 usage: {binary_name} [option] ... [-c cmd | file | -] [arg] ...
 Options:
 -c cmd : program passed in as string (terminates option list)
+-m mod : run library module as a script (terminates option list)
 -h     : print this help message and exit (also --help)
 -i     : inspect interactively after running script
 -O     : optimize (no-op, reserved for compatibility)
@@ -41,7 +43,18 @@ arg ...: arguments passed to program in sys.argv[1:]
     )
 }
 
-fn parse_args(binary_name: &str) -> Result<(RunMode, bool, bool), lexopt::Error> {
+/// Drain the parser's remaining raw arguments to become `sys.argv[1:]`.
+/// `-c`, `-m`, and a script path each terminate option parsing, so anything
+/// after them belongs to the program rather than the launcher.
+fn drain_args(parser: &mut lexopt::Parser) -> Result<Vec<String>, lexopt::Error> {
+    let mut rest = Vec::new();
+    for raw in parser.raw_args()? {
+        rest.push(raw.string()?);
+    }
+    Ok(rest)
+}
+
+fn parse_args(binary_name: &str) -> Result<(RunMode, bool, bool, Vec<String>), lexopt::Error> {
     let mut parser = lexopt::Parser::from_env();
     let mut inspect = false;
     let mut quiet = false;
@@ -50,7 +63,13 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, bool, bool), lexopt::Error>
         match arg {
             Short('c') => {
                 let cmd = parser.value()?.string()?;
-                return Ok((RunMode::Command(cmd), inspect, quiet));
+                let rest = drain_args(&mut parser)?;
+                return Ok((RunMode::Command(cmd), inspect, quiet, rest));
+            }
+            Short('m') => {
+                let module = parser.value()?.string()?;
+                let rest = drain_args(&mut parser)?;
+                return Ok((RunMode::Module(module), inspect, quiet, rest));
             }
             Short('h') | Long("help") => {
                 print!("{}", usage(binary_name));
@@ -65,17 +84,16 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, bool, bool), lexopt::Error>
             }
             Value(script) => {
                 let script = script.string()?;
-                let mode = if script == "-" {
-                    RunMode::Repl
-                } else {
-                    RunMode::Script(script)
-                };
-                return Ok((mode, inspect, quiet));
+                if script == "-" {
+                    return Ok((RunMode::Repl, inspect, quiet, vec![]));
+                }
+                let rest = drain_args(&mut parser)?;
+                return Ok((RunMode::Script(script), inspect, quiet, rest));
             }
             _ => return Err(arg.unexpected()),
         }
     }
-    Ok((RunMode::Repl, inspect, quiet))
+    Ok((RunMode::Repl, inspect, quiet, vec![]))
 }
 
 pub fn main_entry(binary_name: &'static str) {
@@ -122,7 +140,7 @@ fn real_main(binary_name: &str) {
             default_hook(info);
         }
     }));
-    let (mode, inspect, quiet) = match parse_args(binary_name) {
+    let (mode, inspect, quiet, args) = match parse_args(binary_name) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{binary_name}: {e}");
@@ -148,8 +166,23 @@ fn real_main(binary_name: &str) {
             // Initialize sys.path with CWD for -c mode.
             let cwd = std::env::current_dir().unwrap_or_else(|_| Path::new(".").to_path_buf());
             importing::init_sys_path(&cwd);
-            importing::set_sys_argv(&["-c".to_string()]);
+            let mut argv = vec!["-c".to_string()];
+            argv.extend(args);
+            importing::set_sys_argv(&argv);
             run_source(&cmd, Mode::Exec, "<string>");
+            if inspect {
+                repl::run_repl(true);
+            }
+        }
+        RunMode::Module(module) => {
+            // `-m`: sys.path[0] is the cwd (runpy resets argv[0] to the
+            // module's resolved origin via `_run_module_as_main`).
+            let cwd = std::env::current_dir().unwrap_or_else(|_| Path::new(".").to_path_buf());
+            importing::init_sys_path(&cwd);
+            let mut argv = vec![module.clone()];
+            argv.extend(args);
+            importing::set_sys_argv(&argv);
+            run_module(&module);
             if inspect {
                 repl::run_repl(true);
             }
@@ -169,9 +202,9 @@ fn real_main(binary_name: &str) {
                 .canonicalize()
                 .unwrap_or_else(|_| Path::new(".").to_path_buf());
             importing::init_sys_path(&script_dir);
-            // Collect remaining CLI args for sys.argv.
-            let argv = vec![path.clone()];
-            // lexopt consumed script name; remaining values go to sys.argv[1:]
+            // sys.argv[0] is the script path; remaining values go to argv[1:].
+            let mut argv = vec![path.clone()];
+            argv.extend(args);
             importing::set_sys_argv(&argv);
             run_source(&source, Mode::Exec, &path);
             if inspect {
@@ -208,6 +241,80 @@ fn maybe_print_jit_stats() {
     );
 }
 
+/// Shared top-level launcher bootstrap for `run_source` and `run_module`:
+/// register `__build_class__`, create the process `ExecutionContext`, seed
+/// the build-class and `LAST_EXEC_CTX` TLS slots so
+/// `space.getexecutioncontext()` (sys.settrace/getframe) resolves from the
+/// first user statement, and install SIGINT handling (app_main.py:926).
+fn setup_exec_context() -> Rc<PyExecutionContext> {
+    // Register __build_class__ callback (PyPy: setup_builtin_modules)
+    register_build_class();
+    let execution_context = Rc::new(PyExecutionContext::default());
+    set_build_class_exec_ctx(Rc::as_ptr(&execution_context));
+    set_last_exec_ctx(Rc::as_ptr(&execution_context));
+    unsafe {
+        let ec_ptr = Rc::as_ptr(&execution_context) as *mut PyExecutionContext;
+        pyre_interpreter::module::_signal::interp_signal::install_signal_handling(&mut *ec_ptr);
+    }
+    execution_context
+}
+
+/// Run a library module as `__main__` via `runpy._run_module_as_main`,
+/// the `-m` entry point. `vm.run_module` analog.
+fn run_module(module: &str) {
+    let execution_context = setup_exec_context();
+    let ec_ptr = Rc::as_ptr(&execution_context);
+
+    // `_run_module_as_main` reads `sys.modules["__main__"].__dict__` and runs
+    // the module's code in it, so a `__main__` module backed by a fresh dict
+    // must exist before runpy is imported. Reuse the canonical W_DictObject
+    // paired with the storage so `__main__.__dict__` and `globals()` share one
+    // identity (module.py:77 Module.getdict()).
+    let mut namespace = Box::new(execution_context.fresh_dict_storage());
+    namespace.fix_ptr();
+    pyre_interpreter::dict_storage_store(
+        &mut namespace,
+        "__name__",
+        pyre_object::w_str_new("__main__"),
+    );
+    let namespace = Box::into_raw(namespace);
+    let canonical = pyre_interpreter::baseobjspace::dict_storage_to_dict(namespace);
+    let main_module = pyre_object::moduleobject::w_module_new_aliasing_dict(
+        "__main__",
+        namespace as *mut u8,
+        canonical,
+    );
+    importing::set_sys_module("__main__", main_module);
+
+    let result = (|| -> Result<(), pyre_interpreter::PyError> {
+        let runpy = importing::importhook("runpy", canonical, pyre_object::PY_NULL, 0, ec_ptr)?;
+        let func = pyre_interpreter::getattr(runpy, pyre_object::w_str_new("_run_module_as_main"))?;
+        let res = pyre_interpreter::call_function(func, &[pyre_object::w_str_new(module)]);
+        if res.is_null() {
+            return Err(
+                pyre_interpreter::call::take_call_error().unwrap_or_else(|| {
+                    pyre_interpreter::PyError::new(
+                        pyre_interpreter::PyErrorKind::RuntimeError,
+                        "runpy._run_module_as_main returned NULL without an exception",
+                    )
+                }),
+            );
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        if e.kind == PyErrorKind::SystemExit {
+            maybe_print_jit_stats();
+            std::process::exit(system_exit_code(&e));
+        }
+        maybe_print_jit_stats();
+        pyre_interpreter::eprint_exception(&e, true);
+        std::process::exit(1);
+    }
+    maybe_print_jit_stats();
+}
+
 fn run_source(source: &str, mode: Mode, filename: &str) {
     let code = match compile_source_with_filename(source, mode, filename) {
         Ok(code) => code,
@@ -217,26 +324,7 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
         }
     };
 
-    // Register __build_class__ callback (PyPy: setup_builtin_modules)
-    register_build_class();
-
-    let execution_context = Rc::new(PyExecutionContext::default());
-    // Set execution context for __build_class__ to use
-    set_build_class_exec_ctx(Rc::as_ptr(&execution_context));
-    // Eagerly seed the LAST_EXEC_CTX TLS slot so that
-    // `space.getexecutioncontext()` (sys.settrace/setprofile/getframe)
-    // returns the live ExecutionContext from the very first user
-    // statement, not only after the first `eval_frame_plain` entry
-    // updates the slot.  Mirrors PyPy's `space.threadlocals` always
-    // holding the active EC for the current thread.
-    set_last_exec_ctx(Rc::as_ptr(&execution_context));
-    // app_main.py:926 — install SIGINT → default_int_handler so Ctrl-C
-    // raises KeyboardInterrupt, and register the periodic signal-check
-    // action on the execution context.
-    unsafe {
-        let ec_ptr = Rc::as_ptr(&execution_context) as *mut PyExecutionContext;
-        pyre_interpreter::module::_signal::interp_signal::install_signal_handling(&mut *ec_ptr);
-    }
+    let execution_context = setup_exec_context();
     let mut frame = match PyFrame::new_with_context(code, execution_context) {
         Ok(frame) => frame,
         Err(e) => {


### PR DESCRIPTION
#188

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Infrastructure to run the CPython 3.14 regression suite (vendored at `lib-python/3/test/`) against pyre, plus the interpreter fixes that the infra surfaced as blockers for importing the suite. Closes #188.

### Test infrastructure (PyPy-style: per-module subprocess, pristine vendored tests, external baseline)

- `pyre/cpython_tests/run.py` — per-module subprocess runner (script/module/regrtest modes; `PASS`/`FAIL`/`IMPORTERROR`/`CRASH`/`TIMEOUT`/`SKIP` classification; `--full`/`--update-baseline`/`--strict-baseline`/`--report`/`--backend`/`--no-jit`).
- `pyre/cpython_tests/baseline.json` — external expected-status baseline that gates regressions (a recorded `PASS` going non-`PASS` fails CI; a newly-passing module is reported, not gated). Currently **32 `PASS` / 381 `IMPORTERROR` / 20 `SKIP` / 1 `CRASH`** (434 modules, stdlib 3.14.6).
- `pyre/cpython_tests/README.md` — design, usage, and the remaining-gap backlog.
- CI: a gating `cpython-tests` job (dynasm, JIT on, `MAJIT_STRICT=1`) in `pyre-ci.yml`, and a non-gating nightly `--full` workflow across dynasm JIT-on, dynasm JIT-off, and cranelift.

### Interpreter fixes (surfaced while bringing modules to the point they import)

- **`pyrex`**: `-m module` run mode via `runpy._run_module_as_main`, with proper residual-argv draining for `-c`/`-m`/script.
- **`eval`/`runtime_ops`**: `STORE_SLICE` (`obj[i:j] = v`), dispatched through a real slice object.
- **`importing`**: bind a submodule as an attribute on its parent package in `absolute_import`, swallowing only `AttributeError` (with an `ImportWarning`) and propagating other exceptions, per `_bootstrap.py:1346-1352`.
- **`_ast`**: build the AST node hierarchy as heap types (`__module__ == "ast"`) so `ast.py` can subclass/monkeypatch them — unblocks `import ast` and a broad class of dependents (`collections`, `json`, `enum`, …).
- **`pyframe`/`eval` — the gateway fix.** A module-scope inlined comprehension (PEP 709) makes its iteration variable a `CO_FAST_HIDDEN` fast local whose binding actually lives in `w_locals` via `STORE_NAME` (the fast slot stays NULL). Two parity corrections: `STORE_NAME` now writes `w_locals` directly (PyPy `pyopcode.py:855`) instead of via `getdictscope()`→`fast2locals()`, and `fast2locals`/`locals2fast` skip `CO_FAST_HIDDEN` slots (CPython `frameobject.c`; PyPy has no PEP 709). Previously a second top-level binding after a comprehension erased the first — `y=[op for op in range(2)]; op=5; i=6; print(op)` raised `NameError`. This unblocks `import dis` → `inspect` → `unittest`, i.e. the whole suite gateway.

### Validation

- `check.py` **80/80 on both backends** (dynasm, cranelift) with the in-tree stdlib; `pyre-interpreter` cargo tests **362/0**.
- The PEP 709 repro is byte-identical to CPython 3.14; new regression bench `pyre/bench/synth/comprehension_module_scope.py`.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-m/--module` command-line flag to run Python modules directly.
  * Added support for PEP 709 comprehension scope optimizations.

* **Bug Fixes**
  * Fixed slice assignment operations.
  * Improved module import handling for dotted imports.
  * Enhanced AST module type hierarchy.
  * Fixed module-scope variable handling.

* **Tests**
  * Added CPython regression test suite integration.
  * Added nightly continuous compatibility testing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
