### PR TITLE
Dynasm aarch64 codegen imm branch

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -46,10 +46,10 @@ jobs:
     - name: Run cargo fmt --check
       run: cargo fmt --all -- --check
 
-  prepare-charon-llbc:
-    name: prepare Charon/LLBC (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    env:
+  prepare-charon-llbc-linux:
+    name: prepare Charon/LLBC (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    env: &charon-llbc-env
       # Redirect the shared charon/ullbc build dir INTO the workspace so
       # actions/cache can reach it. Locally PYRE_SHARED_BUILD is unset and
       # both scripts default to ../.pyre-build (shared across worktrees).
@@ -59,14 +59,7 @@ jobs:
       # the cache keys below AND install-charon.py's .installed-version
       # stamp, so a pin bump here misses the cache and re-installs.
       CHARON_VERSION: nightly-2026.05.29
-    strategy:
-      fail-fast: false
-      matrix:
-        # On windows-latest install-charon.py builds Charon from source
-        # (no Windows release asset is published); see scripts/install-charon.py.
-        os: [ubuntu-24.04, macos-latest, windows-latest]
-
-    steps:
+    steps: &prepare-charon-llbc-steps
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -132,28 +125,42 @@ jobs:
         retention-days: 1
         if-no-files-found: error
 
-  cargo-test:
-    name: cargo test (${{ matrix.os }}, ${{ matrix.backend }})
-    runs-on: ${{ matrix.os }}
-    needs: prepare-charon-llbc
+  prepare-charon-llbc-macos:
+    name: prepare Charon/LLBC (macos-latest)
+    runs-on: macos-latest
+    env: *charon-llbc-env
+    steps: *prepare-charon-llbc-steps
+
+  prepare-charon-llbc-windows:
+    name: prepare Charon/LLBC (windows-latest)
+    # On windows-latest install-charon.py builds Charon from source
+    # (no Windows release asset is published); see scripts/install-charon.py.
+    runs-on: windows-latest
+    env: *charon-llbc-env
+    steps: *prepare-charon-llbc-steps
+
+  cargo-test-linux:
+    name: cargo test (ubuntu-24.04, ${{ matrix.backend }})
+    runs-on: ubuntu-24.04
+    needs: prepare-charon-llbc-linux
     if: ${{ always() }}
     env:
       # See prepare-charon-llbc: keep the restored Charon install in the
       # workspace so scripts/builds find the same platform-specific path.
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-linux.result }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-latest, windows-latest]
         backend: [dynasm, cranelift]
 
-    steps:
+    steps: &cargo-test-steps
     - name: Check prepare-charon-llbc result
-      if: ${{ needs.prepare-charon-llbc.result != 'success' }}
+      if: ${{ env.PREPARE_CHARON_LLBC_RESULT != 'success' }}
       shell: bash
       run: |
-        echo "prepare-charon-llbc did not succeed: ${{ needs.prepare-charon-llbc.result }}" >&2
+        echo "prepare-charon-llbc did not succeed: ${PREPARE_CHARON_LLBC_RESULT}" >&2
         exit 1
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -212,31 +219,62 @@ jobs:
         sudo docker image prune --all --force || true
         df -h /
     - name: Run cargo test for ${{ matrix.backend }}
+      # Pin bash: on windows-latest the default shell is PowerShell, where
+      # "$BACKEND" does not expand the env var (it would need $env:BACKEND),
+      # so cargo test would run with an empty feature set.
+      shell: bash
       env:
         BACKEND: ${{ matrix.backend }}
       run: cargo test --all --no-default-features --features "$BACKEND"
 
-  pyre-check:
-    name: pyre/check.py (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    needs: prepare-charon-llbc
+  cargo-test-macos:
+    name: cargo test (macos-latest, ${{ matrix.backend }})
+    runs-on: macos-latest
+    needs: prepare-charon-llbc-macos
+    if: ${{ always() }}
+    env:
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-macos.result }}
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [dynasm, cranelift]
+    steps: *cargo-test-steps
+
+  cargo-test-windows:
+    name: cargo test (windows-latest, ${{ matrix.backend }})
+    runs-on: windows-latest
+    needs: prepare-charon-llbc-windows
+    if: ${{ always() }}
+    env:
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-windows.result }}
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [dynasm, cranelift]
+    steps: *cargo-test-steps
+
+  pyre-check-linux:
+    name: pyre/check.py (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    needs: prepare-charon-llbc-linux
     if: ${{ always() }}
     env:
       # See prepare-charon-llbc: restore the shared build dir into the
       # workspace and use the same Charon pin/cache key.
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, macos-latest, windows-latest]
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-linux.result }}
 
-    steps:
+    steps: &pyre-check-steps
     - name: Check prepare-charon-llbc result
-      if: ${{ needs.prepare-charon-llbc.result != 'success' }}
+      if: ${{ env.PREPARE_CHARON_LLBC_RESULT != 'success' }}
       shell: bash
       run: |
-        echo "prepare-charon-llbc did not succeed: ${{ needs.prepare-charon-llbc.result }}" >&2
+        echo "prepare-charon-llbc did not succeed: ${PREPARE_CHARON_LLBC_RESULT}" >&2
         exit 1
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -294,14 +332,34 @@ jobs:
         PYRE_CHECK_PYPY3: ${{ steps.pypy.outputs.python-path }}
       run: ${{ steps.cpython.outputs.python-path }} pyre/check.py
 
+  pyre-check-macos:
+    name: pyre/check.py (macos-latest)
+    runs-on: macos-latest
+    needs: prepare-charon-llbc-macos
+    if: ${{ always() }}
+    env:
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-macos.result }}
+    steps: *pyre-check-steps
+
+  pyre-check-windows:
+    name: pyre/check.py (windows-latest)
+    runs-on: windows-latest
+    needs: prepare-charon-llbc-windows
+    if: ${{ always() }}
+    env:
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-windows.result }}
+    steps: *pyre-check-steps
+
   cpython-tests:
     name: CPython suite (gate)
     # aarch64: the baseline is recorded on darwin-aarch64 and the JIT codegen is
     # arch-specific, so the gate runs where the baseline was observed.
-    # macos-latest is the only aarch64 OS in prepare-charon-llbc's matrix, so its
-    # Charon/LLBC caches (keyed by runner.os-runner.arch) are already prepared.
     runs-on: macos-latest
-    needs: prepare-charon-llbc
+    needs: prepare-charon-llbc-macos
     if: ${{ always() }}
     timeout-minutes: 30
     env:
@@ -309,12 +367,13 @@ jobs:
       # workspace and use the same Charon pin/cache key.
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-macos.result }}
     steps:
     - name: Check prepare-charon-llbc result
-      if: ${{ needs.prepare-charon-llbc.result != 'success' }}
+      if: ${{ env.PREPARE_CHARON_LLBC_RESULT != 'success' }}
       shell: bash
       run: |
-        echo "prepare-charon-llbc did not succeed: ${{ needs.prepare-charon-llbc.result }}" >&2
+        echo "prepare-charon-llbc did not succeed: ${PREPARE_CHARON_LLBC_RESULT}" >&2
         exit 1
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -369,7 +428,7 @@ jobs:
   wasm-build:
     name: wasm build (pyre-wasm, ${{ matrix.binding }})
     runs-on: ubuntu-24.04
-    needs: prepare-charon-llbc
+    needs: prepare-charon-llbc-linux
     if: ${{ always() }}
     env:
       # See prepare-charon-llbc: keep the restored Charon install in the
@@ -377,6 +436,7 @@ jobs:
       # whose build needs the extracted LLBC.
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
+      PREPARE_CHARON_LLBC_RESULT: ${{ needs.prepare-charon-llbc-linux.result }}
     strategy:
       fail-fast: false
       matrix:
@@ -386,10 +446,10 @@ jobs:
 
     steps:
     - name: Check prepare-charon-llbc result
-      if: ${{ needs.prepare-charon-llbc.result != 'success' }}
+      if: ${{ env.PREPARE_CHARON_LLBC_RESULT != 'success' }}
       shell: bash
       run: |
-        echo "prepare-charon-llbc did not succeed: ${{ needs.prepare-charon-llbc.result }}" >&2
+        echo "prepare-charon-llbc did not succeed: ${PREPARE_CHARON_LLBC_RESULT}" >&2
         exit 1
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -410,9 +470,11 @@ jobs:
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: |
-          .pyre-build/charon
-          .pyre-build/charon-src
+        # Must match the prepare job's save path-set exactly: actions/cache
+        # derives the cache version from the path list, so restoring with an
+        # extra .pyre-build/charon-src entry computes a different version than
+        # the single-path save and always misses (failing the cache-hit gate).
+        path: .pyre-build/charon
         key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
     - name: Restore LLBC
       id: restore-llbc

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -885,31 +885,37 @@ impl<'a> AssemblerARM64<'a> {
     /// returning the register numbers to use. Uses x17 for lhs scratch
     /// and x16 for src scratch when the loc is Frame/Immed.
     fn load_3op_into_scratch(&mut self, lhs: &Loc, src: &Loc) -> (u8, u8) {
-        let lhs_reg = match lhs {
-            Loc::Reg(r) => r.value,
-            Loc::Frame(f) => {
-                dynasm!(self.mc ; .arch aarch64 ; ldr x17, [x29, f.ebp_loc.value as u32]);
-                17
-            }
-            Loc::Immed(i) => {
-                self.emit_mov_imm64(17, i.value);
-                17
-            }
-            _ => 17,
-        };
-        let src_reg = match src {
-            Loc::Reg(r) => r.value,
-            Loc::Frame(f) => {
-                dynasm!(self.mc ; .arch aarch64 ; ldr x16, [x29, f.ebp_loc.value as u32]);
-                16
-            }
-            Loc::Immed(i) => {
-                self.emit_mov_imm64(16, i.value);
-                16
-            }
-            _ => 16,
-        };
+        let lhs_reg = self.load_loc_to_reg(lhs, 17);
+        let src_reg = self.load_loc_to_reg(src, 16);
         (lhs_reg, src_reg)
+    }
+
+    /// Load a single operand `loc` into a register, returning its number.
+    /// Register locs are used in place; Frame/Immed locs are materialised
+    /// into the caller-supplied `scratch` register (x16/x17).
+    fn load_loc_to_reg(&mut self, loc: &Loc, scratch: u8) -> u8 {
+        match loc {
+            Loc::Reg(r) => r.value,
+            Loc::Frame(f) => {
+                dynasm!(self.mc ; .arch aarch64 ; ldr X(scratch), [x29, f.ebp_loc.value as u32]);
+                scratch
+            }
+            Loc::Immed(i) => {
+                self.emit_mov_imm64(scratch as u32, i.value);
+                scratch
+            }
+            _ => scratch,
+        }
+    }
+
+    /// If `loc` is a `ConstInt` that fits the AArch64 `#imm12` add/sub
+    /// immediate range, return it for the immediate instruction form.
+    /// Range mirrors `check_imm_box` (`0 <= v < DEFAULT_IMM_SIZE` = 4096).
+    fn addsub_imm12(loc: &Loc) -> Option<i64> {
+        match loc {
+            Loc::Immed(i) if (0..4096).contains(&i.value) => Some(i.value),
+            _ => None,
+        }
     }
 
     /// Emit a 3-operand integer binop: `OP dst, lhs, src`.
@@ -919,6 +925,30 @@ impl<'a> AssemblerARM64<'a> {
     /// `SUB dst, dst, src`. Handles reg/frame/immediate forms for both
     /// operands, routing scratch via x16/x17 as needed.
     fn emit_binop_3op(&mut self, opcode: OpCode, dst_reg: u8, lhs: &Loc, src: &Loc) {
+        // Fold a small non-negative ConstInt rhs into the `add/sub Rd,Rn,#imm12`
+        // immediate form instead of materialising it into a scratch register.
+        // The regalloc (`consider_int_ri_j2` / `consider_int_sub_j2`) only keeps
+        // add/sub rhs as `Loc::Immed`; the range mirrors `check_imm_box`
+        // (`0 <= v < DEFAULT_IMM_SIZE` = 4096, the AArch64 `#imm12` range).
+        if matches!(
+            opcode,
+            OpCode::IntAdd | OpCode::IntSub | OpCode::NurseryPtrIncrement
+        ) {
+            if let Some(im) = Self::addsub_imm12(src) {
+                let l = self.load_loc_to_reg(lhs, 17);
+                let d = dst_reg;
+                // Rd/Rn take the SP-form register family for the `#imm12`
+                // encoding; `XSP(r)` encodes identically to `X(r)` for the
+                // non-SP registers the allocator hands out here.
+                match opcode {
+                    OpCode::IntSub => {
+                        dynasm!(self.mc ; .arch aarch64 ; sub XSP(d), XSP(l), im as u32)
+                    }
+                    _ => dynasm!(self.mc ; .arch aarch64 ; add XSP(d), XSP(l), im as u32),
+                }
+                return;
+            }
+        }
         let (lhs_reg, src_reg) = self.load_3op_into_scratch(lhs, src);
         let d = dst_reg;
         let l = lhs_reg as u8;
@@ -1037,45 +1067,79 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     // ── AArch64 helper: load a 64-bit immediate into register Xn ──
-    //
-    // codebuilder.py:509 `gen_load_int`: emit the minimal sequence — MOVN for
-    // a small negative, otherwise MOVZ of the low halfword plus a MOVK for
-    // each higher halfword up to the highest nonzero one.  Patchable sites
-    // that rewrite a fixed 4-word block in place (`emit_check_frame_depth`)
-    // use `emit_mov_imm64_full` instead.
+    /// Materialise a 64-bit immediate into `reg` using the *minimal*
+    /// movz/movn + movk sequence (1–4 instructions).  This is variable
+    /// length: callers whose emitted block is rewritten in place afterwards
+    /// (the `frame_depth_to_patch` sites, patched by `patch_frame_depth`
+    /// which always writes 4 words) MUST use [`emit_mov_imm64_fixed4`]
+    /// instead, which always emits exactly four words.
     pub(crate) fn emit_mov_imm64(&mut self, reg: u32, val: i64) {
-        let r = reg as u8;
-        if val < 0 {
-            if val < -65536 {
-                self.emit_mov_imm64_full(reg, val);
-            } else {
-                // MOVN Xr, ~val: val in [-65536, -1], so ~val fits in 16 bits.
-                let n = ((!val) as u32) & 0xFFFF;
-                dynasm!(self.mc ; .arch aarch64 ; movn X(r), n);
-            }
-            return;
-        }
         let v = val as u64;
-        dynasm!(self.mc ; .arch aarch64 ; movz X(r), (v & 0xFFFF) as u32);
-        let mut rem = v >> 16;
-        let mut shift = 16u32;
-        while rem != 0 {
-            let hw = (rem & 0xFFFF) as u32;
-            match shift {
-                16 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 16),
-                32 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 32),
-                48 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 48),
-                _ => unreachable!(),
+        let r = reg as u8;
+        let chunks = [
+            (v & 0xFFFF) as u32,
+            ((v >> 16) & 0xFFFF) as u32,
+            ((v >> 32) & 0xFFFF) as u32,
+            ((v >> 48) & 0xFFFF) as u32,
+        ];
+        // Emit only the 16-bit words that actually carry bits.  When the
+        // value is dominated by 1-bits (negative / high constants) seed with
+        // `movn` (which sets every other bit to 1) so fewer `movk` follow;
+        // otherwise seed with `movz` (other bits 0).  Mirrors the minimal
+        // mov-immediate sequence an assembler picks for `gen_load_int`.
+        let ones = chunks.iter().filter(|&&c| c == 0xFFFF).count();
+        let zeros = chunks.iter().filter(|&&c| c == 0).count();
+        let use_movn = ones > zeros;
+        let mut seeded = false;
+        for (idx, &c) in chunks.iter().enumerate() {
+            // Skip words already provided by the seed (0 for movz, 0xFFFF for movn).
+            if (use_movn && c == 0xFFFF) || (!use_movn && c == 0) {
+                continue;
             }
-            rem >>= 16;
-            shift += 16;
+            if !seeded {
+                seeded = true;
+                if use_movn {
+                    let inv = (!c) & 0xFFFF;
+                    match idx {
+                        0 => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv),
+                        1 => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv, lsl 16),
+                        2 => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv, lsl 32),
+                        _ => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv, lsl 48),
+                    }
+                } else {
+                    match idx {
+                        0 => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c),
+                        1 => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c, lsl 16),
+                        2 => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c, lsl 32),
+                        _ => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c, lsl 48),
+                    }
+                }
+            } else {
+                match idx {
+                    0 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c),
+                    1 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c, lsl 16),
+                    2 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c, lsl 32),
+                    _ => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c, lsl 48),
+                }
+            }
+        }
+        // val == 0 (movz path) or val == -1 (movn path) seeds nothing above.
+        if !seeded {
+            if use_movn {
+                dynasm!(self.mc ; .arch aarch64 ; movn X(r), 0);
+            } else {
+                dynasm!(self.mc ; .arch aarch64 ; movz X(r), 0);
+            }
         }
     }
 
-    // codebuilder.py:503 `gen_load_int_full`: the fixed 4-word movz/movk block
-    // for patchable sites where `patch_stack_checks` rewrites all four words in
-    // place (and the redirect-veneer encoder `encode_mov_imm64_words`).
-    pub(crate) fn emit_mov_imm64_full(&mut self, reg: u32, val: i64) {
+    /// Materialise a 64-bit immediate as a fixed four-word
+    /// `movz`/`movk lsl 16`/`movk lsl 32`/`movk lsl 48` block, byte-identical
+    /// to [`encode_mov_imm64_words`].  Used only at the `frame_depth_to_patch`
+    /// sites, whose block is rewritten in place by `patch_frame_depth` (always
+    /// 16 bytes); the variable-length [`emit_mov_imm64`] would let the patch
+    /// overrun into the following instructions.
+    fn emit_mov_imm64_fixed4(&mut self, reg: u32, val: i64) {
         let v = val as u64;
         let r = reg as u8;
         dynasm!(self.mc ; .arch aarch64
@@ -1362,13 +1426,14 @@ impl<'a> AssemblerARM64<'a> {
     /// gcmap (a compile-time pointer) and the depth (a patchable
     /// immediate) need not be marshalled through the stack.
     ///
-    /// The depth immediate is materialized by `emit_mov_imm64` as a fixed
-    /// 4-instruction `movz/movk` block; `frame_depth_to_patch` records each
-    /// block offset (CMP operand + slowpath ARG1) and `patch_stack_checks`
+    /// The depth immediate is materialized by `emit_mov_imm64_fixed4` as a
+    /// fixed 4-instruction `movz/movk` block; `frame_depth_to_patch` records
+    /// each block offset (CMP operand + slowpath ARG1) and `patch_stack_checks`
     /// rewrites all four words at finalize once `frame_depth` is final.
     /// Unlike upstream's variable-length `gen_load_int` (which reserves
-    /// `get_max_size_of_gen_load_int()` NOPs), `emit_mov_imm64` is always
-    /// four words, so no NOP padding is needed.
+    /// `get_max_size_of_gen_load_int()` NOPs), this block is always four
+    /// words, so no NOP padding is needed.  (The general `emit_mov_imm64`
+    /// is variable length and would let the patch overrun the block.)
     fn emit_check_frame_depth(&mut self, gcmap: *mut usize) {
         let frame_len_ofs = (JF_FRAME_OFS + crate::jitframe::LENGTHOFS) as u32;
         let placeholder: i64 = 0xffffff;
@@ -1379,7 +1444,7 @@ impl<'a> AssemblerARM64<'a> {
         );
         // assembler.py:936-941 — gen_load_int ip1, expected_size (patched).
         let cmp_imm_ofs = self.mc.offset().0;
-        self.emit_mov_imm64_full(17, placeholder);
+        self.emit_mov_imm64_fixed4(17, placeholder);
         self.frame_depth_to_patch.push(cmp_imm_ofs);
 
         // assembler.py:942-944 — CMP ip0, ip1; B.GE skip (fast path:
@@ -1422,7 +1487,7 @@ impl<'a> AssemblerARM64<'a> {
         dynasm!(self.mc ; .arch aarch64 ; mov x0, x29);
         // assembler.py:447-449 arg1 = expected_size (depth), patched imm.
         let arg1_imm_ofs = self.mc.offset().0;
-        self.emit_mov_imm64_full(1, placeholder);
+        self.emit_mov_imm64_fixed4(1, placeholder);
         self.frame_depth_to_patch.push(arg1_imm_ofs);
 
         // assembler.py:467 BL realloc_frame.  pyre bakes the C-ABI wrapper
@@ -2096,9 +2161,14 @@ impl<'a> AssemblerARM64<'a> {
                 if let (Some(Loc::Reg(dst)), Some(lhs), Some(src)) =
                     (result_loc, arglocs.first(), arglocs.get(1))
                 {
-                    let (lhs_reg, src_reg) = self.load_3op_into_scratch(lhs, src);
-                    dynasm!(self.mc ; .arch aarch64
-                        ; adds X(dst.value), X(lhs_reg as u8), X(src_reg as u8));
+                    if let Some(im) = Self::addsub_imm12(src) {
+                        let l = self.load_loc_to_reg(lhs, 17);
+                        dynasm!(self.mc ; .arch aarch64 ; adds X(dst.value), XSP(l), im as u32);
+                    } else {
+                        let (lhs_reg, src_reg) = self.load_3op_into_scratch(lhs, src);
+                        dynasm!(self.mc ; .arch aarch64
+                            ; adds X(dst.value), X(lhs_reg as u8), X(src_reg as u8));
+                    }
                     self.guard_success_cc = Some(CC_NO);
                 }
             }
@@ -2107,9 +2177,14 @@ impl<'a> AssemblerARM64<'a> {
                 if let (Some(Loc::Reg(dst)), Some(lhs), Some(src)) =
                     (result_loc, arglocs.first(), arglocs.get(1))
                 {
-                    let (lhs_reg, src_reg) = self.load_3op_into_scratch(lhs, src);
-                    dynasm!(self.mc ; .arch aarch64
-                        ; subs X(dst.value), X(lhs_reg as u8), X(src_reg as u8));
+                    if let Some(im) = Self::addsub_imm12(src) {
+                        let l = self.load_loc_to_reg(lhs, 17);
+                        dynasm!(self.mc ; .arch aarch64 ; subs X(dst.value), XSP(l), im as u32);
+                    } else {
+                        let (lhs_reg, src_reg) = self.load_3op_into_scratch(lhs, src);
+                        dynasm!(self.mc ; .arch aarch64
+                            ; subs X(dst.value), X(lhs_reg as u8), X(src_reg as u8));
+                    }
                     self.guard_success_cc = Some(CC_NO);
                 }
             }
@@ -4352,56 +4427,41 @@ impl<'a> AssemblerARM64<'a> {
 
     fn emit_guard_jcc(&mut self, fail_cc: u8) -> DynamicLabel {
         let fail_label = self.mc.new_dynamic_label();
-        // aarch64: b.cond has 19-bit range (±1MB), which is too short
-        // for forward references to recovery stubs. Use inverted condition
-        // + unconditional branch (26-bit / ±128MB) pattern instead:
-        //   b.NOT_cond >skip ; b =>fail_label ; skip:
-        let skip = self.mc.new_dynamic_label();
-        let inv = invert_cc(fail_cc);
-        match inv {
-            CC_L => dynasm!(self.mc ; .arch aarch64 ; b.lt =>skip),
-            CC_LE => dynasm!(self.mc ; .arch aarch64 ; b.le =>skip),
-            CC_G => dynasm!(self.mc ; .arch aarch64 ; b.gt =>skip),
-            CC_GE => dynasm!(self.mc ; .arch aarch64 ; b.ge =>skip),
-            CC_E => dynasm!(self.mc ; .arch aarch64 ; b.eq =>skip),
-            CC_NE => dynasm!(self.mc ; .arch aarch64 ; b.ne =>skip),
-            CC_B => dynasm!(self.mc ; .arch aarch64 ; b.lo =>skip),
-            CC_BE => dynasm!(self.mc ; .arch aarch64 ; b.ls =>skip),
-            CC_A => dynasm!(self.mc ; .arch aarch64 ; b.hi =>skip),
-            CC_AE => dynasm!(self.mc ; .arch aarch64 ; b.hs =>skip),
-            CC_O => dynasm!(self.mc ; .arch aarch64 ; b.vs =>skip),
-            CC_NO => dynasm!(self.mc ; .arch aarch64 ; b.vc =>skip),
-            CC_S => dynasm!(self.mc ; .arch aarch64 ; b.mi =>skip),
-            CC_NS => dynasm!(self.mc ; .arch aarch64 ; b.pl =>skip),
-            _ => dynasm!(self.mc ; .arch aarch64 ; b.eq =>skip),
-        }
-        dynasm!(self.mc ; .arch aarch64 ; b =>fail_label);
-        dynasm!(self.mc ; .arch aarch64 ; =>skip);
+        self.emit_bcond_to_label(fail_cc, fail_label);
         fail_label
     }
 
-    fn emit_jcc_to_label(&mut self, fail_cc: u8, fail_label: DynamicLabel) {
-        let skip = self.mc.new_dynamic_label();
-        let inv = invert_cc(fail_cc);
-        match inv {
-            CC_L => dynasm!(self.mc ; .arch aarch64 ; b.lt =>skip),
-            CC_LE => dynasm!(self.mc ; .arch aarch64 ; b.le =>skip),
-            CC_G => dynasm!(self.mc ; .arch aarch64 ; b.gt =>skip),
-            CC_GE => dynasm!(self.mc ; .arch aarch64 ; b.ge =>skip),
-            CC_E => dynasm!(self.mc ; .arch aarch64 ; b.eq =>skip),
-            CC_NE => dynasm!(self.mc ; .arch aarch64 ; b.ne =>skip),
-            CC_B => dynasm!(self.mc ; .arch aarch64 ; b.lo =>skip),
-            CC_BE => dynasm!(self.mc ; .arch aarch64 ; b.ls =>skip),
-            CC_A => dynasm!(self.mc ; .arch aarch64 ; b.hi =>skip),
-            CC_AE => dynasm!(self.mc ; .arch aarch64 ; b.hs =>skip),
-            CC_O => dynasm!(self.mc ; .arch aarch64 ; b.vs =>skip),
-            CC_NO => dynasm!(self.mc ; .arch aarch64 ; b.vc =>skip),
-            CC_S => dynasm!(self.mc ; .arch aarch64 ; b.mi =>skip),
-            CC_NS => dynasm!(self.mc ; .arch aarch64 ; b.pl =>skip),
-            _ => dynasm!(self.mc ; .arch aarch64 ; b.eq =>skip),
+    /// Emit a single `b.<cc> =>label` so the guard-success path falls
+    /// through with no taken branch (the failure path takes the branch).
+    ///
+    /// `b.cond` has a 19-bit / ±1MB range; the recovery stub it targets is
+    /// emitted in this same buffer, so for any realistic trace it is well
+    /// within range (±1MB = 262144 instructions, far above the trace-length
+    /// cap).  Should a pathologically large trace overflow it, `finalize()`
+    /// returns `ImpossibleRelocation` which surfaces as `CompilationFailed`
+    /// and the trace falls back to the interpreter — never miscompiled code.
+    fn emit_bcond_to_label(&mut self, cc: u8, label: DynamicLabel) {
+        match cc {
+            CC_L => dynasm!(self.mc ; .arch aarch64 ; b.lt =>label),
+            CC_LE => dynasm!(self.mc ; .arch aarch64 ; b.le =>label),
+            CC_G => dynasm!(self.mc ; .arch aarch64 ; b.gt =>label),
+            CC_GE => dynasm!(self.mc ; .arch aarch64 ; b.ge =>label),
+            CC_E => dynasm!(self.mc ; .arch aarch64 ; b.eq =>label),
+            CC_NE => dynasm!(self.mc ; .arch aarch64 ; b.ne =>label),
+            CC_B => dynasm!(self.mc ; .arch aarch64 ; b.lo =>label),
+            CC_BE => dynasm!(self.mc ; .arch aarch64 ; b.ls =>label),
+            CC_A => dynasm!(self.mc ; .arch aarch64 ; b.hi =>label),
+            CC_AE => dynasm!(self.mc ; .arch aarch64 ; b.hs =>label),
+            CC_O => dynasm!(self.mc ; .arch aarch64 ; b.vs =>label),
+            CC_NO => dynasm!(self.mc ; .arch aarch64 ; b.vc =>label),
+            CC_S => dynasm!(self.mc ; .arch aarch64 ; b.mi =>label),
+            CC_NS => dynasm!(self.mc ; .arch aarch64 ; b.pl =>label),
+            _ => dynasm!(self.mc ; .arch aarch64 ; b.eq =>label),
         }
-        dynasm!(self.mc ; .arch aarch64 ; b =>fail_label);
-        dynasm!(self.mc ; .arch aarch64 ; =>skip);
+    }
+
+    fn emit_jcc_to_label(&mut self, fail_cc: u8, fail_label: DynamicLabel) {
+        self.emit_bcond_to_label(fail_cc, fail_label);
     }
 
     /// Infer fail_arg_types from `op.type_` (via `opref_type`) or
@@ -6770,9 +6830,12 @@ mod tests {
     use super::*;
 
     /// `patch_frame_depth` rewrites the depth placeholder by hand-encoding
-    /// four `movz/movk` words.  They must be byte-identical to what
-    /// `emit_mov_imm64` (dynasm) produces, otherwise the patched bridge
-    /// would load a corrupt depth into the realloc slowpath.
+    /// four `movz/movk` words.  They must be byte-identical to the fixed
+    /// four-word block `emit_mov_imm64_fixed4` (dynasm) emits at the patch
+    /// sites, otherwise the patched bridge would load a corrupt depth into
+    /// the realloc slowpath.  (The inline sequence below is exactly that
+    /// block; the general `emit_mov_imm64` is variable length and is not
+    /// used at patch sites.)
     #[test]
     fn frame_depth_patch_words_match_emit_mov_imm64() {
         // (rd, val): the CMP site targets x17, the ARG1 site x1; cover the

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -904,7 +904,10 @@ impl<'a> AssemblerARM64<'a> {
                 self.emit_mov_imm64(scratch as u32, i.value);
                 scratch
             }
-            _ => scratch,
+            // The regalloc only routes Reg/Frame/Immed operands into the 3-op /
+            // overflow arith paths; an Ebp/Addr loc here means a broken regalloc
+            // contract. Panic instead of emitting arith on a stale scratch reg.
+            other => panic!("load_loc_to_reg expected Reg/Frame/Immed, got {other:?}"),
         }
     }
 
@@ -1064,90 +1067,6 @@ impl<'a> AssemblerARM64<'a> {
         };
         dynasm!(self.mc ; .arch aarch64 ; tst X(r as u8), X(r as u8));
         return;
-    }
-
-    // ── AArch64 helper: load a 64-bit immediate into register Xn ──
-    /// Materialise a 64-bit immediate into `reg` using the *minimal*
-    /// movz/movn + movk sequence (1–4 instructions).  This is variable
-    /// length: callers whose emitted block is rewritten in place afterwards
-    /// (the `frame_depth_to_patch` sites, patched by `patch_frame_depth`
-    /// which always writes 4 words) MUST use [`emit_mov_imm64_fixed4`]
-    /// instead, which always emits exactly four words.
-    pub(crate) fn emit_mov_imm64(&mut self, reg: u32, val: i64) {
-        let v = val as u64;
-        let r = reg as u8;
-        let chunks = [
-            (v & 0xFFFF) as u32,
-            ((v >> 16) & 0xFFFF) as u32,
-            ((v >> 32) & 0xFFFF) as u32,
-            ((v >> 48) & 0xFFFF) as u32,
-        ];
-        // Emit only the 16-bit words that actually carry bits.  When the
-        // value is dominated by 1-bits (negative / high constants) seed with
-        // `movn` (which sets every other bit to 1) so fewer `movk` follow;
-        // otherwise seed with `movz` (other bits 0).  Mirrors the minimal
-        // mov-immediate sequence an assembler picks for `gen_load_int`.
-        let ones = chunks.iter().filter(|&&c| c == 0xFFFF).count();
-        let zeros = chunks.iter().filter(|&&c| c == 0).count();
-        let use_movn = ones > zeros;
-        let mut seeded = false;
-        for (idx, &c) in chunks.iter().enumerate() {
-            // Skip words already provided by the seed (0 for movz, 0xFFFF for movn).
-            if (use_movn && c == 0xFFFF) || (!use_movn && c == 0) {
-                continue;
-            }
-            if !seeded {
-                seeded = true;
-                if use_movn {
-                    let inv = (!c) & 0xFFFF;
-                    match idx {
-                        0 => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv),
-                        1 => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv, lsl 16),
-                        2 => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv, lsl 32),
-                        _ => dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv, lsl 48),
-                    }
-                } else {
-                    match idx {
-                        0 => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c),
-                        1 => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c, lsl 16),
-                        2 => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c, lsl 32),
-                        _ => dynasm!(self.mc ; .arch aarch64 ; movz X(r), c, lsl 48),
-                    }
-                }
-            } else {
-                match idx {
-                    0 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c),
-                    1 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c, lsl 16),
-                    2 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c, lsl 32),
-                    _ => dynasm!(self.mc ; .arch aarch64 ; movk X(r), c, lsl 48),
-                }
-            }
-        }
-        // val == 0 (movz path) or val == -1 (movn path) seeds nothing above.
-        if !seeded {
-            if use_movn {
-                dynasm!(self.mc ; .arch aarch64 ; movn X(r), 0);
-            } else {
-                dynasm!(self.mc ; .arch aarch64 ; movz X(r), 0);
-            }
-        }
-    }
-
-    /// Materialise a 64-bit immediate as a fixed four-word
-    /// `movz`/`movk lsl 16`/`movk lsl 32`/`movk lsl 48` block, byte-identical
-    /// to [`encode_mov_imm64_words`].  Used only at the `frame_depth_to_patch`
-    /// sites, whose block is rewritten in place by `patch_frame_depth` (always
-    /// 16 bytes); the variable-length [`emit_mov_imm64`] would let the patch
-    /// overrun into the following instructions.
-    fn emit_mov_imm64_fixed4(&mut self, reg: u32, val: i64) {
-        let v = val as u64;
-        let r = reg as u8;
-        dynasm!(self.mc ; .arch aarch64
-            ; movz X(r), (v & 0xFFFF) as u32
-            ; movk X(r), ((v >> 16) & 0xFFFF) as u32, lsl 16
-            ; movk X(r), ((v >> 32) & 0xFFFF) as u32, lsl 32
-            ; movk X(r), ((v >> 48) & 0xFFFF) as u32, lsl 48
-        );
     }
 
     /// Emit: load the value of `opref` into RAX (x64) / X0 (aarch64).
@@ -1563,22 +1482,6 @@ impl<'a> AssemblerARM64<'a> {
             }
         });
         flush_icache(adr as *const u8, 16);
-    }
-
-    /// Hand-encode the four ARM64 words `emit_mov_imm64` produces for
-    /// `(rd, val)`: `MOVZ`/`MOVK lsl 16`/`MOVK lsl 32`/`MOVK lsl 48` (64-bit
-    /// variants).  Kept byte-identical to the dynasm output by
-    /// `frame_depth_patch_words_match_emit_mov_imm64`.
-    fn encode_mov_imm64_words(rd: u32, val: i64) -> [u32; 4] {
-        let v = val as u64;
-        let rd = rd & 0x1F;
-        let imm16 = |shift: u32| (((v >> shift) & 0xFFFF) as u32) << 5;
-        [
-            0xD280_0000 | imm16(0) | rd,              // movz Xrd, #imm, lsl 0
-            0xF280_0000 | (1 << 21) | imm16(16) | rd, // movk Xrd, #imm, lsl 16
-            0xF280_0000 | (2 << 21) | imm16(32) | rd, // movk Xrd, #imm, lsl 32
-            0xF280_0000 | (3 << 21) | imm16(48) | rd, // movk Xrd, #imm, lsl 48
-        ]
     }
 
     /// RPython `AbstractCallBuilder.emit`: CALL_ASSEMBLER is a collecting
@@ -6822,51 +6725,5 @@ fn flush_icache(addr: *const u8, len: usize) {
             fn __clear_cache(start: *mut u8, end: *mut u8);
         }
         unsafe { __clear_cache(addr as *mut u8, (addr as *mut u8).add(len)) };
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// `patch_frame_depth` rewrites the depth placeholder by hand-encoding
-    /// four `movz/movk` words.  They must be byte-identical to the fixed
-    /// four-word block `emit_mov_imm64_fixed4` (dynasm) emits at the patch
-    /// sites, otherwise the patched bridge would load a corrupt depth into
-    /// the realloc slowpath.  (The inline sequence below is exactly that
-    /// block; the general `emit_mov_imm64` is variable length and is not
-    /// used at patch sites.)
-    #[test]
-    fn frame_depth_patch_words_match_emit_mov_imm64() {
-        // (rd, val): the CMP site targets x17, the ARG1 site x1; cover the
-        // full 64-bit range so every `movk` hw position is exercised.
-        let cases: &[(u32, i64)] = &[
-            (17, 0),
-            (1, 0xffffff),
-            (17, 56),
-            (1, 0x1234_5678),
-            (17, -1),
-            (1, 0x7fff_ffff_ffff_ffff),
-            (17, 0x0001_0000_0001_0000),
-        ];
-        for &(rd, val) in cases {
-            let mut mc = Assembler::new().unwrap();
-            let r = rd as u8;
-            let v = val as u64;
-            dynasm!(mc ; .arch aarch64
-                ; movz X(r), (v & 0xFFFF) as u32
-                ; movk X(r), ((v >> 16) & 0xFFFF) as u32, lsl 16
-                ; movk X(r), ((v >> 32) & 0xFFFF) as u32, lsl 32
-                ; movk X(r), ((v >> 48) & 0xFFFF) as u32, lsl 48
-            );
-            let buf = mc.finalize().unwrap();
-            let mut expected = [0u32; 4];
-            for (i, w) in expected.iter_mut().enumerate() {
-                let b = i * 4;
-                *w = u32::from_le_bytes([buf[b], buf[b + 1], buf[b + 2], buf[b + 3]]);
-            }
-            let got = AssemblerARM64::encode_mov_imm64_words(rd, val);
-            assert_eq!(got, expected, "rd={rd} val={val:#x}");
-        }
     }
 }

--- a/majit/majit-backend-dynasm/src/aarch64/codebuilder.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/codebuilder.rs
@@ -1,0 +1,144 @@
+/// aarch64/codebuilder.py parity: low-level AArch64 instruction builders.
+///
+/// The Python backend keeps raw machine-code helpers in `codebuilder.py` and
+/// the trace/op lowering in `assembler.py`.  The dynasm backend still stores
+/// the dynasm assembler inside `AssemblerARM64`, but the codebuilder-shaped
+/// helpers live here so PyPy backend patches have the same file boundary.
+use dynasmrt::{DynasmApi, dynasm};
+
+use super::assembler::AssemblerARM64;
+
+impl<'a> AssemblerARM64<'a> {
+    /// codebuilder.py:509 `gen_load_int`.
+    ///
+    /// Materialise a 64-bit immediate into `reg`. This is variable length:
+    /// callers whose emitted block is rewritten in place afterwards (the
+    /// `frame_depth_to_patch` sites, patched by `patch_frame_depth` which
+    /// always writes 4 words) MUST use [`emit_mov_imm64_fixed4`] instead,
+    /// which always emits exactly four words.
+    pub(crate) fn emit_mov_imm64(&mut self, reg: u32, val: i64) {
+        let r = reg as u8;
+        if val < 0 {
+            if val >= -65536 {
+                let inv = ((!val) as u64 & 0xFFFF) as u32;
+                dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv);
+                return;
+            }
+            let inv = ((!val) as u64 & 0xFFFF) as u32;
+            dynasm!(self.mc ; .arch aarch64 ; movn X(r), inv);
+            let mut value = val >> 16;
+            let mut shift = 16;
+            while shift < 64 {
+                let hw = (value & 0xFFFF) as u32;
+                if hw != 0xFFFF {
+                    match shift {
+                        16 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 16),
+                        32 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 32),
+                        48 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 48),
+                        _ => unreachable!(),
+                    }
+                }
+                shift += 16;
+                value >>= 16;
+            }
+            return;
+        }
+        let mut value = val as u64;
+        dynasm!(self.mc ; .arch aarch64 ; movz X(r), (value & 0xFFFF) as u32);
+        value >>= 16;
+        let mut shift = 16;
+        while value != 0 {
+            let hw = (value & 0xFFFF) as u32;
+            match shift {
+                16 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 16),
+                32 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 32),
+                48 => dynasm!(self.mc ; .arch aarch64 ; movk X(r), hw, lsl 48),
+                _ => unreachable!(),
+            }
+            shift += 16;
+            value >>= 16;
+        }
+    }
+
+    /// Materialise a 64-bit immediate as a fixed four-word
+    /// `movz`/`movk lsl 16`/`movk lsl 32`/`movk lsl 48` block, byte-identical
+    /// to [`encode_mov_imm64_words`].  Used only at the `frame_depth_to_patch`
+    /// sites, whose block is rewritten in place by `patch_frame_depth` (always
+    /// 16 bytes); the variable-length [`emit_mov_imm64`] would let the patch
+    /// overrun into the following instructions.
+    pub(super) fn emit_mov_imm64_fixed4(&mut self, reg: u32, val: i64) {
+        let v = val as u64;
+        let r = reg as u8;
+        dynasm!(self.mc ; .arch aarch64
+            ; movz X(r), (v & 0xFFFF) as u32
+            ; movk X(r), ((v >> 16) & 0xFFFF) as u32, lsl 16
+            ; movk X(r), ((v >> 32) & 0xFFFF) as u32, lsl 32
+            ; movk X(r), ((v >> 48) & 0xFFFF) as u32, lsl 48
+        );
+    }
+
+    /// Hand-encode the four ARM64 words `emit_mov_imm64_fixed4` produces for
+    /// `(rd, val)`: `MOVZ`/`MOVK lsl 16`/`MOVK lsl 32`/`MOVK lsl 48` (64-bit
+    /// variants).  Kept byte-identical to the dynasm output by
+    /// `frame_depth_patch_words_match_emit_mov_imm64`.
+    pub(super) fn encode_mov_imm64_words(rd: u32, val: i64) -> [u32; 4] {
+        let v = val as u64;
+        let rd = rd & 0x1F;
+        let imm16 = |shift: u32| (((v >> shift) & 0xFFFF) as u32) << 5;
+        [
+            0xD280_0000 | imm16(0) | rd,              // movz Xrd, #imm, lsl 0
+            0xF280_0000 | (1 << 21) | imm16(16) | rd, // movk Xrd, #imm, lsl 16
+            0xF280_0000 | (2 << 21) | imm16(32) | rd, // movk Xrd, #imm, lsl 32
+            0xF280_0000 | (3 << 21) | imm16(48) | rd, // movk Xrd, #imm, lsl 48
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dynasmrt::aarch64::Assembler;
+    use dynasmrt::{DynasmApi, dynasm};
+
+    use super::*;
+
+    /// `patch_frame_depth` rewrites the depth placeholder by hand-encoding
+    /// four `movz/movk` words.  They must be byte-identical to the fixed
+    /// four-word block `emit_mov_imm64_fixed4` (dynasm) emits at the patch
+    /// sites, otherwise the patched bridge would load a corrupt depth into
+    /// the realloc slowpath.  (The inline sequence below is exactly that
+    /// block; the general `emit_mov_imm64` is variable length and is not
+    /// used at patch sites.)
+    #[test]
+    fn frame_depth_patch_words_match_emit_mov_imm64() {
+        // (rd, val): the CMP site targets x17, the ARG1 site x1; cover the
+        // full 64-bit range so every `movk` hw position is exercised.
+        let cases: &[(u32, i64)] = &[
+            (17, 0),
+            (1, 0xffffff),
+            (17, 56),
+            (1, 0x1234_5678),
+            (17, -1),
+            (1, 0x7fff_ffff_ffff_ffff),
+            (17, 0x0001_0000_0001_0000),
+        ];
+        for &(rd, val) in cases {
+            let mut mc = Assembler::new().unwrap();
+            let r = rd as u8;
+            let v = val as u64;
+            dynasm!(mc ; .arch aarch64
+                ; movz X(r), (v & 0xFFFF) as u32
+                ; movk X(r), ((v >> 16) & 0xFFFF) as u32, lsl 16
+                ; movk X(r), ((v >> 32) & 0xFFFF) as u32, lsl 32
+                ; movk X(r), ((v >> 48) & 0xFFFF) as u32, lsl 48
+            );
+            let buf = mc.finalize().unwrap();
+            let mut expected = [0u32; 4];
+            for (i, w) in expected.iter_mut().enumerate() {
+                let b = i * 4;
+                *w = u32::from_le_bytes([buf[b], buf[b + 1], buf[b + 2], buf[b + 3]]);
+            }
+            let got = AssemblerARM64::encode_mov_imm64_words(rd, val);
+            assert_eq!(got, expected, "rd={rd} val={val:#x}");
+        }
+    }
+}

--- a/majit/majit-backend-dynasm/src/aarch64/mod.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/mod.rs
@@ -6,6 +6,7 @@
 ///           └── AssemblerARM64 (aarch64/assembler.py)
 pub mod arch;
 pub mod assembler;
+pub mod codebuilder;
 pub mod cpu_ext;
 mod opassembler;
 pub mod regalloc;

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -8,6 +8,7 @@
 ///   llsupport/jitframe.py   → jitframe.rs
 ///   x86/assembler.py        → x86/assembler.rs (Assembler386)
 ///   aarch64/assembler.py    → aarch64/assembler.rs (AssemblerARM64)
+///   aarch64/codebuilder.py  → aarch64/codebuilder.rs
 ///   aarch64/opassembler.py  → aarch64/opassembler.rs (ResOpAssembler)
 ///   aarch64/registers.py    → aarch64/registers.rs
 ///

--- a/rpython/jit/backend/aarch64/codebuilder.py
+++ b/rpython/jit/backend/aarch64/codebuilder.py
@@ -509,12 +509,22 @@ class AbstractAarch64Builder(object):
     def gen_load_int(self, r, value):
         """r is the register number, value is the value to be loaded to the
         register"""
-        # XXX optimize!
         if value < 0:
-            if value < -65536:
-                self.gen_load_int_full(r, value)
-            else:
+            if value >= -65536:
                 self.MOVN_r_u16(r, ~value)
+                return
+            # MOVN sets every bit to 1 except the low 16, which it loads;
+            # then patch the higher 16-bit words that are not already
+            # all-ones with MOVK.  Emits 1-4 instructions (was always 4).
+            self.MOVN_r_u16(r, ~value & 0xFFFF)
+            value = value >> 16
+            shift = 16
+            while shift < 64:
+                hw = value & 0xFFFF
+                if hw != 0xFFFF:
+                    self.MOVK_r_u16(r, hw, shift)
+                shift += 16
+                value >>= 16
             return
         self.MOVZ_r_u16(r, value & 0xFFFF, 0)
         value = value >> 16


### PR DESCRIPTION
upstream patch: https://github.com/pypy/pypy/pull/5509/

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored CI workflows to split preparation and test steps into explicit platform-specific jobs, with consistent failure gating and a narrowed cache restore path for the WebAssembly build.

* **Refactor**
  * Improved ARM64 JIT instruction emission by supporting efficient small-immediate add/sub forms, simplifying conditional-branch emission, and enhancing 64-bit immediate handling for more reliable in-place patching.

* **Tests**
  * Added/relocated an ARM64 immediate encoding unit test to ensure fixed-size patch sequences match expected machine words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->