### PR TITLE
jit: FBW blackhole-resume fixes, walker opcode flips, and supporting regalloc/IR changes

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -535,6 +535,13 @@ pub enum PyreHelperKind {
     /// broken baked-NULL-globals shape the walker's may-force NULL-ref
     /// gate rejects.
     CallFn,
+    /// `bh_truth_fn(value)` — the TO_BOOL / `POP_JUMP_IF_*` truth helper
+    /// (`opcode_ops::truth_value`).  Returns the operand's truthiness as a
+    /// raw Int.  The full-body walker recognises this tag to specialise a
+    /// provably-int operand to a pure `guard_class INT` + `getfield intval`
+    /// + `int_is_true`, eliding the `CALL_MAY_FORCE` (and its
+    /// `GUARD_NOT_FORCED` / `GUARD_NO_EXCEPTION`) the generic residual emits.
+    Truth,
 }
 
 impl EffectInfo {

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -6993,6 +6993,35 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "arraylen_vable/rdd>i".to_string(),
         majit_translate::insns::BC_ARRAYLEN_VABLE,
     );
+    // GC array-build family — `BuildTuple` / `BuildList` / `BuildMap` /
+    // `BuildSet` / `BuildString` lower to `new_array_clear` (alloc) +
+    // unrolled `setarrayitem_gc_r` (fill) + a `new*_from_array` residual
+    // (already covered by the residual_call family above).  A
+    // guard-failure resume into a jitcode whose forward path contains a
+    // literal/return tuple (or list/map/set/str) walks the alloc + fill
+    // ops, so the strict builder must wire them or `dispatch_step`
+    // panics on the unwired byte.  Both the const-operand variants
+    // (`cd>r` length, `rcrd` index — what the codewriter emits, since
+    // the length and index are compile-time constants) and the
+    // register-operand variants (`id>r`, `rird`) are registered so the
+    // builder stays correct if the flattener ever colors them into
+    // registers.  Handlers wired in `wire_bhimpl_handlers`.
+    insns.insert(
+        "new_array_clear/cd>r".to_string(),
+        majit_translate::insns::BC_NEW_ARRAY_CLEAR_C,
+    );
+    insns.insert(
+        "new_array_clear/id>r".to_string(),
+        majit_translate::insns::BC_NEW_ARRAY_CLEAR,
+    );
+    insns.insert(
+        "setarrayitem_gc_r/rcrd".to_string(),
+        majit_translate::insns::BC_SETARRAYITEM_GC_R_C,
+    );
+    insns.insert(
+        "setarrayitem_gc_r/rird".to_string(),
+        majit_translate::insns::BC_SETARRAYITEM_GC_R,
+    );
     insns.insert(
         "hint_force_virtualizable/r".to_string(),
         majit_translate::insns::BC_HINT_FORCE_VIRTUALIZABLE,

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -6222,11 +6222,24 @@ fn read_list_f(bh: &BlackholeInterpreter, code: &[u8], pos: usize) -> (Vec<i64>,
 #[inline]
 fn check_residual_call_exception_after(
     bh: &mut BlackholeInterpreter,
+    next_pos: usize,
 ) -> Result<Option<usize>, DispatchError> {
     let exc_val = BH_LAST_EXC_VALUE.with(|c| c.get());
     if exc_val == 0 {
         return Ok(None);
     }
+    // `dispatch_step` stores the handler's return value into `self.position`
+    // only *after* the handler returns, so right now `self.position` still
+    // points at this residual call's first operand byte.  Advance it to
+    // `next_pos` — the post-call position the handler is about to return,
+    // where the codewriter emitted the can-raise opcode's `-live-` /
+    // `catch_exception` adjacency (`codewriter.rs:9161-9188`).  Without this,
+    // `handle_exception_in_frame`'s forward case inspects an operand byte
+    // (never a `catch_exception`) and the backward scan stops at the
+    // *pre*-call `-live-`, so a residual call executed directly during the
+    // walk escapes its enclosing `try` even though the catch sits right
+    // after it.
+    bh.position = next_pos;
     if bh.handle_exception_in_frame(exc_val) {
         return Ok(Some(bh.position));
     }
@@ -6251,7 +6264,7 @@ fn handler_residual_call_irf_i(
     // blackhole.py:1244-1246 → bhimpl_residual_call_irf_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_irf_i(func, &ai, &ar, &af, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p + 1)? {
         return Ok(handler_pc);
     }
     bh.registers_i[dst] = result;
@@ -6272,7 +6285,7 @@ fn handler_residual_call_irf_r(
     // blackhole.py:1247-1249 → bhimpl_residual_call_irf_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_irf_r(func, &ai, &ar, &af, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p + 1)? {
         return Ok(handler_pc);
     }
     bh.registers_r[dst] = result.0 as i64;
@@ -6293,7 +6306,7 @@ fn handler_residual_call_irf_f(
     // blackhole.py:1250-1252 → bhimpl_residual_call_irf_f.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_irf_f(func, &ai, &ar, &af, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p + 1)? {
         return Ok(handler_pc);
     }
     bh.registers_f[dst] = result.to_bits() as i64;
@@ -6314,7 +6327,7 @@ fn handler_residual_call_irf_v(
     // which forwards to cpu.bh_call_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_residual_call_irf_v(func, &ai, &ar, &af, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p)? {
         return Ok(handler_pc);
     }
     Ok(p)
@@ -6334,7 +6347,7 @@ fn handler_residual_call_ir_i(
     // blackhole.py:1234-1236 → bhimpl_residual_call_ir_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_ir_i(func, &ai, &ar, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p + 1)? {
         return Ok(handler_pc);
     }
     bh.registers_i[dst] = result;
@@ -6354,7 +6367,7 @@ fn handler_residual_call_ir_r(
     // blackhole.py:1237-1239 → bhimpl_residual_call_ir_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_ir_r(func, &ai, &ar, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p + 1)? {
         return Ok(handler_pc);
     }
     bh.registers_r[dst] = result.0 as i64;
@@ -6373,7 +6386,7 @@ fn handler_residual_call_ir_v(
     // blackhole.py:1240-1242 → bhimpl_residual_call_ir_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_residual_call_ir_v(func, &ai, &ar, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p)? {
         return Ok(handler_pc);
     }
     Ok(p)
@@ -6392,7 +6405,7 @@ fn handler_residual_call_r_i(
     // blackhole.py:1225-1226 → bhimpl_residual_call_r_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_r_i(func, &ar, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p + 1)? {
         return Ok(handler_pc);
     }
     bh.registers_i[dst] = result;
@@ -6411,7 +6424,7 @@ fn handler_residual_call_r_r(
     // blackhole.py:1227-1229 → bhimpl_residual_call_r_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_r_r(func, &ar, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p + 1)? {
         return Ok(handler_pc);
     }
     bh.registers_r[dst] = result.0 as i64;
@@ -6429,7 +6442,7 @@ fn handler_residual_call_r_v(
     // blackhole.py:1230-1232 → bhimpl_residual_call_r_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_residual_call_r_v(func, &ar, &calldescr);
-    if let Some(handler_pc) = check_residual_call_exception_after(bh)? {
+    if let Some(handler_pc) = check_residual_call_exception_after(bh, p)? {
         return Ok(handler_pc);
     }
     Ok(p)

--- a/pyre/bench/synth/build_container_return_resume.py
+++ b/pyre/bench/synth/build_container_return_resume.py
@@ -1,0 +1,69 @@
+# Builds a container (tuple / list / set / dict / str) AFTER a hot loop and
+# returns it.  The loop-exit guard failure resumes via the blackhole, which
+# then walks the forward path through the container-build residual
+# (new_array_clear + setarrayitem_gc_r + new*_from_array).  Unlike
+# build_tuple_large.py — which builds inside the traced loop body — the build
+# here is reached only on the resume path, exercising the blackhole builder's
+# coverage of the GC array-build family.
+N = 2000000
+
+
+def build_tuple(n):
+    s = 0
+    i = 0
+    while i < n:
+        s = s + i
+        i = i + 1
+    return s, i, n - i
+
+
+def build_list(n):
+    s = 0
+    i = 0
+    while i < n:
+        s = s + (i & 7)
+        i = i + 1
+    return [s, i, s + i]
+
+
+def build_set(n):
+    s = 0
+    i = 0
+    while i < n:
+        s = s + (i % 5)
+        i = i + 1
+    return {s, i, s - i}
+
+
+def build_map(n):
+    s = 0
+    i = 0
+    while i < n:
+        s = s + (i & 3)
+        i = i + 1
+    return {"s": s, "i": i}
+
+
+def build_str(n):
+    s = 0
+    i = 0
+    while i < n:
+        s = s + 1
+        i = i + 1
+    return f"<{s}:{i}>"
+
+
+def main():
+    a, b, c = build_tuple(N)
+    lst = build_list(N)
+    st = build_set(N)
+    mp = build_map(N)
+    text = build_str(N)
+    print(a, b, c)
+    print(lst)
+    print(sorted(st))
+    print(mp["s"], mp["i"])
+    print(text)
+
+
+main()

--- a/pyre/bench/synth/residual_raise_except_resume.py
+++ b/pyre/bench/synth/residual_raise_except_resume.py
@@ -1,0 +1,69 @@
+# A hot loop FOLLOWED by a try/except whose body raises through a
+# *may-force residual call* (`//`, subscript) rather than an explicit
+# `raise`.  The try/except is reached only after the loop's exit guard
+# fails, so the blackhole walks forward and executes the residual call
+# concretely on the resume path.  When that call raises, the exception
+# must be routed to the in-frame `catch_exception` adjacency the
+# codewriter emitted right after the call; previously the catch search
+# started at the call's operand byte (the dispatch loop advances the
+# position only after the handler returns) so the catch was never found
+# and the exception escaped the handler.  This bench pins that a
+# residual-call raise caught on the resume path returns byte-identically.
+#
+# These cases keep only int / immutable-literal locals live across the
+# `try` — a live heap-object local (e.g. a list bound before the `try`)
+# reconstructed on the resume walk is the separate #124 kept-stack gate.
+N = 2000000
+
+
+def divide_by_zero_const(n):
+    i = 0
+    while i < n:
+        i = i + 1
+    try:
+        return 1 // 0
+    except ZeroDivisionError:
+        return -2
+
+
+def divide_by_zero_computed(n):
+    i = 0
+    acc = 0
+    while i < n:
+        acc = acc + 1
+        i = i + 1
+    d = acc - acc
+    try:
+        return acc // d
+    except ZeroDivisionError:
+        return acc + 1
+
+
+def modulo_by_zero(n):
+    i = 0
+    while i < n:
+        i = i + 1
+    try:
+        return i % 0
+    except ZeroDivisionError:
+        return i - 5
+
+
+def tuple_index_resume(n):
+    i = 0
+    while i < n:
+        i = i + 1
+    try:
+        return (10, 20, 30)[i]
+    except IndexError:
+        return -7
+
+
+def main():
+    print(divide_by_zero_const(N))
+    print(divide_by_zero_computed(N))
+    print(modulo_by_zero(N))
+    print(tuple_index_resume(N))
+
+
+main()

--- a/pyre/bench/synth/residual_raise_except_resume.py
+++ b/pyre/bench/synth/residual_raise_except_resume.py
@@ -10,9 +10,12 @@
 # and the exception escaped the handler.  This bench pins that a
 # residual-call raise caught on the resume path returns byte-identically.
 #
-# These cases keep only int / immutable-literal locals live across the
-# `try` — a live heap-object local (e.g. a list bound before the `try`)
-# reconstructed on the resume walk is the separate #124 kept-stack gate.
+# `list_extend_resume` additionally builds a heap-local list via
+# LIST_EXTEND (`[*base]`) *after* the loop, so the loop-exit guard
+# failure resumes through the LIST_EXTEND: the walk must execute the
+# `list_extend` residual.  Previously LIST_EXTEND had no walker handler
+# and emitted an abort that, reached on the resume walk, invalidated the
+# live frame and crashed (SIGSEGV) — the residual port fixes that.
 N = 2000000
 
 
@@ -59,11 +62,24 @@ def tuple_index_resume(n):
         return -7
 
 
+def list_extend_resume(n):
+    i = 0
+    while i < n:
+        i = i + 1
+    base = [10, 20, 30]
+    data = [*base]
+    try:
+        return data[i]
+    except IndexError:
+        return data[0] - 100
+
+
 def main():
     print(divide_by_zero_const(N))
     print(divide_by_zero_computed(N))
     print(modulo_by_zero(N))
     print(tuple_index_resume(N))
+    print(list_extend_resume(N))
 
 
 main()

--- a/pyre/bench/synth/short_circuit_value_kept_stack.py
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.py
@@ -1,0 +1,28 @@
+# Exercises short-circuit `and` / `or` in VALUE context inside a hot loop.
+#
+# `x = (i % 7) and (i + 3)` lowers to `BINARY_OP %; COPY 1; TO_BOOL;
+# POP_JUMP_IF_*`: the COPY-duplicated left operand stays on the operand
+# stack across the branch guard, and the guard's NOT-taken arm resumes
+# with that kept temp live (the #124 kept-stack snapshot shape).  Both the
+# `and` (keeps the falsy left = 0) and `or` (keeps the truthy left) forms
+# are covered, with a flip frequency (every 7th / every 3rd iteration) that
+# makes the guard fail on a varying schedule.
+#
+# Pure arithmetic only, so the checksum is deterministic across runtimes —
+# a parity regression target for the kept-stack branch-guard path.
+N = 200000
+
+
+def main():
+    total = 0
+    i = 0
+    while i < N:
+        a = (i % 7) and (i + 3)
+        b = (i % 3) or (i + 7)
+        c = (i % 5) and (i - 1) or (i + 2)
+        total = total + a + b + c
+        i = i + 1
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/swap_except_return_resume.py
+++ b/pyre/bench/synth/swap_except_return_resume.py
@@ -1,0 +1,58 @@
+# A hot loop FOLLOWED by a try/except whose handler `return`s.  The
+# `return`-from-`except` cleanup compiles to `SWAP 2; POP_EXCEPT;
+# RETURN_VALUE` (the SWAP exchanges the return value with the saved
+# exception state so POP_EXCEPT can pop the state and leave the value at
+# TOS).  The try/except is reached only after the loop's exit guard fails,
+# so the blackhole walks forward through the SWAP on the resume path.
+# Previously the codewriter emitted `abort_permanent` for SWAP, so the
+# resume walk failed ("call failed" / uncaught escape).  This bench pins
+# that the SWAP-bearing handler tail resumes byte-identically.
+N = 2000000
+
+
+def raise_then_return(n):
+    i = 0
+    while i < n:
+        i = i + 1
+    try:
+        raise ValueError(i)
+    except ValueError:
+        return -1
+    return 0
+
+
+def raise_then_return_value(n):
+    i = 0
+    s = 0
+    while i < n:
+        s = s + i
+        i = i + 1
+    try:
+        raise ValueError(s)
+    except ValueError as e:
+        return e.args[0] + 7
+    return 0
+
+
+def computed_except_return(n):
+    i = 0
+    acc = 0
+    while i < n:
+        acc = acc + (i & 1)
+        i = i + 1
+    try:
+        raise IndexError(acc)
+    except IndexError as e:
+        # `return acc - e.args[0] + 5` computes the value before
+        # POP_EXCEPT, forcing the SWAP-2 reorder in the handler tail.
+        return acc - e.args[0] + 5
+    return 0
+
+
+def main():
+    print(raise_then_return(N))
+    print(raise_then_return_value(N))
+    print(computed_except_return(N))
+
+
+main()

--- a/pyre/bench/synth/swap_except_return_resume.py
+++ b/pyre/bench/synth/swap_except_return_resume.py
@@ -49,10 +49,28 @@ def computed_except_return(n):
     return 0
 
 
+def multi_clause_second(n):
+    # Multiple except clauses reached via loop-exit resume: the raised
+    # IndexError must skip the (non-matching) KeyError clause and be caught
+    # by the second clause.  Exercises CHECK_EXC_MATCH against a proper
+    # exception type object on the resume walk.
+    i = 0
+    while i < n:
+        i = i + 1
+    try:
+        raise IndexError(i)
+    except KeyError:
+        return -100
+    except IndexError:
+        return i - 3
+    return 0
+
+
 def main():
     print(raise_then_return(N))
     print(raise_then_return_value(N))
     print(computed_except_return(N))
+    print(multi_clause_second(N))
 
 
 main()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3698,44 +3698,7 @@ impl OpcodeStepExecutor for PyFrame {
     fn list_extend(&mut self, _i: usize) -> Result<(), PyError> {
         let iterable = self.pop();
         let list = self.peek();
-        unsafe {
-            if pyre_object::is_list(iterable) {
-                let src_len = pyre_object::w_list_len(iterable);
-                for j in 0..src_len {
-                    if let Some(item) = pyre_object::w_list_getitem(iterable, j as i64) {
-                        pyre_object::w_list_append(list, item);
-                    }
-                }
-                return Ok(());
-            }
-            if pyre_object::is_tuple(iterable) {
-                let src_len = pyre_object::w_tuple_len(iterable);
-                for j in 0..src_len {
-                    if let Some(item) = pyre_object::w_tuple_getitem(iterable, j as i64) {
-                        pyre_object::w_list_append(list, item);
-                    }
-                }
-                return Ok(());
-            }
-            // Generic iter-protocol fallback for dict/set/range/generator/etc.
-            let iter = crate::baseobjspace::iter(iterable).map_err(|_| {
-                let type_name = (*(*iterable).ob_type).name;
-                PyError::type_error(format!(
-                    "Value after * must be an iterable, not {}",
-                    type_name
-                ))
-            })?;
-            loop {
-                match crate::baseobjspace::next(iter) {
-                    Ok(item) => {
-                        pyre_object::w_list_append(list, item);
-                    }
-                    Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-                    Err(e) => return Err(e),
-                }
-            }
-        }
-        Ok(())
+        crate::opcode_ops::list_extend_value(list, iterable)
     }
 
     fn unsupported(

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -179,6 +179,49 @@ pub fn bool_value_from_truth(value: bool) -> PyObjectRef {
     w_bool_from(value)
 }
 
+/// LIST_EXTEND — extend `list` in place with the items of `iterable`.
+/// Shared by the interpreter's `list_extend` handler and the JIT residual
+/// `bh_list_extend_fn`.  Mirrors `list.extend`: fast paths for list/tuple
+/// sources, generic iterator-protocol fallback otherwise (which surfaces
+/// "Value after * must be an iterable, not <T>" when not iterable).
+pub fn list_extend_value(list: PyObjectRef, iterable: PyObjectRef) -> Result<(), PyError> {
+    unsafe {
+        if pyre_object::is_list(iterable) {
+            let src_len = pyre_object::w_list_len(iterable);
+            for j in 0..src_len {
+                if let Some(item) = pyre_object::w_list_getitem(iterable, j as i64) {
+                    pyre_object::w_list_append(list, item);
+                }
+            }
+            return Ok(());
+        }
+        if pyre_object::is_tuple(iterable) {
+            let src_len = pyre_object::w_tuple_len(iterable);
+            for j in 0..src_len {
+                if let Some(item) = pyre_object::w_tuple_getitem(iterable, j as i64) {
+                    pyre_object::w_list_append(list, item);
+                }
+            }
+            return Ok(());
+        }
+        // Generic iter-protocol fallback for dict/set/range/generator/etc.
+        let iter = crate::baseobjspace::iter(iterable).map_err(|_| {
+            let type_name = (*(*iterable).ob_type).name;
+            PyError::type_error(format!("Value after * must be an iterable, not {}", type_name))
+        })?;
+        loop {
+            match crate::baseobjspace::next(iter) {
+                Ok(item) => {
+                    pyre_object::w_list_append(list, item);
+                }
+                Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    Ok(())
+}
+
 #[majit_macros::jit_may_force]
 pub extern "C" fn jit_truth_value(value: i64) -> i64 {
     truth_value(value as PyObjectRef) as i64

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -207,7 +207,10 @@ pub fn list_extend_value(list: PyObjectRef, iterable: PyObjectRef) -> Result<(),
         // Generic iter-protocol fallback for dict/set/range/generator/etc.
         let iter = crate::baseobjspace::iter(iterable).map_err(|_| {
             let type_name = (*(*iterable).ob_type).name;
-            PyError::type_error(format!("Value after * must be an iterable, not {}", type_name))
+            PyError::type_error(format!(
+                "Value after * must be an iterable, not {}",
+                type_name
+            ))
         })?;
         loop {
             match crate::baseobjspace::next(iter) {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5164,13 +5164,49 @@ fn collect_outer_active_boxes(
                     guard_banks.ref_, banks.ref_,
                 );
             }
-            resume_only_stack
+            let mut subst: std::collections::HashMap<u32, OpRef> = resume_only_stack
                 .into_iter()
                 .zip(guard_only)
                 .map(|((_, resume_color), guard_color)| {
                     (resume_color, regs_r[guard_color as usize])
                 })
-                .collect()
+                .collect();
+            // Live-across kept stack slot: a Ref color live at BOTH the
+            // guard and the resume point (same color) names an operand-
+            // stack slot the not-taken arm preserves.  The walker wrote
+            // its value into the color-indexed `registers_r` bank, but the
+            // `virtualizable_boxes` shadow the owns_vable read sources from
+            // is never updated on the walker path (only the retired trait
+            // `write_stack_slot` writes it), so the shadow returns a stale
+            // trace-seed box.  Supply the walker bank value directly.  Only
+            // genuinely live-across colors qualify (a guard-pc-only scratch
+            // reusing the color is excluded by the `guard_set` membership
+            // test), so a speculatively const-folded kept value absent from
+            // the guard register state still falls through unchanged.
+            for &c in &banks.ref_ {
+                if !guard_set.contains(&c) || subst.contains_key(&c) {
+                    continue;
+                }
+                let Some(s) = crate::state::semantic_ref_slot_for_reg_color(
+                    nlocals,
+                    valid_stack_only,
+                    &local_color_map,
+                    &stack_color_map,
+                    &live_locals,
+                    c as usize,
+                ) else {
+                    continue;
+                };
+                if s < nlocals {
+                    continue;
+                }
+                if let Some(v) = regs_r.get(c as usize).copied() {
+                    if v != OpRef::NONE {
+                        subst.insert(c, v);
+                    }
+                }
+            }
+            subst
         }
         _ => std::collections::HashMap::new(),
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7692,6 +7692,16 @@ fn dispatch_residual_call_iRd_kind(
             write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
+        // #124: a TO_BOOL / POP_JUMP truth residual on a provably-int box
+        // (e.g. the `(i % 7)` in `(i % 7) and (i + 3)`) folds to a pure
+        // `int_is_true`, eliding the may-force call whose force/exc guards
+        // mis-resume the kept short-circuit stack.
+        if ei.pyre_helper == majit_ir::PyreHelperKind::Truth {
+            if let Some(truth) = try_walker_specialize_truth_int(ctx, op.pc, r_args[0])? {
+                write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
+                return Ok((DispatchOutcome::Continue, op.next_pc));
+            }
+        }
     }
 
     // #62: specialize STORE_SUBSCR `list[int] = value` (int / float storage,
@@ -8018,6 +8028,41 @@ fn walker_concrete_ref_object(
         }
         _ => None,
     }
+}
+
+/// #124: walker-native truth specialization for the `truth_fn` residual
+/// (oopspec [`majit_ir::PyreHelperKind::Truth`]).  When the sole Ref operand
+/// is a concrete boxed `W_IntObject` (excluding `W_BoolObject`, whose vtable
+/// + 1-byte `boolval` layout differs), unbox it (`GUARD_CLASS INT` +
+/// `getfield intval`) and record `int_is_true`, stamping the folded concrete
+/// truth.  Returns the raw truth `OpRef` on success; `None` when the operand
+/// is not a concrete non-bool int — the caller then falls through to the
+/// generic may-force residual, preserving `__bool__` / `__len__` semantics.
+///
+/// Eliding the `CALL_MAY_FORCE` here also removes its `GUARD_NOT_FORCED` /
+/// `GUARD_NO_EXCEPTION`, whose kept-stack blackhole resume reads NULL peeled
+/// outer-Label slots in the short-circuit value-context shape
+/// (`(i % 7) and ...`).
+fn try_walker_specialize_truth_int(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    operand: OpRef,
+) -> Result<Option<OpRef>, DispatchError> {
+    let Some(obj) = walker_concrete_ref_object(ctx, operand) else {
+        return Ok(None);
+    };
+    let val = unsafe {
+        if !pyre_object::is_int(obj) || pyre_object::is_bool(obj) {
+            return Ok(None);
+        }
+        pyre_object::w_int_get_value(obj)
+    };
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    let raw = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
+    let truth = ctx.trace_ctx.record_op(OpCode::IntIsTrue, &[raw]);
+    ctx.trace_ctx
+        .set_opref_concrete(truth, majit_ir::Value::Int((val != 0) as i64));
+    Ok(Some(truth))
 }
 
 fn walker_int_specialization_operands(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2301,6 +2301,7 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
         &sym.registers_f,
         outer_jitcode_index,
         entry_py_pc,
+        None,
     );
 
     // pyjitpl.py:82-90 `setup` per-bank allocation: each bank gets
@@ -4960,6 +4961,7 @@ fn collect_outer_active_boxes(
     regs_f: &[OpRef],
     outer_jitcode_index: u32,
     entry_py_pc: u32,
+    guard_py_pc: Option<u32>,
 ) -> Vec<OpRef> {
     let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
         outer_jitcode_index as i32,
@@ -5097,8 +5099,92 @@ fn collect_outer_active_boxes(
         }
         active.push(v);
     }
+    // #124 kept-stack recovery (gated by `guard_py_pc`, set only on the
+    // `PYRE_RELAX_124` branch-guard path).  A branch guard's not-taken arm
+    // resumes at a merge point whose live Ref colors are filled by the
+    // not-taken edge's register move — colors the walk has NOT written at
+    // the guard point, because that move executes only when the branch is
+    // taken at runtime.  Reading `registers_r[merge_color]` there yields a
+    // stale/color-reused box (the #124 corruption: it decodes to a wrong
+    // or null value on the odd-path iteration).  The kept operand-stack
+    // value lives instead in the guard-pc-only color the edge move reads
+    // from.  Recover `{resume merge color -> guard-pc kept value}`
+    // positionally: the not-taken arm preserves the bottom of the operand
+    // stack, so guard-only Ref colors (live at the guard, dead at resume),
+    // taken in ascending color order (the splice colors operand-stack
+    // slots in push order), supply the values for resume-only Ref colors
+    // that name a stack slot, in ascending semantic-slot order.
+    let kept_stack_subst: std::collections::HashMap<u32, OpRef> = match guard_py_pc {
+        Some(gpc) if gpc != entry_py_pc && owns_vable => {
+            let guard_banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+                outer_jitcode_index as i32,
+                gpc as i32,
+            );
+            let resume_set: std::collections::HashSet<u32> = banks.ref_.iter().copied().collect();
+            let guard_set: std::collections::HashSet<u32> =
+                guard_banks.ref_.iter().copied().collect();
+            // Guard-only Ref colors carrying a real walk value.
+            let mut guard_only: Vec<u32> = guard_banks
+                .ref_
+                .iter()
+                .copied()
+                .filter(|c| !resume_set.contains(c))
+                .filter(|&c| {
+                    regs_r
+                        .get(c as usize)
+                        .copied()
+                        .is_some_and(|v| v != OpRef::NONE)
+                })
+                .collect();
+            guard_only.sort_unstable();
+            // Resume-only Ref colors naming an operand-stack slot.
+            let mut resume_only_stack: Vec<(usize, u32)> = banks
+                .ref_
+                .iter()
+                .copied()
+                .filter(|c| !guard_set.contains(c))
+                .filter_map(|c| {
+                    let s = crate::state::semantic_ref_slot_for_reg_color(
+                        nlocals,
+                        valid_stack_only,
+                        &local_color_map,
+                        &stack_color_map,
+                        &live_locals,
+                        c as usize,
+                    )?;
+                    (s >= nlocals).then_some((s, c))
+                })
+                .collect();
+            resume_only_stack.sort_unstable();
+            if std::env::var_os("PYRE_DIAG124C").is_some() {
+                eprintln!(
+                    "[diag124c] guard_py_pc={gpc} entry_py_pc={entry_py_pc} \
+                     guard_live_r={:?} resume_live_r={:?} guard_only={guard_only:?} \
+                     resume_only_stack={resume_only_stack:?}",
+                    guard_banks.ref_, banks.ref_,
+                );
+            }
+            resume_only_stack
+                .into_iter()
+                .zip(guard_only)
+                .map(|((_, resume_color), guard_color)| {
+                    (resume_color, regs_r[guard_color as usize])
+                })
+                .collect()
+        }
+        _ => std::collections::HashMap::new(),
+    };
     for &idx in &banks.ref_ {
         let color = idx as usize;
+        if let Some(&subst) = kept_stack_subst.get(&idx) {
+            // The guard-pc kept value overrides the (unwritten) merge-color
+            // read for this not-taken-arm operand-stack slot.
+            if subst == OpRef::NONE {
+                panic!("{}", dump_ctx("ref", idx));
+            }
+            active.push(subst);
+            continue;
+        }
         let fallback = || {
             regs_r
                 .get(color)
@@ -5277,6 +5363,21 @@ thread_local! {
     /// which is sound for the side-effect-free leaves this path inlines.
     static INLINE_SUBWALK_CAPTURE_BOUNDARY: std::cell::Cell<bool> =
         const { std::cell::Cell::new(false) };
+
+    /// Set (to the branch guard's own jitcode `op.pc`) only for the
+    /// duration of the `walker_capture_snapshot_for_last_guard` call a
+    /// kept-stack branch guard makes under `PYRE_RELAX_124` (#124).  The
+    /// snapshot helper is invoked with the *resume* coordinate
+    /// (`other_target`, the not-taken arm), so the guard's own coordinate
+    /// is otherwise unavailable to the encoder.  `collect_outer_active_
+    /// boxes` reads this to recover the kept operand-stack value(s): a
+    /// branch guard's not-taken arm resumes at a merge point whose live
+    /// Ref color was minted by the not-taken edge's register move and is
+    /// therefore unwritten in the walk's register file at the guard
+    /// point; the value lives instead in the guard-pc-only color the
+    /// edge move reads from.  Null outside the gated kept-stack path.
+    static BRANCH_GUARD_JITCODE_PC: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(usize::MAX) };
 }
 
 /// RAII guard: mark the current scope as an inline sub-walk (see
@@ -6105,6 +6206,21 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 );
             }
             let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
+            // #124 kept-stack recovery: map the guard's own jitcode pc (set
+            // by the branch handler) to its Python opcode so the encoder can
+            // read the guard-pc liveness — the resume `py_pc` is a not-taken
+            // merge point whose live colors the walk has not written.
+            let guard_py_pc = {
+                let guard_jc_pc = BRANCH_GUARD_JITCODE_PC.with(|c| c.get());
+                if guard_jc_pc == usize::MAX {
+                    None
+                } else {
+                    unsafe {
+                        let jc = &*sym.jitcode;
+                        Some(python_pc_for_jitcode_pc(&jc.payload.metadata, guard_jc_pc))
+                    }
+                }
+            };
             let active = collect_outer_active_boxes(
                 sym,
                 ctx.trace_ctx,
@@ -6113,6 +6229,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 ctx.registers_f,
                 jitcode_index,
                 py_pc,
+                guard_py_pc,
             );
             ctx.trace_ctx
                 .capture_snapshot_for_last_guard_with_vable_vref(
@@ -10510,11 +10627,28 @@ fn handle(
                 // fallback (correct, untraced) rather than compile a trace
                 // that corrupts the frame on every odd-path iteration.
                 // Plain `while` / `if` branches resume at depth 0 and pass.
-                if branch_resume_target_stack_depth(other_target).is_some_and(|d| d > 0) {
+                //
+                // `PYRE_RELAX_124` opens the gate so the kept-stack
+                // recovery path in `collect_outer_active_boxes` can be
+                // validated against the #124 repros before it is trusted
+                // in production; the env var is unset everywhere except the
+                // targeted repro runs, so production stays on the decline.
+                let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
+                if !relax_124
+                    && branch_resume_target_stack_depth(other_target).is_some_and(|d| d > 0)
+                {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);
-                walker_capture_snapshot_for_last_guard(ctx, other_target)?;
+                // Publish the guard's own jitcode coordinate so the snapshot
+                // encoder can recover kept operand-stack values from the
+                // guard-pc register file (the resume coordinate
+                // `other_target` names a merge point whose live colors the
+                // walk has not written at the guard point).
+                BRANCH_GUARD_JITCODE_PC.with(|c| c.set(op.pc));
+                let capture = walker_capture_snapshot_for_last_guard(ctx, other_target);
+                BRANCH_GUARD_JITCODE_PC.with(|c| c.set(usize::MAX));
+                capture?;
             }
             let next_pc = if switchcase != 0 { op.next_pc } else { target };
             Ok((DispatchOutcome::Continue, next_pc))

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1960,6 +1960,15 @@ pub struct PyreSym {
     /// of the vable_array_base-based layout. This ensures bridge traces see
     /// frame locals as symbolic InputArgs, not concrete values.
     pub(crate) bridge_local_oprefs: Option<Vec<OpRef>>,
+    /// Bridge-specific override for the kept operand-stack slice of
+    /// registers_r ([nlocals..nlocals+stack_only], semantic-slot == color
+    /// in that prefix). resume.py:1042 parity: setup_bridge_sym resolves
+    /// the live operand-stack temps from the guard's resume data; this
+    /// preserves them so init_symbolic (which runs AFTER setup_bridge_sym
+    /// in pyre's bridge launcher) does not clobber the rebuilt stack tail
+    /// back to NONE, and so the full-body-walk argbox seed can recover the
+    /// kept conditional-expression / short-circuit value (#124).
+    pub(crate) bridge_stack_oprefs: Option<Vec<OpRef>>,
     /// Bridge-specific override for symbolic_local_types.
     /// virtualizable.py:44 + interp_jit.py:25-31: locals_cells_stack_w[*]
     /// is a W_Root array → all items are Type::Ref. setup_bridge_sym
@@ -3725,6 +3734,7 @@ impl PyreSym {
             valuestackdepth: 0,
             nlocals: 0,
             bridge_local_oprefs: None,
+            bridge_stack_oprefs: None,
             bridge_local_types: None,
             vable_last_instr: OpRef::NONE,
             vable_pycode: OpRef::NONE,
@@ -4058,6 +4068,16 @@ impl PyreSym {
             (0..stack_only_depth)
                 .map(|i| OpRef::input_arg_ref(stack_base + i as u32))
                 .collect()
+        } else if let Some(ref bridge_stack) = self.bridge_stack_oprefs {
+            // #124: a bridge resumes from a guard whose live operand stack
+            // setup_bridge_sym already resolved into these OpRefs. The local
+            // override (above) plus the comment at the bridge_local_oprefs
+            // branch assume setup_bridge_sym overwrites the rebuilt tail,
+            // but pyre's launcher runs setup_bridge_sym BEFORE this; so
+            // preserve the kept temps here rather than reset them to NONE.
+            let mut seed = bridge_stack.clone();
+            seed.resize(stack_only_depth, OpRef::NONE);
+            seed
         } else {
             vec![OpRef::NONE; stack_only_depth]
         };
@@ -7472,6 +7492,22 @@ impl JitState for PyreJitState {
         sym.symbolic_stack_types = vec![Type::Ref; stack_only];
         sym.valuestackdepth = bridge_valuestackdepth;
         sym.bridge_local_oprefs = Some(bridge_locals);
+        // #124: preserve the resolved kept operand-stack temps. Within the
+        // semantic prefix [0..nlocals+stack_only] the abstract-register
+        // color equals the semantic slot, so the stack tail is
+        // `bridge_registers_r[nlocals..nlocals+stack_only]`. init_symbolic
+        // runs AFTER setup_bridge_sym in pyre's bridge launcher and would
+        // otherwise reset this tail to NONE; keeping it lets both the
+        // rebuilt registers_r and the full-body-walk argbox seed recover
+        // the kept conditional-expression / short-circuit value.
+        sym.bridge_stack_oprefs = Some(
+            bridge_registers_r
+                .iter()
+                .skip(nlocals)
+                .take(stack_only)
+                .copied()
+                .collect(),
+        );
         sym.bridge_local_types = Some(bridge_local_types);
 
         // pyjitpl.py:3424 `rebuild_state_after_failure` tail —

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -435,6 +435,7 @@ fn run_perfn_walk(
         return None;
     }
 
+    let is_bridge_trace = ctx.is_bridge_trace;
     let mut mi = crate::state::MIFrame::from_sym(ctx, sym, cf_addr, start_pc, start_pc);
 
     // Resolve the five terminal descrs off MetaInterpStaticData so the
@@ -552,6 +553,27 @@ fn run_perfn_walk(
                     seed(portal_ec_reg as u8, ec_box);
                 } else {
                     seed(2, ec_box);
+                }
+            }
+        }
+        // #124: a bridge enters mid-body, where the loop-header merge-point
+        // colors seeded above (the loop's green pycode / red frame+ec) are
+        // reused for live operand-stack temps — the kept conditional-
+        // expression / short-circuit / chained-compare value.  Leaving e.g.
+        // the pycode green at the kept temp's color feeds a stale code object
+        // into its binary op (`unsupported operand type(s) for +: 'code' and
+        // 'int'`).  Override the kept operand-stack colors
+        // [nlocals..nlocals+stack_only) with the resume-data OpRefs
+        // setup_bridge_sym resolved; in that semantic prefix the abstract-
+        // register color equals the semantic slot.  Locals (read through the
+        // vable) and frame/ec (at their own colors) keep the seeding above.
+        if is_bridge_trace {
+            if let Some(ref bridge_stack) = sym.bridge_stack_oprefs {
+                let nl = sym.nlocals;
+                for (i, &opref) in bridge_stack.iter().enumerate() {
+                    if !opref.is_none() {
+                        seed((nl + i) as u8, opref);
+                    }
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8104,6 +8104,27 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // BINARY_OP walker activation via trait-path delegation.
+        //
+        // Same oparg-payload shape (the operator tag is read from an arm
+        // register the r0-only entry leaves unbound).  Delegate to
+        // `OpcodeStepExecutor::binary_op`, which pops the two operands (via
+        // `pop_value`, advancing vsd), emits the type-specialised
+        // arithmetic IR (`int_add_ovf` &c. behind class guards), and pushes
+        // the result.  Unlike the load/store hooks above this is MAY-RAISE
+        // (TypeError on mismatched operands): `binary_op` returns
+        // `Err(PyError)`, which propagates through
+        // `dispatch_via_walker_for_opcode` to `trace_code_step` exactly as
+        // an `execute_opcode_step` error would on the trait leg, so the
+        // recorder's exception handling is identical on either dispatch
+        // leg.  Bypasses `apply_walker_stack_effect` because `pop_value` /
+        // `push_value` handle vsd.
+        if let Instruction::BinaryOp { op } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::binary_op(self, op.get(op_arg))?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_SUBSCR walker activation via trait-path delegation.
         //
         // The auto-gen arm jitcode for `StoreSubscr` is
@@ -9320,6 +9341,11 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // Distinct from StoreFastStoreFast, which stays trait-routed
             // (#405 arm-entry var_nums seeding).
             | Instruction::StoreFast { .. }
+            // BinaryOp handled by the dispatch_via_walker_for_opcode entry
+            // hook: delegates to OpcodeStepExecutor::binary_op (pop_value
+            // ×2 + specialised arithmetic IR + push_value).  May-raise; the
+            // Err propagates to trace_code_step like the trait leg.
+            | Instruction::BinaryOp { .. }
             | Instruction::ExtendedArg
             | Instruction::Resume { .. }
             | Instruction::Cache

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8062,6 +8062,30 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // LOAD_FAST / LOAD_FAST_BORROW walker activation via trait-path
+        // delegation.  Same oparg-payload shape as LoadConst: the auto-gen
+        // arm reads the `var_num` local index from a register the r0-only
+        // arm entry leaves unbound.  Resolve the local index + name
+        // (mirroring `execute_load_fast`, which serves both opcodes) and
+        // delegate to the existing `OpcodeStepExecutor::load_fast_checked`,
+        // whose vable read + `push_value` emits the specialised IR and
+        // advances vsd.  LoadFastBorrow shares the handler — the
+        // borrow-vs-own distinction is a runtime refcount concern the
+        // symbolic IR does not model.
+        if let Instruction::LoadFast { var_num } | Instruction::LoadFastBorrow { var_num } =
+            instruction
+        {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let idx = pyre_interpreter::load_fast_var_num_to_index(*var_num, op_arg);
+            let name = if idx < pyre_interpreter::code_varnames_len(code) {
+                code.varnames[idx].as_ref()
+            } else {
+                "<cell>"
+            };
+            OpcodeStepExecutor::load_fast_checked(self, idx, name)?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_SUBSCR walker activation via trait-path delegation.
         //
         // The auto-gen arm jitcode for `StoreSubscr` is
@@ -9264,6 +9288,14 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // oparg-derived `&ConstantData` operand left unbound by the
             // r0-only arm entry (ResidualCallArgUnbound).
             | Instruction::LoadConst { .. }
+            // LoadFast / LoadFastBorrow handled by the
+            // dispatch_via_walker_for_opcode entry hook: resolves the
+            // var_num local index + name and delegates to
+            // OpcodeStepExecutor::load_fast_checked (push_value advances
+            // vsd).  The auto-gen arm reads the var_num oparg payload from
+            // a register the r0-only arm entry leaves unbound.
+            | Instruction::LoadFast { .. }
+            | Instruction::LoadFastBorrow { .. }
             | Instruction::ExtendedArg
             | Instruction::Resume { .. }
             | Instruction::Cache

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8062,6 +8062,17 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // LOAD_SMALL_INT walker activation — the const-push sibling of
+        // LoadConst (the small int lives in the oparg itself, not the
+        // constant pool).  Delegate to `OpcodeStepExecutor::load_small_int`
+        // (the same method `execute_load_small_int` calls), which emits an
+        // int ConstRef and pushes via `push_value` (advancing vsd).
+        if let Instruction::LoadSmallInt { i } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::load_small_int(self, i64::from(i.get(op_arg)))?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // LOAD_FAST / LOAD_FAST_BORROW walker activation via trait-path
         // delegation.  Same oparg-payload shape as LoadConst: the auto-gen
         // arm reads the `var_num` local index from a register the r0-only
@@ -9327,6 +9338,10 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // oparg-derived `&ConstantData` operand left unbound by the
             // r0-only arm entry (ResidualCallArgUnbound).
             | Instruction::LoadConst { .. }
+            // LoadSmallInt handled by the entry hook (const-push sibling of
+            // LoadConst; small int in the oparg → load_small_int → int
+            // ConstRef + push_value).
+            | Instruction::LoadSmallInt { .. }
             // LoadFast / LoadFastBorrow handled by the
             // dispatch_via_walker_for_opcode entry hook: resolves the
             // var_num local index + name and delegates to

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8033,7 +8033,35 @@ impl MIFrame {
         &mut self,
         instruction: &Instruction,
         op_arg: pyre_interpreter::OpArg,
+        code: &CodeObject,
     ) -> Result<Option<pyre_interpreter::StepResult<FrontendOp>>, PyError> {
+        // LOAD_CONST walker activation via trait-path delegation.
+        //
+        // The auto-gen arm jitcode for `LoadConst` residualises
+        // `opcode_load_const(frame, &ConstantData)` — the `&ConstantData`
+        // operand is oparg-derived (resolved from `consti` against the
+        // code's constant pool), but the per-opcode arm entry
+        // (`dispatch_via_miframe_at_opcode_entry`) seeds only `r0 = frame`,
+        // leaving that operand register unbound — the walk aborts with
+        // `ResidualCallArgUnbound { arg_index: 2 }`.  (A const-specialising
+        // JIT wants the constant BAKED into the IR, not threaded as a
+        // runtime arg, so seeding the register is also the wrong shape.)
+        //
+        // Resolve the constant here and delegate to the existing
+        // `OpcodeStepExecutor::load_const` (the same method
+        // `execute_load_const` calls on the trait leg), which emits the
+        // type-specialised IR (`ConstRef` / `int_constant` / `str_constant`
+        // / …) and pushes via `push_value` — keeping `sym.valuestackdepth`
+        // / vable shadow / concrete mirror coherent.  Same delegation
+        // pattern as the StoreSubscr / PushNull hooks below; bypasses
+        // `apply_walker_stack_effect` because `push_value` handles vsd.
+        if let Instruction::LoadConst { consti } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            let const_idx = consti.get(op_arg);
+            OpcodeStepExecutor::load_const(self, &code.constants[const_idx])?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_SUBSCR walker activation via trait-path delegation.
         //
         // The auto-gen arm jitcode for `StoreSubscr` is
@@ -8148,6 +8176,7 @@ impl MIFrame {
         &mut self,
         instruction: &Instruction,
         op_arg: pyre_interpreter::OpArg,
+        code: &CodeObject,
     ) -> Result<pyre_interpreter::StepResult<FrontendOp>, PyError> {
         // PyPy `_opimpl_*` direct-record entry point — opcodes that bypass
         // the auto-gen arm-jitcode walk and emit IR / produce concrete
@@ -8156,7 +8185,9 @@ impl MIFrame {
         //
         // Returns `Some(step_result)` when the opcode was handled here.
         // The arm-jitcode walker below runs only when this returns `None`.
-        if let Some(step_result) = self.try_walker_direct_opcode_dispatch(instruction, op_arg)? {
+        if let Some(step_result) =
+            self.try_walker_direct_opcode_dispatch(instruction, op_arg, code)?
+        {
             return Ok(step_result);
         }
 
@@ -8444,7 +8475,7 @@ impl MIFrame {
                     && !in_inline_frame
                     && !foldable_list_load_attr
                 {
-                    self.dispatch_via_walker_for_opcode(&instruction, op_arg)
+                    self.dispatch_via_walker_for_opcode(&instruction, op_arg, code)
                 } else {
                     if flip_probe_enabled() {
                         let reason = if !production_walker_handles(&instruction) {
@@ -9225,6 +9256,14 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
     matches!(
         instruction,
         Instruction::Nop
+            // LoadConst handled by the dispatch_via_walker_for_opcode entry
+            // hook: resolves the constant from `consti` + the code pool and
+            // delegates to `OpcodeStepExecutor::load_const`, whose
+            // `push_value` advances vsd.  The auto-gen arm residualises
+            // `opcode_load_const(frame, &ConstantData)` with the
+            // oparg-derived `&ConstantData` operand left unbound by the
+            // r0-only arm entry (ResidualCallArgUnbound).
+            | Instruction::LoadConst { .. }
             | Instruction::ExtendedArg
             | Instruction::Resume { .. }
             | Instruction::Cache

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8446,6 +8446,16 @@ impl MIFrame {
                 {
                     self.dispatch_via_walker_for_opcode(&instruction, op_arg)
                 } else {
+                    if flip_probe_enabled() {
+                        let reason = if !production_walker_handles(&instruction) {
+                            "not-in-allowlist"
+                        } else if in_inline_frame {
+                            "in-inline-frame"
+                        } else {
+                            "foldable-list-load-attr"
+                        };
+                        flip_probe_record(&instruction, reason);
+                    }
                     let shadow_outcome =
                         crate::shadow_walker::shadow_validate_pre(self, &instruction, op_arg);
                     let result = execute_opcode_step(self, code, instruction, op_arg, pc + 1);
@@ -8975,6 +8985,14 @@ impl MIFrame {
                 // walker, which captures a single-frame snapshot under
                 // `MAJIT_SHADOW_WALKER=1` and would diverge from the
                 // trait dispatcher's multi-frame view in inline frames.
+                if flip_probe_enabled() {
+                    let reason = if self.parent_frames.is_empty() {
+                        "toplevel-inline-step"
+                    } else {
+                        "inline-frame"
+                    };
+                    flip_probe_record(&instruction, reason);
+                }
                 let shadow_outcome = if self.parent_frames.is_empty() {
                     crate::shadow_walker::shadow_validate_pre(self, &instruction, op_arg)
                 } else {
@@ -9353,6 +9371,41 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // following CALL.
             | Instruction::PushNull
     )
+}
+
+/// Phase-5 flip-completion probe: is `PYRE_FLIP_PROBE` set?  Read once.
+/// When set, the trait-dispatch fallback callers record each unique
+/// (opcode, reason) that still bypasses the walker, so the residual flip
+/// surface is measurable against the production workload.  Inert (a
+/// single cached bool load) when unset.
+fn flip_probe_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_FLIP_PROBE").is_some())
+}
+
+/// Record one trait-dispatch fallback hit, deduplicated per
+/// (opcode-variant, reason) so each distinct residual case prints once
+/// instead of once-per-opcode-execution.  `reason` distinguishes
+/// not-in-allowlist vs the context gates (inline-frame / foldable
+/// list-method LOAD_ATTR).
+fn flip_probe_record(instruction: &Instruction, reason: &str) {
+    use std::cell::RefCell;
+    use std::collections::HashSet;
+    thread_local! {
+        static SEEN: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+    }
+    let dbg = format!("{instruction:?}");
+    let name = dbg
+        .split(|c: char| c == ' ' || c == '{' || c == '(')
+        .next()
+        .unwrap_or(&dbg);
+    let key = format!("{name}|{reason}");
+    SEEN.with(|seen| {
+        if seen.borrow_mut().insert(key) {
+            eprintln!("[flip-probe] trait-fallback opcode={name} reason={reason}");
+        }
+    });
 }
 
 /// Apply the symbolic-tracker side effects of a walker-handled opcode.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8086,6 +8086,24 @@ impl MIFrame {
             return Ok(Some(pyre_interpreter::StepResult::Continue));
         }
 
+        // STORE_FAST walker activation via trait-path delegation.
+        //
+        // Same oparg-payload shape as LoadFast (the var_num local index is
+        // read from an arm register the r0-only entry leaves unbound).
+        // Delegate to `OpcodeStepExecutor::store_fast`, which pops the TOS
+        // (via `pop_value`, advancing vsd) and emits the `setarrayitem_
+        // vable_r` local write — a VABLE array write (the JIT-modeled,
+        // resume-safe kind), distinct from a globals-dict write.  The
+        // updated local rides the vable shadow to the live PyFrame through
+        // `synchronize_virtualizable`.  No `code` needed (store_fast takes
+        // only the index); bypasses `apply_walker_stack_effect` because
+        // `pop_value` handles vsd.
+        if let Instruction::StoreFast { var_num } = instruction {
+            use pyre_interpreter::OpcodeStepExecutor;
+            OpcodeStepExecutor::store_fast(self, var_num.get(op_arg).as_usize())?;
+            return Ok(Some(pyre_interpreter::StepResult::Continue));
+        }
+
         // STORE_SUBSCR walker activation via trait-path delegation.
         //
         // The auto-gen arm jitcode for `StoreSubscr` is
@@ -9296,6 +9314,12 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // a register the r0-only arm entry leaves unbound.
             | Instruction::LoadFast { .. }
             | Instruction::LoadFastBorrow { .. }
+            // StoreFast handled by the dispatch_via_walker_for_opcode entry
+            // hook: delegates to OpcodeStepExecutor::store_fast (pop_value
+            // advances vsd, setarrayitem_vable_r writes the local).
+            // Distinct from StoreFastStoreFast, which stays trait-routed
+            // (#405 arm-entry var_nums seeding).
+            | Instruction::StoreFast { .. }
             | Instruction::ExtendedArg
             | Instruction::Resume { .. }
             | Instruction::Cache

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3838,28 +3838,16 @@ pub extern "C" fn bh_compare_fn(lhs: i64, rhs: i64, op_code: i64) -> i64 {
     }
 
     // op_code 10 = CHECK_EXC_MATCH isinstance check (from codewriter CheckExcMatch).
-    // lhs = exception value, rhs = exception type to match.
+    // lhs = exception value, rhs = exception type (or tuple of types) to match.
+    // Mirror the interpreter's `check_exc_match_against` =
+    // `exception_match(type(exc), match_class)` (eval.rs:851) so the match
+    // walks the exception class MRO and accepts a tuple of classes.  The
+    // earlier bespoke `ExcKind`-vs-type-name model only handled str / builtin
+    // function match specs and fell through to an unconditional `true` for a
+    // proper exception type object, which made every `except SomeError:`
+    // appear to match — wrong for any clause beyond the first.
     if op_code == 10 {
-        let matched = unsafe {
-            if !pyre_object::is_exception(lhs) {
-                true
-            } else {
-                let kind = pyre_object::w_exception_get_kind(lhs);
-                if pyre_object::is_str(rhs) {
-                    let type_name = pyre_object::w_str_get_value(rhs);
-                    pyre_object::exc_kind_matches(kind, type_name)
-                } else if pyre_interpreter::is_function(rhs)
-                    && pyre_interpreter::is_builtin_code(
-                        pyre_interpreter::function_get_code(rhs) as pyre_object::PyObjectRef
-                    )
-                {
-                    let type_name = pyre_interpreter::function_get_name(rhs);
-                    pyre_object::exc_kind_matches(kind, type_name)
-                } else {
-                    true
-                }
-            }
-        };
+        let matched = pyre_interpreter::eval::check_exc_match_against(lhs, rhs);
         return pyre_object::w_bool_from(matched) as i64;
     }
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3605,6 +3605,25 @@ pub extern "C" fn bh_delete_subscr_fn(obj: i64, index: i64) -> i64 {
     0
 }
 
+/// LIST_EXTEND residual (`list_extend` HLOp → `residual_call_r_v`).
+/// Runs `list.extend(iterable)` through the shared
+/// `opcode_ops::list_extend_value` (the same code the interpreter's
+/// `list_extend` runs); `list` is peeked and mutated in place.  A
+/// non-iterable operand or a user iterator running Python can raise
+/// (`MayForce`).  Void result, so always returns 0; on error the
+/// exception is published through `BH_LAST_EXC_VALUE` for the trailing
+/// `GuardNoException`, matching `bh_delete_subscr_fn`.
+pub extern "C" fn bh_list_extend_fn(list: i64, iterable: i64) -> i64 {
+    if let Err(err) = pyre_interpreter::opcode_ops::list_extend_value(
+        list as pyre_object::PyObjectRef,
+        iterable as pyre_object::PyObjectRef,
+    ) {
+        let exc_obj = err.to_exc_object();
+        publish_residual_call_exception(exc_obj as i64);
+    }
+    0
+}
+
 /// Compute the LOOKUP_METHOD `null_or_self` for blackhole LOAD_ATTR resume,
 /// given the already-resolved `attr` from [`bh_load_attr_fn`].  Delegates to
 /// the shared `compute_load_method_bound`, a pure MRO inspection that never

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2629,6 +2629,25 @@ fn emit_frontend_delete_attr(
     );
 }
 
+/// LIST_EXTEND — records the 2-arg `list_extend(list, iterable)` HLOp
+/// (void result) that `flatten.rs::lower_list_extend_hlop_to_insn`
+/// threads into the `bh_list_extend_fn(list, iterable)` residual.  The
+/// list is peeked (not popped) — the residual mutates it in place.
+fn emit_frontend_list_extend(
+    block: &super::flow::BlockRef,
+    list: super::flow::FlowValue,
+    iterable: super::flow::FlowValue,
+    offset: i64,
+) {
+    record_graph_op(
+        block,
+        "list_extend",
+        vec![list.into(), iterable.into()],
+        None,
+        offset,
+    );
+}
+
 fn emit_frontend_getattr(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3373,6 +3392,7 @@ struct FnPtrIndices {
     unary_invert_fn: HelperHandle,
     unary_not_fn: HelperHandle,
     load_fast_check_fn: HelperHandle,
+    list_extend_fn: HelperHandle,
 }
 
 /// Register every blackhole helper fn pointer with the assembler in
@@ -3727,6 +3747,14 @@ fn register_helper_fn_pointers(
         cpu.unary_negative_fn as *const (),
         CallFlavor::MayForce,
     );
+    // `bh_list_extend_fn` extends a list in place from an arbitrary
+    // iterable; iterating it runs user `__iter__`/`__next__` → `MayForce`.
+    // Appended last to preserve fn_ptr indices.
+    let list_extend_fn = bind(
+        assembler,
+        cpu.list_extend_fn as *const (),
+        CallFlavor::MayForce,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -3775,6 +3803,7 @@ fn register_helper_fn_pointers(
         unary_invert_fn,
         unary_not_fn,
         load_fast_check_fn,
+        list_extend_fn,
     }
 }
 
@@ -4771,6 +4800,11 @@ impl CodeWriter {
                     idx: load_fast_check_fn_idx,
                     flavor: _load_fast_check_fn_flavor,
                 },
+            list_extend_fn:
+                HelperHandle {
+                    idx: list_extend_fn_idx,
+                    flavor: _list_extend_fn_flavor,
+                },
         } = register_helper_fn_pointers(&mut assembler, self.cpu());
 
         // codewriter.py:37 `portal_jd = self.callcontrol.jitdriver_sd_from_portal_graph(graph)`
@@ -4850,6 +4884,7 @@ impl CodeWriter {
                 unary_invert_fn_idx,
                 unary_not_fn_idx,
                 load_fast_check_fn_idx,
+                list_extend_fn_idx,
             });
         }
 
@@ -8545,10 +8580,33 @@ impl CodeWriter {
                             emit_abort_permanent!(py_pc);
                         }
 
-                        // ListExtend(i): peek list, pop iterable. Net: -1.
-                        Instruction::ListExtend { .. } => {
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            emit_abort_permanent!(py_pc);
+                        // ListExtend(i): PEEK(i) list (mutated in place, stays
+                        // on the stack), POP iterable (TOS). Net: -1.
+                        // `list.extend(iterable)` via the `list_extend` residual.
+                        Instruction::ListExtend { i } => {
+                            let oparg = i.get(op_arg) as usize;
+                            current_depth = current_depth.saturating_sub(1);
+                            emit_vsd!(current_depth, py_pc);
+                            let iterable_value =
+                                pop_ref_or_fresh(&mut current_state, &mut graph);
+                            // PEEK(oparg): after popping the iterable, PEEK(1) is
+                            // the new TOS, so the list sits at `len - oparg`.
+                            // Clone its FlowValue without popping — the residual
+                            // mutates it in place and it stays live for STORE_FAST.
+                            let list_value = {
+                                let len = current_state.stack.len();
+                                if oparg >= 1 && oparg <= len {
+                                    current_state.stack[len - oparg].clone()
+                                } else {
+                                    fresh_ref_value(&mut graph)
+                                }
+                            };
+                            emit_frontend_list_extend(
+                                &current_block.block(),
+                                list_value,
+                                iterable_value,
+                                py_pc as i64,
+                            );
                         }
 
                         // SetUpdate(i): peek set, pop iterable. Net: -1.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8604,8 +8604,7 @@ impl CodeWriter {
                             let oparg = i.get(op_arg) as usize;
                             current_depth = current_depth.saturating_sub(1);
                             emit_vsd!(current_depth, py_pc);
-                            let iterable_value =
-                                pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let iterable_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             // PEEK(oparg): after popping the iterable, PEEK(1) is
                             // the new TOS, so the list sits at `len - oparg`.
                             // Clone its FlowValue without popping — the residual

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8081,15 +8081,68 @@ impl CodeWriter {
                             emit_abort_permanent!(py_pc);
                         }
 
-                        // Swap: swap TOS with TOS[i]. No net stack effect.
-                        // pyopcode.py SWAP / eval.rs:1029-1034.
                         Instruction::Swap { i } => {
+                            // SWAP(n): exchange TOS with the value n
+                            // slots below it.  Stack values flow by symbolic
+                            // `FlowValue` identity — every consumer reads the
+                            // FlowValue, not the positional register (see
+                            // `emit_ref_return!` / `emit_pushvalue_ref!`'s
+                            // `let _ = $src`), and regalloc colors by Variable,
+                            // not by stack position — so the symbolic swap below
+                            // carries the value exchange for the compiled trace.
+                            // The two affected stack slots also mirror to the
+                            // virtualizable array at `stack_base_absolute + depth`
+                            // (jtransform.py:1898 `do_fixed_list_setitem`, vable
+                            // branch); a guard-failure resume walk reconstructs
+                            // the live frame from those slots, so emit the crossed
+                            // `setarrayitem_vable_r` writes that keep the mirror
+                            // consistent.  Previously this arm emitted
+                            // `abort_permanent`, which made any resume walk that
+                            // reached a SWAP (e.g. the `return`-from-`except`
+                            // cleanup `SWAP 2; POP_EXCEPT; RETURN_VALUE`) fail.
                             let depth = i.get(op_arg) as usize;
                             let stack_len = current_state.stack.len();
                             if depth > 0 && depth <= stack_len {
-                                current_state.stack.swap(stack_len - 1, stack_len - depth);
+                                let tos_idx = stack_len - 1;
+                                let other_idx = stack_len - depth;
+                                current_state.stack.swap(tos_idx, other_idx);
+                                if is_portal && tos_idx != other_idx {
+                                    let tos_value = current_state.stack[tos_idx].clone();
+                                    let other_value = current_state.stack[other_idx].clone();
+                                    let tos_slot: super::flow::FlowValue =
+                                        super::flow::Constant::signed(
+                                            (stack_base_absolute + tos_idx) as i64,
+                                        )
+                                        .into();
+                                    let other_slot: super::flow::FlowValue =
+                                        super::flow::Constant::signed(
+                                            (stack_base_absolute + other_idx) as i64,
+                                        )
+                                        .into();
+                                    record_graph_op(
+                                        &current_block.block(),
+                                        "setarrayitem_vable_r",
+                                        vable_setarrayitem_ref_graph_args(
+                                            frame_var.into(),
+                                            tos_slot.into(),
+                                            tos_value.into(),
+                                        ),
+                                        None,
+                                        py_pc as i64,
+                                    );
+                                    record_graph_op(
+                                        &current_block.block(),
+                                        "setarrayitem_vable_r",
+                                        vable_setarrayitem_ref_graph_args(
+                                            frame_var.into(),
+                                            other_slot.into(),
+                                            other_value.into(),
+                                        ),
+                                        None,
+                                        py_pc as i64,
+                                    );
+                                }
                             }
-                            emit_abort_permanent!(py_pc);
                         }
 
                         // LoadFastAndClear: push local, clear it. Net: +1.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1372,14 +1372,22 @@ fn reserve_local_ref_colors_in_place(
 /// re-separated, so the resume reverse map stays non-injective.
 ///
 /// This simulates the same in-order union-find merge the regalloc applies
-/// and skips any pair whose union would place two different frame-local
-/// slots — or a frame-local slot and a stack slot — in one group.  A
-/// skipped pair's endpoints get a `*_copy` at flatten time instead of
-/// sharing a register — correct, since they hold distinct frame slots.
-/// Two stack slots MAY still coalesce (their colors are allowed to alias),
-/// matching [`collect_distinct_slot_interference_pairs`], so within-slot
-/// pairs and stack↔stack pairs are kept.  Splice-only (production passes
-/// the unfiltered pairs and is byte-identical).
+/// and skips any pair whose union would place two different frame slots —
+/// two distinct frame-local slots, two distinct stack slots, or a
+/// frame-local and a stack slot — in one group.  A skipped pair's
+/// endpoints get a `*_copy` at flatten time instead of sharing a register —
+/// correct, since they hold distinct frame slots.  Two distinct stack slots
+/// must not coalesce either: a guard compare's two operands occupy adjacent
+/// stack slots and are simultaneously live, so merging them aliases one
+/// register across both operands and the pre-merge voids the SSA-liveness
+/// edge that would otherwise keep them apart (the assumption in
+/// [`collect_distinct_slot_interference_pairs`] that simultaneously-live
+/// stack slots interfere through normal liveness only holds once the
+/// pre-merge no longer collapses them).  Distinct stack slots that are
+/// disjoint-live stay free to share a color — the chordal coloring aliases
+/// them when no interference edge forces them apart, so this only forbids
+/// the union-find MERGE, not color reuse.  Only WITHIN-slot pairs survive.
+/// Splice-only (production passes the unfiltered pairs and is byte-identical).
 fn filter_cross_slot_coalesce_pairs(
     pairs: &[(super::flow::VariableId, super::flow::VariableId)],
     walker_slot_for_variable: &[Option<u16>],
@@ -1412,15 +1420,29 @@ fn filter_cross_slot_coalesce_pairs(
     };
     let local_of =
         |id: VariableId| -> Option<u16> { slot_of(id).filter(|s| (*s as usize) < nlocals) };
-    let is_stack =
-        |id: VariableId| -> bool { slot_of(id).is_some_and(|s| (s as usize) >= nlocals) };
+    let stack_of =
+        |id: VariableId| -> Option<u16> { slot_of(id).filter(|s| (*s as usize) >= nlocals) };
+    // Claim at most one slot of a given kind for the merged group, treating
+    // a second distinct slot of that kind as a conflict.  Returns the
+    // claimed slot (if any) or signals a conflict.
+    let claim_slot = |candidates: [Option<u16>; 4]| -> Result<Option<u16>, ()> {
+        let mut claimed: Option<u16> = None;
+        for s in candidates.into_iter().flatten() {
+            match claimed {
+                None => claimed = Some(s),
+                Some(c) if c == s => {}
+                Some(_) => return Err(()),
+            }
+        }
+        Ok(claimed)
+    };
     let mut parent: HashMap<VariableId, VariableId> = HashMap::new();
     // Frame-local slot claimed by each union-find root (absent = the group
     // touches no frame-local slot).
     let mut group_local: HashMap<VariableId, u16> = HashMap::new();
-    // Roots whose group already touches at least one stack slot.
-    let mut group_has_stack: std::collections::HashSet<VariableId> =
-        std::collections::HashSet::new();
+    // Stack slot claimed by each union-find root (absent = the group touches
+    // no stack slot).
+    let mut group_stack: HashMap<VariableId, u16> = HashMap::new();
     let mut kept = Vec::with_capacity(pairs.len());
     for &(a, b) in pairs {
         parent.entry(a).or_insert(a);
@@ -1434,45 +1456,39 @@ fn filter_cross_slot_coalesce_pairs(
         // The single frame-local slot the merged group may claim, or a
         // conflict if the two groups + raw endpoints name 2+ distinct
         // frame-local slots.
-        let mut claimed: Option<u16> = None;
-        let mut conflict = false;
-        for s in [
+        let Ok(claimed_local) = claim_slot([
             group_local.get(&ra).copied(),
             group_local.get(&rb).copied(),
             local_of(a),
             local_of(b),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            match claimed {
-                None => claimed = Some(s),
-                Some(c) if c == s => {}
-                Some(_) => {
-                    conflict = true;
-                    break;
-                }
-            }
-        }
-        if conflict {
+        ]) else {
             continue;
-        }
-        let merged_has_stack = group_has_stack.contains(&ra)
-            || group_has_stack.contains(&rb)
-            || is_stack(a)
-            || is_stack(b);
+        };
+        // Likewise the single stack slot the merged group may claim: two
+        // distinct stack slots hold simultaneously-live values (e.g. the
+        // two operands of a guard compare), so merging them would alias one
+        // register across both and the pre-merge would void the SSA-liveness
+        // edge that keeps them apart.  Reject the cross-slot stack merge.
+        let Ok(claimed_stack) = claim_slot([
+            group_stack.get(&ra).copied(),
+            group_stack.get(&rb).copied(),
+            stack_of(a),
+            stack_of(b),
+        ]) else {
+            continue;
+        };
         // A frame-local slot must not share a register group with any stack
-        // slot (① local↔stack collision), so reject a merge that would put
-        // a claimed local and a stack slot together.
-        if claimed.is_some() && merged_has_stack {
+        // slot (local↔stack collision), so reject a merge that would put a
+        // claimed local and a claimed stack slot together.
+        if claimed_local.is_some() && claimed_stack.is_some() {
             continue;
         }
         parent.insert(rb, ra);
-        if let Some(s) = claimed {
+        if let Some(s) = claimed_local {
             group_local.insert(ra, s);
         }
-        if merged_has_stack {
-            group_has_stack.insert(ra);
+        if let Some(s) = claimed_stack {
+            group_stack.insert(ra, s);
         }
         kept.push((a, b));
     }
@@ -10692,20 +10708,22 @@ mod tests {
         assert!(pairs.is_empty());
     }
 
-    /// The coalesce filter drops a pair that would merge a frame
-    /// local with a stack slot (keeping the local↔stack interference edge
-    /// effective), but keeps a pair that merges two stack slots.
+    /// The coalesce filter drops any pair that would merge two distinct
+    /// frame slots — local↔stack AND stack↔stack — but keeps a within-slot
+    /// pair (two Variables pinned to the same stack slot).
     #[test]
-    fn filter_cross_slot_coalesce_pairs_rejects_local_stack_keeps_stack_stack() {
-        // V0 → local slot 0; V1 → stack slot 3; V2 → stack slot 4.
-        let walker_slot_for_variable = vec![Some(0u16), Some(3u16), Some(4u16)];
-        // local↔stack pair (V0,V1) must be dropped; stack↔stack (V1,V2) kept.
+    fn filter_cross_slot_coalesce_pairs_rejects_all_cross_slot_merges() {
+        // V0 → local slot 0; V1,V3 → stack slot 3; V2 → stack slot 4.
+        let walker_slot_for_variable = vec![Some(0u16), Some(3u16), Some(4u16), Some(3u16)];
+        // local↔stack (V0,V1) dropped; cross-slot stack↔stack (V1,V2)
+        // dropped; within-slot stack (V1,V3) kept.
         let pairs = vec![
             (VariableId(0), VariableId(1)),
             (VariableId(1), VariableId(2)),
+            (VariableId(1), VariableId(3)),
         ];
         let kept = filter_cross_slot_coalesce_pairs(&pairs, &walker_slot_for_variable, 1);
-        assert_eq!(kept, vec![(VariableId(1), VariableId(2))]);
+        assert_eq!(kept, vec![(VariableId(1), VariableId(3))]);
     }
 
     /// A single qualifying frame-local slot yields no interference pairs.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7624,7 +7624,6 @@ impl CodeWriter {
                                 .last()
                                 .cloned()
                                 .unwrap_or_else(|| fresh_ref_value(&mut graph).into());
-                            let scratch_match = ssarepr.fresh_var(Kind::Ref, scratch_ref_base).0;
                             // CheckExcMatch
                             // compare_fn factor refactor.  `compare_fn` is
                             // the same helper used by COMPARE_OP — the
@@ -7654,10 +7653,28 @@ impl CodeWriter {
                                 ResKind::Ref,
                                 py_pc as i64,
                             );
-                            pin!(cmp_result, scratch_match);
-                            let result_value = fresh_ref_value(&mut graph);
+                            // Push the compare result itself, not a fresh
+                            // disconnected ref.  A fresh `result_value` has no
+                            // producing op, so its register colour is never
+                            // written during the body walk; PopJumpIfFalse then
+                            // feeds that unwritten register to `truth_fn`, which
+                            // reads NULL and mis-branches once the regalloc
+                            // colours the fresh ref differently from the compare
+                            // result (reproducible on a nested except resume).
+                            // Mirror CompareOp (codewriter.rs:6744): pin the
+                            // result to the stack slot it is pushed to so
+                            // PopJumpIfFalse's pop re-pins the same value to the
+                            // same slot and `truth_fn` reads the compare's own
+                            // register.
+                            let result_value: super::flow::FlowValue = match cmp_result {
+                                Some(v) => v.into(),
+                                None => fresh_ref_value(&mut graph).into(),
+                            };
+                            if let super::flow::FlowValue::Variable(v) = &result_value {
+                                pin!(Some(*v), stack_base + current_depth);
+                            }
                             current_state.stack.push(result_value.clone());
-                            emit_pushvalue_ref!(current_depth, scratch_match, result_value, py_pc);
+                            emit_pushvalue_ref!(current_depth, current_depth, result_value, py_pc);
                         }
 
                         Instruction::PopExcept => {

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -58,6 +58,9 @@ pub struct Cpu {
     pub binary_slice_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// DELETE_SUBSCR residual — `(obj, index) → void` (`del obj[index]`).
     pub delete_subscr_fn: extern "C" fn(i64, i64) -> i64,
+    /// LIST_EXTEND residual — `(list, iterable) → void` (`list.extend(iterable)`,
+    /// list peeked + mutated in place).
+    pub list_extend_fn: extern "C" fn(i64, i64) -> i64,
     /// DELETE_ATTR residual — `(obj, code, name_idx) → void` (`del obj.name`).
     /// Resolves the name from the code object and runs generic `delattr`.
     pub delete_attr_fn: extern "C" fn(i64, i64, i64) -> i64,
@@ -238,6 +241,7 @@ impl Cpu {
             binary_slice_fn: crate::call_jit::bh_binary_slice_fn,
             delete_subscr_fn: crate::call_jit::bh_delete_subscr_fn,
             delete_attr_fn: crate::call_jit::bh_delete_attr_fn,
+            list_extend_fn: crate::call_jit::bh_list_extend_fn,
             format_simple_fn: crate::call_jit::bh_format_simple_fn,
             format_with_spec_fn: crate::call_jit::bh_format_with_spec_fn,
             convert_value_fn: crate::call_jit::bh_convert_value_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4653,7 +4653,12 @@ fn build_residual_call_r_i_insn_from_operands(
     arg_operand: Operand,
     dst_reg: Register,
 ) -> Insn {
-    let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    let mut effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    // Helper-recognition tag for the full-body walker: a provably-int truth
+    // operand specialises to `guard_class INT` + `getfield intval` +
+    // `int_is_true`, eliding the may-force call's GUARD_NOT_FORCED /
+    // GUARD_NO_EXCEPTION (mirrors the StoreSubscr / BinaryOp tags).
+    effect_info.pyre_helper = majit_ir::PyreHelperKind::Truth;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref],

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3354,6 +3354,13 @@ pub struct LoweringContext {
     /// or raises the unbound NameError (reads no heap, runs no user code →
     /// `Plain`).
     pub load_fast_check_fn_idx: u16,
+    /// `list_extend_fn` descrs-pool index.  LIST_EXTEND records the
+    /// `list_extend(list, iterable)` HLOp lowered to
+    /// `residual_call_r_v(ConstInt(fn_idx), ListR([list, iterable]), Descr)`
+    /// (void result) via [`lower_list_extend_hlop_to_insn`] (the two-Ref
+    /// DELETE_SUBSCR shape); `bh_list_extend_fn` extends the list in place
+    /// from an arbitrary iterable (user `__iter__`/`__next__` → `MayForce`).
+    pub list_extend_fn_idx: u16,
 }
 
 /// Map a BINARY_OP HLOp opname (`add`/.../`xor`/`getitem` plus the
@@ -4827,6 +4834,9 @@ where
     if let Some(insn) = lower_delsubscr_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_list_extend_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
     if let Some(insn) = lower_delete_attr_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
@@ -5568,6 +5578,45 @@ where
     Some(build_residual_call_r_v_insn_from_operands(
         ctx.delete_subscr_fn_idx,
         vec![obj_operand, key_operand],
+        CallFlavor::MayForce,
+        majit_ir::PyreHelperKind::None,
+    ))
+}
+
+/// Lower the LIST_EXTEND pyre HLOp `list_extend(list, iterable)` → void
+/// — the same two-Ref void shape as [`lower_delsubscr_hlop_to_insn`] — to
+/// `residual_call_r_v(ConstInt(list_extend_fn_idx), ListR([list,
+/// iterable]), Descr)`.  `bh_list_extend_fn(list, iterable)` runs
+/// `opcode_ops::list_extend_value` (the same code the interpreter's
+/// `list_extend` runs); iterating an arbitrary iterable may invoke user
+/// `__iter__`/`__next__` → `MayForce`.
+///
+/// Returns `None` for non-`list_extend` opnames or non-void shapes so the
+/// caller can fall through to other lowering arms.
+pub fn lower_list_extend_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "list_extend" {
+        return None;
+    }
+    if op.args.len() != 2 {
+        return None;
+    }
+    if op.result.is_some() {
+        return None;
+    }
+    let list_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let iterable_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.list_extend_fn_idx,
+        vec![list_operand, iterable_operand],
         CallFlavor::MayForce,
         majit_ir::PyreHelperKind::None,
     ))
@@ -7038,6 +7087,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut on = SSARepr::new("setattr_on");
         let mut on_regallocs = make_regallocs();
@@ -7192,6 +7242,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("retired_families");
@@ -7333,6 +7384,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("trailing_live");
@@ -7437,6 +7489,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("multi_block_lowering");
@@ -7585,6 +7638,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("pyre_walker_2exit");
@@ -7778,6 +7832,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         });
 
         let mut regallocs = perform_register_allocation_all_kinds(&graph);
@@ -8020,6 +8075,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8128,6 +8184,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8180,6 +8237,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
 
         let hlop = SpaceOperation::new("sub", vec![lhs.into(), rhs.into()], Some(result.into()), 0);
@@ -8309,6 +8367,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8396,6 +8455,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8454,6 +8514,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8504,6 +8565,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let hlop = SpaceOperation::new("eq", vec![lhs.into(), rhs.into()], Some(result.into()), 0);
         let mut get_register = identity_register_mapper();
@@ -8561,6 +8623,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8645,6 +8708,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8692,6 +8756,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let hlop = SpaceOperation::new("bool", vec![cond.into()], Some(result.into()), 0);
         let mut get_register = identity_register_mapper();
@@ -8753,6 +8818,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8830,6 +8896,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8892,6 +8959,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let hlop = SpaceOperation::new(
             "setitem",
@@ -8969,6 +9037,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9022,6 +9091,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9075,6 +9145,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9133,6 +9204,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9205,6 +9277,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -10600,6 +10673,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         flatten_graph_for_test_with_lowering(&graph, &mut ssarepr, ctx, Some(cpu));
         ssarepr
@@ -10894,6 +10968,7 @@ mod tests {
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
+            list_extend_fn_idx: 0,
         };
         let null_or_self_var = Variable::new(VariableId(10), Kind::Ref);
         let op = super::super::flow::SpaceOperation::new(
@@ -11011,6 +11086,7 @@ mod tests {
             unary_not_fn_idx: 110,
             load_fast_check_fn_idx: 111,
             unary_negative_fn_idx: 112,
+            list_extend_fn_idx: 113,
         };
         let code_const = Constant::new(
             super::super::flow::ConstantValue::Signed(0x2000),


### PR DESCRIPTION
#73

## Summary

JIT full-body-walk (FBW) blackhole-resume fixes, opcode walker flips, and supporting regalloc/IR changes on the `pc-map` branch.

- **LIST_EXTEND residual**: extract the interpreter `list_extend` body into the shared `opcode_ops::list_extend_value`; add the `bh_list_extend_fn` residual (`cpu.list_extend_fn`), record the `list_extend(list, iterable)` HLOp (`emit_frontend_list_extend`), and lower it via `lower_list_extend_hlop_to_insn` (`residual_call_r_v`). The codewriter `ListExtend` arm now peeks the list / pops the iterable instead of emitting `abort_permanent`.
- **SWAP**: lower `Instruction::Swap` to a symbolic stack swap plus crossed `setarrayitem_vable_r` mirror writes (portal only) instead of `abort_permanent`, so a guard-failure resume walk reaching a SWAP (e.g. the `SWAP 2; POP_EXCEPT; RETURN_VALUE` return-from-`except` tail) does not fail.
- **CHECK_EXC_MATCH**: `bh_compare_fn` op_code 10 now calls `eval::check_exc_match_against` (exception class MRO + tuple of types) instead of the `ExcKind`/type-name model that fell through to unconditional `true` for a type object. The codewriter `CheckExcMatch` arm pushes the compare result (pinned to its stack slot) rather than a fresh producer-less ref that regalloc could color to an unwritten register.
- **Residual-call exception routing**: `check_residual_call_exception_after` takes a `next_pos` argument and sets `bh.position` to the post-call site before the in-frame catch search, so a residual call executed during the walk routes a raised exception to the `catch_exception` adjacency after it.
- **GC array-build family**: register `new_array_clear` / `setarrayitem_gc_r` (const- and register-operand variants) in `build_inline_call_only_bh_builder` so a resume walk through a container build (tuple/list/map/set/str) does not panic on an unwired byte.
- **Walker opcode flips (FBW)**: flip `LoadConst`, `LoadSmallInt`, `LoadFast`, `LoadFastBorrow`, `StoreFast`, and `BinaryOp` to the walker via entry-hook delegation to the existing `OpcodeStepExecutor` trait methods; thread `&CodeObject` through `try_walker_direct_opcode_dispatch` / `dispatch_via_walker_for_opcode`; extend `production_walker_handles`. Add the `PYRE_FLIP_PROBE` instrumentation that records each `(opcode, reason)` trait-dispatch fallback.
- **TO_BOOL truth residual**: add `PyreHelperKind::Truth`; tag the `residual_call_r_i` truth helper with it (`flatten.rs`) and specialize a provably-int operand to `guard_class INT` + `getfield intval` + `int_is_true` (`try_walker_specialize_truth_int`), eliding the may-force call.
- **#124 kept-stack recovery** (gated by `PYRE_RELAX_124`): recover kept operand-stack values in a branch-guard snapshot (`collect_outer_active_boxes` `kept_stack_subst`, `BRANCH_GUARD_JITCODE_PC` thread-local); preserve resolved kept stack temps across bridge setup (`PyreSym::bridge_stack_oprefs`, `init_symbolic` seeding, `run_perfn_walk` bridge stack override).
- **Regalloc**: `filter_cross_slot_coalesce_pairs` (splice-only) now also rejects a union that would merge two distinct stack slots, not only local↔stack; only within-slot pairs survive.
- **Benches**: add `build_container_return_resume.py`, `residual_raise_except_resume.py`, `swap_except_return_resume.py`, `short_circuit_value_kept_stack.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized list extension operations (`list.extend()` and `*` unpacking) through specialized JIT code paths
  * Integer truthiness specialization in JIT compilation
  * Improved exception handling during trace resumption with better stack recovery
  * Enhanced operand-stack preservation for bridge traces

* **Tests**
  * Added benchmarks for container operations, exception handling, and short-circuit evaluation during trace resumption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->