### PR TITLE
Collapse the module/exec globals double-storage onto the canonical dict object

### DIFF
--- a/pyre/bench/synth/exec_defined_global_read.py
+++ b/pyre/bench/synth/exec_defined_global_read.py
@@ -1,0 +1,38 @@
+N = 200
+
+
+def main():
+    # A function defined inside `exec(src, fresh_dict)` captures the fresh
+    # dict as its `__globals__`.  Calling it enough to JIT-compile a trace
+    # must keep resolving its module globals (LOAD_GLOBAL `ADDEND`) — the
+    # frame's globals object is the exec dict, and its backing storage must
+    # stay live after `exec` returns.
+    ns = {}
+    exec(
+        "ADDEND = 3\n"
+        "def hot(n):\n"
+        "    s = 0\n"
+        "    i = 0\n"
+        "    while i < n:\n"
+        "        s = s + i + ADDEND\n"
+        "        i = i + 1\n"
+        "    return s\n",
+        ns,
+    )
+    hot = ns["hot"]
+    total = 0
+    for _ in range(N):
+        total = total + hot(N)
+    print(total)
+
+    # STORE_GLOBAL inside an exec-defined function writes the exec dict.
+    exec("def setter():\n global Z\n Z = 99\n", ns)
+    ns["setter"]()
+    print(ns.get("Z"))
+
+    # A global mutated after exec is visible to the exec-defined reader.
+    ns["ADDEND"] = 10
+    print(hot(5))
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3860,14 +3860,9 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
                 "__globals__" => {
                     // `funcobject.py:325 fget_func_globals` returns
-                    // `self.w_func_globals` directly.  Pyre's cached
-                    // `function_get_globals_obj` returns the same
-                    // canonical W_DictObject as
-                    // `dict_storage_to_dict(function_get_globals(obj))`
-                    // (mirror_target invariant) but skips the
-                    // HashMap lookup on subsequent reads — every
-                    // `f.__globals__` access on the same function
-                    // re-uses the slot stamped on first call.
+                    // `self.w_func_globals` directly — the function's
+                    // `w_func_globals_obj` field, the canonical W_DictObject
+                    // shared with the defining module's `__dict__`.
                     return Ok(unsafe { crate::function_get_globals_obj(obj) });
                 }
                 "__defaults__" => {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4283,19 +4283,30 @@ fn exec_or_eval(
             }
         }
 
-        /// Restore the user dict's pre-exec proxy and clear the temp
-        /// storage's `mirror_target`.  Idempotent.  Called via `Drop`
-        /// on every exit path including `?` early-returns and
-        /// panic-unwinds.
+        /// Tear down the forward proxy / back-mirror — but only when we do
+        /// NOT own a temp storage.
+        ///
+        /// For a fresh user dict the temp `DictStorage` is leaked (`Drop`)
+        /// and must stay attached as the dict's `dict_storage_proxy` with
+        /// its `mirror_target` intact: functions defined during the run
+        /// capture the user dict OBJECT as `__globals__`, and
+        /// `get_w_globals()` recovers their raw storage through that proxy.
+        /// Restoring the pre-exec (typically null) proxy or clearing the
+        /// mirror would orphan the leaked temp and resolve a captured
+        /// function's globals to a null raw.  So the owned case persists.
+        ///
+        /// The reuse path (existing proxy) and the empty binding own no
+        /// temp and never swapped a proxy, so there is nothing to undo.
+        /// Idempotent; called explicitly after the run and again on `Drop`.
         unsafe fn detach(&mut self) {
+            if self.owned.is_some() {
+                return;
+            }
             unsafe {
                 if self.proxy_attached {
                     pyre_object::w_dict_set_dict_storage_proxy(self.backing, self.saved_proxy);
                     self.proxy_attached = false;
                     self.saved_proxy = std::ptr::null_mut();
-                }
-                if let Some(storage) = self.owned.as_deref_mut() {
-                    storage.set_mirror_target(pyre_object::PY_NULL);
                 }
             }
         }
@@ -4311,18 +4322,19 @@ fn exec_or_eval(
             // `pypy/interpreter/pyopcode.py:771-776 EXEC_STMT` runs the
             // frame on the user-supplied dict directly — there is no
             // temp storage to release because the dict object IS the
-            // canonical store.  Pyre's pre-Phase-5-cutover model
-            // allocates a temp `DictStorage` and mirrors writes back
-            // into the user dict via `mirror_target`; functions defined
-            // during `exec` capture `w_func_globals = temp_storage_ptr`,
-            // so dropping the `Box<DictStorage>` here would dangle the
-            // captures and surface as a use-after-free on the next
-            // `g["reader"]()` invocation.  Leak the Box until the full
-            // `LegacyGlobalsBox` retirement lands (remaining
-            // slice — frame.w_globals becomes a PyObjectRef so the
-            // captured globals identity IS the backing dict and no
-            // temp is needed).  Memory cost is one DictStorage per
-            // exec invocation, which is bounded by program lifetime.
+            // canonical store.  Pyre allocates a temp `DictStorage` and
+            // mirrors writes back into the user dict via `mirror_target`.
+            // Functions defined during `exec` capture the user dict
+            // OBJECT as `__globals__`; `get_w_globals()` recovers their
+            // raw storage through the dict's `dict_storage_proxy`, which
+            // points at this temp.  `detach()` therefore leaves the proxy
+            // and mirror attached for the owned case, and the Box is
+            // leaked here so the proxy never dangles — dropping it would
+            // surface as a use-after-free (or, post-cutover, a null raw
+            // and a JIT-resume null deref) on the next `g["reader"]()`.
+            // Leak persists until exec runs on the dict object directly
+            // and no temp is needed.  Memory cost is one DictStorage per
+            // exec invocation, bounded by program lifetime.
             if let Some(storage) = self.owned.take() {
                 let _ = Box::into_raw(storage);
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4132,217 +4132,66 @@ fn exec_or_eval(
         }
     }
 
-    /// Build a `DictStorage` mirror for the user dict and bind the
-    /// user dict's `W_DictObject` as the storage's `mirror_target`,
-    /// so every storage-side write (STORE_GLOBAL) and delete
-    /// (DELETE_GLOBAL) propagates straight back into the user dict's
-    /// entries Vec while exec runs.  PyPy `pyopcode.py:771-776`
-    /// achieves the same shape by running the frame on the user dict
-    /// directly; pyre's frame layout still uses `*mut DictStorage`
-    /// for the bytecode-handler fastpath, so we get parity by paring
-    /// a forward storage proxy (W_DictObject → storage, already
-    /// wired) with this back-mirror (storage → W_DictObject) — the
-    /// two halves stand in for PyPy's single `W_DictMultiObject`.
+    /// Ensure the globals dict OBJECT carries a str-keyed `DictStorage`
+    /// proxy for the bytecode globals fastpath (LOAD_GLOBAL /
+    /// STORE_GLOBAL / DELETE_GLOBAL).
     ///
-    /// The initial population copy is mandatory because the bytecode
-    /// handlers read from `*mut DictStorage`; LOAD_GLOBAL would
-    /// otherwise miss every binding the user dict already held.  The
-    /// mirror runs from this point on so no post-exec drain is
-    /// needed: the user dict is always in sync.
+    /// `pypy/interpreter/pyopcode.py:771-776` runs the frame on the user
+    /// dict directly; pyre's bytecode handlers still read a `*mut
+    /// DictStorage`, so the dict needs a storage proxy attached.  Module
+    /// dicts and dicts returned by `globals()` already carry one — reused
+    /// as-is, so a second `exec(src, g)` allocates nothing (heap-stable).
     ///
-    /// RAII binding for the frame's globals storage.
+    /// A fresh dict (`exec(src, {})`) gets one storage allocated,
+    /// pre-populated from its str-keyed entries (LOAD_GLOBAL must see
+    /// bindings the dict already held), back-mirrored (`set_mirror_target`,
+    /// so STORE_GLOBAL / DELETE_GLOBAL through the storage propagate into
+    /// the dict's entries), and attached as the proxy (so the dict's own
+    /// `__setitem__` fans str-keyed writes back into the storage via
+    /// `maybe_sync_dict_storage_store`).  The two halves stand in for
+    /// PyPy's single `W_DictMultiObject`.
     ///
-    /// Lifecycle (PyPy `pyopcode.py:771-776` parity — the user dict
-    /// and the frame's `w_globals` are one and the same throughout
-    /// the run):
-    ///
-    /// * **User dict has an existing `dict_storage_proxy`** (typical
-    ///   for `module.__dict__` whose proxy is the module's own
-    ///   storage with a back-mirror to the entries Vec): the binding
-    ///   reuses that proxy directly as the frame's globals.  No temp
-    ///   allocation, no proxy swap, no post-exec replay — STORE_GLOBAL
-    ///   / DELETE_GLOBAL inside `exec("del x", module.__dict__)` land
-    ///   on the very dict the module sees afterwards.
-    ///
-    /// * **User dict has no existing proxy** (typical fresh
-    ///   `exec(src, {})`): the binding owns a temp `DictStorage`
-    ///   pre-populated from the user dict's str-keyed entries with
-    ///   `mirror_target = backing`; `attach_forward_proxy` is called
-    ///   exactly once after all fallible setup so a `?` early-return
-    ///   never leaves a dangling proxy hand-off.
-    ///
-    /// `Drop` (and `detach`) clears both halves idempotently: forward
-    /// proxy restored to its pre-exec value, and `mirror_target`
-    /// reset on the temp storage so the box can drop without an
-    /// observer holding a freed pointer.  This is the cleanup hole
-    /// guard for `createframe` and `setdictscope_object` early
-    /// returns.
-    struct GlobalsBinding {
-        /// Owned temp storage when allocated; `None` when reusing an
-        /// existing proxy storage.
-        owned: Option<Box<crate::DictStorage>>,
-        /// The storage the frame uses for `w_globals`.  Either the
-        /// owned temp storage's interior pointer, or the user dict's
-        /// existing proxy.
-        storage_ptr: *mut crate::DictStorage,
-        /// User dict's W_DictObject backing (`PY_NULL` when no user
-        /// dict, e.g. `exec(src)` with no globals arg).
-        backing: pyre_object::PyObjectRef,
-        /// `true` once `attach_forward_proxy` swapped the user dict's
-        /// proxy to point at our temp storage; cleared by `detach`.
-        proxy_attached: bool,
-        /// User dict's pre-attach proxy, restored by `detach` when
-        /// `proxy_attached` is true.  Always null otherwise.
-        saved_proxy: *mut u8,
-    }
-
-    impl GlobalsBinding {
-        fn empty() -> Self {
-            Self {
-                owned: None,
-                storage_ptr: std::ptr::null_mut(),
-                backing: std::ptr::null_mut(),
-                proxy_attached: false,
-                saved_proxy: std::ptr::null_mut(),
-            }
+    /// The storage is owned by the dict for its lifetime — functions
+    /// defined during the run capture the dict OBJECT as `__globals__` and
+    /// recover this storage via `get_w_globals()` — so it is intentionally
+    /// leaked alongside the dict rather than freed.  Retires with the
+    /// `dict_storage_proxy` bridge when the dict becomes the single store.
+    fn ensure_globals_storage_proxy(w_globals_obj: pyre_object::PyObjectRef) {
+        if w_globals_obj.is_null() {
+            return;
         }
-
-        fn from_user_dict(d: pyre_object::PyObjectRef) -> Self {
-            let backing = unsafe { crate::type_methods::resolve_dict_backing(d) };
-            if backing.is_null() {
-                return Self::empty();
-            }
-            let existing_proxy = unsafe { pyre_object::w_dict_get_dict_storage_proxy(backing) };
-            if !existing_proxy.is_null() {
-                // Reuse the existing proxy storage directly.  PyPy
-                // `pyopcode.py:771` — the frame runs on the very
-                // same dict the caller passed in, so `exec("del x",
-                // module.__dict__)` removes from the module's
-                // storage rather than a temp copy that gets thrown
-                // away.  No proxy swap, no replay, no extra
-                // bookkeeping.
-                return Self {
-                    owned: None,
-                    storage_ptr: existing_proxy as *mut crate::DictStorage,
-                    backing,
-                    proxy_attached: false,
-                    saved_proxy: std::ptr::null_mut(),
-                };
-            }
-            // Fresh user dict — allocate a temp storage, pre-populate
-            // from the user dict's str-keyed entries, and bind the
-            // back-mirror so storage-side writes propagate to the
-            // user dict's entries Vec while exec runs.  Forward proxy
-            // attach is deferred to `attach_forward_proxy` so any
-            // fallible setup between here and `frame.run()`
-            // (createframe, setdictscope_object) cannot leave the
-            // user dict pointing at a Box we're about to drop.
-            let mut ns = Box::new(crate::DictStorage::new());
-            unsafe {
-                for (key, value) in pyre_object::w_dict_items(backing) {
-                    if !value.is_null() && pyre_object::is_str(key) {
-                        let name = pyre_object::w_str_get_value(key).to_string();
-                        crate::dict_storage_store(&mut ns, &name, value);
-                    }
-                }
-                ns.set_mirror_target(backing);
-            }
-            ns.fix_ptr();
-            let storage_ptr: *mut crate::DictStorage = ns.as_mut() as *mut _;
-            Self {
-                owned: Some(ns),
-                storage_ptr,
-                backing,
-                proxy_attached: false,
-                saved_proxy: std::ptr::null_mut(),
-            }
+        // Dispatch storage on `resolve_dict_backing` (a dict subclass
+        // resolves to itself; a dict-proxy / mapping to its inner dict),
+        // mirroring PyPy's storage-vs-original split.
+        let backing = unsafe { crate::type_methods::resolve_dict_backing(w_globals_obj) };
+        if backing.is_null() {
+            return;
         }
-
-        /// Attach the temp storage as the user dict's
-        /// `dict_storage_proxy` so alias mutations
-        /// (`exec("g['x']=1; y=x", g)`) propagate from the user
-        /// dict's W_DictObject into the frame's storage.  No-op when
-        /// reusing an existing proxy.  Call exactly once, AFTER all
-        /// fallible setup, so a `?` early-return cannot leave the
-        /// user dict pointing at a Box we're about to drop.
-        unsafe fn attach_forward_proxy(&mut self) {
-            unsafe {
-                if self.proxy_attached
-                    || self.owned.is_none()
-                    || self.backing.is_null()
-                    || self.storage_ptr.is_null()
-                {
-                    return;
-                }
-                self.saved_proxy = pyre_object::w_dict_get_dict_storage_proxy(self.backing);
-                pyre_object::w_dict_set_dict_storage_proxy(
-                    self.backing,
-                    self.storage_ptr as *mut u8,
-                );
-                self.proxy_attached = true;
-            }
+        if !unsafe { pyre_object::w_dict_get_dict_storage_proxy(backing) }.is_null() {
+            // module.__dict__ / globals() / a dict reused across exec —
+            // already storage-backed, nothing to allocate.
+            return;
         }
-
-        /// Tear down the forward proxy / back-mirror — but only when we do
-        /// NOT own a temp storage.
-        ///
-        /// For a fresh user dict the temp `DictStorage` is leaked (`Drop`)
-        /// and must stay attached as the dict's `dict_storage_proxy` with
-        /// its `mirror_target` intact: functions defined during the run
-        /// capture the user dict OBJECT as `__globals__`, and
-        /// `get_w_globals()` recovers their raw storage through that proxy.
-        /// Restoring the pre-exec (typically null) proxy or clearing the
-        /// mirror would orphan the leaked temp and resolve a captured
-        /// function's globals to a null raw.  So the owned case persists.
-        ///
-        /// The reuse path (existing proxy) and the empty binding own no
-        /// temp and never swapped a proxy, so there is nothing to undo.
-        /// Idempotent; called explicitly after the run and again on `Drop`.
-        unsafe fn detach(&mut self) {
-            if self.owned.is_some() {
-                return;
-            }
-            unsafe {
-                if self.proxy_attached {
-                    pyre_object::w_dict_set_dict_storage_proxy(self.backing, self.saved_proxy);
-                    self.proxy_attached = false;
-                    self.saved_proxy = std::ptr::null_mut();
+        let mut ns = Box::new(crate::DictStorage::new());
+        unsafe {
+            for (key, value) in pyre_object::w_dict_items(backing) {
+                if !value.is_null() && pyre_object::is_str(key) {
+                    let name = pyre_object::w_str_get_value(key).to_string();
+                    crate::dict_storage_store(&mut ns, &name, value);
                 }
             }
+            ns.set_mirror_target(backing);
         }
-
-        fn storage_ptr(&self) -> *mut crate::DictStorage {
-            self.storage_ptr
+        ns.fix_ptr();
+        let storage_ptr: *mut crate::DictStorage = ns.as_mut() as *mut _;
+        unsafe {
+            pyre_object::w_dict_set_dict_storage_proxy(backing, storage_ptr as *mut u8);
         }
-    }
-
-    impl Drop for GlobalsBinding {
-        fn drop(&mut self) {
-            unsafe { self.detach() }
-            // `pypy/interpreter/pyopcode.py:771-776 EXEC_STMT` runs the
-            // frame on the user-supplied dict directly — there is no
-            // temp storage to release because the dict object IS the
-            // canonical store.  Pyre allocates a temp `DictStorage` and
-            // mirrors writes back into the user dict via `mirror_target`.
-            // Functions defined during `exec` capture the user dict
-            // OBJECT as `__globals__`; `get_w_globals()` recovers their
-            // raw storage through the dict's `dict_storage_proxy`, which
-            // points at this temp.  `detach()` therefore leaves the proxy
-            // and mirror attached for the owned case, and the Box is
-            // leaked here so the proxy never dangles — dropping it would
-            // surface as a use-after-free (or, post-cutover, a null raw
-            // and a JIT-resume null deref) on the next `g["reader"]()`.
-            // Leak persists until exec runs on the dict object directly
-            // and no temp is needed.  Memory cost is one DictStorage per
-            // exec invocation, bounded by program lifetime.
-            if let Some(storage) = self.owned.take() {
-                let _ = Box::into_raw(storage);
-            }
-        }
+        // Owned by the dict for its lifetime; leaked rather than freed.
+        let _ = Box::into_raw(ns);
     }
 
     fn ensure_eval_builtins(
-        ns: &mut crate::DictStorage,
         w_globals_obj: pyre_object::PyObjectRef,
         exec_ctx: *const crate::PyExecutionContext,
     ) -> Result<(), crate::PyError> {
@@ -4353,30 +4202,24 @@ fn exec_or_eval(
         //
         // This is intentionally NOT pyopcode.py:773's `setdefault`
         // call-method path; dict-subclass `setdefault` overrides do
-        // not fire for eval() in PyPy.
+        // not fire for eval() in PyPy.  Dispatch on the dict object so
+        // the str-keyed write fans into the storage proxy.
         let w_builtin = if !exec_ctx.is_null() {
             unsafe { (*exec_ctx).get_builtin() }
         } else {
             pyre_object::PY_NULL
         };
-        if w_builtin.is_null() {
+        if w_builtin.is_null() || w_globals_obj.is_null() {
             return Ok(());
         }
-        if !w_globals_obj.is_null() {
-            let key = pyre_object::w_str_new("__builtins__");
-            if !crate::baseobjspace::contains(w_globals_obj, key)? {
-                crate::baseobjspace::setitem(w_globals_obj, key, w_builtin)?;
-            }
-            return Ok(());
-        }
-        if crate::dict_storage_get(ns, "__builtins__").is_none() {
-            crate::dict_storage_store(ns, "__builtins__", w_builtin);
+        let key = pyre_object::w_str_new("__builtins__");
+        if !crate::baseobjspace::contains(w_globals_obj, key)? {
+            crate::baseobjspace::setitem(w_globals_obj, key, w_builtin)?;
         }
         Ok(())
     }
 
     fn ensure_exec_builtins(
-        ns: &mut crate::DictStorage,
         w_globals_obj: pyre_object::PyObjectRef,
         caller_frame: *const crate::PyFrame,
         exec_ctx: *const crate::PyExecutionContext,
@@ -4388,7 +4231,9 @@ fn exec_or_eval(
         // builtin picked at caller-frame creation (`pyframe.py:115-116`),
         // not the EC's default.  When the caller frame's picked builtin
         // is unavailable (e.g. exec called from outside any frame), fall
-        // through to the EC default.
+        // through to the EC default.  The receiver is the ORIGINAL
+        // `w_globals` object so a dict-subclass `setdefault` override
+        // fires.
         let w_builtin = if !caller_frame.is_null() {
             unsafe { (*caller_frame).get_builtin() }
         } else if !exec_ctx.is_null() {
@@ -4396,23 +4241,12 @@ fn exec_or_eval(
         } else {
             pyre_object::PY_NULL
         };
-        if w_builtin.is_null() {
+        if w_builtin.is_null() || w_globals_obj.is_null() {
             return Ok(());
         }
-        // PyPy `space.call_method(w_globals, 'setdefault', ...)` —
-        // the receiver is the ORIGINAL `w_globals` object, not the
-        // backing W_DictObject that GlobalsBinding strips off via
-        // `resolve_dict_backing`.  Dispatching on the user object lets
-        // dict-subclass `setdefault` overrides fire.
-        if !w_globals_obj.is_null() {
-            let key = pyre_object::w_str_new("__builtins__");
-            let setdefault = crate::baseobjspace::getattr_str(w_globals_obj, "setdefault")?;
-            crate::call_and_check(setdefault, &[key, w_builtin])?;
-            return Ok(());
-        }
-        if crate::dict_storage_get(ns, "__builtins__").is_none() {
-            crate::dict_storage_store(ns, "__builtins__", w_builtin);
-        }
+        let key = pyre_object::w_str_new("__builtins__");
+        let setdefault = crate::baseobjspace::getattr_str(w_globals_obj, "setdefault")?;
+        crate::call_and_check(setdefault, &[key, w_builtin])?;
         Ok(())
     }
 
@@ -4443,72 +4277,29 @@ fn exec_or_eval(
         unsafe { (*caller_frame).execution_context }
     };
 
-    let implicit_globals_arg = if !is_none_or_null(globals_arg) {
+    // pyopcode.py:2005-2009 ensure_ns — the globals object is the
+    // user-supplied dict, else the caller frame's globals, else a fresh
+    // empty dict (`exec(src)` outside any frame, PyPy `newdict('module')`).
+    let w_globals_obj = if !is_none_or_null(globals_arg) {
         globals_arg
     } else if !caller_frame.is_null() {
         unsafe { (*caller_frame).get_w_globals_obj() }
     } else {
-        pyre_object::PY_NULL
+        pyre_object::w_dict_new()
     };
-    let mut globals_binding = if !is_none_or_null(implicit_globals_arg) {
-        GlobalsBinding::from_user_dict(implicit_globals_arg)
+    // Seed the str-keyed storage proxy that the LOAD_GLOBAL / STORE_GLOBAL
+    // bytecode fastpath reads, mirroring the dict's str entries.  A dict
+    // already backing a frame (module.__dict__ / globals()) keeps its proxy.
+    ensure_globals_storage_proxy(w_globals_obj);
+    // pyopcode.py:773-774 `space.call_method(w_globals, 'setdefault', ...)`
+    // (exec) and compiling.py:109-110 `space.setitem_str(w_globals, ...)`
+    // (eval) dispatch on the ORIGINAL `w_globals` object so a dict-subclass
+    // `setdefault` / `__contains__` / `__setitem__` override fires; the
+    // str-keyed write fans into the storage proxy seeded above.
+    if is_eval {
+        ensure_eval_builtins(w_globals_obj, exec_ctx)?;
     } else {
-        GlobalsBinding::empty()
-    };
-    // Anonymous fallback storage for the no-globals + no-caller-frame
-    // path (`exec(src)` outside any frame).  Owned outside the
-    // GlobalsBinding because it has no W_DictObject backing — there
-    // is nothing to mirror to and no proxy to swap.
-    let mut anon_globals: Option<Box<crate::DictStorage>> = None;
-    let mut globals_ptr = if !globals_binding.storage_ptr().is_null() {
-        globals_binding.storage_ptr()
-    } else if !caller_frame.is_null() {
-        unsafe { (*caller_frame).get_w_globals() }
-    } else {
-        std::ptr::null_mut()
-    };
-    if globals_ptr.is_null() {
-        let mut storage = Box::new(crate::DictStorage::new());
-        storage.fix_ptr();
-        let raw: *mut crate::DictStorage = storage.as_mut() as *mut _;
-        anon_globals = Some(storage);
-        globals_ptr = raw;
-    }
-    // Attach the forward proxy BEFORE seeding `__builtins__` so PyPy's
-    // eval `setitem_str` / exec `call_method(..., 'setdefault', ...)`
-    // lands in BOTH the user dict's W_DictObject AND the frame storage
-    // that `pick_builtin` / LOAD_GLOBAL will consult.  PyPy's single
-    // `W_DictMultiObject` makes this a non-issue; pyre's split storage
-    // requires the proxy bridge live before the write.  Drop detaches
-    // even on `?` early-return from builtins seeding / createframe.
-    unsafe {
-        globals_binding.attach_forward_proxy();
-    }
-    if !globals_ptr.is_null() {
-        // pyopcode.py:807 `space.call_method(w_globals, 'setdefault', ...)`
-        // (exec) and compiling.py:109 `space.contains_w(w_globals, ...)` /
-        // `space.setitem_str(w_globals, ...)` (eval) dispatch on the
-        // ORIGINAL `w_globals` object that `ensure_ns` returned — the
-        // user-supplied dict (possibly a subclass) for the explicit case,
-        // or the caller frame's `get_w_globals()` object for the implicit
-        // case.  Use `implicit_globals_arg`, NOT `globals_binding.backing`:
-        // the latter is `resolve_dict_backing`'s stripped W_DictObject,
-        // which bypasses dict-subclass `setdefault` / `__contains__` /
-        // `__setitem__` overrides.  `globals_ptr` is only pyre's temporary
-        // storage carrier while `PyFrame.w_globals` is still raw, so writes
-        // through the original object propagate to it via the forward proxy
-        // attached above.
-        let w_globals_obj = implicit_globals_arg;
-        if is_eval {
-            ensure_eval_builtins(unsafe { &mut *globals_ptr }, w_globals_obj, exec_ctx)?;
-        } else {
-            ensure_exec_builtins(
-                unsafe { &mut *globals_ptr },
-                w_globals_obj,
-                caller_frame,
-                exec_ctx,
-            )?;
-        }
+        ensure_exec_builtins(w_globals_obj, caller_frame, exec_ctx)?;
     }
 
     // pypy/interpreter/pyopcode.py:771-776 — `code.exec_code(space,
@@ -4564,14 +4355,14 @@ fn exec_or_eval(
     // surfaces pyframe.py:242-246's TypeError "directly executed code
     // object may not contain free variables" directly — exec()'s
     // closure-mismatch TypeError was already raised above.
-    let mut frame = match crate::createframe(code_obj_ref as *const (), globals_ptr, exec_ctx, None)
-    {
-        Ok(frame) => frame,
-        Err(err) => {
-            let _ = raw_code;
-            return Err(err);
-        }
-    };
+    let mut frame =
+        match crate::createframe_obj(code_obj_ref as *const (), w_globals_obj, exec_ctx, None) {
+            Ok(frame) => frame,
+            Err(err) => {
+                let _ = raw_code;
+                return Err(err);
+            }
+        };
     frame.fix_array_ptrs();
     // eval.py:32 frame.setdictscope(w_locals, ...) — only when locals
     // were separately supplied.  Without this call, initialize_frame_scopes'
@@ -4596,20 +4387,11 @@ fn exec_or_eval(
     // `eval(compile("(x for x in [])", ..., 'eval'))` of generator-flagged
     // code returns the wrapped generator object instead of executing the
     // body inline.
+    // STORE_GLOBAL / DELETE_GLOBAL writes during the run land on the
+    // storage proxy and back-mirror to the dict object, so the user dict
+    // and the frame's globals stay one and the same throughout the run
+    // (pyopcode.py:771-776 parity — no entry/exit drain needed).
     let result = frame.run();
-
-    // Explicit detach so the proxy/mirror state is cleared BEFORE
-    // `globals_binding` drops; `Drop` then becomes idempotent and
-    // covers the rare panic-unwind path.  STORE_GLOBAL /
-    // DELETE_GLOBAL writes during exec already landed on the user
-    // dict via the back-mirror, and alias mutations propagated
-    // through the forward proxy, so no post-exec drain is needed
-    // (PyPy `pyopcode.py:771-776` parity — the user dict and the
-    // frame's globals are one and the same throughout the run).
-    unsafe {
-        globals_binding.detach();
-    }
-    let _ = anon_globals; // keep anon storage alive across exec
 
     let _ = raw_code; // keep raw_code alive until after exec for safety.
     match result {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -10,7 +10,7 @@ use rustpython_wtf8::Wtf8Buf;
 
 use crate::{
     DictStorage, PyError, PyResult, builtin_code_get, dispatch_callable, function_get_closure,
-    function_get_globals, function_get_globals_obj,
+    function_get_globals_obj,
 };
 
 struct FrameLocalsRoot {
@@ -433,7 +433,8 @@ fn call_user_function_with_eval(
     eval_fn: EvalFn,
 ) -> PyResult {
     let w_code = unsafe { crate::getcode(callable) };
-    let globals = unsafe { function_get_globals(callable) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(callable) };
     let closure = unsafe { function_get_closure(callable) };
     let func_code = unsafe {
@@ -485,7 +486,8 @@ pub fn call_user_function_resolved(
     let _depth_guard = increment_call_depth();
 
     let w_code = unsafe { crate::getcode(callable) };
-    let globals = unsafe { function_get_globals(callable) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(callable) };
     let closure = unsafe { function_get_closure(callable) };
     let func_code = unsafe {
@@ -712,7 +714,8 @@ pub fn call_user_function_plain_with_ctx(
     args: &[PyObjectRef],
 ) -> PyResult {
     let w_code = unsafe { crate::getcode(callable) };
-    let globals = unsafe { function_get_globals(callable) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(callable) };
     let closure = unsafe { function_get_closure(callable) };
     let func_code = unsafe {
@@ -1540,7 +1543,8 @@ pub fn call_with_kwargs(
             }
 
             // Create frame and execute
-            let globals = unsafe { function_get_globals(callable) };
+            // Raw storage is recovered from `w_globals_obj` by the frame builder.
+            let globals = std::ptr::null_mut();
             let w_globals_obj = unsafe { function_get_globals_obj(callable) };
             let closure = unsafe { function_get_closure(callable) };
             let mut func_frame = crate::pyframe::FrameBox::new(
@@ -1976,7 +1980,8 @@ fn issubtype_ptr(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
 /// Helper: call a user function with arbitrary args from descriptor context.
 fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
     let w_code = unsafe { crate::getcode(func) };
-    let globals = unsafe { function_get_globals(func) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
     let func_code = unsafe {
@@ -2059,7 +2064,8 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
 /// packed `*args` / `**kwargs` slots as extra positionals.
 fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
     let w_code = unsafe { crate::getcode(func) };
-    let globals = unsafe { function_get_globals(func) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
     let func_code = unsafe {
@@ -2461,7 +2467,8 @@ fn build_class_inner(
     w_orig_bases: Option<PyObjectRef>,
 ) -> PyResult {
     let w_code = unsafe { crate::getcode(body_fn) };
-    let globals = unsafe { function_get_globals(body_fn) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(body_fn) };
     let closure = unsafe { function_get_closure(body_fn) };
     let func_code = unsafe {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1453,18 +1453,20 @@ impl NamespaceOpcodeHandler for PyFrame {
         // on the globals' backing W_ModuleDictObject so a repeated
         // LOAD_GLOBAL miss reuses the cached builtin entry instead of
         // re-walking `__builtins__.w_dict` every iteration.
-        // `celldict.py:285-291 _LOAD_GLOBAL_cached`: when
-        // `debugdata.w_globals is not pycode.w_globals` the entire
+        // `celldict.py:285-291 _LOAD_GLOBAL_cached`: when the frame's
+        // globals is not the pycode's first-seen globals the entire
         // cached path is bypassed via `_load_global_fallback` — both
         // the per-pycode `_globals_caches[nameindex]` slot AND the
         // strategy-level `get_global_cache(varname)` install are
         // skipped, because both would attach a cache to a module that
         // is not the one being executed.  Identity is checked via
-        // `pycode.w_globals == frame.w_globals` (raw pointer equality
-        // mirrors PyPy's `is` on the wrapped dict — `dict_storage_to_dict`
-        // preserves identity via the `mirror_target` invariant so the
-        // PyObjectRef comparison would agree, but the raw form skips a
-        // memoized wrap until the JIT-vable cutover lands).
+        // `pycode.w_globals == frame.get_w_globals()` (raw pointer
+        // equality mirrors PyPy's `is` on the wrapped dict).
+        // `get_w_globals()` recovers the raw storage from the frame's
+        // canonical `w_globals_obj`; `dict_storage_to_dict` /
+        // `w_dict_get_dict_storage_proxy` are mutual inverses under the
+        // `mirror_target` invariant, so this raw comparison agrees with
+        // the object `is` check.
         let pycode_matches_frame: bool = unsafe {
             let cw = crate::pycode::w_code_get_w_globals(self.pycode as PyObjectRef);
             !cw.is_null() && std::ptr::eq(cw, self.get_w_globals())

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1245,10 +1245,15 @@ impl SharedOpcodeHandler for PyFrame {
         // the frame's view — no lazy `dict_storage_to_dict` second
         // resolution that could surface a different W_DictObject.
         let w_globals_obj = self.get_w_globals_obj();
+        // Capture the globals OBJECT only; the raw `*mut DictStorage` is
+        // recovered from the object via the proxy back-link wherever a frame
+        // built from this function still needs it.  Threading a raw here is
+        // what dangled exec-defined functions when the exec temp storage was
+        // freed (the `GlobalsBinding` leak), so it is dropped.
         Ok(
             crate::runtime_ops::make_function_from_code_obj_with_globals_obj(
                 code_obj,
-                self.get_w_globals(),
+                std::ptr::null_mut(),
                 w_globals_obj,
             ),
         )

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1250,10 +1250,12 @@ impl SharedOpcodeHandler for PyFrame {
         // built from this function still needs it.  Threading a raw here is
         // what dangled exec-defined functions when the exec temp storage was
         // freed (the `GlobalsBinding` leak), so it is dropped.
-        Ok(crate::runtime_ops::make_function_from_code_obj_with_globals_obj(
-            code_obj,
-            w_globals_obj,
-        ))
+        Ok(
+            crate::runtime_ops::make_function_from_code_obj_with_globals_obj(
+                code_obj,
+                w_globals_obj,
+            ),
+        )
     }
 
     fn call_callable(

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1250,13 +1250,10 @@ impl SharedOpcodeHandler for PyFrame {
         // built from this function still needs it.  Threading a raw here is
         // what dangled exec-defined functions when the exec temp storage was
         // freed (the `GlobalsBinding` leak), so it is dropped.
-        Ok(
-            crate::runtime_ops::make_function_from_code_obj_with_globals_obj(
-                code_obj,
-                std::ptr::null_mut(),
-                w_globals_obj,
-            ),
-        )
+        Ok(crate::runtime_ops::make_function_from_code_obj_with_globals_obj(
+            code_obj,
+            w_globals_obj,
+        ))
     }
 
     fn call_callable(

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -277,11 +277,7 @@ impl pyre_object::lltype::GcType for Function {
 /// `name` is the function name string (leaked).
 /// `w_func_globals_obj` is the defining module's namespace dict object
 /// (shared), or `PY_NULL` for a globals-less carrier.
-pub fn function_new(
-    code: *const (),
-    name: String,
-    w_func_globals_obj: PyObjectRef,
-) -> PyObjectRef {
+pub fn function_new(code: *const (), name: String, w_func_globals_obj: PyObjectRef) -> PyObjectRef {
     function_new_with_closure(code, name, w_func_globals_obj, PY_NULL)
 }
 
@@ -298,7 +294,14 @@ pub fn function_new_with_closure(
     w_func_globals_obj: PyObjectRef,
     closure: PyObjectRef,
 ) -> PyObjectRef {
-    function_new_impl(&FUNCTION_TYPE, code, name, w_func_globals_obj, closure, true)
+    function_new_impl(
+        &FUNCTION_TYPE,
+        code,
+        name,
+        w_func_globals_obj,
+        closure,
+        true,
+    )
 }
 
 fn function_new_impl(
@@ -369,7 +372,14 @@ pub fn function_new_with_fixed_code(
     name: String,
     w_func_globals_obj: PyObjectRef,
 ) -> PyObjectRef {
-    function_new_impl(&FUNCTION_TYPE, code, name, w_func_globals_obj, PY_NULL, false)
+    function_new_impl(
+        &FUNCTION_TYPE,
+        code,
+        name,
+        w_func_globals_obj,
+        PY_NULL,
+        false,
+    )
 }
 
 /// function.py:706 — `class BuiltinFunction(Function): can_change_code = False`

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -6,6 +6,7 @@
 //! When called, the interpreter creates a new PyFrame that *shares*
 //! the globals pointer (no clone).
 
+#[cfg(test)]
 use crate::executioncontext::DictStorage;
 use pyre_object::pyobject::*;
 
@@ -16,14 +17,14 @@ pub static BUILTIN_FUNCTION_TYPE: PyType = pyre_object::pyobject::new_pytype("bu
 
 /// User-defined function object.
 ///
-/// Layout: `[ob_type | code | can_change_code | name_ptr | w_func_globals | closure]`
+/// Layout: `[ob_type | code | can_change_code | name_ptr | closure]`
 /// - `code`: pointer to a Code object (W_CodeObject for user funcs, BuiltinCode for builtins).
 ///   function.py:47 — `_immutable_fields_ = ['code?', ...]`
 /// - `can_change_code`: function.py:33 — True by default; False for
 ///   `FunctionWithFixedCode` subclass (used by builtins).
 /// - `name_ptr`: leaked `Box<String>` containing the function name
-/// - `w_func_globals`: raw pointer to the module-level namespace (shared)
 /// - `closure`:  tuple of cell objects, or PY_NULL if no closure
+/// - `w_func_globals_obj`: the module namespace dict object (`__globals__`)
 #[repr(C)]
 pub struct Function {
     pub ob: PyObject,
@@ -35,8 +36,6 @@ pub struct Function {
     pub can_change_code: bool,
     /// Function name (leaked Box<String>).
     pub name: *const String,
-    /// PyPy: W_Function.w_func_globals
-    pub w_func_globals: *mut DictStorage,
     /// Closure: tuple of cell objects from the enclosing scope,
     /// or PY_NULL if this function has no free variables.
     pub closure: PyObjectRef,
@@ -48,16 +47,16 @@ pub struct Function {
     pub w_kw_defs: PyObjectRef,
     /// function.py:56 — `self.w_module = None`
     pub w_module: PyObjectRef,
-    /// Lazy-resolved canonical W_DictObject sibling for `w_func_globals`.
+    /// PyPy: W_Function.w_func_globals — the module namespace dict object.
     ///
     /// `function.py:57 self.w_func_globals = w_globals` stores the dict
-    /// object directly in PyPy.  Pyre keeps the storage pointer in
-    /// `w_func_globals` (JIT call-site layout reads it for createframe)
-    /// and caches the canonical W_DictObject here once resolved, so
+    /// object directly; this is the function's sole globals carrier, so
     /// `function.__globals__` returns the same identity as the module's
-    /// `__dict__` and frames built from this function share globals.
-    /// `PY_NULL` until `function_get_globals_obj()` performs the
-    /// `dict_storage_to_dict` lookup once.
+    /// `__dict__` and frames built from this function share globals.  The
+    /// raw `*mut DictStorage` a frame builder needs is recovered from this
+    /// object via the `dict_storage_proxy` back-link
+    /// (`w_dict_get_dict_storage_proxy`).  `PY_NULL` for globals-less
+    /// carriers (gateway builtins).
     pub w_func_globals_obj: PyObjectRef,
     /// `function.py:50 w_ann=None` constructor default plus
     /// `function.py:548-551 fget_func_annotations` lazy-init shape:
@@ -163,8 +162,6 @@ fn function_write_barrier(obj: PyObjectRef) {
 pub const FUNCTION_CODE_OFFSET: usize = std::mem::offset_of!(Function, code);
 /// Field offset of `name` within `Function`.
 pub const FUNCTION_NAME_OFFSET: usize = std::mem::offset_of!(Function, name);
-/// Field offset of `w_func_globals` within `Function`.
-pub const FUNCTION_GLOBALS_OFFSET: usize = std::mem::offset_of!(Function, w_func_globals);
 /// Field offset of `closure` within `Function`.
 pub const FUNCTION_CLOSURE_OFFSET: usize = std::mem::offset_of!(Function, closure);
 /// Field offset of `defs_w` within `Function`.
@@ -227,10 +224,8 @@ pub const FUNCTION_OBJECT_SIZE: usize = std::mem::size_of::<Function>();
 /// W_Function.code? — an immutable GC reference traced as part of the
 /// closure / defs_w / w_kw_defs / w_module set.
 ///
-/// The remaining fields are non-GC: `can_change_code` is a `bool`,
-/// `name` is a manually-managed `*const String`, `w_func_globals` is a
-/// `*mut DictStorage` (manually-managed pointer to non-GC storage —
-/// see DictStorage GC migration TODO).
+/// The remaining fields are non-GC: `can_change_code` is a `bool` and
+/// `name` is a manually-managed `*const String`.
 ///
 /// `ob.w_class` is intentionally absent, mirroring how W_IntObject /
 /// W_FloatObject leave the typeptr-shaped header field out of their
@@ -242,10 +237,9 @@ pub const FUNCTION_GC_PTR_OFFSETS: [usize; 12] = [
     FUNCTION_DEFS_W_OFFSET,
     FUNCTION_W_KW_DEFS_OFFSET,
     FUNCTION_W_MODULE_OFFSET,
-    // Lazy-cached canonical W_DictObject sibling for the storage in
-    // `w_func_globals`.  Once resolved it must survive minor
-    // collection — the `dict_storage_to_dict` mirror_target invariant
-    // keeps the same identity across the function's lifetime.
+    // `function.py:57 w_func_globals` — the module namespace dict object,
+    // the function's sole globals carrier; traced for the lifetime of the
+    // function so its `__globals__` identity survives minor collection.
     FUNCTION_W_FUNC_GLOBALS_OBJ_OFFSET,
     // `function.py:50 w_ann` — annotations dict, allocated lazily on
     // first read by the getter or stamped at MAKE_FUNCTION time.
@@ -281,113 +275,55 @@ impl pyre_object::lltype::GcType for Function {
 ///
 /// `code` is a pointer to a Code object (W_CodeObject) cast to `*const ()`.
 /// `name` is the function name string (leaked).
-/// `w_func_globals` is the defining module's namespace pointer (shared).
+/// `w_func_globals_obj` is the defining module's namespace dict object
+/// (shared), or `PY_NULL` for a globals-less carrier.
 pub fn function_new(
     code: *const (),
     name: String,
-    w_func_globals: *mut DictStorage,
+    w_func_globals_obj: PyObjectRef,
 ) -> PyObjectRef {
-    function_new_with_closure(code, name, w_func_globals, PY_NULL)
+    function_new_with_closure(code, name, w_func_globals_obj, PY_NULL)
 }
 
 /// Allocate a new `Function` with a closure.
 ///
-/// `closure` is a tuple of cell objects, or PY_NULL if no closure.
+/// `pypy/interpreter/function.py:54-57 Function.__init__` —
+/// `self.w_func_globals = w_globals` stores the user-visible
+/// `__globals__` dict object directly, so the function's `__globals__`
+/// identity IS the supplied `PyObjectRef`.  `closure` is a tuple of cell
+/// objects, or PY_NULL if no closure.
 pub fn function_new_with_closure(
     code: *const (),
     name: String,
-    w_func_globals: *mut DictStorage,
-    closure: PyObjectRef,
-) -> PyObjectRef {
-    function_new_impl(
-        &FUNCTION_TYPE,
-        code,
-        name,
-        w_func_globals,
-        PY_NULL,
-        closure,
-        true,
-    )
-}
-
-/// `pypy/interpreter/function.py:54-57 Function.__init__` —
-/// `self.w_func_globals = w_globals` stores the user-visible
-/// `__globals__` dict object directly.  Use this entry point when
-/// the caller already has the canonical `PyObjectRef` (e.g. MAKE_FUNCTION
-/// dispatched from a frame whose `w_globals_obj` is resolved); it
-/// bypasses `function_new_impl`'s lazy `dict_storage_to_dict`
-/// resolution so the function's `__globals__` identity IS the supplied
-/// PyObjectRef from the moment of construction.
-///
-/// `w_func_globals_obj` may be `PY_NULL` — falls back to the lazy
-/// resolution path then.
-pub fn function_new_with_globals_obj(
-    code: *const (),
-    name: String,
-    w_func_globals: *mut DictStorage,
     w_func_globals_obj: PyObjectRef,
     closure: PyObjectRef,
 ) -> PyObjectRef {
-    function_new_impl(
-        &FUNCTION_TYPE,
-        code,
-        name,
-        w_func_globals,
-        w_func_globals_obj,
-        closure,
-        true,
-    )
+    function_new_impl(&FUNCTION_TYPE, code, name, w_func_globals_obj, closure, true)
 }
 
 fn function_new_impl(
     ob_type: &'static PyType,
     code: *const (),
     name: String,
-    w_func_globals: *mut DictStorage,
-    w_func_globals_obj_hint: PyObjectRef,
+    w_func_globals_obj: PyObjectRef,
     closure: PyObjectRef,
     can_change_code: bool,
 ) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`) for
-    // the `lltype::malloc_typed` call below. `closure` and `code` are
-    // PyObjectRef-shaped GC roots across the alloc — `BuiltinCode`
-    // lives in the GC heap (`gateway.rs:298 malloc_typed`) and
-    // `W_CodeObject` is currently raw/immortal; the walker's
-    // `is_in_nursery` filter (`majit-gc/src/collector.rs:764`) is what
-    // makes the heterogeneous case safe. `w_func_globals` is a
-    // host-allocated DictStorage (raw), and `name_ptr` is allocated
+    // the `lltype::malloc_typed` call below. `closure`, `code`, and
+    // `w_func_globals_obj` are PyObjectRef-shaped GC roots across the
+    // alloc — `BuiltinCode` lives in the GC heap (`gateway.rs:298
+    // malloc_typed`) and `W_CodeObject` is currently raw/immortal; the
+    // walker's `is_in_nursery` filter (`majit-gc/src/collector.rs:764`)
+    // is what makes the heterogeneous case safe. `name_ptr` is allocated
     // below via `malloc_raw` (non-GC) and stored into the struct as
     // part of the same `malloc_typed` call, so it never spans a
     // collection point.
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(closure);
     pyre_object::gc_roots::pin_root(code as PyObjectRef);
-
-    // `function.py:57 self.w_func_globals = w_globals` stores the
-    // dict object directly.  Pyre keeps both the storage pointer
-    // (for the JIT call-site layout) and the canonical W_DictObject
-    // sibling.  Resolve the sibling NOW so the freshly-allocated
-    // function carries a stable `__globals__` identity from
-    // construction onward; `function_get_globals_obj`'s lazy
-    // fallback becomes a zero-hit safety net for synthetic test
-    // stubs that pass a null storage pointer.  This is the first
-    // step toward collapsing the dual storage to
-    // a single `PyObjectRef` field requires that every Function
-    // already has its `__globals__` resolved at construction time.
-    // Prefer the explicit `PyObjectRef` hint when the caller already
-    // resolved the canonical `__globals__` identity (MAKE_FUNCTION
-    // dispatched from a frame whose `w_globals_obj` is populated, or
-    // a builtin module's loader handing in the `W_ModuleDictObject`).
-    // Fall back to the legacy lazy `dict_storage_to_dict` resolution
-    // for synthetic test stubs and callers that have only the raw
-    // storage pointer.
-    let w_func_globals_obj = if !w_func_globals_obj_hint.is_null() {
-        w_func_globals_obj_hint
-    } else if w_func_globals.is_null() {
-        PY_NULL
-    } else {
-        crate::baseobjspace::dict_storage_to_dict(w_func_globals)
-    };
+    // `function.py:57 self.w_func_globals = w_globals` stores the dict
+    // object directly as the function's sole globals carrier.
     pyre_object::gc_roots::pin_root(w_func_globals_obj);
 
     let name_ptr = pyre_object::lltype::malloc_raw(name) as *const String;
@@ -399,7 +335,6 @@ fn function_new_impl(
         code,
         can_change_code,
         name: name_ptr,
-        w_func_globals,
         closure,
         defs_w: PY_NULL,
         w_kw_defs: PY_NULL,
@@ -432,17 +367,9 @@ fn function_new_impl(
 pub fn function_new_with_fixed_code(
     code: *const (),
     name: String,
-    w_func_globals: *mut DictStorage,
+    w_func_globals_obj: PyObjectRef,
 ) -> PyObjectRef {
-    function_new_impl(
-        &FUNCTION_TYPE,
-        code,
-        name,
-        w_func_globals,
-        PY_NULL,
-        PY_NULL,
-        false,
-    )
+    function_new_impl(&FUNCTION_TYPE, code, name, w_func_globals_obj, PY_NULL, false)
 }
 
 /// function.py:706 — `class BuiltinFunction(Function): can_change_code = False`
@@ -450,14 +377,13 @@ pub fn function_new_with_fixed_code(
 pub fn function_new_builtin(
     code: *const (),
     name: String,
-    w_func_globals: *mut DictStorage,
+    w_func_globals_obj: PyObjectRef,
 ) -> PyObjectRef {
     function_new_impl(
         &BUILTIN_FUNCTION_TYPE,
         code,
         name,
-        w_func_globals,
-        PY_NULL,
+        w_func_globals_obj,
         PY_NULL,
         false,
     )
@@ -521,7 +447,6 @@ pub unsafe fn builtin_function_set_module(obj: PyObjectRef, w_module: PyObjectRe
     unsafe {
         let stampable = py_type_check(obj, &BUILTIN_FUNCTION_TYPE)
             || (py_type_check(obj, &FUNCTION_TYPE)
-                && (*(obj as *const Function)).w_func_globals.is_null()
                 && (*(obj as *const Function)).w_func_globals_obj.is_null());
         if stampable {
             let func = obj as *mut Function;
@@ -693,7 +618,7 @@ pub unsafe fn fset_func_qualname(
 ///
 /// `self.qualname` is initialised from `qualname or self.name` at
 /// `function.py:54 __init__`.  MAKE_FUNCTION
-/// (`runtime_ops::make_function_from_code_obj`) stamps `w_qualname`
+/// (`runtime_ops::make_function_from_code_obj_with_globals_obj`) stamps `w_qualname`
 /// from `codeobj.co_qualname` at construction, so subsequent
 /// `__code__ = new_code` assignments do NOT alter `__qualname__`
 /// (matching `pypy/interpreter/pyopcode.py:1457` + `function.py:54`).
@@ -714,7 +639,7 @@ pub unsafe fn function_get_qualname(obj: PyObjectRef) -> String {
 }
 
 /// `function.py:54 self.qualname = qualname or self.name` setter —
-/// used by MAKE_FUNCTION (`runtime_ops::make_function_from_code_obj`)
+/// used by MAKE_FUNCTION (`runtime_ops::make_function_from_code_obj_with_globals_obj`)
 /// to freeze the qualified name immediately after `function_new`.
 /// Bypasses `_check_code_mutable` because this is the construction
 /// path; user code goes through `fset_func_qualname` instead.
@@ -741,50 +666,19 @@ pub unsafe fn fget_func_name(obj: PyObjectRef) -> PyObjectRef {
     unsafe { pyre_object::w_str_new(function_get_name(obj)) }
 }
 
-/// Get the globals namespace pointer from a function object.
+/// Return the canonical W_DictObject stored as `function.w_func_globals`.
+///
+/// `function.py:57 self.w_func_globals = w_globals` stores the dict
+/// object directly; this is a plain field load.  Returns `PY_NULL` for
+/// a globals-less carrier (gateway builtins); callers that want the raw
+/// `*mut DictStorage` recover it from this object via
+/// `w_dict_get_dict_storage_proxy`.
 ///
 /// # Safety
 /// `obj` must point to a valid `Function`.
 #[inline]
-pub unsafe fn function_get_globals(obj: PyObjectRef) -> *mut DictStorage {
-    unsafe { (*(obj as *const Function)).w_func_globals }
-}
-
-/// Return the canonical W_DictObject paired with `function.w_func_globals`.
-///
-/// `function.py:57 self.w_func_globals = w_globals` stores the dict
-/// object directly in PyPy.  Pyre's split storage / W_DictObject
-/// model means callers that want object identity
-/// (`function.__globals__ is module.__dict__`,
-/// `f.__globals__ is g.__globals__` for sibling closures) need to
-/// reach the canonical sibling.  `function_new_impl` resolves the
-/// sibling at construction time via `dict_storage_to_dict` and
-/// stores it directly in `w_func_globals_obj`, so the fast path is
-/// a plain field load.
-///
-/// The lazy fallback below is retained as a safety net for synthetic
-/// test stubs that bypass `function_new_impl` and leave
-/// `w_func_globals_obj` unset; production call sites (`MAKE_FUNCTION`,
-/// `function_new_with_fixed_code`, `function_new_builtin`) always
-/// reach this getter with the slot pre-populated.
-///
-/// Returns `PY_NULL` when `w_func_globals` is null (zero-arg test
-/// stubs); callers should null-check before dereferencing.
-///
-/// # Safety
-/// `obj` must point to a valid `Function`.
 pub unsafe fn function_get_globals_obj(obj: PyObjectRef) -> PyObjectRef {
-    let func = unsafe { &mut *(obj as *mut Function) };
-    if !func.w_func_globals_obj.is_null() {
-        return func.w_func_globals_obj;
-    }
-    if func.w_func_globals.is_null() {
-        return pyre_object::PY_NULL;
-    }
-    let resolved = crate::baseobjspace::dict_storage_to_dict(func.w_func_globals);
-    function_write_barrier(obj);
-    func.w_func_globals_obj = resolved;
-    resolved
+    unsafe { (*(obj as *const Function)).w_func_globals_obj }
 }
 
 /// Get the closure tuple from a function object.
@@ -1501,12 +1395,9 @@ pub unsafe fn fset_func_closure(obj: PyObjectRef, closure: PyObjectRef) {
 /// After fdel___module__ writes w_none(), subsequent reads return
 /// None without re-computing from globals.
 ///
-/// TODO: reach for `w_func_globals_obj` (the canonical
-/// PyObjectRef the user actually sees via `__globals__`) and route
-/// through `w_dict_getitem_str`, which dispatches `is_module_dict`
-/// to `ModuleDictStrategy::getitem_str` (`celldict.py:143-145`).
-/// Falls back to the legacy raw-DictStorage read only when the
-/// PyObjectRef hasn't been resolved yet (synthetic test stubs).
+/// Routes through `w_func_globals_obj` (the canonical PyObjectRef the
+/// user sees via `__globals__`) and dispatches `dict.get` so dict
+/// subclasses that override `get` are observed.
 #[inline]
 pub unsafe fn fget___module__(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
@@ -1529,15 +1420,6 @@ pub unsafe fn fget___module__(obj: PyObjectRef) -> PyObjectRef {
                 } else {
                     result
                 };
-            } else if !(*func).w_func_globals.is_null() {
-                // Legacy `*mut DictStorage` fast-path for synthetic
-                // test stubs (`function_new` callers that skip
-                // `dict_storage_to_dict` lazy resolution).
-                function_write_barrier(obj);
-                (*func).w_module = (*(*func).w_func_globals)
-                    .get("__name__")
-                    .copied()
-                    .unwrap_or(pyre_object::w_none());
             } else {
                 // function.py:508: self.w_module = space.w_None
                 function_write_barrier(obj);
@@ -1553,7 +1435,7 @@ pub unsafe fn fget___module__(obj: PyObjectRef) -> PyObjectRef {
 #[inline]
 pub unsafe fn descr_function__new__(
     code: *const (),
-    w_globals: *mut DictStorage,
+    w_globals: PyObjectRef,
     w_name: PyObjectRef,
     _argdefs: PyObjectRef,
     w_closure: PyObjectRef,
@@ -1618,7 +1500,7 @@ pub unsafe fn _cleanup_(_obj: PyObjectRef) -> bool {
 #[inline]
 pub unsafe fn descr_builtinfunction__new__(
     code: *const (),
-    w_globals: *mut DictStorage,
+    w_globals: PyObjectRef,
     w_name: PyObjectRef,
     _argdefs: PyObjectRef,
     w_closure: PyObjectRef,
@@ -2131,7 +2013,6 @@ fn _flat_pycall(
 ) -> PyObjectRef {
     // call.rs:423-424 parity — increment call depth for JIT depth tracking.
     let _depth_guard = crate::call::increment_call_depth();
-    let globals = unsafe { function_get_globals(func) };
     let w_globals_obj = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
 
@@ -2143,7 +2024,7 @@ fn _flat_pycall(
         match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
             code,
             &[], // locals filled below directly from stack
-            globals,
+            std::ptr::null_mut(),
             w_globals_obj,
             frame.execution_context,
             closure,
@@ -2206,7 +2087,6 @@ fn _flat_pycall_defaults(
     dropvalues: usize,
 ) -> PyObjectRef {
     let _depth_guard = crate::call::increment_call_depth();
-    let globals = unsafe { function_get_globals(func) };
     let w_globals_obj = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
 
@@ -2215,7 +2095,7 @@ fn _flat_pycall_defaults(
         match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
             code,
             &[], // locals filled below
-            globals,
+            std::ptr::null_mut(),
             w_globals_obj,
             frame.execution_context,
             closure,
@@ -2282,13 +2162,14 @@ mod tests {
         let raw_code = 0xDEAD_BEEF as *const ();
         let w_code = crate::w_code_new(raw_code);
         let mut ns = DictStorage::new();
-        let obj = function_new(w_code as *const (), "myfunc".to_string(), &mut ns);
+        let w_globals_obj = crate::baseobjspace::dict_storage_to_dict(&mut ns as *mut DictStorage);
+        let obj = function_new(w_code as *const (), "myfunc".to_string(), w_globals_obj);
         unsafe {
             assert!(is_function(obj));
             assert!(!is_int(obj));
             assert_eq!(function_get_code(obj), w_code as *const ());
             assert_eq!(function_get_name(obj), "myfunc");
-            assert_eq!(function_get_globals(obj), &mut ns as *mut DictStorage);
+            assert_eq!(function_get_globals_obj(obj), w_globals_obj);
             assert!(function_get_closure(obj).is_null());
         }
     }
@@ -2297,8 +2178,7 @@ mod tests {
     fn test_function_field_offsets() {
         assert_eq!(FUNCTION_CODE_OFFSET, 16); // after PyObject { ob_type(8) + w_class(8) }
         assert_eq!(FUNCTION_NAME_OFFSET, 32); // after code(8) + can_change_code(1) + padding(7)
-        assert_eq!(FUNCTION_GLOBALS_OFFSET, 40); // after name
-        assert_eq!(FUNCTION_CLOSURE_OFFSET, 48); // after w_func_globals
+        assert_eq!(FUNCTION_CLOSURE_OFFSET, 40); // after name
     }
 
     /// Guard against drift between the constant colocated with

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -700,7 +700,7 @@ pub unsafe fn builtin_code_get_docstring(obj: PyObjectRef) -> PyObjectRef {
 ///   `fn = FunctionWithFixedCode(space, code, None, defs, forcename=gateway.name)`
 pub fn make_builtin_function(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
     let code = builtin_code_new(name, func);
-    crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 /// Like `make_builtin_function` but tagged as `BuiltinFunction`
@@ -712,7 +712,7 @@ pub fn make_builtin_function(name: &'static str, func: BuiltinCodeFn) -> PyObjec
 /// `builtin_function_or_method` type.
 pub fn make_builtin_function_as_builtin(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
     let code = builtin_code_new(name, func);
-    crate::function_new_builtin(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_builtin(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 /// `make_builtin_function` for a builtin with a declared argument
@@ -724,7 +724,7 @@ pub fn make_builtin_function_with_signature(
     signature: Signature,
 ) -> PyObjectRef {
     let code = builtin_code_new_with_signature(name, func, None, signature);
-    crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 /// `make_builtin_function`, optionally carrying a `Signature`.  `Some`
@@ -770,7 +770,7 @@ pub fn make_builtin_function_with_arity_and_maybe_sig(
         None => std::ptr::null(),
     };
     let code = builtin_code_new_full(name, func, None, arity, sig);
-    crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 /// `make_builtin_function` with known fixed arity for fast-path dispatch.
@@ -780,7 +780,7 @@ pub fn make_builtin_function_with_arity(
     arity: u16,
 ) -> PyObjectRef {
     let code = builtin_code_new_with_arity(name, func, arity);
-    crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 /// `make_builtin_function` with `fast_natural_arity = PASSTHROUGHARGS1` —
@@ -790,7 +790,7 @@ pub fn make_builtin_function_passthrough_args1(
     func: BuiltinCodeFn,
 ) -> PyObjectRef {
     let code = builtin_code_new_passthrough_args1(name, func);
-    crate::function_new_with_fixed_code(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 /// mixedmodule.py:116 parity — wrap a BuiltinCodeFn as BuiltinFunction.
@@ -799,7 +799,7 @@ pub fn make_builtin_function_passthrough_args1(
 /// must not synthesize a bound method.
 pub fn make_module_builtin_function(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
     let code = builtin_code_new(name, func);
-    crate::function_new_builtin(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_builtin(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 /// `make_module_builtin_function` with known fixed arity for fast-path dispatch.
@@ -809,7 +809,7 @@ pub fn make_module_builtin_function_with_arity(
     arity: u16,
 ) -> PyObjectRef {
     let code = builtin_code_new_with_arity(name, func, arity);
-    crate::function_new_builtin(code as *const (), name.to_string(), std::ptr::null_mut())
+    crate::function_new_builtin(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
 #[cfg(test)]

--- a/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
+++ b/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
@@ -73,22 +73,19 @@ fn build_frame_stub_chain(top: *mut crate::pyframe::PyFrame) -> PyObjectRef {
         // `f_locals` by running `fast2locals()` and exposing the
         // resulting `debugdata.w_locals` dict.
         let w_locals_obj = frame_ref.getdictscope_w().unwrap_or(pyre_object::PY_NULL);
-        // pyframe.py:128 get_w_globals: `debugdata.w_globals` wins over
-        // `pycode.w_globals`.  Resolve the object FRESH from the raw
-        // (debugdata-first) `get_w_globals()` rather than the cached
-        // `get_w_globals_obj()`, whose `w_globals_obj` slot can lag a
-        // later `set_w_globals`/debugdata change while `PyFrame.w_globals`
-        // is still raw.
-        let w_globals = frame_ref.get_w_globals();
+        // pyframe.py:128 get_w_globals returns the globals dict object.  The
+        // canonical `w_globals_obj` is co-assigned with `debugdata.w_globals`
+        // at every frame constructor, so it never lags the raw storage.
+        let w_globals_obj = frame_ref.get_w_globals_obj();
         let pycode = frame_ref.pycode as pyre_object::PyObjectRef;
         let lineno = frame_ref.fget_f_lineno() as i64;
         let _ = crate::baseobjspace::setattr_str(
             stub,
             "f_globals",
-            if w_globals.is_null() {
+            if w_globals_obj.is_null() {
                 pyre_object::w_none()
             } else {
-                crate::baseobjspace::dict_storage_to_dict(w_globals as *const crate::DictStorage)
+                w_globals_obj
             },
         );
         let _ = crate::baseobjspace::setattr_str(

--- a/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
+++ b/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
@@ -74,8 +74,8 @@ fn build_frame_stub_chain(top: *mut crate::pyframe::PyFrame) -> PyObjectRef {
         // resulting `debugdata.w_locals` dict.
         let w_locals_obj = frame_ref.getdictscope_w().unwrap_or(pyre_object::PY_NULL);
         // pyframe.py:128 get_w_globals returns the globals dict object.  The
-        // canonical `w_globals_obj` is co-assigned with `debugdata.w_globals`
-        // at every frame constructor, so it never lags the raw storage.
+        // canonical `w_globals_obj` is seeded by every frame constructor and
+        // is the source of truth for the frame's globals.
         let w_globals_obj = frame_ref.get_w_globals_obj();
         let pycode = frame_ref.pycode as pyre_object::PyObjectRef;
         let lineno = frame_ref.fget_f_lineno() as i64;

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -495,8 +495,6 @@ pub struct FrameDebugData {
     /// `STORE/LOAD/DELETE_NAME` route through `space.setitem/getitem
     /// /delitem(w_locals_object, ...)` when this field is non-null.
     pub w_locals_object: PyObjectRef,
-    /// pyframe.py:49 — set in __init__ from pycode.w_globals
-    pub w_globals: *mut DictStorage,
     /// pyframe.py:37
     pub w_f_trace: PyObjectRef,
     /// pyframe.py:40
@@ -516,11 +514,14 @@ pub struct FrameDebugData {
 }
 
 impl FrameDebugData {
-    pub fn new(pycode: *const (), init_lineno: isize) -> Self {
+    // `_pycode` keeps the constructor shape of `pyframe.py:48
+    // FrameDebugData.__init__(self, pycode, init_lineno)`.  The frame's
+    // globals object now lives in `PyFrame.w_globals_obj`, so debugdata no
+    // longer snapshots `pycode.w_globals`.
+    pub fn new(_pycode: *const (), init_lineno: isize) -> Self {
         Self {
             w_locals: std::ptr::null_mut(),
             w_locals_object: pyre_object::PY_NULL,
-            w_globals: unsafe { crate::w_code_get_w_globals(pycode as PyObjectRef) },
             w_f_trace: pyre_object::PY_NULL,
             is_being_profiled: false,
             is_in_line_tracing: false,
@@ -932,8 +933,11 @@ impl PyFrame {
             clear_debugdata_ptr(&mut self.debugdata);
             clear_block_chain(&mut self.lastblock);
         }
-        if unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) } {
-            self.getorcreate_debug_data(-1).w_globals = w_globals;
+        // pyframe.py:103 — stamp `pycode.w_globals` (the first-globals cache
+        // the LOAD_GLOBAL fast path keys on); side effect only, since the
+        // gated debugdata snapshot retired in favour of `w_globals_obj`.
+        unsafe {
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
         }
         // `pyframe.py:114-115` — `self.builtin = space.builtin.pick_builtin(
         // w_globals)`.  pyre keeps the picked builtin and the canonical
@@ -1163,8 +1167,11 @@ impl PyFrame {
         let nlocals = unsafe { (&*raw).varnames.len() };
         let ncells = unsafe { ncells(&*raw) };
         let size = nlocals + ncells + 16; // small stack
-        let stores_global =
-            unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) };
+        // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
+        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        unsafe {
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
+        }
         let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
         // `pyframe.py:98 __init__(self, space, code, w_globals, ...)`
         // stores `w_globals` as the canonical W_DictObject directly.
@@ -1196,9 +1203,6 @@ impl PyFrame {
             w_builtin,
             w_globals_obj,
         };
-        if stores_global {
-            frame.getorcreate_debug_data(-1).w_globals = w_globals;
-        }
         frame
     }
 
@@ -1279,8 +1283,11 @@ impl PyFrame {
         let num_cells = ncells(code_ref);
         let max_stack = code_ref.max_stackdepth as usize;
 
-        let stores_global =
-            unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) };
+        // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
+        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        unsafe {
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
+        }
         let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
         // `pyframe.py:98 __init__` — `self.w_globals = w_globals` stores
         // the W_DictObject directly; eager `dict_storage_to_dict`
@@ -1309,9 +1316,6 @@ impl PyFrame {
             w_builtin,
             w_globals_obj,
         };
-        if stores_global {
-            frame.getorcreate_debug_data(-1).w_globals = w_globals;
-        }
         // Module-level w_locals = w_globals binding flows naturally
         // through `createframe → initialize_frame_scopes` since RustPython
         // codegen emits empty flags for the module seed CodeInfo
@@ -2504,8 +2508,11 @@ impl PyFrame {
             }
         }
 
-        let stores_global =
-            unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, globals) };
+        // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
+        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        unsafe {
+            crate::w_code_frame_stores_global(code as PyObjectRef, globals);
+        }
 
         let mut frame = PyFrame {
             execution_context,
@@ -2525,9 +2532,6 @@ impl PyFrame {
             w_globals_obj,
         };
         frame.init_cells();
-        if stores_global {
-            frame.getorcreate_debug_data(-1).w_globals = globals;
-        }
         frame
     }
 
@@ -2800,8 +2804,11 @@ pub fn createframe_obj(
     } else {
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(w_globals_obj) as *mut DictStorage }
     };
-    let stores_global =
-        unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) };
+    // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the gated
+    // debugdata snapshot retired in favour of `w_globals_obj`).
+    unsafe {
+        crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
+    }
 
     let size = num_locals + num_cells + max_stack;
     let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals_obj, execution_context);
@@ -2822,9 +2829,6 @@ pub fn createframe_obj(
         w_builtin,
         w_globals_obj,
     });
-    if stores_global {
-        frame.getorcreate_debug_data(-1).w_globals = w_globals;
-    }
     // pyframe.py:119 — final step of __init__.  PY_NULL plays the role of
     // Python `None` per the existing `initialize_frame_scopes` convention
     // (pyframe.rs:664).  Top-level module / interactive / expression code

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -115,11 +115,13 @@ pub struct PyFrame {
     ///
     /// **Population**: eagerly resolved at frame construction by calling
     /// `dict_storage_to_dict(w_globals)` on the raw storage handed to the
-    /// constructor, so every reader after construction observes the same
-    /// W_DictObject across the frame's lifetime.  `get_w_globals_obj()`'s
-    /// null-check arm remains as a safety net for synthetic test stubs
-    /// that hand-build PyFrame without going through the canonical
-    /// constructors.
+    /// constructor (or threaded through directly by the obj-taking
+    /// constructors), so every reader after construction observes the same
+    /// W_DictObject across the frame's lifetime.  This is the source of
+    /// truth: `get_w_globals_obj()` returns it directly and
+    /// `get_w_globals()` recovers the raw storage from it via
+    /// `w_dict_get_dict_storage_proxy`.  Synthetic test stubs that
+    /// hand-build PyFrame without a real globals leave it `PY_NULL`.
     pub w_globals_obj: PyObjectRef,
 }
 
@@ -824,40 +826,35 @@ impl PyFrame {
         self.code()
     }
 
-    /// pyframe.py:129-133 get_w_globals
+    /// pyframe.py:129-133 get_w_globals — the raw `*mut DictStorage`
+    /// backing this frame's globals.  `pyframe.py:49 self.w_globals =
+    /// w_globals` keeps the canonical W_DictObject as the single field;
+    /// pyre's split layout makes `w_globals_obj` that source of truth and
+    /// recovers the raw storage from it via `w_dict_get_dict_storage_proxy`
+    /// (the inverse of `dict_storage_to_dict`).
     #[inline]
     pub fn get_w_globals(&self) -> *mut DictStorage {
-        match self.getdebug_data() {
-            Some(data) => data.w_globals,
-            None => unsafe { crate::w_code_get_w_globals(self.pycode as PyObjectRef) },
+        if self.w_globals_obj.is_null() {
+            std::ptr::null_mut()
+        } else {
+            unsafe {
+                pyre_object::w_dict_get_dict_storage_proxy(self.w_globals_obj) as *mut DictStorage
+            }
         }
     }
 
-    /// Resolve the canonical W_DictObject paired with `self.w_globals`,
-    /// caching the result in the adjacent `w_globals_obj` slot.
+    /// The canonical W_DictObject for this frame's globals
+    /// (`pyframe.py:49 self.w_globals = w_globals`).  Every frame
+    /// constructor seeds `w_globals_obj` eagerly, so this is a plain
+    /// field read; callers wanting object identity
+    /// (`function.__globals__ is frame.f_globals`, `globals() is
+    /// module.__dict__`, etc.) read it directly.
     ///
-    /// PyPy `pyframe.py:49 self.w_globals = w_globals` stores the dict
-    /// object directly so the equivalent question never arises there.
-    /// Pyre's split storage / W_DictObject layout means callers that
-    /// want object identity (`function.__globals__ is frame.f_globals`,
-    /// `globals() is module.__dict__`, etc.) need the canonical
-    /// W_DictObject sibling.  `dict_storage_to_dict` returns the same
-    /// instance on every call (`mirror_target` invariant), and the
-    /// cache field skips the lookup on subsequent calls.
-    ///
-    /// Returns `PY_NULL` when `w_globals` is null (test stubs); callers
-    /// that expect a dict should null-check before dereferencing.
-    pub fn get_w_globals_obj(&mut self) -> PyObjectRef {
-        if !self.w_globals_obj.is_null() {
-            return self.w_globals_obj;
-        }
-        let storage = self.get_w_globals();
-        if storage.is_null() {
-            return pyre_object::PY_NULL;
-        }
-        let resolved = crate::baseobjspace::dict_storage_to_dict(storage);
-        self.w_globals_obj = resolved;
-        resolved
+    /// Returns `PY_NULL` when the frame has no globals (test stubs);
+    /// callers that expect a dict should null-check before dereferencing.
+    #[inline]
+    pub fn get_w_globals_obj(&self) -> PyObjectRef {
+        self.w_globals_obj
     }
 
     /// pyframe.py:135 get_w_f_trace

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -835,13 +835,7 @@ impl PyFrame {
     /// (the inverse of `dict_storage_to_dict`).
     #[inline]
     pub fn get_w_globals(&self) -> *mut DictStorage {
-        if self.w_globals_obj.is_null() {
-            std::ptr::null_mut()
-        } else {
-            unsafe {
-                pyre_object::w_dict_get_dict_storage_proxy(self.w_globals_obj) as *mut DictStorage
-            }
-        }
+        w_globals_obj_storage(self.w_globals_obj)
     }
 
     /// The canonical W_DictObject for this frame's globals
@@ -2792,6 +2786,26 @@ pub fn createframe_obj(
     //   self.valuestackdepth = code.co_nlocals + ncellvars + nfreevars
     //   ...
     //   self.initialize_frame_scopes(outer_func, code)
+    //
+    // Normalize a dict-subclass globals (`exec(src, G())`) to its inner
+    // `__dict_data__` dict.  The storage proxy that LOAD_GLOBAL reads lives
+    // on the `W_DictObject`, and downstream readers key off this object —
+    // `get_w_globals`, MAKE_FUNCTION's `function.__globals__`, and the JIT
+    // inline / callee globals readers — so the frame must hold the
+    // `W_DictObject`, not the subclass instance whose layout has no proxy
+    // slot.  No-op for a plain dict / module dict (`resolve_dict_backing`
+    // returns the argument).  Converges to holding the object directly when
+    // the raw `DictStorage` proxy retires.
+    let w_globals_obj = if w_globals_obj.is_null() {
+        w_globals_obj
+    } else {
+        let backing = crate::type_methods::resolve_dict_backing(w_globals_obj);
+        if backing.is_null() {
+            w_globals_obj
+        } else {
+            backing
+        }
+    };
     let raw = unsafe { crate::w_code_get_ptr(code as PyObjectRef) as *const CodeObject };
     let code_ref = unsafe { &*raw };
     let num_locals = code_ref.varnames.len();
@@ -2799,11 +2813,7 @@ pub fn createframe_obj(
     let max_stack = code_ref.max_stackdepth as usize;
     // The `frame_stores_global` check and the debug-data snapshot still read
     // the raw storage; recover it from the object via the proxy back-link.
-    let w_globals = if w_globals_obj.is_null() {
-        std::ptr::null_mut()
-    } else {
-        unsafe { pyre_object::w_dict_get_dict_storage_proxy(w_globals_obj) as *mut DictStorage }
-    };
+    let w_globals = w_globals_obj_storage(w_globals_obj);
     // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the gated
     // debugdata snapshot retired in favour of `w_globals_obj`).
     unsafe {
@@ -2846,6 +2856,21 @@ pub fn createframe_obj(
     }
 
     Ok(frame)
+}
+
+/// Recover the str-keyed storage proxy backing a globals OBJECT.  Resolves
+/// a dict subclass to its inner `__dict_data__` dict first: the proxy lives
+/// on the `W_DictObject`, so reading it straight off the subclass instance
+/// would dereference an unrelated offset.
+pub(crate) fn w_globals_obj_storage(w_globals_obj: PyObjectRef) -> *mut DictStorage {
+    if w_globals_obj.is_null() {
+        return std::ptr::null_mut();
+    }
+    let backing = crate::type_methods::resolve_dict_backing(w_globals_obj);
+    if backing.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe { pyre_object::w_dict_get_dict_storage_proxy(backing) as *mut DictStorage }
 }
 
 /// `space.finditem_str(w_obj, key)` — `space.getitem` with KeyError

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2745,6 +2745,29 @@ pub fn createframe(
     execution_context: *const PyExecutionContext,
     outer_func: Option<PyObjectRef>,
 ) -> Result<FrameBox, crate::PyError> {
+    // Legacy raw-storage entry: resolve the canonical W_DictObject sibling
+    // and delegate to `createframe_obj`.  `dict_storage_to_dict` and
+    // `w_dict_get_dict_storage_proxy` are mutual inverses under the
+    // `mirror_target` invariant, so the round-trip preserves identity.
+    let w_globals_obj = if w_globals.is_null() {
+        PY_NULL
+    } else {
+        crate::baseobjspace::dict_storage_to_dict(w_globals)
+    };
+    createframe_obj(code, w_globals_obj, execution_context, outer_func)
+}
+
+/// `baseobjspace.py:796 createframe` with the globals passed as the dict
+/// OBJECT (`pyframe.py:49 self.w_globals = w_globals` stores the object).
+/// The legacy raw `*mut DictStorage` is recovered from the object via the
+/// proxy back-link only for the `frame_stores_global` check and the
+/// FrameDebugData.w_globals snapshot, both of which retire in later steps.
+pub fn createframe_obj(
+    code: *const (),
+    w_globals_obj: PyObjectRef,
+    execution_context: *const PyExecutionContext,
+    outer_func: Option<PyObjectRef>,
+) -> Result<FrameBox, crate::PyError> {
     // pyframe.py:98-119 PyFrame.__init__ — line-by-line.
     //   self.space = space               (pyre: implicit, no field)
     //   self.pycode = code               (pycode field below)
@@ -2762,23 +2785,18 @@ pub fn createframe(
     let num_locals = code_ref.varnames.len();
     let num_cells = ncells(code_ref);
     let max_stack = code_ref.max_stackdepth as usize;
+    // The `frame_stores_global` check and the debug-data snapshot still read
+    // the raw storage; recover it from the object via the proxy back-link.
+    let w_globals = if w_globals_obj.is_null() {
+        std::ptr::null_mut()
+    } else {
+        unsafe { pyre_object::w_dict_get_dict_storage_proxy(w_globals_obj) as *mut DictStorage }
+    };
     let stores_global =
         unsafe { crate::w_code_frame_stores_global(code as PyObjectRef, w_globals) };
 
     let size = num_locals + num_cells + max_stack;
-    let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
-    // `pyframe.py:98 __init__` — `self.w_globals = w_globals` stores the
-    // dict object directly so `frame.w_globals` retains object identity
-    // for the lifetime of the frame.  pyre's split layout pairs the raw
-    // `*mut DictStorage` with the canonical W_DictObject via
-    // `dict_storage_to_dict`; populate the slot eagerly here too (the
-    // legacy `new_with_namespace` constructor already does this) so
-    // callers reading `frame.w_globals_obj` see a non-null PyObjectRef.
-    let w_globals_obj = if w_globals.is_null() {
-        PY_NULL
-    } else {
-        crate::baseobjspace::dict_storage_to_dict(w_globals)
-    };
+    let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals_obj, execution_context);
     let mut frame = FrameBox::new(PyFrame {
         execution_context,
         pycode: code,

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2456,6 +2456,17 @@ impl PyFrame {
         closure: PyObjectRef,
         w_builtin: PyObjectRef,
     ) -> Self {
+        // Recover the legacy raw storage from the object (the `mirror_target`
+        // inverse of `dict_storage_to_dict`) so the `frame_stores_global`
+        // stamp and the debug-data snapshot see the canonical storage even
+        // when the caller threads a null raw (obj-only functions, e.g.
+        // MAKE_FUNCTION).  A null `w_globals_obj` (test stubs) keeps the
+        // passed raw.
+        let globals = if w_globals_obj.is_null() {
+            globals
+        } else {
+            unsafe { pyre_object::w_dict_get_dict_storage_proxy(w_globals_obj) as *mut DictStorage }
+        };
         let code_ref = unsafe {
             &*(crate::w_code_get_ptr(code as pyre_object::PyObjectRef) as *const CodeObject)
         };

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -66,16 +66,15 @@ fn decode_name(name_ptr: i64, name_len: i64) -> Option<&'static str> {
 
 #[majit_macros::dont_look_inside]
 pub extern "C" fn jit_make_function_from_globals(globals: i64, code_obj: i64) -> i64 {
+    // `globals` is the globals OBJECT (the JIT threads the vable
+    // `w_globals_obj` slot).  Capture it directly; the raw `*mut DictStorage`
+    // is recovered from the object wherever a frame still needs it.
     let w_globals_obj = globals as PyObjectRef;
-    let ds = if w_globals_obj.is_null() {
-        std::ptr::null_mut()
-    } else {
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(w_globals_obj)
-                as *mut DictStorage
-        }
-    };
-    make_function_from_code_obj_with_globals_obj(code_obj as PyObjectRef, ds, w_globals_obj) as i64
+    make_function_from_code_obj_with_globals_obj(
+        code_obj as PyObjectRef,
+        std::ptr::null_mut(),
+        w_globals_obj,
+    ) as i64
 }
 
 #[majit_macros::dont_look_inside]

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -15,24 +15,13 @@ use crate::{
     is_function, w_code_get_ptr,
 };
 
-pub fn make_function_from_code_obj(
-    code_obj: PyObjectRef,
-    globals: *mut DictStorage,
-) -> PyObjectRef {
-    make_function_from_code_obj_with_globals_obj(code_obj, globals, pyre_object::PY_NULL)
-}
-
 /// `pypy/interpreter/pyopcode.py:1457 MAKE_FUNCTION` stamps the new
 /// function's `w_func_globals = self.w_globals` directly from the
-/// running frame's dict object.  This entry point accepts the
-/// already-resolved canonical PyObjectRef (`w_globals_obj`) alongside
-/// the legacy raw storage pointer so the freshly-created function
-/// inherits the frame's exact `__globals__` identity rather than
-/// going through `function_new_impl`'s lazy `dict_storage_to_dict`
-/// fallback (which might allocate a fresh sibling W_DictObject).
+/// running frame's dict object.  This entry point accepts the canonical
+/// PyObjectRef (`w_globals_obj`) so the freshly-created function inherits
+/// the frame's exact `__globals__` identity.
 pub fn make_function_from_code_obj_with_globals_obj(
     code_obj: PyObjectRef,
-    globals: *mut DictStorage,
     w_globals_obj: PyObjectRef,
 ) -> PyObjectRef {
     let code_ptr = unsafe { w_code_get_ptr(code_obj) };
@@ -44,10 +33,9 @@ pub fn make_function_from_code_obj_with_globals_obj(
     // `co_qualname`.  `pyopcode.py:1457 MAKE_FUNCTION` then stamps the
     // qualified name from `codeobj.co_qualname`, which is why a later
     // `__code__ = new_code` assignment does NOT change `__qualname__`.
-    let func = crate::function::function_new_with_globals_obj(
+    let func = crate::function::function_new_with_closure(
         code_obj as *const (),
         code.obj_name.to_string(),
-        globals,
         w_globals_obj,
         pyre_object::PY_NULL,
     );
@@ -70,11 +58,7 @@ pub extern "C" fn jit_make_function_from_globals(globals: i64, code_obj: i64) ->
     // `w_globals_obj` slot).  Capture it directly; the raw `*mut DictStorage`
     // is recovered from the object wherever a frame still needs it.
     let w_globals_obj = globals as PyObjectRef;
-    make_function_from_code_obj_with_globals_obj(
-        code_obj as PyObjectRef,
-        std::ptr::null_mut(),
-        w_globals_obj,
-    ) as i64
+    make_function_from_code_obj_with_globals_obj(code_obj as PyObjectRef, w_globals_obj) as i64
 }
 
 #[majit_macros::dont_look_inside]

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -1006,7 +1006,6 @@ pub fn emit_new_pyframe_inline_self_recursive(
     array_size: usize,
     valuestackdepth: usize,
     pycode: OpRef,
-    w_globals: OpRef,
     w_globals_obj: OpRef,
     ec: OpRef,
 ) -> OpRef {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7382,8 +7382,19 @@ fn try_walker_call_assembler_self_recursive(
     if pyre_interpreter::ncells(callee_code) != 0 {
         return Ok(None);
     }
-    let callee_globals = unsafe { pyre_interpreter::function_get_globals(callable) };
+    // Recover the legacy raw storage from the object via the proxy back-link
+    // for the `frame_stores_global` stamp; the function's own raw slot is
+    // null (MAKE_FUNCTION captures the object only), so reading it would
+    // mis-stamp `pycode.w_globals`.
     let callee_globals_obj = unsafe { pyre_interpreter::function_get_globals_obj(callable) };
+    let callee_globals = if callee_globals_obj.is_null() {
+        std::ptr::null_mut()
+    } else {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(callee_globals_obj)
+                as *mut pyre_interpreter::DictStorage
+        }
+    };
     if unsafe {
         pyre_interpreter::w_code_frame_stores_global(
             w_code as pyre_object::PyObjectRef,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7435,7 +7435,6 @@ fn try_walker_call_assembler_self_recursive(
     // Build the callee PyFrame inline (Branch A): a single positional
     // local, no cells, constant code / globals.
     let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
-    let w_globals_const = ctx.trace_ctx.const_ref(callee_globals as i64);
     let w_globals_obj_const = ctx.trace_ctx.const_ref(callee_globals_obj as i64);
     let callee_frame = crate::helpers::emit_new_pyframe_inline_self_recursive(
         ctx.trace_ctx,
@@ -7443,7 +7442,6 @@ fn try_walker_call_assembler_self_recursive(
         nlocals + max_stack,
         nlocals,
         pycode_const,
-        w_globals_const,
         w_globals_obj_const,
         ec,
     );

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11198,8 +11198,8 @@ pub(crate) fn assemble_bridge_inline_pending(
     // pyframe.py:128-132 get_w_globals(): a frame's globals come from its OWN
     // pycode (`jit.promote(self.pycode).w_globals`), not the caller. Resolve
     // the callee's globals from `recipe.w_code` — the same `pycode.w_globals`
-    // the forward inline path reads via `function_get_globals` — so a
-    // cross-module inlined callee's LOAD_GLOBAL sees the callee module's
+    // the callee module exposes through its function's `w_func_globals_obj` —
+    // so a cross-module inlined callee's LOAD_GLOBAL sees the callee module's
     // namespace. `reconstruct_inline_recipe` aborts the multi-frame path when
     // the callee code has no resolved globals, so `globals` is non-null here.
     let globals = unsafe { pyre_interpreter::w_code_get_w_globals(recipe.w_code as PyObjectRef) };

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -77,6 +77,11 @@ pub fn trace_bytecode(
     // A stale flag from a prior trace on this thread must not leak into
     // this trace's adoption decision.
     WALK_END_FLUSH_COMMITTED.with(|c| c.set(false));
+    // Likewise clear any no-replay finish payload a prior trace left
+    // unconsumed.  The FBW walk re-clears this in `run_perfn_walk`; the
+    // trait leg (`trace_step_result_to_action`) has no such epilogue, so
+    // reset here covers both before either can stash a capture.
+    crate::jitcode_dispatch::fbw_finish_payload_reset();
     // Likewise drop any cross-frame-resume abort request a prior aborted
     // trace left unconsumed (`metainterp::interpret` clears it on the normal
     // path; this guards the paths that exit before the poll runs).

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -446,13 +446,22 @@ fn emit_call_assembler_callee_frame(
             let nlocals = callee_code.varnames.len();
             let ncells = pyre_interpreter::ncells(callee_code);
             let max_stack = callee_code.max_stackdepth as usize;
-            let callee_globals = unsafe { function_get_globals(concrete_callable) };
-            // R3.3b: also resolve the canonical W_DictObject sibling so the
-            // inline new-PyFrame helper populates `PyFrame.w_globals_obj`
-            // in lockstep with the raw slot, matching what production
-            // Rust constructors do at heap allocation.
+            // Resolve the canonical W_DictObject sibling so the inline
+            // new-PyFrame helper populates `PyFrame.w_globals_obj`, and
+            // recover the legacy raw storage from it via the proxy back-link
+            // for the `frame_stores_global` stamp.  The function's own raw
+            // slot is null (MAKE_FUNCTION captures the object only), so
+            // reading it here would mis-stamp `pycode.w_globals`.
             let callee_globals_obj =
                 unsafe { pyre_interpreter::function_get_globals_obj(concrete_callable) };
+            let callee_globals = if callee_globals_obj.is_null() {
+                std::ptr::null_mut()
+            } else {
+                unsafe {
+                    pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(callee_globals_obj)
+                        as *mut pyre_interpreter::DictStorage
+                }
+            };
             let stores_global = unsafe {
                 pyre_interpreter::w_code_frame_stores_global(
                     w_callee_code as PyObjectRef,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -200,8 +200,8 @@ use pyre_interpreter::eval::{attach_raise_cause, normalize_raise_cause};
 use pyre_interpreter::truth_value as objspace_truth_value;
 use pyre_interpreter::{
     OpcodeStepExecutor, PyError, SharedOpcodeHandler, call_function, decode_instruction_at,
-    execute_opcode_step, function_get_defaults, function_get_globals, function_get_globals_obj,
-    is_builtin_code, is_function, range_iter_continues,
+    execute_opcode_step, function_get_defaults, function_get_globals_obj, is_builtin_code,
+    is_function, range_iter_continues,
 };
 
 use pyre_object::PyObjectRef;
@@ -7319,7 +7319,8 @@ impl MIFrame {
         let caller_exec_ctx = self.sym().concrete_execution_context;
         let caller_namespace_ptr = self.sym().concrete_namespace;
         let w_code = unsafe { pyre_interpreter::getcode(concrete_callable) };
-        let globals = unsafe { function_get_globals(concrete_callable) };
+        // Raw storage is recovered from `callee_globals_obj` by the frame builder.
+        let globals = std::ptr::null_mut();
         let callee_globals_obj = unsafe { function_get_globals_obj(concrete_callable) };
         let closure = unsafe { pyre_interpreter::function_get_closure(concrete_callable) };
         // pyjitpl.py:1396-1401 element-wise greenkey — `(code_ptr, 0)`

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -461,7 +461,6 @@ fn emit_call_assembler_callee_frame(
             };
             if ncells == 0 && !stores_global {
                 let pycode_const = ctx.const_ref(w_callee_code as i64);
-                let w_globals_const = ctx.const_ref(callee_globals as i64);
                 let w_globals_obj_const = ctx.const_ref(callee_globals_obj as i64);
                 let ec = this.ensure_execution_context(ctx);
                 let frame = crate::helpers::emit_new_pyframe_inline_self_recursive(
@@ -470,7 +469,6 @@ fn emit_call_assembler_callee_frame(
                     nlocals + ncells + max_stack,
                     nlocals + ncells,
                     pycode_const,
-                    w_globals_const,
                     w_globals_obj_const,
                     ec,
                 );

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -9717,6 +9717,31 @@ fn classify_concrete(cv: ConcreteValue) -> (bool, bool) {
     }
 }
 
+/// No-replay portal-exit capture for the trait tracer's top-level
+/// `*_return` / `yield_value`: stash the concrete return value so a
+/// synchronous trace that started at a loop header but fell through to
+/// `done_with_this_frame` (the back-edge counter tripped on the loop's
+/// terminal iteration → the loop test exited immediately and the trace
+/// walked the post-loop tail to the frame return) hands that result back
+/// directly instead of replaying the already-executed tail.  Mirrors the
+/// FBW walker's `*_return` arms (`jitcode_dispatch.rs`
+/// `fbw_finish_concrete_set`); the value is consumed in `eval.rs`.
+///
+/// Only a genuine concrete value is stashed — a `Null` / null `Ref`
+/// (untracked return) leaves the stash empty so the portal degrades to
+/// the legacy `ContinueRunningNormally` replay rather than fabricating a
+/// `None` return.
+fn capture_top_level_finish_concrete(cv: ConcreteValue) {
+    let genuine = match cv {
+        ConcreteValue::Int(_) | ConcreteValue::Float(_) | ConcreteValue::Bool(_) => true,
+        ConcreteValue::Ref(obj) => !obj.is_null(),
+        ConcreteValue::Null => false,
+    };
+    if genuine {
+        crate::jitcode_dispatch::fbw_finish_concrete_set(cv);
+    }
+}
+
 pub(crate) fn trace_step_result_to_action(
     state: &mut MIFrame,
     result: Result<pyre_interpreter::StepResult<FrontendOp>, PyError>,
@@ -9843,6 +9868,9 @@ pub(crate) fn trace_step_result_to_action(
             // unboxed the return value to Int/Float, ensure_boxed_for_ca
             // re-boxes it (NewWithVtable + SetfieldGc).
             let value = fop.opref;
+            // No-replay portal exit: stash the concrete return for the
+            // loop-header-fell-through-to-return case (see helper doc).
+            capture_top_level_finish_concrete(fop.concrete);
             let finish_value =
                 state.with_ctx(|this, ctx| crate::state::ensure_boxed_for_ca(ctx, this, value));
             // pyjitpl.py:3222 store_token_in_vable
@@ -9859,6 +9887,9 @@ pub(crate) fn trace_step_result_to_action(
             // pyjitpl.py:3198 compile_done_with_this_frame parity:
             // Yield uses the same Ref result_type.
             let value = fop.opref;
+            // No-replay portal exit: stash the concrete yielded value for
+            // the loop-header-fell-through-to-yield case (see helper doc).
+            capture_top_level_finish_concrete(fop.concrete);
             let finish_value =
                 state.with_ctx(|this, ctx| crate::state::ensure_boxed_for_ca(ctx, this, value));
             // pyjitpl.py:3222 store_token_in_vable (same as return path)

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -37,8 +37,8 @@ fn pyre_probe_bh_startup_enabled() -> bool {
 
 use pyre_interpreter::bytecode::{Instruction, OpArgState};
 use pyre_interpreter::{
-    PyResult, function_get_closure, function_get_defaults, function_get_globals,
-    function_get_globals_obj, function_get_name, is_function, register_jit_exc_raiser,
+    PyResult, function_get_closure, function_get_defaults, function_get_globals_obj,
+    function_get_name, is_function, register_jit_exc_raiser,
     register_jit_function_caller,
 };
 use pyre_object::intobject::w_int_get_value;
@@ -2585,7 +2585,8 @@ fn create_callee_frame_impl_1_boxed(
 ) -> i64 {
     let w_code = unsafe { pyre_interpreter::getcode(callable) };
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
-    let globals = unsafe { function_get_globals(callable) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(callable) };
     let one_arg = [boxed_arg];
     let args = fill_positional_defaults_for_jit_call(callable, w_code, &one_arg);
@@ -2740,7 +2741,8 @@ fn create_callee_frame_impl(caller_frame: i64, callable: i64, args: &[PyObjectRe
     let callable = callable as PyObjectRef;
     let w_code = unsafe { pyre_interpreter::getcode(callable) };
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
-    let globals = unsafe { function_get_globals(callable) };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let w_globals_obj = unsafe { function_get_globals_obj(callable) };
     let args = fill_positional_defaults_for_jit_call(callable, w_code, args);
     let args = args.as_ref();

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -38,8 +38,7 @@ fn pyre_probe_bh_startup_enabled() -> bool {
 use pyre_interpreter::bytecode::{Instruction, OpArgState};
 use pyre_interpreter::{
     PyResult, function_get_closure, function_get_defaults, function_get_globals_obj,
-    function_get_name, is_function, register_jit_exc_raiser,
-    register_jit_function_caller,
+    function_get_name, is_function, register_jit_exc_raiser, register_jit_function_caller,
 };
 use pyre_object::intobject::w_int_get_value;
 use pyre_object::intobject::w_int_new;

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -553,14 +553,8 @@ pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
             as *const *const pyre_interpreter::PyExecutionContext);
         (code, w_globals_obj, ec)
     };
-    let namespace = if !w_globals_obj.is_null() {
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(w_globals_obj)
-                as *mut pyre_interpreter::DictStorage
-        }
-    } else {
-        std::ptr::null_mut()
-    };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let namespace = std::ptr::null_mut();
 
     let mut func_frame =
         PyFrame::new_for_call_with_globals_obj(code, &[], namespace, w_globals_obj, exec_ctx);
@@ -2657,10 +2651,8 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
     let func_code = caller.pycode;
     let w_globals_obj = caller.w_globals_obj;
-    let globals = unsafe {
-        pyre_object::w_dict_get_dict_storage_proxy(w_globals_obj)
-            as *mut pyre_interpreter::DictStorage
-    };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let execution_context = caller.execution_context;
 
     let arena = arena_ref();
@@ -2854,10 +2846,8 @@ pub extern "C" fn jit_create_self_recursive_callee_frame_1_raw_int(
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
     let func_code = caller.pycode;
     let w_globals_obj = caller.w_globals_obj;
-    let globals = unsafe {
-        pyre_object::w_dict_get_dict_storage_proxy(w_globals_obj)
-            as *mut pyre_interpreter::DictStorage
-    };
+    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let globals = std::ptr::null_mut();
     let execution_context = caller.execution_context;
 
     let boxed = pyre_object::intobject::w_int_new(raw_int_arg);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4399,6 +4399,28 @@ fn bound_reached(
                         .warm_state_mut()
                         .clear_tracing_flag(green_key);
                 }
+                // No-replay portal exit for a walk that started at this
+                // loop header but fell through to `done_with_this_frame`
+                // (the back-edge counter tripped on the loop's terminal
+                // iteration, so the loop test exited immediately and the
+                // walk traced the post-loop tail to the frame return).
+                // The walk executed the tail's residual calls concretely
+                // and captured the concrete return value; re-running the
+                // freshly compiled trace for THIS invocation
+                // (ContinueRunningNormally re-enters the live frame still
+                // parked at the loop header) would re-apply those already
+                // executed side effects.  Hand the captured result back
+                // directly, mirroring the `jit_merge_point_hook` tracing
+                // site (which carries the same no-replay logic for the
+                // merge-point-driven trace path).
+                if let Some(cv) = pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
+                    let result = match cv {
+                        // A void return stashes `Null`, i.e. Python `None`.
+                        pyre_jit_trace::state::ConcreteValue::Null => w_none(),
+                        other => other.to_pyobj(),
+                    };
+                    return Some(LoopResult::Done(Ok(result)));
+                }
                 return Some(LoopResult::ContinueRunningNormally);
             }
             outcome

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1242,7 +1242,12 @@ unsafe fn w_module_dict_setitem_str_internal(
         let storage = &mut *(*(obj as *mut W_ModuleDictObject)).dstorage;
         strategy.setitem_str(storage, key, w_value);
     }
-    maybe_sync_dict_storage_store(proxy, crate::w_str_new(key), w_value);
+    // Only wrap the key into a W_StrObject when there is a proxy to forward
+    // to.  The back-mirror from `DictStorage::insert` runs with a null proxy
+    // (`fire_proxy=false`), so eagerly allocating the key here would discard it.
+    if !proxy.is_null() {
+        maybe_sync_dict_storage_store(proxy, crate::w_str_new(key), w_value);
+    }
 }
 
 /// `celldict.py:143-145 getitem_str`.


### PR DESCRIPTION
#128 third target

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Collapses the module/exec frame-globals **double-storage** toward a single dict
object. Before this branch a frame's globals lived twice: as the canonical
`W_DictObject` (`w_globals_obj`) *and* as a separate raw `*mut DictStorage`
snapshot copied onto the frame debugdata, the function, the code object, and the
execution context. This branch makes `w_globals_obj` the single source of truth
and recovers the raw storage from it (via the dict's storage proxy) only on the
few paths that still require a `*mut DictStorage`, moving toward the single
`W_DictMultiObject` shape PyPy carries.

The remaining double-storage — the off-GC storage proxy itself, still read first
by `LOAD_GLOBAL` and forwarded by the manual `walk_pyframe_roots` GC walk — is
intentionally kept; retiring it is blocked on the JIT loop-bearing-callee
globals fold (the `#128` CA-boundary work) and is left for a follow-up.

### Globals sourced from the dict object

- `createframe_obj` accepts the globals **object**; `createframe` becomes a thin
  raw wrapper over it, and all production frame builders route through it.
- `MAKE_FUNCTION` captures the globals object only; the call-frame builder
  derives the raw storage from it.
- The JIT inline-frame `stores_global` raw is derived from the globals object.
- `get_w_globals()` is re-sourced from `w_globals_obj` (through the storage
  proxy) instead of a debugdata/pycode snapshot.
- `sys` frame `f_globals` resolves via `w_globals_obj`; the dead inline-frame
  `w_globals` parameter is dropped.

### Raw snapshots removed

- `FrameDebugData.w_globals` raw snapshot field.
- `Function.w_func_globals` raw field (the globals object remains).
- The self-recursive callee frame builders pass null raw globals; the frame
  builder re-derives the raw when it is actually needed.

### exec / eval

- `exec`/`eval` run on the globals object directly; the `GlobalsBinding`
  temp-swap-and-leak machinery is removed. The previously-leaked globals storage
  stays attached as the dict's proxy so `LOAD_GLOBAL`/`STORE_GLOBAL` keep
  resolving against it.

### Adjacent fixes

- A loop-header trace that falls through to a frame return now delivers a
  no-replay portal exit, preventing post-loop tail double-execution.
- The module-dict back-mirror skips key wrapping when the proxy is null.

18 files changed, +476 / −641. check.py 128/128 on both dynasm and cranelift.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
