### PR TITLE
jit: opname-dispatch spine + repr/prebuilt-string slices

### DIFF
--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -4234,6 +4234,9 @@ impl JitCodeBuilder {
             constants_i: self.constants_i,
             constants_r: self.constants_r,
             constants_f: self.constants_f,
+            // This builder constructs bytecode directly and never emits
+            // prebuilt-string ref constants, so the descriptor bank is empty.
+            str_consts: Vec::new(),
             c_num_regs_i: self.num_regs_i,
             c_num_regs_r: self.num_regs_r,
             c_num_regs_f: self.num_regs_f,

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -566,9 +566,10 @@ fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
             value,
             ..
         } => vec![base.clone(), elem_index.clone(), value.clone()],
-        OpKind::Call { args, .. } | OpKind::JitDebug { args } | OpKind::NewTuple { args } => {
-            args.clone()
-        }
+        OpKind::Call { args, .. }
+        | OpKind::JitDebug { args }
+        | OpKind::NewTuple { args }
+        | OpKind::LoweredBlackholeOp { args, .. } => args.clone(),
         OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => vec![cond.clone()],
         OpKind::GuardValue { value, .. }
         | OpKind::AssertGreen { value, .. }

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -803,6 +803,10 @@ pub(crate) fn remap_op_kind(
         OpKind::NewTuple { args } => OpKind::NewTuple {
             args: args.iter().map(&remap_var).collect(),
         },
+        OpKind::LoweredBlackholeOp { opname, args } => OpKind::LoweredBlackholeOp {
+            opname: opname.clone(),
+            args: args.iter().map(&remap_var).collect(),
+        },
         OpKind::LoadStatic {
             segments,
             ty,
@@ -841,6 +845,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
             vec![]
         }
         OpKind::NewTuple { args } => args.iter().map(clone_var).collect(),
+        OpKind::LoweredBlackholeOp { args, .. } => args.iter().map(clone_var).collect(),
         OpKind::VableForce { base } => vec![clone_var(base)],
         OpKind::JitMergePoint {
             greens_i,
@@ -1177,6 +1182,12 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::LoopHeader { .. }
         | OpKind::Live
         | OpKind::VableForce { .. }
+        // `LoweredBlackholeOp` carries register-shaped blackhole insns
+        // (`strlen`/`strgetitem`/`strsetitem`/`newstr`) whose side-effect
+        // class is opname-dependent (the `newstr` malloc + `strsetitem`
+        // store mutate).  Conservatively side-effecting so the dead-op
+        // sweep never drops a store or an allocation.
+        | OpKind::LoweredBlackholeOp { .. }
         | OpKind::Abort { .. } => false,
     }
 }

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -98,7 +98,7 @@ fn use_c_form(opname: &str) -> bool {
 // kind-search, no fallback — exactly mirroring RPython's
 // `Register(kind, index)` invariant from `flatten.py:28-33`.
 use crate::flowspace::model::ConstValue;
-use crate::jitcode::{BhCallDescr, JitCodeBody};
+use crate::jitcode::{BhCallDescr, JitCodeBody, StrConstDescriptor};
 use crate::regalloc::RegAllocResult;
 
 /// Assembler — converts SSARepr to JitCode.
@@ -349,6 +349,7 @@ impl Assembler {
             constants_i: Vec::new(),
             constants_r: Vec::new(),
             constants_f: Vec::new(),
+            str_consts: Vec::new(),
             num_regs_i,
             num_regs_r,
             num_regs_f,
@@ -442,6 +443,7 @@ impl Assembler {
             constants_i: state.constants_i,
             constants_r: state.constants_r,
             constants_f: state.constants_f,
+            str_consts: state.str_consts,
             c_num_regs_i: num_regs_i as u16,
             c_num_regs_r: num_regs_r as u16,
             c_num_regs_f: num_regs_f as u16,
@@ -2554,6 +2556,19 @@ impl Assembler {
     }
 
     fn emit_const_r(&mut self, value: &ConstValue, state: &mut AssemblyState) -> u8 {
+        // A prebuilt `Ptr(STR)` constant cannot be baked as a runtime
+        // address: the translator runs in a separate build-script process,
+        // so the `_ptr` target is process-local garbage at runtime.  Record
+        // the string's bytes + precomputed hash for runtime materialization
+        // and pool a non-canonical sentinel that the jitcode-load pass
+        // overwrites with the live immortal STR GcStruct address.
+        if let ConstValue::LLPtr(p) = value {
+            if let Some((bytes, hash)) =
+                crate::translator::rtyper::lltypesystem::rstr::prebuilt_str_bytes_and_hash(p)
+            {
+                return self.emit_str_const_r(bytes, hash, state);
+            }
+        }
         let bits = match value {
             ConstValue::HostObject(obj) => obj.identity_id() as i64,
             ConstValue::LLAddress(
@@ -2562,6 +2577,37 @@ impl Assembler {
             other => panic!("raise/r constant pool does not support {other:?}"),
         };
         self.emit_const_r_bits(bits, state)
+    }
+
+    /// Record a prebuilt-string constant for runtime materialization and
+    /// pool its sentinel, returning the `r`-bank register index.  Identical
+    /// literals (by bytes) share one descriptor and one sentinel, so
+    /// [`Self::emit_const_r_bits`]' dedup-by-bits collapses them to a single
+    /// pool entry — the analog of upstream `emit_const`'s `value_key` dedup
+    /// (`assembler.py:116`).
+    fn emit_str_const_r(
+        &mut self,
+        bytes: Vec<u8>,
+        precomputed_hash: i64,
+        state: &mut AssemblyState,
+    ) -> u8 {
+        if let Some(ordinal) = state.str_consts.iter().position(|d| d.bytes == bytes) {
+            return self.emit_const_r_bits(str_const_sentinel(ordinal), state);
+        }
+        let ordinal = state.str_consts.len();
+        let constants_r_index = state.constants_r.len();
+        let reg = self.emit_const_r_bits(str_const_sentinel(ordinal), state);
+        debug_assert_eq!(
+            state.constants_r.len(),
+            constants_r_index + 1,
+            "a fresh str-const sentinel must push a new constants_r slot"
+        );
+        state.str_consts.push(StrConstDescriptor {
+            constants_r_index,
+            bytes,
+            precomputed_hash,
+        });
+        reg
     }
 
     fn emit_const_r_bits(&mut self, bits: i64, state: &mut AssemblyState) -> u8 {
@@ -2593,12 +2639,34 @@ impl Assembler {
     }
 }
 
+/// Non-canonical tag marking a deferred prebuilt-string slot in
+/// `constants_r`.  x86-64 user addresses occupy `0..2^48`, so this high-word
+/// pattern can never alias a real GCREF / host-static address; the low 48
+/// bits carry the [`StrConstDescriptor`] ordinal.  The runtime load pass
+/// overwrites every such slot with a live immortal STR address before the
+/// jitcode is used, so the sentinel is never dereferenced (a non-canonical
+/// deref would fault, surfacing any missed patch immediately).
+pub const STR_CONST_SENTINEL_BASE: i64 = 0x7E57_0000_0000_0000u64 as i64;
+
+/// `STR_CONST_SENTINEL_BASE | ordinal` — see [`STR_CONST_SENTINEL_BASE`].
+fn str_const_sentinel(ordinal: usize) -> i64 {
+    debug_assert!(
+        (ordinal as u64) < (1u64 << 48),
+        "too many prebuilt-string constants in one jitcode"
+    );
+    STR_CONST_SENTINEL_BASE | ordinal as i64
+}
+
 /// Per-assembly state (RPython: Assembler.setup() fields).
 struct AssemblyState {
     code: Vec<u8>,
     constants_i: Vec<i64>,
     constants_r: Vec<i64>,
     constants_f: Vec<i64>,
+    /// Prebuilt-string constants recorded while assembling, committed to
+    /// [`JitCodeBody::str_consts`].  Parallel to `constants_r`: each entry
+    /// owns the `constants_r` slot named by its `constants_r_index`.
+    str_consts: Vec<StrConstDescriptor>,
     num_regs_i: usize,
     num_regs_r: usize,
     num_regs_f: usize,
@@ -3994,6 +4062,7 @@ mod tests {
             constants_i: Vec::new(),
             constants_r: Vec::new(),
             constants_f: Vec::new(),
+            str_consts: Vec::new(),
             num_regs_i: 4,
             num_regs_r: 0,
             num_regs_f: 0,
@@ -4329,6 +4398,49 @@ mod tests {
 
         assert_eq!(body.constants_r, vec![module.identity_id() as i64]);
         assert!(asm.insns.contains_key("ref_return/r"));
+    }
+
+    #[test]
+    fn emit_const_r_records_prebuilt_string_descriptor_and_dedups() {
+        use crate::translator::rtyper::lltypesystem::rstr::{
+            const_str_cache_llstr, ll_strhash_value,
+        };
+        let str_const = |s: &[u8]| {
+            ConstValue::LLPtr(Box::new(
+                const_str_cache_llstr(s).expect("cache llstr"),
+            ))
+        };
+        let mut asm = Assembler::new();
+        let mut state = empty_state();
+
+        // A prebuilt `Ptr(STR)` no longer panics: it records a descriptor
+        // and pools a sentinel slot for runtime materialization.
+        let reg_a = asm.emit_const_r(&str_const(b"hello"), &mut state);
+        assert_eq!(state.str_consts.len(), 1);
+        assert_eq!(state.str_consts[0].bytes, b"hello".to_vec());
+        assert_eq!(
+            state.str_consts[0].precomputed_hash,
+            ll_strhash_value(b"hello")
+        );
+        assert_eq!(state.str_consts[0].constants_r_index, 0);
+        assert_eq!(state.constants_r, vec![str_const_sentinel(0)]);
+
+        // The same literal dedups to the same descriptor + pool slot.
+        let reg_a2 = asm.emit_const_r(&str_const(b"hello"), &mut state);
+        assert_eq!(reg_a2, reg_a);
+        assert_eq!(state.str_consts.len(), 1);
+        assert_eq!(state.constants_r.len(), 1);
+
+        // A distinct literal gets a distinct descriptor + sentinel slot.
+        let reg_b = asm.emit_const_r(&str_const(b"world"), &mut state);
+        assert_ne!(reg_b, reg_a);
+        assert_eq!(state.str_consts.len(), 2);
+        assert_eq!(state.str_consts[1].bytes, b"world".to_vec());
+        assert_eq!(state.str_consts[1].constants_r_index, 1);
+        assert_eq!(
+            state.constants_r,
+            vec![str_const_sentinel(0), str_const_sentinel(1)]
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -2336,6 +2336,7 @@ impl Assembler {
                 OpKind::LoopHeader { .. } => "LoopHeader",
                 OpKind::Abort { .. } => "Abort",
                 OpKind::NewTuple { .. } => "NewTuple",
+                OpKind::LoweredBlackholeOp { .. } => "LoweredBlackholeOp",
                 OpKind::LoadStatic { .. } => "LoadStatic",
             }
         }
@@ -3628,6 +3629,13 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::RecordQuasiImmutField { .. } => "record_quasiimmut_field".into(),
         OpKind::Abort { .. } => "abort".into(),
         OpKind::NewTuple { .. } => "newtuple".into(),
+        // The opname-dispatch spine lowers the rtyper helper graphs to
+        // register-shaped blackhole insns, carrying the resolved opname
+        // (`strlen`/`strgetitem`/`strsetitem`/`newstr`/…) verbatim.  The
+        // blackhole interpreter resolves the handler by this name, and
+        // `Assembler::get_opnum` assigns its byte dynamically when the
+        // opname has no fixed `insns.rs` slot.
+        OpKind::LoweredBlackholeOp { opname, .. } => opname.clone(),
         // RPython's codewriter never sees a crate-static carrier:
         // LOAD_GLOBAL is resolved to a Constant before JitCode assembly.
         // The flowspace adapter must either fold `LoadStatic` to a
@@ -4443,11 +4451,8 @@ mod tests {
         use crate::translator::rtyper::lltypesystem::rstr::{
             const_str_cache_llstr, ll_strhash_value,
         };
-        let str_const = |s: &[u8]| {
-            ConstValue::LLPtr(Box::new(
-                const_str_cache_llstr(s).expect("cache llstr"),
-            ))
-        };
+        let str_const =
+            |s: &[u8]| ConstValue::LLPtr(Box::new(const_str_cache_llstr(s).expect("cache llstr")));
         let mut asm = Assembler::new();
         let mut state = empty_state();
 

--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -4401,6 +4401,44 @@ mod tests {
     }
 
     #[test]
+    fn assemble_ref_return_with_prebuilt_string_constant() {
+        use crate::translator::rtyper::lltypesystem::rstr::{
+            const_str_cache_llstr, ll_strhash_value,
+        };
+        // A `RefReturn` of a prebuilt `Ptr(STR)` constant drives a real
+        // `ConstValue::LLPtr(STR)` through the whole assembler emit path
+        // (encode_regorconst_source -> emit_const('r') -> emit_const_r ->
+        // emit_str_const_r) and commits the recorded descriptor into the
+        // produced `JitCodeBody.str_consts`.  This is the build-side half of
+        // the deferred-materialization loop the runtime `materialize_str_consts`
+        // pass closes (the runtime half is covered in pyre-jit-trace).
+        let mut flat = SSARepr {
+            name: "return_prebuilt_string".into(),
+            insns: vec![FlatOp::RefReturn(crate::flatten::RegOrConst::Const(
+                crate::flowspace::model::Constant::new(ConstValue::LLPtr(Box::new(
+                    const_str_cache_llstr(b"hi").expect("cache llstr"),
+                ))),
+            ))],
+            num_blocks: 1,
+            insns_pos: None,
+        };
+
+        let regallocs = empty_regallocs();
+        let mut asm = Assembler::new();
+        let body = asm.assemble(&mut flat, &regallocs);
+
+        // The committed body carries the deferred descriptor, and the
+        // `constants_r` slot it names holds the non-canonical sentinel the
+        // runtime load pass overwrites with the live STR address.
+        assert_eq!(body.str_consts.len(), 1);
+        assert_eq!(body.str_consts[0].bytes, b"hi".to_vec());
+        assert_eq!(body.str_consts[0].precomputed_hash, ll_strhash_value(b"hi"));
+        let idx = body.str_consts[0].constants_r_index;
+        assert_eq!(body.constants_r[idx], str_const_sentinel(0));
+        assert!(asm.insns.contains_key("ref_return/r"));
+    }
+
+    #[test]
     fn emit_const_r_records_prebuilt_string_descriptor_and_dedups() {
         use crate::translator::rtyper::lltypesystem::rstr::{
             const_str_cache_llstr, ll_strhash_value,

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -729,6 +729,21 @@ pub struct CallControl {
     /// RPython: `CallControl.unfinished_graphs` — graphs pending assembly.
     unfinished_graphs: Vec<CallPath>,
 
+    /// Opname-dispatch convergence spine ("Spine B"): rtyper low-level
+    /// helper graphs registered as their `crate::flowspace::model::
+    /// FunctionGraph` (opname `SpaceOperation`s) rather than as a rich
+    /// `crate::model::FunctionGraph` in [`Self::function_graphs`].  These
+    /// graphs are born only in opname form (the rtyper lowers them in
+    /// place via `genop`, with no rich-`OpKind` twin), so the drain loop
+    /// routes them through `jtransform_opname::lower_graph` — which emits
+    /// rich `OpKind` into a fresh graph that re-enters the shared
+    /// flatten/regalloc/assembler tail — instead of the rich-`OpKind`
+    /// `Transformer::transform` path.  Keyed by `CallPath` so the caller's
+    /// `direct_call` resolves to the same shell via `target_to_path`.
+    /// `take_opname_graph` consumes the entry during the drain so the
+    /// graph is lowered exactly once.
+    opname_graphs: HashMap<CallPath, crate::flowspace::model::FunctionGraph>,
+
     /// `call.py:22 virtualref_info = None` — class-level default,
     /// populated by `CodeWriter.setup_vrefinfo`
     /// (`codewriter.py:91-94`) before
@@ -1209,6 +1224,7 @@ impl CallControl {
             builtin_factory_registry: std::cell::RefCell::new(HashMap::new()),
             finished_jitcodes: Vec::new(),
             unfinished_graphs: Vec::new(),
+            opname_graphs: HashMap::new(),
             virtualref_info: None,
             callinfocollection: majit_ir::CallInfoCollection::new(),
             descr_indices: DescrIndexRegistry::default(),
@@ -3066,6 +3082,45 @@ impl CallControl {
         self.jitcodes.insert(path.clone(), arc.clone());
         self.unfinished_graphs.push(path.clone());
         arc
+    }
+
+    /// Register an rtyper low-level helper graph in opname (`SpaceOperation`)
+    /// form for the opname-dispatch convergence spine ("Spine B").
+    ///
+    /// Records the helper's `crate::flowspace::model::FunctionGraph` in
+    /// [`Self::opname_graphs`] and allocates its `Arc<JitCode>` shell via
+    /// [`Self::get_jitcode`] — which appends `path` to `unfinished_graphs`
+    /// so the drain loop picks it up exactly like a rich-`OpKind` graph.
+    /// The drain routes it through `jtransform_opname::lower_graph` instead
+    /// of `Transformer::transform` because the helper has no rich-`OpKind`
+    /// twin in [`Self::function_graphs`].  Returns the shell so a caller can
+    /// hold a stable handle before the body is assembled.
+    pub fn register_opname_helper_graph(
+        &mut self,
+        path: CallPath,
+        graph: crate::flowspace::model::FunctionGraph,
+    ) -> std::sync::Arc<crate::jitcode::JitCode> {
+        self.opname_graphs.insert(path.clone(), graph);
+        self.get_jitcode(&path)
+    }
+
+    /// Consume the opname helper graph registered under `path`, if any.
+    ///
+    /// The drain loop calls this before the `function_graphs` lookup;
+    /// `Some(graph)` routes the path through the opname-dispatch spine and
+    /// removes it from [`Self::opname_graphs`] so the lowering runs once.
+    /// `None` falls through to the rich-`OpKind` `function_graphs` path.
+    pub fn take_opname_graph(
+        &mut self,
+        path: &CallPath,
+    ) -> Option<crate::flowspace::model::FunctionGraph> {
+        self.opname_graphs.remove(path)
+    }
+
+    /// Whether `path` is registered as an opname-dispatch helper graph.
+    /// Read-only peek used where a borrow of the graph is not yet needed.
+    pub fn has_opname_graph(&self, path: &CallPath) -> bool {
+        self.opname_graphs.contains_key(path)
     }
 
     /// Read-only handle lookup. Returns `None` for paths that have not

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -6880,6 +6880,15 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         // RPython `newtuple` is a `PureOperation` (`operation.py:542`);
         // pure tuple construction cannot raise.
         OpKind::NewTuple { .. } => RaiseClass::No,
+        // `LoweredBlackholeOp` carries register-shaped blackhole insns
+        // lowered from the rtyper helper graphs.  String allocation
+        // (`newstr`/`newunicode`) has `canraise = (MemoryError,)`; the
+        // read/write/length insns (`strlen`/`strgetitem`/`strsetitem`/
+        // `unicode*`) cannot raise (LL_OPERATIONS `canraise = ()`).
+        OpKind::LoweredBlackholeOp { opname, .. } => match opname.as_str() {
+            "newstr" | "newunicode" => RaiseClass::MemoryErrorOnly,
+            _ => RaiseClass::No,
+        },
         // `LoadStatic` reads a `static` declaration's address — a
         // compile-time constant.  `LOAD_GLOBAL` analog
         // (`flowspace/flowcontext.py:1098`); cannot raise.

--- a/majit/majit-translate/src/jit_codewriter/codewriter.rs
+++ b/majit/majit-translate/src/jit_codewriter/codewriter.rs
@@ -628,6 +628,40 @@ impl CodeWriter {
             crate::jit_codewriter::type_state::apply_from_flowspace_variables(value_to_var);
         }
 
+        // Steps 2-4 (regalloc → flatten → liveness/assemble → calldescr →
+        // commit) operate on the rewritten `crate::model::FunctionGraph` and
+        // are shared verbatim with the opname-dispatch spine, so they live in
+        // `finalize_rewritten_graph_to_jitcode`.
+        self.finalize_rewritten_graph_to_jitcode(
+            &mut rewritten.graph,
+            path,
+            callcontrol,
+            jitcode,
+            verbose,
+            index,
+        );
+    }
+
+    /// Shared assembler tail for both codewriter spines.
+    ///
+    /// Spine A (`transform_graph_to_jitcode`) reaches here after the rtyper
+    /// dual-gate + `Transformer::transform` produced a rewritten rich-`OpKind`
+    /// graph; Spine B (`transform_opname_graph_to_jitcode`) reaches here after
+    /// `jtransform_opname::lower_graph` produced an equivalent rich-`OpKind`
+    /// graph from the rtyper's opname `SpaceOperation`s.  From this point the
+    /// pipeline is identical — Steps 2-4 (codewriter.py:45-67): regalloc →
+    /// flatten → liveness/assemble → `get_jitcode_calldescr` → commit body →
+    /// assign `jitcode.index`.  Each Variable's `.concretetype` cell is the
+    /// kind source (the upstream `getkind(v.concretetype)` access).
+    fn finalize_rewritten_graph_to_jitcode(
+        &mut self,
+        rewritten_graph: &mut crate::model::FunctionGraph,
+        path: &crate::parse::CallPath,
+        callcontrol: &mut CallControl,
+        jitcode: &std::sync::Arc<JitCode>,
+        verbose: bool,
+        index: usize,
+    ) {
         // Step 2: regalloc (codewriter.py:45-47)
         // RPython: for kind in KINDS: regallocs[kind] = perform_register_allocation(graph, kind)
         // Pyre reads each per-value kind via
@@ -636,7 +670,7 @@ impl CodeWriter {
         // `getkind(v.concretetype)` access.
         // Stamp canonical exceptblock kinds first so the rtyper-skip
         // path still gets `(etype=Int, evalue=Ref)`.
-        crate::regalloc::augment_canonical_exceptblock_on_graph(&mut rewritten.graph);
+        crate::regalloc::augment_canonical_exceptblock_on_graph(rewritten_graph);
         // Void-widening (exceptiontransform parity).  A scoped
         // `Result<(), PyError>` callee declares `FUNC.RESULT = void`
         // (`return_type = "()"`, stamped in `front::mir`), but its CFG
@@ -649,9 +683,9 @@ impl CodeWriter {
         // `declared==v && cfg==r` gate is exactly the unit-shell case; a
         // genuinely void CFG (`cfg==v`) needs no rewrite.
         if callcontrol.declared_return_kind(path) == Some('v')
-            && graph_result_kind(&rewritten.graph) == 'r'
+            && graph_result_kind(rewritten_graph) == 'r'
         {
-            crate::front::result_exc::widen_unit_return_to_void(&mut rewritten.graph);
+            crate::front::result_exc::widen_unit_return_to_void(rewritten_graph);
             // Sweep the unit producers the widen just orphaned.  Clearing
             // the returnblock args/inputargs leaves the `()` ctor (or a
             // tail-forwarded `Ref` call result) unread; without a dead-op
@@ -660,11 +694,11 @@ impl CodeWriter {
             // `remove_dead_links_and_setattrs` runs after exceptiontransform
             // for the same reason — `prune_dead_phis` keeps raising/impure
             // producers and only drops the genuinely pure dead unit shells.
-            crate::model::prune_dead_phis(&mut rewritten.graph);
+            crate::model::prune_dead_phis(rewritten_graph);
         }
         let mut regallocs = crate::jit_codewriter::transform_profile::time_phase(
             "step2_perform_all_register_allocations",
-            || crate::regalloc::perform_all_register_allocations(&rewritten.graph),
+            || crate::regalloc::perform_all_register_allocations(rewritten_graph),
         );
 
         // Step 3: flatten (codewriter.py:53)
@@ -679,7 +713,7 @@ impl CodeWriter {
         // invocation order verbatim.
         let mut ssarepr =
             crate::jit_codewriter::transform_profile::time_phase("step3_flatten_graph", || {
-                crate::flatten::flatten_graph(&rewritten.graph, &mut regallocs)
+                crate::flatten::flatten_graph(rewritten_graph, &mut regallocs)
             });
 
         // Step 3b + 4: liveness + assemble (codewriter.py:56,67)
@@ -708,7 +742,7 @@ impl CodeWriter {
         // graphs that disagree with their declared signature surface
         // immediately.
         {
-            let start_block = rewritten.graph.block(rewritten.graph.startblock);
+            let start_block = rewritten_graph.block(rewritten_graph.startblock);
             let mut arg_classes = String::new();
             // RPython `call.py:181-187 get_jitcode_calldescr` derives
             // `FUNC.ARGS` from `lltype.typeOf(fnptr).TO.ARGS`
@@ -729,7 +763,7 @@ impl CodeWriter {
                 };
                 arg_classes.push(class);
             }
-            let cfg_kind = graph_result_kind(&rewritten.graph);
+            let cfg_kind = graph_result_kind(rewritten_graph);
             let declared_kind = callcontrol.declared_return_kind(path);
             let result_type = declared_kind.unwrap_or(cfg_kind);
             // Cross-check: when both sources are present they must agree,
@@ -755,7 +789,7 @@ impl CodeWriter {
                         || (d == 'i' && cfg_kind == 'r')
                 }),
                 "graph {} declared FUNC.RESULT={} but CFG return kind is {}",
-                rewritten.graph.name,
+                rewritten_graph.name,
                 declared_kind.unwrap(),
                 cfg_kind,
             );
@@ -803,6 +837,38 @@ impl CodeWriter {
             // dependency.
             eprintln!("[CodeWriter] {}", jitcode.name);
         }
+    }
+
+    /// Spine B entry: lower an rtyper opname helper graph and finalize it.
+    ///
+    /// The drain loop routes a path here (instead of through
+    /// `transform_graph_to_jitcode`) when `CallControl::take_opname_graph`
+    /// yields the registered `crate::flowspace::model::FunctionGraph`.
+    /// `jtransform_opname::lower_graph` transduces it to an equivalent
+    /// rich-`OpKind` `crate::model::FunctionGraph`, which then re-enters the
+    /// shared `finalize_rewritten_graph_to_jitcode` tail.  None of the
+    /// Spine-A front steps (dual-gate concretetype publish,
+    /// `lower_indirect_calls`, unit-variant fold, classdef-hint stamping) run:
+    /// the helper graph is already low-level and fully typed on each
+    /// `Variable.concretetype` cell.
+    fn transform_opname_graph_to_jitcode(
+        &mut self,
+        flow_graph: &crate::flowspace::model::FunctionGraph,
+        path: &crate::parse::CallPath,
+        callcontrol: &mut CallControl,
+        jitcode: &std::sync::Arc<JitCode>,
+        verbose: bool,
+        index: usize,
+    ) {
+        let mut lowered = crate::jit_codewriter::jtransform_opname::lower_graph(flow_graph);
+        self.finalize_rewritten_graph_to_jitcode(
+            &mut lowered,
+            path,
+            callcontrol,
+            jitcode,
+            verbose,
+            index,
+        );
     }
 
     /// RPython: `CodeWriter.make_jitcodes(verbose)` (codewriter.py:74-89).
@@ -859,6 +925,38 @@ impl CodeWriter {
                 break;
             };
             let iter_start = std::time::Instant::now();
+            // Spine B (opname-dispatch convergence): rtyper low-level helper
+            // graphs are registered as opname `SpaceOperation`s and have no
+            // rich-`OpKind` twin in `function_graphs`, so they are routed here
+            // before the lookup below (which they intentionally miss).
+            // `take_opname_graph` is empty for the rich-`OpKind` corpus, so
+            // this branch is never taken for a Spine-A graph.
+            if let Some(flow_graph) = callcontrol.take_opname_graph(&path) {
+                // RPython `codewriter.py:80` index = len(all_jitcodes).
+                let index = callcontrol.finished_jitcodes_len();
+                self.transform_opname_graph_to_jitcode(
+                    &flow_graph,
+                    &path,
+                    callcontrol,
+                    &jitcode,
+                    /* verbose = */ false,
+                    index,
+                );
+                callcontrol.finish_jitcode(jitcode.clone());
+                // Helper graphs are never portal graphs, so no
+                // `jitdriver_sd` wiring is needed (Spine A handles that).
+                if profile {
+                    drain_count += 1;
+                    let elapsed = iter_start.elapsed().as_secs_f64();
+                    if elapsed >= 0.5 {
+                        eprintln!(
+                            "[PYRE_PROFILE_DRAIN] graph #{:>3} {:>7.3}s name={}",
+                            drain_count, elapsed, jitcode.name,
+                        );
+                    }
+                }
+                continue;
+            }
             let Some(graph) = callcontrol.function_graphs().get(&path).cloned() else {
                 // RPython `enum_pending_graphs` (codewriter.py:79-84)
                 // never yields a jitcode whose graph is missing —

--- a/majit/majit-translate/src/jit_codewriter/jitcode.rs
+++ b/majit/majit-translate/src/jit_codewriter/jitcode.rs
@@ -49,6 +49,24 @@ use serde::{Deserialize, Serialize};
 /// Field-by-field mapping below preserves the RPython names. Where
 /// RPython uses `chr(int)` to pack a 0..255 register count into a single
 /// byte we use `u8` directly; the value range is identical.
+/// A prebuilt-string constant whose runtime STR GcStruct is materialized
+/// at jitcode-load time (the build-time translator cannot allocate it; see
+/// [`JitCodeBody::str_consts`]).  The content key is `bytes`; identical
+/// literals across a jitcode share one descriptor.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct StrConstDescriptor {
+    /// Position in [`JitCodeBody::constants_r`] holding the sentinel that
+    /// the runtime load pass overwrites with the live STR address.
+    pub constants_r_index: usize,
+    /// The string's bytes (Latin-1 / Py2 `str` embedding, the `chars`
+    /// payload of the prebuilt `Ptr(STR)` container).
+    pub bytes: Vec<u8>,
+    /// `ll_strhash_value(bytes)` (the `0 -> 29872897` not-computed fixup
+    /// already applied), written to the STR block's `hash` field at
+    /// offset 0 so the runtime never recomputes it.
+    pub precomputed_hash: i64,
+}
+
 /// Body of a `JitCode` — populated once by the assembler after
 /// `transform_graph_to_jitcode` runs the full codewriter pipeline.
 ///
@@ -80,6 +98,19 @@ pub struct JitCodeBody {
     /// `i64` so the runtime register file can consume the pool entries
     /// without a re-bitcast.
     pub constants_f: Vec<i64>,
+    /// Prebuilt-string constants deferred to runtime materialization.
+    /// RPython bakes a prebuilt `Ptr(STR)` GCREF straight into
+    /// `constants_r` (`assembler.py:109-116`) because the translator and
+    /// the runtime metainterp share one C binary.  pyre's translator runs
+    /// in a separate build-script process, so it cannot allocate the
+    /// runtime STR block an `r`-bank constant must point at.  Each entry
+    /// records a string's bytes + precomputed hash and pairs them with a
+    /// `constants_r` slot holding a non-canonical sentinel; the runtime
+    /// load pass materializes an immortal STR GcStruct and overwrites that
+    /// slot with its live address before the jitcode is used.  Default
+    /// empty: existing jitcodes carry no deferred strings.
+    #[serde(default)]
+    pub str_consts: Vec<StrConstDescriptor>,
     /// RPython `jitcode.py:37-39` `self.c_num_regs_i = chr(num_regs_i)`.
     /// RPython packs into a single chr (`assert num_regs_i < 256`); pyre
     /// uses `u16` to keep CPython 3.13 codes that legitimately exceed 255

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -4139,6 +4139,10 @@ fn remap_op(
         OpKind::NewTuple { args } => OpKind::NewTuple {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
         },
+        OpKind::LoweredBlackholeOp { opname, args } => OpKind::LoweredBlackholeOp {
+            opname: opname.clone(),
+            args: args.iter().map(|a| remap_value(a, aliases)).collect(),
+        },
         OpKind::GuardValue { value, kind_char } => OpKind::GuardValue {
             value: remap_value(value, aliases),
             kind_char: *kind_char,

--- a/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
@@ -25,20 +25,658 @@
 //! `CallControl::take_opname_graph` returns its registered flowspace graph.
 //! Until a helper is registered via
 //! `CallControl::register_opname_helper_graph`, this module is dead code.
+//!
+//! ## String-helper fusion (S1 scope)
+//!
+//! The string-repr family stores its character data as an `Array(Char)` /
+//! `Array(UniChar)` *inline* in the GC `STR` / `UNICODE` struct, so a
+//! `getsubstruct(s, "chars")` yields an interior pointer with no standalone
+//! runtime object.  The blackhole interpreter has no interior-pointer model;
+//! instead it carries by-name handlers that take the **string object** plus
+//! register-shaped operands: `strlen(s)`, `strgetitem(s, i)`,
+//! `strsetitem(s, i, c)`, `newstr(n)` (and the `unicode*` / `newunicode`
+//! peers).  The transducer therefore *fuses* the `getsubstruct` + array op
+//! pair back into the string opcode — `getsubstruct` itself emits nothing and
+//! records `chars_array_var → string_var`; a following `getarraysize` /
+//! `getarrayitem` / `setarrayitem` on that array re-references the recorded
+//! string operand.  This mirrors upstream `s.chars[i]`, where the chars
+//! substruct is re-derived at each access from the string in hand.
+//!
+//! The fusion is **block-local**: it relies on the `getsubstruct` and its
+//! consuming array op living in the same block, with the string operand
+//! available there.  A helper that hoists the substruct out of a loop and
+//! threads the *interior chars pointer* through block Phi inputargs (rather
+//! than threading the string itself) cannot be fused this way — the string
+//! origin is lost across the Phi.  Such graphs are out of scope for this
+//! slice; the transducer fail-loud `expect`s a recorded alias rather than
+//! silently miscompiling.
 
-use crate::flowspace::model::FunctionGraph as FlowGraph;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::flowspace::model::Variable as FVar;
+use crate::flowspace::model::{
+    Block as FlowBlock, ConstValue, FunctionGraph as FlowGraph, Hlvalue,
+};
+use crate::model::{BlockId, ExitCase, ExitSwitch, Link, LinkArg, OpKind, ValueType};
+use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, PtrTarget};
+
+/// Block identity key — flowspace blocks are `Rc<RefCell<Block>>` with no
+/// inherent id, so identity is the allocation address (RPython compares
+/// `Block` objects by Python identity; `iterblocks` already keys its
+/// visited-set on `Rc::as_ptr`).
+type FlowBlockKey = *const RefCell<FlowBlock>;
+
+/// The blackhole opcode family for a given string-element width.  `str*`
+/// handlers operate on `Array(Char)`-backed `STR`; `unicode*` /
+/// `newunicode` on `Array(UniChar)`-backed `UNICODE`.
+struct StrFamily {
+    /// `strlen` / `unicodelen` — array length of the inline chars array.
+    len: &'static str,
+    /// `strgetitem` / `unicodegetitem` — read one element.
+    getitem: &'static str,
+    /// `strsetitem` / `unicodesetitem` — write one element (void).
+    setitem: &'static str,
+    /// `newstr` / `newunicode` — variable-size allocation by length.
+    alloc: &'static str,
+}
+
+impl StrFamily {
+    const STR: StrFamily = StrFamily {
+        len: "strlen",
+        getitem: "strgetitem",
+        setitem: "strsetitem",
+        alloc: "newstr",
+    };
+    const UNICODE: StrFamily = StrFamily {
+        len: "unicodelen",
+        getitem: "unicodegetitem",
+        setitem: "unicodesetitem",
+        alloc: "newunicode",
+    };
+}
 
 /// Lower an rtyper low-level helper graph (opname `SpaceOperation`s) to an
 /// equivalent rich-`OpKind` `crate::model::FunctionGraph`.
 ///
-/// S1 (ll_strconcat foothold) implements the per-opname transduction for the
-/// helper's opname set `{getsubstruct, getarraysize, int_add, malloc_varsize,
-/// int_lt, getarrayitem, setarrayitem}`.  Until then no graph is registered
-/// through `CallControl::register_opname_helper_graph`, so the drain loop's
-/// Spine-B branch is never taken and this body is unreachable.
-pub fn lower_graph(_graph: &FlowGraph) -> crate::model::FunctionGraph {
-    unimplemented!(
-        "jtransform_opname::lower_graph: opname-dispatch transduction lands in S1 \
-         (ll_strconcat foothold)"
-    )
+/// The flowspace `Variable`s are reused verbatim as the model graph's
+/// operands and block inputargs — they are the same
+/// `crate::flowspace::model::Variable` type and carry their `concretetype`
+/// cell through unchanged, so no value-bridge round-trip is needed.
+pub fn lower_graph(graph: &FlowGraph) -> crate::model::FunctionGraph {
+    let mut out = crate::model::FunctionGraph::new(graph.name.clone());
+    let family = detect_family(graph);
+
+    // Map each flowspace block to a model `BlockId`.  The three canonical
+    // blocks (`startblock`/`returnblock`/`exceptblock`) are pre-seeded onto
+    // the model graph's own canonical ids so links into them resolve.
+    let mut block_map: HashMap<FlowBlockKey, BlockId> = HashMap::new();
+    block_map.insert(Rc::as_ptr(&graph.startblock), out.startblock);
+    block_map.insert(Rc::as_ptr(&graph.returnblock), out.returnblock);
+    block_map.insert(Rc::as_ptr(&graph.exceptblock), out.exceptblock);
+
+    let flow_blocks = graph.iterblocks();
+
+    // Pass 1 — allocate model blocks for every reachable block and copy each
+    // block's inputarg `Variable`s across (the canonical blocks already
+    // exist; interior blocks get fresh ids).
+    for fb in &flow_blocks {
+        let key = Rc::as_ptr(fb);
+        let id = *block_map.entry(key).or_insert_with(|| out.create_block());
+        let inputargs: Vec<FVar> = fb
+            .borrow()
+            .inputargs
+            .iter()
+            .filter_map(hlvalue_as_var)
+            .collect();
+        out.block_mut(id).inputargs = inputargs;
+    }
+    // The return/except blocks may not appear in `iterblocks` (e.g. a graph
+    // with no raising edge never reaches `exceptblock`); set their inputargs
+    // from the flowspace canonical blocks so the model return value carries
+    // the helper's concretetype.
+    let return_inputargs: Vec<FVar> = graph
+        .returnblock
+        .borrow()
+        .inputargs
+        .iter()
+        .filter_map(hlvalue_as_var)
+        .collect();
+    let return_id = out.returnblock;
+    out.block_mut(return_id).inputargs = return_inputargs;
+
+    // Pass 2 — transduce each block's operations + control flow.
+    for fb in &flow_blocks {
+        let id = block_map[&Rc::as_ptr(fb)];
+        let fb_ref = fb.borrow();
+
+        // `getsubstruct` aliases are block-local: a chars-array Variable maps
+        // back to the string Variable it was derived from in this block.
+        let mut chars_alias: HashMap<FVar, FVar> = HashMap::new();
+        for op in &fb_ref.operations {
+            transduce_op(&mut out, id, op, &mut chars_alias, &family);
+        }
+
+        let exitswitch = if fb_ref.canraise() {
+            Some(ExitSwitch::LastException)
+        } else {
+            match &fb_ref.exitswitch {
+                Some(Hlvalue::Variable(v)) => Some(ExitSwitch::Value(v.clone())),
+                _ => None,
+            }
+        };
+
+        let exits: Vec<Link> = fb_ref
+            .exits
+            .iter()
+            .map(|link_ref| {
+                let link = link_ref.borrow();
+                let target = link
+                    .target
+                    .as_ref()
+                    .expect("opname-spine link has no target block");
+                let target_id = block_map[&Rc::as_ptr(target)];
+                let args: Vec<LinkArg> = link
+                    .args
+                    .iter()
+                    .map(|arg| {
+                        linkarg_from_hlvalue(
+                            arg.as_ref().expect("opname-spine link arg is undefined"),
+                        )
+                    })
+                    .collect();
+                let exitcase = match &link.exitcase {
+                    Some(Hlvalue::Constant(c)) => exitcase_from_const(&c.value),
+                    _ => None,
+                };
+                Link::new_mixed(args, target_id, exitcase)
+            })
+            .collect();
+
+        drop(fb_ref);
+        if exitswitch.is_some() || !exits.is_empty() {
+            out.set_control_flow_metadata(id, exitswitch, exits);
+        }
+    }
+
+    out
+}
+
+/// Transduce a single flowspace `SpaceOperation` into the model graph at
+/// `block`, materialising any constant operands as `ConstInt`/`ConstBool`
+/// ops and fusing `getsubstruct`-derived array accesses into the string
+/// blackhole opcodes.
+fn transduce_op(
+    out: &mut crate::model::FunctionGraph,
+    block: BlockId,
+    op: &crate::flowspace::model::SpaceOperation,
+    chars_alias: &mut HashMap<FVar, FVar>,
+    family: &StrFamily,
+) {
+    match op.opname.as_str() {
+        // `getsubstruct(s, "chars")` — interior pointer with no runtime
+        // object; record the alias and emit nothing.  The string operand is
+        // always a Variable in the helper graphs.
+        "getsubstruct" => {
+            let string_var = expect_var(&op.args[0]);
+            let chars_var = expect_var(&op.result);
+            chars_alias.insert(chars_var, string_var);
+        }
+        // `len(s.chars)` → `strlen(s)` / `unicodelen(s)`.
+        "getarraysize" => {
+            let string_var = resolve_string(chars_alias, &op.args[0]);
+            let result = expect_var(&op.result);
+            out.push_op_with_result_var(
+                block,
+                OpKind::LoweredBlackholeOp {
+                    opname: family.len.to_string(),
+                    args: vec![string_var],
+                },
+                result,
+            );
+        }
+        // `s.chars[i]` → `strgetitem(s, i)` / `unicodegetitem(s, i)`.
+        "getarrayitem" => {
+            let string_var = resolve_string(chars_alias, &op.args[0]);
+            let index = materialize(out, block, &op.args[1]);
+            let result = expect_var(&op.result);
+            out.push_op_with_result_var(
+                block,
+                OpKind::LoweredBlackholeOp {
+                    opname: family.getitem.to_string(),
+                    args: vec![string_var, index],
+                },
+                result,
+            );
+        }
+        // `s.chars[i] = c` → `strsetitem(s, i, c)` / `unicodesetitem(...)`.
+        // Void result.
+        "setarrayitem" => {
+            let string_var = resolve_string(chars_alias, &op.args[0]);
+            let index = materialize(out, block, &op.args[1]);
+            let value = materialize(out, block, &op.args[2]);
+            out.push_op_var(
+                block,
+                OpKind::LoweredBlackholeOp {
+                    opname: family.setitem.to_string(),
+                    args: vec![string_var, index, value],
+                },
+                false,
+            );
+        }
+        // `malloc_varsize(STR, gc, n)` → `newstr(n)` / `newunicode(n)`.  The
+        // struct lltype and gc-flavor operands carry no runtime value for the
+        // blackhole allocator, which is keyed by the string family.
+        "malloc_varsize" => {
+            let size = materialize(out, block, &op.args[2]);
+            let result = expect_var(&op.result);
+            out.push_op_with_result_var(
+                block,
+                OpKind::LoweredBlackholeOp {
+                    opname: family.alloc.to_string(),
+                    args: vec![size],
+                },
+                result,
+            );
+        }
+        // Integer arithmetic / comparison — `int_add`/`int_lt`/… → `BinOp`
+        // with the bare op name (the assembler re-prefixes `int_`).  Constant
+        // operands materialise as `ConstInt`/`ConstBool` since `BinOp` takes
+        // two Variables.
+        name if name.starts_with("int_") => {
+            let bare = name.strip_prefix("int_").unwrap().to_string();
+            let lhs = materialize(out, block, &op.args[0]);
+            let rhs = materialize(out, block, &op.args[1]);
+            let result = expect_var(&op.result);
+            let result_ty = value_type_of(&result);
+            out.push_op_with_result_var(
+                block,
+                OpKind::BinOp {
+                    op: bare,
+                    lhs,
+                    rhs,
+                    result_ty,
+                },
+                result,
+            );
+        }
+        other => panic!("jtransform_opname::lower_graph: unsupported opname {other:?}"),
+    }
+}
+
+/// Resolve the string Variable backing a chars-array operand via the
+/// block-local `getsubstruct` alias map.  Fail-loud if the array was not
+/// produced by a same-block `getsubstruct` (e.g. threaded across a Phi —
+/// out of scope for this slice).
+fn resolve_string(chars_alias: &HashMap<FVar, FVar>, arr: &Hlvalue) -> FVar {
+    let arr_var = expect_var(arr);
+    chars_alias
+        .get(&arr_var)
+        .cloned()
+        .expect("array operand was not a same-block getsubstruct(\"chars\") result")
+}
+
+/// Map a flowspace operand to a model operand `Variable`, materialising
+/// constants into `ConstInt`/`ConstBool` ops pushed ahead of the consumer.
+fn materialize(out: &mut crate::model::FunctionGraph, block: BlockId, hlv: &Hlvalue) -> FVar {
+    match hlv {
+        Hlvalue::Variable(v) => v.clone(),
+        Hlvalue::Constant(c) => {
+            let (kind, lltype) = match &c.value {
+                ConstValue::Int(n) => (OpKind::ConstInt(*n), LowLevelType::Signed),
+                ConstValue::Bool(b) => (OpKind::ConstBool(*b), LowLevelType::Bool),
+                other => panic!(
+                    "jtransform_opname::lower_graph: cannot materialise constant operand {other:?}"
+                ),
+            };
+            let result = out
+                .push_op_var(block, kind, true)
+                .expect("ConstInt/ConstBool op produces a result var");
+            // `push_op_var` mints the result with `ConcreteType::Unknown`;
+            // stamp the int-bank kind so regalloc colours it.
+            result.set_concretetype(Some(lltype));
+            result
+        }
+    }
+}
+
+/// Map a flowspace link arg (`Variable` or `Constant`) to the model
+/// `LinkArg` — model links carry mixed var/const args directly.
+fn linkarg_from_hlvalue(hlv: &Hlvalue) -> LinkArg {
+    match hlv {
+        Hlvalue::Variable(v) => LinkArg::Value(v.clone()),
+        Hlvalue::Constant(c) => LinkArg::Const(c.clone()),
+    }
+}
+
+/// Map a flowspace exitcase constant to the model `ExitCase`.
+fn exitcase_from_const(value: &ConstValue) -> Option<ExitCase> {
+    match value {
+        ConstValue::Bool(b) => Some(ExitCase::Bool(*b)),
+        other => Some(ExitCase::Const(other.clone())),
+    }
+}
+
+/// `Hlvalue::Variable` → its `Variable`; `None` for a constant.
+fn hlvalue_as_var(hlv: &Hlvalue) -> Option<FVar> {
+    match hlv {
+        Hlvalue::Variable(v) => Some(v.clone()),
+        Hlvalue::Constant(_) => None,
+    }
+}
+
+/// Expect an `Hlvalue` to be a `Variable` (the position is always a Variable
+/// in the helper graphs the transducer accepts).
+fn expect_var(hlv: &Hlvalue) -> FVar {
+    match hlv {
+        Hlvalue::Variable(v) => v.clone(),
+        Hlvalue::Constant(c) => {
+            panic!("jtransform_opname::lower_graph: expected a Variable, found constant {c:?}")
+        }
+    }
+}
+
+/// Map a `Variable`'s `concretetype` to the model `ValueType` for `BinOp`'s
+/// `result_ty` — the `getkind`-collapsed kind space (`Char`/`Bool`/`Signed`
+/// all land in the int bank).
+fn value_type_of(var: &FVar) -> ValueType {
+    use crate::model::ConcreteType;
+    match crate::model::FunctionGraph::concretetype_of(var) {
+        ConcreteType::Signed => ValueType::Int,
+        ConcreteType::GcRef => ValueType::Ref(None),
+        ConcreteType::Float => ValueType::Float,
+        ConcreteType::Void => ValueType::Void,
+        ConcreteType::Unknown => ValueType::Int,
+    }
+}
+
+/// A helper graph operates on a single string width, so the family is a
+/// graph-wide property: `unicode*` if any operand carries an
+/// `Array(UniChar)` pointer, else `str*`.
+fn detect_family(graph: &FlowGraph) -> StrFamily {
+    let is_unicode = graph.iterblocks().iter().any(|block| {
+        block.borrow().operations.iter().any(|op| {
+            op.args
+                .iter()
+                .chain(std::iter::once(&op.result))
+                .any(|hlv| matches!(hlv, Hlvalue::Variable(v) if is_unichar_array_ptr(v)))
+        })
+    });
+    if is_unicode {
+        StrFamily::UNICODE
+    } else {
+        StrFamily::STR
+    }
+}
+
+/// Whether a `Variable`'s `concretetype` is `Ptr(Array(UniChar))` — the
+/// chars-array pointer of a `UNICODE` object.
+fn is_unichar_array_ptr(var: &FVar) -> bool {
+    match var.concretetype() {
+        Some(LowLevelType::Ptr(ptr)) => {
+            matches!(&ptr.TO, PtrTarget::Array(arr) if matches!(arr.OF, LowLevelType::UniChar))
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lower_graph;
+    use crate::flowspace::model::{
+        Block, BlockRefExt, ConstValue, FunctionGraph as FlowGraph, Hlvalue, Link, SpaceOperation,
+    };
+    use crate::model::{ExitCase, ExitSwitch, OpKind};
+    use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+    use crate::translator::rtyper::lltypesystem::rstr::{
+        STRPTR, chars_array_ptr_lltype_from_strptr, struct_lltype_from_strptr,
+    };
+    use crate::translator::rtyper::rmodel::{gc_flavor_const, lowlevel_type_const};
+    use crate::translator::rtyper::rtyper::{constant_with_lltype, variable_with_lltype};
+
+    fn chars_field() -> Hlvalue {
+        constant_with_lltype(ConstValue::byte_str("chars"), LowLevelType::Void)
+    }
+    fn signed_const(n: i64) -> Hlvalue {
+        constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed)
+    }
+    fn bool_const(b: bool) -> Hlvalue {
+        constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool)
+    }
+
+    /// Build a single-string-type opname helper graph in the fusion-friendly
+    /// shape: the chars substruct is re-derived *block-locally* from a
+    /// threaded `STR` operand (never threaded as an interior pointer across a
+    /// Phi).  Exercises the full S1 opname set:
+    ///
+    /// ```text
+    /// start(s):
+    ///     chars  = getsubstruct(s, "chars")
+    ///     len    = getarraysize(chars)
+    ///     newstr = malloc_varsize(STR, gc, len)
+    ///     cond   = int_lt(0, len)
+    ///     if cond -> copy(s, newstr) else -> return(newstr)
+    /// copy(s, newstr):
+    ///     chars_s  = getsubstruct(s, "chars")
+    ///     c        = getarrayitem(chars_s, 0)
+    ///     newchars = getsubstruct(newstr, "chars")
+    ///     setarrayitem(newchars, 0, c)
+    ///     -> return(newstr)
+    /// ```
+    fn build_fusable_str_helper() -> FlowGraph {
+        let strptr = STRPTR.clone();
+        let chars_ptr = chars_array_ptr_lltype_from_strptr(&strptr).expect("chars ptr lltype");
+        let struct_lltype = struct_lltype_from_strptr(&strptr).expect("struct lltype");
+
+        let s = variable_with_lltype("s", strptr.clone());
+        let startblock = Block::shared(vec![Hlvalue::Variable(s.clone())]);
+        let return_var = variable_with_lltype("result", strptr.clone());
+        let graph = FlowGraph::with_return_var(
+            "ll_test_fusable_str_helper",
+            startblock.clone(),
+            Hlvalue::Variable(return_var),
+        );
+
+        // copy block threads the STRING pointers (s, newstr), NOT interior
+        // chars pointers — so each consumer re-derives its substruct locally.
+        let s_c = variable_with_lltype("s", strptr.clone());
+        let newstr_c = variable_with_lltype("newstr", strptr.clone());
+        let copy_block = Block::shared(vec![
+            Hlvalue::Variable(s_c.clone()),
+            Hlvalue::Variable(newstr_c.clone()),
+        ]);
+
+        // ---- startblock.
+        let chars = variable_with_lltype("chars", chars_ptr.clone());
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "getsubstruct",
+            vec![Hlvalue::Variable(s.clone()), chars_field()],
+            Hlvalue::Variable(chars.clone()),
+        ));
+        let len = variable_with_lltype("len", LowLevelType::Signed);
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "getarraysize",
+            vec![Hlvalue::Variable(chars)],
+            Hlvalue::Variable(len.clone()),
+        ));
+        let newstr = variable_with_lltype("newstr", strptr.clone());
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "malloc_varsize",
+            vec![
+                lowlevel_type_const(struct_lltype),
+                gc_flavor_const().expect("gc flavor const"),
+                Hlvalue::Variable(len.clone()),
+            ],
+            Hlvalue::Variable(newstr.clone()),
+        ));
+        let cond = variable_with_lltype("cond", LowLevelType::Bool);
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "int_lt",
+            vec![signed_const(0), Hlvalue::Variable(len)],
+            Hlvalue::Variable(cond.clone()),
+        ));
+        startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond));
+        startblock.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(s), Hlvalue::Variable(newstr.clone())],
+                Some(copy_block.clone()),
+                Some(bool_const(true)),
+            )
+            .into_ref(),
+            Link::new(
+                vec![Hlvalue::Variable(newstr)],
+                Some(graph.returnblock.clone()),
+                Some(bool_const(false)),
+            )
+            .into_ref(),
+        ]);
+
+        // ---- copy block.
+        let chars_s = variable_with_lltype("chars_s", chars_ptr.clone());
+        copy_block.borrow_mut().operations.push(SpaceOperation::new(
+            "getsubstruct",
+            vec![Hlvalue::Variable(s_c), chars_field()],
+            Hlvalue::Variable(chars_s.clone()),
+        ));
+        let c = variable_with_lltype("c", LowLevelType::Char);
+        copy_block.borrow_mut().operations.push(SpaceOperation::new(
+            "getarrayitem",
+            vec![Hlvalue::Variable(chars_s), signed_const(0)],
+            Hlvalue::Variable(c.clone()),
+        ));
+        let newchars = variable_with_lltype("newchars", chars_ptr);
+        copy_block.borrow_mut().operations.push(SpaceOperation::new(
+            "getsubstruct",
+            vec![Hlvalue::Variable(newstr_c.clone()), chars_field()],
+            Hlvalue::Variable(newchars.clone()),
+        ));
+        let set = variable_with_lltype("set", LowLevelType::Void);
+        copy_block.borrow_mut().operations.push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(newchars),
+                signed_const(0),
+                Hlvalue::Variable(c),
+            ],
+            Hlvalue::Variable(set),
+        ));
+        copy_block.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(newstr_c)],
+                Some(graph.returnblock.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+
+        graph
+    }
+
+    #[test]
+    fn lower_graph_fuses_str_helper_to_blackhole_opcodes() {
+        let flow = build_fusable_str_helper();
+        let model = lower_graph(&flow);
+
+        // start(0) / return(1) / except(2) / copy(3).
+        assert_eq!(model.blocks.len(), 4);
+
+        let mut blackhole = Vec::new();
+        let mut binops = Vec::new();
+        let mut const_ints = 0;
+        let mut residual = Vec::new();
+        for block in &model.blocks {
+            for op in &block.operations {
+                match &op.kind {
+                    OpKind::LoweredBlackholeOp { opname, .. } => blackhole.push(opname.clone()),
+                    OpKind::BinOp { op, .. } => binops.push(op.clone()),
+                    OpKind::ConstInt(_) => const_ints += 1,
+                    other => residual.push(format!("{other:?}")),
+                }
+            }
+        }
+        blackhole.sort();
+
+        // `getsubstruct` emits nothing; `getarraysize`/`getarrayitem`/
+        // `setarrayitem`/`malloc_varsize` fuse to the string blackhole ops.
+        assert_eq!(
+            blackhole,
+            vec!["newstr", "strgetitem", "strlen", "strsetitem"]
+        );
+        // `int_lt` lowers to a bare-named `BinOp`.
+        assert_eq!(binops, vec!["lt"]);
+        // The constant `0` is materialised once per consumer: `int_lt`,
+        // `getarrayitem`, `setarrayitem`.
+        assert_eq!(const_ints, 3);
+        assert!(residual.is_empty(), "unexpected residual ops: {residual:?}");
+    }
+
+    #[test]
+    fn lower_graph_preserves_bool_branch_control_flow() {
+        let flow = build_fusable_str_helper();
+        let model = lower_graph(&flow);
+
+        // startblock is a 2-way bool branch on the `int_lt` result.
+        let start = model.block(model.startblock);
+        assert!(matches!(start.exitswitch, Some(ExitSwitch::Value(_))));
+        assert_eq!(start.exits.len(), 2);
+        let cases: Vec<&Option<ExitCase>> = start.exits.iter().map(|l| &l.exitcase).collect();
+        assert!(cases.contains(&&Some(ExitCase::Bool(true))));
+        assert!(cases.contains(&&Some(ExitCase::Bool(false))));
+
+        // The true branch targets the copy block, which holds the read/write
+        // string ops; the false branch returns directly.
+        let true_link = start
+            .exits
+            .iter()
+            .find(|l| l.exitcase == Some(ExitCase::Bool(true)))
+            .expect("true exit");
+        let copy_block = model.block(true_link.target);
+        let copy_opnames: Vec<&str> = copy_block
+            .operations
+            .iter()
+            .filter_map(|op| match &op.kind {
+                OpKind::LoweredBlackholeOp { opname, .. } => Some(opname.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(copy_opnames.contains(&"strgetitem"));
+        assert!(copy_opnames.contains(&"strsetitem"));
+
+        let false_link = start
+            .exits
+            .iter()
+            .find(|l| l.exitcase == Some(ExitCase::Bool(false)))
+            .expect("false exit");
+        assert_eq!(false_link.target, model.returnblock);
+    }
+
+    /// End-to-end: register the opname helper through Spine B and drive the
+    /// drain loop, proving the transduced graph survives the shared
+    /// regalloc/flatten/assemble tail and commits a non-empty `JitCode` body.
+    /// This is the test that actually exercises the `LoweredBlackholeOp`
+    /// assembler encode + dynamic byte assignment.
+    #[test]
+    fn lower_graph_drains_to_a_jitcode_body() {
+        use crate::jit_codewriter::call::CallControl;
+        use crate::jit_codewriter::codewriter::CodeWriter;
+        use crate::jit_codewriter::jtransform::GraphTransformConfig;
+        use crate::parse::CallPath;
+
+        let flow = build_fusable_str_helper();
+        let path = CallPath::from_segments(["ll_test_fusable_str_helper"]);
+
+        let mut callcontrol = CallControl::new();
+        let jitcode = callcontrol.register_opname_helper_graph(path, flow);
+        assert!(jitcode.try_body().is_none(), "shell starts bodyless");
+
+        let mut codewriter = CodeWriter::new();
+        codewriter.drain_pending_graphs(&mut callcontrol, &GraphTransformConfig::default());
+
+        let body = jitcode
+            .try_body()
+            .expect("Spine-B drain commits a jitcode body");
+        assert!(!body.code.is_empty(), "assembled bytecode is non-empty");
+        assert_eq!(jitcode.try_index(), Some(0));
+    }
 }

--- a/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
@@ -280,6 +280,25 @@ fn transduce_op(
                 result,
             );
         }
+        // `copystrcontent(src, dst, srcstart, dststart, length)` /
+        // `copyunicodecontent(...)` — bulk char copy.  Both string operands
+        // are whole objects (not chars-array interior pointers), so they
+        // bypass the `chars_alias` map.  Void result.
+        "copystrcontent" | "copyunicodecontent" => {
+            let src = expect_var(&op.args[0]);
+            let dst = expect_var(&op.args[1]);
+            let srcstart = materialize(out, block, &op.args[2]);
+            let dststart = materialize(out, block, &op.args[3]);
+            let length = materialize(out, block, &op.args[4]);
+            out.push_op_var(
+                block,
+                OpKind::LoweredBlackholeOp {
+                    opname: op.opname.clone(),
+                    args: vec![src, dst, srcstart, dststart, length],
+                },
+                false,
+            );
+        }
         // Integer arithmetic / comparison — `int_add`/`int_lt`/… → `BinOp`
         // with the bare op name (the assembler re-prefixes `int_`).  Constant
         // operands materialise as `ConstInt`/`ConstBool` since `BinOp` takes
@@ -678,5 +697,61 @@ mod tests {
             .expect("Spine-B drain commits a jitcode body");
         assert!(!body.code.is_empty(), "assembled bytecode is non-empty");
         assert_eq!(jitcode.try_index(), Some(0));
+    }
+
+    /// End-to-end: the restructured production `ll_strconcat` helper lowers
+    /// cleanly through Spine B.  The two `copystrcontent` ops become void
+    /// `LoweredBlackholeOp`s, the source-length reads fuse to `strlen`, and
+    /// the cross-Phi `resolve_string` fail-loud is never reached because no
+    /// per-char loop (strgetitem/strsetitem) survives.
+    #[test]
+    fn lower_graph_lowers_strconcat_helper_to_copystrcontent() {
+        use crate::translator::rtyper::lltypesystem::rstr::{
+            STRPTR, build_ll_strconcat_helper_graph,
+        };
+
+        let helper = build_ll_strconcat_helper_graph("ll_strconcat", STRPTR.clone())
+            .expect("build strconcat helper");
+        let flow = helper.graph.borrow();
+        let model = lower_graph(&flow);
+
+        let mut blackhole = Vec::new();
+        for block in &model.blocks {
+            for op in &block.operations {
+                if let OpKind::LoweredBlackholeOp { opname, args } = &op.kind {
+                    blackhole.push(opname.clone());
+                    if opname == "copystrcontent" {
+                        assert_eq!(args.len(), 5, "copystrcontent has 5 operands");
+                        assert!(op.result.is_none(), "copystrcontent is void");
+                    }
+                }
+            }
+        }
+
+        // Two source-length reads (strlen) + one alloc (newstr) + two copies.
+        assert_eq!(
+            blackhole.iter().filter(|n| *n == "strlen").count(),
+            2,
+            "two strlen source-length reads"
+        );
+        assert_eq!(blackhole.iter().filter(|n| *n == "newstr").count(), 1);
+        assert_eq!(
+            blackhole.iter().filter(|n| *n == "copystrcontent").count(),
+            2,
+            "two copystrcontent bulk copies"
+        );
+        // No per-char string ops: the loop is gone, so resolve_string never runs.
+        assert!(
+            !blackhole
+                .iter()
+                .any(|n| n == "strgetitem" || n == "strsetitem"),
+            "no per-char string ops survive: {blackhole:?}"
+        );
+
+        // start forwards unconditionally into the returnblock.
+        let start = model.block(model.startblock);
+        assert!(start.exitswitch.is_none(), "start exit is unconditional");
+        assert_eq!(start.exits.len(), 1);
+        assert_eq!(start.exits[0].target, model.returnblock);
     }
 }

--- a/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
@@ -1,0 +1,44 @@
+//! Opname-dispatch transducer for the codewriter convergence ("Spine B").
+//!
+//! The production codewriter consumes the rich-`OpKind`
+//! `crate::model::FunctionGraph` (`jtransform.rs`'s `Transformer::transform`
+//! dispatches on `OpKind::FieldRead`/`OpKind::Call`/…).  The rtyper, however,
+//! already lowers the *flowspace* graph to upstream-shaped low-level
+//! `SpaceOperation`s (`getfield`/`setfield`/`getarrayitem`/`malloc_varsize`/
+//! `int_add`/…) in place, and certain helper graphs (the `ll_str*` family
+//! built by `lltypesystem/rstr.rs`) are born ONLY in that opname form — they
+//! have no rich-`OpKind` twin and are discarded today.
+//!
+//! [`lower_graph`] is the convergence transducer: it consumes such a
+//! `crate::flowspace::model::FunctionGraph` and emits an equivalent
+//! `crate::model::FunctionGraph` (rich `OpKind`), which then re-enters the
+//! EXISTING flatten/regalloc/assembler tail unchanged
+//! (`CodeWriter::finalize_rewritten_graph_to_jitcode`).  This is the port of
+//! `jtransform.py`'s `_rewrite_ops[op.opname]` dispatch
+//! (`jtransform.py:238`), reading each `Variable.concretetype` directly (the
+//! upstream `getkind(v.concretetype)` path) rather than through the
+//! `value_to_var` bridge the rich-`OpKind` spine uses.
+//!
+//! Coexistence: a graph's ops are either all rich-`OpKind` (Spine A) or all
+//! opname (Spine B); the two never mix within one graph.  The drain loop
+//! routes a path to this module only when
+//! `CallControl::take_opname_graph` returns its registered flowspace graph.
+//! Until a helper is registered via
+//! `CallControl::register_opname_helper_graph`, this module is dead code.
+
+use crate::flowspace::model::FunctionGraph as FlowGraph;
+
+/// Lower an rtyper low-level helper graph (opname `SpaceOperation`s) to an
+/// equivalent rich-`OpKind` `crate::model::FunctionGraph`.
+///
+/// S1 (ll_strconcat foothold) implements the per-opname transduction for the
+/// helper's opname set `{getsubstruct, getarraysize, int_add, malloc_varsize,
+/// int_lt, getarrayitem, setarrayitem}`.  Until then no graph is registered
+/// through `CallControl::register_opname_helper_graph`, so the drain loop's
+/// Spine-B branch is never taken and this body is unreachable.
+pub fn lower_graph(_graph: &FlowGraph) -> crate::model::FunctionGraph {
+    unimplemented!(
+        "jtransform_opname::lower_graph: opname-dispatch transduction lands in S1 \
+         (ll_strconcat foothold)"
+    )
+}

--- a/majit/majit-translate/src/jit_codewriter/mod.rs
+++ b/majit/majit-translate/src/jit_codewriter/mod.rs
@@ -14,6 +14,11 @@ pub mod format;
 pub mod insns;
 pub mod jitcode;
 pub mod jtransform;
+// Opname-dispatch transducer ("Spine B"): lowers rtyper low-level helper
+// graphs (opname `SpaceOperation`s) to rich-`OpKind` graphs that re-enter the
+// shared flatten/regalloc/assembler tail. Port of `jtransform.py`'s
+// `_rewrite_ops[op.opname]` dispatch; see the module docs.
+pub mod jtransform_opname;
 // No upstream sibling: an inert, env-gated diagnostic that gauges how much
 // of the rtyped flowspace graph an opname-dispatching jtransform would
 // already accept. Never on the production path; see the module docs.

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1011,6 +1011,30 @@ pub enum OpKind {
         args: Vec<crate::flowspace::model::Variable>,
     },
 
+    /// A pre-lowered, register-shaped blackhole opcode emitted by the
+    /// opname-dispatch convergence spine (`jit_codewriter::jtransform_opname`).
+    ///
+    /// The rtyper lowers certain helper graphs (the `ll_str*` family) to
+    /// upstream-shaped low-level `SpaceOperation`s whose opnames map 1:1 onto
+    /// a register-only blackhole insn with NO descriptor operand — e.g.
+    /// `strlen` (`r>i`), `strgetitem` (`ri>i`), `strsetitem` (`rii`),
+    /// `newstr` (`i>r`).  Rather than mint a distinct rich `OpKind` per such
+    /// opname (each forcing an arm in every exhaustive `OpKind` match), the
+    /// transducer carries the blackhole `opname` and its operand `Variable`s
+    /// directly here.  The assembler's default `encode_op` arm emits
+    /// `{opname}/{argcodes}`, with operand kinds inferred from each operand's
+    /// register bank and the result kind (if any) appended from `op.result`
+    /// — matching the `bhimpl_<opname>` argcode shape the runtime handler is
+    /// keyed on (`blackhole.rs`).
+    ///
+    /// Only for opnames whose lowering is a single register-shaped insn with
+    /// no descriptor and no special effect classification; descriptor-bearing
+    /// ops (getfield/getarrayitem/…) keep their dedicated rich `OpKind`s.
+    LoweredBlackholeOp {
+        opname: String,
+        args: Vec<crate::flowspace::model::Variable>,
+    },
+
     /// A single-segment path resolving to a crate-local `static`
     /// declaration (typically a SHOUTY_CASE constant like
     /// `GC_WEAKREF_TYPE`, `INT_TYPE`, `MODULE_DICT_TYPE`).

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -379,6 +379,15 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         // `newtuple` yields a `Ref` to the freshly allocated tuple
         // object (RPython `SomeTuple` lowers to `Ptr<GcStruct>`).
         OpKind::NewTuple { .. } => ValueType::Ref(None),
+        // `LoweredBlackholeOp` is born only in the opname-dispatch spine
+        // (`jtransform_opname::lower_graph`), whose graphs re-enter the
+        // shared tail at `finalize_rewritten_graph_to_jitcode` and never
+        // pass through this legacy annotator.  Its result type is already
+        // fixed by the lowering (`Variable.concretetype`), so the legacy
+        // inference path has nothing to contribute.
+        OpKind::LoweredBlackholeOp { .. } => {
+            unreachable!("LoweredBlackholeOp is opname-spine-only; legacy annotator runs on Spine A")
+        }
         // `LoadStatic` carries the declared `ValueType` of the static
         // directly (extracted from the `syn::Item::Static.ty` at
         // `register::extract_static_decls`).

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -221,6 +221,47 @@ pub fn const_str_cache_llstr(s: &[u8]) -> Result<_ptr, String> {
     })
 }
 
+/// Inverse of [`llstr`] / [`const_str_cache_llstr`]: read back the
+/// Latin-1 byte payload and `hash`-slot value of a prebuilt `Ptr(STR)`
+/// container.  The codewriter uses this to lower a prebuilt-string
+/// `ConstValue::LLPtr(STR)` into a runtime-materialized descriptor: the
+/// build-time `_ptr` is process-local, so only its bytes + precomputed
+/// hash survive into the serialized jitcode.
+///
+/// Returns `None` for null, a non-struct target, a missing/empty-typed
+/// `chars` field, or a non-`Char` element (a `Ptr(UNICODE)` container,
+/// whose `chars` are `UniChar`, is out of scope here — Unicode prebuilt
+/// constants are a separate lowering).
+pub fn prebuilt_str_bytes_and_hash(p: &_ptr) -> Option<(Vec<u8>, i64)> {
+    if !p.nonzero() {
+        return None;
+    }
+    let _ptr_obj::Struct(st) = p._obj0_value().ok().flatten()? else {
+        return None;
+    };
+    let fields = st._fields.lock().unwrap();
+    // `chars` mirrors the read side of `llstr`'s per-index fill.
+    let Some((_, LowLevelValue::Array(chars))) = fields.iter().find(|(n, _)| n == "chars") else {
+        return None;
+    };
+    let mut bytes = Vec::with_capacity(chars.getlength());
+    for i in 0..chars.getlength() {
+        match chars.getitem(i) {
+            // `u8 as char` is the Latin-1 embedding `llstr` writes, so the
+            // low byte round-trips every value 0..=255.
+            Some(LowLevelValue::Char(c)) => bytes.push(c as u32 as u8),
+            _ => return None,
+        }
+    }
+    // `const_str_cache_llstr` precomputes and stores `hash` (rstr.py:199);
+    // a bare `llstr` leaves the malloc-zeroed `0` (lazy not-computed).
+    let hash = match fields.iter().find(|(n, _)| n == "hash") {
+        Some((_, LowLevelValue::Signed(h))) => *h,
+        _ => ll_strhash_value(&bytes),
+    };
+    Some((bytes, hash))
+}
+
 /// `nullptr(self.lowleveltype.TO)` for the `value is None` arm of
 /// `BaseLLStringRepr.convert_const` (`lltypesystem/rstr.py:192-193`).
 pub fn null_str_ptr() -> _ptr {
@@ -8698,6 +8739,33 @@ mod tests {
         // An uncached `llstr` of the same bytes mints a fresh container.
         let fresh = llstr(b"cache-identity-probe").expect("uncached llstr");
         assert_ne!(p1, fresh, "llstr must not consult the cache");
+    }
+
+    /// [`prebuilt_str_bytes_and_hash`] is the inverse of
+    /// [`const_str_cache_llstr`]: the bytes round-trip (incl. `0x00`/`0xFF`)
+    /// and the precomputed `hash` slot is read back, so the codewriter can
+    /// lower a prebuilt `Ptr(STR)` to a deferred runtime descriptor.  Null
+    /// pointers yield `None`.
+    #[test]
+    fn prebuilt_str_bytes_and_hash_round_trips_cache_llstr() {
+        let bytes: &[u8] = &[b'h', 0x00, 0xFF, b'i'];
+        let p = const_str_cache_llstr(bytes).expect("cache llstr");
+        let (got_bytes, got_hash) =
+            prebuilt_str_bytes_and_hash(&p).expect("prebuilt STR must decode");
+        assert_eq!(got_bytes, bytes, "bytes must round-trip every value");
+        assert_eq!(
+            got_hash,
+            ll_strhash_value(bytes),
+            "hash slot must carry the precomputed ll_strhash value"
+        );
+        // The empty string decodes to empty bytes with the `-1` hash.
+        let empty = const_str_cache_llstr(b"").expect("cache llstr empty");
+        assert_eq!(
+            prebuilt_str_bytes_and_hash(&empty),
+            Some((Vec::new(), ll_strhash_value(b"")))
+        );
+        // A typed null `Ptr(STR)` is not a prebuilt string.
+        assert_eq!(prebuilt_str_bytes_and_hash(&null_str_ptr()), None);
     }
 
     /// `nullptr(self.lowleveltype.TO)` arm of

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -8166,37 +8166,24 @@ pub(crate) fn build_ll_stritem_checked_helper_graph(
 ///     return newstr
 /// ```
 ///
-/// Pyre lowers `s.malloc(N)` to a `malloc_varsize` SpaceOperation
-/// (rstr.py:1131 emit pattern: `[cTEMP, cflags, size]`) and inlines
-/// the two `copy_contents_from_str` calls as explicit per-char copy
-/// loops over `s.chars` / `newstr.chars` — the upstream
-/// `copy_string_contents` itself is a `mh.copy_string_contents`
-/// adtmeth wrapper that, after rtyping, decomposes into the same
-/// `getarrayitem` / `setarrayitem` loop shape.
+/// Pyre lowers `s.malloc(N)` to a `malloc_varsize` SpaceOperation and
+/// the two `copy_contents_from_str` calls to two `copystrcontent`
+/// (`copyunicodecontent` for UNICODE) ops — the same op the JIT
+/// codewriter produces for the `stroruni.copy_contents` oopspec. Both
+/// operands are whole string objects, so no interior chars pointer is
+/// materialised.
 ///
-/// 5-block-plus-returnblock CFG:
-/// - **start**: extract chars1/len1/chars2/len2, compute
-///   `total = int_add(len1, len2)`, allocate `newstr` via
-///   `malloc_varsize(struct_lltype, gc_flavor, total)`, fetch
-///   `newchars = getsubstruct(newstr, 'chars')`. Forward into
-///   `block_copy1_cond(newstr, newchars, chars1, chars2, len1, len2, 0)`.
-/// - **block_copy1_cond**: `cond = int_lt(i, len1)`. True →
-///   `block_copy1_body`; False → `block_copy2_cond(..., 0)`.
-/// - **block_copy1_body**: `c = getarrayitem(chars1, i)`,
-///   `setarrayitem(newchars, i, c)`, `i_next = int_add(i, 1)`. Cycle
-///   back into `block_copy1_cond` with `i_next`.
-/// - **block_copy2_cond**: `cond = int_lt(j, len2)`. True →
-///   `block_copy2_body`; False → returnblock(newstr).
-/// - **block_copy2_body**: `c = getarrayitem(chars2, j)`,
-///   `dst_idx = int_add(len1, j)`, `setarrayitem(newchars, dst_idx,
-///   c)`, `j_next = int_add(j, 1)`. Cycle back into
-///   `block_copy2_cond` with `j_next`.
+/// Straight-line CFG (start → returnblock):
+/// - **start**: `chars1 = getsubstruct(s1, 'chars')`,
+///   `len1 = getarraysize(chars1)`; likewise `chars2` / `len2`;
+///   `total = int_add(len1, len2)`; `newstr = malloc_varsize(struct,
+///   gc, total)`; `copystrcontent(s1, newstr, 0, 0, len1)`;
+///   `copystrcontent(s2, newstr, 0, len1, len2)`. Forward into
+///   `returnblock(newstr)`.
 ///
-/// Polymorphic over `Ptr(STR)` / `Ptr(UNICODE)`. The chars-array
-/// element type drives the lltype of the per-loop `c` temporary
-/// (Char or UniChar); `setarrayitem` does not require a per-element-
-/// type op selection (unlike `char_eq` vs `unichar_eq`) since it
-/// emits a single op name.
+/// Polymorphic over `Ptr(STR)` / `Ptr(UNICODE)`: the chars-array
+/// element type (Char / UniChar) selects `copystrcontent` vs
+/// `copyunicodecontent`.
 pub(crate) fn build_ll_strconcat_helper_graph(
     name: &str,
     ptr_lltype: LowLevelType,
@@ -8225,8 +8212,6 @@ pub(crate) fn build_ll_strconcat_helper_graph(
 
     let struct_lltype = struct_lltype_from_strptr(&ptr_lltype)?;
 
-    let bool_true = || constant_with_lltype(ConstValue::Bool(true), LowLevelType::Bool);
-    let bool_false = || constant_with_lltype(ConstValue::Bool(false), LowLevelType::Bool);
     let signed_const = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
     let chars_field_const =
         || constant_with_lltype(ConstValue::byte_str("chars"), LowLevelType::Void);
@@ -8244,80 +8229,15 @@ pub(crate) fn build_ll_strconcat_helper_graph(
         Hlvalue::Variable(return_var),
     );
 
-    // ---- Block declarations: copy1_cond / copy1_body / copy2_cond / copy2_body.
-    //
-    // copy1 carries (newstr, newchars, chars1, chars2, len1, len2, i).
-    let newstr_for_c1c = variable_with_lltype("newstr", ptr_lltype.clone());
-    let newchars_for_c1c = variable_with_lltype("newchars", chars_array_ptr_lltype.clone());
-    let chars1_for_c1c = variable_with_lltype("chars1", chars_array_ptr_lltype.clone());
-    let chars2_for_c1c = variable_with_lltype("chars2", chars_array_ptr_lltype.clone());
-    let len1_for_c1c = variable_with_lltype("len1", LowLevelType::Signed);
-    let len2_for_c1c = variable_with_lltype("len2", LowLevelType::Signed);
-    let i_for_c1c = variable_with_lltype("i", LowLevelType::Signed);
-    let block_copy1_cond = Block::shared(vec![
-        Hlvalue::Variable(newstr_for_c1c.clone()),
-        Hlvalue::Variable(newchars_for_c1c.clone()),
-        Hlvalue::Variable(chars1_for_c1c.clone()),
-        Hlvalue::Variable(chars2_for_c1c.clone()),
-        Hlvalue::Variable(len1_for_c1c.clone()),
-        Hlvalue::Variable(len2_for_c1c.clone()),
-        Hlvalue::Variable(i_for_c1c.clone()),
-    ]);
-
-    let newstr_for_c1b = variable_with_lltype("newstr", ptr_lltype.clone());
-    let newchars_for_c1b = variable_with_lltype("newchars", chars_array_ptr_lltype.clone());
-    let chars1_for_c1b = variable_with_lltype("chars1", chars_array_ptr_lltype.clone());
-    let chars2_for_c1b = variable_with_lltype("chars2", chars_array_ptr_lltype.clone());
-    let len1_for_c1b = variable_with_lltype("len1", LowLevelType::Signed);
-    let len2_for_c1b = variable_with_lltype("len2", LowLevelType::Signed);
-    let i_for_c1b = variable_with_lltype("i", LowLevelType::Signed);
-    let block_copy1_body = Block::shared(vec![
-        Hlvalue::Variable(newstr_for_c1b.clone()),
-        Hlvalue::Variable(newchars_for_c1b.clone()),
-        Hlvalue::Variable(chars1_for_c1b.clone()),
-        Hlvalue::Variable(chars2_for_c1b.clone()),
-        Hlvalue::Variable(len1_for_c1b.clone()),
-        Hlvalue::Variable(len2_for_c1b.clone()),
-        Hlvalue::Variable(i_for_c1b.clone()),
-    ]);
-
-    // copy2 carries (newstr, newchars, chars2, len1, len2, j) — chars1
-    // is no longer needed once copy1 finishes.
-    let newstr_for_c2c = variable_with_lltype("newstr", ptr_lltype.clone());
-    let newchars_for_c2c = variable_with_lltype("newchars", chars_array_ptr_lltype.clone());
-    let chars2_for_c2c = variable_with_lltype("chars2", chars_array_ptr_lltype.clone());
-    let len1_for_c2c = variable_with_lltype("len1", LowLevelType::Signed);
-    let len2_for_c2c = variable_with_lltype("len2", LowLevelType::Signed);
-    let j_for_c2c = variable_with_lltype("j", LowLevelType::Signed);
-    let block_copy2_cond = Block::shared(vec![
-        Hlvalue::Variable(newstr_for_c2c.clone()),
-        Hlvalue::Variable(newchars_for_c2c.clone()),
-        Hlvalue::Variable(chars2_for_c2c.clone()),
-        Hlvalue::Variable(len1_for_c2c.clone()),
-        Hlvalue::Variable(len2_for_c2c.clone()),
-        Hlvalue::Variable(j_for_c2c.clone()),
-    ]);
-
-    let newstr_for_c2b = variable_with_lltype("newstr", ptr_lltype.clone());
-    let newchars_for_c2b = variable_with_lltype("newchars", chars_array_ptr_lltype.clone());
-    let chars2_for_c2b = variable_with_lltype("chars2", chars_array_ptr_lltype.clone());
-    let len1_for_c2b = variable_with_lltype("len1", LowLevelType::Signed);
-    let len2_for_c2b = variable_with_lltype("len2", LowLevelType::Signed);
-    let j_for_c2b = variable_with_lltype("j", LowLevelType::Signed);
-    let block_copy2_body = Block::shared(vec![
-        Hlvalue::Variable(newstr_for_c2b.clone()),
-        Hlvalue::Variable(newchars_for_c2b.clone()),
-        Hlvalue::Variable(chars2_for_c2b.clone()),
-        Hlvalue::Variable(len1_for_c2b.clone()),
-        Hlvalue::Variable(len2_for_c2b.clone()),
-        Hlvalue::Variable(j_for_c2b.clone()),
-    ]);
-
-    // ---- start: extract chars + lengths, malloc_varsize, get newchars.
+    // ---- start: extract source lengths, malloc the result, then copy each
+    //      source's chars into it via copystrcontent.  Mirrors upstream
+    //      `ll_strconcat` (rstr.py:428): malloc + two `copy_contents_from_str`
+    //      calls, each rewritten by the JIT codewriter to a single
+    //      `copystrcontent` op.
     let chars1 = variable_with_lltype("chars1", chars_array_ptr_lltype.clone());
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "getsubstruct",
-        vec![Hlvalue::Variable(s1), chars_field_const()],
+        vec![Hlvalue::Variable(s1.clone()), chars_field_const()],
         Hlvalue::Variable(chars1.clone()),
     ));
     let len1 = variable_with_lltype("len1", LowLevelType::Signed);
@@ -8329,7 +8249,7 @@ pub(crate) fn build_ll_strconcat_helper_graph(
     let chars2 = variable_with_lltype("chars2", chars_array_ptr_lltype.clone());
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "getsubstruct",
-        vec![Hlvalue::Variable(s2), chars_field_const()],
+        vec![Hlvalue::Variable(s2.clone()), chars_field_const()],
         Hlvalue::Variable(chars2.clone()),
     ));
     let len2 = variable_with_lltype("len2", LowLevelType::Signed);
@@ -8357,222 +8277,42 @@ pub(crate) fn build_ll_strconcat_helper_graph(
         ],
         Hlvalue::Variable(newstr.clone()),
     ));
-    let newchars = variable_with_lltype("newchars", chars_array_ptr_lltype.clone());
+    // Two bulk copies: `copystrcontent(src, dst, srcstart, dststart, length)`
+    // for STR / `copyunicodecontent` for UNICODE.  The operands are whole
+    // string objects, so there is no interior chars pointer to thread.
+    let copy_opname = if matches!(elem_lltype, LowLevelType::Char) {
+        "copystrcontent"
+    } else {
+        "copyunicodecontent"
+    };
+    let void_copy1 = variable_with_lltype("copy1", LowLevelType::Void);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "getsubstruct",
-        vec![Hlvalue::Variable(newstr.clone()), chars_field_const()],
-        Hlvalue::Variable(newchars.clone()),
+        copy_opname,
+        vec![
+            Hlvalue::Variable(s1),
+            Hlvalue::Variable(newstr.clone()),
+            signed_const(0),
+            signed_const(0),
+            Hlvalue::Variable(len1.clone()),
+        ],
+        Hlvalue::Variable(void_copy1),
+    ));
+    let void_copy2 = variable_with_lltype("copy2", LowLevelType::Void);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        copy_opname,
+        vec![
+            Hlvalue::Variable(s2),
+            Hlvalue::Variable(newstr.clone()),
+            signed_const(0),
+            Hlvalue::Variable(len1),
+            Hlvalue::Variable(len2),
+        ],
+        Hlvalue::Variable(void_copy2),
     ));
     startblock.closeblock(vec![
         Link::new(
-            vec![
-                Hlvalue::Variable(newstr),
-                Hlvalue::Variable(newchars),
-                Hlvalue::Variable(chars1),
-                Hlvalue::Variable(chars2),
-                Hlvalue::Variable(len1),
-                Hlvalue::Variable(len2),
-                signed_const(0),
-            ],
-            Some(block_copy1_cond.clone()),
-            None,
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_copy1_cond: int_lt(i, len1).
-    let cond1 = variable_with_lltype("cond1", LowLevelType::Bool);
-    block_copy1_cond
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_lt",
-            vec![
-                Hlvalue::Variable(i_for_c1c.clone()),
-                Hlvalue::Variable(len1_for_c1c.clone()),
-            ],
-            Hlvalue::Variable(cond1.clone()),
-        ));
-    block_copy1_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond1));
-    block_copy1_cond.closeblock(vec![
-        Link::new(
-            vec![
-                Hlvalue::Variable(newstr_for_c1c.clone()),
-                Hlvalue::Variable(newchars_for_c1c.clone()),
-                Hlvalue::Variable(chars1_for_c1c.clone()),
-                Hlvalue::Variable(chars2_for_c1c.clone()),
-                Hlvalue::Variable(len1_for_c1c.clone()),
-                Hlvalue::Variable(len2_for_c1c.clone()),
-                Hlvalue::Variable(i_for_c1c.clone()),
-            ],
-            Some(block_copy1_body.clone()),
-            Some(bool_true()),
-        )
-        .into_ref(),
-        Link::new(
-            vec![
-                Hlvalue::Variable(newstr_for_c1c),
-                Hlvalue::Variable(newchars_for_c1c),
-                Hlvalue::Variable(chars2_for_c1c),
-                Hlvalue::Variable(len1_for_c1c),
-                Hlvalue::Variable(len2_for_c1c),
-                signed_const(0),
-            ],
-            Some(block_copy2_cond.clone()),
-            Some(bool_false()),
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_copy1_body: c = getarrayitem(chars1, i); setarrayitem;
-    //      i_next = int_add(i, 1); cycle back.
-    let c1 = variable_with_lltype("c", elem_lltype.clone());
-    block_copy1_body
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "getarrayitem",
-            vec![
-                Hlvalue::Variable(chars1_for_c1b.clone()),
-                Hlvalue::Variable(i_for_c1b.clone()),
-            ],
-            Hlvalue::Variable(c1.clone()),
-        ));
-    let void_set1 = variable_with_lltype("set1", LowLevelType::Void);
-    block_copy1_body
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "setarrayitem",
-            vec![
-                Hlvalue::Variable(newchars_for_c1b.clone()),
-                Hlvalue::Variable(i_for_c1b.clone()),
-                Hlvalue::Variable(c1),
-            ],
-            Hlvalue::Variable(void_set1),
-        ));
-    let i_next = variable_with_lltype("i_next", LowLevelType::Signed);
-    block_copy1_body
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_add",
-            vec![Hlvalue::Variable(i_for_c1b), signed_const(1)],
-            Hlvalue::Variable(i_next.clone()),
-        ));
-    block_copy1_body.closeblock(vec![
-        Link::new(
-            vec![
-                Hlvalue::Variable(newstr_for_c1b),
-                Hlvalue::Variable(newchars_for_c1b),
-                Hlvalue::Variable(chars1_for_c1b),
-                Hlvalue::Variable(chars2_for_c1b),
-                Hlvalue::Variable(len1_for_c1b),
-                Hlvalue::Variable(len2_for_c1b),
-                Hlvalue::Variable(i_next),
-            ],
-            Some(block_copy1_cond.clone()),
-            None,
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_copy2_cond: int_lt(j, len2).
-    let cond2 = variable_with_lltype("cond2", LowLevelType::Bool);
-    block_copy2_cond
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_lt",
-            vec![
-                Hlvalue::Variable(j_for_c2c.clone()),
-                Hlvalue::Variable(len2_for_c2c.clone()),
-            ],
-            Hlvalue::Variable(cond2.clone()),
-        ));
-    block_copy2_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond2));
-    block_copy2_cond.closeblock(vec![
-        Link::new(
-            vec![
-                Hlvalue::Variable(newstr_for_c2c.clone()),
-                Hlvalue::Variable(newchars_for_c2c.clone()),
-                Hlvalue::Variable(chars2_for_c2c.clone()),
-                Hlvalue::Variable(len1_for_c2c.clone()),
-                Hlvalue::Variable(len2_for_c2c.clone()),
-                Hlvalue::Variable(j_for_c2c.clone()),
-            ],
-            Some(block_copy2_body.clone()),
-            Some(bool_true()),
-        )
-        .into_ref(),
-        Link::new(
-            vec![Hlvalue::Variable(newstr_for_c2c)],
+            vec![Hlvalue::Variable(newstr)],
             Some(graph.returnblock.clone()),
-            Some(bool_false()),
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_copy2_body: c = getarrayitem(chars2, j);
-    //      dst_idx = int_add(len1, j); setarrayitem(newchars, dst_idx, c);
-    //      j_next = int_add(j, 1); cycle back.
-    let c2 = variable_with_lltype("c", elem_lltype);
-    block_copy2_body
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "getarrayitem",
-            vec![
-                Hlvalue::Variable(chars2_for_c2b.clone()),
-                Hlvalue::Variable(j_for_c2b.clone()),
-            ],
-            Hlvalue::Variable(c2.clone()),
-        ));
-    let dst_idx = variable_with_lltype("dst_idx", LowLevelType::Signed);
-    block_copy2_body
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_add",
-            vec![
-                Hlvalue::Variable(len1_for_c2b.clone()),
-                Hlvalue::Variable(j_for_c2b.clone()),
-            ],
-            Hlvalue::Variable(dst_idx.clone()),
-        ));
-    let void_set2 = variable_with_lltype("set2", LowLevelType::Void);
-    block_copy2_body
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "setarrayitem",
-            vec![
-                Hlvalue::Variable(newchars_for_c2b.clone()),
-                Hlvalue::Variable(dst_idx),
-                Hlvalue::Variable(c2),
-            ],
-            Hlvalue::Variable(void_set2),
-        ));
-    let j_next = variable_with_lltype("j_next", LowLevelType::Signed);
-    block_copy2_body
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_add",
-            vec![Hlvalue::Variable(j_for_c2b), signed_const(1)],
-            Hlvalue::Variable(j_next.clone()),
-        ));
-    block_copy2_body.closeblock(vec![
-        Link::new(
-            vec![
-                Hlvalue::Variable(newstr_for_c2b),
-                Hlvalue::Variable(newchars_for_c2b),
-                Hlvalue::Variable(chars2_for_c2b),
-                Hlvalue::Variable(len1_for_c2b),
-                Hlvalue::Variable(len2_for_c2b),
-                Hlvalue::Variable(j_next),
-            ],
-            Some(block_copy2_cond.clone()),
             None,
         )
         .into_ref(),
@@ -10861,33 +10601,48 @@ mod tests {
         }
     }
 
-    /// `ll_strconcat` synthesises a 5-block-plus-returnblock CFG:
-    /// start emits getsubstruct + getarraysize × 2 + int_add (total)
-    /// + **malloc_varsize** + getsubstruct (newchars), then enters
-    /// block_copy1_cond which loops int_lt + body (getarrayitem +
-    /// setarrayitem + int_add); on cond=False forwards into
-    /// block_copy2_cond with j=0 which loops int_lt + body
-    /// (getarrayitem + int_add(len1, j) for the destination index +
-    /// setarrayitem + int_add). False branch of copy2_cond returns
-    /// newstr.
+    /// `ll_strconcat` synthesises a straight-line `start → returnblock`
+    /// CFG: start emits getsubstruct + getarraysize × 2 + int_add
+    /// (total) + **malloc_varsize** + two **copystrcontent** ops, then
+    /// forwards `newstr` into the returnblock.  Mirrors upstream
+    /// `ll_strconcat` (rstr.py:428): malloc + two `copy_contents_from_str`
+    /// calls (each rewritten to a single `copystrcontent`), no per-char
+    /// loop.
     ///
-    /// First emission of `malloc_varsize` SpaceOperation from inside
-    /// an rstr helper graph: arg shape is `[Constant(struct_lltype),
-    /// Constant({'flavor': 'gc'}), length_var]` matching upstream
-    /// rstr.py:1131.
+    /// Pins the exact `copystrcontent` operand wiring (src/dst objects,
+    /// srcstart/dststart/length) so a transposed argument cannot slip
+    /// through structural shape checks alone.
     #[test]
-    fn build_ll_strconcat_synthesizes_malloc_varsize_and_two_copy_loops_for_str() {
+    fn build_ll_strconcat_synthesizes_malloc_varsize_and_two_copystrcontent_for_str() {
+        fn as_var(hlv: &Hlvalue) -> crate::flowspace::model::Variable {
+            match hlv {
+                Hlvalue::Variable(v) => v.clone(),
+                other => panic!("expected Variable operand, got {other:?}"),
+            }
+        }
+        fn assert_same_var(
+            hlv: &Hlvalue,
+            expected: &crate::flowspace::model::Variable,
+            what: &str,
+        ) {
+            assert!(
+                matches!(hlv, Hlvalue::Variable(v) if v == expected),
+                "copystrcontent {what} operand mismatch: {hlv:?}"
+            );
+        }
+        fn assert_zero(hlv: &Hlvalue, what: &str) {
+            assert!(
+                matches!(hlv, Hlvalue::Constant(c) if c.value == ConstValue::Int(0)),
+                "copystrcontent {what} must be Int(0): {hlv:?}"
+            );
+        }
+
         let helper = build_ll_strconcat_helper_graph("ll_strconcat", STRPTR.clone())
             .expect("build_ll_strconcat_helper_graph for STR");
         let inner = helper.graph.borrow();
+        let sb = inner.startblock.borrow();
 
-        // start: 6 ops (getsubstruct, getarraysize, getsubstruct,
-        // getarraysize, int_add, malloc_varsize, getsubstruct).
-        let start_ops = {
-            let sb = inner.startblock.borrow();
-            let names: Vec<String> = sb.operations.iter().map(|op| op.opname.clone()).collect();
-            names
-        };
+        let start_ops: Vec<String> = sb.operations.iter().map(|op| op.opname.clone()).collect();
         assert_eq!(
             start_ops,
             vec![
@@ -10897,127 +10652,72 @@ mod tests {
                 "getarraysize",
                 "int_add",
                 "malloc_varsize",
-                "getsubstruct",
+                "copystrcontent",
+                "copystrcontent",
             ],
-            "start emits chars1/len1/chars2/len2/total + malloc_varsize + newchars"
+            "start emits chars1/len1/chars2/len2/total + malloc_varsize + two copystrcontent"
         );
 
-        // malloc_varsize op (5th op, 0-indexed) takes 3 args:
-        // [Constant(LowLevelType::Struct), Constant(Dict), Variable(total)].
-        let mv_op = {
-            let sb = inner.startblock.borrow();
-            sb.operations[5].clone()
-        };
+        // malloc_varsize (op[5]) still takes [Constant(struct lltype),
+        // Constant(flags dict), Variable(total)].
+        let mv_op = &sb.operations[5];
         assert_eq!(mv_op.opname, "malloc_varsize");
         assert_eq!(mv_op.args.len(), 3);
-        let Hlvalue::Constant(struct_const) = &mv_op.args[0] else {
-            panic!("malloc_varsize arg[0] must be Constant carrying struct lltype");
-        };
-        assert!(matches!(struct_const.value, ConstValue::LowLevelType(_)));
-        let Hlvalue::Constant(flavor_const) = &mv_op.args[1] else {
-            panic!("malloc_varsize arg[1] must be Constant carrying flags dict");
-        };
-        assert!(matches!(flavor_const.value, ConstValue::Dict(_)));
+        assert!(
+            matches!(&mv_op.args[0], Hlvalue::Constant(c) if matches!(c.value, ConstValue::LowLevelType(_)))
+        );
+        assert!(
+            matches!(&mv_op.args[1], Hlvalue::Constant(c) if matches!(c.value, ConstValue::Dict(_)))
+        );
         assert!(matches!(mv_op.args[2], Hlvalue::Variable(_)));
 
-        // start has a single unconditional exit into block_copy1_cond
-        // (carrying newstr/newchars/chars1/chars2/len1/len2/0).
-        let block_copy1_cond = {
-            let sb = inner.startblock.borrow();
-            assert_eq!(sb.exits.len(), 1, "start has a single unconditional exit");
-            let link = sb.exits[0].clone();
-            link.borrow().target.as_ref().unwrap().clone()
-        };
+        // Capture the source/length/result Variables to compare against the
+        // copystrcontent operands by identity.
+        let s1_var = as_var(&sb.operations[0].args[0]);
+        let len1_var = as_var(&sb.operations[1].result);
+        let s2_var = as_var(&sb.operations[2].args[0]);
+        let len2_var = as_var(&sb.operations[3].result);
+        let newstr_var = as_var(&sb.operations[5].result);
 
-        // block_copy1_cond: int_lt(i, len1); 2 exits.
-        let (block_copy1_body, block_copy2_cond) = {
-            let cb = block_copy1_cond.borrow();
-            let names: Vec<&str> = cb.operations.iter().map(|op| op.opname.as_str()).collect();
-            assert_eq!(names, vec!["int_lt"]);
-            assert_eq!(cb.exits.len(), 2);
-            let mut body: Option<crate::flowspace::model::BlockRef> = None;
-            let mut next: Option<crate::flowspace::model::BlockRef> = None;
-            for link in &cb.exits {
-                let lb = link.borrow();
-                let exitcase_is_true = matches!(
-                    lb.exitcase,
-                    Some(Hlvalue::Constant(ref c)) if c.value == ConstValue::Bool(true)
-                );
-                let target = lb.target.as_ref().unwrap().clone();
-                if exitcase_is_true {
-                    body = Some(target);
-                } else {
-                    next = Some(target);
-                }
-            }
-            (body.unwrap(), next.unwrap())
-        };
+        // copy1 = copystrcontent(s1, newstr, srcstart=0, dststart=0, length=len1).
+        let copy1 = &sb.operations[6];
+        assert_eq!(copy1.opname, "copystrcontent");
+        assert_eq!(copy1.args.len(), 5);
+        assert_same_var(&copy1.args[0], &s1_var, "copy1 src");
+        assert_same_var(&copy1.args[1], &newstr_var, "copy1 dst");
+        assert_zero(&copy1.args[2], "copy1 srcstart");
+        assert_zero(&copy1.args[3], "copy1 dststart");
+        assert_same_var(&copy1.args[4], &len1_var, "copy1 length");
 
-        // block_copy1_body: getarrayitem + setarrayitem + int_add;
-        // unconditional cycle back into block_copy1_cond.
-        {
-            let bb = block_copy1_body.borrow();
-            let names: Vec<&str> = bb.operations.iter().map(|op| op.opname.as_str()).collect();
-            assert_eq!(names, vec!["getarrayitem", "setarrayitem", "int_add"]);
-            assert_eq!(bb.exits.len(), 1);
-            let cycle_target = bb.exits[0].borrow().target.as_ref().unwrap().clone();
-            assert!(
-                std::rc::Rc::ptr_eq(&cycle_target, &block_copy1_cond),
-                "copy1_body must cycle back into copy1_cond"
-            );
-        }
+        // copy2 = copystrcontent(s2, newstr, srcstart=0, dststart=len1, length=len2).
+        let copy2 = &sb.operations[7];
+        assert_eq!(copy2.opname, "copystrcontent");
+        assert_eq!(copy2.args.len(), 5);
+        assert_same_var(&copy2.args[0], &s2_var, "copy2 src");
+        assert_same_var(&copy2.args[1], &newstr_var, "copy2 dst");
+        assert_zero(&copy2.args[2], "copy2 srcstart");
+        assert_same_var(&copy2.args[3], &len1_var, "copy2 dststart");
+        assert_same_var(&copy2.args[4], &len2_var, "copy2 length");
 
-        // block_copy2_cond: int_lt(j, len2); 2 exits, False → returnblock.
-        let block_copy2_body = {
-            let cb = block_copy2_cond.borrow();
-            let names: Vec<&str> = cb.operations.iter().map(|op| op.opname.as_str()).collect();
-            assert_eq!(names, vec!["int_lt"]);
-            assert_eq!(cb.exits.len(), 2);
-            let mut body: Option<crate::flowspace::model::BlockRef> = None;
-            let mut return_target_seen = false;
-            for link in &cb.exits {
-                let lb = link.borrow();
-                let exitcase_is_true = matches!(
-                    lb.exitcase,
-                    Some(Hlvalue::Constant(ref c)) if c.value == ConstValue::Bool(true)
-                );
-                let target = lb.target.as_ref().unwrap().clone();
-                if exitcase_is_true {
-                    body = Some(target);
-                } else {
-                    assert!(
-                        std::rc::Rc::ptr_eq(&target, &inner.returnblock),
-                        "copy2_cond False branch must return"
-                    );
-                    return_target_seen = true;
-                }
-            }
-            assert!(return_target_seen);
-            body.unwrap()
-        };
-
-        // block_copy2_body: getarrayitem + int_add(len1, j) for dst_idx
-        // + setarrayitem + int_add(j, 1); cycle back into copy2_cond.
-        {
-            let bb = block_copy2_body.borrow();
-            let names: Vec<&str> = bb.operations.iter().map(|op| op.opname.as_str()).collect();
-            assert_eq!(
-                names,
-                vec!["getarrayitem", "int_add", "setarrayitem", "int_add"]
-            );
-            assert_eq!(bb.exits.len(), 1);
-            let cycle_target = bb.exits[0].borrow().target.as_ref().unwrap().clone();
-            assert!(std::rc::Rc::ptr_eq(&cycle_target, &block_copy2_cond));
-        }
+        // start has a single unconditional exit to the returnblock carrying [newstr].
+        assert_eq!(sb.exits.len(), 1, "start has a single unconditional exit");
+        let exit = sb.exits[0].borrow();
+        assert!(exit.exitcase.is_none(), "exit is unconditional");
+        assert!(
+            std::rc::Rc::ptr_eq(exit.target.as_ref().unwrap(), &inner.returnblock),
+            "start forwards into the returnblock"
+        );
+        assert_eq!(exit.args.len(), 1);
+        assert_same_var(exit.args[0].as_ref().unwrap(), &newstr_var, "return newstr");
     }
 
     /// `ll_unicode_concat` synthesised against `Ptr(UNICODE)` produces
-    /// the same CFG shape as `ll_strconcat` modulo elem type. Locks
-    /// in that the malloc_varsize struct const for UNICODE differs
-    /// from the STR one (otherwise the helper-cache families would
-    /// alias).
+    /// the same straight-line CFG as `ll_strconcat` modulo elem type:
+    /// the malloc_varsize struct const differs (otherwise the
+    /// helper-cache families would alias) and the bulk copies select
+    /// `copyunicodecontent` rather than `copystrcontent`.
     #[test]
-    fn build_ll_strconcat_synthesizes_unicode_struct_const_in_malloc_varsize() {
+    fn build_ll_strconcat_unicode_differs_in_struct_const_and_copy_opname() {
         let str_helper =
             build_ll_strconcat_helper_graph("ll_strconcat", STRPTR.clone()).expect("STR strconcat");
         let uni_helper = build_ll_strconcat_helper_graph("ll_unicode_concat", UNICODEPTR.clone())
@@ -11025,21 +10725,34 @@ mod tests {
         let str_inner = str_helper.graph.borrow();
         let uni_inner = uni_helper.graph.borrow();
 
-        let str_struct_const = {
+        let (str_struct_const, str_copy_opnames) = {
             let sb = str_inner.startblock.borrow();
             let mv = &sb.operations[5];
             assert_eq!(mv.opname, "malloc_varsize");
-            mv.args[0].clone()
+            let copies: Vec<String> = sb.operations[6..8]
+                .iter()
+                .map(|op| op.opname.clone())
+                .collect();
+            (mv.args[0].clone(), copies)
         };
-        let uni_struct_const = {
+        let (uni_struct_const, uni_copy_opnames) = {
             let sb = uni_inner.startblock.borrow();
             let mv = &sb.operations[5];
             assert_eq!(mv.opname, "malloc_varsize");
-            mv.args[0].clone()
+            let copies: Vec<String> = sb.operations[6..8]
+                .iter()
+                .map(|op| op.opname.clone())
+                .collect();
+            (mv.args[0].clone(), copies)
         };
         assert!(
             format!("{str_struct_const:?}") != format!("{uni_struct_const:?}"),
             "STR and UNICODE malloc_varsize struct constants must differ"
+        );
+        assert_eq!(str_copy_opnames, vec!["copystrcontent", "copystrcontent"]);
+        assert_eq!(
+            uni_copy_opnames,
+            vec!["copyunicodecontent", "copyunicodecontent"]
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -418,7 +418,7 @@ fn emit_chars_length_ops(
 /// `SomePtr`-shaped annotation (upstream `lltype.py:1530+`'s
 /// `SomePtr.__init__` rejects bare container types — see
 /// `llannotation.rs:159-167`).
-fn chars_array_ptr_lltype_from_strptr(
+pub(crate) fn chars_array_ptr_lltype_from_strptr(
     ptr_lltype: &LowLevelType,
 ) -> Result<LowLevelType, TyperError> {
     let LowLevelType::Ptr(ptr) = ptr_lltype else {
@@ -463,7 +463,9 @@ fn chars_array_ptr_lltype_from_strptr(
 /// struct lltype (mirrors upstream `cTEMP = inputconst(Void, TEMPBUF)`
 /// at rstr.py:1129 where `TEMPBUF` is the resolved GcStruct itself,
 /// not its Ptr wrapper).
-fn struct_lltype_from_strptr(ptr_lltype: &LowLevelType) -> Result<LowLevelType, TyperError> {
+pub(crate) fn struct_lltype_from_strptr(
+    ptr_lltype: &LowLevelType,
+) -> Result<LowLevelType, TyperError> {
     let LowLevelType::Ptr(ptr) = ptr_lltype else {
         return Err(TyperError::message(format!(
             "struct_lltype_from_strptr expects Ptr(STR/UNICODE), got {ptr_lltype:?}"

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -589,6 +589,11 @@ fn dispatch_rtype_op(
         (PtrRepr, IntegerRepr, "setitem") | (InteriorPtrRepr, IntegerRepr, "setitem") => {
             committed(r1.rtype_setitem(hop))
         }
+        // rlist.py:272-284 — pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem.
+        // FixedSizeListRepr handles the nonneg + dum_nocheck branch (bare
+        // setarrayitem); the checkidx (IndexError) and negative-index
+        // branches surface a TyperError until those helpers land.
+        (FixedSizeListRepr, IntegerRepr, "setitem") => committed(r1.rtype_setitem(hop)),
 
         // rptr.py:165-184 — pointer comparison accepts any repr on the
         // other side and coerces both args to the pointer repr.

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -501,6 +501,11 @@ fn dispatch_rtype_op(
         (PtrRepr, IntegerRepr, "getitem") | (InteriorPtrRepr, IntegerRepr, "getitem") => {
             committed(r1.rtype_getitem(hop))
         }
+        // rlist.py:245-267 — pair(AbstractBaseListRepr, IntegerRepr).rtype_getitem.
+        // FixedSizeListRepr (Rust slice / fixed array) handles the nonneg +
+        // checkidx=False branch (bare getarrayitem); the negative-index and
+        // checkidx branches surface a TyperError until those helpers land.
+        (FixedSizeListRepr, IntegerRepr, "getitem") => committed(r1.rtype_getitem(hop)),
         // rtuple.py:264-273 — `pairtype(TupleRepr, IntegerRepr).rtype_getitem`.
         (TupleRepr, IntegerRepr, "getitem") => {
             committed(super::rtuple::pair_tuple_int_rtype_getitem(r1, hop))

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -506,6 +506,11 @@ fn dispatch_rtype_op(
         // checkidx=False branch (bare getarrayitem); the negative-index and
         // checkidx branches surface a TyperError until those helpers land.
         (FixedSizeListRepr, IntegerRepr, "getitem") => committed(r1.rtype_getitem(hop)),
+        // rrange.py:34-50 — pair(AbstractRangeRepr, IntegerRepr).rtype_getitem.
+        // RangeRepr handles the constant-step + nonneg + dum_nocheck branch
+        // (start + index*step); the checkidx, negative-index, and
+        // variable-step branches surface a TyperError until those land.
+        (RangeRepr, IntegerRepr, "getitem") => committed(r1.rtype_getitem(hop)),
         // rtuple.py:264-273 — `pairtype(TupleRepr, IntegerRepr).rtype_getitem`.
         (TupleRepr, IntegerRepr, "getitem") => {
             committed(super::rtuple::pair_tuple_int_rtype_getitem(r1, hop))

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -204,6 +204,86 @@ impl Repr for FixedSizeListRepr {
         )?;
         hop.gendirectcall(&helper, args)
     }
+
+    /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem`
+    /// (`rlist.py:272-284`):
+    ///
+    /// ```python
+    /// def rtype_setitem((r_lst, r_int), hop):
+    ///     if hop.has_implicit_exception(IndexError):
+    ///         spec = dum_checkidx
+    ///     else:
+    ///         spec = dum_nocheck
+    ///     v_func = hop.inputconst(Void, spec)
+    ///     v_lst, v_index, v_item = hop.inputargs(r_lst, Signed, r_lst.item_repr)
+    ///     if hop.args_s[1].nonneg:
+    ///         llfn = ll_setitem_nonneg
+    ///     else:
+    ///         llfn = ll_setitem
+    ///     hop.exception_is_here()
+    ///     return hop.gendirectcall(llfn, v_func, v_lst, v_index, v_item)
+    /// ```
+    ///
+    /// `FixedSizeListRepr` handles the `dum_nocheck` + nonneg fast path:
+    /// `ll_setitem_nonneg(dum_nocheck, l, index, item)` collapses (no
+    /// IndexError branch, `index >= 0` is a debug `ll_assert`) through
+    /// `l.ll_setitem_fast` → `ll_fixed_setitem_fast(l, index, item)` →
+    /// `l[index] = item` (`lltypesystem/rlist.py:407-410`) to the bare
+    /// `setarrayitem` on the `Ptr(GcArray)` receiver. The third inputarg
+    /// converts to `item_repr` (the gcref-wrapped element repr). The
+    /// `checkidx` (implicit-IndexError) and negative-index (`ll_setitem`)
+    /// branches surface a `TyperError` until those helpers land — Rust
+    /// slice indexing never produces them.
+    fn rtype_setitem(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::annotator::model::SomeValue;
+        if hop.has_implicit_exception("IndexError") {
+            return Err(TyperError::message(
+                "list rtype_setitem: checkidx IndexError branch not yet ported",
+            ));
+        }
+        let s1 = hop
+            .args_s
+            .borrow()
+            .get(1)
+            .cloned()
+            .ok_or_else(|| TyperError::message("list rtype_setitem: args_s[1] missing"))?;
+        let nonneg = match &s1 {
+            SomeValue::Integer(i) => i.nonneg,
+            other => {
+                return Err(TyperError::message(format!(
+                    "list rtype_setitem: args_s[1] must be SomeInteger, got {other:?}"
+                )));
+            }
+        };
+        if !nonneg {
+            return Err(TyperError::message(
+                "list rtype_setitem: negative-index ll_setitem branch not yet ported",
+            ));
+        }
+        let args = hop.inputargs(vec![
+            ConvertedTo::Repr(self),
+            ConvertedTo::LowLevelType(&LowLevelType::Signed),
+            ConvertedTo::Repr(self.item_repr.as_ref()),
+        ])?;
+        hop.exception_is_here()?;
+        let item_lltype = self.item_repr.lowleveltype().clone();
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let item_for_builder = item_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_fixed_setitem_fast".to_string(),
+            vec![ptr_lltype, LowLevelType::Signed, item_lltype],
+            LowLevelType::Void,
+            move |_rtyper, _args, _result| {
+                build_ll_fixed_setitem_fast_helper_graph(
+                    "ll_fixed_setitem_fast",
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, args)
+    }
 }
 
 /// Synthesise `LLHelpers`-style `ll_fixed_length`
@@ -476,6 +556,69 @@ pub(crate) fn build_ll_fixed_getitem_fast_helper_graph(
     ))
 }
 
+/// Synthesise `ll_fixed_setitem_fast` (`lltypesystem/rlist.py:407-410`):
+///
+/// ```python
+/// def ll_fixed_setitem_fast(l, index, item):
+///     ll_assert(index < len(l), "fixed setitem out of bounds")
+///     l[index] = item
+/// ```
+///
+/// The `ll_assert` is a debug-only bound check (no production op); the
+/// `FixedSizeListRepr` receiver IS the `Ptr(GcArray)`, so the body is the
+/// single `setarrayitem(l, index, item)` op. The function falls off the
+/// end (`return None`), so the returnblock receives the `Void` `None`
+/// constant.
+pub(crate) fn build_ll_fixed_setitem_fast_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let l_arg = variable_with_lltype("l", ptr_lltype);
+    let index_arg = variable_with_lltype("index", LowLevelType::Signed);
+    let item_arg = variable_with_lltype("item", item_lltype);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(index_arg.clone()),
+        Hlvalue::Variable(item_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let v_void = variable_with_lltype("v", LowLevelType::Void);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setarrayitem",
+        vec![
+            Hlvalue::Variable(l_arg),
+            Hlvalue::Variable(index_arg),
+            Hlvalue::Variable(item_arg),
+        ],
+        Hlvalue::Variable(v_void),
+    ));
+    let none_const = Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::None,
+        LowLevelType::Void,
+    ));
+    startblock.closeblock(vec![
+        Link::new(vec![none_const], Some(graph.returnblock.clone()), None).into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -690,5 +833,154 @@ mod tests {
             Some(signed_repr() as Arc<dyn Repr>),
         ]);
         assert!(list_repr.rtype_getitem(&hop).is_err());
+    }
+
+    /// rlist.py:272-284 nonneg + dum_nocheck branch — `setitem` on a
+    /// `FixedSizeListRepr` lowers to a `direct_call` of
+    /// `ll_fixed_setitem_fast` (a single `setarrayitem` on the
+    /// `Ptr(GcArray)` receiver), preceded by `hop.exception_is_here()`.
+    #[test]
+    fn fixed_size_list_setitem_nonneg_emits_direct_call_to_ll_fixed_setitem_fast() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        // The third inputarg converts to `item_repr`; `convertvar`
+        // short-circuits on `std::ptr::eq`, so `args_r[2]` must be the
+        // exact stored `item_repr` instance.
+        let item_repr = list_repr.item_repr.clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_item = Variable::new();
+        v_item.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Void));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "setitem".to_string(),
+                vec![
+                    Hlvalue::Variable(v_list),
+                    Hlvalue::Variable(v_idx),
+                    Hlvalue::Variable(v_item),
+                ],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ true,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)),
+            SomeValue::Integer(SomeInteger::new(false, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+            Some(item_repr),
+        ]);
+
+        let result = list_repr
+            .rtype_setitem(&hop)
+            .unwrap_or_else(|err| panic!("list setitem nonneg: {err:?}"));
+        assert!(result.is_some());
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "rtype_setitem must call hop.exception_is_here()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_fixed_setitem_fast"),
+            "expected 'll_fixed_setitem_fast' in {dbg}"
+        );
+    }
+
+    /// Negative-index annotation (`args_s[1].nonneg == false`) is not yet
+    /// ported (the `ll_setitem` neg-fix branch); like the `checkidx`
+    /// (implicit-IndexError) branch it surfaces a `TyperError` so the
+    /// subject stays on the legacy walker. Rust slice indexing never
+    /// produces a negative index.
+    #[test]
+    fn fixed_size_list_setitem_negative_index_is_deferred() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        let item_repr = list_repr.item_repr.clone();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_item = Variable::new();
+        v_item.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Void));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "setitem".to_string(),
+                vec![
+                    Hlvalue::Variable(v_list),
+                    Hlvalue::Variable(v_idx),
+                    Hlvalue::Variable(v_item),
+                ],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ true,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ false, false)),
+            SomeValue::Integer(SomeInteger::new(false, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+            Some(item_repr),
+        ]);
+        assert!(list_repr.rtype_setitem(&hop).is_err());
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -54,8 +54,8 @@ pub struct FixedSizeListRepr {
     state: ReprState,
     lltype: LowLevelType,
     /// `self.item_repr` (`lltypesystem/rlist.py:177`) — the internal
-    /// (gcref-wrapped) element repr.
-    #[allow(dead_code)]
+    /// (gcref-wrapped) element repr; its lowleveltype is the array
+    /// element type and the `getitem` result type.
     item_repr: Arc<dyn Repr>,
 }
 
@@ -130,6 +130,79 @@ impl Repr for FixedSizeListRepr {
             },
         )?;
         hop.gendirectcall(&helper, vlist)
+    }
+
+    /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_getitem`
+    /// (`rlist.py:247-267`):
+    ///
+    /// ```python
+    /// def rtype_getitem((r_lst, r_int), hop, checkidx=False):
+    ///     v_lst, v_index = hop.inputargs(r_lst, Signed)
+    ///     ...
+    ///     spec = dum_nocheck
+    ///     hop.exception_cannot_occur()
+    ///     ...
+    ///     if hop.args_s[1].nonneg:
+    ///         llfn = ll_getitem_nonneg
+    ///     ...
+    ///     v_res = hop.gendirectcall(llfn, ..., v_lst, v_index)
+    ///     return r_lst.recast(hop.llops, v_res)
+    /// ```
+    ///
+    /// `FixedSizeListRepr` is the non-resized list — a Rust slice
+    /// (`&[T]`) or fixed array, indexed by `usize` values that annotate
+    /// as a non-negative `SomeInteger`. Only the `ll_getitem_nonneg` +
+    /// `dum_nocheck` branch arises, and that chain collapses through
+    /// `ll_getitem_foldable_nonneg` → `ll_fixed_getitem_fast(l, index)` →
+    /// `l[index]` (`lltypesystem/rlist.py:402-405`) to the bare
+    /// `getarrayitem` on the `Ptr(GcArray)` receiver. The negative-index
+    /// (`ll_getitem`) and `checkidx` (IndexError-raising) branches surface
+    /// a `TyperError` until those helpers land — Rust slice indexing never
+    /// produces them. `recast` is a no-op here (the item lltype is already
+    /// the array element type).
+    fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::annotator::model::SomeValue;
+        let s1 = hop
+            .args_s
+            .borrow()
+            .get(1)
+            .cloned()
+            .ok_or_else(|| TyperError::message("list rtype_getitem: args_s[1] missing"))?;
+        let nonneg = match &s1 {
+            SomeValue::Integer(i) => i.nonneg,
+            other => {
+                return Err(TyperError::message(format!(
+                    "list rtype_getitem: args_s[1] must be SomeInteger, got {other:?}"
+                )));
+            }
+        };
+        if !nonneg {
+            return Err(TyperError::message(
+                "list rtype_getitem: negative-index ll_getitem branch not yet ported",
+            ));
+        }
+        let args = hop.inputargs(vec![
+            ConvertedTo::Repr(self),
+            ConvertedTo::LowLevelType(&LowLevelType::Signed),
+        ])?;
+        hop.exception_cannot_occur()?;
+        let item_lltype = self.item_repr.lowleveltype().clone();
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let item_for_builder = item_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_fixed_getitem_fast".to_string(),
+            vec![ptr_lltype, LowLevelType::Signed],
+            item_lltype,
+            move |_rtyper, _args, _result| {
+                build_ll_fixed_getitem_fast_helper_graph(
+                    "ll_fixed_getitem_fast",
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, args)
     }
 }
 
@@ -346,12 +419,74 @@ pub(crate) fn build_ll_length_helper_graph(
     ))
 }
 
+/// Synthesise `ll_fixed_getitem_fast` (`lltypesystem/rlist.py:402-405`):
+///
+/// ```python
+/// def ll_fixed_getitem_fast(l, index):
+///     ll_assert(index < len(l), "fixed getitem out of bounds")
+///     return l[index]
+/// ```
+///
+/// The `ll_assert` is a debug-only bound check (no production op); the
+/// `FixedSizeListRepr` receiver IS the `Ptr(GcArray)`, so the body is the
+/// single `getarrayitem(l, index) -> ITEM` op (unlike `ll_stritem_nonneg`,
+/// which `getsubstruct`s the nested `chars` array first).
+pub(crate) fn build_ll_fixed_getitem_fast_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let l_arg = variable_with_lltype("l", ptr_lltype);
+    let index_arg = variable_with_lltype("index", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(index_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", item_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let v_item = variable_with_lltype("item", item_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarrayitem",
+        vec![Hlvalue::Variable(l_arg), Hlvalue::Variable(index_arg)],
+        Hlvalue::Variable(v_item.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_item)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string()],
+        func,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::annotator::annrpython::RPythonAnnotator;
+    use crate::annotator::listdef::ListDef;
+    use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
+    use crate::flowspace::model::Variable;
     use crate::translator::rtyper::pairtype::ReprClassId;
-    use crate::translator::rtyper::rint::IntegerRepr;
+    use crate::translator::rtyper::rint::{IntegerRepr, signed_repr};
+    use crate::translator::rtyper::rmodel::rtyper_makerepr;
+    use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
 
     fn fresh_rtyper() -> Rc<RPythonTyper> {
         let ann = RPythonAnnotator::new(None, None, None, false);
@@ -397,10 +532,6 @@ mod tests {
 
     #[test]
     fn makerepr_resized_somelist_routes_to_list_repr() {
-        use crate::annotator::listdef::ListDef;
-        use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
-        use crate::translator::rtyper::rmodel::rtyper_makerepr;
-
         let rtyper = fresh_rtyper_live();
         // `resized=true` → the `ListRepr` (resized) branch.
         let ldef = ListDef::new(
@@ -417,10 +548,6 @@ mod tests {
 
     #[test]
     fn makerepr_nonresized_somelist_routes_to_fixed_size_list_repr() {
-        use crate::annotator::listdef::ListDef;
-        use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
-        use crate::translator::rtyper::rmodel::rtyper_makerepr;
-
         let rtyper = fresh_rtyper_live();
         // `resized=false` → the `FixedSizeListRepr` branch (unchanged).
         let ldef = ListDef::new(
@@ -433,5 +560,135 @@ mod tests {
         let repr = rtyper_makerepr(&sv, &rtyper).expect("rtyper_makerepr non-resized list");
         assert_eq!(repr.class_name(), "FixedSizeListRepr");
         assert_eq!(repr.repr_class_id(), ReprClassId::FixedSizeListRepr);
+    }
+
+    /// rlist.py:247-267 nonneg + checkidx=False branch — `getitem` on a
+    /// `FixedSizeListRepr` lowers to a `direct_call` of
+    /// `ll_fixed_getitem_fast` (a single `getarrayitem` on the
+    /// `Ptr(GcArray)` receiver), preceded by `hop.exception_cannot_occur()`.
+    #[test]
+    fn fixed_size_list_getitem_nonneg_emits_direct_call_to_ll_fixed_getitem_fast() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        // A single shared repr instance: `convertvar` short-circuits on
+        // `std::ptr::eq` of the `&dyn Repr`, so `args_r[0]` and the `self`
+        // routed through `rtype_getitem` must be the same object.
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "getitem".to_string(),
+                vec![Hlvalue::Variable(v_list), Hlvalue::Variable(v_idx)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ false,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+        ]);
+
+        let result = list_repr
+            .rtype_getitem(&hop)
+            .unwrap_or_else(|err| panic!("list getitem nonneg: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "checkidx=False path must call hop.exception_cannot_occur()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_fixed_getitem_fast"),
+            "expected 'll_fixed_getitem_fast' in {dbg}"
+        );
+    }
+
+    /// Negative-index annotation (`args_s[1].nonneg == false`) is not yet
+    /// ported (the `ll_getitem` neg-fix branch) — it surfaces a
+    /// `TyperError` so the subject stays on the legacy walker rather than
+    /// miscompiling. Rust slice indexing never produces it.
+    #[test]
+    fn fixed_size_list_getitem_negative_index_is_deferred() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "getitem".to_string(),
+                vec![Hlvalue::Variable(v_list), Hlvalue::Variable(v_idx)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ false,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ false, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+        ]);
+        assert!(list_repr.rtype_getitem(&hop).is_err());
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -3780,11 +3780,17 @@ mod tests {
             "mutated range-list must not select RangeRepr"
         );
 
-        // step==1 but resized (⇒ mutated) → the deferred resized ListRepr
-        // arm (Err), never RangeRepr.
+        // step==1 but resized (⇒ mutated) → selects resized ListRepr, never RangeRepr.
         let ldef_resized = ListDef::new(None, item, false, true);
         ldef_resized.listitem_rc().borrow_mut().range_step = Some(1);
-        assert!(rtyper_makerepr(&SomeValue::List(SomeList::new(ldef_resized)), &rtyper).is_err());
+        let repr_resized =
+            rtyper_makerepr(&SomeValue::List(SomeList::new(ldef_resized)), &rtyper);
+        assert!(
+            repr_resized
+                .map(|r| r.class_name() != "RangeRepr")
+                .unwrap_or(true),
+            "resized range-list must not select RangeRepr"
+        );
 
         // step==1, not mutated, but impossible item → not RangeRepr.
         let ldef_imp = ListDef::new(None, SomeValue::Impossible, false, false);

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -3783,8 +3783,7 @@ mod tests {
         // step==1 but resized (⇒ mutated) → selects resized ListRepr, never RangeRepr.
         let ldef_resized = ListDef::new(None, item, false, true);
         ldef_resized.listitem_rc().borrow_mut().range_step = Some(1);
-        let repr_resized =
-            rtyper_makerepr(&SomeValue::List(SomeList::new(ldef_resized)), &rtyper);
+        let repr_resized = rtyper_makerepr(&SomeValue::List(SomeList::new(ldef_resized)), &rtyper);
         assert!(
             repr_resized
                 .map(|r| r.class_name() != "RangeRepr")

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -152,6 +152,95 @@ impl Repr for RangeRepr {
         )?;
         hop.gendirectcall(&helper, v_rng)
     }
+
+    /// RPython `pair(AbstractRangeRepr, IntegerRepr).rtype_getitem`
+    /// (`rrange.py:34-50`):
+    ///
+    /// ```python
+    /// def rtype_getitem((r_rng, r_int), hop):
+    ///     if hop.has_implicit_exception(IndexError):
+    ///         spec = dum_checkidx
+    ///     else:
+    ///         spec = dum_nocheck
+    ///     v_func = hop.inputconst(Void, spec)
+    ///     v_lst, v_index = hop.inputargs(r_rng, Signed)
+    ///     if r_rng.step != 0:
+    ///         cstep = hop.inputconst(Signed, r_rng.step)
+    ///     else:
+    ///         cstep = r_rng._getstep(v_lst, hop)
+    ///     if hop.args_s[1].nonneg:
+    ///         llfn = ll_rangeitem_nonneg
+    ///     else:
+    ///         llfn = ll_rangeitem
+    ///     hop.exception_is_here()
+    ///     return hop.gendirectcall(llfn, v_func, v_lst, v_index, cstep)
+    /// ```
+    ///
+    /// The constant-step (`step != 0`) + nonneg + `dum_nocheck` fast path:
+    /// `ll_rangeitem_nonneg(dum_nocheck, l, index, step)` collapses (no
+    /// IndexError branch) to `l.start + index * step` (`rrange.py:74-77`).
+    /// Unlike `rtype_len`, the formula is `int_mul` + `int_add` with no
+    /// floor-division, so any constant step lowers here. `step` is baked
+    /// as the `inputconst(Signed, self.step)` runtime arg. The `checkidx`
+    /// (implicit-IndexError, needs `_ll_rangelen` floor-division), the
+    /// negative-index (`ll_rangeitem`), and the variable-step `RANGEST`
+    /// (`step == 0`, needs `_getstep`) branches surface a `TyperError`
+    /// until those land.
+    fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::annotator::model::SomeValue;
+        if hop.has_implicit_exception("IndexError") {
+            return Err(TyperError::message(
+                "RangeRepr.rtype_getitem: checkidx IndexError branch not yet ported",
+            ));
+        }
+        if self.step == 0 {
+            return Err(TyperError::message(
+                "RangeRepr.rtype_getitem: variable-step RANGEST (_getstep) not yet ported",
+            ));
+        }
+        let s1 = hop
+            .args_s
+            .borrow()
+            .get(1)
+            .cloned()
+            .ok_or_else(|| TyperError::message("RangeRepr.rtype_getitem: args_s[1] missing"))?;
+        let nonneg = match &s1 {
+            SomeValue::Integer(i) => i.nonneg,
+            other => {
+                return Err(TyperError::message(format!(
+                    "RangeRepr.rtype_getitem: args_s[1] must be SomeInteger, got {other:?}"
+                )));
+            }
+        };
+        if !nonneg {
+            return Err(TyperError::message(
+                "RangeRepr.rtype_getitem: negative-index ll_rangeitem branch not yet ported",
+            ));
+        }
+        let mut args = hop.inputargs(vec![
+            ConvertedTo::Repr(self),
+            ConvertedTo::LowLevelType(&LowLevelType::Signed),
+        ])?;
+        args.push(constant_with_lltype(
+            ConstValue::Int(self.step),
+            LowLevelType::Signed,
+        ));
+        hop.exception_is_here()?;
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_rangeitem_nonneg".to_string(),
+            vec![ptr_lltype, LowLevelType::Signed, LowLevelType::Signed],
+            LowLevelType::Signed,
+            move |_rtyper, _args, _result| {
+                build_ll_rangeitem_nonneg_helper_graph(
+                    "ll_rangeitem_nonneg",
+                    ptr_for_builder.clone(),
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, args)
+    }
 }
 
 /// Synthesise the `ll_rangelen1` helper graph (`rrange.py:68-72`):
@@ -241,6 +330,79 @@ pub(crate) fn build_ll_rangelen1_helper_graph(
     ))
 }
 
+/// Synthesise the `ll_rangeitem_nonneg` helper graph (`rrange.py:74-77`)
+/// for the `dum_nocheck` case (the `dum_checkidx` IndexError branch is
+/// folded out):
+///
+/// ```python
+/// def ll_rangeitem_nonneg(func, l, index, step):
+///     ...
+///     return l.start + index * step
+/// ```
+///
+/// Single block: `start = getfield(l, 'start'); prod = int_mul(index,
+/// step); result = int_add(start, prod)`. `step` is a runtime arg (the
+/// `inputconst(Signed, self.step)` the caller appends).
+pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let l_arg = variable_with_lltype("l", ptr_lltype);
+    let index_arg = variable_with_lltype("index", LowLevelType::Signed);
+    let step_arg = variable_with_lltype("step", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(index_arg.clone()),
+        Hlvalue::Variable(step_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
+
+    let v_start = variable_with_lltype("start", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l_arg), field_const("start")],
+        Hlvalue::Variable(v_start.clone()),
+    ));
+    let v_prod = variable_with_lltype("prod", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_mul",
+        vec![Hlvalue::Variable(index_arg), Hlvalue::Variable(step_arg)],
+        Hlvalue::Variable(v_prod.clone()),
+    ));
+    let v_result = variable_with_lltype("result", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(v_start), Hlvalue::Variable(v_prod)],
+        Hlvalue::Variable(v_result.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -291,5 +453,164 @@ mod tests {
         assert_eq!(ops, vec!["getfield", "getfield", "int_sub", "int_lt"]);
         assert!(startblock.exitswitch.is_some());
         assert_eq!(startblock.exits.len(), 2);
+    }
+
+    #[test]
+    fn build_ll_rangeitem_nonneg_helper_graph_synthesizes_getfield_mul_add() {
+        let ptr = RangeRepr::new(1).unwrap().lowleveltype().clone();
+        let g = build_ll_rangeitem_nonneg_helper_graph("ll_rangeitem_nonneg", ptr).unwrap();
+        let inner = g.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        // start = l.start; prod = index * step; result = start + prod.
+        assert_eq!(ops, vec!["getfield", "int_mul", "int_add"]);
+        assert!(startblock.exitswitch.is_none());
+        assert_eq!(startblock.exits.len(), 1);
+        // (l, index, step) inputargs.
+        assert_eq!(startblock.inputargs.len(), 3);
+    }
+
+    /// rrange.py:34-50 constant-step + nonneg branch — `getitem` on a
+    /// `RangeRepr` lowers to a `direct_call` of `ll_rangeitem_nonneg`
+    /// (`start + index*step`), preceded by `hop.exception_is_here()`, with
+    /// the constant step appended as the trailing arg.
+    #[test]
+    fn rangerepr_getitem_nonneg_const_step_emits_direct_call_to_ll_rangeitem_nonneg() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::annotator::listdef::ListDef;
+        use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
+        use crate::flowspace::model::{SpaceOperation, Variable};
+        use crate::translator::rtyper::rint::signed_repr;
+        use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        // step == 2 (constant step != 1) — the formula handles any step.
+        let range_repr: Arc<RangeRepr> = Arc::new(RangeRepr::new(2).expect("RangeRepr::new(2)"));
+        let range_lltype = range_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_rng = Variable::new();
+        v_rng.set_concretetype(Some(range_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "getitem".to_string(),
+                vec![Hlvalue::Variable(v_rng), Hlvalue::Variable(v_idx)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        // args_s[0] (the range sequence) is not inspected by rtype_getitem
+        // (only args_s[1].nonneg); a generic SomeList stands in.
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ false,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(range_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+        ]);
+
+        let result = range_repr
+            .rtype_getitem(&hop)
+            .unwrap_or_else(|err| panic!("range getitem nonneg: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(ops._called_exception_is_here_or_cannot_occur);
+        // direct_call args: funcptr, v_rng, v_index, cstep (the baked step).
+        assert_eq!(ops.ops[0].args.len(), 4);
+        let Hlvalue::Constant(cstep) = &ops.ops[0].args[3] else {
+            panic!("expected Constant step as last direct_call arg");
+        };
+        assert!(matches!(cstep.value, ConstValue::Int(2)));
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_rangeitem_nonneg"),
+            "expected 'll_rangeitem_nonneg' in {dbg}"
+        );
+    }
+
+    /// Negative-index (`args_s[1].nonneg == false`) needs the `ll_rangeitem`
+    /// length normalisation (`_ll_rangelen` floor-division), deferred; like
+    /// the checkidx and variable-step branches it surfaces a `TyperError`.
+    #[test]
+    fn rangerepr_getitem_negative_index_is_deferred() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::annotator::listdef::ListDef;
+        use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
+        use crate::flowspace::model::{SpaceOperation, Variable};
+        use crate::translator::rtyper::rint::signed_repr;
+        use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let range_repr: Arc<RangeRepr> = Arc::new(RangeRepr::new(1).expect("RangeRepr::new(1)"));
+        let range_lltype = range_repr.lowleveltype().clone();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_rng = Variable::new();
+        v_rng.set_concretetype(Some(range_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "getitem".to_string(),
+                vec![Hlvalue::Variable(v_rng), Hlvalue::Variable(v_idx)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ false,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ false, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(range_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+        ]);
+        assert!(range_repr.rtype_getitem(&hop).is_err());
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -72,6 +72,12 @@ fn load_all_jitcodes() -> &'static [Arc<JitCode>] {
     // still 1 here, no consumer has cloned yet — using
     // `pyre_interpreter::jit_trace_fnaddrs()`'s runtime values.
     crate::runtime_fnaddr_patch::patch_constants_i_fnaddrs(&mut vec);
+    // Deferred prebuilt-string constants the codewriter could not allocate
+    // at build time (separate process) carry a non-canonical sentinel in
+    // `constants_r`; materialize their immortal STR blocks and overwrite the
+    // sentinels here, while refcount is still 1 — before any consumer can
+    // observe a sentinel as a forged GCREF.
+    crate::runtime_fnaddr_patch::materialize_str_consts(&mut vec);
     // RPython codewriter.py:80: `all_jitcodes[jitcode.index] is jitcode`.
     // Check at load time so any regression in
     // `collect_jitcodes_in_alloc_order` is caught immediately.

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -109,3 +109,200 @@ pub fn patch_constants_i_fnaddrs(jitcodes: &mut Vec<Arc<JitCode>>) {
         }
     }
 }
+
+/// STR `GcStruct` layout (`rstr.py:1226` `extra_item_after_alloc=True`),
+/// byte-identical to `bh_alloc_lowlevel_string` / `bh_newstr` (pyre-jit
+/// `eval.rs`) and the `malloc_varsize(STR)` the cutover codewriter lowers
+/// `ll_strconcat` into: `[hash:i64 @0][length:usize @8][chars:u8 @16..][NUL]`.
+/// The `chars` array stores its length inline at `@8` (RPython array length
+/// prefix) and an extra trailing byte for the C null terminator.
+const STR_HASH_OFFSET: usize = 0;
+const STR_LEN_OFFSET: usize = std::mem::size_of::<usize>();
+const STR_CHARS_OFFSET: usize = 2 * std::mem::size_of::<usize>();
+const STR_BASE_SIZE: usize = STR_CHARS_OFFSET + 1;
+
+/// High 16 bits of a deferred prebuilt-string sentinel (see
+/// [`majit_translate::assembler::STR_CONST_SENTINEL_BASE`]).  x86-64 user
+/// addresses occupy `0..2^48`, so a real GCREF / host-static address always
+/// has these bits clear, while every sentinel has them set to the base
+/// pattern.
+const SENTINEL_HIGH_MASK: u64 = 0xFFFF_0000_0000_0000;
+
+/// Allocate and fill one immortal runtime STR block for a prebuilt-string
+/// constant, returning its address.  `alloc_zeroed` (never freed, outside
+/// the nursery/oldgen) gives a block the collector treats as a non-moving
+/// root target (`can_move = false`); the trailing NUL at `chars + len` is
+/// the zeroed extra item.  The layout mirrors the runtime allocator exactly
+/// so the block is indistinguishable from a `bh_newstr` result to every
+/// downstream reader (`getarraysize`, `getarrayitem`, `ll_strhash`).
+fn materialize_prebuilt_str(bytes: &[u8], precomputed_hash: i64) -> i64 {
+    let total = STR_BASE_SIZE + bytes.len();
+    let layout = std::alloc::Layout::from_size_align(total, std::mem::align_of::<usize>())
+        .expect("prebuilt STR layout");
+    let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+    assert!(!ptr.is_null(), "prebuilt STR alloc_zeroed returned null");
+    unsafe {
+        (ptr.add(STR_HASH_OFFSET) as *mut i64).write(precomputed_hash);
+        (ptr.add(STR_LEN_OFFSET) as *mut usize).write(bytes.len());
+        for (i, &b) in bytes.iter().enumerate() {
+            ptr.add(STR_CHARS_OFFSET + i).write(b);
+        }
+    }
+    ptr as i64
+}
+
+/// Materialize every deferred prebuilt-string constant the codewriter
+/// recorded (`JitCodeBody.str_consts`, [`patch_constants_i_fnaddrs`]'s
+/// sibling).  The build-time translator could not allocate a runtime STR
+/// block, so it pooled a non-canonical sentinel in the slot named by each
+/// descriptor's `constants_r_index`; here we allocate the immortal block and
+/// overwrite the sentinel with its live address.  Runs at load time, before
+/// `Box::leak` publishes the table — refcount must be 1 (`Arc::get_mut`), so
+/// no consumer can observe the sentinel as a forged GCREF.
+///
+/// Identical literals are interned by bytes across the whole table so one
+/// immortal block (one identity) is shared, the runtime analog of the
+/// assembler's per-jitcode dedup.
+pub fn materialize_str_consts(jitcodes: &mut Vec<Arc<JitCode>>) {
+    let mut interned: HashMap<Vec<u8>, i64> = HashMap::new();
+    for arc in jitcodes.iter_mut() {
+        // Body-less placeholder shells, and bodies with no deferred strings
+        // (the common case — only cutover string literals record any), need
+        // no work and must not trip `Arc::get_mut` for nothing.
+        if arc.try_body().is_none_or(|b| b.str_consts.is_empty()) {
+            continue;
+        }
+        let jc = Arc::get_mut(arc).expect(
+            "materialize_str_consts: Arc<JitCode> already shared before patch — \
+             every caller must run this before publishing the table to consumers",
+        );
+        let body = jc.body_mut();
+        for i in 0..body.str_consts.len() {
+            let idx = body.str_consts[i].constants_r_index;
+            let hash = body.str_consts[i].precomputed_hash;
+            let addr = {
+                let bytes = &body.str_consts[i].bytes;
+                if let Some(&a) = interned.get(bytes) {
+                    a
+                } else {
+                    let owned = bytes.clone();
+                    let a = materialize_prebuilt_str(&owned, hash);
+                    interned.insert(owned, a);
+                    a
+                }
+            };
+            // The slot must still hold its non-canonical sentinel — never a
+            // real address (which has the high bits clear).
+            debug_assert_eq!(
+                (body.constants_r[idx] as u64) & SENTINEL_HIGH_MASK,
+                (majit_translate::assembler::STR_CONST_SENTINEL_BASE as u64) & SENTINEL_HIGH_MASK,
+                "constants_r[{idx}] did not hold a prebuilt-string sentinel",
+            );
+            body.constants_r[idx] = addr;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use majit_translate::assembler::STR_CONST_SENTINEL_BASE;
+    use majit_translate::jitcode::{JitCode, JitCodeBody, StrConstDescriptor};
+
+    fn sentinel(ordinal: i64) -> i64 {
+        STR_CONST_SENTINEL_BASE | ordinal
+    }
+
+    /// Build a fresh `Arc<JitCode>` whose body carries `descs` plus a
+    /// `constants_r` pre-seeded with the matching sentinels, mirroring the
+    /// assembler's emit (ordinal == position in `str_consts`).
+    fn jitcode_with_str_consts(descs: Vec<StrConstDescriptor>) -> Arc<JitCode> {
+        let len = descs
+            .iter()
+            .map(|d| d.constants_r_index + 1)
+            .max()
+            .unwrap_or(0);
+        let mut constants_r = vec![0_i64; len];
+        for (ordinal, d) in descs.iter().enumerate() {
+            constants_r[d.constants_r_index] = sentinel(ordinal as i64);
+        }
+        let jc = JitCode::new("test");
+        jc.set_body(JitCodeBody {
+            str_consts: descs,
+            constants_r,
+            ..Default::default()
+        });
+        Arc::new(jc)
+    }
+
+    /// Read back a materialized STR block: `(length, bytes, hash)`.
+    unsafe fn read_str_block(addr: i64) -> (usize, Vec<u8>, i64) {
+        let p = addr as *const u8;
+        let hash = unsafe { *(p.add(STR_HASH_OFFSET) as *const i64) };
+        let len = unsafe { *(p.add(STR_LEN_OFFSET) as *const usize) };
+        let mut bytes = Vec::with_capacity(len);
+        for i in 0..len {
+            bytes.push(unsafe { *p.add(STR_CHARS_OFFSET + i) });
+        }
+        (len, bytes, hash)
+    }
+
+    #[test]
+    fn materialize_str_consts_overwrites_sentinel_with_str_block() {
+        let descs = vec![StrConstDescriptor {
+            constants_r_index: 0,
+            bytes: b"hello".to_vec(),
+            precomputed_hash: 0x1234_5678,
+        }];
+        let mut jcs = vec![jitcode_with_str_consts(descs)];
+        materialize_str_consts(&mut jcs);
+
+        let addr = jcs[0].body().constants_r[0];
+        assert_ne!(addr, sentinel(0), "sentinel must be overwritten");
+        assert_eq!(
+            (addr as u64) & SENTINEL_HIGH_MASK,
+            0,
+            "a real STR address must have the sentinel high bits clear",
+        );
+        let (len, bytes, hash) = unsafe { read_str_block(addr) };
+        assert_eq!(len, 5);
+        assert_eq!(bytes, b"hello");
+        assert_eq!(hash, 0x1234_5678);
+    }
+
+    #[test]
+    fn materialize_str_consts_interns_identical_bytes_across_jitcodes() {
+        let desc = || StrConstDescriptor {
+            constants_r_index: 0,
+            bytes: b"x".to_vec(),
+            precomputed_hash: 7,
+        };
+        let mut jcs = vec![
+            jitcode_with_str_consts(vec![desc()]),
+            jitcode_with_str_consts(vec![desc()]),
+        ];
+        materialize_str_consts(&mut jcs);
+        let a0 = jcs[0].body().constants_r[0];
+        let a1 = jcs[1].body().constants_r[0];
+        assert_eq!(a0, a1, "identical literals must share one immortal block");
+        assert_ne!(a0, sentinel(0));
+    }
+
+    #[test]
+    fn materialize_str_consts_empty_string_has_trailing_nul() {
+        let descs = vec![StrConstDescriptor {
+            constants_r_index: 0,
+            bytes: Vec::new(),
+            precomputed_hash: -1,
+        }];
+        let mut jcs = vec![jitcode_with_str_consts(descs)];
+        materialize_str_consts(&mut jcs);
+        let addr = jcs[0].body().constants_r[0];
+        let (len, bytes, hash) = unsafe { read_str_block(addr) };
+        assert_eq!(len, 0);
+        assert!(bytes.is_empty());
+        assert_eq!(hash, -1);
+        let nul = unsafe { *(addr as *const u8).add(STR_CHARS_OFFSET) };
+        assert_eq!(nul, 0, "extra_item_after_alloc trailing NUL must be zeroed");
+    }
+}


### PR DESCRIPTION
#122

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Four incremental workstreams toward the `#266` legacy-walker cutover, each landed as a
minimal verified slice (`cargo test -p majit-translate --lib` green; `pyre/check.py`
dynasm 127/127 + cranelift 127/127; rtyper skip-census unchanged at 646).

- **`#305` — list/range repr indexing.** `FixedSizeListRepr::rtype_getitem`/`rtype_setitem`
  (`rlist.rs`) and `RangeRepr::rtype_getitem` (`rrange.rs`) port the nonnegative-index,
  no-implicit-exception (`dum_nocheck`) fast path of `pair(AbstractBaseListRepr,
  IntegerRepr)` (`rlist.py:247`) and `pair(AbstractRangeRepr, IntegerRepr)` (`rrange.py:34`).
  Range indexing lowers to `start + index*step` via `ll_rangeitem_nonneg`.

- **`#277` W1 — prebuilt-string ref constants.** The codewriter records a byte-string
  `ConstValue` as a deferred `StrConstDescriptor` (`JitCodeBody.str_consts`) and emits a
  sentinel into the `constants_r` slot; at jitcode load, `materialize_str_consts`
  (`pyre-jit-trace`) allocates one immortal, byte-interned runtime STR block per literal
  and overwrites the sentinel before the table is published.

- **`#308`/`#309` W2 — codewriter opname-dispatch spine (inert scaffolding).** A second
  lowering spine for rtyper opname helper graphs: `jtransform_opname::lower_graph`
  transduces the `ll_str*` helper family into rich `OpKind`s (including the generic
  `OpKind::LoweredBlackholeOp`) and reuses the shared finalize tail. `ll_strconcat` is
  restructured into two `copystrcontent` ops so it lowers end-to-end through this spine.
  No production code registers an opname graph yet, so the path is exercised only by
  tests.

- A resized-`ListRepr` test comment/assertion correction.

## Self-review

### Prompt & Model

Model: code generated with Claude Opus; parity review run with gpt-5.5 (plus the Codex
PR bot).

Prompt: the recommended gpt-5.5 static-parity prompt above — assess by static analysis
whether the `git diff main` changes are equivalent to the corresponding RPython/PyPy
sources.

### Answer

gpt-5.5 reported **no Section 1 items** (no parity regression vs `main`). It raised five
Section 2 items ("other mismatches introduced by our patch"); the Codex PR bot separately
raised two P2 inline notes. Each was verified against the code and RPython upstream.
**None is a reachable bug or miscompile**: every unsupported shape is rejected with a loud
typed `Err`/`None` (never an `unwrap`/`expect`/`panic!` on a live path), every *accepted*
shape lowers identically to upstream, and the two reachability-sensitive items are inert
today because their producers are test-only or `Skip`-routed. Two are recorded as
preconditions to fix *before* the relevant path goes live.

#### Section 2 — mismatches introduced by this patch (5)

- **Spine-B opname route is disconnected from production helper creation** — *inert
  scaffolding, accurate.* `CallControl::register_opname_helper_graph` has exactly one
  caller in the tree, inside `#[cfg(test)] mod tests` (`jtransform_opname.rs`), so
  `take_opname_graph` always returns `None` in production and the drain falls through to
  the normal rich-`OpKind` (Spine-A) `function_graphs` path (`codewriter.rs`). The
  module says so verbatim in its own doc. The reviewer's structural note is correct
  (`opname_graphs` is a Rust-side side channel with no exact upstream twin — `call.py`
  queues every graph through the single `get_jitcode`/`enum_pending_graphs` pipeline),
  but its load-bearing claim is not: the `#305` list/range slices do **not** depend on
  this route. They build helpers via `lowlevel_helper_function_with_builder` +
  `gendirectcall` (Spine-A) and assemble correctly regardless of Spine-B's state.

- **The transducer only lowers the narrow `ll_str*` shape** — *inert scaffolding,
  accurate.* `transduce_op` covers only the string-helper opnames
  (`getsubstruct`/`getarraysize`/`getarrayitem`/`setarrayitem`/`malloc_varsize`/
  `copystrcontent`|`copyunicodecontent`/`int_*`) with a fail-loud `other => panic!` and a
  `.expect` on `resolve_string` — the faithful port of `rewrite_operation`'s `KeyError`
  raise (`jtransform.py:238`); it cannot silently miscompile. The new
  FixedSizeListRepr/RangeRepr/resized-ListRepr helpers emit bare `getarrayitem`/
  `setarrayitem`/`getfield` and would need new arms — but they never reach the transducer
  (they enter the rich-`OpKind` corpus via `gendirectcall`). The two paths are disjoint
  on this branch. *Forward note:* routing list/range helpers through Spine B later
  requires `getfield` + bare-array arms first.

- **`FixedSizeListRepr.rtype_getitem`/`rtype_setitem` are partial** — *deliberate `#305`
  slice, accurate.* Ports the (nonneg, `dum_nocheck`) cell of the `rlist.py:247-284`
  matrix; the checkidx (implicit-`IndexError`), possibly-negative-index, and
  non-`SomeInteger`-arg variants are deferred and rejected with a loud `TyperError`
  (routed to the same `is_known_unported` → codewriter `Skip` soft-fail used by the
  existing slices). A Rust `&[T]`/fixed-array source never annotates a possibly-negative
  `SomeInteger` and never carries an implicit `IndexError`, so the rejected branches are
  not reachable by any live corpus subject — unit-test-validated completeness,
  census-neutral.

- **`RangeRepr.rtype_getitem` is partial** — *deliberate `#305` slice, accurate but not a
  divergence for the accepted shape.* This dispatch is on a live path (`pairtype.rs`),
  so to be explicit: the accepted (const-nonzero-step, nonneg, `dum_nocheck`) shape lowers
  via `ll_rangeitem_nonneg` to `getfield start; int_mul index*step; int_add` — exactly
  `start + index*step`. In upstream `ll_rangeitem_nonneg` (`rrange.py:74-77`) the
  bounds-check is guarded by `func is dum_checkidx`; the accepted shape always passes
  `dum_nocheck`, so that branch is provably dead and the helper reduces to the same
  arithmetic. Dropping the `Void` `func` arg and the dead branch only removes folded-out
  code — it narrows which shapes are accepted, it does not change the lowering of any
  accepted shape. The implicit-`IndexError`, variable-step (`step == 0`), and
  negative-index shapes each reject loudly.

- **Prebuilt string constants are STR-only (no `CONST_UNICODE_CACHE`)** — *deliberate
  `#277` W1 slice, accurate, unreachable today.* `prebuilt_str_bytes_and_hash` decodes
  only the STR/`Char` container and returns `None` for UNICODE/`UniChar` (per its
  docstring). Upstream `BaseLLStringRepr.convert_const` is shared between String/Unicode,
  so this is a genuine partial port — but pyre's `UnicodeRepr` does not yet override
  `convert_const` (it inherits the trait default returning a typed `TyperError`), and the
  only builder of a `Ptr(UNICODE)` (`alloc_array_unicode`) is test-only, so `emit_const_r`
  never sees an `LLPtr(UNICODE)` on a live path and the `None` arm / assembler panic are
  unreachable for unicode. **Follow-up coupling:** when `UnicodeRepr.convert_const` is
  ported to materialize a prebuilt `Ptr(UNICODE)`, `prebuilt_str_bytes_and_hash` must be
  extended to decode the `UniChar` chars array in the same change.

#### Codex PR-bot inline notes (2, both P2)

- **`call.rs:3104` "Register opname helpers with call resolution"** — same root as the
  first Section-2 item. A helper registered via `register_opname_helper_graph` is only
  inserted into `opname_graphs`/queued with `get_jitcode`, not exposed to
  `target_to_path`/`graphs_from`, so an rtyped caller's `direct_call` to it would resolve
  as residual. Correct, but inert: nothing registers an opname helper in production, so no
  rtyped caller has a `direct_call` to one today. This is a precondition for the W2 cutover
  (when an opname helper becomes a live callee, it must be made visible to call resolution),
  not a current bug.

- **`runtime_fnaddr_patch.rs:148` "Use the trace CPU string layout for STR constants"** —
  *accurate and important; inert today; recorded as a cutover precondition.*
  `materialize_prebuilt_str` writes the low-level lltype layout `[hash@0, len@8, chars@16,
  NUL]`, but the installed `PyreCpu::bh_strlen`/`bh_strgetitem` read the `W_StrObject`
  object shape (`value: *mut Wtf8Buf` at offset 16) — so a prebuilt STR block would have
  its first chars bytes dereferenced as a `Wtf8Buf*`. The block matches neither live reader
  (the compiled fast path also uses the `W_StrObject` descr). It cannot fire today:
  `JitCodeBody.str_consts` is provably always empty — the producer (`emit_str_const_r`) is
  test-only, the W2 spine is unregistered (dead), and string literals are `Skip`-routed to
  the legacy walker, so `materialize_str_consts` early-returns. **Precondition before the
  W1/W2 string-literal cutover flips live:** `materialize_prebuilt_str` must build a
  `W_StrObject`-shaped block (immortal `[ob_header | value:*mut Wtf8Buf | byte_len | len]`,
  tagged with the STR GC type id) — or `PyreCpu` must grow a distinct low-level-STR path.

#### Update — review fixes landed (4 commits, ssa-repr)

Both Codex preconditions were promoted from "cutover precondition" to **fixed**, plus the
purity refinement, after a verification workflow. Gates green and all three are inert on
the live corpus: `majit-translate` lib 2555/0; `pyre-jit-trace` str tests 3/3 (validated
against the real `bh_strlen`/`bh_strgetitem` readers); `check.py` dynasm 127/127 +
cranelift 127/127; rtyper skip-census unchanged at 646.

- `1fd6f12262` **jit-trace: build prebuilt-string const as W_StrObject** — fixes Codex
  `runtime_fnaddr_patch.rs:148`. `materialize_prebuilt_str` now routes through
  `box_str_constant` (the immortal-string builder the interpreter and pyre-jit
  `flatten.rs` already use), producing a real `W_StrObject` the `STR_VALUE_OFFSET` readers
  dereference correctly. `precomputed_hash` is now unused (no hash slot; `ll_strhash`
  recomputes from `value`).
- `4bf3362b81` **codewriter: resolve opname helpers as regular calls** — fixes Codex
  `call.rs:3104`. Registration now records the helper path in a persistent
  `opname_helper_paths` set (surviving `take_opname_graph`'s drain) plus
  `candidate_graphs`, and `target_to_path` recognises it, so a `direct_call` resolves
  `Regular` instead of residual.
- `e31c7fd6ce` **translate: opname-aware LoweredBlackholeOp purity** — fixes the second
  gpt-5.5 round's purity item. `is_pure_op` is now opname-aware (read family pure,
  alloc/store/copy effecting), mirroring `op_can_raise`.

A second gpt-5.5 review round raised four Section-2 items; only the purity one was
fix-now. The other three:

- **(a) Fixed-list getitem omits the upstream result `recast`** — real latent gap,
  **deferred** to the `external_item_repr` (gcref) `#305` slice and documented at the
  getitem (`3230ff792c`). `FixedSizeListRepr::new` drops the `external_item_repr` half of
  `externalvsinternal`, so getitem returns the internal repr — correct for primitive items
  (`external == internal`), wrong only for a GC-instance list. It cannot be added now:
  `convertvar` keys identity on `Arc::ptr_eq`, so a same-lltype identity recast would
  `TyperError` every currently-green getitem.
- **(b) List indexing only on `FixedSizeListRepr`, not `AbstractBaseListRepr`** —
  deliberate `#305` completeness boundary (resized `ListRepr` subscript, shared base
  dispatch, checked/negative variants); census-neutral, no live subject. Deferred.
- **(c) Range getitem const-step subset** — already-triaged `#305` slice; no action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added prebuilt string constant optimization with deferred runtime materialization
  * Implemented indexing operations for lists and ranges
  * Added helper dispatch infrastructure for specialized operation optimization

* **Refactor**
  * Optimized string concatenation operations using bulk copy strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

