### PR TITLE
Z2.5 rtyper cutover: retire legacy-walker fallback (#266) + #164 review fixes + census 674→662

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -634,9 +634,12 @@ impl Bookkeeper {
     /// Spelling MUST match the annotation path
     /// (`flowspace_adapter::translate_op` `SyntheticTransparentCtor` arm)
     /// exactly or the pre-mint is a phantom that never matches the
-    /// lazily-minted class: base = `intern_class_by_qualname(leaf)` (bare
-    /// enum leaf), variant = `intern_class_by_qualname_with_bases(
-    /// "{dotted_owner}.{variant}", [base])`.  `enum_variant_by_discriminant`
+    /// lazily-minted class: base = `intern_class_by_qualname(
+    /// canonical_struct_name(root))` (the same spelling
+    /// `getuniqueclassdef_for_enum_variant` uses, so both resolve to one
+    /// base `HostObject` independent of `STRUCT_ORIGIN_REGISTRY`), variant
+    /// = `intern_class_by_qualname_with_bases("{dotted_owner}.{variant}",
+    /// [base])`.  `enum_variant_by_discriminant`
     /// dual-publishes each enum under both its `::`-qualified path and
     /// its bare leaf; iterate the qualified keys only (the dotted owner
     /// path derives from `key.replace("::", ".")`).  Scoped to unit-only
@@ -673,13 +676,21 @@ impl Bookkeeper {
         pairs.sort();
 
         for (root, variant_names) in pairs {
-            let leaf = root.rsplit("::").next().unwrap_or(&root);
-            let base = self.intern_class_by_qualname(leaf);
+            // Intern the base under `canonical_struct_name(root)`, mirroring
+            // `getuniqueclassdef_for_enum_variant` exactly.  Both interns
+            // canonicalize to `module::Leaf`, but a bare leaf only resolves
+            // to the same key when it is registered in
+            // `STRUCT_ORIGIN_REGISTRY` under `root`'s module; feeding the
+            // qualified root drops that dependency so the pre-mint and the
+            // discriminant-narrowing resolver always share one base lineage
+            // — and the variant subtree is numbered as one bracket.
+            let canon_root = majit_ir::descr::canonical_struct_name(&root);
+            let base = self.intern_class_by_qualname(&canon_root);
             // Ensure the base classdef exists before a variant references
             // it through `getmro`; idempotent with the struct-root loop.
             let _ = self.getuniqueclassdef(&base);
             for variant in variant_names {
-                let qualname = Self::enum_variant_class_qualname(&root, &variant);
+                let qualname = Self::enum_variant_class_qualname(&canon_root, &variant);
                 let variant_host =
                     self.intern_class_by_qualname_with_bases(&qualname, vec![base.clone()]);
                 let _ = self.getuniqueclassdef(&variant_host);

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -583,6 +583,82 @@ impl Bookkeeper {
             .unwrap_or_default()
     }
 
+    /// TODO: no upstream equivalent.  Pre-mint the variant subclasses of
+    /// every unit-only enum so the session-prologue
+    /// [`crate::translator::rtyper::normalizecalls::assign_inheritance_ids`]
+    /// pass numbers each `enum-base + variant-children` subtree as a
+    /// unit.  Called from `PyreCallRegistry::ensure_session` AFTER the
+    /// struct-root loop (so the enum-base classdefs already exist,
+    /// UNNUMBERED) and BEFORE the single `assign_inheritance_ids`.
+    ///
+    /// A variant ctor instantiation (`PyError::type_error` →
+    /// `PyErrorKind::TypeError`) mints its variant class LAZILY during
+    /// annotation, after the prologue numbering has already baked the
+    /// enum base's `[minid,maxid]` bracket.  An on-demand
+    /// `assign_inheritance_ids` re-run then cannot number the fresh
+    /// child (its bracket would have to nest inside the parent's baked
+    /// range — not append-safe), so `ClassesPBCRepr.redispatch_call`
+    /// Skip-classifies the instantiation.  Pre-minting the whole subtree
+    /// here leaves every member UNNUMBERED at the single numbering pass,
+    /// so the contiguous bracket is assigned once and never shifts.
+    ///
+    /// Spelling MUST match the annotation path
+    /// (`flowspace_adapter::translate_op` `SyntheticTransparentCtor` arm)
+    /// exactly or the pre-mint is a phantom that never matches the
+    /// lazily-minted class: base = `intern_class_by_qualname(leaf)` (bare
+    /// enum leaf), variant = `intern_class_by_qualname_with_bases(
+    /// "{dotted_owner}.{variant}", [base])`.  `enum_variant_by_discriminant`
+    /// dual-publishes each enum under both its `::`-qualified path and
+    /// its bare leaf; iterate the qualified keys only (the dotted owner
+    /// path derives from `key.replace("::", ".")`).  Scoped to unit-only
+    /// enums (the same `is_unit_only_enum` gate the ctor arm uses);
+    /// payload-bearing enums keep base-less variant classes until their
+    /// payload reprs land.
+    pub fn pre_register_unit_enum_variant_classes(self: &Rc<Self>) {
+        // Collect (qualified_root, [variant names]) for unit-only enums,
+        // releasing both registry borrows before minting (the intern /
+        // getuniqueclassdef calls re-borrow `pyre_struct_fields` and
+        // `pyre_struct_root_classes`).  Sorted for a deterministic mint
+        // order so the numbering bracket is reproducible.
+        let mut pairs: Vec<(String, Vec<String>)> = {
+            let variant_guard = self.pyre_enum_variant_by_discriminant.borrow();
+            let fields_guard = self.pyre_struct_fields.borrow();
+            let (Some(variants), Some(reg)) = (variant_guard.as_ref(), fields_guard.as_ref())
+            else {
+                return;
+            };
+            variants
+                .iter()
+                .filter(|(root, _)| root.contains("::"))
+                .filter_map(|(root, by_discr)| {
+                    let leaf = root.rsplit("::").next().unwrap_or(root);
+                    reg.is_unit_only_enum(leaf).then(|| {
+                        let mut names: Vec<String> = by_discr.values().cloned().collect();
+                        names.sort();
+                        names.dedup();
+                        (root.clone(), names)
+                    })
+                })
+                .collect()
+        };
+        pairs.sort();
+
+        for (root, variant_names) in pairs {
+            let leaf = root.rsplit("::").next().unwrap_or(&root);
+            let dotted_owner = root.replace("::", ".");
+            let base = self.intern_class_by_qualname(leaf);
+            // Ensure the base classdef exists before a variant references
+            // it through `getmro`; idempotent with the struct-root loop.
+            let _ = self.getuniqueclassdef(&base);
+            for variant in variant_names {
+                let qualname = format!("{dotted_owner}.{variant}");
+                let variant_host =
+                    self.intern_class_by_qualname_with_bases(&qualname, vec![base.clone()]);
+                let _ = self.getuniqueclassdef(&variant_host);
+            }
+        }
+    }
+
     /// Push a classdef into [`Self::needs_generic_instantiate`] unless
     /// it is already present (upstream `dict[cdef] = True` idempotence).
     pub fn push_needs_generic_instantiate(&self, classdef: &Rc<RefCell<ClassDef>>) {

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -583,6 +583,21 @@ impl Bookkeeper {
             .unwrap_or_default()
     }
 
+    /// Canonical dotted qualname for an enum variant subclass.  The
+    /// prologue pre-mint ([`Self::pre_register_unit_enum_variant_classes`])
+    /// and the discriminant-narrowing resolver
+    /// ([`Self::getuniqueclassdef_for_enum_variant`]) MUST intern each
+    /// variant under one spelling: a `::`-vs-`.` split mints two distinct
+    /// `ClassDef`s for the same logical variant, and the single
+    /// `assign_inheritance_ids` pass numbers only the pre-minted (dotted)
+    /// one — the other escapes numbering, so a narrowed
+    /// `SomeInstance(variant)` walls as `ClassesPBCRepr`-Void at dispatch.
+    /// Mirrors the `flowspace_adapter` `SyntheticTransparentCtor` arm
+    /// spelling (`{dotted_owner}.{variant}`).
+    fn enum_variant_class_qualname(canon_root: &str, variant_name: &str) -> String {
+        format!("{}.{variant_name}", canon_root.replace("::", "."))
+    }
+
     /// TODO: no upstream equivalent.  Pre-mint the variant subclasses of
     /// every unit-only enum so the session-prologue
     /// [`crate::translator::rtyper::normalizecalls::assign_inheritance_ids`]
@@ -645,13 +660,12 @@ impl Bookkeeper {
 
         for (root, variant_names) in pairs {
             let leaf = root.rsplit("::").next().unwrap_or(&root);
-            let dotted_owner = root.replace("::", ".");
             let base = self.intern_class_by_qualname(leaf);
             // Ensure the base classdef exists before a variant references
             // it through `getmro`; idempotent with the struct-root loop.
             let _ = self.getuniqueclassdef(&base);
             for variant in variant_names {
-                let qualname = format!("{dotted_owner}.{variant}");
+                let qualname = Self::enum_variant_class_qualname(&root, &variant);
                 let variant_host =
                     self.intern_class_by_qualname_with_bases(&qualname, vec![base.clone()]);
                 let _ = self.getuniqueclassdef(&variant_host);
@@ -1722,9 +1736,11 @@ impl Bookkeeper {
     /// `pairtype(SomeInstance, SomeInstance).improve` (binaryop.py:685)
     /// needs to narrow a `SomeInstance(base)` to `SomeInstance(variant)`.
     /// Identity is the canonical struct-root cache keyed by
-    /// `canonical_struct_name`; both `enum_root` and the `enum_root::variant`
-    /// path normalise to one stable `HostObject` apiece, so repeated
-    /// calls return the same `Rc`.
+    /// `canonical_struct_name`; the base `enum_root` and the dotted
+    /// `enum_root.variant` path ([`Self::enum_variant_class_qualname`])
+    /// each normalise to one stable `HostObject`, so repeated calls
+    /// return the same `Rc` — and the variant `Rc` is the very one the
+    /// prologue pre-mint numbered.
     pub fn getuniqueclassdef_for_enum_variant(
         self: &Rc<Self>,
         enum_root: &str,
@@ -3746,6 +3762,21 @@ mod tests {
             .getuniqueclassdef_for_enum_variant("Color", "Rgb")
             .expect("variant re-lookup");
         assert!(Rc::ptr_eq(&variant, &variant2), "variant identity stable");
+
+        // The narrowing resolver, the prologue pre-mint, and the ctor arm
+        // must all intern ONE variant classdef.  A `::`-spelled variant
+        // would mint a second, distinct classdef that the single
+        // `assign_inheritance_ids` pass never reaches; assert the resolver
+        // returns the dotted-spelled (pre-mint / ctor) classdef.
+        let premint_base = bk.intern_class_by_qualname("Color");
+        let premint_host = bk.intern_class_by_qualname_with_bases("Color.Rgb", vec![premint_base]);
+        let premint = bk
+            .getuniqueclassdef(&premint_host)
+            .expect("pre-mint variant classdef");
+        assert!(
+            Rc::ptr_eq(&variant, &premint),
+            "narrowing variant must be the dotted-spelled pre-mint/ctor classdef"
+        );
 
         // The payoff: improve() narrows SomeInstance(base) to
         // SomeInstance(variant) given the variant as the refinement —

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -598,13 +598,27 @@ impl Bookkeeper {
         format!("{}.{variant_name}", canon_root.replace("::", "."))
     }
 
-    /// TODO: no upstream equivalent.  Pre-mint the variant subclasses of
-    /// every unit-only enum so the session-prologue
+    /// No upstream equivalent — forced by pyre's numbering order, not a
+    /// casual workaround.  Upstream runs `assign_inheritance_ids` ONCE
+    /// inside `RPythonTyper.specialize`, AFTER `annotator.complete()`
+    /// reaches its fixpoint, when every instantiated class — variant
+    /// classes included — already exists; the single numbering pass sees
+    /// the complete set and needs no pre-mint.  pyre cannot follow that
+    /// order: it runs incremental per-subject `specialize_more_blocks`
+    /// (no single post-annotation driver), and `ClassRepr.fill_vtable_root`
+    /// bakes `minid`/`maxid` as eager `Signed` constants into the
+    /// cross-graph-cached vtable, so the ids must be stable in the session
+    /// prologue — before any per-subject annotation discovers a
+    /// lazily-minted variant class.  This pre-mint is the prologue-time
+    /// analogue of upstream's "all classes exist before numbering"
+    /// invariant, restricted to the unit-only enum-variant subtrees that
+    /// would otherwise be minted lazily mid-session: it pre-mints the
+    /// variant subclasses of every unit-only enum so the session-prologue
     /// [`crate::translator::rtyper::normalizecalls::assign_inheritance_ids`]
-    /// pass numbers each `enum-base + variant-children` subtree as a
-    /// unit.  Called from `PyreCallRegistry::ensure_session` AFTER the
-    /// struct-root loop (so the enum-base classdefs already exist,
-    /// UNNUMBERED) and BEFORE the single `assign_inheritance_ids`.
+    /// pass numbers each `enum-base + variant-children` subtree as one
+    /// contiguous bracket.  Called from `PyreCallRegistry::ensure_session`
+    /// AFTER the struct-root loop (so the enum-base classdefs already
+    /// exist, UNNUMBERED) and BEFORE the single `assign_inheritance_ids`.
     ///
     /// A variant ctor instantiation (`PyError::type_error` →
     /// `PyErrorKind::TypeError`) mints its variant class LAZILY during

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -583,21 +583,6 @@ impl Bookkeeper {
             .unwrap_or_default()
     }
 
-    /// Canonical dotted qualname for an enum variant subclass.  The
-    /// prologue pre-mint ([`Self::pre_register_unit_enum_variant_classes`])
-    /// and the discriminant-narrowing resolver
-    /// ([`Self::getuniqueclassdef_for_enum_variant`]) MUST intern each
-    /// variant under one spelling: a `::`-vs-`.` split mints two distinct
-    /// `ClassDef`s for the same logical variant, and the single
-    /// `assign_inheritance_ids` pass numbers only the pre-minted (dotted)
-    /// one — the other escapes numbering, so a narrowed
-    /// `SomeInstance(variant)` walls as `ClassesPBCRepr`-Void at dispatch.
-    /// Mirrors the `flowspace_adapter` `SyntheticTransparentCtor` arm
-    /// spelling (`{dotted_owner}.{variant}`).
-    fn enum_variant_class_qualname(canon_root: &str, variant_name: &str) -> String {
-        format!("{}.{variant_name}", canon_root.replace("::", "."))
-    }
-
     /// No upstream equivalent — forced by pyre's numbering order, not a
     /// casual workaround.  Upstream runs `assign_inheritance_ids` ONCE
     /// inside `RPythonTyper.specialize`, AFTER `annotator.complete()`
@@ -611,9 +596,9 @@ impl Bookkeeper {
     /// prologue — before any per-subject annotation discovers a
     /// lazily-minted variant class.  This pre-mint is the prologue-time
     /// analogue of upstream's "all classes exist before numbering"
-    /// invariant, restricted to the unit-only enum-variant subtrees that
-    /// would otherwise be minted lazily mid-session: it pre-mints the
-    /// variant subclasses of every unit-only enum so the session-prologue
+    /// invariant, restricted to the enum-variant subtrees that would
+    /// otherwise be minted lazily mid-session: it pre-mints the variant
+    /// subclasses of every registered enum so the session-prologue
     /// [`crate::translator::rtyper::normalizecalls::assign_inheritance_ids`]
     /// pass numbers each `enum-base + variant-children` subtree as one
     /// contiguous bracket.  Called from `PyreCallRegistry::ensure_session`
@@ -631,23 +616,25 @@ impl Bookkeeper {
     /// here leaves every member UNNUMBERED at the single numbering pass,
     /// so the contiguous bracket is assigned once and never shifts.
     ///
-    /// Spelling MUST match the annotation path
-    /// (`flowspace_adapter::translate_op` `SyntheticTransparentCtor` arm)
-    /// exactly or the pre-mint is a phantom that never matches the
-    /// lazily-minted class: base = `intern_class_by_qualname(
-    /// canonical_struct_name(root))` (the same spelling
-    /// `getuniqueclassdef_for_enum_variant` uses, so both resolve to one
-    /// base `HostObject` independent of `STRUCT_ORIGIN_REGISTRY`), variant
-    /// = `intern_class_by_qualname_with_bases("{dotted_owner}.{variant}",
-    /// [base])`.  `enum_variant_by_discriminant`
-    /// dual-publishes each enum under both its `::`-qualified path and
-    /// its bare leaf; iterate the qualified keys only (the dotted owner
-    /// path derives from `key.replace("::", ".")`).  Scoped to unit-only
-    /// enums (the same `is_unit_only_enum` gate the ctor arm uses);
-    /// payload-bearing enums keep base-less variant classes until their
-    /// payload reprs land.
-    pub fn pre_register_unit_enum_variant_classes(self: &Rc<Self>) {
-        // Collect (qualified_root, [variant names]) for unit-only enums,
+    /// Spelling MUST match the annotation path or the pre-mint is a
+    /// phantom that never matches the lazily-minted class, so each variant
+    /// is interned through the SAME [`Self::intern_enum_variant_host`]
+    /// primitive the discriminant-narrowing resolver
+    /// ([`Self::getuniqueclassdef_for_enum_variant`]) and the variant ctor
+    /// arm (`flowspace_adapter`'s `SyntheticTransparentCtor`) route through:
+    /// base = `intern_class_by_qualname(canonical_struct_name(root))`,
+    /// variant = `intern_class_by_qualname_with_bases(
+    /// "{canon_root}::{variant}", [base])`.  All three sites thus resolve
+    /// one `HostObject` per variant under the `::`-qualified key.
+    /// `enum_variant_by_discriminant` dual-publishes each enum under both
+    /// its `::`-qualified path and its bare leaf; iterate the qualified
+    /// keys only.  Gated on the same `is_enum_base` predicate the ctor arm
+    /// uses (a flat class whose sole row is the synthetic `__discriminant`
+    /// tag), so the pre-mint covers exactly the variant subclasses the
+    /// adapter can mint — payload-bearing enums included, since their
+    /// payloads live under `{enum}::{variant}` keys, not on the base.
+    pub fn pre_register_enum_variant_classes(self: &Rc<Self>) {
+        // Collect (qualified_root, [variant names]) for every enum base,
         // releasing both registry borrows before minting (the intern /
         // getuniqueclassdef calls re-borrow `pyre_struct_fields` and
         // `pyre_struct_root_classes`).  Sorted for a deterministic mint
@@ -664,7 +651,7 @@ impl Bookkeeper {
                 .filter(|(root, _)| root.contains("::"))
                 .filter_map(|(root, by_discr)| {
                     let leaf = root.rsplit("::").next().unwrap_or(root);
-                    reg.is_unit_only_enum(leaf).then(|| {
+                    reg.is_enum_base(leaf).then(|| {
                         let mut names: Vec<String> = by_discr.values().cloned().collect();
                         names.sort();
                         names.dedup();
@@ -676,23 +663,25 @@ impl Bookkeeper {
         pairs.sort();
 
         for (root, variant_names) in pairs {
-            // Intern the base under `canonical_struct_name(root)`, mirroring
-            // `getuniqueclassdef_for_enum_variant` exactly.  Both interns
-            // canonicalize to `module::Leaf`, but a bare leaf only resolves
-            // to the same key when it is registered in
-            // `STRUCT_ORIGIN_REGISTRY` under `root`'s module; feeding the
-            // qualified root drops that dependency so the pre-mint and the
-            // discriminant-narrowing resolver always share one base lineage
-            // — and the variant subtree is numbered as one bracket.
+            // Materialize the discriminant-only base classdef before a
+            // variant references it through `getmro`; idempotent with the
+            // struct-root loop.  `canonical_struct_name(root)` is the same
+            // spelling `intern_enum_variant_host` resolves the base under,
+            // so the pre-mint and the discriminant-narrowing resolver share
+            // one base lineage and the variant subtree numbers as one
+            // bracket.
             let canon_root = majit_ir::descr::canonical_struct_name(&root);
             let base = self.intern_class_by_qualname(&canon_root);
-            // Ensure the base classdef exists before a variant references
-            // it through `getmro`; idempotent with the struct-root loop.
             let _ = self.getuniqueclassdef(&base);
             for variant in variant_names {
-                let qualname = Self::enum_variant_class_qualname(&canon_root, &variant);
-                let variant_host =
-                    self.intern_class_by_qualname_with_bases(&qualname, vec![base.clone()]);
+                // The SAME interning primitive the discriminant-narrowing
+                // resolver ([`Self::getuniqueclassdef_for_enum_variant`])
+                // and the variant ctor arm (`flowspace_adapter`) use, so
+                // all three sites resolve ONE variant classdef under the
+                // `::`-qualified key — no `.`-vs-`::` split that would mint
+                // a second, distinct sibling the single numbering pass never
+                // reaches.
+                let variant_host = self.intern_enum_variant_host(&root, &variant);
                 let _ = self.getuniqueclassdef(&variant_host);
             }
         }
@@ -1761,8 +1750,8 @@ impl Bookkeeper {
     /// `pairtype(SomeInstance, SomeInstance).improve` (binaryop.py:685)
     /// needs to narrow a `SomeInstance(base)` to `SomeInstance(variant)`.
     /// Identity is the canonical struct-root cache keyed by
-    /// `canonical_struct_name`; the base `enum_root` and the dotted
-    /// `enum_root.variant` path ([`Self::enum_variant_class_qualname`])
+    /// `canonical_struct_name`; the base `enum_root` and the
+    /// `canon_root::variant` path ([`Self::intern_enum_variant_host`])
     /// each normalise to one stable `HostObject`, so repeated calls
     /// return the same `Rc` — and the variant `Rc` is the very one the
     /// prologue pre-mint numbered.
@@ -3789,18 +3778,19 @@ mod tests {
         assert!(Rc::ptr_eq(&variant, &variant2), "variant identity stable");
 
         // The narrowing resolver, the prologue pre-mint, and the ctor arm
-        // must all intern ONE variant classdef.  A `::`-spelled variant
-        // would mint a second, distinct classdef that the single
+        // must all intern ONE variant classdef.  A `.`-vs-`::` split would
+        // mint a second, distinct classdef that the single
         // `assign_inheritance_ids` pass never reaches; assert the resolver
-        // returns the dotted-spelled (pre-mint / ctor) classdef.
-        let premint_base = bk.intern_class_by_qualname("Color");
-        let premint_host = bk.intern_class_by_qualname_with_bases("Color.Rgb", vec![premint_base]);
+        // returns the classdef the pre-mint / ctor obtain through the
+        // shared `intern_enum_variant_host` primitive (the `::`-qualified
+        // key).
+        let premint_host = bk.intern_enum_variant_host("Color", "Rgb");
         let premint = bk
             .getuniqueclassdef(&premint_host)
             .expect("pre-mint variant classdef");
         assert!(
             Rc::ptr_eq(&variant, &premint),
-            "narrowing variant must be the dotted-spelled pre-mint/ctor classdef"
+            "narrowing variant must be the pre-mint/ctor classdef from intern_enum_variant_host"
         );
 
         // The payoff: improve() narrows SomeInstance(base) to

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8835,6 +8835,80 @@ fn extract_fmt_chain(
     Some(FmtChain { pieces, args })
 }
 
+/// Emit a `__str_const` constant of `text` into `bb_id` and return its
+/// Variable — the same synthetic `Call(["__str_const", text])` shape the
+/// constant lowering uses (see [`Lowering::emit_constant`]); the flowspace
+/// adapter pre-folds it to the upstream string `Constant` and types it as
+/// a String.
+#[allow(dead_code)]
+fn emit_str_const(graph: &mut FunctionGraph, bb_id: BlockId, text: &str) -> Variable {
+    use crate::model::{CallTarget, OpKind, ValueType};
+    let var = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+    graph.block_mut(bb_id).operations.push(SpaceOperation {
+        result: Some(var.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__str_const".to_string(), text.to_string()],
+            },
+            args: vec![],
+            result_ty: ValueType::Ref(None),
+        },
+    });
+    var
+}
+
+/// Emit a string concatenation `lhs + rhs` into `bb_id` and return its
+/// Variable. The `"add"` opname passes through the flowspace adapter
+/// unchanged; when both operands type as String the rtyper routes it to
+/// `pair(StringRepr, StringRepr).rtype_add` → `direct_call(ll_strconcat)`.
+#[allow(dead_code)]
+fn emit_str_add(
+    graph: &mut FunctionGraph,
+    bb_id: BlockId,
+    lhs: &Variable,
+    rhs: &Variable,
+) -> Variable {
+    use crate::model::{OpKind, ValueType};
+    let var = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+    graph.block_mut(bb_id).operations.push(SpaceOperation {
+        result: Some(var.clone()),
+        kind: OpKind::BinOp {
+            op: "add".to_string(),
+            lhs: lhs.clone(),
+            rhs: rhs.clone(),
+            result_ty: ValueType::Ref(None),
+        },
+    });
+    var
+}
+
+/// Emit the StringRepr-add left fold that materializes a recognized
+/// `format_args!` chain as a runtime String:
+///
+/// ```text
+/// acc = strconst(pieces[0])
+/// for each arg i:
+///     acc = acc + args[i].value          // render(&str) == identity
+///     acc = acc + strconst(pieces[i+1])
+/// ```
+///
+/// Returns the final String Variable. Each literal piece becomes a
+/// `__str_const` call and each concatenation a `BinOp("add")` the rtyper
+/// lowers through `ll_strconcat`. The caller must have verified every
+/// argument renders by identity (a `&str` `Display`); `Debug` rendering
+/// and non-`&str` `Display` are outside the recognized subset and are
+/// rejected before emission.
+#[allow(dead_code)]
+fn emit_fmt_concat(graph: &mut FunctionGraph, bb_id: BlockId, chain: &FmtChain) -> Variable {
+    let mut acc = emit_str_const(graph, bb_id, &chain.pieces[0]);
+    for (i, arg) in chain.args.iter().enumerate() {
+        acc = emit_str_add(graph, bb_id, &acc, &arg.value);
+        let next_piece = emit_str_const(graph, bb_id, &chain.pieces[i + 1]);
+        acc = emit_str_add(graph, bb_id, &acc, &next_piece);
+    }
+    acc
+}
+
 #[cfg(test)]
 mod tests {
     use super::harden_duplicate_leaf_metadata;
@@ -9207,6 +9281,68 @@ mod tests {
 
         // A non-`Arguments::new` producer is not recognized.
         assert!(extract_fmt_chain(&graph, &pieces_arr).is_none());
+    }
+
+    #[test]
+    fn emit_fmt_concat_builds_interleaved_str_add_fold() {
+        use super::{emit_fmt_concat, FmtArg, FmtArgKind, FmtChain};
+        use crate::flowspace::model::Variable;
+        use crate::model::{CallTarget, FunctionGraph, OpKind};
+
+        // `format!("a{}b{}c", x, y)` → pieces ["a","b","c"], two args.
+        let mut graph = FunctionGraph::new("concat");
+        let bb = graph.create_block();
+        let x = Variable::new();
+        let y = Variable::new();
+        let chain = FmtChain {
+            pieces: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            args: vec![
+                FmtArg {
+                    value: x.clone(),
+                    kind: FmtArgKind::Display,
+                },
+                FmtArg {
+                    value: y.clone(),
+                    kind: FmtArgKind::Display,
+                },
+            ],
+        };
+        let result = emit_fmt_concat(&mut graph, bb, &chain);
+
+        let ops = &graph.blocks.iter().find(|b| b.id == bb).unwrap().operations;
+        // 3 literal `__str_const`s + 4 `add`s = 7 ops.
+        assert_eq!(ops.len(), 7);
+
+        let str_const_text = |i: usize| -> String {
+            match &ops[i].kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.first().map(String::as_str) == Some("__str_const") => {
+                    segments[1].clone()
+                }
+                other => panic!("op[{i}] not a __str_const: {other:?}"),
+            }
+        };
+        let add_operands = |i: usize| -> (u64, u64) {
+            match &ops[i].kind {
+                OpKind::BinOp {
+                    op, lhs, rhs, ..
+                } if op == "add" => (lhs.id(), rhs.id()),
+                other => panic!("op[{i}] not an add: {other:?}"),
+            }
+        };
+        let result_id = |i: usize| ops[i].result.as_ref().unwrap().id();
+
+        assert_eq!(str_const_text(0), "a");
+        assert_eq!(str_const_text(2), "b");
+        assert_eq!(str_const_text(5), "c");
+        // Fold chain: ("a" + x) + "b", then (+ y) + "c".
+        assert_eq!(add_operands(1), (result_id(0), x.id()));
+        assert_eq!(add_operands(3), (result_id(1), result_id(2)));
+        assert_eq!(add_operands(4), (result_id(3), y.id()));
+        assert_eq!(add_operands(6), (result_id(4), result_id(5)));
+        assert_eq!(result.id(), result_id(6));
     }
 
     /// Anchor [`extract_fmt_chain`] to the real lowered IR of

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8658,6 +8658,183 @@ fn resolve_const_int(
     }
 }
 
+/// Whether a `Display` (`{}`) or `Debug` (`{:?}`) placeholder rendered an
+/// argument. Carried by the `fmt::rt::Argument::new_display` /
+/// `new_debug` constructor in the parallel args array (the packed pieces
+/// template does not encode the choice).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+enum FmtArgKind {
+    Display,
+    Debug,
+}
+
+/// One placeholder argument recovered from a `format_args!` chain: the
+/// value Variable the placeholder renders and its Display/Debug flavour.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct FmtArg {
+    value: crate::flowspace::model::Variable,
+    kind: FmtArgKind,
+}
+
+/// The decoded contents of a `format_args!` chain — the literal string
+/// pieces interleaved with the rendered placeholder arguments
+/// (`pieces.len() == args.len() + 1`).
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct FmtChain {
+    pieces: Vec<String>,
+    args: Vec<FmtArg>,
+}
+
+/// Match a `FunctionPath`'s trailing segments against `tail`, so a
+/// crate-qualified spelling (`core::fmt::Arguments::new`) and the
+/// crate-stripped front-end spelling (`fmt::Arguments::new`) both
+/// resolve.
+#[allow(dead_code)]
+fn fmt_path_ends_with(segments: &[String], tail: &[&str]) -> bool {
+    segments.len() >= tail.len()
+        && segments[segments.len() - tail.len()..]
+            .iter()
+            .zip(tail)
+            .all(|(s, t)| s.as_str() == *t)
+}
+
+/// The `fmt::Arguments::new(pieces, args)` constructor that `format_args!`
+/// builds from the on-stack pieces+args arrays.
+#[allow(dead_code)]
+fn is_arguments_new_path(segments: &[String]) -> bool {
+    fmt_path_ends_with(segments, &["Arguments", "new"])
+}
+
+/// Classify a `fmt::rt::Argument::new_display` / `new_debug` constructor
+/// path. Any other path (positional/named/width-bearing argument ctor) is
+/// not in the recognized subset.
+#[allow(dead_code)]
+fn fmt_argument_ctor_kind(segments: &[String]) -> Option<FmtArgKind> {
+    if fmt_path_ends_with(segments, &["Argument", "new_display"]) {
+        Some(FmtArgKind::Display)
+    } else if fmt_path_ends_with(segments, &["Argument", "new_debug"]) {
+        Some(FmtArgKind::Debug)
+    } else {
+        None
+    }
+}
+
+/// Unwrap the `format_args!` argument tuple-ref. Each Display/Debug
+/// argument reaches `Argument::new_display(&v)` as a `FieldRead` off the
+/// on-stack argument `Tuple` aggregate (`&(v,).0`); follow it back to the
+/// value written into that tuple field. Returns `var` unchanged when it
+/// is not produced by a `FieldRead` (value passed directly), and `None`
+/// when the tuple field has conflicting writers.
+#[allow(dead_code)]
+fn unwrap_fmt_arg_tuple_ref(
+    graph: &FunctionGraph,
+    var: &crate::flowspace::model::Variable,
+) -> Option<crate::flowspace::model::Variable> {
+    use crate::model::OpKind;
+    let (block_id, idx) = resolve_to_producer_op(graph, var)?;
+    let block = graph.blocks.iter().find(|b| b.id == block_id)?;
+    let (base, field_name) = match &block.operations.get(idx)?.kind {
+        OpKind::FieldRead { base, field, .. } => (base.clone(), field.name.clone()),
+        _ => return Some(var.clone()),
+    };
+    let mut found: Option<crate::flowspace::model::Variable> = None;
+    for b in &graph.blocks {
+        for op in &b.operations {
+            if let OpKind::FieldWrite {
+                base: write_base,
+                field,
+                value,
+                ..
+            } = &op.kind
+            {
+                if write_base.id() == base.id() && field.name == field_name {
+                    if found.as_ref().is_some_and(|f| f.id() != value.id()) {
+                        return None; // ambiguous: distinct values written
+                    }
+                    found = Some(value.clone());
+                }
+            }
+        }
+    }
+    found
+}
+
+/// Recover one placeholder argument from an args-array element: the
+/// element is the result of a `fmt::rt::Argument::new_display` /
+/// `new_debug` constructor, whose sole argument back-traces (through the
+/// tuple-ref wrap) to the rendered value.
+#[allow(dead_code)]
+fn extract_fmt_arg(
+    graph: &FunctionGraph,
+    arg_elem: &crate::flowspace::model::Variable,
+) -> Option<FmtArg> {
+    use crate::model::{CallTarget, OpKind};
+    let (block_id, idx) = resolve_to_producer_op(graph, arg_elem)?;
+    let block = graph.blocks.iter().find(|b| b.id == block_id)?;
+    let (kind, inner) = match &block.operations.get(idx)?.kind {
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } => (fmt_argument_ctor_kind(segments)?, args.first()?.clone()),
+        _ => return None,
+    };
+    let value = unwrap_fmt_arg_tuple_ref(graph, &inner)?;
+    Some(FmtArg { value, kind })
+}
+
+/// Back-trace a recognized `format_args!` chain from the Variable passed
+/// to `alloc::fmt::format(args)` (the String producer) to the literal
+/// pieces and the Display/Debug argument values. Composes the staged
+/// primitives:
+///   fmt-args → [`resolve_to_producer_op`] → `fmt::Arguments::new(pieces, args)`
+///     · pieces: [`read_array_literal_elements`] → [`resolve_const_int`] per
+///       byte → [`decode_packed_format_pieces`]
+///     · args: [`read_array_literal_elements`] → per element
+///       [`extract_fmt_arg`]
+/// Returns `None` (the recognizer leaves the graph untouched) on any
+/// shape outside the recognized subset, so it never fires on an
+/// unsupported chain.
+#[allow(dead_code)]
+fn extract_fmt_chain(
+    graph: &FunctionGraph,
+    fmt_args_var: &crate::flowspace::model::Variable,
+) -> Option<FmtChain> {
+    use crate::model::{CallTarget, OpKind};
+    // The format(args) argument is the result of `Arguments::new(pieces, args)`.
+    let (block_id, idx) = resolve_to_producer_op(graph, fmt_args_var)?;
+    let block = graph.blocks.iter().find(|b| b.id == block_id)?;
+    let (pieces_var, args_var) = match &block.operations.get(idx)?.kind {
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } if is_arguments_new_path(segments) => (args.first()?.clone(), args.get(1)?.clone()),
+        _ => return None,
+    };
+    // Pieces: an `Array` of `ConstInt` bytes → decode the packed template.
+    let piece_byte_vars = read_array_literal_elements(graph, &pieces_var)?;
+    let mut bytes = Vec::with_capacity(piece_byte_vars.len());
+    for v in &piece_byte_vars {
+        bytes.push(u8::try_from(resolve_const_int(graph, v)?).ok()?);
+    }
+    let (pieces, placeholder_count) = decode_packed_format_pieces(&bytes)?;
+    // Args: an `Array` of `Argument::new_display|new_debug(&v)` ctors, one
+    // per placeholder.
+    let arg_elems = read_array_literal_elements(graph, &args_var)?;
+    if arg_elems.len() != placeholder_count {
+        return None;
+    }
+    let mut args = Vec::with_capacity(arg_elems.len());
+    for elem in &arg_elems {
+        args.push(extract_fmt_arg(graph, elem)?);
+    }
+    Some(FmtChain { pieces, args })
+}
+
 #[cfg(test)]
 mod tests {
     use super::harden_duplicate_leaf_metadata;
@@ -8878,6 +9055,201 @@ mod tests {
                 eprintln!("  exit -> {:?} args={:?}", link.target, link.args);
             }
         }
+    }
+
+    #[test]
+    fn extract_fmt_chain_recovers_pieces_and_args_cross_block() {
+        use super::{extract_fmt_chain, FmtArgKind};
+        use crate::flowspace::model::Variable;
+        use crate::model::{
+            CallTarget, FieldDescriptor, FunctionGraph, Link, OpKind, SpaceOperation, ValueType,
+        };
+
+        // Reconstruct the real `format!("hi{}", ctx)` front-end shape:
+        // block A builds the `Argument::new_display(&ctx)` through the
+        // argument Tuple (`&(ctx,).0`); block B builds the args + pieces
+        // arrays and `Arguments::new`. The args-array element is the
+        // new_display result threaded across the A→B link, so extraction
+        // must follow the cross-block inputarg back to it.
+        let mut graph = FunctionGraph::new("fmt_chain");
+        let a = graph.create_block();
+        let b = graph.create_block();
+
+        // ── block A: Argument::new_display(&ctx) via the arg Tuple ──
+        let ctx = Variable::new();
+        let tuple = Variable::new();
+        graph.block_mut(a).operations.push(SpaceOperation {
+            result: Some(tuple.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor {
+                    name: "Tuple".to_string(),
+                    owner_path: vec![],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(Some("Tuple".to_string())),
+            },
+        });
+        graph.block_mut(a).operations.push(SpaceOperation {
+            result: None,
+            kind: OpKind::FieldWrite {
+                base: tuple.clone(),
+                field: FieldDescriptor::new("__pos_0", Some("Tuple".to_string())),
+                value: ctx.clone(),
+                ty: ValueType::Ref(None),
+            },
+        });
+        let arg_ref = Variable::new();
+        graph.block_mut(a).operations.push(SpaceOperation {
+            result: Some(arg_ref.clone()),
+            kind: OpKind::FieldRead {
+                base: tuple,
+                field: FieldDescriptor::new("__pos_0", Some("Tuple".to_string())),
+                ty: ValueType::Ref(None),
+                pure: false,
+            },
+        });
+        let argument = Variable::new();
+        graph.block_mut(a).operations.push(SpaceOperation {
+            result: Some(argument.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec![
+                        "fmt".to_string(),
+                        "rt".to_string(),
+                        "Argument".to_string(),
+                        "new_display".to_string(),
+                    ],
+                },
+                args: vec![arg_ref],
+                result_ty: ValueType::Ref(Some("Argument".to_string())),
+            },
+        });
+
+        // block B takes the new_display result as its single inputarg.
+        let arg_in = Variable::new();
+        graph.block_mut(b).inputargs = vec![arg_in.clone()];
+        let link = Link::from_variables(&graph, vec![argument], b, None).with_prevblock(a);
+        graph.block_mut(a).exits = vec![link];
+
+        // ── block B: args array, pieces array, Arguments::new ──
+        let args_arr = Variable::new();
+        graph.block_mut(b).operations.push(SpaceOperation {
+            result: Some(args_arr.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor {
+                    name: "Array".to_string(),
+                    owner_path: vec![],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(Some("Array".to_string())),
+            },
+        });
+        graph.block_mut(b).operations.push(SpaceOperation {
+            result: None,
+            kind: OpKind::FieldWrite {
+                base: args_arr.clone(),
+                field: FieldDescriptor::new("__pos_0", Some("Array".to_string())),
+                value: arg_in,
+                ty: ValueType::Ref(None),
+            },
+        });
+        let pieces_arr = Variable::new();
+        graph.block_mut(b).operations.push(SpaceOperation {
+            result: Some(pieces_arr.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor {
+                    name: "Array".to_string(),
+                    owner_path: vec![],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(Some("Array".to_string())),
+            },
+        });
+        // `format!("hi{}")` packed template: [2, 'h', 'i', 0xC0, 0].
+        for (i, byte) in [2i64, 104, 105, 0xC0, 0].iter().enumerate() {
+            let v = Variable::new();
+            graph.block_mut(b).operations.push(SpaceOperation {
+                result: Some(v.clone()),
+                kind: OpKind::ConstInt(*byte),
+            });
+            graph.block_mut(b).operations.push(SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: pieces_arr.clone(),
+                    field: FieldDescriptor::new(format!("__pos_{i}"), Some("Array".to_string())),
+                    value: v,
+                    ty: ValueType::Int,
+                },
+            });
+        }
+        let fmt_args = Variable::new();
+        graph.block_mut(b).operations.push(SpaceOperation {
+            result: Some(fmt_args.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec![
+                        "fmt".to_string(),
+                        "Arguments".to_string(),
+                        "new".to_string(),
+                    ],
+                },
+                args: vec![pieces_arr.clone(), args_arr],
+                result_ty: ValueType::Ref(Some("Arguments".to_string())),
+            },
+        });
+
+        let chain = extract_fmt_chain(&graph, &fmt_args).expect("recognized fmt chain");
+        assert_eq!(chain.pieces, vec!["hi".to_string(), String::new()]);
+        assert_eq!(chain.args.len(), 1);
+        assert_eq!(chain.args[0].kind, FmtArgKind::Display);
+        // The recovered value is `ctx`, unwrapped through the arg Tuple.
+        assert_eq!(chain.args[0].value.id(), ctx.id());
+
+        // A non-`Arguments::new` producer is not recognized.
+        assert!(extract_fmt_chain(&graph, &pieces_arr).is_none());
+    }
+
+    /// Anchor [`extract_fmt_chain`] to the real lowered IR of
+    /// `stack_underflow_error` (= `type_error(format!("stack underflow
+    /// during {context}"))`). Ignored by default (loads the 242MB real
+    /// LLBC); run with `cargo test -p majit-translate --lib
+    /// extract_fmt_chain_matches_real -- --ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn extract_fmt_chain_matches_real_stack_underflow() {
+        use super::{extract_fmt_chain, FmtArgKind};
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "stack_underflow_error")
+            .expect("lower stack_underflow_error");
+
+        // Find the `alloc::fmt::format(args)` call and extract its arg.
+        let fmt_args = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .find_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                } if super::fmt_path_ends_with(segments, &["fmt", "format"]) => args.first().cloned(),
+                _ => None,
+            })
+            .expect("alloc::fmt::format call present");
+
+        let chain = extract_fmt_chain(&graph, &fmt_args).expect("recognized real fmt chain");
+        assert_eq!(
+            chain.pieces,
+            vec!["stack underflow during ".to_string(), String::new()]
+        );
+        assert_eq!(chain.args.len(), 1);
+        assert_eq!(chain.args[0].kind, FmtArgKind::Display);
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9133,7 +9133,7 @@ mod tests {
 
     #[test]
     fn extract_fmt_chain_recovers_pieces_and_args_cross_block() {
-        use super::{extract_fmt_chain, FmtArgKind};
+        use super::{FmtArgKind, extract_fmt_chain};
         use crate::flowspace::model::Variable;
         use crate::model::{
             CallTarget, FieldDescriptor, FunctionGraph, Link, OpKind, SpaceOperation, ValueType,
@@ -9285,7 +9285,7 @@ mod tests {
 
     #[test]
     fn emit_fmt_concat_builds_interleaved_str_add_fold() {
-        use super::{emit_fmt_concat, FmtArg, FmtArgKind, FmtChain};
+        use super::{FmtArg, FmtArgKind, FmtChain, emit_fmt_concat};
         use crate::flowspace::model::Variable;
         use crate::model::{CallTarget, FunctionGraph, OpKind};
 
@@ -9326,9 +9326,7 @@ mod tests {
         };
         let add_operands = |i: usize| -> (u64, u64) {
             match &ops[i].kind {
-                OpKind::BinOp {
-                    op, lhs, rhs, ..
-                } if op == "add" => (lhs.id(), rhs.id()),
+                OpKind::BinOp { op, lhs, rhs, .. } if op == "add" => (lhs.id(), rhs.id()),
                 other => panic!("op[{i}] not an add: {other:?}"),
             }
         };
@@ -9353,7 +9351,7 @@ mod tests {
     #[test]
     #[ignore]
     fn extract_fmt_chain_matches_real_stack_underflow() {
-        use super::{extract_fmt_chain, FmtArgKind};
+        use super::{FmtArgKind, extract_fmt_chain};
         use crate::model::{CallTarget, OpKind};
 
         let path = concat!(
@@ -9374,7 +9372,9 @@ mod tests {
                     target: CallTarget::FunctionPath { segments },
                     args,
                     ..
-                } if super::fmt_path_ends_with(segments, &["fmt", "format"]) => args.first().cloned(),
+                } if super::fmt_path_ends_with(segments, &["fmt", "format"]) => {
+                    args.first().cloned()
+                }
                 _ => None,
             })
             .expect("alloc::fmt::format call present");

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5380,17 +5380,48 @@ impl<'a> Lowering<'a> {
         ) {
             return Ok(false);
         }
-        // Destination must be a word-sized integer carrier.
-        let dest_word = matches!(self.tyref_literal_int_atom(dest_ty), Some("I64" | "Isize"))
-            || matches!(self.tyref_literal_uint_atom(dest_ty), Some("U64" | "Usize"));
-        if !dest_word {
+        // Destination must be a word-sized integer carrier.  A signed
+        // word destination needs the same annotation re-type the cast
+        // path applies (the `Rvalue::Cast` unsigned→signed arm): aliasing
+        // a `uN` source straight into an `iN` carrier preserves the source
+        // `r_uint` annotation and trips the SomeInteger signedness
+        // `UnionError` (binaryop.py:178-202) when the value later meets a
+        // signed operand.  Route signed destinations through
+        // `rarithmetic.intmask` (identity on the i64 carrier, re-types
+        // Signed); alias unsigned destinations directly, as upstream
+        // `widen` leaves no op.
+        let dest_signed_word =
+            matches!(self.tyref_literal_int_atom(dest_ty), Some("I64" | "Isize"));
+        let dest_unsigned_word =
+            matches!(self.tyref_literal_uint_atom(dest_ty), Some("U64" | "Usize"));
+        if !dest_signed_word && !dest_unsigned_word {
             return Ok(false);
         }
-        // Identity widen: bind the destination directly to the operand —
-        // no op materialized, exactly as upstream `widen` leaves none.
         let arg = arg.clone();
-        self.local_var[dest_local] = Some(arg);
         let bb_id = self.block_id[mir_bb];
+        if dest_signed_word {
+            let res = self
+                .graph
+                .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(res.clone()),
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: ["rpython", "rlib", "rarithmetic", "intmask"]
+                            .into_iter()
+                            .map(str::to_string)
+                            .collect(),
+                    },
+                    args: vec![arg],
+                    result_ty: ValueType::Int,
+                },
+            });
+            self.local_var[dest_local] = Some(res);
+        } else {
+            // Identity widen: bind the destination directly to the operand —
+            // no op materialized, exactly as upstream `widen` leaves none.
+            self.local_var[dest_local] = Some(arg);
+        }
         let target_bb = self.block_id[target];
         let link_args = self.edge_args(mir_bb, target)?;
         self.graph.set_goto(bb_id, target_bb, link_args);
@@ -8563,6 +8594,7 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
     let mut current = String::new();
     let mut placeholders = 0usize;
     let mut i = 0;
+    let mut terminated = false;
     while i < bytes.len() {
         let b = bytes[i];
         if b == 0x00 {
@@ -8570,6 +8602,7 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
             if i + 1 != bytes.len() {
                 return None;
             }
+            terminated = true;
             break;
         } else if b == 0xC0 {
             // plain sequential placeholder
@@ -8587,6 +8620,12 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
             // any other control byte = format spec / positional arg: bail
             return None;
         }
+    }
+    // The grammar requires the `0x00` terminator at a segment boundary;
+    // running out of bytes without it is a truncated or wrong array, not
+    // a valid template — bail rather than accept it once wired.
+    if !terminated {
+        return None;
     }
     pieces.push(current);
     Some((pieces, placeholders))
@@ -9038,6 +9077,11 @@ mod tests {
 
         // A 0 byte that is not the final byte bails (terminator is last).
         assert_eq!(decode_packed_format_pieces(&[0, 1, 65, 0]), None);
+
+        // A buffer that runs out without the 0x00 terminator is truncated
+        // or wrong — bail rather than accept a malformed template.
+        assert_eq!(decode_packed_format_pieces(&[2, 104, 105]), None);
+        assert_eq!(decode_packed_format_pieces(&[2, 104, 105, 192]), None);
 
         // Literal-only template (no placeholders) → single piece.
         let (pieces, n) = decode_packed_format_pieces(&[2, 104, 105, 0]).unwrap();

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4146,6 +4146,17 @@ impl<'a> Lowering<'a> {
                 )? {
                     return Ok(());
                 }
+                if self.try_lower_num_from(
+                    mir_bb,
+                    &reg.kind,
+                    &segments,
+                    &args,
+                    dest_local,
+                    &call.dest.ty,
+                    target,
+                )? {
+                    return Ok(());
+                }
                 let alias =
                     if let Some(payload) = self.expect_on_const_ok(&segments, &args, &arg_locals) {
                         // Identity unwrap: the receiver variable was bound
@@ -5310,6 +5321,72 @@ impl<'a> Lowering<'a> {
         // `ConstInt(0)` and `expect`/`unwrap` aliases the payload
         // (`expect_on_const_ok`) without touching the variable.
         self.const_discriminant_locals.insert(dest_local, 0);
+        self.local_var[dest_local] = Some(arg);
+        let bb_id = self.block_id[mir_bb];
+        let target_bb = self.block_id[target];
+        let link_args = self.edge_args(mir_bb, target)?;
+        self.graph.set_goto(bb_id, target_bb, link_args);
+        Ok(true)
+    }
+
+    /// Lower an infallible numeric widening `<i64 as From<u32>>::from(x)`
+    /// (`core::convert::num::<Impl>::from`, Opaque in the LLBC) to an
+    /// identity bind on the destination local.  `From` is implemented in
+    /// core only for value-preserving conversions, and a
+    /// smaller-than-word unsigned source widens into the word-sized
+    /// carrier with no change of value — the same no-op `rarithmetic.py
+    /// widen` performs — so no op is emitted, exactly as the always-`Ok`
+    /// `usize::try_from` payload binds directly
+    /// ([`Lowering::try_lower_usize_try_from`]).  `pyopcode.rs`
+    /// `u32_as_i64` is `i64::from(x: u32)`.  Word-or-wider sources keep
+    /// the `Call` form (no smaller-than-word identity to fold).
+    fn try_lower_num_from(
+        &mut self,
+        mir_bb: usize,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return Ok(false);
+        };
+        if first.as_str() != "core"
+            || module.as_str() != "num"
+            || impl_seg.as_str() != "<Impl>"
+            || leaf.as_str() != "from"
+        {
+            return Ok(false);
+        }
+        let [arg] = args else {
+            return Ok(false);
+        };
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return Ok(false);
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return Ok(false);
+        };
+        let Some(src) = fd.signature.inputs.first() else {
+            return Ok(false);
+        };
+        // Only smaller-than-word unsigned sources widen as a
+        // value-preserving identity in the word carrier (the same gate
+        // `try_lower_usize_try_from` uses).
+        if !matches!(self.tyref_literal_uint_atom(src), Some("U8" | "U16" | "U32")) {
+            return Ok(false);
+        }
+        // Destination must be a word-sized integer carrier.
+        let dest_word = matches!(self.tyref_literal_int_atom(dest_ty), Some("I64" | "Isize"))
+            || matches!(self.tyref_literal_uint_atom(dest_ty), Some("U64" | "Usize"));
+        if !dest_word {
+            return Ok(false);
+        }
+        // Identity widen: bind the destination directly to the operand —
+        // no op materialized, exactly as upstream `widen` leaves none.
+        let arg = arg.clone();
         self.local_var[dest_local] = Some(arg);
         let bb_id = self.block_id[mir_bb];
         let target_bb = self.block_id[target];

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2904,10 +2904,22 @@ impl<'a> Lowering<'a> {
                     }
                     None => (None, None),
                 };
-                let base = self.resolve_place(mir_bb, place)?;
                 let res = self
                     .graph
                     .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                // A local bound directly to its payload by a decomposed
+                // always-`Ok` conversion (`try_lower_usize_try_from`)
+                // carries no runtime enum object — no `__discriminant`
+                // field exists to read.  Its tag is the recorded
+                // constant, so fold to `ConstInt(tag)` (mirrors
+                // `expect_on_const_ok`, which aliases the payload).
+                if let PlaceKind::Local(i) = &place.kind
+                    && let Some(&tag) =
+                        self.const_discriminant_locals.get(&(*i as usize))
+                {
+                    return Ok((Some(OpKind::ConstInt(tag)), res));
+                }
+                let base = self.resolve_place(mir_bb, place)?;
                 Ok((
                     Some(OpKind::FieldRead {
                         base,
@@ -4114,6 +4126,7 @@ impl<'a> Lowering<'a> {
                 let (segments, method_hint) = self.call_target_segments(mir_bb, &reg)?;
                 if self.try_lower_checked_neg(
                     mir_bb,
+                    &reg.kind,
                     &segments,
                     &args,
                     dest_local,
@@ -5097,12 +5110,19 @@ impl<'a> Lowering<'a> {
     /// payload `__pos_0 = neg(v)` (wrapping; the `None` arm never
     /// reads it).  The downstream discriminant switch and payload
     /// downcast then lower through the ordinary enum FieldRead paths.
+    /// The `i64::MIN` sentinel is only correct at word width, so the
+    /// lowering is gated on a word-sized signed operand (`i64`/`isize`)
+    /// — a narrower `checked_neg` overflows at its own narrower `MIN`
+    /// and keeps the generic `Call` form (none arise today; the live
+    /// callers are `neg`'s `int_value` and `rangeobject`'s `step`,
+    /// both `i64`).
     /// Returns `Ok(false)` when the call is not `checked_neg` (or the
     /// destination's `Option` decl cannot be resolved) so the generic
     /// `Call` lowering proceeds.
     fn try_lower_checked_neg(
         &mut self,
         mir_bb: usize,
+        kind: &CallKind,
         segments: &[String],
         args: &[Variable],
         dest_local: usize,
@@ -5122,6 +5142,22 @@ impl<'a> Lowering<'a> {
         let [arg] = args else {
             return Ok(false);
         };
+        // The decomposition compares against `i64::MIN`; restrict it to
+        // word-sized signed operands so a narrower `checked_neg` (which
+        // overflows at its own `MIN`) is not miscompiled.  The operand
+        // is the receiver — `checked_neg(self)` — so read `inputs[0]`.
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return Ok(false);
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return Ok(false);
+        };
+        let Some(src) = fd.signature.inputs.first() else {
+            return Ok(false);
+        };
+        if !matches!(self.tyref_literal_int_atom(src), Some("I64" | "Isize")) {
+            return Ok(false);
+        }
         // Resolve the destination `Option` decl so the FieldWrite owner
         // matches what `resolve_aggregate_adt` would record for a real
         // `Some(..)` construction site of the same type.
@@ -5517,6 +5553,27 @@ impl<'a> Lowering<'a> {
                 }
             })?;
         Some(format!("{owner}::{}", v.name))
+    }
+
+    /// The `Int` width atom (`"I8"` / `"I32"` / `"Isize"` …) of a
+    /// signed-integer literal type, mirroring [`tyref_literal_uint_atom`]
+    /// for the `{"Literal": {"Int": "Isize"}}` shell.  `None` for any
+    /// non-signed-literal type.
+    fn tyref_literal_int_atom<'t>(&self, ty: &'t TyRef) -> Option<&'t str>
+    where
+        'a: 't,
+    {
+        let value = match ty {
+            TyRef::Inline { value: (_, v) } => v,
+            TyRef::Other(v) => v,
+            TyRef::Dedup { id } => self.llbc.dedup_body(*id)?,
+        };
+        value
+            .as_object()?
+            .get("Literal")?
+            .as_object()?
+            .get("Int")?
+            .as_str()
     }
 
     /// Shared tail for the decomposed checked-arithmetic /

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2914,8 +2914,7 @@ impl<'a> Lowering<'a> {
                 // constant, so fold to `ConstInt(tag)` (mirrors
                 // `expect_on_const_ok`, which aliases the payload).
                 if let PlaceKind::Local(i) = &place.kind
-                    && let Some(&tag) =
-                        self.const_discriminant_locals.get(&(*i as usize))
+                    && let Some(&tag) = self.const_discriminant_locals.get(&(*i as usize))
                 {
                     return Ok((Some(OpKind::ConstInt(tag)), res));
                 }
@@ -5375,7 +5374,10 @@ impl<'a> Lowering<'a> {
         // Only smaller-than-word unsigned sources widen as a
         // value-preserving identity in the word carrier (the same gate
         // `try_lower_usize_try_from` uses).
-        if !matches!(self.tyref_literal_uint_atom(src), Some("U8" | "U16" | "U32")) {
+        if !matches!(
+            self.tyref_literal_uint_atom(src),
+            Some("U8" | "U16" | "U32")
+        ) {
             return Ok(false);
         }
         // Destination must be a word-sized integer carrier.
@@ -8470,11 +8472,413 @@ fn scalar_value_to_i64(v: &serde_json::Value) -> Option<i64> {
     None
 }
 
+/// Resolve a `Variable` used as a call argument back to the operation
+/// that produced it, following block-input `Link`s across blocks.
+///
+/// The `fmt`-chain recognizer (#277) fires at `alloc::fmt::format(v)`
+/// where `v` is the `Arguments` value — but `v` reaches that block as an
+/// `inputarg` threaded from the predecessor's `Arguments::new` result via
+/// the outgoing `Link`, not as a direct op result in the current block.
+/// Existing `try_lower_*` folds only read a call's direct args; the fmt
+/// recognizer needs this cross-block back-trace.
+///
+/// Returns `(block, op_index)` of the producing `SpaceOperation`, or
+/// `None` when `var` traces to a `Const`, a function input (no producing
+/// op), a phi merge (a block with more than one incoming `Link`, so no
+/// single producer), or a producer not yet emitted into `graph`.
+//
+// Staged for the #277 recognizer; not yet wired into the call dispatch.
+#[allow(dead_code)]
+fn resolve_to_producer_op(
+    graph: &FunctionGraph,
+    var: &crate::flowspace::model::Variable,
+) -> Option<(BlockId, usize)> {
+    let mut current = var.clone();
+    let mut visited: Vec<u64> = Vec::new();
+    loop {
+        if visited.contains(&current.id()) {
+            return None; // cycle guard
+        }
+        visited.push(current.id());
+
+        // (1) Produced directly by an op in some block?
+        for block in &graph.blocks {
+            for (idx, op) in block.operations.iter().enumerate() {
+                if op.result.as_ref().is_some_and(|r| r.id() == current.id()) {
+                    return Some((block.id, idx));
+                }
+            }
+        }
+
+        // (2) Otherwise it is a block inputarg — follow the single
+        // incoming Link's matching positional arg back one block.
+        let (owner, pos) = graph.blocks.iter().find_map(|block| {
+            block
+                .inputargs
+                .iter()
+                .position(|a| a.id() == current.id())
+                .map(|pos| (block.id, pos))
+        })?;
+        let mut incoming = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.exits.iter())
+            .filter(|link| link.target == owner);
+        let first = incoming.next()?;
+        if incoming.next().is_some() {
+            return None; // phi merge: no single producer
+        }
+        match first.args.get(pos)? {
+            crate::model::LinkArg::Value(v) => current = v.clone(),
+            crate::model::LinkArg::Const(_) => return None,
+        }
+    }
+}
+
+/// Decode the packed format-string template that `format_args!` lowers
+/// its `&[&str]` pieces into.  The pieces argument to `fmt::Arguments::new`
+/// is a `[u8; N]` byte buffer (charon lowers it as an `Array` of `U8`
+/// constant elements); this reconstructs the literal `pieces` and counts
+/// the argument placeholders.
+///
+/// Grammar (verified against the real LLBC for several handler graphs):
+/// - literal segment: a length byte `L` with `L < 0x80`, then `L` bytes
+///   of UTF-8 text appended to the current piece;
+/// - placeholder: the single byte `0xC0` — closes the current piece and
+///   begins the next (the Display-vs-Debug choice lives in the parallel
+///   args array, not in this template, so a placeholder carries no kind);
+/// - terminator: a `0x00` byte (only at a segment boundary; `0`/`0xC0`
+///   bytes inside a literal are consumed by its length prefix).
+///
+/// Returns `(pieces, placeholder_count)` with `pieces.len() ==
+/// placeholder_count + 1`.  Returns `None` (bail, leaving the graph
+/// untouched) on any high-bit control byte other than `0xC0` — i.e. a
+/// format spec with width/precision/fill or an explicit positional/named
+/// argument — and on non-UTF-8 literal bytes.
+//
+// Staged for the #277 recognizer; not yet wired into the call dispatch.
+#[allow(dead_code)]
+fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
+    let mut pieces: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut placeholders = 0usize;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == 0x00 {
+            // terminator — must be the final byte
+            if i + 1 != bytes.len() {
+                return None;
+            }
+            break;
+        } else if b == 0xC0 {
+            // plain sequential placeholder
+            pieces.push(std::mem::take(&mut current));
+            placeholders += 1;
+            i += 1;
+        } else if b < 0x80 {
+            // literal segment of length `b`
+            let start = i + 1;
+            let end = start.checked_add(b as usize)?;
+            let seg = bytes.get(start..end)?;
+            current.push_str(std::str::from_utf8(seg).ok()?);
+            i = end;
+        } else {
+            // any other control byte = format spec / positional arg: bail
+            return None;
+        }
+    }
+    pieces.push(current);
+    Some((pieces, placeholders))
+}
+
+/// Read an `Array` aggregate literal: given the Variable holding a
+/// `SyntheticTransparentCtor { name: "Array" }` result, collect the
+/// values written to its `__pos_0..__pos_{n-1}` fields in index order.
+/// The ctor and its element `FieldWrite`s are emitted into one block by
+/// the `Rvalue::Aggregate` array lowering, so the search is block-local
+/// once the ctor is found. Returns `None` if `array_var` is not produced
+/// by an `Array` ctor, or its `__pos_i` writes are not the contiguous
+/// range `0..n`.
+//
+// Staged for the #277 recognizer; not yet wired into the call dispatch.
+#[allow(dead_code)]
+fn read_array_literal_elements(
+    graph: &FunctionGraph,
+    array_var: &crate::flowspace::model::Variable,
+) -> Option<Vec<crate::flowspace::model::Variable>> {
+    use crate::model::{CallTarget, OpKind};
+    let (block_id, ctor_idx) = resolve_to_producer_op(graph, array_var)?;
+    let block = graph.blocks.iter().find(|b| b.id == block_id)?;
+    match &block.operations.get(ctor_idx)?.kind {
+        OpKind::Call {
+            target: CallTarget::SyntheticTransparentCtor { name, .. },
+            ..
+        } if name == "Array" => {}
+        _ => return None,
+    }
+    let mut by_index: Vec<(usize, crate::flowspace::model::Variable)> = Vec::new();
+    for op in &block.operations {
+        if let OpKind::FieldWrite {
+            base, field, value, ..
+        } = &op.kind
+        {
+            if base.id() == array_var.id() {
+                let idx = field.name.strip_prefix("__pos_")?.parse::<usize>().ok()?;
+                by_index.push((idx, value.clone()));
+            }
+        }
+    }
+    by_index.sort_by_key(|(i, _)| *i);
+    for (expected, (idx, _)) in by_index.iter().enumerate() {
+        if *idx != expected {
+            return None;
+        }
+    }
+    Some(by_index.into_iter().map(|(_, v)| v).collect())
+}
+
+/// Resolve a Variable to the `i64` of the `ConstInt` op that produces it,
+/// following cross-block links via [`resolve_to_producer_op`]. Used to
+/// read the packed-format pieces byte array (each `__pos_i` element is a
+/// `ConstInt` byte).
+//
+// Staged for the #277 recognizer; not yet wired into the call dispatch.
+#[allow(dead_code)]
+fn resolve_const_int(
+    graph: &FunctionGraph,
+    var: &crate::flowspace::model::Variable,
+) -> Option<i64> {
+    use crate::model::OpKind;
+    let (block_id, idx) = resolve_to_producer_op(graph, var)?;
+    let block = graph.blocks.iter().find(|b| b.id == block_id)?;
+    match block.operations.get(idx)?.kind {
+        OpKind::ConstInt(n) => Some(n),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::harden_duplicate_leaf_metadata;
     use super::{cast_kind_is_raw_ptr, cast_pointer_marker_op, charon_type_value_to_ast_string};
     use majit_charon_reader::Llbc;
+
+    #[test]
+    fn resolve_to_producer_op_follows_cross_block_inputarg_link() {
+        use super::resolve_to_producer_op;
+        use crate::flowspace::model::Variable;
+        use crate::model::{FunctionGraph, Link, OpKind, SpaceOperation};
+
+        let mut graph = FunctionGraph::new("xblock");
+        let a = graph.create_block();
+        let b = graph.create_block();
+
+        // block A produces `x` via a ConstInt op.
+        let x = Variable::new();
+        graph.block_mut(a).operations.push(SpaceOperation {
+            result: Some(x.clone()),
+            kind: OpKind::ConstInt(7),
+        });
+
+        // block B takes `w` as its single inputarg; A links to B passing
+        // `x` for `w` (the cross-block threading the recognizer sees).
+        let w = Variable::new();
+        graph.block_mut(b).inputargs = vec![w.clone()];
+        let link = Link::from_variables(&graph, vec![x.clone()], b, None).with_prevblock(a);
+        graph.block_mut(a).exits = vec![link];
+
+        // `w` (block B inputarg) back-traces to A's ConstInt op.
+        assert_eq!(resolve_to_producer_op(&graph, &w), Some((a, 0)));
+        // A direct op result resolves to itself.
+        assert_eq!(resolve_to_producer_op(&graph, &x), Some((a, 0)));
+        // An unrelated free Variable has no producer.
+        assert_eq!(resolve_to_producer_op(&graph, &Variable::new()), None);
+    }
+
+    #[test]
+    fn decode_packed_format_pieces_matches_real_llbc_templates() {
+        use super::decode_packed_format_pieces;
+
+        // The four fixtures below are the verbatim `[u8; N]` pieces buffers
+        // charon lowers for these handler graphs (captured from the real
+        // pyre-interpreter.ullbc). Each asserts the reconstructed pieces +
+        // placeholder count, i.e. the original format string.
+
+        // `format!("stack underflow during {}", context)`
+        let (pieces, n) = decode_packed_format_pieces(&[
+            23, 115, 116, 97, 99, 107, 32, 117, 110, 100, 101, 114, 102, 108, 111, 119, 32, 100,
+            117, 114, 105, 110, 103, 32, 192, 0,
+        ])
+        .unwrap();
+        assert_eq!(
+            pieces,
+            vec!["stack underflow during ".to_string(), String::new()]
+        );
+        assert_eq!(n, 1);
+
+        // `format!("{} indices must be integers or slices, not {}", ..)`
+        let (pieces, n) = decode_packed_format_pieces(&[
+            192, 41, 32, 105, 110, 100, 105, 99, 101, 115, 32, 109, 117, 115, 116, 32, 98, 101, 32,
+            105, 110, 116, 101, 103, 101, 114, 115, 32, 111, 114, 32, 115, 108, 105, 99, 101, 115,
+            44, 32, 110, 111, 116, 32, 192, 0,
+        ])
+        .unwrap();
+        assert_eq!(
+            pieces,
+            vec![
+                String::new(),
+                " indices must be integers or slices, not ".to_string(),
+                String::new(),
+            ]
+        );
+        assert_eq!(n, 2);
+
+        // `format!("'{}' object does not support item assignment", ..)`
+        let (pieces, n) = decode_packed_format_pieces(&[
+            1, 39, 192, 41, 39, 32, 111, 98, 106, 101, 99, 116, 32, 100, 111, 101, 115, 32, 110,
+            111, 116, 32, 115, 117, 112, 112, 111, 114, 116, 32, 105, 116, 101, 109, 32, 97, 115,
+            115, 105, 103, 110, 109, 101, 110, 116, 0,
+        ])
+        .unwrap();
+        assert_eq!(
+            pieces,
+            vec![
+                "'".to_string(),
+                "' object does not support item assignment".to_string(),
+            ]
+        );
+        assert_eq!(n, 1);
+
+        // `format!("__init__() should return None, not '{}'", ..)`
+        let (pieces, n) = decode_packed_format_pieces(&[
+            36, 95, 95, 105, 110, 105, 116, 95, 95, 40, 41, 32, 115, 104, 111, 117, 108, 100, 32,
+            114, 101, 116, 117, 114, 110, 32, 78, 111, 110, 101, 44, 32, 110, 111, 116, 32, 39,
+            192, 1, 39, 0,
+        ])
+        .unwrap();
+        assert_eq!(
+            pieces,
+            vec![
+                "__init__() should return None, not '".to_string(),
+                "'".to_string(),
+            ]
+        );
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn decode_packed_format_pieces_bails_and_handles_edges() {
+        use super::decode_packed_format_pieces;
+
+        // A control byte other than 0xC0 (e.g. a format-spec / positional
+        // placeholder) must bail so the recognizer leaves the graph alone.
+        assert_eq!(decode_packed_format_pieces(&[0xC1, 0]), None);
+        assert_eq!(decode_packed_format_pieces(&[0x80, 0]), None);
+
+        // A literal length that overruns the buffer bails.
+        assert_eq!(decode_packed_format_pieces(&[5, 65, 66, 0]), None);
+
+        // A 0 byte that is not the final byte bails (terminator is last).
+        assert_eq!(decode_packed_format_pieces(&[0, 1, 65, 0]), None);
+
+        // Literal-only template (no placeholders) → single piece.
+        let (pieces, n) = decode_packed_format_pieces(&[2, 104, 105, 0]).unwrap();
+        assert_eq!(pieces, vec!["hi".to_string()]);
+        assert_eq!(n, 0);
+
+        // Two consecutive literal segments accumulate into one piece
+        // (how a >127-byte literal is split); one placeholder follows.
+        let (pieces, n) = decode_packed_format_pieces(&[1, 97, 1, 98, 192, 0]).unwrap();
+        assert_eq!(pieces, vec!["ab".to_string(), String::new()]);
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn read_array_literal_then_decode_pieces_end_to_end() {
+        use super::{decode_packed_format_pieces, read_array_literal_elements, resolve_const_int};
+        use crate::flowspace::model::Variable;
+        use crate::model::{
+            CallTarget, FieldDescriptor, FunctionGraph, OpKind, SpaceOperation, ValueType,
+        };
+
+        // Build the pieces array the way the front-end lowers it: an
+        // `Array` ctor followed by `__pos_i` FieldWrites of ConstInt
+        // bytes. Template for `format!("hi{}")` → pieces ["hi", ""],
+        // one placeholder = bytes [2, 'h', 'i', 0xC0, 0].
+        let mut graph = FunctionGraph::new("arraylit");
+        let a = graph.create_block();
+        let arr = Variable::new();
+        graph.block_mut(a).operations.push(SpaceOperation {
+            result: Some(arr.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor {
+                    name: "Array".to_string(),
+                    owner_path: vec![],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(Some("Array".to_string())),
+            },
+        });
+        let bytes = [2i64, 104, 105, 0xC0, 0];
+        for (i, b) in bytes.iter().enumerate() {
+            let v = Variable::new();
+            graph.block_mut(a).operations.push(SpaceOperation {
+                result: Some(v.clone()),
+                kind: OpKind::ConstInt(*b),
+            });
+            graph.block_mut(a).operations.push(SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: arr.clone(),
+                    field: FieldDescriptor::new(format!("__pos_{i}"), Some("Array".to_string())),
+                    value: v,
+                    ty: ValueType::Ref(None),
+                },
+            });
+        }
+
+        let elements = read_array_literal_elements(&graph, &arr).expect("array elements");
+        assert_eq!(elements.len(), 5);
+        let decoded: Vec<u8> = elements
+            .iter()
+            .map(|v| resolve_const_int(&graph, v).expect("const int") as u8)
+            .collect();
+        assert_eq!(decoded, vec![2, 104, 105, 0xC0, 0]);
+        let (pieces, n) = decode_packed_format_pieces(&decoded).unwrap();
+        assert_eq!(pieces, vec!["hi".to_string(), String::new()]);
+        assert_eq!(n, 1);
+
+        // A non-Array producer (plain ConstInt) is rejected.
+        assert_eq!(read_array_literal_elements(&graph, &elements[0]), None);
+    }
+
+    /// Throwaway IR-capture probe for the #277 fmt recognizer: dumps the
+    /// lowered front-end op sequence for `stack_underflow_error` (the
+    /// canonical `type_error(format!("…{x}"))` chain) so the byte-array
+    /// piece decoder can be anchored to the real `Array`/`ConstInt` shape.
+    /// Ignored by default (loads the 242MB real LLBC); run with
+    /// `cargo test -p majit-translate --lib dump_fmt_chain_ir -- --ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn dump_fmt_chain_ir() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "stack_underflow_error")
+            .expect("lower stack_underflow_error");
+        for block in &graph.blocks {
+            eprintln!("block {:?} inputargs={:?}", block.id, block.inputargs);
+            for (idx, op) in block.operations.iter().enumerate() {
+                eprintln!("  [{idx}] result={:?} kind={:?}", op.result, op.kind);
+            }
+            for link in &block.exits {
+                eprintln!("  exit -> {:?} args={:?}", link.target, link.args);
+            }
+        }
+    }
 
     #[test]
     fn cast_pointer_marker_carries_root_in_path_and_result_type() {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8625,7 +8625,10 @@ fn read_array_literal_elements(
         {
             if base.id() == array_var.id() {
                 let idx = field.name.strip_prefix("__pos_")?.parse::<usize>().ok()?;
-                by_index.push((idx, value.clone()));
+                // A `setfield_gc` inline `Const` element carries no SSA
+                // Variable; the recognizer needs a register operand per slot.
+                let write_var = value.as_variable()?;
+                by_index.push((idx, write_var.clone()));
             }
         }
     }
@@ -8751,10 +8754,13 @@ fn unwrap_fmt_arg_tuple_ref(
             } = &op.kind
             {
                 if write_base.id() == base.id() && field.name == field_name {
-                    if found.as_ref().is_some_and(|f| f.id() != value.id()) {
+                    // A `setfield_gc` inline `Const` carries no SSA Variable;
+                    // the back-trace needs a register operand to follow.
+                    let write_var = value.as_variable()?;
+                    if found.as_ref().is_some_and(|f| f.id() != write_var.id()) {
                         return None; // ambiguous: distinct values written
                     }
-                    found = Some(value.clone());
+                    found = Some(write_var.clone());
                 }
             }
         }
@@ -9083,7 +9089,7 @@ mod tests {
                 kind: OpKind::FieldWrite {
                     base: arr.clone(),
                     field: FieldDescriptor::new(format!("__pos_{i}"), Some("Array".to_string())),
-                    value: v,
+                    value: crate::model::LinkArg::Value(v),
                     ty: ValueType::Ref(None),
                 },
             });
@@ -9168,7 +9174,7 @@ mod tests {
             kind: OpKind::FieldWrite {
                 base: tuple.clone(),
                 field: FieldDescriptor::new("__pos_0", Some("Tuple".to_string())),
-                value: ctx.clone(),
+                value: crate::model::LinkArg::Value(ctx.clone()),
                 ty: ValueType::Ref(None),
             },
         });
@@ -9223,7 +9229,7 @@ mod tests {
             kind: OpKind::FieldWrite {
                 base: args_arr.clone(),
                 field: FieldDescriptor::new("__pos_0", Some("Array".to_string())),
-                value: arg_in,
+                value: crate::model::LinkArg::Value(arg_in),
                 ty: ValueType::Ref(None),
             },
         });
@@ -9251,7 +9257,7 @@ mod tests {
                 kind: OpKind::FieldWrite {
                     base: pieces_arr.clone(),
                     field: FieldDescriptor::new(format!("__pos_{i}"), Some("Array".to_string())),
-                    value: v,
+                    value: crate::model::LinkArg::Value(v),
                     ty: ValueType::Int,
                 },
             });

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8694,8 +8694,8 @@ fn resolve_const_int(
     use crate::model::OpKind;
     let (block_id, idx) = resolve_to_producer_op(graph, var)?;
     let block = graph.blocks.iter().find(|b| b.id == block_id)?;
-    match block.operations.get(idx)?.kind {
-        OpKind::ConstInt(n) => Some(n),
+    match &block.operations.get(idx)?.kind {
+        OpKind::ConstInt(n) => Some(*n),
         _ => None,
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/mod.rs
+++ b/majit/majit-translate/src/translator/rtyper/mod.rs
@@ -33,6 +33,7 @@ pub mod rlist;
 pub mod rmodel;
 pub mod rnone;
 pub mod rpbc;
+pub mod rrange;
 pub mod rstr;
 pub mod rtuple;
 pub mod rtyper;

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -144,6 +144,9 @@ pub enum ReprClassId {
     WeakRefRepr,
     /// `rweakref.py:67 EmulatedWeakRefRepr(BaseWeakRefRepr)`.
     EmulatedWeakRefRepr,
+    /// `rrange.py:43 RangeRepr(AbstractRangeRepr)` — the immutable
+    /// `range()`-result list repr (`GcStruct("range", start, stop)`).
+    RangeRepr,
 }
 
 impl ReprClassId {
@@ -197,6 +200,7 @@ impl ReprClassId {
             AbstractStringRepr => &[AbstractStringRepr, Repr],
             WeakRefRepr => &[WeakRefRepr, Repr],
             EmulatedWeakRefRepr => &[EmulatedWeakRefRepr, Repr],
+            RangeRepr => &[RangeRepr, Repr],
         }
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -448,6 +448,13 @@ impl PyreCallRegistry {
             // populate path's `is_known_unported` tolerance.
             let _ = self.bookkeeper.getuniqueclassdef_for_struct_root(&root);
         }
+        // Pre-mint unit-only enum variant subclasses so each
+        // `enum-base + variants` subtree is numbered as one contiguous
+        // bracket by the single pass below — a variant class minted
+        // lazily after the base's bracket is baked would otherwise stay
+        // unnumbered (not append-safe) and Skip-classify at its
+        // `ClassesPBCRepr` instantiation.
+        self.bookkeeper.pre_register_unit_enum_variant_classes();
         crate::translator::rtyper::normalizecalls::assign_inheritance_ids(&annotator);
         translator.set_rtyper(rtyper.clone());
         *self.session.borrow_mut() = Some((annotator.clone(), rtyper.clone()));

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -448,13 +448,12 @@ impl PyreCallRegistry {
             // populate path's `is_known_unported` tolerance.
             let _ = self.bookkeeper.getuniqueclassdef_for_struct_root(&root);
         }
-        // Pre-mint unit-only enum variant subclasses so each
-        // `enum-base + variants` subtree is numbered as one contiguous
-        // bracket by the single pass below — a variant class minted
-        // lazily after the base's bracket is baked would otherwise stay
-        // unnumbered (not append-safe) and Skip-classify at its
-        // `ClassesPBCRepr` instantiation.
-        self.bookkeeper.pre_register_unit_enum_variant_classes();
+        // Pre-mint enum variant subclasses so each `enum-base + variants`
+        // subtree is numbered as one contiguous bracket by the single pass
+        // below — a variant class minted lazily after the base's bracket is
+        // baked would otherwise stay unnumbered (not append-safe) and
+        // Skip-classify at its `ClassesPBCRepr` instantiation.
+        self.bookkeeper.pre_register_enum_variant_classes();
         crate::translator::rtyper::normalizecalls::assign_inheritance_ids(&annotator);
         translator.set_rtyper(rtyper.clone());
         *self.session.borrow_mut() = Some((annotator.clone(), rtyper.clone()));

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2958,12 +2958,21 @@ pub fn rtyper_makerepr(
             // (`externalvsinternal`'s `gcref=True` arm is likewise
             // deferred — `rclass.rs` — and unreached for `PyObjectRef`
             // items.)
-            let (resized, range_step) = {
+            let (resized, range_step, mutated) = {
                 let li_rc = s_list.listdef.listitem_rc();
                 let li = li_rc.borrow();
-                (li.resized, li.range_step)
+                (li.resized, li.range_step, li.mutated)
             };
-            if let Some(step) = range_step {
+            let s_value = s_list.listdef.s_value();
+            // rlist.py:45 — RangeRepr is selected ONLY when all three hold:
+            // `range_step is not None and not mutated and not
+            // SomeImpossibleValue`. A mutated (e.g. setitem'd / resized)
+            // or still-impossible range-derived list falls through to the
+            // resized→ListRepr / non-resized→FixedSizeListRepr branch
+            // (rlist.py:54-57), exactly as a non-range list does.
+            let range_repr_step =
+                range_step.filter(|_| !mutated && !matches!(s_value, SomeValue::Impossible));
+            if let Some(step) = range_repr_step {
                 if step == 1 {
                     Ok(
                         std::sync::Arc::new(crate::translator::rtyper::rrange::RangeRepr::new(
@@ -2986,7 +2995,7 @@ pub fn rtyper_makerepr(
                     s_list.listdef
                 )))
             } else {
-                let item_r = rtyper.getrepr(&s_list.listdef.s_value())?;
+                let item_r = rtyper.getrepr(&s_value)?;
                 let rtyper_rc = rtyper.self_rc()?;
                 Ok(
                     std::sync::Arc::new(crate::translator::rtyper::rlist::FixedSizeListRepr::new(
@@ -3740,6 +3749,54 @@ mod tests {
         let repr = rtyper_makerepr(&SomeValue::Ptr(SomePtr::new(ptr.clone())), &rtyper).unwrap();
         assert_eq!(repr.class_name(), "PtrRepr");
         assert_eq!(repr.lowleveltype(), &LowLevelType::Ptr(Box::new(ptr)));
+    }
+
+    /// rlist.py:45 — RangeRepr is selected only when `range_step is not
+    /// None and not mutated and not SomeImpossibleValue`; a mutated or
+    /// still-impossible range-derived list falls through to
+    /// FixedSizeListRepr / the deferred resized ListRepr, like any other
+    /// list. Regression guard against gating on `range_step.is_some()`
+    /// alone.
+    #[test]
+    fn somelist_rangerepr_gated_on_not_mutated_and_concrete_item() {
+        use crate::annotator::listdef::ListDef;
+        use crate::annotator::model::{SomeInteger, SomeList};
+
+        let rtyper = rtyper_for_tests();
+        let item = SomeValue::Integer(SomeInteger::new(false, false));
+
+        // step==1, not mutated, concrete item → RangeRepr.
+        let ldef = ListDef::new(None, item.clone(), false, false);
+        ldef.listitem_rc().borrow_mut().range_step = Some(1);
+        let repr = rtyper_makerepr(&SomeValue::List(SomeList::new(ldef)), &rtyper).unwrap();
+        assert_eq!(repr.class_name(), "RangeRepr");
+
+        // step==1 but mutated → falls through to the non-range branch
+        // (FixedSizeListRepr), NOT RangeRepr.
+        let ldef_mut = ListDef::new(None, item.clone(), true, false);
+        ldef_mut.listitem_rc().borrow_mut().range_step = Some(1);
+        let repr_mut = rtyper_makerepr(&SomeValue::List(SomeList::new(ldef_mut)), &rtyper);
+        assert!(
+            repr_mut
+                .map(|r| r.class_name() != "RangeRepr")
+                .unwrap_or(true),
+            "mutated range-list must not select RangeRepr"
+        );
+
+        // step==1 but resized (⇒ mutated) → the deferred resized ListRepr
+        // arm (Err), never RangeRepr.
+        let ldef_resized = ListDef::new(None, item, false, true);
+        ldef_resized.listitem_rc().borrow_mut().range_step = Some(1);
+        assert!(rtyper_makerepr(&SomeValue::List(SomeList::new(ldef_resized)), &rtyper).is_err());
+
+        // step==1, not mutated, but impossible item → not RangeRepr.
+        let ldef_imp = ListDef::new(None, SomeValue::Impossible, false, false);
+        ldef_imp.listitem_rc().borrow_mut().range_step = Some(1);
+        let r_imp = rtyper_makerepr(&SomeValue::List(SomeList::new(ldef_imp)), &rtyper);
+        assert!(
+            r_imp.map(|r| r.class_name() != "RangeRepr").unwrap_or(true),
+            "impossible-item range-list must not select RangeRepr"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2935,13 +2935,16 @@ pub fn rtyper_makerepr(
             //
             //   1. `range_step is not None and not mutated and
             //      not SomeImpossibleValue` → `RangeRepr(range_step)`
-            //      (lltypesystem/rrange.py). Not ported — `RangeRepr`
-            //      has no Rust counterpart yet (the whole `rrange.py`
-            //      surface is deferred, see `SomeIterator` below). A
-            //      range-list is NOT array-backed, so the `Err` arm
-            //      below skips it rather than mis-lowering it as a
-            //      `FixedSizeListRepr` (whose `getarraysize` / item-load
-            //      ops would compile to invalid reads off a non-array).
+            //      (lltypesystem/rrange.py). The step-1 form
+            //      (`range(n)` / `range(a, b)`) lands on
+            //      [`rrange::RangeRepr`]; the general const-step != 1
+            //      and variable-step (`RANGEST`) lengths need
+            //      `ll_rangelen`'s `int_floordiv` (not yet a recognised
+            //      low-level op), so they fall to the `Err` arm. A
+            //      range-list is NOT array-backed, so this never
+            //      mis-lowers as a `FixedSizeListRepr` (whose
+            //      `getarraysize` / item-load ops would compile to
+            //      invalid reads off a non-array).
             //   2. resized listdef → `ListRepr` (`GcStruct("list",
             //      length, items)`) — deferred (the `Err` arm below).
             //   3. non-resized → `FixedSizeListRepr`.
@@ -2960,13 +2963,21 @@ pub fn rtyper_makerepr(
                 let li = li_rc.borrow();
                 (li.resized, li.range_step)
             };
-            if range_step.is_some() {
-                Err(TyperError::missing_rtype_operation(format!(
-                    "SomeList(range_step={range_step:?}).rtyper_makerepr — port \
-                     rpython/rtyper/lltypesystem/rrange.py RangeRepr \
-                     (listdef: {:?})",
-                    s_list.listdef
-                )))
+            if let Some(step) = range_step {
+                if step == 1 {
+                    Ok(
+                        std::sync::Arc::new(crate::translator::rtyper::rrange::RangeRepr::new(
+                            step,
+                        )?) as std::sync::Arc<dyn Repr>,
+                    )
+                } else {
+                    Err(TyperError::missing_rtype_operation(format!(
+                        "SomeList(range_step={step}).rtyper_makerepr — general \
+                         RangeRepr (const step != 1 / variable step) deferred; \
+                         ll_rangelen needs int_floordiv lowering (listdef: {:?})",
+                        s_list.listdef
+                    )))
+                }
             } else if resized {
                 Err(TyperError::missing_rtype_operation(format!(
                     "SomeList(resized).rtyper_makerepr — port \

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2937,9 +2937,11 @@ pub fn rtyper_makerepr(
             //      not SomeImpossibleValue` → `RangeRepr(range_step)`
             //      (lltypesystem/rrange.py). Not ported — `RangeRepr`
             //      has no Rust counterpart yet (the whole `rrange.py`
-            //      surface is deferred, see `SomeIterator` below); a
-            //      range-list therefore falls through to the
-            //      fixed-size repr instead.
+            //      surface is deferred, see `SomeIterator` below). A
+            //      range-list is NOT array-backed, so the `Err` arm
+            //      below skips it rather than mis-lowering it as a
+            //      `FixedSizeListRepr` (whose `getarraysize` / item-load
+            //      ops would compile to invalid reads off a non-array).
             //   2. resized listdef → `ListRepr` (`GcStruct("list",
             //      length, items)`) — deferred (the `Err` arm below).
             //   3. non-resized → `FixedSizeListRepr`.
@@ -2953,8 +2955,19 @@ pub fn rtyper_makerepr(
             // (`externalvsinternal`'s `gcref=True` arm is likewise
             // deferred — `rclass.rs` — and unreached for `PyObjectRef`
             // items.)
-            let resized = s_list.listdef.listitem_rc().borrow().resized;
-            if resized {
+            let (resized, range_step) = {
+                let li_rc = s_list.listdef.listitem_rc();
+                let li = li_rc.borrow();
+                (li.resized, li.range_step)
+            };
+            if range_step.is_some() {
+                Err(TyperError::missing_rtype_operation(format!(
+                    "SomeList(range_step={range_step:?}).rtyper_makerepr — port \
+                     rpython/rtyper/lltypesystem/rrange.py RangeRepr \
+                     (listdef: {:?})",
+                    s_list.listdef
+                )))
+            } else if resized {
                 Err(TyperError::missing_rtype_operation(format!(
                     "SomeList(resized).rtyper_makerepr — port \
                      rpython/rtyper/lltypesystem/rlist.py ListRepr (GcStruct length+items) \

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -1,0 +1,295 @@
+//! RPython `rpython/rtyper/rrange.py` + `lltypesystem/rrange.py` —
+//! minimal `RangeRepr` slice covering the `len(range(...))` lowering for
+//! the step-1 case (`range(n)` / `range(a, b)`), which is the form
+//! `builtin_range` mints for the overwhelmingly common call shapes
+//! (`annotator/builtin.rs:523-528`).
+//!
+//! A `range()` result that is never mutated annotates as a `SomeList`
+//! carrying a non-`None` `range_step` (`annotator/listdef.rs:177`); its
+//! repr is NOT array-backed (`FixedSizeListRepr`) but an immutable
+//! `GcStruct("range", start, stop)` (`lltypesystem/rrange.py:51-57`).
+//!
+//! Deferred to follow-on slices (matching how `FixedSizeListRepr` landed
+//! `rtype_len` first): the general-step `ll_rangelen` length (needs the
+//! `int_floordiv` lowering, not yet a recognised low-level op), the
+//! `RANGEST` variable-step path, `pairtype(RangeRepr, IntegerRepr)`
+//! `rtype_getitem`, and `RangeIteratorRepr`.
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::flowspace::model::{
+    Block, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
+    SpaceOperation,
+};
+use crate::flowspace::pygraph::PyGraph;
+use crate::translator::rtyper::error::TyperError;
+use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, Ptr, PtrTarget, StructType};
+use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
+use crate::translator::rtyper::rtyper::{
+    ConvertedTo, HighLevelOp, RPythonTyper, constant_with_lltype, helper_pygraph_from_graph,
+    variable_with_lltype,
+};
+
+/// RPython `class RangeRepr(AbstractRangeRepr)` (`rrange.py:43-67` +
+/// `rrange.py:10-16`):
+///
+/// ```python
+/// class AbstractRangeRepr(Repr):
+///     def __init__(self, step):
+///         self.step = step
+///         if step != 0:
+///             self.lowleveltype = self.RANGE
+///         else:
+///             self.lowleveltype = self.RANGEST
+/// ```
+///
+/// where (`lltypesystem/rrange.py:51-57`):
+///
+/// ```python
+/// self.RANGE = Ptr(GcStruct("range", ("start", Signed), ("stop", Signed),
+///                           ..., hints = {'immutable': True}))
+/// ```
+///
+/// The `RANGEST` (variable-step `("start", "stop", "step")`) shape and
+/// the `adtmeths` / iterator surface are deferred.
+#[derive(Debug)]
+pub struct RangeRepr {
+    state: ReprState,
+    lltype: LowLevelType,
+    /// `self.step` (`rrange.py:12`) — the constant range step. `0`
+    /// signals upstream's "variable step" (`RANGEST`).
+    step: i64,
+}
+
+impl RangeRepr {
+    /// `AbstractRangeRepr.__init__(self, step)` — picks `RANGE`
+    /// (constant step) or `RANGEST` (variable step) as the low-level
+    /// type. Both are immutable `GcStruct("range", ...)`.
+    pub fn new(step: i64) -> Result<Self, TyperError> {
+        let signed = LowLevelType::Signed;
+        let fields = if step != 0 {
+            vec![
+                ("start".to_string(), signed.clone()),
+                ("stop".to_string(), signed),
+            ]
+        } else {
+            vec![
+                ("start".to_string(), signed.clone()),
+                ("stop".to_string(), signed.clone()),
+                ("step".to_string(), signed),
+            ]
+        };
+        let st = StructType::gc_with_hints(
+            "range",
+            fields,
+            vec![("immutable".to_string(), ConstValue::Bool(true))],
+        );
+        let lltype = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Struct(st),
+        }));
+        Ok(RangeRepr {
+            state: ReprState::new(),
+            lltype,
+            step,
+        })
+    }
+}
+
+impl Repr for RangeRepr {
+    fn lowleveltype(&self) -> &LowLevelType {
+        &self.lltype
+    }
+
+    fn state(&self) -> &ReprState {
+        &self.state
+    }
+
+    fn class_name(&self) -> &'static str {
+        "RangeRepr"
+    }
+
+    fn repr_class_id(&self) -> super::pairtype::ReprClassId {
+        super::pairtype::ReprClassId::RangeRepr
+    }
+
+    /// RPython `AbstractRangeRepr.rtype_len(self, hop)`
+    /// (`rrange.py:22-30`):
+    ///
+    /// ```python
+    /// def rtype_len(self, hop):
+    ///     v_rng, = hop.inputargs(self)
+    ///     if self.step == 1:
+    ///         return hop.gendirectcall(ll_rangelen1, v_rng)
+    ///     elif self.step != 0:
+    ///         v_step = hop.inputconst(Signed, self.step)
+    ///     else:
+    ///         v_step = self._getstep(v_rng, hop)
+    ///     return hop.gendirectcall(ll_rangelen, v_rng, v_step)
+    /// ```
+    ///
+    /// Only the `step == 1` (`ll_rangelen1`) path lands today; the
+    /// general `ll_rangelen` (`_ll_rangelen`'s floor-division) is
+    /// deferred until `int_floordiv` is a recognised low-level op.
+    fn rtype_len(&self, hop: &HighLevelOp) -> RTypeResult {
+        if self.step != 1 {
+            return Err(TyperError::missing_rtype_operation(format!(
+                "RangeRepr.rtype_len(step={}) — general ll_rangelen path \
+                 deferred (needs int_floordiv lowering)",
+                self.step
+            )));
+        }
+        let v_rng = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_rangelen1".to_string(),
+            vec![ptr_lltype],
+            LowLevelType::Signed,
+            move |_rtyper, _args, _result| {
+                build_ll_rangelen1_helper_graph("ll_rangelen1", ptr_for_builder.clone())
+            },
+        )?;
+        hop.gendirectcall(&helper, v_rng)
+    }
+}
+
+/// Synthesise the `ll_rangelen1` helper graph (`rrange.py:68-72`):
+///
+/// ```python
+/// def ll_rangelen1(l):
+///     result = l.stop - l.start
+///     if result < 0:
+///         result = 0
+///     return result
+/// ```
+///
+/// 2-block CFG:
+/// - **start**: `start = getfield(l, 'start'); stop = getfield(l, 'stop');
+///   result = int_sub(stop, start); neg = int_lt(result, 0)`. Switch on
+///   `neg`: True → returnblock with const `0`; False → returnblock with
+///   `result`.
+pub(crate) fn build_ll_rangelen1_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let arg = variable_with_lltype("l", ptr_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(arg.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let signed_const = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
+    let bool_const = |b: bool| constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool);
+
+    // start block: result = l.stop - l.start; neg = result < 0.
+    let v_start = variable_with_lltype("start", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(arg.clone()), field_const("start")],
+        Hlvalue::Variable(v_start.clone()),
+    ));
+    let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(arg), field_const("stop")],
+        Hlvalue::Variable(v_stop.clone()),
+    ));
+    let v_result = variable_with_lltype("result", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![Hlvalue::Variable(v_stop), Hlvalue::Variable(v_start)],
+        Hlvalue::Variable(v_result.clone()),
+    ));
+    let v_neg = variable_with_lltype("neg", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(v_result.clone()), signed_const(0)],
+        Hlvalue::Variable(v_neg.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(v_neg));
+
+    // True (result < 0): clamp to 0.
+    let true_link = Link::new(
+        vec![signed_const(0)],
+        Some(graph.returnblock.clone()),
+        Some(bool_const(true)),
+    )
+    .into_ref();
+    // False: return result unchanged.
+    let false_link = Link::new(
+        vec![Hlvalue::Variable(v_result)],
+        Some(graph.returnblock.clone()),
+        Some(bool_const(false)),
+    )
+    .into_ref();
+    startblock.closeblock(vec![true_link, false_link]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string()],
+        func,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::translator::rtyper::pairtype::ReprClassId;
+
+    #[test]
+    fn rangerepr_step1_lowleveltype_is_immutable_range_gcstruct() {
+        let rr = RangeRepr::new(1).unwrap();
+        assert_eq!(rr.repr_class_id(), ReprClassId::RangeRepr);
+        match rr.lowleveltype() {
+            LowLevelType::Ptr(p) => match &p.TO {
+                PtrTarget::Struct(st) => {
+                    // RANGE = GcStruct("range", start, stop) — two Signed fields.
+                    assert_eq!(st._names_without_voids(), vec!["start", "stop"]);
+                }
+                other => panic!("RangeRepr lltype TO not Struct: {other:?}"),
+            },
+            other => panic!("RangeRepr lltype not Ptr: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rangerepr_variable_step_lowleveltype_is_rangest_gcstruct() {
+        // step == 0 → RANGEST with the extra `step` field.
+        let rr = RangeRepr::new(0).unwrap();
+        match rr.lowleveltype() {
+            LowLevelType::Ptr(p) => match &p.TO {
+                PtrTarget::Struct(st) => {
+                    assert_eq!(st._names_without_voids(), vec!["start", "stop", "step"]);
+                }
+                other => panic!("not Struct: {other:?}"),
+            },
+            other => panic!("not Ptr: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_ll_rangelen1_helper_graph_synthesizes_2_block_cfg() {
+        let ptr = RangeRepr::new(1).unwrap().lowleveltype().clone();
+        let g = build_ll_rangelen1_helper_graph("ll_rangelen1", ptr).unwrap();
+        let inner = g.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(ops, vec!["getfield", "getfield", "int_sub", "int_lt"]);
+        assert!(startblock.exitswitch.is_some());
+        assert_eq!(startblock.exits.len(), 2);
+    }
+}

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9008,7 +9008,11 @@ fn takewhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
 }
 
 /// `takewhile.__setstate__` — `interp_itertools.py W_TakeWhile.descr_setstate`:
-/// `self.stopped = space.bool_w(w_state)`.
+/// `self.stopped = space.bool_w(w_state)`.  `space.bool_w(w)` is
+/// `bool(int_w(w))` (baseobjspace.py:1944): it unwraps an int and
+/// rejects non-ints, NOT the general `is_true` truth test, so
+/// `int_w(...)? != 0` is the exact equivalent (raises on a non-int
+/// state just as `bool_w` does).
 fn takewhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &mut *(args[0] as *mut pyre_object::itertoolsmodule::W_TakeWhile) };
     it.stopped = int_w(args.get(1).copied().unwrap_or(w_none()))? != 0;
@@ -9025,7 +9029,8 @@ fn dropwhile_reduce_method(args: &[PyObjectRef]) -> PyResult {
 }
 
 /// `dropwhile.__setstate__` — `interp_itertools.py W_DropWhile.descr_setstate`:
-/// `self.started = space.bool_w(w_state)`.
+/// `self.started = space.bool_w(w_state)` (= `bool(int_w(w))`; see
+/// `takewhile_setstate_method` for the `int_w(...)? != 0` equivalence).
 fn dropwhile_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let it = unsafe { &mut *(args[0] as *mut pyre_object::itertoolsmodule::W_DropWhile) };
     it.started = int_w(args.get(1).copied().unwrap_or(w_none()))? != 0;


### PR DESCRIPTION
#122

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Continues the Z2.5 rtyper cutover (retiring the legacy-walker fallback) on top of #164, which landed on `main` as the squash commit `a83cb5cd91`. Five commits: three #164 review-fix folds, two dual-gate census-drop landings, a parity doc note, and the staged (unwired) #277 fmt-recognizer primitives.

### #164 review fixes (`dd32b65726`)

- **Discriminant fold** — `Rvalue::Discriminant` on a local bound directly to its payload by an always-`Ok` decomposed conversion (`try_lower_usize_try_from`) folds to `ConstInt(tag)` from `const_discriminant_locals` instead of reading a `__discriminant` field no runtime enum object carries. Covers the `match try_from(..)` shape.
- **`checked_neg` width gate** — `try_lower_checked_neg` decomposes to a compare against `i64::MIN`, correct only at word width, so it is now gated on a word-sized signed operand (`i64`/`isize`) via the callee's first input atom (`tyref_literal_int_atom`); a narrower `checked_neg` keeps the generic `Call` form.
- **range-list skip** — `SomeValue::List.rtyper_makerepr` reads `range_step` and skips range-backed lists (RangeRepr unported) rather than mislowering them through `FixedSizeListRepr`, whose `getarraysize` / item-load ops would compile to invalid reads off a non-array.

### Census-drop landings

- **Pre-mint unit-only enum variant classes** (`909757ee37`, census 674 → 664) — register every unit-only enum's variant subclasses before the single `assign_inheritance_ids` pass in `PyreCallRegistry::ensure_session`, so each enum-base + variants subtree is numbered as one contiguous bracket. A variant minted lazily at its `ClassesPBCRepr` instantiation (after the base's bracket was baked) was not append-safe, stayed unnumbered, and was Skip-classified. `class-not-numbered` 58 → 0; 10 graphs lift (`unpack_ex`, `PyError::kind_from_exc`, `excobject::is_exception` / `w_exception_get_kind`, `pyobject::get_instantiate` / `ll_isinstance` / `ll_issubclass`, `tupleobject::is_plain_float_strict`, `typeobject::w_type_get_uses_object_setattr`); zero newly-skipping.
- **`num::From` uint widen identity bind** (`4f922cb236`, census 664 → 662) — fold `core::convert::num::<Impl>::from` (Opaque in LLBC) to an identity bind when the source is a smaller-than-word unsigned (U8/U16/U32) and the destination is a word-sized integer carrier (I64/Isize/U64/Usize). Value-preserving, so no op is emitted — the same shape as the always-`Ok` `usize::try_from` payload bind. Lifts `pyopcode::u32_as_i64` and `typeobject::w_type_get_version_tag` from the legacy-walker fallback.

### Parity doc note (`68e87d6ede`)

`space.bool_w(w)` is `bool(int_w(w))` (`baseobjspace.py:1944`) — it unwraps an int and rejects non-ints, not the general `is_true` truth test — so the existing `int_w(...)? != 0` is the exact equivalent. Recorded on both `takewhile` / `dropwhile` `__setstate__` helpers to settle a recurring review misread.

### Staged #277 fmt-recognizer primitives, unwired (`274b19f538`)

Four `#[allow(dead_code)]` helpers in `front/mir.rs` for the deferred fmt-chain recognizer, with unit tests and an `#[ignore]` LLBC IR-dump probe; none are wired into lowering dispatch, so lowering output and the census are unchanged:

- `resolve_to_producer_op` — cross-block back-trace from a `Variable` to the producing `SpaceOperation` (or const), following single incoming `Link`s.
- `decode_packed_format_pieces` — decode the packed format-string template (literal `[len<0x80][bytes]` segments, `0xC0` placeholder, `0x00` terminator) into literal pieces + placeholder count; bails on unrecognized control bytes and non-UTF-8.
- `read_array_literal_elements` — read an `Array` aggregate ctor's `__pos_i` `FieldWrite`s in index order.
- `resolve_const_int` — resolve a `Variable` to its `ConstInt` value.

### Verification

Census 662 on `ssa-repr`. `check.py` 79/79 dynasm + 79/79 cranelift; `cargo test` lib 2503/0 + 251/0.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
"Structural adaptations."
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pre-mints enum variant subclasses before inheritance-id assignment for consistent numbering.
  * Refines MIR lowering of local discriminants and numeric `from`/`checked_neg` conversions with tighter gating and correct masking/widening behavior.
  * Enhances `format_args!` format-chain recognition/recovery across block boundaries (including more end-to-end coverage).
  * Adds `len(range(...))` `RangeRepr` support and improves repr selection for range-list lowering (with clearer errors for unsupported steps).
* **Documentation**
  * Clarified `takewhile`/`dropwhile` iterator state semantics.
* **Tests**
  * Added/updated unit tests for range repr selection, helper graph generation, and fmt-chain reconstruction/output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->