### PR TITLE
majit: resized ListRepr port, BUILD_LIST residualization, optheap setfield flush, and truth-value lowering fix

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -182,23 +182,26 @@ jobs:
         test -s build/llbc/pyre-object.ullbc
         test -s build/llbc/pyre-interpreter.ullbc
         test -s build/llbc/pyre-jit.ullbc
+    - name: Free up runner disk space
+      if: runner.os == 'Linux'
+      shell: bash
+      # `cargo test --all` builds every workspace member, and the majit
+      # demo interpreters (tlr/tl/tla/tiny2/tiny3/tinyframe/braininterp/
+      # tlc/calc) plus the wasm crates each statically link the full
+      # selected backend. On the cranelift leg those extra binaries
+      # overflow the ubuntu runner's default free disk during the link
+      # (`No space left on device` -> ld terminates with SIGBUS). Reclaim
+      # the preinstalled toolchains CI never uses (~20+ GB) so the whole
+      # workspace's tests build and run instead of excluding crates.
+      run: |
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+          /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
+        sudo docker image prune --all --force || true
+        df -h /
     - name: Run cargo test for ${{ matrix.backend }}
-      # `--workspace` minus the standalone majit demo interpreters and the
-      # wasm crates. Each statically links the full selected backend
-      # (the examples default to cranelift), so `cargo test --all` builds
-      # ~11 redundant backend-linked binaries on top of the real targets;
-      # on the cranelift leg that overflows the ubuntu runner disk during
-      # the link (`No space left on device` -> ld terminates with SIGBUS).
-      # None of the excluded crates carry pyre coverage — pyre plus the
-      # majit crates pyre depends on stay fully tested under both backends.
       env:
         BACKEND: ${{ matrix.backend }}
-      run: >-
-        cargo test --workspace
-        --exclude tlr --exclude tl --exclude tla --exclude tiny2 --exclude tiny3
-        --exclude tinyframe --exclude braininterp --exclude tlc --exclude calc
-        --exclude pyre-wasm --exclude pyre-wasm-test
-        --no-default-features --features "$BACKEND"
+      run: cargo test --all --no-default-features --features "$BACKEND"
 
   pyre-check:
     name: pyre/check.py (${{ matrix.os }})

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -183,9 +183,22 @@ jobs:
         test -s build/llbc/pyre-interpreter.ullbc
         test -s build/llbc/pyre-jit.ullbc
     - name: Run cargo test for ${{ matrix.backend }}
+      # `--workspace` minus the standalone majit demo interpreters and the
+      # wasm crates. Each statically links the full selected backend
+      # (the examples default to cranelift), so `cargo test --all` builds
+      # ~11 redundant backend-linked binaries on top of the real targets;
+      # on the cranelift leg that overflows the ubuntu runner disk during
+      # the link (`No space left on device` -> ld terminates with SIGBUS).
+      # None of the excluded crates carry pyre coverage — pyre plus the
+      # majit crates pyre depends on stay fully tested under both backends.
       env:
         BACKEND: ${{ matrix.backend }}
-      run: cargo test --all --no-default-features --features "$BACKEND"
+      run: >-
+        cargo test --workspace
+        --exclude tlr --exclude tl --exclude tla --exclude tiny2 --exclude tiny3
+        --exclude tinyframe --exclude braininterp --exclude tlc --exclude calc
+        --exclude pyre-wasm --exclude pyre-wasm-test
+        --no-default-features --features "$BACKEND"
 
   pyre-check:
     name: pyre/check.py (${{ matrix.os }})

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -78,11 +78,13 @@ jobs:
       id: charon-cache
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        # The installed charon/charon-driver + .installed-version stamp, plus
-        # (Windows only) the from-source git clone + cargo target/release.
-        path: |
-          .pyre-build/charon
-          .pyre-build/charon-src
+        # Only the installed charon/charon-driver + .installed-version stamp —
+        # all the skip check (charon_bin + stamp) and the main build need.
+        # The Windows from-source tree (.pyre-build/charon-src) is NOT cached:
+        # it shares this key with the binary, so it never aids a miss (a miss
+        # restores nothing and rebuilds fully regardless) and only bloats the
+        # entry against the repo-wide 10 GB cache budget.
+        path: .pyre-build/charon
         key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
         restore-keys: |
           charon-bin-${{ runner.os }}-${{ runner.arch }}-
@@ -116,6 +118,19 @@ jobs:
       if: steps.llbc-cache.outputs.cache-hit != 'true'
       shell: bash
       run: scripts/extract-llbc.py pyre-object pyre-interpreter pyre-jit
+    - name: Upload LLBC artifact
+      # Hand the ullbc set (freshly extracted, or restored from the cache
+      # above) to the downstream jobs as a run-scoped artifact. Unlike
+      # actions/cache, an artifact is exempt from the repo-wide 10 GB cache
+      # budget and its LRU eviction, so a small ullbc set cannot be evicted
+      # between this job and a late-scheduled consumer. The LLBC cache above
+      # is kept only to skip re-extraction across runs.
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
+        retention-days: 1
+        if-no-files-found: error
 
   cargo-test:
     name: cargo test (${{ matrix.os }}, ${{ matrix.backend }})
@@ -147,34 +162,32 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
-    - name: Compute LLBC fingerprint
-      id: llbc-fingerprint
-      shell: bash
-      run: |
-        value="$(scripts/extract-llbc.py --fingerprint pyre-object pyre-interpreter pyre-jit)"
-        echo "value=${value}" >> "$GITHUB_OUTPUT"
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: |
-          .pyre-build/charon
-          .pyre-build/charon-src
+        path: .pyre-build/charon
         key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
-    - name: Restore LLBC
-      id: restore-llbc
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: build/llbc
-        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
-    - name: Check prepared cache hits
-      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' || steps.restore-llbc.outputs.cache-hit != 'true' }}
+    - name: Check prepared Charon cache hit
+      # Charon's cache key is shared repo-wide per OS/arch (no per-run
+      # fingerprint), so it stays LRU-warm and rarely evicts; the LLBC set
+      # is handed over as a run-scoped artifact below instead.
+      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        echo "cache miss from prepare-charon-llbc" >&2
+        echo "Charon cache miss from prepare-charon-llbc" >&2
         echo "Charon cache hit: ${{ steps.restore-charon.outputs.cache-hit }}" >&2
-        echo "LLBC cache hit: ${{ steps.restore-llbc.outputs.cache-hit }}" >&2
         exit 1
+    - name: Download LLBC artifact
+      # Run-scoped handoff from prepare-charon-llbc. Unlike actions/cache,
+      # an artifact is exempt from the repo-wide 10 GB cache budget and its
+      # LRU eviction, so a small ullbc set cannot vanish between prepare and
+      # a late-scheduled consumer (the macOS legs start well after the
+      # Linux/Windows legs — long enough for a cached entry to be evicted).
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
     - name: Verify prepared Charon/LLBC
       shell: bash
       run: |
@@ -242,34 +255,32 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
-    - name: Compute LLBC fingerprint
-      id: llbc-fingerprint
-      shell: bash
-      run: |
-        value="$(scripts/extract-llbc.py --fingerprint pyre-object pyre-interpreter pyre-jit)"
-        echo "value=${value}" >> "$GITHUB_OUTPUT"
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: |
-          .pyre-build/charon
-          .pyre-build/charon-src
+        path: .pyre-build/charon
         key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
-    - name: Restore LLBC
-      id: restore-llbc
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: build/llbc
-        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
-    - name: Check prepared cache hits
-      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' || steps.restore-llbc.outputs.cache-hit != 'true' }}
+    - name: Check prepared Charon cache hit
+      # Charon's cache key is shared repo-wide per OS/arch (no per-run
+      # fingerprint), so it stays LRU-warm and rarely evicts; the LLBC set
+      # is handed over as a run-scoped artifact below instead.
+      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        echo "cache miss from prepare-charon-llbc" >&2
+        echo "Charon cache miss from prepare-charon-llbc" >&2
         echo "Charon cache hit: ${{ steps.restore-charon.outputs.cache-hit }}" >&2
-        echo "LLBC cache hit: ${{ steps.restore-llbc.outputs.cache-hit }}" >&2
         exit 1
+    - name: Download LLBC artifact
+      # Run-scoped handoff from prepare-charon-llbc. Unlike actions/cache,
+      # an artifact is exempt from the repo-wide 10 GB cache budget and its
+      # LRU eviction, so a small ullbc set cannot vanish between prepare and
+      # a late-scheduled consumer (the macOS legs start well after the
+      # Linux/Windows legs — long enough for a cached entry to be evicted).
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
     - name: Verify prepared Charon/LLBC
       shell: bash
       run: |
@@ -317,34 +328,32 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
-    - name: Compute LLBC fingerprint
-      id: llbc-fingerprint
-      shell: bash
-      run: |
-        value="$(scripts/extract-llbc.py --fingerprint pyre-object pyre-interpreter pyre-jit)"
-        echo "value=${value}" >> "$GITHUB_OUTPUT"
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: |
-          .pyre-build/charon
-          .pyre-build/charon-src
+        path: .pyre-build/charon
         key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
-    - name: Restore LLBC
-      id: restore-llbc
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: build/llbc
-        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
-    - name: Check prepared cache hits
-      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' || steps.restore-llbc.outputs.cache-hit != 'true' }}
+    - name: Check prepared Charon cache hit
+      # Charon's cache key is shared repo-wide per OS/arch (no per-run
+      # fingerprint), so it stays LRU-warm and rarely evicts; the LLBC set
+      # is handed over as a run-scoped artifact below instead.
+      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        echo "cache miss from prepare-charon-llbc" >&2
+        echo "Charon cache miss from prepare-charon-llbc" >&2
         echo "Charon cache hit: ${{ steps.restore-charon.outputs.cache-hit }}" >&2
-        echo "LLBC cache hit: ${{ steps.restore-llbc.outputs.cache-hit }}" >&2
         exit 1
+    - name: Download LLBC artifact
+      # Run-scoped handoff from prepare-charon-llbc. Unlike actions/cache,
+      # an artifact is exempt from the repo-wide 10 GB cache budget and its
+      # LRU eviction, so a small ullbc set cannot vanish between prepare and
+      # a late-scheduled consumer (the macOS legs start well after the
+      # Linux/Windows legs — long enough for a cached entry to be evicted).
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
     - name: Verify prepared Charon/LLBC
       shell: bash
       run: |

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1702,12 +1702,24 @@ impl OptHeap {
         }
     }
 
-    /// Flush lazy stores for objects that escape as direct residual-call
-    /// arguments. EffectInfo bitstrings describe global heap effects, but a
-    /// callee can still read fields from objects it receives explicitly.
+    /// Flush lazy stores for objects observable by a residual call: the
+    /// objects that escape as direct arguments (and their transitive
+    /// dependency closure), plus any trace-allocated object that has already
+    /// escaped. EffectInfo bitstrings describe global heap effects, but a
+    /// callee can still read fields from objects it receives explicitly or
+    /// reaches through the escaped heap.
     ///
-    /// Keep this selective: unrelated lazy stores may represent loop-carried
-    /// state that should stay pending until the regular guard/JUMP flush.
+    /// Keep this selective: a lazy store on an object that is still UNESCAPED,
+    /// or one this trace never allocated (e.g. an inputarg carrying
+    /// loop-invariant state), must stay pending until the regular guard/JUMP
+    /// flush. A trace-allocated object that has escaped, however, is now
+    /// globally reachable — a residual call can observe its fields, so its
+    /// pending store must be materialized here (the role
+    /// `force_from_effectinfo` fills in RPython once the EffectInfo path is
+    /// fully ported). Storing such a value into an already-escaped container
+    /// (e.g. an int box into a forced array) escapes it via
+    /// `escape_from_write` WITHOUT recording it in the container's dependency
+    /// list, so the argument closure alone does not reach it.
     ///
     /// Do not remove as a cosmetic PyPy-parity cleanup. The direct parity
     /// change was tested with `python3 pyre/check.py --synthetic-only` and
@@ -1718,6 +1730,46 @@ impl OptHeap {
         heap_pass_idx: usize,
         ctx: &mut OptContext,
     ) {
+        // Owners whose pending lazy stores this residual call can observe:
+        // the escaped-argument closure plus any trace-allocated object that
+        // has already escaped. Built before the mutable cache walk below so
+        // the `is_unescaped`/`seen_allocation` queries do not clash with the
+        // `cached_fields`/`cached_arrayitems` borrow.
+        let mut flush_owners: Vec<OpRef> = escaped_owners.to_vec();
+        {
+            let mut consider = |owner_op: OpRef| {
+                let owner = ctx.get_replacement_opref(owner_op);
+                if flush_owners.contains(&owner) {
+                    return;
+                }
+                let allocated_here = self
+                    .seen_allocation
+                    .get(owner.raw() as usize)
+                    .copied()
+                    .unwrap_or(false);
+                let escaped = ctx
+                    .get_box_replacement_box(owner)
+                    .as_ref()
+                    .map_or(false, |b| !self.is_unescaped(b));
+                if allocated_here && escaped {
+                    flush_owners.push(owner);
+                }
+            };
+            for (_field_idx, _descr, cf) in self.cached_fields.iter() {
+                if let Some(lazy_op) = cf.lazy_set.as_ref() {
+                    consider(lazy_op.arg(0).to_opref());
+                }
+            }
+            for (_descr_idx, _, submap) in self.cached_arrayitems.iter() {
+                for (_index, cai) in submap.const_indexes.iter() {
+                    if let Some(lazy_op) = cai.lazy_set.as_ref() {
+                        consider(lazy_op.arg(0).to_opref());
+                    }
+                }
+            }
+        }
+        let escaped_owners: &[OpRef] = &flush_owners;
+
         let mut field_entries: Vec<_> = self
             .cached_fields
             .iter_mut()

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -4186,11 +4186,20 @@ mod tests {
             args: (0..argc).map(|_| Variable::new()).collect(),
             result_ty: ValueType::Int,
         };
-        assert!(!op_canraise(&core_call(&["core", "cmp", "PartialEq", "eq"], 2)));
-        assert!(!op_canraise(&core_call(&["core", "cmp", "PartialOrd", "lt"], 2)));
+        assert!(!op_canraise(&core_call(
+            &["core", "cmp", "PartialEq", "eq"],
+            2
+        )));
+        assert!(!op_canraise(&core_call(
+            &["core", "cmp", "PartialOrd", "lt"],
+            2
+        )));
         assert!(!op_canraise(&core_call(&["core", "slice", "len"], 1)));
         assert!(!op_canraise(&core_call(&["core", "slice", "iter"], 1)));
-        assert!(!op_canraise(&core_call(&["core", "num", "wrapping_mul"], 2)));
+        assert!(!op_canraise(&core_call(
+            &["core", "num", "wrapping_mul"],
+            2
+        )));
         // `min`/`max` lower to a raising `simple_call`, and a wrong arg
         // count falls through to the general raising `Call` arm.
         assert!(op_canraise(&core_call(&["core", "cmp", "min"], 2)));

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -616,6 +616,33 @@ fn is_str_const_define(kind: &OpKind) -> bool {
     )
 }
 
+/// The pure, non-raising flowspace opname a `core::<family>::<leaf>`
+/// method-call bridge lowers to in [`translate_op`], or `None` when the
+/// path is not such a bridge.  The single source of truth shared by
+/// [`translate_op`] (which emits the op) and [`op_canraise`] (which must
+/// agree the emitted op closes no exception edge), so the two tables
+/// cannot drift.  `core::cmp::{min,max}` is deliberately excluded: it
+/// lowers to a `simple_call(<builtin>)` that keeps the ordinary raising
+/// `CallOp` classification.
+fn nonraising_core_bridge_opname(segments: &[String], arg_count: usize) -> Option<&str> {
+    if segments.len() < 3 || segments[0] != "core" {
+        return None;
+    }
+    let family = segments[1].as_str();
+    let leaf = segments[segments.len() - 1].as_str();
+    match (family, leaf) {
+        // Rich comparisons map to the like-named flowspace op; plain
+        // comparisons carry an empty `canraise` (operation.py).
+        ("cmp", "eq" | "ne" | "lt" | "le" | "gt" | "ge") if arg_count == 2 => Some(leaf),
+        ("slice", "len") if arg_count == 1 => Some("len"),
+        ("slice", "iter") if arg_count == 1 => Some("iter"),
+        // `wrapping_mul` is the Rust spelling of upstream's plain `*`
+        // (lltype `int_mul` wraps); plain `mul` raises nothing.
+        ("num", "wrapping_mul") if arg_count == 2 => Some("mul"),
+        _ => None,
+    }
+}
+
 /// `true` iff the flowspace op(s) this `OpKind` lowers to carry a
 /// non-empty `canraise` (`operation.py`).
 ///
@@ -674,6 +701,17 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
         {
             false
         }
+        // `core::cmp::{eq..ge}` / `core::slice::{len,iter}` /
+        // `core::num::wrapping_mul` lower to pure, non-raising flowspace
+        // ops (see `nonraising_core_bridge_opname`); classify the
+        // originating Call the same way so a `?` tail op does not install
+        // an exception edge the lowered op cannot take.  Matched before
+        // the general `Call` arm.
+        OpKind::Call {
+            target: crate::model::CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } if nonraising_core_bridge_opname(segments, args.len()).is_some() => false,
         // simple_call -> `CallOp.canraise` is `[Exception]` for a
         // non-builtin callable (operation.py:648-661).  Constant builtin
         // callables (int / float / chr / unicode) carry the narrower
@@ -1202,43 +1240,34 @@ pub fn translate_op(
                     // chain reaches unaryop.py / binaryop.py /
                     // rbuiltin.py instead of failing FunctionPath
                     // resolution.
-                    if segments.len() >= 3 && segments[0] == "core" {
-                        let family = segments[1].as_str();
+                    // Pure bridges (cmp comparisons / slice len|iter /
+                    // num wrapping_mul) → a like-named non-raising
+                    // flowspace op.  `nonraising_core_bridge_opname` is
+                    // the shared table `op_canraise` mirrors.
+                    if let Some(opname) = nonraising_core_bridge_opname(segments, arg_hls.len()) {
+                        return Ok(vec![FlowspaceOp::new(opname, arg_hls, result)]);
+                    }
+                    // `min`/`max` are the exception: they lower to a
+                    // `simple_call(<builtin>)` (raising like any builtin
+                    // call), so they stay out of the pure-bridge table.
+                    if segments.len() >= 3
+                        && segments[0] == "core"
+                        && segments[1] == "cmp"
+                        && arg_hls.len() == 2
+                    {
                         let leaf = segments[segments.len() - 1].as_str();
-                        match (family, leaf) {
-                            ("cmp", "eq" | "ne" | "lt" | "le" | "gt" | "ge")
-                                if arg_hls.len() == 2 =>
-                            {
-                                return Ok(vec![FlowspaceOp::new(leaf, arg_hls, result)]);
-                            }
-                            ("slice", "len") if arg_hls.len() == 1 => {
-                                return Ok(vec![FlowspaceOp::new("len", arg_hls, result)]);
-                            }
-                            ("slice", "iter") if arg_hls.len() == 1 => {
-                                return Ok(vec![FlowspaceOp::new("iter", arg_hls, result)]);
-                            }
-                            ("num", "wrapping_mul") if arg_hls.len() == 2 => {
-                                return Ok(vec![FlowspaceOp::new("mul", arg_hls, result)]);
-                            }
-                            ("cmp", "min" | "max") if arg_hls.len() == 2 => {
-                                let builtin = HOST_ENV.lookup_builtin(leaf).ok_or_else(|| {
-                                    TyperError::message(format!(
-                                        "builtin `{leaf}` missing from HOST_ENV"
-                                    ))
-                                })?;
-                                let callable = Hlvalue::Constant(Constant::new(
-                                    ConstValue::HostObject(builtin),
-                                ));
-                                let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
-                                call_args.push(callable);
-                                call_args.extend(arg_hls);
-                                return Ok(vec![FlowspaceOp::new(
-                                    "simple_call",
-                                    call_args,
-                                    result,
-                                )]);
-                            }
-                            _ => {}
+                        if matches!(leaf, "min" | "max") {
+                            let builtin = HOST_ENV.lookup_builtin(leaf).ok_or_else(|| {
+                                TyperError::message(format!(
+                                    "builtin `{leaf}` missing from HOST_ENV"
+                                ))
+                            })?;
+                            let callable =
+                                Hlvalue::Constant(Constant::new(ConstValue::HostObject(builtin)));
+                            let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
+                            call_args.push(callable);
+                            call_args.extend(arg_hls);
+                            return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                         }
                     }
                     // `__cast_pointer/<Root>` marker (`front::mir`
@@ -4145,6 +4174,28 @@ mod tests {
         assert!(op_canraise(&binop("div")));
         assert!(!op_canraise(&binop("bitand_assign")));
         assert!(!op_canraise(&binop("add")));
+
+        // `core::*` method bridges that `translate_op` lowers to pure
+        // flowspace ops must classify as non-raising, so a `?` tail does
+        // not install an unreachable exception edge.  Drift here is what
+        // `nonraising_core_bridge_opname` exists to prevent.
+        let core_call = |segs: &[&str], argc: usize| OpKind::Call {
+            target: crate::model::CallTarget::FunctionPath {
+                segments: segs.iter().map(|s| s.to_string()).collect(),
+            },
+            args: (0..argc).map(|_| Variable::new()).collect(),
+            result_ty: ValueType::Int,
+        };
+        assert!(!op_canraise(&core_call(&["core", "cmp", "PartialEq", "eq"], 2)));
+        assert!(!op_canraise(&core_call(&["core", "cmp", "PartialOrd", "lt"], 2)));
+        assert!(!op_canraise(&core_call(&["core", "slice", "len"], 1)));
+        assert!(!op_canraise(&core_call(&["core", "slice", "iter"], 1)));
+        assert!(!op_canraise(&core_call(&["core", "num", "wrapping_mul"], 2)));
+        // `min`/`max` lower to a raising `simple_call`, and a wrong arg
+        // count falls through to the general raising `Call` arm.
+        assert!(op_canraise(&core_call(&["core", "cmp", "min"], 2)));
+        assert!(op_canraise(&core_call(&["core", "cmp", "max"], 2)));
+        assert!(op_canraise(&core_call(&["core", "slice", "len"], 2)));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -126,6 +126,12 @@ pub enum ReprClassId {
     /// (`&[T]`) annotate as a non-resized `SomeList`, so this is the
     /// repr the `len` lowering lands on.
     FixedSizeListRepr,
+    /// `lltypesystem/rlist.py:107 ListRepr(AbstractListRepr,
+    /// BaseListRepr)` — the resized list whose `LIST` lowers to a
+    /// `Ptr(GcStruct("list", ("length", Signed), ("items",
+    /// Ptr(GcArray(ITEM)))))`. Minted when the `listdef` is `resized`
+    /// (an `.append()` consumer marks it so).
+    ListRepr,
     /// `rstr.py:483 AbstractCharRepr` (`CharRepr` lltypesystem
     /// realisation, `lowleveltype = Char`).
     CharRepr,
@@ -192,6 +198,7 @@ impl ReprClassId {
             ClassesPBCRepr => &[ClassesPBCRepr, Repr],
             InstanceRepr => &[InstanceRepr, Repr],
             FixedSizeListRepr => &[FixedSizeListRepr, Repr],
+            ListRepr => &[ListRepr, Repr],
             TupleRepr => &[TupleRepr, Repr],
             CharRepr => &[CharRepr, Repr],
             UniCharRepr => &[UniCharRepr, Repr],

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1284,9 +1284,12 @@ fn rtype_builtin_max(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTy
 /// upstream functions differ only in the `ll_min` / `ll_max` helper
 /// they `gendirectcall`.
 fn rtype_builtin_min_max(hop: &HighLevelOp, helper_name: &str) -> RTypeResult {
+    // Error text names the user-facing builtin (`min` / `max`), not the
+    // internal `ll_*` helper that `gendirectcall` resolves below.
+    let builtin = helper_name.strip_prefix("ll_").unwrap_or(helper_name);
     if hop.nb_args() != 2 {
         return Err(TyperError::message(format!(
-            "{helper_name}: expected nb_args == 2, got {}",
+            "{builtin}: expected nb_args == 2, got {}",
             hop.nb_args()
         )));
     }
@@ -1295,7 +1298,7 @@ fn rtype_builtin_min_max(hop: &HighLevelOp, helper_name: &str) -> RTypeResult {
         r_result_borrow
             .as_ref()
             .cloned()
-            .ok_or_else(|| TyperError::message(format!("{helper_name}: r_result missing")))?
+            .ok_or_else(|| TyperError::message(format!("{builtin}: r_result missing")))?
     };
     let vlist = hop.inputargs(vec![
         ConvertedTo::Repr(r_result.as_ref()),

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -6,12 +6,14 @@
 //! `len` operation by `flowspace_adapter` — lands on this repr's
 //! `rtype_len`.
 //!
-//! The full list repr surface (`ListRepr` resized `GcStruct("list",
-//! length, items)`, the `ADTIList` / `ADTIFixedList` adtmeth tables,
-//! `rtype_method_append` / `getitem` / `setitem` / iterators, and the
-//! `pairtype(BaseListRepr, BaseListRepr)` operations) is deferred to
-//! follow-on slices. Today only the data shape `Ptr(GcArray(ITEM))`
-//! and the `ll_fixed_length` lowering land.
+//! The resized `ListRepr` lands its data shape (`Ptr(GcStruct("list",
+//! ("length", Signed), ("items", Ptr(GcArray(ITEM)))))`) and the
+//! `rtype_len` lowering (`ll_length` reads the `length` field). The
+//! `ADTIList` / `ADTIFixedList` adtmeth tables, `rtype_method_append` /
+//! `getitem` / `setitem` / iterators, the `_ll_list_resize*` family and
+//! the `pairtype(BaseListRepr, BaseListRepr)` operations are deferred to
+//! follow-on slices. For `FixedSizeListRepr` only the data shape
+//! `Ptr(GcArray(ITEM))` and the `ll_fixed_length` lowering land.
 
 use std::rc::Rc;
 use std::sync::Arc;
@@ -22,10 +24,13 @@ use crate::flowspace::model::{
 };
 use crate::flowspace::pygraph::PyGraph;
 use crate::translator::rtyper::error::TyperError;
-use crate::translator::rtyper::lltypesystem::lltype::{ArrayType, LowLevelType, Ptr, PtrTarget};
+use crate::translator::rtyper::lltypesystem::lltype::{
+    ArrayType, LowLevelType, Ptr, PtrTarget, StructType,
+};
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
     ConvertedTo, HighLevelOp, RPythonTyper, helper_pygraph_from_graph, variable_with_lltype,
+    void_field_const,
 };
 
 /// RPython `class FixedSizeListRepr(AbstractFixedSizeListRepr,
@@ -178,4 +183,255 @@ pub(crate) fn build_ll_fixed_length_helper_graph(
         vec!["l".to_string()],
         func,
     ))
+}
+
+/// RPython `class ListRepr(AbstractListRepr, BaseListRepr)`
+/// (`lltypesystem/rlist.py:107-133`):
+///
+/// ```python
+/// def _setup_repr(self):
+///     if 'item_repr' not in self.__dict__:
+///         self.external_item_repr, self.item_repr = externalvsinternal(
+///             self.rtyper, self._item_repr_computer(), gcref=True)
+///     if isinstance(self.LIST, GcForwardReference):
+///         ITEM = self.item_repr.lowleveltype
+///         ITEMARRAY = self.get_itemarray_lowleveltype()
+///         self.LIST.become(GcStruct("list", ("length", Signed),
+///                                           ("items", Ptr(ITEMARRAY)),
+///                                   adtmeths = ADTIList({...}),
+///                                   hints = {'list': True}))
+/// ```
+///
+/// Unlike [`FixedSizeListRepr`] (whose `LIST` is the bare
+/// `GcArray(ITEM)`), the resized list wraps the array in a `length` +
+/// `items` header struct so `append`/resize can grow `items` while the
+/// `length` counter tracks the live element count. The low-level type
+/// is therefore `Ptr(GcStruct("list", length, items))`.
+///
+/// This slice lands the data shape and `rtype_len`; the `ADTIList`
+/// adtmeth table and the `append`/`getitem`/`setitem`/resize ops are
+/// follow-on slices.
+#[derive(Debug)]
+pub struct ListRepr {
+    state: ReprState,
+    lltype: LowLevelType,
+    /// `self.item_repr` (`rlist.py:111`) — the internal (gcref-wrapped)
+    /// element repr.
+    #[allow(dead_code)]
+    item_repr: Arc<dyn Repr>,
+}
+
+impl ListRepr {
+    pub fn new(rtyper: &Rc<RPythonTyper>, item_repr: Arc<dyn Repr>) -> Result<Self, TyperError> {
+        // `externalvsinternal(rtyper, item_repr, gcref=True)` — same
+        // gcref normalisation as `FixedSizeListRepr`: gc `InstanceRepr`
+        // items become the generic `Ptr(OBJECT)` gcref so the array
+        // element type is never a gc container.
+        let (_external, internal) =
+            crate::translator::rtyper::rclass::externalvsinternal(rtyper, item_repr)?;
+        let item_lltype = internal.lowleveltype().clone();
+        // upstream `get_itemarray_lowleveltype()` — `GcArray(ITEM)` (the
+        // `ADTIFixedList` adtmeths it carries are unused until the array
+        // ops land, so the bare array suffices for this slice).
+        let itemarray = ArrayType::gc(item_lltype);
+        let items_ptr = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Array(itemarray),
+        }));
+        // upstream `GcStruct("list", ("length", Signed), ("items",
+        // Ptr(ITEMARRAY)), hints={'list': True})`.
+        let list_struct = StructType::gc_with_hints(
+            "list",
+            vec![
+                ("length".to_string(), LowLevelType::Signed),
+                ("items".to_string(), items_ptr),
+            ],
+            vec![("list".to_string(), ConstValue::Bool(true))],
+        );
+        let lltype = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Struct(list_struct),
+        }));
+        Ok(ListRepr {
+            state: ReprState::new(),
+            lltype,
+            item_repr: internal,
+        })
+    }
+}
+
+impl Repr for ListRepr {
+    fn lowleveltype(&self) -> &LowLevelType {
+        &self.lltype
+    }
+
+    fn state(&self) -> &ReprState {
+        &self.state
+    }
+
+    fn class_name(&self) -> &'static str {
+        "ListRepr"
+    }
+
+    fn repr_class_id(&self) -> super::pairtype::ReprClassId {
+        super::pairtype::ReprClassId::ListRepr
+    }
+
+    /// RPython `AbstractBaseListRepr.rtype_len(self, hop)`
+    /// (`rlist.py:124-130`): the resized list takes the `ll_len`
+    /// (non-foldable) branch, which reads the struct `length` field —
+    /// `ll_length(l)` = `l.length` (`lltypesystem/rlist.py` ADTIList).
+    fn rtype_len(&self, hop: &HighLevelOp) -> RTypeResult {
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_length".to_string(),
+            vec![ptr_lltype],
+            LowLevelType::Signed,
+            move |_rtyper, _args, _result| {
+                build_ll_length_helper_graph("ll_length", ptr_for_builder.clone())
+            },
+        )?;
+        hop.gendirectcall(&helper, vlist)
+    }
+}
+
+/// Synthesise `ll_length(l) -> Signed` (`lltypesystem/rlist.py` ADTIList
+/// `ll_length`):
+///
+/// ```python
+/// def ll_length(l):
+///     return l.length
+/// ```
+///
+/// Single-block graph: `getfield(l, "length") -> Signed`. The receiver
+/// is the `Ptr(GcStruct("list", ...))`, so the length is the struct's
+/// `length` header field (vs `FixedSizeListRepr`'s `getarraysize`).
+pub(crate) fn build_ll_length_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let arg = variable_with_lltype("l", ptr_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(arg.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let v_len = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(arg), void_field_const("length")],
+        Hlvalue::Variable(v_len.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_len)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string()],
+        func,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotator::annrpython::RPythonAnnotator;
+    use crate::translator::rtyper::pairtype::ReprClassId;
+    use crate::translator::rtyper::rint::IntegerRepr;
+
+    fn fresh_rtyper() -> Rc<RPythonTyper> {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        Rc::new(RPythonTyper::new(&ann))
+    }
+
+    /// `initialize_exceptiondata` sets the typer's self-weak, required by
+    /// `rtyper_makerepr`'s `SomeList` arm (`self_rc()`).
+    fn fresh_rtyper_live() -> Rc<RPythonTyper> {
+        let rtyper = fresh_rtyper();
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        rtyper
+    }
+
+    #[test]
+    fn list_repr_lltype_is_ptr_gcstruct_length_items() {
+        // `LIST = GcStruct("list", ("length", Signed), ("items",
+        // Ptr(GcArray(ITEM))))`, lowleveltype `Ptr(LIST)`.
+        let rtyper = fresh_rtyper();
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let repr = ListRepr::new(&rtyper, r_int).expect("ListRepr::new");
+        assert_eq!(repr.class_name(), "ListRepr");
+
+        let LowLevelType::Ptr(ptr) = repr.lowleveltype() else {
+            panic!("ListRepr lltype must be a Ptr");
+        };
+        let PtrTarget::Struct(body) = &ptr.TO else {
+            panic!("ListRepr Ptr target must be a Struct");
+        };
+        assert_eq!(body._name, "list");
+        assert_eq!(body._flds.get("length"), Some(&LowLevelType::Signed));
+        let items = body._flds.get("items").expect("items field");
+        let LowLevelType::Ptr(items_ptr) = items else {
+            panic!("items field must be a Ptr");
+        };
+        assert!(
+            matches!(items_ptr.TO, PtrTarget::Array(_)),
+            "items must point to a GcArray"
+        );
+    }
+
+    #[test]
+    fn makerepr_resized_somelist_routes_to_list_repr() {
+        use crate::annotator::listdef::ListDef;
+        use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
+        use crate::translator::rtyper::rmodel::rtyper_makerepr;
+
+        let rtyper = fresh_rtyper_live();
+        // `resized=true` → the `ListRepr` (resized) branch.
+        let ldef = ListDef::new(
+            None,
+            SomeValue::Integer(SomeInteger::new(false, false)),
+            false,
+            true,
+        );
+        let sv = SomeValue::List(SomeList::new(ldef));
+        let repr = rtyper_makerepr(&sv, &rtyper).expect("rtyper_makerepr resized list");
+        assert_eq!(repr.class_name(), "ListRepr");
+        assert_eq!(repr.repr_class_id(), ReprClassId::ListRepr);
+    }
+
+    #[test]
+    fn makerepr_nonresized_somelist_routes_to_fixed_size_list_repr() {
+        use crate::annotator::listdef::ListDef;
+        use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
+        use crate::translator::rtyper::rmodel::rtyper_makerepr;
+
+        let rtyper = fresh_rtyper_live();
+        // `resized=false` → the `FixedSizeListRepr` branch (unchanged).
+        let ldef = ListDef::new(
+            None,
+            SomeValue::Integer(SomeInteger::new(false, false)),
+            false,
+            false,
+        );
+        let sv = SomeValue::List(SomeList::new(ldef));
+        let repr = rtyper_makerepr(&sv, &rtyper).expect("rtyper_makerepr non-resized list");
+        assert_eq!(repr.class_name(), "FixedSizeListRepr");
+        assert_eq!(repr.repr_class_id(), ReprClassId::FixedSizeListRepr);
+    }
 }

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2946,7 +2946,9 @@ pub fn rtyper_makerepr(
             //      `getarraysize` / item-load ops would compile to
             //      invalid reads off a non-array).
             //   2. resized listdef → `ListRepr` (`GcStruct("list",
-            //      length, items)`) — deferred (the `Err` arm below).
+            //      length, items)`) — data shape + `len` land; the
+            //      `append`/`getitem`/`setitem`/resize ops are follow-on
+            //      slices (`rlist::ListRepr`).
             //   3. non-resized → `FixedSizeListRepr`.
             //
             // Upstream also passes a LAZY `item_repr = lambda:
@@ -2972,6 +2974,7 @@ pub fn rtyper_makerepr(
             // (rlist.py:54-57), exactly as a non-range list does.
             let range_repr_step =
                 range_step.filter(|_| !mutated && !matches!(s_value, SomeValue::Impossible));
+            use crate::translator::rtyper::rlist::{FixedSizeListRepr, ListRepr};
             if let Some(step) = range_repr_step {
                 if step == 1 {
                     Ok(
@@ -2987,21 +2990,15 @@ pub fn rtyper_makerepr(
                         s_list.listdef
                     )))
                 }
-            } else if resized {
-                Err(TyperError::missing_rtype_operation(format!(
-                    "SomeList(resized).rtyper_makerepr — port \
-                     rpython/rtyper/lltypesystem/rlist.py ListRepr (GcStruct length+items) \
-                     (listdef: {:?})",
-                    s_list.listdef
-                )))
             } else {
                 let item_r = rtyper.getrepr(&s_value)?;
                 let rtyper_rc = rtyper.self_rc()?;
-                Ok(
-                    std::sync::Arc::new(crate::translator::rtyper::rlist::FixedSizeListRepr::new(
-                        &rtyper_rc, item_r,
-                    )?) as std::sync::Arc<dyn Repr>,
-                )
+                let repr: std::sync::Arc<dyn Repr> = if resized {
+                    std::sync::Arc::new(ListRepr::new(&rtyper_rc, item_r)?)
+                } else {
+                    std::sync::Arc::new(FixedSizeListRepr::new(&rtyper_rc, item_r)?)
+                };
+                Ok(repr)
             }
         }
         SomeValue::Dict(_) => Err(TyperError::missing_rtype_operation(

--- a/pyre/bench/synth/build_list_resume.py
+++ b/pyre/bench/synth/build_list_resume.py
@@ -1,0 +1,19 @@
+N = 2000000
+
+
+def main():
+    total = 0
+    i = 0
+    while i < N:
+        # A 5-element list display compiles to BUILD_LIST 5 (argc > 3),
+        # the arbitrary-arity form that the fixed three-slot build_list_fn
+        # cannot cover.  The varying elements make the loop's guards deopt,
+        # so the blackhole walks the portal jitcode through BUILD_LIST and
+        # builds the list directly on resume instead of aborting the trace.
+        lst = [i, i + 1, i + 2, i + 3, i + 4]
+        total += (lst[0] + lst[4]) & 7
+        i += 1
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/unary_positive_resume.py
+++ b/pyre/bench/synth/unary_positive_resume.py
@@ -1,0 +1,18 @@
+N = 2000000
+
+
+def main():
+    total = 0
+    i = 0
+    while i < N:
+        # `+x` compiles to CALL_INTRINSIC_1 INTRINSIC_UNARY_POSITIVE.
+        # The varying operands make the loop's guards deopt, so the
+        # blackhole walks the portal jitcode through CALL_INTRINSIC_1 and
+        # computes `+value` directly on resume instead of aborting the
+        # trace.
+        total += (+i + +(i + 1)) & 7
+        i += 1
+    print(total)
+
+
+main()

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1149,12 +1149,20 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             "rangeobject::LONG_RANGE_ITER_TYPE",
             rangeobject::LONG_RANGE_ITER_TYPE
         ),
+        pytype_addr!("sreobject::SRE_MATCH_TYPE", sreobject::SRE_MATCH_TYPE),
+        pytype_addr!("sreobject::SRE_PATTERN_TYPE", sreobject::SRE_PATTERN_TYPE),
+        pytype_addr!(
+            "genericaliasobject::GENERIC_ALIAS_TYPE",
+            genericaliasobject::GENERIC_ALIAS_TYPE
+        ),
+        pytype_addr!("superobject::SUPER_TYPE", superobject::SUPER_TYPE),
+        pytype_addr!("unionobject::UNION_TYPE", unionobject::UNION_TYPE),
         // `pyre_interpreter`-local `PyType` singletons.  The `pytype_addr!`
         // macro emits `&pyre_object::$path` and cannot reach these
         // crate-local statics, so capture their addresses directly.  The
         // keys match the front-end `["pyre_interpreter", module, NAME]`
         // global-read segments via the `static_key_matches` `::`-suffix
-        // rule, so the `module::NAME` form suffices.  All four are
+        // rule, so the `module::NAME` form suffices.  All five are
         // compile-time `static … : PyType = new_pytype(…)` so the captured
         // address is the stable runtime identity.
         (
@@ -1168,6 +1176,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
         (
             "gateway::BUILTIN_CODE_TYPE",
             &crate::gateway::BUILTIN_CODE_TYPE as *const _ as i64,
+        ),
+        (
+            "pycode::CODE_TYPE",
+            &crate::pycode::CODE_TYPE as *const _ as i64,
         ),
         (
             "pytraceback::PYTRACEBACK_TYPE",

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3990,6 +3990,22 @@ pub extern "C" fn bh_newtuple_from_array(array: i64) -> i64 {
     pyre_interpreter::runtime_ops::build_tuple_from_refs(&items) as i64
 }
 
+/// BUILD_LIST arbitrary-arity residual: `space.newlist(items_w)`.  The
+/// arity-`> 3` form of BUILD_LIST that the fixed `build_list_fn` (three
+/// item slots) cannot cover; the items travel inside a length-prefixed
+/// forced array exactly like [`bh_newtuple_from_array`].  Allocation-only
+/// (`build_list_from_refs` = `w_list_new`), so `CallFlavor::Plain` with
+/// no trailing `GuardNoException`.
+pub extern "C" fn bh_newlist_from_array(array: i64) -> i64 {
+    let arr = array as *const pyre_object::object_array::GcTypedArray;
+    let len = pyre_object::object_array::gcarray_len(arr);
+    let mut items: Vec<pyre_object::PyObjectRef> = Vec::with_capacity(len);
+    for i in 0..len {
+        items.push(pyre_object::object_array::getarrayitem_ref(arr, i));
+    }
+    pyre_interpreter::runtime_ops::build_list_from_refs(&items) as i64
+}
+
 /// BUILD_MAP residual — the dict counterpart of [`bh_newtuple_from_array`].
 /// The length-prefixed array holds the interleaved `[k0, v0, k1, v1, ...]`
 /// pairs the codewriter unrolled via `setarrayitem_gc_r`;
@@ -4224,23 +4240,6 @@ pub extern "C" fn bh_load_fast_check_fn(value: i64, w_code_ptr: i64, name_idx: i
     .to_exc_object();
     publish_residual_call_exception(exc_obj as i64);
     0
-}
-
-/// BUILD_LIST: `space.newlist(list_w)` consuming a length-prefixed
-/// `GcTypedArray` of refs — the forced `popvalues_mutable` list
-/// (`pyframe.py:408-419`).  Length travels inside the array (offset-0
-/// prefix), so there is no arity cap.  Allocation-only; the items are
-/// pre-existing heap refs, no user code runs.  `w_list_new` selects the
-/// element strategy (`listobject.rs:381`), so a homogeneous-int list
-/// unboxes to the Integer strategy and carries no off-heap ref block.
-pub extern "C" fn bh_newlist_from_array(array: i64) -> i64 {
-    let arr = array as *const pyre_object::object_array::GcTypedArray;
-    let len = pyre_object::object_array::gcarray_len(arr);
-    let mut items: Vec<pyre_object::PyObjectRef> = Vec::with_capacity(len);
-    for i in 0..len {
-        items.push(pyre_object::object_array::getarrayitem_ref(arr, i));
-    }
-    pyre_interpreter::runtime_ops::build_list_from_refs(&items) as i64
 }
 
 #[cfg(test)]

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -142,9 +142,9 @@ pub struct Cpu {
     /// Fragments are already strings (formatted first), so this runs no
     /// user code and is infallible (`Plain`).
     pub build_string_from_array_fn: extern "C" fn(i64) -> i64,
-    /// `newlist(list_w)` — (ref array) → new list.  The array is the
-    /// forced `popvalues_mutable` list; length travels inside the array,
-    /// so any arity fits.
+    /// `newlist(list_w)` (`objspace.py`) — (ref array) → new list.  The
+    /// array is the forced `popvalues_mutable` list; length travels
+    /// inside the array, so any arity fits.
     pub newlist_from_array_fn: extern "C" fn(i64) -> i64,
     /// `bhimpl_unpack_sequence` — (count, seq) → validated tuple of items.
     pub unpack_sequence_fn: extern "C" fn(i64, i64) -> i64,


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
