### PR TITLE
Finalize #108 GC-safe const refs and migrate short_inputargs to the box domain (#9)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7547,6 +7547,7 @@ impl CraneliftBackend {
                                             ),
                                             loop_reentry: b.loop_reentry,
                                             invalidated_arc: b.invalidated_arc.clone(),
+                                            gc_table: b.gc_table.clone(),
                                         },
                                     );
                                 }
@@ -14969,9 +14970,12 @@ impl majit_backend::Backend for CraneliftBackend {
         // are scoped to the original loop's CLT, so the tracer batch
         // lands on `original_token`'s `asmmemmgr_gcreftracers`.
         self.register_fail_descrs(original_token, &compiled.fail_descrs);
-        // The bridge's `CompiledLoop` is consumed into `BridgeData` below,
-        // so its `gc_table` would drop with it; pin the table on the
-        // original loop's CLT (same scope as the bridge's fail descrs).
+        // Pin the bridge's `gc_table` on the original loop's CLT (same scope
+        // as the bridge's fail descrs, `compile.py:183-186`). The bridge code
+        // lives in the global `JITModule` and is also attached to fail descrs
+        // in other tokens, so each `BridgeData` below additionally holds an
+        // Arc clone — the table outlives every token that can dispatch to the
+        // bridge, not only `original_token`.
         if let Some(table) = compiled.gc_table.clone() {
             self.register_gc_table(original_token, table);
         }
@@ -15046,6 +15050,7 @@ impl majit_backend::Backend for CraneliftBackend {
                     max_output_slots: compiled.max_output_slots,
 
                     invalidated_arc: Some(invalidated_arc),
+                    gc_table: compiled.gc_table.clone(),
                 },
             );
             // Cranelift can't patch machine code like RPython's x86 backend.
@@ -15089,6 +15094,7 @@ impl majit_backend::Backend for CraneliftBackend {
                                         ),
                                         loop_reentry: b.loop_reentry,
                                         invalidated_arc: b.invalidated_arc.clone(),
+                                        gc_table: b.gc_table.clone(),
                                     },
                                 );
                             }
@@ -15227,6 +15233,7 @@ impl majit_backend::Backend for CraneliftBackend {
                             ),
                             loop_reentry: b.loop_reentry,
                             invalidated_arc: b.invalidated_arc.clone(),
+                            gc_table: b.gc_table.clone(),
                         },
                     );
                 }

--- a/majit/majit-backend-cranelift/src/guard.rs
+++ b/majit/majit-backend-cranelift/src/guard.rs
@@ -88,6 +88,14 @@ pub struct BridgeData {
     /// invalidation flag (AtomicBool). Holding an Arc clone keeps the flag
     /// alive as long as the bridge exists.
     pub invalidated_arc: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Per-loop `GcTable` whose base the bridge's machine code (which lives
+    /// in the global `JITModule`, outliving any single token) bakes in to
+    /// load reference constants. The bridge is attached to fail descrs in
+    /// several tokens; each holds an Arc clone so the table — and the slots
+    /// the baked base points at — stays alive and GC-walked as long as any
+    /// of them can dispatch to the bridge, not only while `original_token`
+    /// lives. `None` when the bridge has no reference constants.
+    pub gc_table: Option<Arc<majit_gc::GcTable>>,
 }
 
 unsafe impl Send for BridgeData {}

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2471,12 +2471,20 @@ impl<'a> AssemblerARM64<'a> {
             // The slot value is GC-forwarded in place by the gc_table
             // root walker, so each load observes the relocated object.
             OpCode::LoadFromGcTable => {
-                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
-                {
-                    let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
-                    self.emit_mov_imm64(dst.value as u32, slot_addr as i64);
-                    dynasm!(self.mc ; .arch aarch64 ; ldr X(dst.value), [X(dst.value)]);
-                }
+                let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
+                else {
+                    panic!(
+                        "LoadFromGcTable expects [Immed(index)] and a register result, \
+                         got arglocs={arglocs:?} result={result_loc:?}"
+                    );
+                };
+                debug_assert_ne!(
+                    self.gc_table_base, 0,
+                    "LoadFromGcTable emitted without a GcTable base"
+                );
+                let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
+                self.emit_mov_imm64(dst.value as u32, slot_addr as i64);
+                dynasm!(self.mc ; .arch aarch64 ; ldr X(dst.value), [X(dst.value)]);
             }
             // `opassembler.py:269-270 emit_op_cast_ptr_to_int =
             // _genop_same_as` / `emit_op_cast_int_to_ptr = _genop_same_as`.

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -3199,14 +3199,22 @@ impl<'a> Assembler386<'a> {
             // The slot value is GC-forwarded in place by the gc_table
             // root walker, so each load observes the relocated object.
             OpCode::LoadFromGcTable => {
-                if let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
-                {
-                    let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
-                    dynasm!(self.mc ; .arch x64
-                        ; mov Rq(dst.value), QWORD slot_addr as i64
-                        ; mov Rq(dst.value), [Rq(dst.value)]
+                let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
+                else {
+                    panic!(
+                        "LoadFromGcTable expects [Immed(index)] and a register result, \
+                         got arglocs={arglocs:?} result={result_loc:?}"
                     );
-                }
+                };
+                debug_assert_ne!(
+                    self.gc_table_base, 0,
+                    "LoadFromGcTable emitted without a GcTable base"
+                );
+                let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
+                dynasm!(self.mc ; .arch x64
+                    ; mov Rq(dst.value), QWORD slot_addr as i64
+                    ; mov Rq(dst.value), [Rq(dst.value)]
+                );
             }
             // `assembler.py:1528 genop_cast_ptr_to_int = _genop_same_as`
             // / `:1529 genop_cast_int_to_ptr = _genop_same_as`.  PyPy's

--- a/majit/majit-gc/src/gcreftracer.rs
+++ b/majit/majit-gc/src/gcreftracer.rs
@@ -184,6 +184,49 @@ mod tests {
     }
 
     #[test]
+    fn baked_load_reads_forwarded_ref_after_move() {
+        // End-to-end model of a ref constant surviving across compilation and
+        // later execution. The backend bakes a `LoadFromGcTable` as a load of
+        // `*(base + index*WORD)` (rewrite.py:1100 `remove_constptr`), with
+        // `base` fixed at compile time. A moving collection forwards the slot
+        // value in place (gcreftracer.py `trace`), so a later execution of the
+        // baked load observes the relocated address — no stale immediate. This
+        // is the shared dynasm/cranelift `LoadFromGcTable` contract; wasm never
+        // runs the GC rewrite (loud-panic), so it has no moving-GC ref-const
+        // path to cover.
+        let _serialize = TEST_REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let table = GcTable::from_gcrefs(&[GcRef(0x1000), GcRef(0x2000)]);
+        // `base` is the value baked into the trace at compile time.
+        let base = table.base_addr();
+        // `GcRef` is `#[repr(transparent)]` over `usize` and `Cell<GcRef>`
+        // shares that layout, so `base + index*WORD` addresses `slots[index]`
+        // exactly as the emitted machine load does.
+        let baked_load = |index: usize| -> usize {
+            // SAFETY: `index < len`; the slot is a live `Cell<GcRef>` (usize).
+            unsafe { *((base + index * core::mem::size_of::<usize>()) as *const usize) }
+        };
+        assert_eq!(baked_load(0), 0x1000, "pre-move load reads the original ref");
+        assert_eq!(baked_load(1), 0x2000);
+        // A moving collection relocates 0x1000 -> 0x9000.
+        table.trace(&mut |r| {
+            if r.0 == 0x1000 {
+                r.0 = 0x9000;
+            }
+        });
+        assert_eq!(
+            table.base_addr(),
+            base,
+            "baked base address is stable across the collection"
+        );
+        assert_eq!(
+            baked_load(0),
+            0x9000,
+            "post-move load via the baked base reads the forwarded ref"
+        );
+        assert_eq!(baked_load(1), 0x2000, "unmoved ref unchanged");
+    }
+
+    #[test]
     fn dropping_table_deregisters_from_walk() {
         let _serialize = TEST_REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // A sentinel unlikely to collide with any other test's table.

--- a/majit/majit-gc/src/gcreftracer.rs
+++ b/majit/majit-gc/src/gcreftracer.rs
@@ -205,7 +205,11 @@ mod tests {
             // SAFETY: `index < len`; the slot is a live `Cell<GcRef>` (usize).
             unsafe { *((base + index * core::mem::size_of::<usize>()) as *const usize) }
         };
-        assert_eq!(baked_load(0), 0x1000, "pre-move load reads the original ref");
+        assert_eq!(
+            baked_load(0),
+            0x1000,
+            "pre-move load reads the original ref"
+        );
         assert_eq!(baked_load(1), 0x2000);
         // A moving collection relocates 0x1000 -> 0x9000.
         table.trace(&mut |r| {

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -2838,7 +2838,18 @@ impl GcRewriterImpl {
 
 impl GcRewriter for GcRewriterImpl {
     fn rewrite_for_gc(&self, ops: &[Op]) -> Vec<Op> {
-        self.rewrite_for_gc_with_constants(ops, &VecAssoc::new()).0
+        let (rewritten, _constants, gcrefs) =
+            self.rewrite_for_gc_with_constants(ops, &VecAssoc::new());
+        // This wrapper drops the gc_table output list. A non-null ConstPtr
+        // operand is rewritten to LoadFromGcTable, which needs that list to
+        // build the table; callers carrying one must use the
+        // constants-returning form. Fail fast rather than emit IR whose
+        // table is silently discarded.
+        assert!(
+            gcrefs.is_empty(),
+            "rewrite_for_gc discards gc_table refs; use rewrite_for_gc_with_constants"
+        );
+        rewritten
     }
 
     fn rewrite_for_gc_with_constants(

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3353,18 +3353,6 @@ impl OptContext {
     /// returns whatever is stored — PtrInfo *or* IntBound — and calls
     /// `info.make_guards(...)` uniformly.
     fn collect_use_box_guards(&mut self, preamble_op: &Op) -> (Vec<Op>, Vec<Op>) {
-        // shortpreamble.py:383-396: guards for InputArg args only
-        let short_inputargs: Vec<crate::r#box::BoxRef> = self
-            .imported_short_preamble_builder
-            .as_ref()
-            .map(|b| b.short_inputargs().to_vec())
-            .or_else(|| {
-                self.active_short_preamble_producer
-                    .as_ref()
-                    .map(|b| b.short_inputargs().to_vec())
-            })
-            .unwrap_or_default();
-
         // shortpreamble.py:383-401 line-by-line:
         //
         //   for arg in preamble_op.getarglist():
@@ -3447,7 +3435,15 @@ impl OptContext {
             if arg.is_constant() || arg.is_none() {
                 continue;
             }
-            let is_input = short_inputargs.iter().any(|a| a.to_opref() == arg);
+            // shortpreamble.py:386 `isinstance(arg, AbstractInputArg)` — the
+            // classification is the arg's TYPE, not membership in
+            // `short_inputargs`. A renamed short inputarg and an original
+            // label arg are both AbstractInputArg; either way an input arg's
+            // forwarded info must NOT be cleared (it lives across iterations).
+            let is_input = matches!(
+                arg,
+                OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+            );
             if let Some(info) = snapshot_forwarded(self, arg) {
                 arg_entries.push(ArgEntry {
                     arg,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6157,9 +6157,8 @@ impl OptContext {
             let env = OptBoxEnv { ctx: self };
             let snapshot_debug: Vec<(OpRef, OpRef, bool, Type)> = snapshot_boxes
                 .iter()
-                .copied()
                 .map(|boxref| {
-                    let boxref = boxref.opref;
+                    let boxref = boxref.opref();
                     let resolved = self.get_replacement_opref(boxref);
                     let is_virtual = self
                         .get_box_replacement_box(boxref)
@@ -6172,9 +6171,8 @@ impl OptContext {
             let vable_debug: Vec<(OpRef, OpRef, bool, Type)> = snapshot
                 .vable_array
                 .iter()
-                .copied()
                 .map(|boxref| {
-                    let boxref = boxref.opref;
+                    let boxref = boxref.opref();
                     let resolved = self.get_replacement_opref(boxref);
                     let is_virtual = self
                         .get_box_replacement_box(boxref)

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -310,6 +310,18 @@ pub(crate) fn merge_backend_constants_from_ctx(
             crate::r#box::Forwarded::Const(c) => c.to_value(),
             _ => return,
         };
+        // A ref constant is never resolved from this backend pool: a referenced
+        // (live) ref operand is an inline ConstPtr that `remove_constptr`
+        // (rewrite.rs:613) rewrites to `LoadFromGcTable`, loading from the
+        // GC-traced gc_table. Only dead (non-result) const-folded positions
+        // reach here, and the recorder invariant (recorder.rs:209) forbids a
+        // `RefOp(pos)` operand from referencing a dead position, so a ref entry
+        // is vestigial. Dropping it keeps the pool — and the `CompiledTrace`
+        // constants cloned from it — free of raw `GcRef`, which has no GC root
+        // walker (the gc_table is the sole GC-traced ref store).
+        if matches!(value, majit_ir::Value::Ref(_)) {
+            return;
+        }
         if idx < live_positions.len() && live_positions[idx] {
             return;
         }
@@ -325,6 +337,15 @@ pub(crate) fn merge_backend_constants_from_ctx(
     for op in ctx.resop_refs.values() {
         consider(op);
     }
+    // No raw `GcRef` survives in the backend constant pool: the only other
+    // entries are pre-existing ones the caller threaded in, which must already
+    // hold no ref for the same reason.
+    debug_assert!(
+        constants
+            .values()
+            .all(|v| !matches!(v, majit_ir::Value::Ref(_))),
+        "backend constant pool must not retain a raw GcRef (use the gc_table)"
+    );
 }
 
 /// RPython unroll.py: import_state virtual info for Phase 2.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2157,7 +2157,7 @@ impl Optimizer {
             .chain(self.snapshot_vable_boxes.iter())
             .chain(self.snapshot_vref_boxes.iter())
             .flatten()
-            .flat_map(|boxes| boxes.iter().map(|boxref| boxref.opref))
+            .flat_map(|boxes| boxes.iter().map(|boxref| boxref.opref()))
             .filter(|opref| !opref.is_none() && !opref.is_constant())
             .map(|opref| opref.raw())
             .max()

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -3080,13 +3080,34 @@ mod tests {
         let ref_arg_const = OpRef::const_ptr(GcRef(0x4242));
         let result_ptr = GcRef(0xDEAD_BEEF);
 
-        let mut ops = vec![Op::new(
-            OpCode::CallPureR,
-            &[
-                BoxRef::from_opref(func_const),
-                BoxRef::from_opref(ref_arg_const),
-            ],
-        )];
+        // op0 hits the seeded cache and folds to a Ref constant. A second
+        // residual CallPureR (distinct key, no cache hit) consumes op0's
+        // result, so the fold is observed where it matters in production: the
+        // folded Ref reaches its consumer as an inline `ConstPtr` operand
+        // (later rewritten to `LoadFromGcTable` by the GC rewrite). #108: a Ref
+        // constant is NEVER exported as a raw `GcRef` into the backend constant
+        // pool — that pool has no GC root walker, so refs live only in the
+        // GC-traced gc_table. (The Int analog at :3037 DOES export to the pool;
+        // ints carry no GC concern.)
+        let func_const2 = OpRef::const_int(0xF00D);
+        let mut ops = vec![
+            Op::new(
+                OpCode::CallPureR,
+                &[
+                    BoxRef::from_opref(func_const),
+                    BoxRef::from_opref(ref_arg_const),
+                ],
+            ),
+            // arg(1) references op0's result position (RefOp(0)); after the
+            // fold it resolves to the inline ConstPtr of the cached result.
+            Op::new(
+                OpCode::CallPureR,
+                &[
+                    BoxRef::from_opref(func_const2),
+                    BoxRef::from_opref(OpRef::ref_op(0)),
+                ],
+            ),
+        ];
         assign_positions(&mut ops);
         // `assign_positions` types op.pos via result_type() → CallPureR
         // gives a Ref-typed position OpRef.
@@ -3106,25 +3127,35 @@ mod tests {
         opt.add_pass(Box::new(OptPure::new()));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1);
+        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 0);
 
-        // The 2nd identical CallPureR collapses to the cached constant —
-        // the op is removed entirely.
-        assert!(
-            result.is_empty(),
-            "identical-const-args CallPureR must be removed by call_pure_results fold; got {result:?}"
-        );
-        let folded = constants.get(&ops[0].pos.get().raw());
-        // The folded constant must be Ref-typed, value == result_ptr.
+        // op0 collapses to the cached constant (removed); op1 is the residual
+        // call that consumes it.
         assert_eq!(
-            folded,
-            Some(&Value::Ref(result_ptr)),
-            "CallPureR fold must yield ConstPtr(result_ptr), got {folded:?}"
+            result.len(),
+            1,
+            "op0 folds via call_pure_results; op1 residual remains; got {result:?}"
         );
-        // Critically: NOT a ConstInt of the same numeric value.
+        // A pure call with no cache hit lowers to a residual `CallR`.
+        let consumer = &result[0];
+        assert_eq!(consumer.opcode, OpCode::CallR);
+        // The folded constant reaches the consumer as ConstPtr(result_ptr)
+        // (history.py:314), NOT a ConstInt of the same numeric value
+        // (resoperation.py:638 `RefOp.type = 'r'`).
+        assert_eq!(
+            consumer.arg(1).to_opref(),
+            OpRef::const_ptr(result_ptr),
+            "CallPureR fold must yield ConstPtr(result_ptr), got {:?}",
+            consumer.arg(1).to_opref()
+        );
         assert!(
-            !matches!(folded, Some(Value::Int(_))),
-            "folded CallPureR constant aliased to Value::Int — ConstPtr/ConstInt distinction lost"
+            !matches!(consumer.arg(1).to_opref(), OpRef::ConstInt(_)),
+            "folded CallPureR constant aliased to ConstInt — ConstPtr/ConstInt distinction lost"
+        );
+        // #108: no raw GcRef is exported into the backend constant pool.
+        assert!(
+            constants.values().all(|v| !matches!(v, Value::Ref(_))),
+            "backend constant pool must not retain a raw GcRef (use the gc_table); got {constants:?}"
         );
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -675,8 +675,10 @@ impl ShortBoxes {
         // comes from the op-position counter so it is unique and accounted
         // for by `opref_high_water`; `raw()` shares the op/inputarg integer
         // space, so a fresh op position is a fresh inputarg position too.
-        let renamed =
-            crate::r#box::BoxRef::new_inputarg(arg_type, ctx.alloc_op_position_typed(arg_type).raw());
+        let renamed = crate::r#box::BoxRef::new_inputarg(
+            arg_type,
+            ctx.alloc_op_position_typed(arg_type).raw(),
+        );
         // `short_inputargs[i]` pairs with `label_args[i]`; callers feed args
         // in label-arg order (production: optimizer.rs preview loop), so an
         // append lands at the matching slot.

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -466,10 +466,20 @@ pub struct ShortBoxes {
     /// shortpreamble.py:256 `renamed = OpHelpers.inputarg_from_tp(box.type)`
     /// mints a fresh producer-less InputArg box per label slot; the stored
     /// boxes ARE the short preamble's Label args (shortpreamble.py:443).
-    /// pyre keeps the renamed box on the label arg's position (the rename
-    /// is positional), so each entry is a fresh position-only box minted
-    /// once here and compared by position.
+    /// Each entry is a fresh InputArg box whose position is allocated from
+    /// the op-position counter (`alloc_op_position_typed`), so its identity
+    /// is DISTINCT from the original label arg (`shortpreamble.py:257`
+    /// `ShortInputArg(box, renamed)` — `box` and `renamed` are two objects).
+    /// `short_inputargs[i]` corresponds to `label_args[i]` positionally.
     short_inputargs: Vec<BoxRef>,
+    /// shortpreamble.py:256 `box = label_args[i]` — the ORIGINAL label-arg
+    /// references, kept so `potential_ops`/lookups resolve a label arg by
+    /// its own opref (`shortpreamble.py:259 potential_ops[box]`). pyre needs
+    /// this explicitly because OpRef positions are not object identities:
+    /// once `short_inputargs[i]` is a distinct renamed box, it no longer
+    /// carries the original label-arg identity, so the original must be
+    /// stored separately. `label_args[i]` pairs with `short_inputargs[i]`.
+    label_args: Vec<OpRef>,
     /// shortpreamble.py: boxes_in_production — cycle-detection set
     /// for `materialize_one` recursion, keyed by the result Box
     /// (shortpreamble.py:314 `self.boxes_in_production[shortop.res]`).
@@ -550,28 +560,32 @@ impl ShortBoxes {
             const_short_boxes: Vec::new(),
             known_constants: VecSet::new(),
             short_inputargs: Vec::new(),
+            label_args: Vec::new(),
             boxes_in_production: VecSet::new(),
             num_label_args,
         }
     }
 
+    /// shortpreamble.py:254-259 — record the original label args. The
+    /// matching `short_inputargs` renamed boxes are minted lazily by
+    /// `add_short_input_arg` (one per `box`, in `label_args` order), so
+    /// only the originals are stored here.
     pub fn with_label_args(label_args: &[OpRef]) -> Self {
         let mut boxes = Self::new(label_args.len());
-        for &arg in label_args.iter() {
-            boxes.short_inputargs.push(BoxRef::from_opref(arg));
-        }
+        boxes.label_args = label_args.to_vec();
         boxes
     }
 
+    /// shortpreamble.py:259 `self.potential_ops[box]` — resolve a label
+    /// arg to its slot by the ORIGINAL box opref (not the renamed
+    /// `short_inputargs` box, which is a distinct identity).
     pub fn lookup_label_arg(&self, opref: OpRef) -> Option<usize> {
-        self.short_inputargs
-            .iter()
-            .position(|a| a.to_opref() == opref)
+        self.label_args.iter().position(|&a| a == opref)
     }
 
     /// RPython parity: check if opref is reachable in the short preamble.
     pub fn is_reachable(&self, opref: OpRef) -> bool {
-        self.short_inputargs.iter().any(|a| a.to_opref() == opref)
+        self.label_args.iter().any(|&a| a == opref)
             || opref.is_constant()
             || self.potential_ops.iter().any(|(k, _)| *k == opref)
     }
@@ -646,19 +660,38 @@ impl ShortBoxes {
                  (shortpreamble.py:255-259)"
             );
         }
-        let label_arg_idx = self.lookup_label_arg(arg);
-        // shortpreamble.py:257 `ShortInputArg(box, renamed)` — the SAME_AS
-        // replay arg is the label-arg Box itself (= `res`); bind its
-        // producer once and share the object.
+        // shortpreamble.py:256 `box = label_args[i]` — record the original.
+        // `with_label_args` pre-seeds `label_args`; the standalone
+        // `create_short_boxes` path (empty `label_args`) appends here.
+        let label_arg_idx = match self.lookup_label_arg(arg) {
+            Some(idx) => idx,
+            None => {
+                self.label_args.push(arg);
+                self.label_args.len() - 1
+            }
+        };
+        // shortpreamble.py:257 `renamed = OpHelpers.inputarg_from_tp(box.type)`
+        // — a FRESH InputArg distinct from the original `box`. Its position
+        // comes from the op-position counter so it is unique and accounted
+        // for by `opref_high_water`; `raw()` shares the op/inputarg integer
+        // space, so a fresh op position is a fresh inputarg position too.
+        let renamed =
+            crate::r#box::BoxRef::new_inputarg(arg_type, ctx.alloc_op_position_typed(arg_type).raw());
+        // `short_inputargs[i]` pairs with `label_args[i]`; callers feed args
+        // in label-arg order (production: optimizer.rs preview loop), so an
+        // append lands at the matching slot.
+        debug_assert_eq!(
+            label_arg_idx,
+            self.short_inputargs.len(),
+            "add_short_input_arg must be called in label_args order so \
+             short_inputargs[i] pairs with label_args[i]"
+        );
+        self.short_inputargs.push(renamed);
+        // shortpreamble.py:257 `ShortInputArg(box, renamed)` — `res` is the
+        // original `box`; the SAME_AS replay arg is that box. Exported
+        // entries carry original positions and are renamed to the matching
+        // `short_inputargs` slot at import (`produced_short_boxes_from_exported_boxes`).
         let arg_box = ctx.materialize_box_at(arg);
-        // shortpreamble.py:255-259 — `short_inputargs` carry those same
-        // label-arg Box objects. Rebind the position-only skeleton slot
-        // from `with_label_args` so every consumer (create_short_inputargs
-        // → ExportedState → produced_short_boxes rename) shares the
-        // canonical producer-bound box.
-        if let Some(idx) = label_arg_idx {
-            self.short_inputargs[idx] = arg_box.clone();
-        }
         let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[arg_box.clone()]);
         same_as.pos.set(arg);
         self.potential_ops.insert(
@@ -667,7 +700,7 @@ impl ShortBoxes {
                 res: arg_box,
                 op: std::rc::Rc::new(same_as),
                 kind: PreambleOpKind::InputArg,
-                label_arg_idx,
+                label_arg_idx: Some(label_arg_idx),
                 invented_name: false,
                 same_as_source: None,
             }),
@@ -727,9 +760,12 @@ impl ShortBoxes {
                 }
             });
         }
-        // Label args are always available as inputs (RPython: isinstance(op, InputArgIntOp))
-        if let Some(arg) = self.short_inputargs.iter().find(|a| a.to_opref() == opref) {
-            return Some(arg.clone());
+        // Label args are always available as inputs (RPython: isinstance(op, InputArgIntOp)).
+        // Return the ORIGINAL label-arg box; exported entries carry original
+        // positions and are renamed to the matching short_inputargs slot at
+        // import. Match by the original opref, not the (distinct) renamed box.
+        if self.label_args.iter().any(|&a| a == opref) {
+            return Some(ctx.materialize_box_at(opref));
         }
         None
     }
@@ -3828,6 +3864,39 @@ mod tests {
             alias.1.same_as_source.as_ref().map(|b| b.to_opref()),
             Some(OpRef::int_op(10))
         );
+    }
+
+    #[test]
+    fn test_short_inputargs_have_distinct_renamed_identity() {
+        // shortpreamble.py:256-258 `renamed = OpHelpers.inputarg_from_tp(box.type)`
+        // — each short inputarg is a FRESH InputArg distinct from the original
+        // label arg `box`. pyre's old position-identity model reused the label
+        // arg's OpRef; this test locks the distinct-renamed-box parity.
+        let mut ctx = crate::optimizeopt::OptContext::new(256);
+        let label_args = [OpRef::int_op(10), OpRef::ref_op(11)];
+        let mut sb = ShortBoxes::with_label_args(&label_args);
+        sb.add_short_input_arg(&mut ctx, OpRef::int_op(10), majit_ir::Type::Int);
+        sb.add_short_input_arg(&mut ctx, OpRef::ref_op(11), majit_ir::Type::Ref);
+
+        let si = sb.create_short_inputargs(&label_args);
+        assert_eq!(si.len(), 2);
+
+        // (A) DISTINCT identity: the renamed box is not the original label arg.
+        assert_ne!(si[0].to_opref(), OpRef::int_op(10));
+        assert_ne!(si[1].to_opref(), OpRef::ref_op(11));
+
+        // (B) the renamed boxes are InputArg-kind of the matching type
+        // (inputarg_from_tp(box.type)).
+        assert!(matches!(si[0].to_opref(), OpRef::InputArgInt(_)));
+        assert!(matches!(si[1].to_opref(), OpRef::InputArgRef(_)));
+        assert_eq!(si[0].to_opref().ty(), Some(majit_ir::Type::Int));
+        assert_eq!(si[1].to_opref().ty(), Some(majit_ir::Type::Ref));
+
+        // (C) lookups still resolve a label arg by its ORIGINAL opref
+        // (shortpreamble.py:259 potential_ops[box]).
+        assert_eq!(sb.lookup_label_arg(OpRef::int_op(10)), Some(0));
+        assert_eq!(sb.lookup_label_arg(OpRef::ref_op(11)), Some(1));
+        assert!(sb.is_reachable(OpRef::int_op(10)));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -312,9 +312,7 @@ impl UnrollOptimizer {
                     for sb in boxes {
                         if let Some(majit_ir::Value::Ref(gcref)) = sb.opref_box.const_value() {
                             if !gcref.is_null() {
-                                slots.push(
-                                    (&sb.opref_box as *const BoxRef) as usize,
-                                );
+                                slots.push((&sb.opref_box as *const BoxRef) as usize);
                             }
                         }
                     }
@@ -714,6 +712,7 @@ impl UnrollOptimizer {
                             short_preamble: None,
                             renamed_inputargs: state.renamed_inputargs.clone(),
                             short_inputargs: Vec::new(),
+                            short_label_args: Vec::new(),
                             runtime_boxes: Vec::new(),
                             patchguardop: None,
                             phase1_emit_high_water: self.next_global_opref,
@@ -1130,6 +1129,7 @@ impl UnrollOptimizer {
             exported_vs,
             exported_end_args,
             exported_short_inputargs,
+            exported_short_label_args,
             exported_short_boxes_produced,
             exported_renamed_inputargs,
             exported_runtime_boxes,
@@ -1142,6 +1142,7 @@ impl UnrollOptimizer {
                 es.virtual_state.clone(),
                 es.end_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
                 es.short_inputargs.clone(),
+                es.short_label_args.clone(),
                 es.short_boxes.clone(),
                 es.renamed_inputargs
                     .iter()
@@ -1306,20 +1307,57 @@ impl UnrollOptimizer {
                 &exported_short_boxes_produced,
             )
         });
-        // shortpreamble.py:414-425 parity: store PtrInfo for each inputarg.
-        // In RPython, preamble_op.set_forwarded(info) attaches PtrInfo to
-        // the short_inputarg Box. In majit, we extract from Phase 2 final_ctx
-        // so inline_short_preamble can propagate to jump_args.
+        // shortpreamble.py:416-425 parity: attach PtrInfo to each short
+        // inputarg. RPython keys the info by the ORIGINAL res box
+        // (`op = produced_op.short_op.res; info = exported_infos.get(op)`)
+        // and forwards it onto the renamed `preamble_op`. The renamed short
+        // inputarg carries no PtrInfo of its own, so the lookup MUST use the
+        // original `short_label_args[i]` (paired 1:1 with `short_inputargs[i]`),
+        // not the renamed box — otherwise a distinct renamed identity yields
+        // None and the loop-carried info (e.g. KnownClass) is dropped.
         if let Some(ref final_ctx) = opt_p2.final_ctx {
+            debug_assert_eq!(
+                initial_sp.inputargs.len(),
+                exported_short_label_args.len(),
+                "short_inputargs must pair 1:1 with short_label_args for info carry"
+            );
             let mut infos = Vec::with_capacity(initial_sp.inputargs.len());
-            for inputarg in &initial_sp.inputargs {
-                let info = final_ctx
-                    .resolve_box_box_opt(inputarg)
+            for (i, inputarg) in initial_sp.inputargs.iter().enumerate() {
+                // Phase-2 info of the original box this short inputarg renames.
+                let original = exported_short_label_args.get(i).copied();
+                let info = original
+                    .and_then(|o| final_ctx.get_box_replacement_box(o))
+                    .or_else(|| final_ctx.resolve_box_box_opt(inputarg))
                     .as_ref()
                     .and_then(|b| final_ctx.peek_ptr_info(b));
                 infos.push(info);
             }
             initial_sp.inputarg_infos = infos;
+        }
+        // shortpreamble.py:255-259 renamed-short_inputargs: the short-preamble
+        // Label is the renamed `short_inputargs`, but use_box guards still
+        // reference the ORIGINAL Phase-1 label args (`short_label_args`) because
+        // pyre keeps disjoint Phase-1/Phase-2 box namespaces. Seed
+        // `phase1_inputargs` with the originals (paired 1:1 with the renamed
+        // Label / jump_args) so inline_short_preamble (unroll.rs:3691) maps an
+        // original-referencing guard arg to its jump_arg. Mirrors the existing
+        // phase1_inputargs adaptation; no-op when the Label already IS the
+        // originals (the two box sets coincide).
+        if initial_sp.phase1_inputargs.is_none()
+            && initial_sp.inputargs.len() == exported_short_label_args.len()
+        {
+            let differs = exported_short_label_args
+                .iter()
+                .zip(initial_sp.inputargs.iter())
+                .any(|(orig, label)| *orig != label.to_opref());
+            if differs {
+                initial_sp.phase1_inputargs = Some(
+                    exported_short_label_args
+                        .iter()
+                        .map(|&o| BoxRef::from_opref(o))
+                        .collect(),
+                );
+            }
         }
         let opt_unroll = OptUnroll::new();
         let target_token = opt_unroll.finalize_short_preamble(
@@ -1941,6 +1979,14 @@ pub struct ExportedState {
     /// objects themselves (shortpreamble.py:430 / unroll.py:480), shared
     /// with the renamed operands inside `short_boxes`.
     pub short_inputargs: Vec<crate::r#box::BoxRef>,
+    /// The ORIGINAL `label_args + virtuals` oprefs that `short_inputargs[i]`
+    /// renames (`shortpreamble.py:256 box = label_args[i]`). pyre stores
+    /// these explicitly because the renamed `short_inputargs[i]` no longer
+    /// carries the original identity; the exported short boxes reference
+    /// original positions and are renamed to `short_inputargs[i]` at import,
+    /// and the Phase-2 `result_map` slot lookup resolves a short-box key
+    /// (an original position) to its slot through this list.
+    pub short_label_args: Vec<OpRef>,
     /// unroll.py: runtime_boxes — live values at the original jump point.
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
     /// Default `Vec::new()` until the export site populates it; callers
@@ -2030,14 +2076,27 @@ impl ExportedState {
         exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
         renamed_inputargs: Vec<OpRef>,
         short_inputargs: Vec<crate::r#box::BoxRef>,
+        short_label_args: Vec<OpRef>,
     ) -> Self {
         // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
         // pre-derives the per-OpRef ProducedShortOp view (with label-arg
         // refs renamed to short-inputarg slots) and stores it directly,
         // matching RPython's `ExportedState.short_boxes`.
+        //
+        // The rename source is `short_label_args` (= label_args + virtuals),
+        // the full list `short_inputargs[i]` corresponds to — NOT `end_args`
+        // (label args only). Exported ops can reference a virtual position
+        // through a ShortInputArg dependency, so virtuals must rename too
+        // (`shortpreamble.py:255-259` registers every `label_args + virtuals`
+        // entry as a ShortInputArg).
+        debug_assert_eq!(
+            short_label_args.len(),
+            short_inputargs.len(),
+            "short_label_args must pair 1:1 with short_inputargs"
+        );
         let short_boxes =
             crate::optimizeopt::shortpreamble::produced_short_boxes_from_exported_boxes(
-                &end_args,
+                &short_label_args,
                 &short_inputargs,
                 &exported_short_boxes,
             );
@@ -2059,6 +2118,7 @@ impl ExportedState {
                 .map(|&a| BoxRef::from_opref(a))
                 .collect(),
             short_inputargs,
+            short_label_args,
             runtime_boxes: Vec::new(),
             patchguardop: None,
             phase1_emit_high_water: 0,
@@ -2187,6 +2247,12 @@ impl ExportedState {
         for arg in &self.short_inputargs {
             arg.walk_const_ptr_refs(visitor);
         }
+        // short_label_args are original label/virtual positions (op/inputarg
+        // kinds, never ConstPtr), so visit_opref is a no-op; walked for
+        // completeness and forward-compatibility.
+        for arg in &mut self.short_label_args {
+            visit_opref(arg, visitor);
+        }
         visit_boxrefs(&self.runtime_boxes, visitor);
         if let Some(patchguardop) = self.patchguardop.as_ref() {
             visit_op(patchguardop, visitor);
@@ -2240,6 +2306,9 @@ impl ExportedState {
         }
         for arg in &self.short_inputargs {
             visit(arg.to_opref());
+        }
+        for &arg in &self.short_label_args {
+            visit(arg);
         }
         for arg in &self.runtime_boxes {
             visit(arg.to_opref());
@@ -2580,6 +2649,7 @@ impl Clone for ExportedState {
             short_preamble: self.short_preamble.clone(),
             renamed_inputargs: self.renamed_inputargs.clone(),
             short_inputargs: self.short_inputargs.clone(),
+            short_label_args: self.short_label_args.clone(),
             runtime_boxes: self.runtime_boxes.clone(),
             patchguardop: self.patchguardop.clone(),
             phase1_emit_high_water: self.phase1_emit_high_water,
@@ -2908,18 +2978,25 @@ impl OptUnroll {
         // back to the local recompute.
         let short_inputargs: Vec<crate::r#box::BoxRef> = if ctx.exported_short_inputargs.is_empty()
         {
+            // No preview pass ran (test ExportedState setups): mint the fresh
+            // renamed InputArg boxes directly, mirroring `add_short_input_arg`
+            // (shortpreamble.py:257 `OpHelpers.inputarg_from_tp(box.type)`).
+            // Each is DISTINCT from its `short_args[i]` original so the rename
+            // is a real rename, not an identity no-op.
             short_args
                 .iter()
-                .map(|&a| crate::r#box::BoxRef::from_opref(a))
+                .map(|&a| {
+                    let ty = a.ty().unwrap_or_else(|| {
+                        panic!("short preamble inputarg {a:?} has no value type")
+                    });
+                    crate::r#box::BoxRef::new_inputarg(ty, ctx.alloc_op_position_typed(ty).raw())
+                })
                 .collect()
         } else {
             debug_assert_eq!(
-                ctx.exported_short_inputargs
-                    .iter()
-                    .map(|b| b.to_opref())
-                    .collect::<Vec<_>>(),
-                short_args,
-                "preview-pass create_short_inputargs diverged from the \
+                ctx.exported_short_inputargs.len(),
+                short_args.len(),
+                "preview-pass create_short_inputargs length diverged from the \
                      export-site label_args + virtuals recompute"
             );
             ctx.exported_short_inputargs.clone()
@@ -2945,7 +3022,7 @@ impl OptUnroll {
         // PyPy never carries into `short_boxes`, polluting the dict.
         let short_boxes_for_info =
             crate::optimizeopt::shortpreamble::produced_short_boxes_from_exported_boxes(
-                &label_args,
+                &short_args,
                 &short_inputargs,
                 &exported_short_boxes,
             );
@@ -2991,6 +3068,10 @@ impl OptUnroll {
             exported_short_boxes,
             renamed_inputargs.to_vec(),
             short_inputargs,
+            // shortpreamble.py:255-259 rename source = `label_args + virtuals`
+            // (the full list `short_inputargs` corresponds to), not label
+            // args alone — virtuals are registered as ShortInputArgs too.
+            short_args.clone(),
         );
         // `OptContext::next_pos` is the strict upper bound on raw OpRefs
         // Phase 1 allocated, including intermediates folded / forwarded
@@ -4034,10 +4115,14 @@ impl OptUnroll {
             let result = match produced.kind {
                 crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
                 | crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant => {
+                    // `source` is the short-box key = an ORIGINAL label/virtual
+                    // position. Match it against `short_label_args` (originals);
+                    // `short_inputargs[slot]` is now a distinct renamed box and
+                    // would never equal `source`.
                     if let Some(slot) = exported_state
-                        .short_inputargs
+                        .short_label_args
                         .iter()
-                        .position(|arg| arg.to_opref() == *source)
+                        .position(|a| *a == *source)
                     {
                         short_args.get(slot).copied()
                     } else {
@@ -5521,6 +5606,7 @@ mod tests {
             Vec::new(),
             vec![OpRef::int_op(14)],
             vec![BoxRef::from_opref(OpRef::int_op(23))],
+            vec![OpRef::int_op(23)],
         );
 
         assert_eq!(exported.opref_high_water(), 110);
@@ -5766,6 +5852,7 @@ mod tests {
             }],
             vec![old_ref],
             vec![BoxRef::from_opref(old_ref)],
+            vec![old_ref],
         );
         state.short_boxes.push((
             old_ref,
@@ -6752,6 +6839,7 @@ mod tests {
             }],
             Vec::new(),
             vec![BoxRef::from_opref(source)],
+            vec![source],
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
             8,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2169,6 +2169,13 @@ impl ExportedState {
             visit_opref(key, visitor);
             visit_produced_short_op(produced, visitor);
         }
+        // The key stays an `OpRef`, not a `BoxRef` (unlike the migrated #108
+        // sites): this is a value-keyed const lookup, and `BoxRef` is ordered
+        // and compared by `Rc` identity (no `Ord`, `Eq` via `Rc::ptr_eq`), so
+        // two `ConstPtr` boxes carrying the same gcref would be distinct keys
+        // and the dedup the map relies on would break. `visit_opref` already
+        // forwards the key's inline gcref canonically, and `visit_value`
+        // forwards the stored `Value::Ref`, so the slot is GC-safe as-is.
         for (key, value) in self.short_box_const_values.iter_entries_mut() {
             visit_opref(key, visitor);
             visit_value(value, visitor);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -310,9 +310,11 @@ impl UnrollOptimizer {
             for slot in map.iter_mut() {
                 if let Some(boxes) = slot {
                     for sb in boxes {
-                        if let majit_ir::OpRef::ConstPtr(gcref) = sb.opref {
+                        if let Some(majit_ir::Value::Ref(gcref)) = sb.opref_box.const_value() {
                             if !gcref.is_null() {
-                                slots.push((&mut sb.opref as *mut majit_ir::OpRef) as usize);
+                                slots.push(
+                                    (&sb.opref_box as *const BoxRef) as usize,
+                                );
                             }
                         }
                     }
@@ -5373,7 +5375,7 @@ fn remap_snapshot_boxes(
 ) -> Vec<SnapshotBox> {
     boxes
         .iter()
-        .map(|&boxref| boxref.map_opref(|opref| ref_map.get(&opref).copied().unwrap_or(opref)))
+        .map(|boxref| boxref.map_opref(|opref| ref_map.get(&opref).copied().unwrap_or(opref)))
         .collect()
 }
 

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -33,7 +33,16 @@ fn register_to_box_int(opref: OpRef, value: i64) -> OpBox {
 #[inline]
 fn register_to_box_ref(opref: OpRef, value: i64) -> OpBox {
     if opref.is_constant() {
-        OpBox::ConstPtr(value as u64)
+        // history.py:314 `ConstPtr.value` is the single object field. The
+        // forwarded gcref lives in the ConstPtr payload (the `ref_regs`
+        // BoxRef's Cell, updated in place by `walk_active_trace_refs`), so
+        // read it from `opref` rather than the unforwarded `ref_values`
+        // mirror, which is stale after a moving collection.
+        let bits = match opref {
+            OpRef::ConstPtr(gcref) => gcref.0 as u64,
+            _ => value as u64,
+        };
+        OpBox::ConstPtr(bits)
     } else {
         OpBox::ResOp(opref.raw())
     }
@@ -882,7 +891,14 @@ impl MIFrame {
                     let value = self.ref_values[idx]
                         .expect("get_list_of_active_snapshot_boxes: ref value uninitialized");
                     if opref.is_constant() {
-                        SnapshotTagged::Const(value, Type::Ref)
+                        // history.py:314 `ConstPtr.value` — take the forwarded
+                        // gcref from the BoxRef-derived ConstPtr, not the
+                        // unforwarded `ref_values` mirror (stale after a move).
+                        let bits = match opref {
+                            OpRef::ConstPtr(gcref) => gcref.0 as i64,
+                            _ => value,
+                        };
+                        SnapshotTagged::Const(bits, Type::Ref)
                     } else {
                         SnapshotTagged::Box(opref, Type::Ref)
                     }

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -440,9 +440,9 @@ fn collect_snapshot_const_ptr_slots(maps: &mut [&mut SnapshotBoxes]) -> Vec<usiz
         for slot in map.iter_mut() {
             if let Some(boxes) = slot {
                 for sb in boxes {
-                    if let majit_ir::OpRef::ConstPtr(gcref) = sb.opref {
+                    if let Some(majit_ir::Value::Ref(gcref)) = sb.opref_box.const_value() {
                         if !gcref.is_null() {
-                            slots.push((&mut sb.opref as *mut majit_ir::OpRef) as usize);
+                            slots.push((&sb.opref_box as *const BoxRef) as usize);
                         }
                     }
                 }
@@ -1073,11 +1073,10 @@ pub struct MetaInterp<M: Clone> {
     /// loop depends on. After compilation, the caller registers the loop's
     /// invalidation flag on each dep. Cleared on each compile attempt.
     pub last_quasi_immutable_deps: Vec<(u64, u32)>,
-    /// Addresses of live `SnapshotBox.opref` slots containing
-    /// `OpRef::ConstPtr` during compilation. RPython traces the
-    /// `ConstPtr.value` field in place; pyre's root walker follows these
-    /// slots directly so a moving GC updates the snapshot boxes the optimizer
-    /// will read.
+    /// Addresses of live `SnapshotBox.opref_box` `BoxRef`s holding a `Const`
+    /// reference during compilation. RPython traces the `ConstPtr.value` field
+    /// in place; pyre's root walker follows these slots directly so a moving
+    /// GC updates the snapshot boxes the optimizer will read.
     pub(crate) compile_snapshot_refs: Vec<usize>,
     /// Set by compile_bridge when optimizer returns retrace_requested=true.
     /// Checked by compile_bridge_trace to return RetraceNeeded.
@@ -1544,18 +1543,16 @@ impl<M: Clone> MetaInterp<M> {
     /// compilation. Cleared after compilation completes.
     pub fn walk_compile_snapshot_refs(&mut self, mut visitor: impl FnMut(&mut GcRef)) {
         for &slot_addr in &self.compile_snapshot_refs {
-            // SAFETY: entries are collected from `SnapshotBox.opref` slots
+            // SAFETY: entries are collected from `SnapshotBox.opref_box` slots
             // owned by the in-flight optimizer/OptContext and cleared at every
             // compile exit. The extra-root walker runs on the same thread while
             // compilation is paused for GC, mirroring RPython's in-place field
             // update of `ConstPtr.value`.
-            let opref = unsafe { &mut *(slot_addr as *mut majit_ir::OpRef) };
+            let b = unsafe { &*(slot_addr as *const BoxRef) };
             // Forward the snapshot slot's inline const gcref through the
-            // canonical BoxRef-Const walk, writing the updated ref back in
-            // place (mirroring an in-place ConstPtr.value field update).
-            let b = BoxRef::from_opref(*opref);
+            // canonical BoxRef-Const walk; the `Cell` get/set inside forwards
+            // the moved address in place (an in-place `ConstPtr.value` update).
             b.walk_const_ptr_refs(&mut visitor);
-            *opref = b.to_opref();
         }
     }
 
@@ -18252,7 +18249,7 @@ mod tests {
             snapshot_get(&prepared.snapshot_boxes, 0)
                 .unwrap()
                 .iter()
-                .map(|boxref| boxref.opref)
+                .map(|boxref| boxref.opref())
                 .collect::<Vec<_>>(),
             vec![
                 OpRef::input_arg_int(10),
@@ -18264,7 +18261,7 @@ mod tests {
             snapshot_get(&prepared.snapshot_vable_boxes, 0)
                 .unwrap()
                 .iter()
-                .map(|boxref| boxref.opref)
+                .map(|boxref| boxref.opref())
                 .collect::<Vec<_>>(),
             vec![OpRef::input_arg_ref(11), OpRef::ref_op(12)]
         );

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -219,27 +219,41 @@ pub struct Snapshot {
 /// at construction time. The explicit `tp` field stays around so the
 /// SnapshotBox API can answer `box.type` without re-decoding the
 /// variant on every read.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct SnapshotBox {
-    pub opref: majit_ir::OpRef,
+    /// The box this snapshot slot references, stored as a `BoxRef` so a
+    /// `Const{Ptr}` slot's inline gcref is GC-forwarded in place through the
+    /// canonical `BoxRef::walk_const_ptr_refs` (history.py:314
+    /// `ConstPtr.value`). Read the trace-position `OpRef` view via
+    /// [`SnapshotBox::opref`].
+    pub opref_box: majit_ir::box_ref::BoxRef,
     pub tp: Option<majit_ir::Type>,
 }
 
 impl SnapshotBox {
     pub fn untyped(opref: majit_ir::OpRef) -> Self {
-        SnapshotBox { opref, tp: None }
+        SnapshotBox {
+            opref_box: majit_ir::box_ref::BoxRef::from_opref(opref),
+            tp: None,
+        }
     }
 
     pub fn typed(opref: majit_ir::OpRef, tp: majit_ir::Type) -> Self {
         SnapshotBox {
-            opref,
+            opref_box: majit_ir::box_ref::BoxRef::from_opref(opref),
             tp: Some(tp),
         }
     }
 
-    pub fn map_opref(self, f: impl FnOnce(majit_ir::OpRef) -> majit_ir::OpRef) -> Self {
+    /// The trace-position `OpRef` view of this slot (inverse of
+    /// `BoxRef::from_opref`).
+    pub fn opref(&self) -> majit_ir::OpRef {
+        self.opref_box.to_opref()
+    }
+
+    pub fn map_opref(&self, f: impl FnOnce(majit_ir::OpRef) -> majit_ir::OpRef) -> Self {
         SnapshotBox {
-            opref: f(self.opref),
+            opref_box: majit_ir::box_ref::BoxRef::from_opref(f(self.opref())),
             tp: self.tp,
         }
     }
@@ -3694,8 +3708,8 @@ impl ResumeDataLoopMemo {
         numb_state: &mut NumberingState,
         env: &dyn BoxEnv,
     ) -> Result<(), TagOverflow> {
-        for &snapshot_box in boxes {
-            let raw_opref = snapshot_box.opref;
+        for snapshot_box in boxes {
+            let raw_opref = snapshot_box.opref();
             if raw_opref.is_none() {
                 numb_state.append_short(NULLREF);
                 continue;

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -932,7 +932,7 @@ def main():
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       13,      2,       13)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)
-        chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,       None,    1.5)
+        chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,       None,    2)
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",        5,       2,       7,       2,       7)
         chk.run_bench("nbody",          f"{B}/nbody.py",               10,       3,       None,    3,       None)
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       None)


### PR DESCRIPTION
Closes #108

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Carries the remaining #108 work on top of the merged PR #190 (per-loop
`gc_table` + `rgc.can_move` baking guard), plus the #9 short-preamble
box-domain migration the #108 review had deferred.

### #108 — GC-safe backend reference constants (finalize)

Post-merge review fixes for the merged `gc_table` / `can_move` work:

- **cranelift bridge `gc_table` keepalive** — bridge code lives in the global
  `JITModule` and is attached to multiple tokens, but the baked `GcTable` base
  was pinned only on the original token; clone the `Arc<GcTable>` into every
  attached token (Codex P1).
- **fail fast on broken `LoadFromGcTable` / gc_table-ref contracts** — silent
  `if let` → `let…else { panic! }` on loc-shape mismatch, `debug_assert_ne!`
  the table base, and `assert!(gcrefs.is_empty())` in the constants-less rewrite
  wrapper (CodeRabbit).
- **`SnapshotBox` reference stored as `BoxRef`** — drops the `*mut OpRef`
  snapshot reinterpret; the walk is now canonical `BoxRef::walk_const_ptr_refs`.
- **const ref register reads the forwarded gcref**, not the stale `ref_values`
  integer mirror (Codex §3#1).
- short_box_const_values OpRef key documented as a NO-GO (`BoxRef` has no `Ord`
  and identity `Eq`).

Closing the epic:

- **drop ref constants from the backend constant pool** —
  `merge_backend_constants_from_ctx` no longer exports `Value::Ref` into the
  per-trace pool / `CompiledTrace.constants`, which has no GC root walker. Ref
  entries there are vestigial: the pool only holds dead const-folded positions,
  the recorder invariant forbids a `RefOp(pos)` operand from referencing one,
  and real ref operands are inline `ConstPtr` rewritten to `LoadFromGcTable`.
  Closes the issue's known `CompiledTrace.constants` gap.
- **moving-GC ref-constant survival test** — `baked_load_reads_forwarded_ref_after_move`
  models the baked `LoadFromGcTable` reading a forwarded slot after a collection.

The issue's extended `Const::RefHandle` / `rd_consts` handle-table criteria are
**declined as an upstream divergence**: `walk_rd_consts_refs` + the `rd_consts`
`UnsafeCell` faithfully emulate RPython's automatic `ConstPtr` object-graph
tracing (`history.py:307`); a handle table has no parity basis. Full rationale
in the issue.

### #9 — renamed `short_inputargs` box-domain migration

- **classify use_box args by type, not `short_inputargs` membership** —
  `isinstance(arg, AbstractInputArg)` (shortpreamble.py:386), so an input arg's
  forwarded info is not cleared across iterations.
- **mint distinct renamed `short_inputargs` boxes** —
  `OpHelpers.inputarg_from_tp(box.type)` (shortpreamble.py:256-259);
  `label_args` / `short_label_args` hold the originals, and `phase1_inputargs`
  is seeded with the originals so `inline_short_preamble` maps an
  original-referencing use_box guard to its jump_arg. Removes the 3.5×
  nested_loop regression the naive flip caused.

### Validation

- `cargo test -p majit-metainterp` 1319/0 (dynasm) + 1317/0 (cranelift);
  `cargo test -p majit-gc` 159/0.
- `pyre/check.py` 127/127 both backends on aarch64 **and** x86_64/Rosetta;
  `trace.rs:820` OOB canary clean.
- nested_loop 1.2× / 1.1× (no regression vs the pre-flip baseline).

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection reference handling and forwarding across optimization and compilation phases for greater correctness
  * Enhanced code generation validation with clearer error diagnostics when encountering invalid operand patterns

* **Tests**
  * Added comprehensive test coverage for garbage collection reference behavior during code execution and optimization

* **Chores**
  * Updated benchmark comparison thresholds and refined internal optimizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->