### PR TITLE
jit: FBW walker — self-recursive CALL_ASSEMBLER routing, residual-call vable isolation, arity-2 int tuple unpack

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -542,6 +542,27 @@ pub enum PyreHelperKind {
     /// + `int_is_true`, eliding the `CALL_MAY_FORCE` (and its
     /// `GUARD_NOT_FORCED` / `GUARD_NO_EXCEPTION`) the generic residual emits.
     Truth,
+    /// `bh_unpack_sequence_fn(count, seq)` — the UNPACK_SEQUENCE validator
+    /// emitted by the codewriter UNPACK_SEQUENCE arm.  Validates the exact
+    /// length and returns the normalized tuple.  The full-body walker
+    /// recognises this tag to fold an arity-2 specialised int tuple to a
+    /// `guard_class` + pass-through, eliding the opaque residual so the
+    /// partner [`PyreHelperKind::UnpackItem`] reads fold against it.
+    UnpackSequence,
+    /// `bh_unpack_item_fn(index, tuple)` — the per-index UNPACK_SEQUENCE item
+    /// reader.  The full-body walker recognises this tag to read `value0` /
+    /// `value1` from a specialised int tuple directly (`getfield_gc_pure_i`
+    /// + `wrapint`), so the unpacked items stay unboxed ints through the
+    /// downstream BINARY_OP int fold.
+    UnpackItem,
+    /// `bh_newtuple_from_array(array)` — the BUILD_TUPLE array consumer that
+    /// `lower_tuple_build_hlop_to_insn` emits after `new_array_clear` +
+    /// `setarrayitem_gc`.  The full-body walker recognises this tag to
+    /// virtualize an arity-2 plain-int tuple as a `spec_ii`
+    /// `new_with_vtable` + `value0` / `value1` (mirroring
+    /// `trace_build_tuple_value`), so the backing array build and the
+    /// partner [`PyreHelperKind::UnpackItem`] reads DCE to a pure-int loop.
+    NewtupleFromArray,
 }
 
 impl EffectInfo {

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -394,8 +394,7 @@ fn save_object(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Res
         return Ok(());
     }
     if unsafe { pyre_object::is_bool(w_obj) } {
-        save_bool(ctx, buf, w_obj)?;
-        return Ok(());
+        return save_bool(ctx, buf, w_obj);
     }
     if unsafe { pyre_object::is_int_or_long(w_obj) } {
         save_long(ctx, buf, w_obj)?;

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1674,7 +1674,22 @@ where
         next_instr,
         delta.get(op_arg).as_usize(),
     ))?;
-    Ok(step)
+    // Rebuild the StepResult per variant so the Result-of-PyError
+    // lowering sees a concrete `Ok(StepResult::_)` shell to rewrite. A
+    // bare `Ok(step)` forward of the method's same-typed Result collapses
+    // in MIR, leaving this scoped wrapper with no rewritable return.
+    match step {
+        StepResult::Continue => Ok(StepResult::Continue),
+        StepResult::Return(value) => Ok(StepResult::Return(value)),
+        StepResult::CloseLoop {
+            jump_args,
+            loop_header_pc,
+        } => Ok(StepResult::CloseLoop {
+            jump_args,
+            loop_header_pc,
+        }),
+        StepResult::Yield(value) => Ok(StepResult::Yield(value)),
+    }
 }
 
 pub fn execute_pop_jump_if_false<E: OpcodeStepExecutor>(
@@ -1910,7 +1925,22 @@ where
     E: ControlFlowOpcodeHandler,
 {
     let step = executor.return_value()?;
-    Ok(step)
+    // Rebuild the StepResult per variant so the Result-of-PyError
+    // lowering sees a concrete `Ok(StepResult::_)` shell to rewrite. A
+    // bare `Ok(step)` forward of the method's same-typed Result collapses
+    // in MIR, leaving this scoped wrapper with no rewritable return.
+    match step {
+        StepResult::Continue => Ok(StepResult::Continue),
+        StepResult::Return(value) => Ok(StepResult::Return(value)),
+        StepResult::CloseLoop {
+            jump_args,
+            loop_header_pc,
+        } => Ok(StepResult::CloseLoop {
+            jump_args,
+            loop_header_pc,
+        }),
+        StepResult::Yield(value) => Ok(StepResult::Yield(value)),
+    }
 }
 
 pub fn execute_return_generator<E: OpcodeStepExecutor>(
@@ -2848,7 +2878,22 @@ pub fn execute_unsupported<E: OpcodeStepExecutor>(
     instruction: Instruction,
 ) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
     let step = executor.unsupported(&instruction)?;
-    Ok(step)
+    // Rebuild the StepResult per variant so the Result-of-PyError
+    // lowering sees a concrete `Ok(StepResult::_)` shell to rewrite. A
+    // bare `Ok(step)` forward of the method's same-typed Result collapses
+    // in MIR, leaving this scoped wrapper with no rewritable return.
+    match step {
+        StepResult::Continue => Ok(StepResult::Continue),
+        StepResult::Return(value) => Ok(StepResult::Return(value)),
+        StepResult::CloseLoop {
+            jump_args,
+            loop_header_pc,
+        } => Ok(StepResult::CloseLoop {
+            jump_args,
+            loop_header_pc,
+        }),
+        StepResult::Yield(value) => Ok(StepResult::Yield(value)),
+    }
 }
 
 pub fn execute_opcode_step<E: OpcodeStepExecutor>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4611,10 +4611,28 @@ fn try_execute_residual_call_via_executor(
     // and corrupt this walk's `TraceCtx` (flaky `libsystem_malloc` freelist
     // abort during deep recursion).  Plain C-helper callees never re-enter, so
     // the guard is a no-op for them.
+    //
+    // In RPython the tracing metainterp and the executing (blackhole /
+    // compiled) interpreter are SEPARATE objects, so `do_residual_call`
+    // never perturbs the tracer's `MetaInterp.vable_ptr` /
+    // `virtualizable_boxes`.  Pyre shares one `TraceCtx` across the walk
+    // and any re-entrant JIT activity the concrete call triggers: a
+    // self-recursive `CALL_ASSEMBLER` callee that re-enters compiled code
+    // and deopts runs `set_vable_ptr` for the nested frames, leaving
+    // `virtualizable_heap_ptr` pointing at a nested callee frame whose
+    // `vable_token` is still the live JIT FORCE_TOKEN.  The next
+    // `tracing_before_residual_call` in this same walk would then assert on
+    // the non-NONE token (virtualizable.rs:565).  Snapshot the standard
+    // virtualizable pointer and restore it after the call so the walk's
+    // subsequent vable token protocol / field reads see the frame being
+    // traced, mirroring RPython's separate-state isolation.
+    let saved_vable_heap_ptr = ctx.trace_ctx.virtualizable_heap_ptr();
     let exec_result = {
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
+    ctx.trace_ctx
+        .set_virtualizable_heap_ptr(saved_vable_heap_ptr.unwrap_or(std::ptr::null()));
     // pyjitpl.py:3349-3353 `vinfo.tracing_after_residual_call(virtualizable)`
     // heap half: a cleared token means the callee forced the virtualizable —
     // the frame escaped, the trace must abort (pyjitpl.py:3365

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8048,6 +8048,20 @@ fn dispatch_residual_call_iRd_kind(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
+    // #195 / #73: virtualize an arity-2 plain-int BUILD_TUPLE
+    // (`newtuple_from_array`) as a `spec_ii` `new_with_vtable` +
+    // `value0` / `value1`, so the backing array build and the partner
+    // UNPACK_SEQUENCE reads DCE to a pure-int loop.  Falls through to the
+    // opaque residual for any other shape (SAFE — never declined).
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::NewtupleFromArray
+        && try_walker_specialize_newtuple(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // pyjitpl.py:2063 forces-branch sub-case: when the descr's
     // `call_release_gil_target` is a non-NULL `(realfuncaddr, saveerr)`
     // pair, route through `direct_call_release_gil` which records
@@ -8848,6 +8862,288 @@ fn try_walker_specialize_binary_op_int(
         majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
     );
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
+/// FBW fold of the UNPACK_SEQUENCE two-residual lowering (`unpack_sequence_fn`
+/// validator + per-index `unpack_item_fn` reader emitted by the codewriter
+/// UNPACK_SEQUENCE arm) for an arity-2 specialised int tuple: guard the
+/// `spec_ii` class once, then read `value0` / `value1` directly
+/// (`getfield_gc_pure_i` + `wrapint`) so the unpacked items stay unboxed ints
+/// through the downstream BINARY_OP int fold — the walker analogue of the
+/// trait path's `W_SpecialisedTupleObject_ii` value0/value1 reads.  Returns
+/// `Ok(Some(()))` when folded (the caller returns `Continue`); `Ok(None)` to
+/// fall through to the opaque residual record, which stays correct for any
+/// other shape — so a non-foldable sequence is NOT declined to the trait leg.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_specialize_unpack(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    helper: majit_ir::PyreHelperKind,
+    i_args: &[OpRef],
+    r_args: &[OpRef],
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || !ctx.is_full_body_walk || dst_bank != 'r' {
+        return Ok(None);
+    }
+    let (Some(&int_arg), Some(&seq)) = (i_args.first(), r_args.first()) else {
+        return Ok(None);
+    };
+    let Some(majit_ir::Value::Int(int_val)) = ctx.trace_ctx.box_value(int_arg) else {
+        return Ok(None);
+    };
+    let Some(concrete_seq) = walker_concrete_ref_object(ctx, seq) else {
+        return Ok(None);
+    };
+    // Only the arity-2 int specialised tuple is folded today; any other shape
+    // falls through to the opaque residual (correct, slower).
+    let spec_ii = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_II_TYPE
+        as *const pyre_object::pyobject::PyType;
+    if !std::ptr::eq(unsafe { (*concrete_seq).ob_type }, spec_ii) {
+        return Ok(None);
+    }
+    match helper {
+        majit_ir::PyreHelperKind::UnpackSequence => {
+            // `spec_ii` is always arity 2, so the class guard subsumes the
+            // exact-length check `unpack_sequence_fn` performs.
+            if int_val != 2 {
+                return Ok(None);
+            }
+            if !ctx.trace_ctx.heap_cache().is_class_known(seq) {
+                let type_const = ctx.trace_ctx.const_int(spec_ii as i64);
+                ctx.trace_ctx
+                    .record_guard(OpCode::GuardClass, &[seq, type_const], 0);
+                walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+                ctx.trace_ctx
+                    .heap_cache_mut()
+                    .class_now_known(seq, spec_ii as i64);
+            }
+            // Pass `seq` through as the validated tuple; the per-index
+            // `unpack_item_fn` reads below fold off it.
+            write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, seq)?;
+            Ok(Some(()))
+        }
+        majit_ir::PyreHelperKind::UnpackItem => {
+            if !(0..2).contains(&int_val) {
+                return Ok(None);
+            }
+            // Authentic boxed element (small-int caching / identity); fall
+            // through to the opaque residual if it cannot be executed.
+            let Some(elem_ptr) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+                return Ok(None);
+            };
+            // The class was already guarded by the partner `unpack_sequence_fn`
+            // fold (its validated-tuple passthrough reg == `seq`).
+            let descr = if int_val == 0 {
+                crate::descr::specialised_tuple_ii_value0_descr()
+            } else {
+                crate::descr::specialised_tuple_ii_value1_descr()
+            };
+            let raw = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, seq, descr);
+            let boxed = crate::state::wrapint(ctx.trace_ctx, raw);
+            ctx.trace_ctx.set_opref_concrete(
+                boxed,
+                majit_ir::Value::Ref(majit_ir::GcRef(elem_ptr as usize)),
+            );
+            write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+            Ok(Some(()))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Walker-native mirror of the trait `trace_guard_exact_w_class`
+/// (`trace_opcode.rs`): emit `getfield_gc_r(w_class)` → `ptr_eq(expected)`
+/// → `guard_true` so the spec_ii fast path only stays live for an element
+/// whose Python-level `w_class` is the canonical type object — a later
+/// subclass sharing the payload `ob_type` side-exits rather than being
+/// silently rewrapped as a plain int.  Skipped for an unescaped element (a
+/// fresh `wrapint` box is provably plain, and reading its `w_class` would
+/// force the box OptVirtualize removes).
+fn walker_guard_exact_w_class(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    obj: OpRef,
+    expected_typeobj: pyre_object::PyObjectRef,
+) -> Result<(), DispatchError> {
+    if expected_typeobj.is_null() || ctx.trace_ctx.heap_cache().is_unescaped(obj) {
+        return Ok(());
+    }
+    let actual =
+        crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, obj, crate::descr::w_class_descr());
+    let expected = ctx.trace_ctx.const_ref(expected_typeobj as i64);
+    let eq = ctx.trace_ctx.record_op(OpCode::PtrEq, &[actual, expected]);
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[eq])
+}
+
+/// #195 / #73: FBW virtualization of an arity-2 plain-int BUILD_TUPLE.
+/// `lower_tuple_build_hlop_to_insn` lowers BUILD_TUPLE to `new_array_clear`
+/// + per-index `setarrayitem_gc` + a `newtuple_from_array` residual
+/// (oopspec [`majit_ir::PyreHelperKind::NewtupleFromArray`]).  When both
+/// backing-array elements are concrete plain `W_IntObject`, re-emit the
+/// trait `trace_build_tuple_value` spec_ii shape walker-native
+/// (`new_with_vtable` + `w_class` / `value0` / `value1` `setfield_gc`),
+/// reading the elements straight out of the array heap-cache so the array
+/// build keeps no consumer and DCEs.  The partner
+/// [`try_walker_specialize_unpack`] then folds the `value0` / `value1`
+/// reads off the virtual tuple, collapsing build→unpack to a pure-int loop.
+///
+/// Returns `Ok(Some(()))` when folded (the caller returns `Continue`);
+/// `Ok(None)` to fall through to the opaque residual, which stays correct
+/// for any other shape (object tuple, arity ≠ 2, long element, cache miss)
+/// — so a non-foldable build is NOT declined to the trait leg.
+fn try_walker_specialize_newtuple(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    r_args: &[OpRef],
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || !ctx.is_full_body_walk || dst_bank != 'r' {
+        return Ok(None);
+    }
+    if r_args.len() != 1 {
+        return Ok(None);
+    }
+    let arr = r_args[0];
+    // Read the two backing-array element boxes out of the heap-cache (the
+    // values the BUILD_TUPLE `setarrayitem_gc` ops stored); a cache miss
+    // (non-const index / clobbered array) bails to the opaque residual.
+    let descr_idx = crate::state::pyobject_gcarray_descr().index();
+    let (Some(e0), Some(e1)) = (
+        ctx.trace_ctx
+            .heapcache_getarrayitem(arr, OpRef::ConstInt(0), descr_idx),
+        ctx.trace_ctx
+            .heapcache_getarrayitem(arr, OpRef::ConstInt(1), descr_idx),
+    ) else {
+        return Ok(None);
+    };
+    // Arity must be exactly 2 (the only specialised int tuple).  A BUILD_TUPLE
+    // array sets every index before `newtuple_from_array`, so a cached element
+    // at index 2 means arity ≥ 3 → fall through to the residual (a wrongly
+    // built arity-2 spec_ii would length-mismatch the arity-N unpack).
+    if ctx
+        .trace_ctx
+        .heapcache_getarrayitem(arr, OpRef::ConstInt(2), descr_idx)
+        .is_some()
+    {
+        return Ok(None);
+    }
+    let (Some(c0), Some(c1)) = (
+        walker_concrete_ref_object(ctx, e0),
+        walker_concrete_ref_object(ctx, e1),
+    ) else {
+        return Ok(None);
+    };
+    // Only the arity-2 plain-int specialised tuple is folded today.  Gate
+    // on `is_plain_int1` (rejects int subclasses + non-fitting longs) AND
+    // an exact `&INT_TYPE` `ob_type` — that excludes the fits-in-word
+    // `W_LongObject` arm `is_plain_int1` also accepts, which would need the
+    // long unbox the trait `trace_plain_int_payload` does (out of scope
+    // here).  Any other shape falls through to the residual (correct).
+    let int_ty = &pyre_object::pyobject::INT_TYPE as *const pyre_object::pyobject::PyType;
+    let both_plain_int = unsafe {
+        pyre_object::is_plain_int1(c0)
+            && pyre_object::is_plain_int1(c1)
+            && std::ptr::eq((*c0).ob_type, int_ty)
+            && std::ptr::eq((*c1).ob_type, int_ty)
+    };
+    if !both_plain_int {
+        return Ok(None);
+    }
+    // Concrete element int payloads (already proven plain `W_IntObject`).
+    let (v0, v1) = unsafe {
+        (
+            pyre_object::w_int_get_value(c0),
+            pyre_object::w_int_get_value(c1),
+        )
+    };
+
+    // --- emit the virtual spec_ii (walker-native trace_build_tuple_value) ---
+    // Paired `w_class` guard per element so a runtime int subclass sharing
+    // `&INT_TYPE`'s payload side-exits, then the plain-int payload unbox.
+    let int_typeobj = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::INT_TYPE);
+    walker_guard_exact_w_class(ctx, op_pc, e0, int_typeobj)?;
+    walker_guard_exact_w_class(ctx, op_pc, e1, int_typeobj)?;
+    let int_type_addr = int_ty as i64;
+    let raw0 = walker_unbox_int_typed(
+        ctx,
+        op_pc,
+        e0,
+        int_type_addr,
+        crate::descr::int_intval_descr(),
+    )?;
+    let raw1 = walker_unbox_int_typed(
+        ctx,
+        op_pc,
+        e1,
+        int_type_addr,
+        crate::descr::int_intval_descr(),
+    )?;
+
+    let tuple = ctx.trace_ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::specialised_tuple_ii_size_descr(),
+    );
+    ctx.trace_ctx.heap_cache_mut().new_object(tuple);
+    // `ob_type` is the JIT vtable; Python-level `type()` reads `w_class`,
+    // which all specialised tuple variants share at the public `tuple`
+    // typedef.
+    let tuple_w_class = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE);
+    if !tuple_w_class.is_null() {
+        let wc = ctx.trace_ctx.const_ref(tuple_w_class as i64);
+        ctx.trace_ctx.record_op_with_descr(
+            OpCode::SetfieldGc,
+            &[tuple, wc],
+            crate::descr::specialised_tuple_ii_w_class_descr(),
+        );
+        ctx.trace_ctx.heapcache_setfield_cached(
+            tuple,
+            crate::descr::specialised_tuple_ii_w_class_descr().index(),
+            wc,
+        );
+    }
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[tuple, raw0],
+        crate::descr::specialised_tuple_ii_value0_descr(),
+    );
+    ctx.trace_ctx.heapcache_setfield_cached(
+        tuple,
+        crate::descr::specialised_tuple_ii_value0_descr().index(),
+        raw0,
+    );
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[tuple, raw1],
+        crate::descr::specialised_tuple_ii_value1_descr(),
+    );
+    ctx.trace_ctx.heapcache_setfield_cached(
+        tuple,
+        crate::descr::specialised_tuple_ii_value1_descr().index(),
+        raw1,
+    );
+    // Concrete spec_ii shadow for the dst (read by the partner unpack fold's
+    // `walker_concrete_ref_object` + `unpack_item_fn` execution).  Built
+    // directly from the element payloads — `newtuple_from_array(arr)` cannot
+    // be executed concretely (the virtual array `arr` has no concrete
+    // shadow).  Constructed last so the construct→root window holds no
+    // intervening runtime allocation: stamping `tuple`'s concrete roots the
+    // fresh spec_ii via the trace's concrete-shadow set.
+    let tuple_ptr = pyre_object::specialisedtupleobject::w_specialised_tuple_ii_new(v0, v1);
+    if tuple_ptr.is_null() {
+        return Ok(None);
+    }
+    ctx.trace_ctx.set_opref_concrete(
+        tuple,
+        majit_ir::Value::Ref(majit_ir::GcRef(tuple_ptr as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, tuple)?;
     Ok(Some(()))
 }
 
@@ -9977,6 +10273,29 @@ fn dispatch_residual_call_iIRd_kind(
                 }
             }
         }
+    }
+
+    // UNPACK_SEQUENCE fold (#73): read an arity-2 specialised int tuple's
+    // elements directly so the unpacked items stay unboxed ints (the trait
+    // path's value0/value1 fold).  A non-foldable shape falls through to the
+    // opaque residual below — correct, no decline.
+    if matches!(
+        ei.pyre_helper,
+        majit_ir::PyreHelperKind::UnpackSequence | majit_ir::PyreHelperKind::UnpackItem
+    ) && try_walker_specialize_unpack(
+        ctx,
+        op.pc,
+        ei.pyre_helper,
+        &i_args,
+        &r_args,
+        &allboxes,
+        call_descr,
+        dst,
+        dst_bank,
+    )?
+    .is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
     // pyjitpl.py:2063 forces-branch sub-case: route release-gil through

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7704,6 +7704,33 @@ fn try_walker_inline_user_call(
     // `recursive-call-assembler`, so route the enclosing key there
     // (`FBW_DECLINED_KEYS`) instead of recording the slow residual.
     if !callee_fast_path_inlinable(body.code, callee_descr_refs, ctx) {
+        // #62: a self-recursive single-int call (`fib`'s shape) the fast-path
+        // inline cannot serve is handled instead by the direct
+        // `CALL_ASSEMBLER` arm (`try_walker_call_assembler_self_recursive`).
+        // That arm is only reached when this inline attempt returns
+        // `Ok(None)`; an `Err` propagates out of the dispatcher via `?` and
+        // preempts it.  Detect the self-recursive single-int shape and fall
+        // through so the CA arm gets its chance.  Gate on the same
+        // `PYRE_FBW_REC_CA` flag the CA arm uses: when it is off the CA arm
+        // declines and the call would land on a deopt-storming residual, so
+        // keep the trait-leg decline there.  Non-self-recursive loop/branch
+        // callees always keep the decline (FBW_DECLINED_KEYS → trait leg).
+        let rec_ca_on =
+            std::env::var_os("PYRE_FBW_REC_CA").as_deref() != Some(std::ffi::OsStr::new("0"));
+        let is_self_recursive_single_int = rec_ca_on
+            && nparams == 1
+            && {
+                let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+                !sym_ptr.is_null()
+                    && unsafe { (*(*sym_ptr).jitcode).code } as usize == w_code as usize
+            }
+            && matches!(
+                arg_concretes.get(2),
+                Some(ConcreteValue::Ref(a)) if !a.is_null() && unsafe { pyre_object::is_int(*a) }
+            );
+        if is_self_recursive_single_int {
+            return Ok(None);
+        }
         return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
     }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4790,12 +4790,12 @@ impl CodeWriter {
                 },
             unpack_sequence_fn:
                 HelperHandle {
-                    idx: _unpack_sequence_fn_idx,
+                    idx: unpack_sequence_fn_idx,
                     flavor: _unpack_sequence_fn_flavor,
                 },
             unpack_item_fn:
                 HelperHandle {
-                    idx: _unpack_item_fn_idx,
+                    idx: unpack_item_fn_idx,
                     flavor: _unpack_item_fn_flavor,
                 },
             build_slice_fn:
@@ -8323,29 +8323,54 @@ impl CodeWriter {
                             }
                         }
 
-                        // CPython 3.13 UNPACK_SEQUENCE: pop 1 (seq), push `count`.
-                        // Emit abort_permanent (no getitem helper yet) but
-                        // adjust current_depth so subsequent instructions don't
-                        // underflow.
+                        // UNPACK_SEQUENCE: pop 1 (seq), push `count` items.
+                        // `unpack_sequence_fn(n, seq)` validates the exact length
+                        // (raises ValueError/TypeError on a mismatch or a
+                        // non-sequence) and returns the normalized tuple; each
+                        // `unpack_item_fn(k, tuple)` then produces one item with a
+                        // residual result the walker binds, matching
+                        // opcode_unpack_sequence.
                         Instruction::UnpackSequence { count } => {
                             let n = count.get(op_arg) as usize;
-                            // Pop the sequence. The unpack residual reads it from a
-                            // stable scratch register so the item pushes below (which
-                            // reuse the popped stack slots) cannot clobber it; this
-                            // residual threading is walker-stream-only — the canonical
-                            // splice owns the production lowering via `insert_renamings`.
+                            // Pop the sequence; keep its FlowValue as the residual
+                            // arg. The graph def-use (seq -> unpack_sequence_fn ->
+                            // tuple -> unpack_item_fn) keeps both alive across the
+                            // item pushes below (which reuse the popped stack slots),
+                            // so no manual scratch reservation is needed.
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
-                            let _ = pop_ref_or_fresh(&mut current_state, &mut graph);
-                            let _ = ssarepr.fresh_var(Kind::Ref, scratch_ref_base).0;
-                            // unpack_sequence_fn(n, seq) → tuple of exactly n items;
-                            // raises ValueError/TypeError on length mismatch or a
-                            // non-sequence, matching opcode_unpack_sequence.
-                            let _ = ssarepr.fresh_var(Kind::Ref, scratch_ref_base).0;
+                            let seq_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let tuple_var = residual_call!(
+                                unpack_sequence_fn_idx,
+                                CallFlavor::Plain,
+                                majit_ir::PyreHelperKind::UnpackSequence,
+                                vec![super::flow::Constant::signed(n as i64).into()],
+                                vec![seq_value],
+                                vec![],
+                                vec![Kind::Int, Kind::Ref],
+                                ResKind::Ref,
+                                py_pc as i64,
+                            );
+                            let tuple_value = tuple_var
+                                .map(super::flow::FlowValue::from)
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
                             // Push the items in reverse so the stack top is item[0]
                             // (opcode_unpack_sequence pushes `items.into_iter().rev()`).
-                            for _k in (0..n).rev() {
+                            for k in (0..n).rev() {
                                 let item_dst = stack_base + current_depth;
-                                let item_value = fresh_ref_value(&mut graph);
+                                let item_var = residual_call!(
+                                    unpack_item_fn_idx,
+                                    CallFlavor::Plain,
+                                    majit_ir::PyreHelperKind::UnpackItem,
+                                    vec![super::flow::Constant::signed(k as i64).into()],
+                                    vec![tuple_value.clone()],
+                                    vec![],
+                                    vec![Kind::Int, Kind::Ref],
+                                    ResKind::Ref,
+                                    py_pc as i64,
+                                );
+                                let item_value = item_var
+                                    .map(super::flow::FlowValue::from)
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph));
                                 if let super::flow::FlowValue::Variable(v) = &item_value {
                                     pin!(Some(*v), item_dst);
                                 }

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4125,7 +4125,7 @@ where
                 ctx.newtuple_from_array_fn_idx,
                 vec![array_operand],
                 CallFlavor::Plain,
-                majit_ir::PyreHelperKind::None,
+                majit_ir::PyreHelperKind::NewtupleFromArray,
                 dst_reg,
             ))
         }


### PR DESCRIPTION
as #171 dependency

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Full-body walker (FBW) fixes that advance the trait-tracer retirement (#73), plus a pyopcode lowering fix. Four commits:

**`8c3e5db3` pyopcode: rebuild `StepResult` per variant in three forwarding `execute_*` wrappers.** `execute_jump_backward`, `execute_return_value`, and `execute_unsupported` forwarded the inner method's `Result<StepResult, PyError>` with `let step = m()?; Ok(step)`. That shape MIR-collapses to a bare forward of a non-scoped callee, so the Result-of-PyError lowering finds no `Ok`/`Err` ctor to rewrite and fails with "scoped Result-of-PyError callee with no rewritable returns". Replaced with a per-variant match that rebuilds a concrete `Ok(StepResult::_)` shell, matching every other `execute_*` wrapper. (Includes a small `_pickle` `save_object` branch dedup.)

**`392c3fb2` jit: virtualize arity-2 plain-int BUILD_TUPLE/UNPACK_SEQUENCE in the FBW.** Lowers UNPACK_SEQUENCE in the codewriter to `unpack_sequence_fn(n, seq)` + per-index `unpack_item_fn(k, tuple)` residuals and tags `newtuple_from_array` (new `PyreHelperKind` variants `UnpackSequence`/`UnpackItem`/`NewtupleFromArray`). `try_walker_specialize_newtuple` reads the backing-array elements out of the heap cache (a pure cache read, no emitted `getarrayitem`), gates on arity exactly 2 with both elements plain `W_IntObject`, and emits a walker-native specialised int tuple (`spec_ii`) built directly via `w_specialised_tuple_ii_new`. The partner `try_walker_specialize_unpack` folds `value0`/`value1` off the virtual tuple; the backing array and the `spec_ii` both DCE, collapsing build→unpack to a pure-int loop. Any other shape (object tuple, arity != 2, long element, cache miss) falls through to the opaque residual.

**`de19f030` jit: restore tracing `virtualizable_heap_ptr` after a walker residual call.** A self-recursive CALL_ASSEMBLER callee executed concretely during the walk re-enters compiled code and deopts; the nested MetaInterp's `set_vable_ptr` leaves `virtualizable_heap_ptr` pointing at a nested callee frame whose `vable_token` is still the live FORCE_TOKEN, so the next `tracing_before_residual_call` asserts on the non-NONE token (`virtualizable.rs:565`). Snapshot `virtualizable_heap_ptr` before the call and restore it afterward so the tracing context's standard virtualizable survives the residual, as in RPython where the tracing and executing interpreters are separate objects.

**`ff2f5363` jit: route self-recursive single-int calls to the CALL_ASSEMBLER arm.** `try_walker_inline_user_call` declined loop/branch callees with `Err(LoopBearingCalleeInlineUnsupported)`, which propagated via `?` and preempted the self-recursive CALL_ASSEMBLER arm (`try_walker_call_assembler_self_recursive`) that runs afterward. Detects the self-recursive single-int shape (`fib`: `PYRE_FBW_REC_CA` on, `nparams == 1`, self-recursive code identity, int `arg0`) at the decline and returns `Ok(None)` so control reaches the CA arm; non-self-recursive loop/branch callees keep the `Err` (trait leg). `recursion`/`fib_recursive` now emit CALL_ASSEMBLER for the recursive call.

Verification: `check.py` 127/127 dynasm + 127/127 cranelift, default and `PYRE_FBW_INLINE=0`, GC-stress nursery 64K clean; `cargo test -p pyre-jit-trace` green; verified on arm64 and x86_64 (Rosetta).

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
