### PR TITLE
ci: save rust-cache on main only; finish LLBC artifact handoff

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -74,6 +74,10 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        # Restore-only on PRs (they pull main's cache via restore-keys); save
+        # only on main so per-PR target caches don't multiply across refs past
+        # GitHub's 10 GB cache budget and trigger LRU eviction.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Cache Charon binary
       id: charon-cache
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -162,6 +166,10 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        # Restore-only on PRs (they pull main's cache via restore-keys); save
+        # only on main so per-PR target caches don't multiply across refs past
+        # GitHub's 10 GB cache budget and trigger LRU eviction.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -255,6 +263,10 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        # Restore-only on PRs (they pull main's cache via restore-keys); save
+        # only on main so per-PR target caches don't multiply across refs past
+        # GitHub's 10 GB cache budget and trigger LRU eviction.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -328,6 +340,10 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        # Restore-only on PRs (they pull main's cache via restore-keys); save
+        # only on main so per-PR target caches don't multiply across refs past
+        # GitHub's 10 GB cache budget and trigger LRU eviction.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -400,6 +416,10 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
+        # Restore-only on PRs (they pull main's cache via restore-keys); save
+        # only on main so per-PR target caches don't multiply across refs past
+        # GitHub's 10 GB cache budget and trigger LRU eviction.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Compute LLBC fingerprint
       id: llbc-fingerprint
       shell: bash

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -420,34 +420,27 @@ jobs:
         # only on main so per-PR target caches don't multiply across refs past
         # GitHub's 10 GB cache budget and trigger LRU eviction.
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - name: Compute LLBC fingerprint
-      id: llbc-fingerprint
-      shell: bash
-      run: |
-        value="$(scripts/extract-llbc.py --fingerprint pyre-object pyre-interpreter pyre-jit)"
-        echo "value=${value}" >> "$GITHUB_OUTPUT"
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: |
-          .pyre-build/charon
-          .pyre-build/charon-src
+        path: .pyre-build/charon
         key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
-    - name: Restore LLBC
-      id: restore-llbc
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: build/llbc
-        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
-    - name: Check prepared cache hits
-      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' || steps.restore-llbc.outputs.cache-hit != 'true' }}
+    - name: Check prepared Charon cache hit
+      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        echo "cache miss from prepare-charon-llbc" >&2
+        echo "Charon cache miss from prepare-charon-llbc" >&2
         echo "Charon cache hit: ${{ steps.restore-charon.outputs.cache-hit }}" >&2
-        echo "LLBC cache hit: ${{ steps.restore-llbc.outputs.cache-hit }}" >&2
         exit 1
+    - name: Download LLBC artifact
+      # Run-scoped handoff from prepare-charon-llbc — an artifact is exempt
+      # from the repo-wide 10 GB cache budget / LRU eviction, unlike the
+      # actions/cache restore it replaces. Mirrors the other consumer jobs.
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
     - name: Verify prepared Charon/LLBC
       shell: bash
       run: |


### PR DESCRIPTION
## Problem

PR #198's macOS CI jobs failed fast at the *Check prepared cache hits* guard: the prepared LLBC entry that `prepare-charon-llbc` saved was **LRU-evicted before the late-scheduled macOS consumers restored it**. The repo's Actions cache had exceeded GitHub's **10 GB limit** (~10–12 GB across `main` + open PR refs), and the dominant consumers are the per-ref Swatinem `rust-cache` target caches (~500–600 MB each × job × ref).

\#198 already moved the main consumers' LLBC handoff from `actions/cache` to `upload`/`download-artifact` (run-scoped, not evictable). This PR cuts the root footprint and finishes that migration.

## Changes

1. **rust-cache: save only on `main`.** `save-if: ${{ github.ref == 'refs/heads/main' }}` on all five Swatinem steps (prepare, cargo-test, pyre-check, cpython-tests, wasm-build). PR jobs become **restore-only** and pull `main`'s default-branch cache via `restore-keys`, so each PR no longer persists its own ~500–600 MB target cache.
   - Cost: a PR's own incremental build state is not carried across its pushes (it recompiles its diff from `main`'s baseline each run); deps and unchanged crates still come warm from `main`.
   - Hits work because GitHub lets any PR restore the **default-branch** cache; this is the pattern Swatinem documents for `save-if`.

2. **wasm-build: LLBC via artifact.** The one consumer #198's migration missed — it still restored LLBC with `actions/cache` and hard-failed on a miss. Switched to `download-artifact` and dropped `.pyre-build/charon-src` from its Charon restore path, matching the other jobs.

## Effect

Removes the per-ref cache multiplication that pushed the repo past the budget, and makes the LLBC handoff eviction-proof across **all** consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)