### PR TITLE
FBW: more walker opcode routing, flag-gated multi-frame inline snapshot, and #124 jitcode_pc resume carrier

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -13962,8 +13962,8 @@ fn collect_guards(
             {
                 use majit_ir::resumedata::{get_frame_value_count_fn, rebuild_from_numbering};
                 let fvc = get_frame_value_count_fn();
-                let fvc_ref: Option<&dyn Fn(i32, i32) -> usize> =
-                    fvc.as_ref().map(|f| f as &dyn Fn(i32, i32) -> usize);
+                let fvc_ref: Option<&dyn Fn(i32, i32, i32) -> usize> =
+                    fvc.as_ref().map(|f| f as &dyn Fn(i32, i32, i32) -> usize);
                 let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len());
                 let (_nfa, _vable, _vref, frames) = rebuild_from_numbering(
                     &rd_numb_bytes,
@@ -14012,8 +14012,8 @@ fn collect_guards(
             use majit_ir::resumedata::{self, RebuiltValue, rebuild_from_numbering};
             let rd_consts_ref: &[majit_ir::Const] = &rd_consts_data;
             let fvc = majit_ir::resumedata::get_frame_value_count_fn();
-            let fvc_ref: Option<&dyn Fn(i32, i32) -> usize> =
-                fvc.as_ref().map(|f| f as &dyn Fn(i32, i32) -> usize);
+            let fvc_ref: Option<&dyn Fn(i32, i32, i32) -> usize> =
+                fvc.as_ref().map(|f| f as &dyn Fn(i32, i32, i32) -> usize);
             let num_virtuals = rd_vi.as_ref().map_or(0, |v| v.len());
             let (_num_failargs, _vable_values, _vref_values, frames) = rebuild_from_numbering(
                 &rd_numb_bytes,

--- a/majit/majit-ir/src/resumedata.rs
+++ b/majit/majit-ir/src/resumedata.rs
@@ -21,16 +21,18 @@ static FRAME_VALUE_COUNT_FN: AtomicUsize = AtomicUsize::new(0);
 
 /// Register the global frame_value_count callback.
 ///
-/// Signature: `(jitcode_index, py_pc) -> count`.  The implementation
-/// translates `py_pc` through `pc_map` to look up `get_live_vars_info`;
-/// pyre's portal-bridge fallback (`PyJitCodeMetadata.depth_at_py_pc`) is
-/// py_pc-keyed pending its own TODO retirement.
-pub fn set_frame_value_count_fn(f: fn(i32, i32) -> usize) {
+/// Signature: `(jitcode_index, py_pc, jitcode_pc) -> count`.  The
+/// implementation prefers the carried direct `jitcode_pc` (`#124`
+/// Approach B) when it names a valid startpoint, else translates `py_pc`
+/// through `pc_map` to look up `get_live_vars_info`; pyre's portal-bridge
+/// fallback (`PyJitCodeMetadata.depth_at_py_pc`) is py_pc-keyed pending
+/// its own TODO retirement.
+pub fn set_frame_value_count_fn(f: fn(i32, i32, i32) -> usize) {
     FRAME_VALUE_COUNT_FN.store(f as usize, Ordering::Relaxed);
 }
 
 /// Get the registered frame_value_count callback (if any).
-pub fn get_frame_value_count_fn() -> Option<fn(i32, i32) -> usize> {
+pub fn get_frame_value_count_fn() -> Option<fn(i32, i32, i32) -> usize> {
     let p = FRAME_VALUE_COUNT_FN.load(Ordering::Relaxed);
     if p == 0 {
         None
@@ -455,11 +457,13 @@ fn decode_tagged(
 /// (`get_current_position_info`) at the decode site to know how many
 /// values each frame has.
 ///
-/// `frame_value_count`: when `Some(f)`, `f(jitcode_index, pc)` returns
-/// the number of tagged values for that frame (RPython parity: liveness-
-/// driven decode). When `None`, all remaining items after `(jitcode_index,
-/// pc)` are consumed as a single frame (backward-compat for callers that
-/// only ever see single-frame data).
+/// `frame_value_count`: when `Some(f)`, `f(jitcode_index, pc, jitcode_pc)`
+/// returns the number of tagged values for that frame (RPython parity:
+/// liveness-driven decode). The carried `jitcode_pc` (`#124`) lets the
+/// callback resolve the precise resume coordinate when it names a valid
+/// startpoint. When `None`, all remaining items after `(jitcode_index, pc,
+/// jitcode_pc)` are consumed as a single frame (backward-compat for callers
+/// that only ever see single-frame data).
 ///
 /// `fail_arg_types`: parent guard's per-failarg type vector. resume.py:1245
 /// `decode_box(num, kind)` parity — TAGBOX values use this to fill in their
@@ -469,7 +473,7 @@ pub fn rebuild_from_numbering(
     rd_numb: &[u8],
     rd_consts: &[Const],
     fail_arg_types: &[Type],
-    frame_value_count: Option<&dyn Fn(i32, i32) -> usize>,
+    frame_value_count: Option<&dyn Fn(i32, i32, i32) -> usize>,
     num_virtuals: usize,
 ) -> (i32, Vec<RebuiltValue>, Vec<RebuiltValue>, Vec<RebuiltFrame>) {
     let mut reader = resumecode::Reader::new(rd_numb);
@@ -528,8 +532,10 @@ pub fn rebuild_from_numbering(
             NO_JITCODE_PC
         };
         let box_count = if let Some(f) = &frame_value_count {
-            // RPython parity: liveness-driven frame boundary.
-            f(jitcode_index, pc)
+            // RPython parity: liveness-driven frame boundary.  The carried
+            // `jitcode_pc` (`#124`) lets the callback prefer the precise
+            // resume coordinate over the lossy `pc_map` translation.
+            f(jitcode_index, pc, jitcode_pc)
         } else {
             // Single-frame fallback: consume all remaining items.
             (total_size as usize).saturating_sub(reader.items_read)

--- a/majit/majit-ir/src/resumedata.rs
+++ b/majit/majit-ir/src/resumedata.rs
@@ -73,6 +73,24 @@ pub const TAGVIRTUAL: u8 = 3;
 /// decode at resume time.
 pub const AFTER_RESIDUAL_CALL_PC_FLAG: i32 = 1 << 14;
 
+/// Sentinel for a snapshot frame's `jitcode_pc` word: "no direct JitCode
+/// resume coordinate — translate the Python `pc` through `pc_map` as
+/// before".
+///
+/// Each per-frame header carries a `jitcode_pc` word after `pc`.  Normally
+/// it is this sentinel and the frame resumes via the Python `pc` →
+/// `pc_map` indirection (`resolve_resume_pc`).  A branch guard whose
+/// not-taken arm keeps operand-stack temps the JitCode virtualized cannot
+/// be described by the merge-target Python pc: its kept temps are only
+/// live at the *guard* JitCode position, not at the resume Python opcode
+/// boundary.  For such guards the capture stores the guard's JitCode byte
+/// offset here (a non-negative value), and both the box-count liveness
+/// query and the blackhole `setposition` resolve directly off it,
+/// bypassing `pc_map` — the direct `setposition(jitcode, pc)` shape
+/// (`pyjitpl.py:2610-2624`) without the pc round-trip.  The Python `pc`
+/// word stays populated for interpreter re-entry / `last_instr`.
+pub const NO_JITCODE_PC: i32 = -1;
+
 /// Fold the after-residual-call marker into a snapshot frame pc word.
 /// `pc` must be a non-negative Python PC `< AFTER_RESIDUAL_CALL_PC_FLAG`.
 /// The bound is enforced in release builds, not only under `debug_assert`,
@@ -361,6 +379,9 @@ pub struct RebuiltFrame {
     /// PC because pyre traces Python bytecode rather than JitCode.  See
     /// `[[project-issue73-phase5-design]]`.
     pub pc: i32,
+    /// Direct JitCode resume coordinate, or [`NO_JITCODE_PC`] when the
+    /// frame resumes through the Python `pc` → `pc_map` translation.
+    pub jitcode_pc: i32,
     pub values: Vec<RebuiltValue>,
 }
 
@@ -500,6 +521,12 @@ pub fn rebuild_from_numbering(
         } else {
             0
         };
+        // Per-frame `jitcode_pc` word (after `pc`).  See [`NO_JITCODE_PC`].
+        let jitcode_pc = if reader.has_more() && reader.items_read < total_size as usize {
+            reader.next_item()
+        } else {
+            NO_JITCODE_PC
+        };
         let box_count = if let Some(f) = &frame_value_count {
             // RPython parity: liveness-driven frame boundary.
             f(jitcode_index, pc)
@@ -524,6 +551,7 @@ pub fn rebuild_from_numbering(
         frames.push(RebuiltFrame {
             jitcode_index,
             pc,
+            jitcode_pc,
             values,
         });
     }

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2380,7 +2380,7 @@ pub fn convert_and_run_from_pyjitpl(
 /// `resolve_jitcode` is `metainterp_sd.jitcodes[jitcode_pos]` in RPython.
 pub fn resume_in_blackhole(
     builder: &mut BlackholeInterpBuilder,
-    resolve_jitcode: &dyn Fn(i32, i32) -> Option<crate::resume::ResolvedJitCode>,
+    resolve_jitcode: &dyn Fn(i32, i32, i32) -> Option<crate::resume::ResolvedJitCode>,
     rd_numb: &[u8],
     rd_consts: &[majit_ir::Const],
     all_liveness: &[u8],

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2636,6 +2636,7 @@ mod tests {
             framestack: vec![SnapshotFrame {
                 jitcode_index: 0,
                 pc: 8,
+                jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                 boxes: vec![OpRef::input_arg_int(1).into()],
             }],
         };

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -543,8 +543,8 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             {
                 use majit_ir::resumedata::{RebuiltValue, rebuild_from_numbering};
                 let fvc = majit_ir::resumedata::get_frame_value_count_fn();
-                let fvc_ref: Option<&dyn Fn(i32, i32) -> usize> =
-                    fvc.as_ref().map(|f| f as &dyn Fn(i32, i32) -> usize);
+                let fvc_ref: Option<&dyn Fn(i32, i32, i32) -> usize> =
+                    fvc.as_ref().map(|f| f as &dyn Fn(i32, i32, i32) -> usize);
                 let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len());
                 let (_num_failargs, vable_values, _vref_values, frames) = rebuild_from_numbering(
                     &rd_numb_bytes,
@@ -660,8 +660,8 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                 {
                     use majit_ir::resumedata::{RebuiltValue, rebuild_from_numbering};
                     let fvc = majit_ir::resumedata::get_frame_value_count_fn();
-                    let fvc_ref: Option<&dyn Fn(i32, i32) -> usize> =
-                        fvc.as_ref().map(|f| f as &dyn Fn(i32, i32) -> usize);
+                    let fvc_ref: Option<&dyn Fn(i32, i32, i32) -> usize> =
+                        fvc.as_ref().map(|f| f as &dyn Fn(i32, i32, i32) -> usize);
                     let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len());
                     let (num_failargs, vable_values, vref_values, frames) = rebuild_from_numbering(
                         &rd_numb_bytes,

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2306,14 +2306,17 @@ impl TraceCtx {
 
     /// Multi-frame variant of [`capture_snapshot_for_last_guard`].
     ///
-    /// Mirrors `opencoder.py:819-832 capture_resumedata` which walks
-    /// `framestack[-1] .. framestack[0]` and emits one `SnapshotFrame`
-    /// per `MIFrame`.  `frames[0]` is the TOP frame (currently
-    /// executing); `frames[1..]` are the paused parents in walker-call-
-    /// order (immediate caller, then its caller, etc.).
+    /// `frames` must be ordered **outermost-first** — `frames[0]` is the
+    /// outermost (root) frame and the last element is the top (currently
+    /// executing) frame.  This is the order `Snapshot.frames` requires
+    /// (`recorder.rs:54`) and is what the resume decoder consumes; the
+    /// trait-leg encoder reaches it by building an innermost-first `lead`
+    /// and `lead.reverse()`-ing (`trace_opcode.rs:4254`).  `capture_resumedata`
+    /// (`opencoder.py:819-832`) iterates `framestack[-1] .. framestack[0]`,
+    /// i.e. innermost-first, but the stored snapshot order is outermost-first.
     ///
     /// Each frame triple `(jitcode_index, py_pc, boxes)` is encoded
-    /// into `Snapshot.frames` in the order given.  Callers are
+    /// into `Snapshot.frames` verbatim in the order given.  Callers are
     /// responsible for deduplicating box positions across frames
     /// (RPython's `_number_boxes` does this implicitly via the memo
     /// table; pyre's `Snapshot.encode` does the same in

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -660,6 +660,7 @@ impl TreeLoop {
                         .map(|f| crate::recorder::SnapshotFrame {
                             jitcode_index: f.jitcode_index,
                             pc: f.pc,
+                            jitcode_pc: f.jitcode_pc,
                             boxes: f.boxes.iter().map(&remap_tagged).collect(),
                         })
                         .collect(),
@@ -2227,6 +2228,7 @@ impl TraceCtx {
             active_boxes,
             jitcode_index,
             pc,
+            majit_ir::resumedata::NO_JITCODE_PC,
             &[],
             &[],
         );
@@ -2252,6 +2254,7 @@ impl TraceCtx {
         active_boxes: &[OpRef],
         jitcode_index: u32,
         pc: u32,
+        jitcode_pc: i32,
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
     ) {
@@ -2270,6 +2273,7 @@ impl TraceCtx {
             frames: vec![crate::recorder::SnapshotFrame {
                 jitcode_index,
                 pc,
+                jitcode_pc,
                 boxes,
             }],
             vable_boxes: vable_boxes.to_vec(),
@@ -2288,6 +2292,7 @@ impl TraceCtx {
         active_boxes: &[OpRef],
         jitcode_index: u32,
         pc: u32,
+        jitcode_pc: i32,
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
     ) {
@@ -2296,6 +2301,7 @@ impl TraceCtx {
             frames: vec![crate::recorder::SnapshotFrame {
                 jitcode_index,
                 pc,
+                jitcode_pc,
                 boxes,
             }],
             vable_boxes: vable_boxes.to_vec(),
@@ -2315,13 +2321,19 @@ impl TraceCtx {
     /// (`opencoder.py:819-832`) iterates `framestack[-1] .. framestack[0]`,
     /// i.e. innermost-first, but the stored snapshot order is outermost-first.
     ///
-    /// Each frame triple `(jitcode_index, py_pc, boxes)` is encoded
-    /// into `Snapshot.frames` verbatim in the order given.  Callers are
+    /// Each frame tuple `(jitcode_index, py_pc, jitcode_pc, boxes)` is
+    /// encoded into `Snapshot.frames` verbatim in the order given;
+    /// `jitcode_pc` is the guard's JitCode byte offset for kept-stack
+    /// resume, or `NO_JITCODE_PC` for frames that resume via `py_pc`.
+    /// Callers are
     /// responsible for deduplicating box positions across frames
     /// (RPython's `_number_boxes` does this implicitly via the memo
     /// table; pyre's `Snapshot.encode` does the same in
     /// `resume.rs:1898 _number_boxes`).
-    pub fn capture_snapshot_for_last_guard_multi_frame(&mut self, frames: &[(u32, u32, &[OpRef])]) {
+    pub fn capture_snapshot_for_last_guard_multi_frame(
+        &mut self,
+        frames: &[(u32, u32, i32, &[OpRef])],
+    ) {
         self.capture_snapshot_for_last_guard_multi_frame_with_vable_vref(frames, &[], &[]);
     }
 
@@ -2335,13 +2347,13 @@ impl TraceCtx {
     /// it sees in the trace-time MIFrame stack.
     pub fn capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
         &mut self,
-        frames: &[(u32, u32, &[OpRef])],
+        frames: &[(u32, u32, i32, &[OpRef])],
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
     ) {
         let recorder_frames: Vec<crate::recorder::SnapshotFrame> = frames
             .iter()
-            .map(|(jitcode_index, py_pc, boxes)| {
+            .map(|(jitcode_index, py_pc, jitcode_pc, boxes)| {
                 // Walker-leg frames never carry the after-residual-call
                 // marker, so each raw pc must leave bit 14 free or
                 // `decode_resume_pc` mis-reads it as marked
@@ -2355,6 +2367,7 @@ impl TraceCtx {
                 crate::recorder::SnapshotFrame {
                     jitcode_index: *jitcode_index,
                     pc: *py_pc,
+                    jitcode_pc: *jitcode_pc,
                     boxes: encoded,
                 }
             })
@@ -2801,6 +2814,7 @@ impl TraceCtx {
             frames: vec![crate::recorder::SnapshotFrame {
                 jitcode_index: 0,
                 pc: self.last_traced_pc as u32,
+                jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                 boxes: Vec::new(),
             }],
             vable_boxes: Vec::new(),

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2257,43 +2257,42 @@ impl<S: JitState> JitDriver<S> {
                 let last_resolved: std::cell::RefCell<
                     Option<std::sync::Arc<majit_metainterp::JitCode>>,
                 > = std::cell::RefCell::new(None);
-                let resolve_jitcode =
-                    |jitcode_index: i32,
-                     pc: i32,
-                     _carried_jitcode_pc: i32|
-                     -> Option<crate::resume::ResolvedJitCode> {
-                        let resolved_jitcode = if last_resolved.borrow().is_none() {
-                            // Root frame: clone the dispatch JitCode
-                            // singleton registered at install time
-                            // (`register_dispatch_jitcode`).  Returns
-                            // None only when the proc-macro lowerer
-                            // rejected the dispatch body shape and
-                            // install skipped registration.
-                            dispatch_jitcode.as_ref()?.clone()
-                        } else {
-                            // Sub-frame: index into the parent's
-                            // `descrs` array.  Mirrors RPython
-                            // `BC_INLINE_CALL` operand decoding
-                            // (`blackhole.py:150-157`) where the `j`
-                            // argcode resolves through `descrs[idx]`.
-                            let parent = last_resolved
-                                .borrow()
-                                .as_ref()
-                                .expect("parent exists")
-                                .clone();
-                            parent
-                                .exec
-                                .descrs
-                                .get(jitcode_index as usize)
-                                .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)?
-                                .clone()
-                        };
-                        *last_resolved.borrow_mut() = Some(resolved_jitcode.clone());
-                        Some(crate::resume::ResolvedJitCode::new(
-                            resolved_jitcode,
-                            pc as usize,
-                        ))
+                let resolve_jitcode = |jitcode_index: i32,
+                                       pc: i32,
+                                       _carried_jitcode_pc: i32|
+                 -> Option<crate::resume::ResolvedJitCode> {
+                    let resolved_jitcode = if last_resolved.borrow().is_none() {
+                        // Root frame: clone the dispatch JitCode
+                        // singleton registered at install time
+                        // (`register_dispatch_jitcode`).  Returns
+                        // None only when the proc-macro lowerer
+                        // rejected the dispatch body shape and
+                        // install skipped registration.
+                        dispatch_jitcode.as_ref()?.clone()
+                    } else {
+                        // Sub-frame: index into the parent's
+                        // `descrs` array.  Mirrors RPython
+                        // `BC_INLINE_CALL` operand decoding
+                        // (`blackhole.py:150-157`) where the `j`
+                        // argcode resolves through `descrs[idx]`.
+                        let parent = last_resolved
+                            .borrow()
+                            .as_ref()
+                            .expect("parent exists")
+                            .clone();
+                        parent
+                            .exec
+                            .descrs
+                            .get(jitcode_index as usize)
+                            .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)?
+                            .clone()
                     };
+                    *last_resolved.borrow_mut() = Some(resolved_jitcode.clone());
+                    Some(crate::resume::ResolvedJitCode::new(
+                        resolved_jitcode,
+                        pc as usize,
+                    ))
+                };
 
                 let fallback_alloc = crate::resume::NullAllocator;
                 let allocator: &dyn crate::resume::BlackholeAllocator = self
@@ -4191,38 +4190,37 @@ impl<S: JitState> JitDriver<S> {
                 let last_resolved: std::cell::RefCell<
                     Option<std::sync::Arc<majit_metainterp::JitCode>>,
                 > = std::cell::RefCell::new(None);
-                let resolve_jitcode =
-                    |jitcode_index: i32,
-                     pc: i32,
-                     _carried_jitcode_pc: i32|
-                     -> Option<crate::resume::ResolvedJitCode> {
-                        let resolved_jitcode = if last_resolved.borrow().is_none() {
-                            // Root frame: clone the dispatch JitCode
-                            // singleton registered at install time
-                            // (`register_dispatch_jitcode`).  Returns
-                            // None only when the proc-macro lowerer
-                            // rejected the dispatch body shape and
-                            // install skipped registration.
-                            dispatch_jitcode.as_ref()?.clone()
-                        } else {
-                            let parent = last_resolved
-                                .borrow()
-                                .as_ref()
-                                .expect("parent exists")
-                                .clone();
-                            parent
-                                .exec
-                                .descrs
-                                .get(jitcode_index as usize)
-                                .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)?
-                                .clone()
-                        };
-                        *last_resolved.borrow_mut() = Some(resolved_jitcode.clone());
-                        Some(crate::resume::ResolvedJitCode::new(
-                            resolved_jitcode,
-                            pc as usize,
-                        ))
+                let resolve_jitcode = |jitcode_index: i32,
+                                       pc: i32,
+                                       _carried_jitcode_pc: i32|
+                 -> Option<crate::resume::ResolvedJitCode> {
+                    let resolved_jitcode = if last_resolved.borrow().is_none() {
+                        // Root frame: clone the dispatch JitCode
+                        // singleton registered at install time
+                        // (`register_dispatch_jitcode`).  Returns
+                        // None only when the proc-macro lowerer
+                        // rejected the dispatch body shape and
+                        // install skipped registration.
+                        dispatch_jitcode.as_ref()?.clone()
+                    } else {
+                        let parent = last_resolved
+                            .borrow()
+                            .as_ref()
+                            .expect("parent exists")
+                            .clone();
+                        parent
+                            .exec
+                            .descrs
+                            .get(jitcode_index as usize)
+                            .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)?
+                            .clone()
                     };
+                    *last_resolved.borrow_mut() = Some(resolved_jitcode.clone());
+                    Some(crate::resume::ResolvedJitCode::new(
+                        resolved_jitcode,
+                        pc as usize,
+                    ))
+                };
 
                 let fallback_alloc = crate::resume::NullAllocator;
                 let allocator: &dyn crate::resume::BlackholeAllocator = self

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2258,7 +2258,10 @@ impl<S: JitState> JitDriver<S> {
                     Option<std::sync::Arc<majit_metainterp::JitCode>>,
                 > = std::cell::RefCell::new(None);
                 let resolve_jitcode =
-                    |jitcode_index: i32, pc: i32| -> Option<crate::resume::ResolvedJitCode> {
+                    |jitcode_index: i32,
+                     pc: i32,
+                     _carried_jitcode_pc: i32|
+                     -> Option<crate::resume::ResolvedJitCode> {
                         let resolved_jitcode = if last_resolved.borrow().is_none() {
                             // Root frame: clone the dispatch JitCode
                             // singleton registered at install time
@@ -4189,7 +4192,10 @@ impl<S: JitState> JitDriver<S> {
                     Option<std::sync::Arc<majit_metainterp::JitCode>>,
                 > = std::cell::RefCell::new(None);
                 let resolve_jitcode =
-                    |jitcode_index: i32, pc: i32| -> Option<crate::resume::ResolvedJitCode> {
+                    |jitcode_index: i32,
+                     pc: i32,
+                     _carried_jitcode_pc: i32|
+                     -> Option<crate::resume::ResolvedJitCode> {
                         let resolved_jitcode = if last_resolved.borrow().is_none() {
                             // Root frame: clone the dispatch JitCode
                             // singleton registered at install time

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6205,19 +6205,21 @@ impl OptContext {
             for (i, &size) in sizes.iter().enumerate() {
                 let end = (offset + size).min(snapshot_boxes.len());
                 let frame_boxes: Vec<SnapshotBox> = snapshot_boxes[offset..end].to_vec();
-                let (jitcode_index, pc, jitcode_pc) = frame_pcs
-                    .get(i)
-                    .copied()
-                    .unwrap_or((0, 0, majit_ir::resumedata::NO_JITCODE_PC));
+                let (jitcode_index, pc, jitcode_pc) = frame_pcs.get(i).copied().unwrap_or((
+                    0,
+                    0,
+                    majit_ir::resumedata::NO_JITCODE_PC,
+                ));
                 frames.push((jitcode_index, pc, jitcode_pc, frame_boxes));
                 offset = end;
             }
             Snapshot::multi_frame_boxes_with_jitcode_pc(frames)
         } else {
-            let (jitcode_index, pc, jitcode_pc) = frame_pcs
-                .first()
-                .copied()
-                .unwrap_or((0, 0, majit_ir::resumedata::NO_JITCODE_PC));
+            let (jitcode_index, pc, jitcode_pc) =
+                frame_pcs
+                    .first()
+                    .copied()
+                    .unwrap_or((0, 0, majit_ir::resumedata::NO_JITCODE_PC));
             Snapshot::single_frame_boxes_with_jitcode_pc(
                 jitcode_index,
                 pc,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -39,7 +39,7 @@ use std::collections::VecDeque;
 
 pub type SnapshotBoxes = Vec<Option<Vec<SnapshotBox>>>;
 pub type SnapshotFrameSizes = Vec<Option<Vec<usize>>>;
-pub type SnapshotFramePcs = Vec<Option<Vec<(i32, i32)>>>;
+pub type SnapshotFramePcs = Vec<Option<Vec<(i32, i32, i32)>>>;
 
 pub(crate) fn snapshot_get<T>(store: &[Option<T>], pos: i32) -> Option<&T> {
     if pos < 0 {
@@ -6205,14 +6205,25 @@ impl OptContext {
             for (i, &size) in sizes.iter().enumerate() {
                 let end = (offset + size).min(snapshot_boxes.len());
                 let frame_boxes: Vec<SnapshotBox> = snapshot_boxes[offset..end].to_vec();
-                let (jitcode_index, pc) = frame_pcs.get(i).copied().unwrap_or((0, 0));
-                frames.push((jitcode_index, pc, frame_boxes));
+                let (jitcode_index, pc, jitcode_pc) = frame_pcs
+                    .get(i)
+                    .copied()
+                    .unwrap_or((0, 0, majit_ir::resumedata::NO_JITCODE_PC));
+                frames.push((jitcode_index, pc, jitcode_pc, frame_boxes));
                 offset = end;
             }
-            Snapshot::multi_frame_boxes(frames)
+            Snapshot::multi_frame_boxes_with_jitcode_pc(frames)
         } else {
-            let (jitcode_index, pc) = frame_pcs.first().copied().unwrap_or((0, 0));
-            Snapshot::single_frame_boxes(jitcode_index, pc, snapshot_boxes.clone())
+            let (jitcode_index, pc, jitcode_pc) = frame_pcs
+                .first()
+                .copied()
+                .unwrap_or((0, 0, majit_ir::resumedata::NO_JITCODE_PC));
+            Snapshot::single_frame_boxes_with_jitcode_pc(
+                jitcode_index,
+                pc,
+                jitcode_pc,
+                snapshot_boxes.clone(),
+            )
         };
         // pyjitpl.py:2588: vable_array stores virtualizable_boxes.
         // ni/vsd are constants (TAGINT/TAGCONST) so they don't affect

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -6944,6 +6944,7 @@ pub fn build_state_field_snapshot(
         snapshot_frames.push(crate::recorder::SnapshotFrame {
             jitcode_index,
             pc: frame.pc as u32,
+            jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
             boxes,
         });
     }

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -553,10 +553,10 @@ fn snapshot_map_from_trace_snapshots(
         // AND vref_array. resume.py:243-247 _number_boxes consumes
         // vref_array as a separate section after vable_array.
         let vref_boxes: Vec<SnapshotBox> = snap.vref_boxes.iter().map(&tagged_to_box).collect();
-        let frame_pcs: Vec<(i32, i32)> = snap
+        let frame_pcs: Vec<(i32, i32, i32)> = snap
             .frames
             .iter()
-            .map(|f| (f.jitcode_index as i32, f.pc as i32))
+            .map(|f| (f.jitcode_index as i32, f.pc as i32, f.jitcode_pc))
             .collect();
         let id = id as i32;
         snapshot_insert(&mut box_map, id, boxes);
@@ -19332,6 +19332,7 @@ mod tests {
                 frames: vec![crate::recorder::SnapshotFrame {
                     jitcode_index: 0,
                     pc: 123,
+                    jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                     boxes: vec![crate::recorder::SnapshotTagged::Box(
                         OpRef::int_op(0),
                         majit_ir::Type::Int,

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -74,6 +74,12 @@ pub struct SnapshotFrame {
     /// context; the runtime translates `py_pc` through `pc_map` at resume
     /// time until pyre's walker-as-tracer epic lands.
     pub pc: u32,
+    /// Guard's JitCode byte offset for kept-stack resume, or
+    /// `NO_JITCODE_PC` (-1) when this frame resumes through the Python
+    /// `pc` → `pc_map` translation.  Populated by the full-body walker at
+    /// the guard from the walk cursor (`op.pc` / `BRANCH_GUARD_JITCODE_PC`);
+    /// trait-leg and bridge/embedder frames keep the sentinel.
+    pub jitcode_pc: i32,
     /// Tagged references to the live boxes in this frame.
     pub boxes: Vec<SnapshotTagged>,
 }

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -301,13 +301,30 @@ impl Snapshot {
     }
 
     pub fn single_frame_boxes(jitcode_index: i32, pc: i32, boxes: Vec<SnapshotBox>) -> Self {
+        Self::single_frame_boxes_with_jitcode_pc(
+            jitcode_index,
+            pc,
+            majit_ir::resumedata::NO_JITCODE_PC,
+            boxes,
+        )
+    }
+
+    /// Like [`single_frame_boxes`], but carries the guard's JitCode byte
+    /// offset (`jitcode_pc`) for kept-stack resume.  Callers that have no
+    /// JitCode coordinate pass [`majit_ir::resumedata::NO_JITCODE_PC`].
+    pub fn single_frame_boxes_with_jitcode_pc(
+        jitcode_index: i32,
+        pc: i32,
+        jitcode_pc: i32,
+        boxes: Vec<SnapshotBox>,
+    ) -> Self {
         Snapshot {
             vable_array: Vec::new(),
             vref_array: Vec::new(),
             framestack: vec![SnapshotFrame {
                 jitcode_index,
                 pc,
-                jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
+                jitcode_pc,
                 boxes,
             }],
         }
@@ -337,15 +354,32 @@ impl Snapshot {
     }
 
     pub fn multi_frame_boxes(frames: Vec<(i32, i32, Vec<SnapshotBox>)>) -> Self {
+        Self::multi_frame_boxes_with_jitcode_pc(
+            frames
+                .into_iter()
+                .map(|(jitcode_index, pc, boxes)| {
+                    (jitcode_index, pc, majit_ir::resumedata::NO_JITCODE_PC, boxes)
+                })
+                .collect(),
+        )
+    }
+
+    /// Like [`multi_frame_boxes`], but each frame tuple carries the
+    /// guard's JitCode byte offset (`jitcode_pc`, 3rd element) for
+    /// kept-stack resume.  Frames with no JitCode coordinate pass
+    /// [`majit_ir::resumedata::NO_JITCODE_PC`].
+    pub fn multi_frame_boxes_with_jitcode_pc(
+        frames: Vec<(i32, i32, i32, Vec<SnapshotBox>)>,
+    ) -> Self {
         Snapshot {
             vable_array: Vec::new(),
             vref_array: Vec::new(),
             framestack: frames
                 .into_iter()
-                .map(|(jitcode_index, pc, boxes)| SnapshotFrame {
+                .map(|(jitcode_index, pc, jitcode_pc, boxes)| SnapshotFrame {
                     jitcode_index,
                     pc,
-                    jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
+                    jitcode_pc,
                     boxes,
                 })
                 .collect(),
@@ -4702,6 +4736,55 @@ mod tests {
         let (val, tagbits) = untag(items[9] as i16);
         assert_eq!(tagbits, TAGBOX);
         assert_eq!(val, 1);
+    }
+
+    #[test]
+    fn test_single_frame_with_jitcode_pc_carries_offset_into_numbering() {
+        // #124 Approach B (M2): the production capture factory writes the
+        // guard's real JitCode byte offset into the per-frame `jitcode_pc`
+        // word of `rd_numb`, where `single_frame` / the legacy
+        // `single_frame_boxes` write `NO_JITCODE_PC` (`test_memo_number_simple`
+        // pins the sentinel at the same slot, `items[6]`).
+        use majit_ir::OpRef;
+        let mut memo = ResumeDataLoopMemo::new();
+        let env = SimpleBoxEnv::new();
+        let snapshot = Snapshot::single_frame_boxes_with_jitcode_pc(
+            0,
+            8,
+            42,
+            vec![OpRef::const_int(42).into(), OpRef::int_op(1).into()],
+        );
+        let numb_state = memo.number(&snapshot, &env, -1).unwrap();
+        let items = crate::resumecode::unpack_all(&numb_state.create_numbering());
+        // Empty vable/vref single-frame header:
+        // items[4]=jitcode_index(0) items[5]=pc(8) items[6]=jitcode_pc.
+        assert_eq!(items[4], 0); // jitcode_index
+        assert_eq!(items[5], 8); // pc
+        assert_eq!(items[6], 42); // jitcode_pc carried by the M2 factory
+        assert_ne!(items[6], majit_ir::resumedata::NO_JITCODE_PC);
+    }
+
+    #[test]
+    fn test_multi_frame_with_jitcode_pc_per_frame() {
+        // #124 Approach B (M2): the multi-frame factory carries a distinct
+        // `jitcode_pc` per frame; a frame with no JitCode coordinate keeps
+        // the `NO_JITCODE_PC` sentinel.
+        use majit_ir::OpRef;
+        let mut memo = ResumeDataLoopMemo::new();
+        let env = SimpleBoxEnv::new();
+        let snapshot = Snapshot::multi_frame_boxes_with_jitcode_pc(vec![
+            (0, 10, majit_ir::resumedata::NO_JITCODE_PC, vec![OpRef::int_op(1).into()]),
+            (1, 20, 55, vec![OpRef::int_op(2).into()]),
+        ]);
+        let items = crate::resumecode::unpack_all(&memo.number(&snapshot, &env, -1).unwrap().create_numbering());
+        // Frame 0: items[4]=jitcode(0) items[5]=pc(10) items[6]=jitcode_pc(sentinel) items[7]=box
+        assert_eq!(items[4], 0);
+        assert_eq!(items[5], 10);
+        assert_eq!(items[6], majit_ir::resumedata::NO_JITCODE_PC);
+        // Frame 1: items[8]=jitcode(1) items[9]=pc(20) items[10]=jitcode_pc(55) items[11]=box
+        assert_eq!(items[8], 1);
+        assert_eq!(items[9], 20);
+        assert_eq!(items[10], 55);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -5048,7 +5048,7 @@ mod tests {
 
         // Roundtrip with liveness-based closure.
         let rd_consts: Vec<majit_ir::Const> = memo.consts().to_vec();
-        let frame_count = |jitcode_index: i32, _pc: i32| -> usize {
+        let frame_count = |jitcode_index: i32, _pc: i32, _jitcode_pc: i32| -> usize {
             match jitcode_index {
                 0 => 2, // Frame 0 has 2 boxes
                 1 => 2, // Frame 1 has 2 boxes
@@ -5201,9 +5201,10 @@ mod tests {
             BC_CATCH_EXCEPTION as i32,
             BC_RVMPROF_CODE as i32,
         );
-        let resolve_jitcode = |_jitcode_pos: i32, _pc: i32| -> Option<ResolvedJitCode> {
-            Some(ResolvedJitCode::new(runtime.clone(), 0))
-        };
+        let resolve_jitcode =
+            |_jitcode_pos: i32, _pc: i32, _jitcode_pc: i32| -> Option<ResolvedJitCode> {
+                Some(ResolvedJitCode::new(runtime.clone(), 0))
+            };
 
         let all_liveness: Vec<u8> = vec![0, 0, 0];
         let (bh, virtualizable_ptr) = blackhole_from_resumedata(
@@ -6711,14 +6712,18 @@ impl<'a> ResumeDataDirectReader<'a> {
         resolve_jitcode: &dyn Fn(
             i32,
             i32,
+            i32,
         )
             -> Option<(std::sync::Arc<crate::jitcode::JitCode>, usize, u8)>,
         outputs: &mut Vec<i64>,
     ) -> bool {
         while !self.done_reading() {
-            // resume.py:1338-1340 read_jitcode_pos_pc.
-            let (jitcode_pos, pc, _jitcode_pc) = self.read_jitcode_pos_pc();
-            let Some((jitcode, resolved_pc, op_live)) = resolve_jitcode(jitcode_pos, pc) else {
+            // resume.py:1338-1340 read_jitcode_pos_pc.  `#124`: forward the
+            // carried direct JitCode pc to the resolver.
+            let (jitcode_pos, pc, jitcode_pc) = self.read_jitcode_pos_pc();
+            let Some((jitcode, resolved_pc, op_live)) =
+                resolve_jitcode(jitcode_pos, pc, jitcode_pc)
+            else {
                 return false;
             };
             // `blackhole.rs:1435 get_current_position_info` parity —
@@ -7059,7 +7064,7 @@ impl ResolvedJitCode {
 
 pub fn blackhole_from_resumedata<'a>(
     builder: &mut crate::blackhole::BlackholeInterpBuilder,
-    resolve_jitcode: &dyn Fn(i32, i32) -> Option<ResolvedJitCode>,
+    resolve_jitcode: &dyn Fn(i32, i32, i32) -> Option<ResolvedJitCode>,
     rd_numb: &'a [u8],
     rd_consts: &'a [majit_ir::Const],
     all_liveness: &'a [u8],
@@ -7112,9 +7117,11 @@ pub fn blackhole_from_resumedata<'a>(
         nextbh.nextblackholeinterp = curbh;
 
         // resume.py:1338-1340
-        let (jitcode_pos, pc, _jitcode_pc) = resumereader.read_jitcode_pos_pc();
-        // resume.py:1339-1340: jitcode = jitcodes[jitcode_pos]; curbh.setposition(jitcode, pc)
-        let resolved = resolve_jitcode(jitcode_pos, pc)?;
+        let (jitcode_pos, pc, jitcode_pc) = resumereader.read_jitcode_pos_pc();
+        // resume.py:1339-1340: jitcode = jitcodes[jitcode_pos]; curbh.setposition(jitcode, pc).
+        // `#124`: pass the carried direct JitCode pc so the resolver can
+        // prefer it over the lossy `pc_map` translation.
+        let resolved = resolve_jitcode(jitcode_pos, pc, jitcode_pc)?;
         if std::env::var_os("MAJIT_BH_DEBUG").is_some() {
             eprintln!(
                 "[bh-frame] jitcode_pos={jitcode_pos} encoded_pc={pc} resolved_pc={}",

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -358,7 +358,12 @@ impl Snapshot {
             frames
                 .into_iter()
                 .map(|(jitcode_index, pc, boxes)| {
-                    (jitcode_index, pc, majit_ir::resumedata::NO_JITCODE_PC, boxes)
+                    (
+                        jitcode_index,
+                        pc,
+                        majit_ir::resumedata::NO_JITCODE_PC,
+                        boxes,
+                    )
                 })
                 .collect(),
         )
@@ -4773,10 +4778,17 @@ mod tests {
         let mut memo = ResumeDataLoopMemo::new();
         let env = SimpleBoxEnv::new();
         let snapshot = Snapshot::multi_frame_boxes_with_jitcode_pc(vec![
-            (0, 10, majit_ir::resumedata::NO_JITCODE_PC, vec![OpRef::int_op(1).into()]),
+            (
+                0,
+                10,
+                majit_ir::resumedata::NO_JITCODE_PC,
+                vec![OpRef::int_op(1).into()],
+            ),
             (1, 20, 55, vec![OpRef::int_op(2).into()]),
         ]);
-        let items = crate::resumecode::unpack_all(&memo.number(&snapshot, &env, -1).unwrap().create_numbering());
+        let items = crate::resumecode::unpack_all(
+            &memo.number(&snapshot, &env, -1).unwrap().create_numbering(),
+        );
         // Frame 0: items[4]=jitcode(0) items[5]=pc(10) items[6]=jitcode_pc(sentinel) items[7]=box
         assert_eq!(items[4], 0);
         assert_eq!(items[5], 10);

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -275,6 +275,11 @@ pub struct SnapshotFrame {
     /// here as a deviation (see `[[project-issue73-phase5-design]]`).
     /// Resume readers translate via `PyJitCode::resume_jitcode_pc_for`.
     pub pc: i32,
+    /// Direct JitCode resume coordinate, or
+    /// [`majit_ir::resumedata::NO_JITCODE_PC`] when this frame resumes
+    /// through the Python `pc` → `pc_map` translation.  A branch-guard
+    /// kept-stack capture stores the guard's JitCode byte offset here.
+    pub jitcode_pc: i32,
     /// Live boxes for this frame's registers (resume.py:253).
     pub boxes: Vec<SnapshotBox>,
 }
@@ -302,6 +307,7 @@ impl Snapshot {
             framestack: vec![SnapshotFrame {
                 jitcode_index,
                 pc,
+                jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                 boxes,
             }],
         }
@@ -339,6 +345,7 @@ impl Snapshot {
                 .map(|(jitcode_index, pc, boxes)| SnapshotFrame {
                     jitcode_index,
                     pc,
+                    jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                     boxes,
                 })
                 .collect(),
@@ -1973,6 +1980,9 @@ impl EncodedResumeData {
         for frame in frames {
             rd_numb.push(frame.jitcode_index as i64);
             rd_numb.push(encode_u64(frame.pc));
+            // Per-frame `jitcode_pc` word; the test/embedder path never
+            // captures a guard coordinate, so it stays the sentinel.
+            rd_numb.push(majit_ir::resumedata::NO_JITCODE_PC as i64);
             // resume.py:253 _number_boxes(snapshot_iter, iter_array(snapshot), numb_state)
             for source in &frame.slot_map {
                 let tagged = memo.encode_tagged_source(source, &mut liveboxes, &mut box_map);
@@ -2059,6 +2069,9 @@ impl EncodedResumeData {
         while cursor < items_resume_len {
             let jitcode_index = self.next_word(&mut cursor) as i32;
             let pc = decode_u64(self.next_word(&mut cursor));
+            // Per-frame `jitcode_pc` word (after `pc`); discarded on this
+            // layout-decode path, which carries only `FrameInfo`.
+            let _jitcode_pc = self.next_word(&mut cursor);
             let slot_count = if frame_idx < self.frame_sizes.len() {
                 self.frame_sizes[frame_idx]
             } else {
@@ -3914,6 +3927,9 @@ impl ResumeDataLoopMemo {
         for frame in &snapshot.framestack {
             numb_state.append_int(frame.jitcode_index as i64);
             numb_state.append_int(frame.pc as i64);
+            // Per-frame `jitcode_pc` word (after `pc`); see
+            // `majit_ir::resumedata::NO_JITCODE_PC`.
+            numb_state.append_int(frame.jitcode_pc as i64);
             self._number_boxes(&frame.boxes, &mut numb_state, env)?;
         }
 
@@ -4255,6 +4271,8 @@ impl ResumeDataLoopMemo {
         for frame in &rd.frames {
             rd_numb.push(frame.jitcode_index as i64);
             rd_numb.push(encode_u64(frame.pc));
+            // Per-frame `jitcode_pc` word; sentinel on the test/embedder path.
+            rd_numb.push(majit_ir::resumedata::NO_JITCODE_PC as i64);
             for source in &frame.slot_map {
                 let tagged = self.encode_tagged_source(source, &mut liveboxes, &mut box_map);
                 rd_numb.push(tagged);
@@ -4670,16 +4688,18 @@ mod tests {
         assert_eq!(items[4], 0);
         // items[5] = pc = 8
         assert_eq!(items[5], 8);
-        // items[6] = inline-Const(42) tagged as TAGINT(42) since 42 fits in 13 bits
-        let (val, tagbits) = untag(items[6] as i16);
+        // items[6] = jitcode_pc = NO_JITCODE_PC (sentinel)
+        assert_eq!(items[6], majit_ir::resumedata::NO_JITCODE_PC);
+        // items[7] = inline-Const(42) tagged as TAGINT(42) since 42 fits in 13 bits
+        let (val, tagbits) = untag(items[7] as i16);
         assert_eq!(tagbits, TAGINT);
         assert_eq!(val, 42);
-        // items[7] = OpRef::int_op(1) tagged as TAGBOX(0) — first live box
-        let (val, tagbits) = untag(items[7] as i16);
+        // items[8] = OpRef::int_op(1) tagged as TAGBOX(0) — first live box
+        let (val, tagbits) = untag(items[8] as i16);
         assert_eq!(tagbits, TAGBOX);
         assert_eq!(val, 0);
-        // items[8] = OpRef::int_op(2) tagged as TAGBOX(1) — second live box
-        let (val, tagbits) = untag(items[8] as i16);
+        // items[9] = OpRef::int_op(2) tagged as TAGBOX(1) — second live box
+        let (val, tagbits) = untag(items[9] as i16);
         assert_eq!(tagbits, TAGBOX);
         assert_eq!(val, 1);
     }
@@ -4770,16 +4790,18 @@ mod tests {
         let items = crate::resumecode::unpack_all(&numb_state.create_numbering());
         // items[1] = num_failargs: 0 (not patched — RPython patches in finish())
         assert_eq!(items[1], 0);
-        // items[6] = OpRef::int_op(1) → TAGBOX(0)
-        let (val, tagbits) = untag(items[6] as i16);
+        // items[6] = jitcode_pc = NO_JITCODE_PC (sentinel)
+        assert_eq!(items[6], majit_ir::resumedata::NO_JITCODE_PC);
+        // items[7] = OpRef::int_op(1) → TAGBOX(0)
+        let (val, tagbits) = untag(items[7] as i16);
         assert_eq!(tagbits, TAGBOX);
         assert_eq!(val, 0);
-        // items[7] = OpRef::ref_op(2) → TAGVIRTUAL(0)
-        let (val, tagbits) = untag(items[7] as i16);
+        // items[8] = OpRef::ref_op(2) → TAGVIRTUAL(0)
+        let (val, tagbits) = untag(items[8] as i16);
         assert_eq!(tagbits, TAGVIRTUAL);
         assert_eq!(val, 0);
-        // items[8] = OpRef::int_op(3) → TAGBOX(1)
-        let (val, tagbits) = untag(items[8] as i16);
+        // items[9] = OpRef::int_op(3) → TAGBOX(1)
+        let (val, tagbits) = untag(items[9] as i16);
         assert_eq!(tagbits, TAGBOX);
         assert_eq!(val, 1);
     }
@@ -4891,7 +4913,9 @@ mod tests {
         let numb_state = memo.number(&snapshot, &env, -1).unwrap();
         let items = crate::resumecode::unpack_all(&numb_state.create_numbering());
 
-        let (val, tagbits) = untag(items[6] as i16);
+        // items[6] = jitcode_pc (sentinel); items[7] = the frame's box.
+        assert_eq!(items[6], majit_ir::resumedata::NO_JITCODE_PC);
+        let (val, tagbits) = untag(items[7] as i16);
         assert_eq!(tagbits, TAGVIRTUAL);
         assert_eq!(val, 0);
         assert_eq!(numb_state.num_boxes, 0);
@@ -4911,11 +4935,13 @@ mod tests {
                 SnapshotFrame {
                     jitcode_index: 0,
                     pc: 10,
+                    jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                     boxes: vec![OpRef::int_op(1).into(), OpRef::const_int(99).into()],
                 },
                 SnapshotFrame {
                     jitcode_index: 1,
                     pc: 20,
+                    jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                     boxes: vec![OpRef::int_op(2).into(), OpRef::int_op(3).into()],
                 },
             ],
@@ -4928,12 +4954,14 @@ mod tests {
         // Multi-frame encoding: no box_count, RPython parity.
         let items = crate::resumecode::unpack_all(&rd_numb);
         assert_eq!(items[1], 3); // num_failargs: 3 boxes patched
-        // Frame 0: items[4]=jitcode(0), items[5]=pc(10), items[6..7]=tagged
+        // Frame 0: items[4]=jitcode(0), items[5]=pc(10), items[6]=jitcode_pc, items[7..8]=tagged
         assert_eq!(items[4], 0);
         assert_eq!(items[5], 10);
-        // Frame 1: items[8]=jitcode(1), items[9]=pc(20), items[10..11]=tagged
-        assert_eq!(items[8], 1);
-        assert_eq!(items[9], 20);
+        assert_eq!(items[6], majit_ir::resumedata::NO_JITCODE_PC);
+        // Frame 1: items[9]=jitcode(1), items[10]=pc(20), items[11]=jitcode_pc, items[12..13]=tagged
+        assert_eq!(items[9], 1);
+        assert_eq!(items[10], 20);
+        assert_eq!(items[11], majit_ir::resumedata::NO_JITCODE_PC);
 
         // Roundtrip with liveness-based closure.
         let rd_consts: Vec<majit_ir::Const> = memo.consts().to_vec();
@@ -5026,6 +5054,7 @@ mod tests {
             framestack: vec![SnapshotFrame {
                 jitcode_index: 0,
                 pc: 8,
+                jitcode_pc: 13,
                 boxes: vec![OpRef::int_op(1).into()],
             }],
         };
@@ -5045,11 +5074,12 @@ mod tests {
         assert_eq!(items[5], 0); // vref_array_length
         assert_eq!(items[6], 0); // jitcode_index
         assert_eq!(items[7], 8); // pc
+        assert_eq!(items[8], 13); // jitcode_pc
 
         // The frame slot reuses the payload tag because numbering follows
         // Box identity exactly: upstream dedups only when the same Box object
         // appears twice, and in this test we passed the same OpRef twice.
-        let (val, tagbits) = untag(items[8] as i16);
+        let (val, tagbits) = untag(items[9] as i16);
         assert_eq!(tagbits, TAGBOX);
         assert_eq!(val, 0);
     }
@@ -5067,6 +5097,7 @@ mod tests {
         writer.append_int(0); // vref_array length
         writer.append_int(0); // jitcode_pos
         writer.append_int(0); // pc
+        writer.append_int(majit_ir::resumedata::NO_JITCODE_PC as i64); // jitcode_pc
         writer.patch_current_size(0);
         let rd_numb = writer.create_numbering();
 
@@ -6291,11 +6322,15 @@ impl<'a> ResumeDataDirectReader<'a> {
 
     // ---- AbstractResumeDataReader methods (resume.py:928-1038) ----
 
-    /// resume.py:928 read_jitcode_pos_pc.
-    pub fn read_jitcode_pos_pc(&mut self) -> (i32, i32) {
+    /// resume.py:928 read_jitcode_pos_pc.  Returns
+    /// `(jitcode_pos, pc, jitcode_pc)`; `jitcode_pc` is the direct JitCode
+    /// resume coordinate or `NO_JITCODE_PC` (see
+    /// `majit_ir::resumedata::NO_JITCODE_PC`).
+    pub fn read_jitcode_pos_pc(&mut self) -> (i32, i32, i32) {
         let jitcode_pos = self.resumecodereader.next_item();
         let pc = self.resumecodereader.next_item();
-        (jitcode_pos, pc)
+        let jitcode_pc = self.resumecodereader.next_item();
+        (jitcode_pos, pc, jitcode_pc)
     }
 
     /// resume.py:933 next_int
@@ -6599,7 +6634,7 @@ impl<'a> ResumeDataDirectReader<'a> {
     ) -> bool {
         while !self.done_reading() {
             // resume.py:1338-1340 read_jitcode_pos_pc.
-            let (jitcode_pos, pc) = self.read_jitcode_pos_pc();
+            let (jitcode_pos, pc, _jitcode_pc) = self.read_jitcode_pos_pc();
             let Some((jitcode, resolved_pc, op_live)) = resolve_jitcode(jitcode_pos, pc) else {
                 return false;
             };
@@ -6994,7 +7029,7 @@ pub fn blackhole_from_resumedata<'a>(
         nextbh.nextblackholeinterp = curbh;
 
         // resume.py:1338-1340
-        let (jitcode_pos, pc) = resumereader.read_jitcode_pos_pc();
+        let (jitcode_pos, pc, _jitcode_pc) = resumereader.read_jitcode_pos_pc();
         // resume.py:1339-1340: jitcode = jitcodes[jitcode_pos]; curbh.setposition(jitcode, pc)
         let resolved = resolve_jitcode(jitcode_pos, pc)?;
         if std::env::var_os("MAJIT_BH_DEBUG").is_some() {

--- a/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
+++ b/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
@@ -27,6 +27,7 @@ fn attach_single_frame_snapshot(ctx: &mut TraceCtx, pc: u32, boxes: &[(OpRef, Ty
         frames: vec![SnapshotFrame {
             jitcode_index: 0,
             pc,
+            jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
             boxes: boxes
                 .iter()
                 .map(|(opref, tp)| SnapshotTagged::Box(*opref, *tp))

--- a/majit/majit-metainterp/tests/resume_parity.rs
+++ b/majit/majit-metainterp/tests/resume_parity.rs
@@ -45,11 +45,14 @@ fn resume_py_public_encoding_uses_tagged_numbering() {
     assert_eq!(encoded.rd_numb[0] as usize, encoded.rd_numb.len());
     assert_eq!(encoded.rd_consts, vec![Const::Int(large_const)]);
     // Header layout (resume.py:231-253):
-    // [size, count, vable_array_len, vref_array_len, jitcode_index, pc, ...slots]
+    // [size, count, vable_array_len, vref_array_len, jitcode_index, pc,
+    //  jitcode_pc, ...slots]
     // rd_numb[1] = count: 1 livebox (FailArg(0) in frame slot)
     assert_eq!(encoded.rd_numb[1], 1);
+    // rd_numb[6] = jitcode_pc sentinel (NO_JITCODE_PC) on the encode path.
+    assert_eq!(encoded.rd_numb[6], -1);
 
-    let slot_words = &encoded.rd_numb[6..12];
+    let slot_words = &encoded.rd_numb[7..13];
     assert_eq!(untag(slot_words[0]), (0, TAG_BOX));
     assert_eq!(untag(slot_words[1]), (7, TAG_INT));
     assert_eq!(untag(slot_words[2]), (0, TAG_CONST));
@@ -227,7 +230,8 @@ fn resume_py_compact_liveboxes_numbering() {
     // liveboxes[0] = 0, liveboxes[1] = 7
     assert_eq!(encoded.liveboxes, vec![0, 7]);
     // TAGBOX(0) for FailArg(0), TAGBOX(1) for FailArg(7)
-    let slot_words = &encoded.rd_numb[6..9];
+    // rd_numb[6] is the jitcode_pc sentinel; slots start at [7].
+    let slot_words = &encoded.rd_numb[7..10];
     assert_eq!(untag(slot_words[0]), (0, TAG_BOX));
     assert_eq!(untag(slot_words[1]), (1, TAG_BOX));
     assert_eq!(untag(slot_words[2]), (42, TAG_INT));
@@ -261,7 +265,8 @@ fn resume_py_dedup_same_box_same_number() {
     assert_eq!(encoded.rd_numb[1], 2);
     assert_eq!(encoded.liveboxes, vec![5, 3]);
     // Both FailArg(5) slots get TAGBOX(0), FailArg(3) gets TAGBOX(1)
-    let slot_words = &encoded.rd_numb[6..9];
+    // rd_numb[6] is the jitcode_pc sentinel; slots start at [7].
+    let slot_words = &encoded.rd_numb[7..10];
     assert_eq!(untag(slot_words[0]), (0, TAG_BOX));
     assert_eq!(untag(slot_words[1]), (0, TAG_BOX));
     assert_eq!(untag(slot_words[2]), (1, TAG_BOX));

--- a/majit/majit-translate/src/jit_codewriter/jitcode.rs
+++ b/majit/majit-translate/src/jit_codewriter/jitcode.rs
@@ -542,6 +542,41 @@ impl JitCode {
         crate::liveness::decode_offset(&self.code, pc + 1)
     }
 
+    /// `True` when `pc` is a recorded resume startpoint (`jitcode.py:85`
+    /// `assert pc in self._startpoints`).  The `#124` direct-JitCode
+    /// resume path consults this to decide whether a carried `jitcode_pc`
+    /// can drive `setposition`/liveness directly instead of routing the
+    /// stored Python pc through the lossy `pc_map`.  `False` for an
+    /// unassembled jitcode (`startpoints is None`) or a pc outside the set.
+    pub fn is_valid_startpoint(&self, pc: usize) -> bool {
+        self.startpoints.as_ref().is_some_and(|s| s.contains(&pc))
+    }
+
+    /// `True` when `get_live_vars_info(pc, op_live)` would decode without
+    /// hitting `_missing_liveness` — i.e. `pc` is anchored at a `-live-`
+    /// marker either directly (`code[pc] == op_live`) or via the same
+    /// `OFFSET_SIZE + 1` backtrack `get_live_vars_info` performs
+    /// (`code[pc - OFFSET_SIZE - 1] == op_live`).
+    ///
+    /// `is_valid_startpoint` alone is NOT sufficient for the `#124`
+    /// direct-resume gate: the assembler records a startpoint before
+    /// EVERY emitted op, so a synthesized specialization guard whose
+    /// carried `jitcode_pc` is a `residual_call`/`may_force` CALL op
+    /// (emitted as `[funcptr, Call, -live-]`, the marker AFTER the call)
+    /// passes `is_valid_startpoint` yet has no preceding `-live-` — feeding
+    /// it to `get_live_vars_info` panics.  This predicate rejects those so
+    /// the resolver falls back to the `pc_map` translation of the stored
+    /// Python pc, which lands on the opcode's own start marker.
+    pub fn can_decode_live_vars(&self, pc: usize, op_live: u8) -> bool {
+        if self.code.get(pc) == Some(&op_live) {
+            return true;
+        }
+        match pc.checked_sub(crate::liveness::OFFSET_SIZE + 1) {
+            Some(back) => self.code.get(back) == Some(&op_live),
+            None => false,
+        }
+    }
+
     /// RPython `jitcode.py:95-100` `_missing_liveness(self, pc)`:
     ///
     /// ```python

--- a/pyre/bench/synth/binary_slice_index.py
+++ b/pyre/bench/synth/binary_slice_index.py
@@ -1,0 +1,71 @@
+# BINARY_SLICE evaluates each non-None bound through __index__
+# (eval_slice_index) instead of reading the raw int field, so a custom
+# __index__, a bool, and a non-int __index__ result behave like the
+# slice(start, stop) + __getitem__ fallback.  Only the exception type is
+# printed so the line matches across CPython/PyPy/Pyre.
+#
+# (A plain float bound is a separate, pre-existing interpreter gap — getindex_w
+# reads a float's bits as an integer instead of raising — so it is not
+# exercised here.)
+N = 50000
+
+
+class Idx:
+    def __init__(self, v):
+        self.v = v
+
+    def __index__(self):
+        return self.v
+
+
+class BadIdx:
+    def __index__(self):
+        return "not-an-int"
+
+
+def show(label, fn):
+    try:
+        print(label, fn())
+    except Exception as e:
+        print(label, type(e).__name__)
+
+
+def main():
+    seq = "abcdefghij"
+    lst = list(range(10))
+    tup = tuple(range(10))
+
+    # Hot loop: the JIT-compiled BINARY_SLICE residual must run __index__ on
+    # the instance bounds every iteration.  A fast path that read the raw int
+    # field of the bound object would mis-slice or crash on the instance.
+    acc = 0
+    i = 0
+    while i < N:
+        a = Idx(i % 5)
+        b = Idx(i % 5 + 3)
+        acc = acc + len(seq[a:b]) + len(lst[a:b]) + len(tup[a:b])
+        i = i + 1
+    print("acc", acc)
+
+    # __index__ bounds resolve to the same slice as plain ints.
+    show("str_idx", lambda: seq[Idx(2):Idx(6)])
+    show("list_idx", lambda: sum(lst[Idx(2):Idx(6)]))
+    show("tuple_idx", lambda: sum(tup[Idx(2):Idx(6)]))
+
+    # bool is an int subtype; True/False are valid bounds.
+    show("bool_bound", lambda: seq[True:4])
+
+    # An __index__ that returns a non-int -> TypeError.
+    show("badidx_bound", lambda: seq[BadIdx():4])
+
+    # None bounds still default to 0 / len.
+    show("none_start", lambda: seq[:4])
+    show("none_stop", lambda: sum(lst[6:]))
+
+    # Code-point-boundary slicing over a lone surrogate, with __index__ bounds.
+    surr = "a\ud800b"
+    show("surrogate_len", lambda: len(surr[Idx(1):Idx(3)]))
+    show("surrogate_ord", lambda: ord(surr[Idx(1):Idx(2)]))
+
+
+main()

--- a/pyre/bench/synth/build_set_hashability.py
+++ b/pyre/bench/synth/build_set_hashability.py
@@ -1,0 +1,80 @@
+# BUILD_SET (the {...} set literal) hashes every element through
+# space.hash_w, so an unhashable element — a list, or an instance whose
+# __hash__ is None / raises / returns a non-int — raises instead of silently
+# building a set, and a user __hash__ is actually invoked.  Only the
+# exception type is printed so the line matches across CPython/PyPy/Pyre.
+N = 50000
+
+
+class HashRaises:
+    def __hash__(self):
+        raise ValueError("nope")
+
+
+class NoHash:
+    __hash__ = None
+
+
+class BadHash:
+    def __hash__(self):
+        return "not-an-int"
+
+
+HASH_CALLS = []
+
+
+class Counted:
+    def __init__(self, v):
+        self.v = v
+
+    def __hash__(self):
+        HASH_CALLS.append(self.v)
+        return self.v
+
+
+def show(label, fn):
+    try:
+        fn()
+        print(label, "NO-RAISE")
+    except Exception as e:
+        print(label, type(e).__name__)
+
+
+def main():
+    # Hot loop: the JIT-compiled BUILD_SET residual builds 3-element sets
+    # whose elements carry a user __hash__; the fallible residual path must
+    # stay benign (no spurious raise) when every element is hashable.
+    acc = 0
+    i = 0
+    while i < N:
+        s = {Counted(i), Counted(i + 1), Counted(i + 2)}
+        acc = acc + len(s)
+        i = i + 1
+    print("acc", acc)
+    print("hash_called", len(HASH_CALLS) > 0)
+
+    # An unhashable list element raises TypeError.
+    show("list_elem", lambda: {[1, 2]})
+
+    # __hash__ = None raises TypeError (an infallible identity hash would
+    # silently accept this).
+    show("nohash_elem", lambda: {NoHash()})
+
+    # A raising __hash__ propagates its own exception (not swallowed).
+    show("raising_hash", lambda: {HashRaises()})
+
+    # A __hash__ returning a non-int raises TypeError.
+    show("badhash_elem", lambda: {BadHash()})
+
+    # A nested unhashable (tuple containing a list) raises TypeError.
+    show("nested_unhashable", lambda: {([1],)})
+
+    # Elements hash left-to-right: the leading raising __hash__ wins over the
+    # trailing unhashable list (ValueError, not TypeError).
+    show("left_to_right", lambda: {HashRaises(), [1]})
+
+    # Successful-build dedup is unchanged for hashable builtins.
+    print("dedup", len({1, 1, 2, "a", "a", (1, 2), (1, 2)}))
+
+
+main()

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -56,11 +56,11 @@ def _detect_pyre_stdlib():
 
 PYRE_STDLIB = _detect_pyre_stdlib()
 
-# Opt-in (`--fbw-inline-multiframe`): export PYRE_FBW_INLINE_MULTIFRAME=1 into
-# pyre child runs so the #68 forward-branch multi-frame inline path is exercised
-# and parity-checked. Off by default; the path is otherwise reached by no
-# corpus run, so this is the only local coverage gate for it.
-FBW_INLINE_MULTIFRAME = False
+# Opt-out (`--no-fbw-inline-multiframe`): export PYRE_FBW_INLINE_MULTIFRAME=0 into
+# pyre child runs to exercise the #68 multi-frame inline rollback escape hatch.
+# The path is on by default, so the default run already parity-checks it; this
+# opt-out validates the flag-off fallback.
+FBW_INLINE_MULTIFRAME_OFF = False
 
 BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
@@ -228,8 +228,8 @@ def pyre_env():
     # in the environment wins.
     if PYRE_STDLIB and "PYRE_STDLIB" not in env:
         env["PYRE_STDLIB"] = PYRE_STDLIB
-    if FBW_INLINE_MULTIFRAME:
-        env["PYRE_FBW_INLINE_MULTIFRAME"] = "1"
+    if FBW_INLINE_MULTIFRAME_OFF:
+        env["PYRE_FBW_INLINE_MULTIFRAME"] = "0"
     return env
 
 
@@ -888,11 +888,11 @@ def parse_args():
         help="per-script timeout in seconds for synthetic benchmarks",
     )
     parser.add_argument(
-        "--fbw-inline-multiframe",
+        "--no-fbw-inline-multiframe",
         action="store_true",
-        help="run pyre with PYRE_FBW_INLINE_MULTIFRAME=1 (#68 forward-branch "
-        "multi-frame inline path); validates that path's parity before its "
-        "default-flip is contemplated",
+        help="run pyre with PYRE_FBW_INLINE_MULTIFRAME=0 (#68 forward-branch "
+        "multi-frame inline is on by default; this exercises the rollback "
+        "escape hatch)",
     )
     parser.add_argument("pyre_path", nargs="?", default="")
     args = parser.parse_args()
@@ -914,9 +914,9 @@ def parse_args():
 
 def main():
     args = parse_args()
-    if args.fbw_inline_multiframe:
-        global FBW_INLINE_MULTIFRAME
-        FBW_INLINE_MULTIFRAME = True
+    if args.no_fbw_inline_multiframe:
+        global FBW_INLINE_MULTIFRAME_OFF
+        FBW_INLINE_MULTIFRAME_OFF = True
     chk = Check(args)
 
     backends = [args.backend] if args.backend else ["dynasm", "cranelift"]

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -56,6 +56,12 @@ def _detect_pyre_stdlib():
 
 PYRE_STDLIB = _detect_pyre_stdlib()
 
+# Opt-in (`--fbw-inline-multiframe`): export PYRE_FBW_INLINE_MULTIFRAME=1 into
+# pyre child runs so the #68 forward-branch multi-frame inline path is exercised
+# and parity-checked. Off by default; the path is otherwise reached by no
+# corpus run, so this is the only local coverage gate for it.
+FBW_INLINE_MULTIFRAME = False
+
 BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
 SNAP_DIR = "pyre/check.snap"
@@ -222,6 +228,8 @@ def pyre_env():
     # in the environment wins.
     if PYRE_STDLIB and "PYRE_STDLIB" not in env:
         env["PYRE_STDLIB"] = PYRE_STDLIB
+    if FBW_INLINE_MULTIFRAME:
+        env["PYRE_FBW_INLINE_MULTIFRAME"] = "1"
     return env
 
 
@@ -879,6 +887,13 @@ def parse_args():
         default=20.0,
         help="per-script timeout in seconds for synthetic benchmarks",
     )
+    parser.add_argument(
+        "--fbw-inline-multiframe",
+        action="store_true",
+        help="run pyre with PYRE_FBW_INLINE_MULTIFRAME=1 (#68 forward-branch "
+        "multi-frame inline path); validates that path's parity before its "
+        "default-flip is contemplated",
+    )
     parser.add_argument("pyre_path", nargs="?", default="")
     args = parser.parse_args()
 
@@ -899,6 +914,9 @@ def parse_args():
 
 def main():
     args = parse_args()
+    if args.fbw_inline_multiframe:
+        global FBW_INLINE_MULTIFRAME
+        FBW_INLINE_MULTIFRAME = True
     chk = Check(args)
 
     backends = [args.backend] if args.backend else ["dynasm", "cranelift"]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3759,8 +3759,18 @@ pub fn collect_iterable(obj: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyE
 /// Create a `set` from a slice of elements.
 ///
 /// PyPy: `setobject.py` W_SetObject.descr_init → `_initialize_set`.
+/// Each `add` hashes the element through `space.hash_w`, so an unhashable
+/// one (or a raising / `None` / non-int `__hash__`) raises. Build the set
+/// element-by-element so the first such element surfaces in left-to-right
+/// order before it is stored; `w_set_add` keeps the `dict_keys_equal`
+/// dedup, and the hash itself is not used for storage.
 pub fn builtin_set_from_items(items: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(pyre_object::w_set_from_items(items))
+    let set = pyre_object::w_set_new();
+    for &item in items {
+        try_hash_value(item)?;
+        unsafe { pyre_object::w_set_add(set, item) };
+    }
+    Ok(set)
 }
 
 /// `dict()` — PyPy: dictobject.py W_DictMultiObject.descr_init

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -635,12 +635,12 @@ pub fn binary_slice_values(
             let s = if pyre_object::is_none(start) {
                 0
             } else {
-                pyre_object::w_int_get_value(start)
+                crate::sliceobject::eval_slice_index(start)?
             };
             let e = if pyre_object::is_none(stop) {
                 len
             } else {
-                pyre_object::w_int_get_value(stop)
+                crate::sliceobject::eval_slice_index(stop)?
             };
             let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
             let e = if e < 0 { (len + e).max(0) } else { e.min(len) } as usize;
@@ -662,12 +662,12 @@ pub fn binary_slice_values(
             let s = if pyre_object::is_none(start) {
                 0
             } else {
-                pyre_object::w_int_get_value(start)
+                crate::sliceobject::eval_slice_index(start)?
             };
             let e = if pyre_object::is_none(stop) {
                 len
             } else {
-                pyre_object::w_int_get_value(stop)
+                crate::sliceobject::eval_slice_index(stop)?
             };
             let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
             let e = (if e < 0 { (len + e).max(0) } else { e.min(len) } as usize).max(s);
@@ -680,12 +680,12 @@ pub fn binary_slice_values(
             let s = if pyre_object::is_none(start) {
                 0
             } else {
-                pyre_object::w_int_get_value(start)
+                crate::sliceobject::eval_slice_index(start)?
             };
             let e = if pyre_object::is_none(stop) {
                 len
             } else {
-                pyre_object::w_int_get_value(stop)
+                crate::sliceobject::eval_slice_index(stop)?
             };
             let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
             let e = if e < 0 { (len + e).max(0) } else { e.min(len) } as usize;

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -1000,6 +1000,110 @@ pub fn emit_box_float_inline(
 ///    (`f_generator_nowref`, `w_yielding_from`, `f_backref`) are written
 ///    explicitly to match the same constructor shape instead of relying on
 ///    an implicit backend zero-fill side effect.
+/// Build a VIRTUAL callee `PyFrame` for a multi-frame inline (#68) from
+/// already-boxed positional argument refs.  Same field-complete frame shape as
+/// [`emit_new_pyframe_inline_self_recursive`] but seeds `locals[0..nparams]`
+/// from `param_boxes` (Ref boxes at the Python call boundary) instead of
+/// boxing a single raw int.  The frame is the callee MIFrame's `frame` red —
+/// `_opimpl_inline_call*` / `perform_call`+`setup_call` create a fresh frame
+/// per inlined call (`pyjitpl.py:2445-2476,1862-1874`); the box stays virtual
+/// on the hot path (the optimizer folds `NewWithVtable`+`SetfieldGc`) and is
+/// materialized lazily only on guard failure.  Field-complete so a forced
+/// materialization (`materialize_virtual_from_rd`) never dereferences an unset
+/// field.
+pub fn emit_new_pyframe_inline_with_params(
+    ctx: &mut TraceCtx,
+    param_boxes: &[OpRef],
+    array_size: usize,
+    valuestackdepth: usize,
+    pycode: OpRef,
+    w_globals_obj: OpRef,
+    ec: OpRef,
+) -> OpRef {
+    use crate::descr::{
+        pyframe_code_descr, pyframe_execution_context_descr, pyframe_f_backref_descr,
+        pyframe_f_generator_nowref_descr, pyframe_locals_cells_stack_descr,
+        pyframe_next_instr_descr, pyframe_size_descr, pyframe_stack_depth_descr,
+        pyframe_w_globals_obj_descr, pyframe_w_yielding_from_descr,
+    };
+    use crate::state::pyobject_gcarray_descr;
+
+    // locals_cells_stack_w array, zero-filled so an unbound local reads PY_NULL.
+    let len_ref = ctx.const_int(array_size as i64);
+    let array_descr = pyobject_gcarray_descr();
+    let locals_array =
+        ctx.record_op_with_descr(OpCode::NewArrayClear, &[len_ref], array_descr.clone());
+    ctx.heap_cache_mut().new_object(locals_array);
+
+    // locals[i] = param_boxes[i] — the positional arguments (already boxed).
+    for (i, &p) in param_boxes.iter().enumerate() {
+        let idx = ctx.const_int(i as i64);
+        ctx.record_op_with_descr(
+            OpCode::SetarrayitemGc,
+            &[locals_array, idx, p],
+            array_descr.clone(),
+        );
+    }
+
+    let new_frame = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], pyframe_size_descr());
+    ctx.heap_cache_mut().new_object(new_frame);
+
+    let ec_descr = pyframe_execution_context_descr();
+    let ec_idx = ec_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, ec], ec_descr);
+    ctx.heapcache_setfield_cached(new_frame, ec_idx, ec);
+
+    let code_descr = pyframe_code_descr();
+    let code_idx = code_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, pycode], code_descr);
+    ctx.heapcache_setfield_cached(new_frame, code_idx, pycode);
+
+    let globals_obj_descr = pyframe_w_globals_obj_descr();
+    let globals_obj_idx = globals_obj_descr.index();
+    ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[new_frame, w_globals_obj],
+        globals_obj_descr,
+    );
+    ctx.heapcache_setfield_cached(new_frame, globals_obj_idx, w_globals_obj);
+
+    let locals_descr = pyframe_locals_cells_stack_descr();
+    let locals_idx = locals_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, locals_array], locals_descr);
+    ctx.heapcache_setfield_cached(new_frame, locals_idx, locals_array);
+
+    let vsd = ctx.const_int(valuestackdepth as i64);
+    let vsd_descr = pyframe_stack_depth_descr();
+    let vsd_idx = vsd_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, vsd], vsd_descr);
+    ctx.heapcache_setfield_cached(new_frame, vsd_idx, vsd);
+
+    let neg_one = ctx.const_int(-1);
+    let last_instr_descr = pyframe_next_instr_descr();
+    let last_instr_idx = last_instr_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, neg_one], last_instr_descr);
+    ctx.heapcache_setfield_cached(new_frame, last_instr_idx, neg_one);
+
+    let null_ref = ctx.const_ref(pyre_object::PY_NULL as i64);
+
+    let generator_descr = pyframe_f_generator_nowref_descr();
+    let generator_idx = generator_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, null_ref], generator_descr);
+    ctx.heapcache_setfield_cached(new_frame, generator_idx, null_ref);
+
+    let yielding_descr = pyframe_w_yielding_from_descr();
+    let yielding_idx = yielding_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, null_ref], yielding_descr);
+    ctx.heapcache_setfield_cached(new_frame, yielding_idx, null_ref);
+
+    let backref_descr = pyframe_f_backref_descr();
+    let backref_idx = backref_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_frame, null_ref], backref_descr);
+    ctx.heapcache_setfield_cached(new_frame, backref_idx, null_ref);
+
+    new_frame
+}
+
 pub fn emit_new_pyframe_inline_self_recursive(
     ctx: &mut TraceCtx,
     raw_int_arg: OpRef,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5626,6 +5626,69 @@ impl Drop for InlineCalleeConstsGuard {
     }
 }
 
+/// One paused caller frame the multi-frame inline snapshot must carry
+/// (#68/#124).  Computed at the inline CALL site — where the caller's live
+/// register banks are still in scope — and read back at guard-capture time
+/// (where the walk context is the callee's, so the caller banks are gone).
+#[derive(Clone)]
+struct InlineParentFrame {
+    /// The caller's jitcode index (`(*JitCode).index`).
+    jitcode_index: u32,
+    /// The caller's resume Python pc: the CALL's return point (fallthrough),
+    /// where the next opcode pops the call result.  First slice keeps this a
+    /// plain py_pc (`< AFTER_RESIDUAL_CALL_PC_FLAG`); a CALL inside a
+    /// try-block (catch marker) declines multi-frame.
+    resume_py_pc: u32,
+    /// The caller's `in_a_call` active boxes at `resume_py_pc` — the liveness
+    /// at the return point with the not-yet-produced call-result slot nulled
+    /// (`get_list_of_active_boxes(in_a_call=true)` parity, trace_opcode.rs:1779).
+    boxes: Vec<OpRef>,
+}
+
+thread_local! {
+    /// FBW inline parent-frame chain (#68/#124): for a guard emitted inside an
+    /// inlined callee sub-walk, the chain of paused caller frames the
+    /// multi-frame snapshot must carry, OUTERMOST-FIRST (the `Snapshot.frames`
+    /// order, recorder.rs:56).  A caller is pushed at the inline CALL site and
+    /// popped when its sub-walk returns, so the innermost caller is last and a
+    /// `reverse()` is not needed.  Empty outside the gated multi-frame inline
+    /// path (`PYRE_FBW_INLINE_MULTIFRAME`); the single-frame collapse
+    /// (caller-boundary re-execute, [`INLINE_SUBWALK_CAPTURE_BOUNDARY`]) stays
+    /// the default for straight-line callees.
+    static FBW_INLINE_PARENT_FRAMES: std::cell::RefCell<Vec<InlineParentFrame>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// RAII guard: push a paused caller frame onto the FBW inline parent-frame
+/// chain for the lifetime of its callee sub-walk; pop on drop so nested
+/// inlines unwind to their parent.
+struct InlineParentFrameGuard;
+
+impl InlineParentFrameGuard {
+    fn enter(frame: InlineParentFrame) -> Self {
+        FBW_INLINE_PARENT_FRAMES.with(|s| s.borrow_mut().push(frame));
+        InlineParentFrameGuard
+    }
+}
+
+impl Drop for InlineParentFrameGuard {
+    fn drop(&mut self) {
+        FBW_INLINE_PARENT_FRAMES.with(|s| {
+            s.borrow_mut().pop();
+        });
+    }
+}
+
+/// `PYRE_FBW_INLINE_MULTIFRAME` (#68): opt-in to inlining branch-bearing
+/// callees with a multi-frame guard snapshot, instead of declining them to
+/// the trait leg (`LoopBearingCalleeInlineUnsupported`).  Off by default —
+/// the multi-frame snapshot encode↔decode contract for walker-emitted
+/// callee-frame guards is validated under this flag (function_calls byte-exact
+/// + corpus) before any production default flip (which is Linux-CI gated).
+fn fbw_inline_multiframe_enabled() -> bool {
+    std::env::var_os("PYRE_FBW_INLINE_MULTIFRAME").is_some()
+}
+
 /// RAII guard: set [`FULL_BODY_SNAPSHOT_SYM`] for the lifetime of a
 /// full-body walk and restore the prior value on drop (so any nesting
 /// restores the parent rather than clearing to null).
@@ -6313,6 +6376,35 @@ fn walker_capture_snapshot_for_last_guard_impl(
     // capture below, which resumes at the CALL site (re-execute the
     // call on deopt — see `INLINE_SUBWALK_CAPTURE_BOUNDARY`).
     let inline_subwalk = INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get());
+    // #68 multi-frame inline guard: a guard emitted inside an inlined callee
+    // sub-walk with paused caller frames on `FBW_INLINE_PARENT_FRAMES` resumes
+    // BOTH the callee (at its own pc) and the caller(s) (at the CALL return
+    // point), instead of collapsing to the caller boundary (re-execute).  Only
+    // the gated forward-branch inline path (`PYRE_FBW_INLINE_MULTIFRAME`)
+    // populates the chain; straight-line callees keep the empty chain + the
+    // single-frame collapse below.
+    if inline_subwalk {
+        // Fire the multi-frame snapshot only when the paused-caller chain
+        // covers the FULL current inline depth: `FBW_INLINE_PARENT_FRAMES`
+        // (callers pushed by the gated multiframe path) must have one entry per
+        // active inlined callee (`FBW_INLINE_CODE_STACK`).  A nested
+        // straight-line callee inlined under a multiframe ancestor (e.g.
+        // `add3` inside a multiframe `mix`) pushes NO parent frame, so its own
+        // guards see a SHORTER chain than the callee depth — fall through to
+        // the single-frame collapse (the strict callee's resume-at-CALL
+        // behavior) rather than emit a chain that skips the intermediate frame.
+        let n_parents = FBW_INLINE_PARENT_FRAMES.with(|s| s.borrow().len());
+        let n_callees = FBW_INLINE_CODE_STACK.with(|s| s.borrow().len());
+        if n_parents > 0 && n_parents == n_callees {
+            let parent_frames = FBW_INLINE_PARENT_FRAMES.with(|s| s.borrow().clone());
+            return walker_capture_multi_frame_inline_snapshot(
+                ctx,
+                op_pc,
+                after_residual_call,
+                parent_frames,
+            );
+        }
+    }
     if !inline_subwalk && !full_body_sym.is_null() {
         // SAFETY: the pointer is set only for the lifetime of the
         // full-body `dispatch_via_miframe` (the guard restores it on
@@ -6524,6 +6616,198 @@ fn walker_capture_snapshot_for_last_guard_impl(
             &ctx.outer_active_boxes,
             ctx.outer_jitcode_index,
             ctx.entry_py_pc,
+            &vable_boxes,
+            &vref_boxes,
+        );
+    Ok(())
+}
+
+/// Build the paused caller frame for a multi-frame inline snapshot (#68),
+/// computed at the inline CALL site where the caller's live register banks
+/// (`ctx.registers_*`) are still in scope.  `call_jit_pc` is the CALL op's
+/// jitcode pc in the caller.  Returns `None` (→ caller declines the inline)
+/// when the caller frame is not snapshot-able for this first slice: missing
+/// liveness/pc_map, a CALL inside a try-block (catch marker resume pc is not
+/// representable in the multi-frame capture's bit-14-free py_pc slot), or no
+/// result on the operand stack at the return point.
+///
+/// The caller resumes at the CALL's return point (fallthrough) with the
+/// not-yet-produced call-result slot nulled — `get_list_of_active_boxes(
+/// in_a_call=true)` parity (`trace_opcode.rs:1779`).  Reuses
+/// [`collect_outer_active_boxes`] (the caller owns the portal virtualizable)
+/// after temporarily nulling the result slot's register.
+fn compute_inline_caller_frame(
+    ctx: &mut WalkContext<'_, '_>,
+    call_jit_pc: usize,
+) -> Option<InlineParentFrame> {
+    let caller_sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if caller_sym_ptr.is_null() {
+        return None;
+    }
+    // SAFETY: set for the lifetime of the top-level `dispatch_via_miframe`;
+    // read-only access to immutable layout fields.
+    let caller_sym = unsafe { &*caller_sym_ptr };
+    if caller_sym.jitcode.is_null() {
+        return None;
+    }
+    let (jitcode_index, fallthrough_py_pc, code_ptr) = unsafe {
+        let jc = &*caller_sym.jitcode;
+        if jc.payload.code_ptr.is_null() || jc.payload.metadata.pc_map.is_empty() {
+            return None;
+        }
+        let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
+        // A CALL inside a try-block resumes at its own catch via a bit-14
+        // marker pc, which the multi-frame capture's `py_pc < FLAG` assert
+        // rejects — decline this slice.
+        if jc.payload.after_residual_call_resume_pc_for(call_py).is_some() {
+            return None;
+        }
+        let code = &*jc.payload.code_ptr;
+        let fallthrough = crate::metainterp::semantic_fallthrough_pc(code, call_py) as u32;
+        (jc.index as u32, fallthrough, jc.payload.code_ptr)
+    };
+    // The call result is the top operand-stack slot at the return point.
+    let depth = unsafe {
+        crate::liveness::liveness_for(code_ptr)
+            .depth_at_py_pc()
+            .get(fallthrough_py_pc as usize)
+            .copied()
+            .unwrap_or(0) as usize
+    };
+    if depth == 0 {
+        return None;
+    }
+    let result_idx = depth - 1;
+    let stack_color_map = crate::state::stack_slot_color_map_at(jitcode_index as i32);
+    let result_color = *stack_color_map.get(result_idx)? as usize;
+    // Null the not-yet-produced result slot, build the box list, then restore
+    // the caller's register (the inlined callee, not the walk, produces the
+    // result; the inner frame supplies it on resume).
+    let null_ref = ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64);
+    let saved = ctx.registers_r.get(result_color).copied();
+    if result_color < ctx.registers_r.len() {
+        ctx.registers_r[result_color] = null_ref;
+    }
+    let boxes = collect_outer_active_boxes(
+        caller_sym,
+        ctx.trace_ctx,
+        ctx.registers_i,
+        ctx.registers_r,
+        ctx.registers_f,
+        jitcode_index,
+        fallthrough_py_pc,
+        None,
+    );
+    if let (Some(saved), true) = (saved, result_color < ctx.registers_r.len()) {
+        ctx.registers_r[result_color] = saved;
+    }
+    Some(InlineParentFrame {
+        jitcode_index,
+        resume_py_pc: fallthrough_py_pc,
+        boxes,
+    })
+}
+
+/// Emit a multi-frame inline guard snapshot (#68): the inlined callee's OWN
+/// (top/innermost) frame built from the live sub-walk register banks, plus the
+/// pre-computed paused caller frame(s) on [`FBW_INLINE_PARENT_FRAMES`].  Frame
+/// order is OUTERMOST-FIRST (`recorder.rs:56` / `build_resumed_frames`
+/// `eval.rs:6505`): the parent chain followed by the callee top frame.  The
+/// stale doc on `capture_snapshot_for_last_guard_multi_frame_with_vable_vref`
+/// claiming `frames[0]=top` is wrong — the function writes frames verbatim.
+fn walker_capture_multi_frame_inline_snapshot(
+    ctx: &mut WalkContext<'_, '_>,
+    callee_op_pc: usize,
+    after_residual_call: bool,
+    parent_frames: Vec<InlineParentFrame>,
+) -> Result<(), DispatchError> {
+    if !ctx.trace_ctx.vable_snapshot_buildable() {
+        return Err(DispatchError::GuardSnapshotVableUntyped { pc: callee_op_pc });
+    }
+    // Callee (top/innermost) frame: map the guard's jitcode pc to the callee's
+    // own Python pc, read liveness from the live sub-walk register banks.
+    let Some(callee_w_code) = FBW_INLINE_CODE_STACK.with(|s| s.borrow().last().copied()) else {
+        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+    };
+    let Some(callee_jitcode_index) = crate::state::ensure_jitcode_index(callee_w_code as *const ())
+    else {
+        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+    };
+    let Some(callee_pjc) = crate::state::pyjitcode_for_jitcode_index(callee_jitcode_index) else {
+        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+    };
+    if callee_pjc.metadata.pc_map.is_empty() || callee_pjc.code_ptr.is_null() {
+        return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc });
+    }
+    let callee_py_pc = unsafe {
+        let code = &*callee_pjc.code_ptr;
+        let mut py = python_pc_for_jitcode_pc(&callee_pjc.metadata, callee_op_pc);
+        py = skip_python_trivia_forward(code, py as usize) as u32;
+        if after_residual_call {
+            py = crate::metainterp::semantic_fallthrough_pc(code, py as usize) as u32;
+        }
+        py
+    };
+    let callee_boxes = collect_callee_active_boxes(
+        ctx.registers_i,
+        ctx.registers_r,
+        ctx.registers_f,
+        callee_jitcode_index as u32,
+        callee_py_pc,
+    );
+
+    // Publish the OUTERMOST caller's vable scalars for its resume coordinate so
+    // the resume reader restores the caller's `PyFrame` at the CALL return
+    // point rather than the stale loop-header seed the walker never crosses
+    // `set_orgpc` to update (mirror of the single-frame path above, 6366-6426).
+    let outer = &parent_frames[0];
+    let caller_sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if !caller_sym_ptr.is_null() {
+        let caller_sym = unsafe { &*caller_sym_ptr };
+        if caller_sym.owns_virtualizable_shadow() && !caller_sym.jitcode.is_null() {
+            let last_instr_value = outer.resume_py_pc as i64 - 1;
+            let last_instr_op = ctx.trace_ctx.const_int(last_instr_value);
+            crate::trace_opcode::mirror_vable_static_to_boxes(
+                ctx.trace_ctx,
+                "last_instr",
+                last_instr_op,
+                Value::Int(last_instr_value),
+            );
+            let vsd_value = unsafe {
+                let jc = &*caller_sym.jitcode;
+                if jc.payload.code_ptr.is_null() {
+                    caller_sym.valuestackdepth as i64
+                } else {
+                    let lv = crate::liveness::liveness_for(jc.payload.code_ptr);
+                    match lv.depth_at_py_pc().get(outer.resume_py_pc as usize).copied() {
+                        Some(d) => (caller_sym.nlocals + d as usize) as i64,
+                        None => caller_sym.valuestackdepth as i64,
+                    }
+                }
+            };
+            let vsd_op = ctx.trace_ctx.const_int(vsd_value);
+            crate::trace_opcode::mirror_vable_static_to_boxes(
+                ctx.trace_ctx,
+                "valuestackdepth",
+                vsd_op,
+                Value::Int(vsd_value),
+            );
+        }
+    }
+
+    let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
+
+    // Frame tuples, OUTERMOST-FIRST: the paused caller chain, then the callee
+    // top frame last (innermost).
+    let mut frames: Vec<(u32, u32, &[OpRef])> = Vec::with_capacity(parent_frames.len() + 1);
+    for pf in &parent_frames {
+        frames.push((pf.jitcode_index, pf.resume_py_pc, pf.boxes.as_slice()));
+    }
+    frames.push((callee_jitcode_index as u32, callee_py_pc, callee_boxes.as_slice()));
+
+    ctx.trace_ctx
+        .capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
+            &frames,
             &vable_boxes,
             &vref_boxes,
         );
@@ -7234,6 +7518,98 @@ fn inline_resolvable_static_vable_read(
     )
 }
 
+/// Relaxed variant of [`callee_fast_path_inlinable`] for the multi-frame
+/// inline path (#68, `PYRE_FBW_INLINE_MULTIFRAME`): a FORWARD `goto_if_not`
+/// (branch target ahead of the branch op) is now inlinable because its
+/// in-callee guard resumes through a multi-frame snapshot
+/// ([`walker_capture_snapshot_for_last_guard_impl`]'s parent-frame branch).
+/// A BACKWARD `goto_if_not` (a loop back-edge) and any `switch` still decline:
+/// a loop in the callee needs a `jit_merge_point` the inline snapshot does
+/// not model, and a multi-target switch is not yet handled.  Non-static vable
+/// reads decline exactly as in the strict predicate (a vable-bearing callee
+/// would abort `VableBoxNotSeeded`).
+fn callee_fast_path_inlinable_allowing_forward_branch(
+    body_code: &[u8],
+    callee_descr_refs: &[DescrRef],
+    ctx: &WalkContext<'_, '_>,
+) -> bool {
+    let mut pc = 0usize;
+    while pc < body_code.len() {
+        let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
+            return false;
+        };
+        if d.opname.starts_with("switch") {
+            return false;
+        }
+        if d.opname.starts_with("goto_if_not") {
+            // `iL`: 2B LE label at operand offset 1 (after the 1B Int reg).
+            let target = read_label(body_code, &d, 1);
+            if target <= d.pc {
+                return false;
+            }
+        }
+        if d.opname.contains("vable")
+            && !inline_resolvable_static_vable_read(body_code, &d, callee_descr_refs, ctx)
+        {
+            return false;
+        }
+        pc = d.next_pc;
+    }
+    true
+}
+
+/// Active boxes for an inlined callee's OWN frame in a multi-frame snapshot
+/// (#68).  The fast-path inline predicate guarantees the callee does not own a
+/// virtualizable (any vable op declines the inline), so the owns_vable /
+/// portal-reg / semantic-slot machinery in [`collect_outer_active_boxes`]
+/// reduces to a plain per-bank `registers_{i,r,f}[live_color]` read — RPython
+/// `pyjitpl.py:218-225 _get_list_of_active_boxes`, banks in int → ref → float
+/// order to match the `all_liveness` header layout the decoder consumes.  A
+/// liveness-active register holding `OpRef::NONE` is a tracer-side invariant
+/// violation (callee banks are sized to the jitcode num_regs co-published with
+/// liveness), so panic loudly rather than bleed NONE into the encoder.
+fn collect_callee_active_boxes(
+    regs_i: &[OpRef],
+    regs_r: &[OpRef],
+    regs_f: &[OpRef],
+    callee_jitcode_index: u32,
+    callee_py_pc: u32,
+) -> Vec<OpRef> {
+    let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+        callee_jitcode_index as i32,
+        callee_py_pc as i32,
+    );
+    let mut active = Vec::with_capacity(banks.int.len() + banks.ref_.len() + banks.float.len());
+    let read = |bank: &[OpRef], idx: u32, name: &str| -> OpRef {
+        let v = bank.get(idx as usize).copied().unwrap_or_else(|| {
+            panic!(
+                "collect_callee_active_boxes: liveness-active {name} register {idx} out of \
+                 range (callee_jitcode_index={callee_jitcode_index}, \
+                 callee_py_pc={callee_py_pc}, bank_len={})",
+                bank.len()
+            )
+        });
+        if v == OpRef::NONE {
+            panic!(
+                "collect_callee_active_boxes: liveness-active {name} register {idx} holds \
+                 OpRef::NONE (callee_jitcode_index={callee_jitcode_index}, \
+                 callee_py_pc={callee_py_pc})"
+            );
+        }
+        v
+    };
+    for &idx in &banks.int {
+        active.push(read(regs_i, idx, "int"));
+    }
+    for &idx in &banks.ref_ {
+        active.push(read(regs_r, idx, "ref"));
+    }
+    for &idx in &banks.float {
+        active.push(read(regs_f, idx, "float"));
+    }
+    active
+}
+
 /// #62: full-body-walk direct `CALL_ASSEMBLER` for a self-recursive call
 /// at the inline recursion-bound boundary (dev-gated `PYRE_FBW_REC_CA`).
 ///
@@ -7712,7 +8088,19 @@ fn try_walker_inline_user_call(
     // The trait leg inlines such callees via `push_inline_frame` +
     // `recursive-call-assembler`, so route the enclosing key there
     // (`FBW_DECLINED_KEYS`) instead of recording the slow residual.
-    if !callee_fast_path_inlinable(body.code, callee_descr_refs, ctx) {
+    let strict_inlinable = callee_fast_path_inlinable(body.code, callee_descr_refs, ctx);
+    // #68: under `PYRE_FBW_INLINE_MULTIFRAME`, a forward-branch-bearing callee
+    // is inlinable with a multi-frame guard snapshot (its in-callee branch
+    // guard resumes through `walker_capture_multi_frame_inline_snapshot` rather
+    // than collapsing to the caller boundary).  Restricted to a TOP-LEVEL
+    // caller (single inline level) for this slice: a nested caller's jitcode
+    // index is not the inherited `outer_jitcode_index`, and its paused-frame
+    // chain needs deeper grandparent plumbing.
+    let try_multiframe = !strict_inlinable
+        && fbw_inline_multiframe_enabled()
+        && ctx.is_top_level
+        && callee_fast_path_inlinable_allowing_forward_branch(body.code, callee_descr_refs, ctx);
+    if !strict_inlinable && !try_multiframe {
         // #62: a self-recursive single-int call (`fib`'s shape) the fast-path
         // inline cannot serve is handled instead by the direct
         // `CALL_ASSEMBLER` arm (`try_walker_call_assembler_self_recursive`).
@@ -7797,6 +8185,21 @@ fn try_walker_inline_user_call(
         callee_concrete_r[reg] = arg_concretes[2 + i];
     }
 
+    // #68: a forward-branch callee inlined under the multi-frame path needs a
+    // paused caller frame on `FBW_INLINE_PARENT_FRAMES` so its in-callee guards
+    // snapshot both frames.  Compute it here, while the caller's live register
+    // banks (`ctx.registers_*`) are still in scope — at guard-capture time the
+    // walk context is the callee's.  A caller frame that is not snapshot-able
+    // (try-block catch marker / missing liveness) declines to the trait leg.
+    let parent_frame = if try_multiframe {
+        match compute_inline_caller_frame(ctx, op.pc) {
+            Some(pf) => Some(pf),
+            None => return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc }),
+        }
+    } else {
+        None
+    };
+
     let callee_outcome = {
         let mut sub_wc = WalkContext {
             registers_r: &mut callee_regs_r,
@@ -7838,6 +8241,10 @@ fn try_walker_inline_user_call(
         // unseeded portal frame to its compile-time constants for the
         // lifetime of the sub-walk.
         let _callee_consts = InlineCalleeConstsGuard::enter(inline_consts);
+        // #68 multi-frame: push the paused caller frame for the lifetime of the
+        // callee sub-walk so its branch guards capture both frames (no-op when
+        // `parent_frame` is None — the strict straight-line inline path).
+        let _parent_frame_guard = parent_frame.map(InlineParentFrameGuard::enter);
         let (outcome, _end_pc) = match walk(body.code, 0, &mut sub_wc) {
             Ok(v) => v,
             Err(e) => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6659,7 +6659,11 @@ fn compute_inline_caller_frame(
         // A CALL inside a try-block resumes at its own catch via a bit-14
         // marker pc, which the multi-frame capture's `py_pc < FLAG` assert
         // rejects — decline this slice.
-        if jc.payload.after_residual_call_resume_pc_for(call_py).is_some() {
+        if jc
+            .payload
+            .after_residual_call_resume_pc_for(call_py)
+            .is_some()
+        {
             return None;
         }
         let code = &*jc.payload.code_ptr;
@@ -6786,9 +6790,14 @@ fn walker_capture_multi_frame_inline_snapshot(
             let code = &*callee_pjc.code_ptr;
             let lo = callee_py_pc.saturating_sub(3);
             for py in lo..callee_py_pc + 5 {
-                if let Some((instr, arg)) = pyre_interpreter::decode_instruction_at(code, py as usize)
+                if let Some((instr, arg)) =
+                    pyre_interpreter::decode_instruction_at(code, py as usize)
                 {
-                    let mark = if py == callee_py_pc { " <== resume" } else { "" };
+                    let mark = if py == callee_py_pc {
+                        " <== resume"
+                    } else {
+                        ""
+                    };
                     eprintln!("[fbw-mf-diag]   py{py}: {instr:?} arg={arg:?}{mark}");
                 }
             }
@@ -6826,7 +6835,11 @@ fn walker_capture_multi_frame_inline_snapshot(
                     caller_sym.valuestackdepth as i64
                 } else {
                     let lv = crate::liveness::liveness_for(jc.payload.code_ptr);
-                    match lv.depth_at_py_pc().get(outer.resume_py_pc as usize).copied() {
+                    match lv
+                        .depth_at_py_pc()
+                        .get(outer.resume_py_pc as usize)
+                        .copied()
+                    {
                         Some(d) => (caller_sym.nlocals + d as usize) as i64,
                         None => caller_sym.valuestackdepth as i64,
                     }
@@ -6850,7 +6863,11 @@ fn walker_capture_multi_frame_inline_snapshot(
     for pf in &parent_frames {
         frames.push((pf.jitcode_index, pf.resume_py_pc, pf.boxes.as_slice()));
     }
-    frames.push((callee_jitcode_index as u32, callee_py_pc, callee_boxes.as_slice()));
+    frames.push((
+        callee_jitcode_index as u32,
+        callee_py_pc,
+        callee_boxes.as_slice(),
+    ));
 
     ctx.trace_ctx
         .capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
@@ -8251,6 +8268,87 @@ fn try_walker_inline_user_call(
         }
         callee_regs_r[reg] = r_args[2 + i];
         callee_concrete_r[reg] = arg_concretes[2 + i];
+    }
+
+    // #68: seed the callee's `frame` / `ec` reds that the codewriter
+    // force-alives at every pc (portal_frame_reg / portal_ec_reg).  The
+    // sym-less fast path seeds only the param colors above, leaving the reds
+    // OpRef::NONE so an in-callee guard snapshot cannot source them
+    // (`collect_callee_active_boxes` declines).  RPython seeds these reds as
+    // part of `setup_call(allboxes)` for a recursive-portal inline
+    // (`pyjitpl.py:1862-1874`, reds=['frame','ec'] `interp_jit.py:67`): a
+    // freshly-built (virtual) callee `PyFrame` plus the caller's shared `ec`.
+    // pyre's "every function is its own portal" model makes every inlined
+    // callee portal-shaped, so the same seeding applies.  The frame box stays
+    // virtual on the hot path (the optimizer folds the NewWithVtable away) and
+    // is materialized only on guard failure; `collect_callee_active_boxes` is
+    // then unchanged (it finds real boxes).  Gated on `try_multiframe` so the
+    // strict straight-line inline path is byte-identical.
+    if try_multiframe {
+        // Branch-A frame shape only (mirror REC_CA): no cells.
+        let raw = unsafe {
+            pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+                as *const pyre_interpreter::CodeObject
+        };
+        if raw.is_null() {
+            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        }
+        let callee_code = unsafe { &*raw };
+        if pyre_interpreter::ncells(callee_code) != 0 {
+            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        }
+        let nlocals = callee_code.varnames.len();
+        let frame_array_size = nlocals + callee_code.max_stackdepth as usize;
+
+        let Some(callee_jitcode_index) =
+            crate::state::ensure_jitcode_index(callee_code_key as *const ())
+        else {
+            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        };
+        let (frame_reg, ec_reg) = crate::state::portal_red_regs_at(callee_jitcode_index as i32);
+        if frame_reg == u16::MAX
+            || ec_reg == u16::MAX
+            || frame_reg as usize >= callee_regs_r.len()
+            || ec_reg as usize >= callee_regs_r.len()
+        {
+            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        }
+
+        // ec red: the shared ExecutionContext (perform_call threads the
+        // caller's ec down).  Seeded `sym.execution_context`, else recovered
+        // off the caller portal frame (mirror REC_CA jitcode_dispatch.rs:7873).
+        let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+        if sym_ptr.is_null() {
+            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        }
+        let sym = unsafe { &*sym_ptr };
+        let callee_ec = if !sym.execution_context.is_none() {
+            sym.execution_context
+        } else {
+            ctx.trace_ctx.record_op_with_descr(
+                OpCode::GetfieldGcR,
+                &[sym.frame],
+                crate::descr::pyframe_execution_context_descr(),
+            )
+        };
+
+        let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
+        let w_globals_obj_const = ctx.trace_ctx.const_ref(inline_consts.w_globals_obj as i64);
+        let param_boxes: Vec<OpRef> = (0..nparams).map(|i| r_args[2 + i]).collect();
+        let callee_frame = crate::helpers::emit_new_pyframe_inline_with_params(
+            ctx.trace_ctx,
+            &param_boxes,
+            frame_array_size,
+            nlocals,
+            pycode_const,
+            w_globals_obj_const,
+            callee_ec,
+        );
+
+        callee_regs_r[frame_reg as usize] = callee_frame;
+        callee_concrete_r[frame_reg as usize] = ConcreteValue::Null;
+        callee_regs_r[ec_reg as usize] = callee_ec;
+        callee_concrete_r[ec_reg as usize] = ConcreteValue::Null;
     }
 
     // #68: a forward-branch callee inlined under the multi-frame path needs a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5687,14 +5687,21 @@ impl Drop for InlineParentFrameGuard {
     }
 }
 
-/// `PYRE_FBW_INLINE_MULTIFRAME` (#68): opt-in to inlining branch-bearing
-/// callees with a multi-frame guard snapshot, instead of declining them to
-/// the trait leg (`LoopBearingCalleeInlineUnsupported`).  Off by default —
-/// the multi-frame snapshot encode↔decode contract for walker-emitted
-/// callee-frame guards is validated under this flag (function_calls byte-exact
-/// + corpus) before any production default flip (which is Linux-CI gated).
+/// `PYRE_FBW_INLINE_MULTIFRAME` (#68): inline branch-bearing callees with a
+/// multi-frame guard snapshot, instead of declining them to the trait leg
+/// (`LoopBearingCalleeInlineUnsupported`).  Default-on; `PYRE_FBW_INLINE_MULTIFRAME=0`
+/// (or `false`) is the rollback escape hatch.  The multi-frame snapshot
+/// encode↔decode contract for walker-emitted callee-frame guards is validated
+/// byte-exact (function_calls + corpus) on both backends.
 fn fbw_inline_multiframe_enabled() -> bool {
-    std::env::var_os("PYRE_FBW_INLINE_MULTIFRAME").is_some()
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_INLINE_MULTIFRAME") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
 }
 
 /// RAII guard: set [`FULL_BODY_SNAPSHOT_SYM`] for the lifetime of a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2332,6 +2332,7 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
         outer_jitcode_index,
         entry_py_pc,
         None,
+        majit_ir::resumedata::NO_JITCODE_PC,
     );
 
     // pyjitpl.py:82-90 `setup` per-bank allocation: each bank gets
@@ -5049,10 +5050,17 @@ fn collect_outer_active_boxes(
     outer_jitcode_index: u32,
     entry_py_pc: u32,
     guard_py_pc: Option<u32>,
+    carried_jitcode_pc: i32,
 ) -> Vec<OpRef> {
-    let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+    // `#124` Approach B: resolve the base live-box set through the carried
+    // JitCode coordinate so the encoder's color set matches the decoder's
+    // (`setup_bridge_sym` / `rebuild_inline_callee`), which read the same
+    // carried word.  With the flag off `carried_jitcode_pc` is ignored and
+    // this is the plain `pc_map`-keyed query.
+    let banks = crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         outer_jitcode_index as i32,
         entry_py_pc as i32,
+        carried_jitcode_pc,
     );
     let mut active = Vec::with_capacity(banks.int.len() + banks.ref_.len() + banks.float.len());
     // RPython `pyjitpl.py:216-233 _get_list_of_active_boxes` reads
@@ -6585,23 +6593,46 @@ fn walker_capture_snapshot_for_last_guard_impl(
             } else {
                 unsafe {
                     let jc = &*sym.jitcode;
-                    Some(python_pc_for_jitcode_pc(&jc.payload.metadata, guard_jc_pc_raw))
+                    Some(python_pc_for_jitcode_pc(
+                        &jc.payload.metadata,
+                        guard_jc_pc_raw,
+                    ))
                 }
             };
             // #124 Approach B (M2): carry the guard's raw JitCode byte offset
-            // as the resume coordinate.  A branch guard stashes its own pc in
-            // `BRANCH_GUARD_JITCODE_PC` (the kept-stack-across-branch precision
-            // `setposition(jitcode, miframe.pc)` preserves); any other guard's
-            // own offset is `op_pc`, a real coordinate on `sym.jitcode` in the
-            // full-body walk.  `after_residual_call` guards resume BEFORE the
-            // call, so their `op_pc` is not a valid resume coordinate — those
-            // keep the sentinel and resume via `py_pc` → `pc_map`.
+            // as the resume coordinate ONLY for branch guards — they stash
+            // their own pc in `BRANCH_GUARD_JITCODE_PC`, the
+            // kept-stack-across-branch precision `setposition(jitcode,
+            // miframe.pc)` preserves and the lossy `py_pc → pc_map` collapses.
+            //
+            // Every other guard (guard_value / guard_class / guard_no_exception,
+            // the `after_residual_call` family) resumes at a `py_pc` whose
+            // operand stack is in a deterministic state with no kept temp, so
+            // its `pc_map` translation is already exact; it keeps the sentinel
+            // and decodes via `py_pc → pc_map`, identical to the flag-off
+            // baseline.  Carrying `op_pc` for those broke encoder ↔ decoder
+            // symmetry: `collect_outer_active_boxes` resolves the reg banks at
+            // the carried coordinate but `live_locals` / `stack_color_map` at
+            // `entry_py_pc`, and for a non-branch guard `op_pc != pc_map[py_pc]`
+            // — the two windows diverge and the decoded box layout mismatches.
             let guard_jitcode_pc: i32 = if guard_jc_pc_raw != usize::MAX {
                 guard_jc_pc_raw as i32
-            } else if after_residual_call {
-                majit_ir::resumedata::NO_JITCODE_PC
             } else {
-                op_pc as i32
+                majit_ir::resumedata::NO_JITCODE_PC
+            };
+            // #124 Approach B: when the carrier holds the guard's own pc (a
+            // branch guard whose not-taken arm is reached by RE-EXECUTING
+            // `goto_if_not`), resume at the guard's Python pc too.  Keying the
+            // snapshot's resume pc on the guard coordinate makes the encoder
+            // liveness window (`collect_outer_active_boxes`), the blackhole
+            // `setposition`, and the cranelift bridge re-trace entry all agree
+            // — the kept operand stack is naturally live at the guard pc, so
+            // the positional `kept_stack_subst` recovery (gpc == entry_py_pc)
+            // is skipped.  Flag-off, `resume_py_pc` stays `py_pc`.
+            let resume_py_pc = if crate::pyjitcode::m3_jitcode_pc_enabled() {
+                guard_py_pc.unwrap_or(py_pc)
+            } else {
+                py_pc
             };
             let active = collect_outer_active_boxes(
                 sym,
@@ -6610,14 +6641,15 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 ctx.registers_r,
                 ctx.registers_f,
                 jitcode_index,
-                py_pc,
+                resume_py_pc,
                 guard_py_pc,
+                guard_jitcode_pc,
             );
             ctx.trace_ctx
                 .capture_snapshot_for_last_guard_with_vable_vref(
                     &active,
                     jitcode_index,
-                    py_pc,
+                    resume_py_pc,
                     guard_jitcode_pc,
                     &vable_boxes,
                     &vref_boxes,
@@ -6722,6 +6754,7 @@ fn compute_inline_caller_frame(
         jitcode_index,
         fallthrough_py_pc,
         None,
+        majit_ir::resumedata::NO_JITCODE_PC,
     );
     if let (Some(saved), true) = (saved, result_color < ctx.registers_r.len()) {
         ctx.registers_r[result_color] = saved;
@@ -12096,24 +12129,40 @@ fn handle(
                 // that corrupts the frame on every odd-path iteration.
                 // Plain `while` / `if` branches resume at depth 0 and pass.
                 //
-                // `PYRE_RELAX_124` opens the gate so the kept-stack
-                // recovery path in `collect_outer_active_boxes` can be
-                // validated against the #124 repros before it is trusted
-                // in production; the env var is unset everywhere except the
-                // targeted repro runs, so production stays on the decline.
-                let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
-                if !relax_124
-                    && branch_resume_target_stack_depth(other_target).is_some_and(|d| d > 0)
-                {
+                // Only a kept-stack (depth > 0) resume target is the #124
+                // case; a plain `while` / `if` resumes at depth 0 and the
+                // single-frame snapshot models it exactly.
+                let kept_stack =
+                    branch_resume_target_stack_depth(other_target).is_some_and(|d| d > 0);
+                // #124 Approach B (M4): the kept-stack guard resumes precisely
+                // at its own JitCode pc through the M3 carrier
+                // (`BRANCH_GUARD_JITCODE_PC` → rd_numb → `setposition`), so
+                // when M3 is enabled the gate opens and the guard compiles
+                // instead of declining to the interpreter.  `PYRE_RELAX_124`
+                // is the standalone validation opener — it exercises the
+                // kept-stack recovery path against the #124 repros without the
+                // M3 decode.  With both off, production keeps the conservative
+                // decline (a guard-failure deopt at depth > 0 would restore a
+                // wrong value into a loop-carried slot via the lossy
+                // `py_pc → pc_map` translation).
+                let kept_stack_resume_enabled = crate::pyjitcode::m3_jitcode_pc_enabled()
+                    || std::env::var_os("PYRE_RELAX_124").is_some();
+                if kept_stack && !kept_stack_resume_enabled {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);
-                // Publish the guard's own jitcode coordinate so the snapshot
-                // encoder can recover kept operand-stack values from the
-                // guard-pc register file (the resume coordinate
-                // `other_target` names a merge point whose live colors the
-                // walk has not written at the guard point).
-                BRANCH_GUARD_JITCODE_PC.with(|c| c.set(op.pc));
+                // Publish the guard's own jitcode coordinate ONLY for the
+                // kept-stack case so the snapshot encoder recovers the kept
+                // operand-stack values from the guard-pc register file (the
+                // resume coordinate `other_target` names a merge point whose
+                // live colors the walk has not written at the guard point).
+                // A depth-0 branch resumes losslessly at `other_target` via
+                // the baseline `py_pc → pc_map` path; routing it through the
+                // guard-pc carrier would resume one opcode early (re-running
+                // `goto_if_not`) and desync the decoded box layout.
+                if kept_stack {
+                    BRANCH_GUARD_JITCODE_PC.with(|c| c.set(op.pc));
+                }
                 let capture = walker_capture_snapshot_for_last_guard(ctx, other_target);
                 BRANCH_GUARD_JITCODE_PC.with(|c| c.set(usize::MAX));
                 capture?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12136,15 +12136,15 @@ fn handle(
                     branch_resume_target_stack_depth(other_target).is_some_and(|d| d > 0);
                 // #124 Approach B (M4): the kept-stack guard resumes precisely
                 // at its own JitCode pc through the M3 carrier
-                // (`BRANCH_GUARD_JITCODE_PC` → rd_numb → `setposition`), so
-                // when M3 is enabled the gate opens and the guard compiles
-                // instead of declining to the interpreter.  `PYRE_RELAX_124`
-                // is the standalone validation opener — it exercises the
-                // kept-stack recovery path against the #124 repros without the
-                // M3 decode.  With both off, production keeps the conservative
-                // decline (a guard-failure deopt at depth > 0 would restore a
-                // wrong value into a loop-carried slot via the lossy
-                // `py_pc → pc_map` translation).
+                // (`BRANCH_GUARD_JITCODE_PC` → rd_numb → `setposition`), so the
+                // gate opens and the guard compiles instead of declining to the
+                // interpreter.  M3 is on by default, so production takes this
+                // path.  `PYRE_RELAX_124` is the standalone opener exercising
+                // the kept-stack recovery path without the M3 decode.  Only when
+                // M3 is force-disabled (`PYRE_M3_JITCODE_PC=0`) AND `PYRE_RELAX_124`
+                // is unset does the conservative decline apply (a guard-failure
+                // deopt at depth > 0 would otherwise restore a wrong value into a
+                // loop-carried slot via the lossy `py_pc → pc_map` translation).
                 let kept_stack_resume_enabled = crate::pyjitcode::m3_jitcode_pc_enabled()
                     || std::env::var_os("PYRE_RELAX_124").is_some();
                 if kept_stack && !kept_stack_resume_enabled {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6748,13 +6748,60 @@ fn walker_capture_multi_frame_inline_snapshot(
         }
         py
     };
+    if std::env::var_os("PYRE_FBW_MF_DIAG").is_some() {
+        let local_cm = crate::state::local_slot_color_map_at(callee_jitcode_index as i32);
+        let stack_cm = crate::state::stack_slot_color_map_at(callee_jitcode_index as i32);
+        let depth = callee_pjc
+            .metadata
+            .depth_at_py_pc
+            .get(callee_py_pc as usize)
+            .copied()
+            .unwrap_or(0);
+        let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+            callee_jitcode_index as i32,
+            callee_py_pc as i32,
+        );
+        eprintln!(
+            "[fbw-mf-diag] callee jc={callee_jitcode_index} op_pc={callee_op_pc} \
+             py_pc={callee_py_pc} after_residual={after_residual_call} depth={depth} \
+             local_color_map={local_cm:?} stack_color_map={stack_cm:?}"
+        );
+        eprintln!(
+            "[fbw-mf-diag]   live banks: i={:?} r={:?} f={:?}",
+            banks.int, banks.ref_, banks.float
+        );
+        for &c in &banks.ref_ {
+            eprintln!(
+                "[fbw-mf-diag]   regs_r[{c}] = {:?}",
+                ctx.registers_r.get(c as usize)
+            );
+        }
+        for &c in &banks.int {
+            eprintln!(
+                "[fbw-mf-diag]   regs_i[{c}] = {:?}",
+                ctx.registers_i.get(c as usize)
+            );
+        }
+        unsafe {
+            let code = &*callee_pjc.code_ptr;
+            let lo = callee_py_pc.saturating_sub(3);
+            for py in lo..callee_py_pc + 5 {
+                if let Some((instr, arg)) = pyre_interpreter::decode_instruction_at(code, py as usize)
+                {
+                    let mark = if py == callee_py_pc { " <== resume" } else { "" };
+                    eprintln!("[fbw-mf-diag]   py{py}: {instr:?} arg={arg:?}{mark}");
+                }
+            }
+        }
+    }
     let callee_boxes = collect_callee_active_boxes(
         ctx.registers_i,
         ctx.registers_r,
         ctx.registers_f,
         callee_jitcode_index as u32,
         callee_py_pc,
-    );
+        callee_op_pc,
+    )?;
 
     // Publish the OUTERMOST caller's vable scalars for its resume coordinate so
     // the resume reader restores the caller's `PyFrame` at the CALL return
@@ -7568,46 +7615,67 @@ fn callee_fast_path_inlinable_allowing_forward_branch(
 /// liveness-active register holding `OpRef::NONE` is a tracer-side invariant
 /// violation (callee banks are sized to the jitcode num_regs co-published with
 /// liveness), so panic loudly rather than bleed NONE into the encoder.
+/// Build the inlined callee (top/innermost) snapshot frame's live box list
+/// from the sub-walk register banks at the guard's callee py_pc.
+///
+/// Unlike [`collect_outer_active_boxes`], the callee sub-walk is sym-less and
+/// owns no virtualizable, so none of the vable-shadow / portal-red / #124
+/// kept-stack recovery applies — every live color must be present directly in
+/// the sub-walk's `registers_*`.  A liveness-active color the sub-walk never
+/// wrote (`OpRef::NONE` — e.g. a static-ref operand-stack slot that trace-time
+/// int-specialization left only in the int bank, or a py_pc↔jit_pc round-trip
+/// landing on a different liveness window) cannot be sourced, so return `Err`
+/// to abort the multi-frame inline and fall back to the trait leg rather than
+/// encode a NONE box.  `PYRE_FBW_MF_DIAG` dumps the missing color.
 fn collect_callee_active_boxes(
     regs_i: &[OpRef],
     regs_r: &[OpRef],
     regs_f: &[OpRef],
     callee_jitcode_index: u32,
     callee_py_pc: u32,
-) -> Vec<OpRef> {
+    callee_op_pc: usize,
+) -> Result<Vec<OpRef>, DispatchError> {
     let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
         callee_jitcode_index as i32,
         callee_py_pc as i32,
     );
     let mut active = Vec::with_capacity(banks.int.len() + banks.ref_.len() + banks.float.len());
-    let read = |bank: &[OpRef], idx: u32, name: &str| -> OpRef {
-        let v = bank.get(idx as usize).copied().unwrap_or_else(|| {
-            panic!(
-                "collect_callee_active_boxes: liveness-active {name} register {idx} out of \
-                 range (callee_jitcode_index={callee_jitcode_index}, \
-                 callee_py_pc={callee_py_pc}, bank_len={})",
-                bank.len()
-            )
-        });
-        if v == OpRef::NONE {
-            panic!(
-                "collect_callee_active_boxes: liveness-active {name} register {idx} holds \
-                 OpRef::NONE (callee_jitcode_index={callee_jitcode_index}, \
-                 callee_py_pc={callee_py_pc})"
-            );
+    let diag = std::env::var_os("PYRE_FBW_MF_DIAG").is_some();
+    let read = |bank: &[OpRef], idx: u32, name: &str| -> Result<OpRef, DispatchError> {
+        match bank.get(idx as usize).copied() {
+            Some(v) if v != OpRef::NONE => Ok(v),
+            other => {
+                if diag {
+                    eprintln!(
+                        "[fbw-mf-diag] decline: callee {name} reg {idx} {} \
+                         (callee_jitcode_index={callee_jitcode_index}, \
+                         callee_py_pc={callee_py_pc}, bank_len={}, \
+                         live_i={:?} live_r={:?} live_f={:?})",
+                        if other.is_none() {
+                            "out-of-range"
+                        } else {
+                            "holds OpRef::NONE"
+                        },
+                        bank.len(),
+                        banks.int,
+                        banks.ref_,
+                        banks.float,
+                    );
+                }
+                Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: callee_op_pc })
+            }
         }
-        v
     };
     for &idx in &banks.int {
-        active.push(read(regs_i, idx, "int"));
+        active.push(read(regs_i, idx, "int")?);
     }
     for &idx in &banks.ref_ {
-        active.push(read(regs_r, idx, "ref"));
+        active.push(read(regs_r, idx, "ref")?);
     }
     for &idx in &banks.float {
-        active.push(read(regs_f, idx, "float"));
+        active.push(read(regs_f, idx, "float")?);
     }
-    active
+    Ok(active)
 }
 
 /// #62: full-body-walk direct `CALL_ASSEMBLER` for a self-recursive call

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6290,11 +6290,16 @@ fn walker_capture_inline_nonstandard_vable_guard(
     // leaves this path inlines (the non-standard identity guard is itself
     // deterministic and never fails at runtime).
     let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
+    // The non-standard identity guard resumes at the caller's CALL
+    // boundary (`entry_py_pc`), re-executing the whole call on deopt —
+    // there is no kept-stack JitCode coordinate to preserve, so the
+    // frame resumes through the Python pc → pc_map path.
     ctx.trace_ctx
         .capture_snapshot_for_last_guard_op_with_vable_vref(
             &ctx.outer_active_boxes,
             ctx.outer_jitcode_index,
             ctx.entry_py_pc,
+            majit_ir::resumedata::NO_JITCODE_PC,
             &vable_boxes,
             &vref_boxes,
         );
@@ -6574,16 +6579,29 @@ fn walker_capture_snapshot_for_last_guard_impl(
             // by the branch handler) to its Python opcode so the encoder can
             // read the guard-pc liveness — the resume `py_pc` is a not-taken
             // merge point whose live colors the walk has not written.
-            let guard_py_pc = {
-                let guard_jc_pc = BRANCH_GUARD_JITCODE_PC.with(|c| c.get());
-                if guard_jc_pc == usize::MAX {
-                    None
-                } else {
-                    unsafe {
-                        let jc = &*sym.jitcode;
-                        Some(python_pc_for_jitcode_pc(&jc.payload.metadata, guard_jc_pc))
-                    }
+            let guard_jc_pc_raw = BRANCH_GUARD_JITCODE_PC.with(|c| c.get());
+            let guard_py_pc = if guard_jc_pc_raw == usize::MAX {
+                None
+            } else {
+                unsafe {
+                    let jc = &*sym.jitcode;
+                    Some(python_pc_for_jitcode_pc(&jc.payload.metadata, guard_jc_pc_raw))
                 }
+            };
+            // #124 Approach B (M2): carry the guard's raw JitCode byte offset
+            // as the resume coordinate.  A branch guard stashes its own pc in
+            // `BRANCH_GUARD_JITCODE_PC` (the kept-stack-across-branch precision
+            // `setposition(jitcode, miframe.pc)` preserves); any other guard's
+            // own offset is `op_pc`, a real coordinate on `sym.jitcode` in the
+            // full-body walk.  `after_residual_call` guards resume BEFORE the
+            // call, so their `op_pc` is not a valid resume coordinate — those
+            // keep the sentinel and resume via `py_pc` → `pc_map`.
+            let guard_jitcode_pc: i32 = if guard_jc_pc_raw != usize::MAX {
+                guard_jc_pc_raw as i32
+            } else if after_residual_call {
+                majit_ir::resumedata::NO_JITCODE_PC
+            } else {
+                op_pc as i32
             };
             let active = collect_outer_active_boxes(
                 sym,
@@ -6600,6 +6618,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     &active,
                     jitcode_index,
                     py_pc,
+                    guard_jitcode_pc,
                     &vable_boxes,
                     &vref_boxes,
                 );
@@ -6608,7 +6627,8 @@ fn walker_capture_snapshot_for_last_guard_impl(
     }
 
     // Per-opcode arm path: `op_pc` (arm-local PC) is not a blackhole
-    // resume point, so the snapshot uses the static outer coordinate.
+    // resume point, so the snapshot uses the static outer coordinate and
+    // resumes via the Python pc → pc_map path (no JitCode coordinate).
     let _ = op_pc;
     let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
     ctx.trace_ctx
@@ -6616,6 +6636,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
             &ctx.outer_active_boxes,
             ctx.outer_jitcode_index,
             ctx.entry_py_pc,
+            majit_ir::resumedata::NO_JITCODE_PC,
             &vable_boxes,
             &vref_boxes,
         );
@@ -6857,15 +6878,40 @@ fn walker_capture_multi_frame_inline_snapshot(
 
     let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
 
+    // #124 Approach B (M2): the callee (top) frame carries the guard's raw
+    // JitCode byte offset as the resume coordinate (mirror of the
+    // single-frame path).  A branch guard stashes its own callee pc in
+    // `BRANCH_GUARD_JITCODE_PC`; otherwise the guard's own offset is
+    // `callee_op_pc`.  `after_residual_call` guards resume BEFORE the call
+    // and keep the sentinel.  The paused caller frames resume at the CALL
+    // return point via the Python pc → pc_map path, so they keep the
+    // sentinel too (no kept-stack coordinate is carried for them in M2).
+    let callee_jitcode_pc: i32 = {
+        let g = BRANCH_GUARD_JITCODE_PC.with(|c| c.get());
+        if g != usize::MAX {
+            g as i32
+        } else if after_residual_call {
+            majit_ir::resumedata::NO_JITCODE_PC
+        } else {
+            callee_op_pc as i32
+        }
+    };
+
     // Frame tuples, OUTERMOST-FIRST: the paused caller chain, then the callee
     // top frame last (innermost).
-    let mut frames: Vec<(u32, u32, &[OpRef])> = Vec::with_capacity(parent_frames.len() + 1);
+    let mut frames: Vec<(u32, u32, i32, &[OpRef])> = Vec::with_capacity(parent_frames.len() + 1);
     for pf in &parent_frames {
-        frames.push((pf.jitcode_index, pf.resume_py_pc, pf.boxes.as_slice()));
+        frames.push((
+            pf.jitcode_index,
+            pf.resume_py_pc,
+            majit_ir::resumedata::NO_JITCODE_PC,
+            pf.boxes.as_slice(),
+        ));
     }
     frames.push((
         callee_jitcode_index as u32,
         callee_py_pc,
+        callee_jitcode_pc,
         callee_boxes.as_slice(),
     ));
 

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -300,17 +300,23 @@ pub fn portal_red_pre_regalloc_slots(nlocals: usize, max_stackdepth: usize) -> (
     (portal_frame_reg, portal_ec_reg)
 }
 
-/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default off).
+/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default on).
 ///
-/// When set, guard frames resume at their carried direct JitCode pc
-/// instead of the lossy `pc_map` translation of the stored Python pc, and
-/// the encoder collects the guard-pc live box set directly rather than the
-/// resume-pc set patched by the positional kept-stack heuristic.  Off by
-/// default so production keeps the heuristic path; the kept-stack-precision
-/// payoff is validated by flipping the flag on (corpus + CI).
+/// Guard frames resume at their carried direct JitCode pc instead of the
+/// lossy `pc_map` translation of the stored Python pc, and the encoder
+/// collects the guard-pc live box set directly rather than the resume-pc set
+/// patched by the positional kept-stack heuristic.  On by default; set
+/// `PYRE_M3_JITCODE_PC=0` (or `false`) to force the legacy heuristic path
+/// back on as a rollback escape hatch.
 pub(crate) fn m3_jitcode_pc_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M3_JITCODE_PC").is_some())
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M3_JITCODE_PC") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
 }
 
 impl PyJitCode {

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -300,6 +300,19 @@ pub fn portal_red_pre_regalloc_slots(nlocals: usize, max_stackdepth: usize) -> (
     (portal_frame_reg, portal_ec_reg)
 }
 
+/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default off).
+///
+/// When set, guard frames resume at their carried direct JitCode pc
+/// instead of the lossy `pc_map` translation of the stored Python pc, and
+/// the encoder collects the guard-pc live box set directly rather than the
+/// resume-pc set patched by the positional kept-stack heuristic.  Off by
+/// default so production keeps the heuristic path; the kept-stack-precision
+/// payoff is validated by flipping the flag on (corpus + CI).
+pub(crate) fn m3_jitcode_pc_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M3_JITCODE_PC").is_some())
+}
+
 impl PyJitCode {
     pub fn new(payload: PyJitCodePayload) -> Self {
         Self {
@@ -454,6 +467,46 @@ impl PyJitCode {
         } else {
             self.resume_jitcode_pc_for(py_pc as usize)
         }
+    }
+
+    /// `#124` Approach B resolver: translate a guard frame's resume
+    /// coordinate, preferring the carried direct JitCode pc (`carried`,
+    /// the rd_numb per-frame `jitcode_pc` word populated by M2) over the
+    /// lossy `pc_map` translation of the stored Python pc.
+    ///
+    /// `resolve_resume_pc(raw_pc)` routes the Python pc through `pc_map`,
+    /// which collapses every kept-operand-stack-across-branch state at one
+    /// Python pc to a single JitCode offset — the precision loss `#124`
+    /// fixes.  When `carried` names a valid startpoint, it IS the
+    /// kept-stack-precise coordinate `setposition(jitcode, miframe.pc)`
+    /// preserves upstream, so it is returned directly.
+    ///
+    /// The encoder (box collection) and decoder (box count + setposition)
+    /// both funnel through this with identical `(raw_pc, carried, op_live)`,
+    /// so the chosen offset — and hence the live-box layout — is symmetric
+    /// by construction.  Gated by [`m3_jitcode_pc_enabled`]: with the flag
+    /// off the carried word is ignored and behaviour is identical to
+    /// [`Self::resolve_resume_pc`].
+    ///
+    /// The carried word is preferred only when it is a `-live-`-anchored
+    /// coordinate ([`JitCode::can_decode_live_vars`]); a startpoint that is
+    /// not so anchored (a synthesized specialization guard's `may_force`
+    /// CALL op) falls through to the `pc_map` translation so
+    /// `get_live_vars_info` never hits `_missing_liveness`.
+    pub fn resolve_resume_pc_with_jitcode_pc(
+        &self,
+        raw_pc: i32,
+        carried: i32,
+        op_live: u8,
+    ) -> Option<usize> {
+        if m3_jitcode_pc_enabled() && carried != majit_ir::resumedata::NO_JITCODE_PC && carried >= 0
+        {
+            let jp = carried as usize;
+            if self.jitcode.can_decode_live_vars(jp, op_live) {
+                return Some(jp);
+            }
+        }
+        self.resolve_resume_pc(raw_pc)
     }
 
     /// Skeleton slot inserted by [`Self::skeleton`] — neither `code`

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8687,8 +8687,8 @@ mod tests {
     /// chordal coalescing legitimately reuses a color across slots that are
     /// never simultaneously live, so the shared inverse
     /// `semantic_ref_slot_for_reg_color` — called by the encode side
-    /// (collect_outer_active_boxes) and both decode sides
-    /// (restore_guard_failure_values / setup_bridge_sym) — must disambiguate
+    /// (collect_outer_active_boxes) and the decode side
+    /// (restore_guard_failure_values) — must disambiguate
     /// by the live window: the live stack prefix first, then the live locals.
     ///
     /// Layout: nlocals=2, max_stackdepth=3, live stack depth 2 (stack_only=2).

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11010,6 +11010,7 @@ mod tests {
             frames: vec![RebuiltFrame {
                 jitcode_index,
                 pc: 0,
+                jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                 values: vec![
                     RebuiltValue::Box(8, Type::Ref),
                     RebuiltValue::Box(9, Type::Ref),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1188,7 +1188,7 @@ pub(crate) fn sub_jitcode_descr_pool_for_code(code: *const ()) -> Option<SubDesc
 /// `LiveVars` analysis over the Python bytecode. This path is used
 /// for inlined callee frames whose majit_jitcode has not been built
 /// at trace time.
-pub fn frame_value_count_at(jitcode_index: i32, pc: i32) -> usize {
+pub fn frame_value_count_at(jitcode_index: i32, pc: i32, carried_jitcode_pc: i32) -> usize {
     ensure_finish_setup();
     METAINTERP_SD.with(|r| {
         let sd = r.borrow();
@@ -1199,10 +1199,13 @@ pub fn frame_value_count_at(jitcode_index: i32, pc: i32) -> usize {
         };
         let payload = &jc.payload;
         // The rd_numb pc word may carry the after-residual-call marker;
-        // `resolve_resume_pc` routes it through the right map, while
-        // `real_pc` is the plain Python PC for the py_pc-keyed fallbacks.
+        // `resolve_resume_pc_with_jitcode_pc` prefers the carried direct
+        // JitCode pc (`#124`) when it names a valid startpoint and otherwise
+        // routes the marker through the right map.  `real_pc` is the plain
+        // Python PC for the py_pc-keyed fallbacks.
         let real_pc = majit_ir::resumedata::decode_resume_pc(pc).0;
-        let resolved_jit_pc: Option<usize> = payload.resolve_resume_pc(pc);
+        let resolved_jit_pc: Option<usize> =
+            payload.resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, sd.op_live);
         if let Some(jit_pc) = resolved_jit_pc {
             let off = payload.jitcode.get_live_vars_info(jit_pc, sd.op_live);
             let all_liveness: &[u8] = &sd.liveness_info;
@@ -1379,6 +1382,25 @@ pub fn frame_liveness_reg_indices_by_bank_at(
     jitcode_index: i32,
     pc: i32,
 ) -> FrameLivenessRegIndices {
+    frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+        jitcode_index,
+        pc,
+        majit_ir::resumedata::NO_JITCODE_PC,
+    )
+}
+
+/// `#124` Approach B encoder/decoder liveness query: identical to
+/// [`frame_liveness_reg_indices_by_bank_at`] but resolves the JitCode
+/// coordinate through [`PyJitCode::resolve_resume_pc_with_jitcode_pc`],
+/// preferring the carried `jitcode_pc` over the lossy `pc_map`.  The
+/// snapshot encoder (`collect_outer_active_boxes`) and the bridge/inline
+/// decoders (`setup_bridge_sym`, `rebuild_inline_callee`) call this with
+/// the SAME carried word so their register color sets agree.
+pub fn frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+    jitcode_index: i32,
+    pc: i32,
+    carried_jitcode_pc: i32,
+) -> FrameLivenessRegIndices {
     ensure_finish_setup();
     METAINTERP_SD.with(|r| {
         let sd = r.borrow();
@@ -1415,7 +1437,8 @@ pub fn frame_liveness_reg_indices_by_bank_at(
                 float: Vec::new(),
             };
         }
-        let resolved_jit_pc: Option<usize> = payload.resolve_resume_pc(pc);
+        let resolved_jit_pc: Option<usize> =
+            payload.resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, sd.op_live);
         let Some(jit_pc) = resolved_jit_pc else {
             return FrameLivenessRegIndices::default();
         };
@@ -5090,7 +5113,11 @@ fn reconstruct_inline_recipe(
     }
     let nlocals = code_ref.varnames.len();
 
-    let reg_indices = frame_liveness_reg_indices_by_bank_at(frame.jitcode_index, frame.pc);
+    let reg_indices = frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+        frame.jitcode_index,
+        frame.pc,
+        frame.jitcode_pc,
+    );
     // resume.py:1054 consume_boxes: the liveness enumeration count must match
     // the encoded frame section exactly.
     if reg_indices.total_len() != frame.values.len() {
@@ -7202,8 +7229,11 @@ impl JitState for PyreJitState {
         // a single `registers_X` vector by abstract register color —
         // there is no `idx < nlocals` decode.
         let frame0 = &resume_data.frames[0];
-        let reg_indices =
-            crate::state::frame_liveness_reg_indices_by_bank_at(frame0.jitcode_index, frame0.pc);
+        let reg_indices = crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+            frame0.jitcode_index,
+            frame0.pc,
+            frame0.jitcode_pc,
+        );
         let stack_only = bridge_valuestackdepth.saturating_sub(nlocals);
         let bridge_reg_len = nlocals + stack_only;
         let mut bridge_registers_r = vec![OpRef::NONE; bridge_reg_len];

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4203,6 +4203,7 @@ impl MIFrame {
             lead.push(majit_metainterp::recorder::SnapshotFrame {
                 jitcode_index: parent_jitcode_index,
                 pc: parent_pc as u32,
+                jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
                 boxes: Self::fail_args_to_snapshot_boxes_typed(&parent_active, parent_types, ctx),
             });
         }
@@ -4241,6 +4242,7 @@ impl MIFrame {
         let top_frame = majit_metainterp::recorder::SnapshotFrame {
             jitcode_index: top_jitcode_index,
             pc: top_pc as u32,
+            jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
             boxes: Self::fail_args_to_snapshot_boxes_typed(
                 top_active_boxes,
                 top_snapshot_types,
@@ -4346,6 +4348,7 @@ impl MIFrame {
         let helper_frame = majit_metainterp::recorder::SnapshotFrame {
             jitcode_index: helper_jitcode_index,
             pc: helper_pc as u32,
+            jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
             boxes: Self::fail_args_to_snapshot_boxes_typed(boxes, &helper_types, ctx),
         };
 
@@ -4379,6 +4382,7 @@ impl MIFrame {
         let self_frame = majit_metainterp::recorder::SnapshotFrame {
             jitcode_index: self_jitcode_index,
             pc: self.fallthrough_pc as u32,
+            jitcode_pc: majit_ir::resumedata::NO_JITCODE_PC,
             boxes: Self::fail_args_to_snapshot_boxes_typed(&self_active, self_types, ctx),
         };
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9746,6 +9746,12 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             | Instruction::EndFor
             | Instruction::UnaryNot
             | Instruction::UnaryInvert
+            // UnaryNegative walks the same MayForce residual-call arm as
+            // UnaryInvert/UnaryNot: pop 1, `residual_call_r_r(unary_negative_fn)`
+            // (`emit_frontend_neg` → `lower_unary_negative_hlop_to_insn`,
+            // a user `__neg__` may run Python), push 1 (net 0).  No oparg
+            // payload, so the #405 arm-seeding hazard does not apply.
+            | Instruction::UnaryNegative
             // ToBool handled by the dispatch_via_walker_for_opcode entry hook:
             // delegates to the stack-neutral no-op `to_bool` (truthiness is
             // re-evaluated by the following branch / UnaryNot guard, so the
@@ -10057,6 +10063,7 @@ fn apply_walker_stack_effect(state: &mut MIFrame, instruction: &Instruction) {
         }
         Instruction::UnaryNot
         | Instruction::UnaryInvert
+        | Instruction::UnaryNegative
         | Instruction::GetIter
         | Instruction::MatchMapping
         | Instruction::MatchSequence

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1497,7 +1497,10 @@ pub fn blackhole_resume_via_rd_numb(
 
     // resume.py:1339 jitcodes[jitcode_pos]: resolve jitcode_index + pc
     // through the trace-side MetaInterpStaticData.jitcodes store.
-    let resolve_jitcode = |jitcode_index: i32, pc: i32| -> Option<resume::ResolvedJitCode> {
+    let resolve_jitcode = |jitcode_index: i32,
+                           pc: i32,
+                           carried_jitcode_pc: i32|
+     -> Option<resume::ResolvedJitCode> {
         if pc < 0 {
             return None;
         }
@@ -1505,7 +1508,9 @@ pub fn blackhole_resume_via_rd_numb(
         if pyjitcode.has_abort_opcode() {
             return None;
         }
-        let resolved_pc = pyjitcode.resolve_resume_pc(pc)?;
+        let op_live = pyre_jit_trace::state::blackhole_control_opcodes().0 as u8;
+        let resolved_pc =
+            pyjitcode.resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, op_live)?;
         // resume.py:1339 reads from one `jitcodes[]` store.  pyre's
         // `state::code_for_jitcode_index` indices name the runtime
         // `MetaInterpStaticData.jitcodes` table keyed by CodeObject; they
@@ -4653,7 +4658,8 @@ pub fn cranelift_resumedata_deopt(
     }
     let op_live = op_live_i32 as u8;
     let resolve_jitcode = |jitcode_index: i32,
-                           pc: i32|
+                           pc: i32,
+                           carried_jitcode_pc: i32|
      -> Option<(
         std::sync::Arc<majit_metainterp::jitcode::JitCode>,
         usize,
@@ -4666,7 +4672,8 @@ pub fn cranelift_resumedata_deopt(
         if pyjitcode.has_abort_opcode() {
             return None;
         }
-        let resolved_pc = pyjitcode.resolve_resume_pc(pc)?;
+        let resolved_pc =
+            pyjitcode.resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, op_live)?;
         Some((pyjitcode.jitcode.clone(), resolved_pc, op_live))
     };
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1497,32 +1497,30 @@ pub fn blackhole_resume_via_rd_numb(
 
     // resume.py:1339 jitcodes[jitcode_pos]: resolve jitcode_index + pc
     // through the trace-side MetaInterpStaticData.jitcodes store.
-    let resolve_jitcode = |jitcode_index: i32,
-                           pc: i32,
-                           carried_jitcode_pc: i32|
-     -> Option<resume::ResolvedJitCode> {
-        if pc < 0 {
-            return None;
-        }
-        let pyjitcode = pyre_jit_trace::state::pyjitcode_for_jitcode_index(jitcode_index)?;
-        if pyjitcode.has_abort_opcode() {
-            return None;
-        }
-        let op_live = pyre_jit_trace::state::blackhole_control_opcodes().0 as u8;
-        let resolved_pc =
-            pyjitcode.resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, op_live)?;
-        // resume.py:1339 reads from one `jitcodes[]` store.  pyre's
-        // `state::code_for_jitcode_index` indices name the runtime
-        // `MetaInterpStaticData.jitcodes` table keyed by CodeObject; they
-        // are not the same index space as `jitcode_runtime::ALL_JITCODES`
-        // (build-time opcode-dispatch artifacts).  Do not cross-lookup the
-        // canonical store by `jitcode_index` until pyre actually shares a
-        // single JitCode object graph end-to-end.
-        Some(
-            resume::ResolvedJitCode::new(pyjitcode.jitcode.clone(), resolved_pc)
-                .with_virtualizable_stack_base(pyjitcode.metadata.stack_base),
-        )
-    };
+    let resolve_jitcode =
+        |jitcode_index: i32, pc: i32, carried_jitcode_pc: i32| -> Option<resume::ResolvedJitCode> {
+            if pc < 0 {
+                return None;
+            }
+            let pyjitcode = pyre_jit_trace::state::pyjitcode_for_jitcode_index(jitcode_index)?;
+            if pyjitcode.has_abort_opcode() {
+                return None;
+            }
+            let op_live = pyre_jit_trace::state::blackhole_control_opcodes().0 as u8;
+            let resolved_pc =
+                pyjitcode.resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, op_live)?;
+            // resume.py:1339 reads from one `jitcodes[]` store.  pyre's
+            // `state::code_for_jitcode_index` indices name the runtime
+            // `MetaInterpStaticData.jitcodes` table keyed by CodeObject; they
+            // are not the same index space as `jitcode_runtime::ALL_JITCODES`
+            // (build-time opcode-dispatch artifacts).  Do not cross-lookup the
+            // canonical store by `jitcode_index` until pyre actually shares a
+            // single JitCode object graph end-to-end.
+            Some(
+                resume::ResolvedJitCode::new(pyjitcode.jitcode.clone(), resolved_pc)
+                    .with_virtualizable_stack_base(pyjitcode.metadata.stack_base),
+            )
+        };
 
     // resume.py:983-991 _prepare_virtuals: convert RdVirtualInfo → VirtualInfo
     // for lazy materialization in getvirtual_ptr/getvirtual_int.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6013,7 +6013,9 @@ pub(crate) fn decode_and_restore_guard_failure(
 /// Decode rd_numb to produce typed values via
 /// `majit_ir::resumedata::rebuild_from_numbering`. Each slot is TAGBOX
 /// (deadframe), TAGCONST (constant), TAGINT (small int), or TAGVIRTUAL
-/// (virtual to materialize). Single-frame only (no per-jitcode liveness).
+/// (virtual to materialize). Consumes only the outermost frame's values,
+/// but splits frames by per-jitcode liveness so the box-section boundary is
+/// correct for multi-frame (inlined-callee) guards.
 ///
 /// Returns `(typed_values, rd_numb_frame_pc)`. The frame PC from rd_numb
 /// is the liveness PC used by get_list_of_active_boxes during encoding.
@@ -6027,6 +6029,15 @@ fn rebuild_typed_from_rd_numb(
 ) -> (Vec<Value>, Option<usize>, HashMap<usize, Value>) {
     use majit_ir::resumedata::rebuild_from_numbering;
 
+    // resume.py:1049-1055 parity: bound each frame's box section by jitcode
+    // liveness (the same per-(jitcode,pc) count the encoder used). Without it,
+    // the single-frame fallback makes `frames[0]` swallow every remaining
+    // item — including subsequent inline frames' headers — which is benign
+    // only as long as the over-read lands on valid tagged values. This
+    // function consumes only `frames.first()`, but it must still consume the
+    // header word stream symmetrically so that boundary is correct for
+    // multi-frame (inlined-callee) guards.
+    let cb = pyre_jit_trace::state::frame_value_count_at;
     let num_virtuals = exit_layout
         .storage
         .as_deref()
@@ -6035,7 +6046,7 @@ fn rebuild_typed_from_rd_numb(
         rd_numb,
         rd_consts,
         &exit_layout.exit_types,
-        None,
+        Some(&cb),
         num_virtuals,
     );
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7578,7 +7578,11 @@ mod tests {
             "selected resume pc must decode the raw-int local slot"
         );
         assert_eq!(
-            trace_state::frame_value_count_at(jitcode_index, resume_pc as i32),
+            trace_state::frame_value_count_at(
+                jitcode_index,
+                resume_pc as i32,
+                majit_ir::resumedata::NO_JITCODE_PC,
+            ),
             live_regs.len(),
             "frame-value count must come from the same compiled jitcode liveness block"
         );

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9908,16 +9908,30 @@ impl CodeWriter {
         // `link.args ↔ target.inputargs` pairs once here so the canonical
         // pass observes the pre-renaming graph.
         //
-        // Parity note (regression vs PyPy): these pairs are pre-merged into
-        // the union-find BEFORE `make_dependencies`.  PyPy `regalloc.py:79-96
-        // coalesce_variables` + `:98-112 _try_coalesce` coalesce post-
-        // `make_dependencies` with the `v0 not in dg.neighbours[w0]`
-        // interference check; the pre-merge bypasses that check and silently
-        // merges pairs PyPy would reject.  Honouring the check measurably
-        // regresses cranelift (fib_recursive/raise_catch/fannkuch TIMEOUT),
-        // because the walker's colour-aggressive emit diverges from the
-        // canonical interference-respecting coloring.
+        // These pairs are pre-merged into the union-find BEFORE
+        // `make_dependencies` in `perform_register_allocation_with_pairs`.
+        // PyPy `regalloc.py:79-96 coalesce_variables` + `:98-112
+        // _try_coalesce` coalesce a `link.args ↔ target.inputargs` pair only
+        // when the two endpoints do NOT interfere (`v0 not in
+        // dg.neighbours[w0]`, py:105); the pre-merge bypasses that check.
+        // Filter the candidates through PyPy's interference check here, on
+        // the SAME pre-renaming graph PyPy runs the CFG sweep over (the
+        // collect below precedes `flatten`'s `insert_renamings`), so an
+        // interfering pair is dropped exactly as upstream would drop it.
+        // The earlier blanket-honour attempt that regressed cranelift
+        // (fib_recursive/raise_catch/fannkuch TIMEOUT) checked interference
+        // on the POST-renaming graph, where `insert_renamings` manufactures
+        // spurious interference; checking on the pre-renaming graph keeps
+        // the non-interfering walker pins (so the canonical coloring still
+        // matches the walker emit) while rejecting the genuinely-interfering
+        // short-circuit `(i and C)` PHI ↔ loop-var merge that collapses the
+        // kept operand-stack slot's color onto the loop var (#124 float).
         let cfg_variable_pairs = collect_cfg_coalesce_pairs(&graph);
+        let cfg_variable_pairs = super::regalloc::filter_coalesce_pairs_by_interference(
+            &graph,
+            Kind::Ref,
+            &cfg_variable_pairs,
+        );
         let mut graph_regallocs = super::regalloc::perform_register_allocation_all_kinds_with_pairs(
             &graph,
             &cfg_variable_pairs,

--- a/pyre/pyre-jit/src/jit/regalloc.rs
+++ b/pyre/pyre-jit/src/jit/regalloc.rs
@@ -580,6 +580,74 @@ pub fn perform_register_allocation_with_pairs_and_interference(
     }
 }
 
+/// Apply PyPy's `_try_coalesce` interference check
+/// (`rpython/tool/algo/regalloc.py:98-112`, the `v0 not in
+/// dg.neighbours[w0]` guard at py:105) to a candidate list of coalesce
+/// pairs and return only the pairs PyPy would accept.
+///
+/// `perform_register_allocation_with_pairs` pre-merges its
+/// `extra_coalesce_pairs` into the union-find BEFORE `make_dependencies`,
+/// which bypasses the interference check — silently coalescing pairs PyPy
+/// would reject when the two endpoints are simultaneously live (e.g. a
+/// short-circuit `(i and C)` PHI result that coalesces with the loop var
+/// `i` on the `and`-false edge, yet both are live across the following
+/// `or` guard: `i` for the loop's `i = i + 1`, the PHI result as the
+/// guard's kept operand-stack temp).  That merge collapses the kept slot's
+/// color onto `i`, so a const-folded kept value (`(i and 2.5) == 2.5`) is
+/// never recoverable at the guard snapshot (#124 float tail).
+///
+/// PyPy runs the check on the PRE-renaming graph (the CFG coalesce sweep
+/// precedes `flatten.py:154 insert_renamings`); this filter does the same
+/// by building the dependency graph on `graph` (the same pre-renaming graph
+/// `collect_cfg_coalesce_pairs` reads) with an EMPTY union-find, so
+/// `make_dependencies` records true interference.  It then replays the
+/// `_try_coalesce` chain incrementally — projecting each endpoint through
+/// the cumulative union-find and coalescing the dependency graph on each
+/// accepted pair — so transitive interference is honoured exactly as
+/// upstream `coalesce_variables` does.  Pairs whose endpoints already share
+/// a rep are kept (the pre-merge is a no-op for them); pairs whose reps
+/// interfere are dropped.
+///
+/// This is the parity-correct replacement for the unconditional pre-merge:
+/// non-interfering pins (walker scratch ↔ inputarg) survive, so the
+/// canonical coloring still matches the walker's emit, while the
+/// interfering `(i, PHI)` pair is rejected.
+pub fn filter_coalesce_pairs_by_interference(
+    graph: &FlowGraph,
+    kind: Kind,
+    pairs: &[(super::flow::VariableId, super::flow::VariableId)],
+) -> Vec<(super::flow::VariableId, super::flow::VariableId)> {
+    let mut allocator = RegAllocator::new(graph, kind);
+    allocator.make_dependencies();
+    let mut kept = Vec::with_capacity(pairs.len());
+    for &(v_id, w_id) in pairs {
+        if v_id == w_id {
+            continue;
+        }
+        let v0 = allocator._unionfind.find_rep(v_id);
+        let w0 = allocator._unionfind.find_rep(w_id);
+        if v0 == w0 {
+            // Already merged by an earlier accepted pair — pre-merging it
+            // again is a no-op, so keep it (matches `_try_coalesce`'s
+            // `v0 is w0` early return, which leaves the pair coalesced).
+            kept.push((v_id, w_id));
+            continue;
+        }
+        if allocator._depgraph.has_edge(&v0, &w0) {
+            // `regalloc.py:105` rejects an interfering pair.
+            continue;
+        }
+        let (_, rep) = allocator._unionfind.union(v0, w0);
+        if rep == v0 {
+            allocator._depgraph.coalesce(w0, v0);
+        } else {
+            allocator._depgraph.coalesce(v0, w0);
+        }
+        kept.push((v_id, w_id));
+    }
+    kept
+}
+
 /// Run `perform_register_allocation` once per `Kind` and collect
 /// the per-kind `GraphAllocationResult`s, mirroring
 /// `rpython/jit/codewriter/codewriter.py:44-46`:


### PR DESCRIPTION
#73

## Summary

Continues the #73 full-body-walk (FBW) tracer cutover: routes more Python opcodes through the JitCode-bytecode walker entry hook, adds a flag-gated multi-frame guard snapshot for inlined callees, fixes a multi-frame guard-failure decode bug, and lands the #124 Approach B M1 carrier (a per-frame JitCode resume coordinate in `rd_numb`).

### Walker opcode routing

Adds `dispatch_via_walker_for_opcode` entry hooks so these opcode families dispatch through the full-body walker instead of the trait leg:

- **BUILD_TUPLE** — routes via the no-arity-cap `new_array_clear` + `setarrayitem_gc_r` + `new*_from_array` residual array-build path, the same path BUILD_LIST already walks; the arity-2 specialised-build `InlineCallArityMismatch` no longer applies.
- **LOAD_NAME / STORE_NAME** — resolve `namei` against `code.names` and delegate to `load_name` / `store_name`, keeping the celldict `ModuleDictStrategy` fast path. (The auto-gen arm left the `&str` name residual-call arg unbound.)
- **LOAD_FAST_LOAD_FAST / LOAD_FAST_BORROW_LOAD_FAST_BORROW** — decode both packed `var_nums` indices; pure loads, so the #405 arm-seeding hazard does not apply.
- **STORE_FAST_LOAD_FAST / STORE_FAST_STORE_FAST** — delegate to the safe `pop_value` + `setarrayitem_vable_r` local-write path; the entry hook bypasses the arm walk, so the #405 arm-seeding hazard does not apply.
- **UNPACK_SEQUENCE** — entry hook pops the sequence via `pop_value` (concrete-shadow stack supplies the concrete sequence) and bypasses the `InlineCallArityMismatch` arm.
- **COMPARE_OP** (non-fused) — the fused compare+jump form is still intercepted upstream by `try_fused_compare_goto_if_not`; this handles the value-context compare.
- **LOAD_GLOBAL** — decode the packed `namei` (`name_idx = raw >> 1`, `push_null = raw & 1`); there is no MIFrame override, so the IR is byte-identical to the trait leg (confirmed under `MAJIT_SHADOW_WALKER`).
- **UNARY_NEGATIVE** — same MayForce `residual_call_r_r(unary_negative_fn)` shape as UNARY_INVERT / UNARY_NOT (pop one, call the `__neg__` helper which may run Python, push the result, net 0, no oparg); added to `production_walker_handles` and the net-0 1-in-1-out group in `apply_walker_stack_effect`.

### Regalloc support

`filter_coalesce_pairs_by_interference` replays `make_dependencies` + `_try_coalesce` on the pre-renaming graph so CFG coalesce pairs honor the `regalloc.py:105` interference guard (`v0 not in dg.neighbours[w0]`) the pre-merge path otherwise bypassed.

### Flag-gated multi-frame inline snapshot (#68, `PYRE_FBW_INLINE_MULTIFRAME`, default OFF)

Behind the flag, the walker can inline a forward-branch-bearing top-level callee and emit a multi-frame guard snapshot for branches taken inside the inlined callee:

- `FBW_INLINE_PARENT_FRAMES` parent-Python-frame chain (outermost-first) + RAII guard.
- `compute_inline_caller_frame` builds the paused caller frame at the CALL site; `collect_callee_active_boxes` reads the callee sub-walk banks at the guard's callee pc.
- `walker_capture_multi_frame_inline_snapshot` assembles `[paused callers…, callee]` and calls `capture_snapshot_for_last_guard_multi_frame_with_vable_vref`.
- The callee `frame` / `ec` portal reds (force-alived by the codewriter at every pc) are seeded via a virtual callee PyFrame (`emit_new_pyframe_inline_with_params`, folded on the hot path, materialized only on deopt), mirroring `setup_call`'s recursive-portal reds.

With the flag on, in-callee type guards fire the multi-frame snapshot and resume correctly across the deopt-storm. An in-callee branch guard whose not-taken arm resumes mid-hoisted-call-staging declines safely to the trait leg — the #124 kept-stack-across-branch architectural limit (resume at a Python pc cannot restore operand-stack slots the JitCode virtualized/hoisted). Flag-off, the path is inert.

### Multi-frame guard-failure decode fix

`rebuild_typed_from_rd_numb` (the dynasm guard-failure restore decode) passed `None` for `frame_value_count`, so the single-frame fallback (`box_count = remaining items`) made `frames[0]` consume every remaining `rd_numb` item. For multi-frame (inlined-callee) guards that swallowed the inner frames' headers; the over-read was benign only while it landed on valid tagged box words. It now passes `frame_value_count_at`, mirroring `build_resumed_frames`, so each frame's box section is bounded by its per-`(jitcode, pc)` liveness. The function still consumes only `frames.first()`; only the header-stream walk is corrected. (This pre-existing latent bug is exposed and made fatal by the `rd_numb` carrier below — the `-1` sentinel decodes as `TAGVIRTUAL(-1)` — but the fix is independent of it.)

### #124 resume-coordinate carrier (Approach B M1, inert)

Reserves a per-frame `jitcode_pc` word after each frame's `pc` in the `rd_numb` stream, plus a matching field on `resume::SnapshotFrame` and `RebuiltFrame`. All producers write the `NO_JITCODE_PC` sentinel (`-1`) and all consumers read and ignore it, so the value is inert; only the slot is reserved. Sites: `number` / `from_semantic` / `encode_shared` encoders and `rebuild_from_numbering` / `read_jitcode_pos_pc` / `decode_layout` decoders; the `resume_parity` layout-pin tests shift their box-section indices by one. This is the carrier for storing the guard's JitCode byte offset as the resume coordinate (`setposition(jitcode, miframe.pc)` parity), which a later change populates and decodes box counts off of, removing the Python-pc → `pc_map` round-trip that loses kept-stack-across-branch precision.

### Contract test

`resume_symmetry_roundtrip_coalesced_color_map` pins the shared encode↔decode inverse `semantic_ref_slot_for_reg_color` for the non-identity, coalesced color map that multi-frame inline and #124 kept-stack produce (the prior end-to-end decode test exercised only the empty-map identity fallback).

### Validation

`check.py` dynasm **127/127** and cranelift **127/127** at `PYRE_JIT="threshold=40,trace_eagerness=20"`; `function_calls` byte-exact `320103199572` flag-on and flag-off; `MAJIT_SHADOW_WALKER` no IR divergence flag-on; `cargo test -p majit-metainterp` lib **1315 passed / 0 failed** plus all integration tests; pyre-jit-trace / pyre-jit lib tests green.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
