### PR TITLE
charon: cutover census drain — stdlib/fmt folds + JIT accessor residualization

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1901,7 +1901,30 @@ impl<'a> Lowering<'a> {
                 self.block_entry_local_var[bb] = self.local_var.clone();
             }
             self.lower_block(bb)?;
-            let ex = self.getstate();
+            let mut ex = self.getstate();
+            // Scrub phantom locals before threading.  A slot bound to a
+            // Variable that is neither an inputarg nor an op result of this
+            // block has no definition in the produced graph — e.g. a MIR
+            // local the body never assigns, conservatively kept live by
+            // `compute_mir_liveness` and prebound in `new`, that the
+            // fully-inlined source leaves dead (the unread `MaybeUninit`
+            // scratch a monomorphized `core::ptr::swap` carries).  The
+            // monotonic path threads only `target_input_locals` (live-in)
+            // via per-block prebind inputargs, so its copy is always a
+            // defined block inputarg; the framestate threads every `Some`
+            // slot positionally, so an undefined phantom would reach Pass 2
+            // as a `Link.arg` defined at no source.  Drop it to `None`: a
+            // dead local is irrelevant, and a later read of a genuinely
+            // live-but-undefined slot still fails loud as an uninitialised
+            // local through `resolve_place` — the same use-before-def
+            // signal the monotonic `edge_args` raises.
+            for slot in ex.entries.iter_mut() {
+                if let Some(v) = slot
+                    && !self.graph.variable_defined_in_block(bb_id, v)
+                {
+                    *slot = None;
+                }
+            }
             exit_state[bb] = Some(ex.clone());
             // Union this exit into each model successor's entry state.
             // Successors are read off the just-closed exits (the model

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3970,6 +3970,18 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<String>::deref` / `<Vec<T>>::deref` (+ `deref_mut`) —
+                // identity in the lifted value model (String/&str and
+                // Vec/&[T] share one repr), so alias the destination to
+                // the receiver instead of emitting a `deref` method call
+                // the rtyper cannot route on the classdef-less receiver.
+                if args.len() == 1 && self.is_container_identity_deref(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // Workspace `Index::index` / `IndexMut::index_mut`
                 // impls (`FixedObjectArray` and friends) bottom out at
                 // raw-slice construction (`as_mut_slice` →
@@ -4905,6 +4917,33 @@ impl<'a> Lowering<'a> {
             }
         }
         tyref_class_root(dest_ty, self.llbc)
+    }
+
+    /// `<String as Deref>::deref(&self) -> &str` / `<Vec<T> as
+    /// Deref>::deref(&self) -> &[T]` (and their `deref_mut`).  Unlike the
+    /// `Box`/`FrameBox` handles [`Self::deref_cast_root`] reinterprets as a
+    /// typed struct pointer, the owning-container deref returns the same
+    /// value the lifted model already carries: Rust `String`/`&str` both
+    /// lower to the immutable rpy_string and `Vec<T>`/`&[T]` both to the
+    /// rpy_list, so `*s` is identity.  `deref_cast_root` returns `None`
+    /// here (a `str`/slice target has no class root), so without this the
+    /// callsite falls through to a `CallTarget::Method` `deref` getattr the
+    /// rtyper cannot route on the classdef-less receiver.  Bind the
+    /// destination to the argument instead, the same alias shape as the
+    /// blanket-`into` identity above.
+    fn is_container_identity_deref(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        let np = fd.item_meta.name_path();
+        if !(np.ends_with("::deref") || np.ends_with("::deref_mut")) {
+            return false;
+        }
+        deref_impl_owner_leaf(self.llbc, fd)
+            .is_some_and(|leaf| matches!(leaf.as_str(), "String" | "Vec"))
     }
 
     /// The blanket `impl<I: Iterator> IntoIterator for I`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1007,6 +1007,16 @@ pub fn lower_fun_decl(llbc: &Llbc, fd: &FunDecl) -> Result<FunctionGraph, LowerE
     lower_fun_decl_with_static_addrs(llbc, fd, crate::HostStaticAddrs::default())
 }
 
+/// Whether the framestate-threaded lowering runs for acyclic bodies.
+/// Default-on; `PYRE_MIR_FRAMESTATE=0` / `=false` is the rollback escape
+/// hatch to the monotonic lowering.
+fn framestate_enabled() -> bool {
+    !matches!(
+        std::env::var("PYRE_MIR_FRAMESTATE").as_deref(),
+        Ok("0") | Ok("false")
+    )
+}
+
 pub fn lower_fun_decl_with_static_addrs(
     llbc: &Llbc,
     fd: &FunDecl,
@@ -1115,33 +1125,36 @@ pub fn lower_fun_decl_with_static_addrs(
         }
         Ok(())
     };
-    // Opt-in framestate-threaded lowering for acyclic bodies (the GAP-B
-    // path that threads locals as block inputargs / phis).  Default
-    // (flag unset) keeps the monotonic lowering so the gate stays green
-    // while the new path is validated.  On a framestate failure the body
-    // falls back to the monotonic path — so flag-on is never worse than
-    // flag-off — unless `PYRE_MIR_FRAMESTATE_STRICT` is set, which
-    // propagates the error for debugging.
-    if std::env::var_os("PYRE_MIR_FRAMESTATE").is_some() {
+    // Framestate-threaded lowering for acyclic bodies (the GAP-B path
+    // that threads locals as block inputargs / phis).  Default-on;
+    // `PYRE_MIR_FRAMESTATE=0` rolls back to the monotonic lowering.  On a
+    // framestate failure the body falls back to the monotonic path — so
+    // the threaded path is never worse than the monotonic one — unless
+    // `PYRE_MIR_FRAMESTATE_STRICT` is set, which propagates the error for
+    // debugging.
+    if framestate_enabled() {
         let mut lo = Lowering::new(llbc, name.clone(), &u, static_addrs, fd.generics.as_ref())?;
         if lo.mir_model_is_acyclic() {
-            match lo.lower_framestate() {
-                Ok(()) => {
-                    // Run the shared post-lowering stage uniformly, same
-                    // as the linear / RPO paths below.  `finish` folds
-                    // constant exitswitches, drops `Abort` arms and runs
-                    // `simplify_lowered_graph`; gating it on result-exc
-                    // activity would let the framestate path keep dead
-                    // arms the other strategies prune, diverging the
-                    // graph for the same body.  The result-exc-specific
-                    // `clear_unreachable_blocks` stays gated inside
-                    // `finish`, and the exception-link ABI (raise-through
-                    // vs Result return) the transforms install runs here
-                    // too — uniform across lowering strategies.
-                    finish(&mut lo)?;
-                    return Ok(lo.graph);
-                }
+            // Treat the threaded lowering and its shared post-lowering
+            // stage (`finish`) as one attempt.  `finish` runs uniformly,
+            // same as the linear / RPO paths below — it folds constant
+            // exitswitches, drops `Abort` arms, runs `simplify_lowered_graph`
+            // and installs the exception-link ABI (raise-through vs Result
+            // return); gating it on result-exc activity would let the
+            // framestate path keep dead arms the other strategies prune.
+            // A post-pass (e.g. the result-exc diamond rewrite) can reject
+            // a body the threading itself accepted, and the threading can
+            // fail on a CFG shape it does not yet model, so fold both into
+            // one fallback: on any error fall through to the monotonic path
+            // below, which is known to lower the body — the threaded path
+            // is never worse than the monotonic one.
+            let attempt = lo.lower_framestate().and_then(|()| finish(&mut lo));
+            match attempt {
+                Ok(()) => return Ok(lo.graph),
                 Err(e) => {
+                    if std::env::var_os("PYRE_MIR_FRAMESTATE_DEBUG").is_some() {
+                        eprintln!("[FRAMESTATE fallback] {:?}: {e:?}", name);
+                    }
                     if std::env::var_os("PYRE_MIR_FRAMESTATE_STRICT").is_some() {
                         return Err(e);
                     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3332,6 +3332,7 @@ impl<'a> Lowering<'a> {
                     .static_addr_op(&segments)
                     .or_else(|| self.static_int_value_op(&segments))
                     .or_else(|| self.const_eval_global(id))
+                    .or_else(|| self.fold_size_const_global(id))
                     .or_else(|| primitive_float_const(&segments))
                     .unwrap_or_else(|| OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
@@ -3759,6 +3760,62 @@ impl<'a> Lowering<'a> {
             // diverge from the `Rvalue::Use(Const)` treatment.
             DecodedConst::Str(_) | DecodedConst::FnPath(_) => None,
         }
+    }
+
+    /// Fold a `NamedConst` global whose initializer is exactly
+    /// `size_of::<T>()` / `align_of::<T>()` to the concrete byte size /
+    /// alignment Charon resolved for `T`'s layout.  The const's value is
+    /// a build-time constant of the extraction target, so folding it to
+    /// a `ConstInt` removes the residual accessor call the layout-size
+    /// consts (`FUNCTION_OBJECT_SIZE`, `W_DICT_OBJECT_SIZE`, …) otherwise
+    /// lower to (a `FunctionPath` the rtyper cannot register).
+    ///
+    /// `None` for any non-trivial initializer (the `size_of` result must
+    /// flow straight to the return local — `dest` = `_0` — so a computed
+    /// const like `size_of::<A>() + size_of::<B>()` keeps the accessor
+    /// path), a non-ADT type argument (primitive / pointer / tuple, which
+    /// has no `TypeDecl` layout to read), or a layout Charon left
+    /// unresolved.
+    fn fold_size_const_global(&self, def_id: u64) -> Option<OpKind> {
+        let gd = self.llbc.global_by_id(def_id)?;
+        if gd
+            .rest
+            .get("global_kind")
+            .and_then(serde_json::Value::as_str)
+            != Some("NamedConst")
+        {
+            return None;
+        }
+        let init_id = gd.rest.get("init")?.as_u64()?;
+        let body = self.llbc.fn_by_id(init_id)?.unstructured()?;
+        for block in &body.body {
+            let Ok(TermKind::Call { call, .. }) = block.term() else {
+                continue;
+            };
+            // The size/align result must be the const's own value: a
+            // temporary destination means a computed const we must leave
+            // to the accessor path.
+            if !matches!(call.dest.kind, PlaceKind::Local(0)) {
+                continue;
+            }
+            let CallFunc::Regular(reg) = &call.func else {
+                continue;
+            };
+            let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+                continue;
+            };
+            let want_align = match self.llbc.fn_by_id(*id)?.item_meta.name_path().as_str() {
+                "core::mem::size_of" => false,
+                "core::mem::align_of" => true,
+                _ => continue,
+            };
+            let ty = reg.generics.get("types")?.as_array()?.first()?;
+            let adt = self.resolve_tyexpr_to_adt_def_id(ty)?;
+            let layout = self.llbc.type_by_id(adt)?.layout_for_target("")?;
+            let value = if want_align { layout.align } else { layout.size }?;
+            return Some(OpKind::ConstInt(value as i64));
+        }
+        None
     }
 
     // -----------------------------------------------------------------------
@@ -11342,6 +11399,52 @@ mod tests {
         );
         assert_eq!(args, vec![arg]);
         assert_eq!(result_ty, ValueType::Ref(Some("W_CastTarget".to_string())));
+    }
+
+    /// Anchor [`Lowering::fold_size_const_global`] to the real lowered
+    /// IR of `function_new_impl` (= reads `FUNCTION_OBJECT_SIZE`, a
+    /// `const usize = size_of::<Function>()`).  The global read must fold
+    /// to `Function`'s concrete byte size (144) rather than residualize
+    /// as an unregisterable `FunctionPath` accessor call.  Ignored by
+    /// default (loads the 249MB real LLBC); run with `cargo test -p
+    /// majit-translate --lib fold_size_const_real -- --ignored`.
+    #[test]
+    #[ignore]
+    fn fold_size_const_real_function_object_size() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "function_new_impl").expect("lower function_new_impl");
+
+        let ops: Vec<&OpKind> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .map(|op| &op.kind)
+            .collect();
+
+        // The `size_of::<Function>()` const read folded to its byte size.
+        assert!(
+            ops.iter().any(|k| matches!(k, OpKind::ConstInt(144))),
+            "expected a ConstInt(144) for the folded FUNCTION_OBJECT_SIZE"
+        );
+        // No residual accessor call to the const remains.
+        let residual = ops.iter().any(|k| {
+            matches!(
+                k,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().is_some_and(|s| s.ends_with("FUNCTION_OBJECT_SIZE"))
+            )
+        });
+        assert!(
+            !residual,
+            "FUNCTION_OBJECT_SIZE must not residualize as a FunctionPath call"
+        );
     }
 
     /// Minimal `Llbc` carrying only `trait_impls` — the surface

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1363,19 +1363,6 @@ struct Lowering<'a> {
     /// rewires into `ExitSwitch::LastException` exits after the body
     /// lowering completes.
     result_exc_call_results: Vec<Variable>,
-    /// `Variable.id()`s whose binding was resolved from a `Copy`/`Move`
-    /// operand whose place type is the string value-model family
-    /// (`String` ADT or the `str` builtin).  The `#277` `format_args!`
-    /// recognizer ([`Lowering::fmt_chain_all_string_display`]) consults
-    /// this set to verify every `{}` placeholder argument renders by
-    /// identity (a `&str`/`String` `Display`) before folding the chain to
-    /// a string concat; an argument absent from the set is not provably
-    /// string-family and the whole chain is left unfolded (fail-closed).
-    /// The post-build graph cannot recover this — `tyref_to_value_type`
-    /// collapses both `String` and `&str` to `Ref(None)` — so the
-    /// classification is stamped here at resolve time when the Charon
-    /// `TyRef` is still in hand.
-    fmt_arg_string_vars: std::collections::HashSet<u64>,
 }
 
 impl<'a> Lowering<'a> {
@@ -1506,7 +1493,6 @@ impl<'a> Lowering<'a> {
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
-            fmt_arg_string_vars: std::collections::HashSet::new(),
         })
     }
 
@@ -2988,19 +2974,7 @@ impl<'a> Lowering<'a> {
     /// Resolve an [`Operand`] to the Variable the IR should reference.
     fn resolve_operand(&mut self, mir_bb: usize, op: Operand) -> Result<Variable, LowerError> {
         match op {
-            Operand::Copy(place) | Operand::Move(place) => {
-                // Record the resolved Variable as string-family when the
-                // operand's place types as `String`/`&str`, so the #277
-                // `format_args!` recognizer can verify a placeholder
-                // argument renders by identity (see `fmt_arg_string_vars`).
-                let is_string = tyref_is_string_adt(&place.ty, self.llbc)
-                    || tyref_strips_to_str(&place.ty, self.llbc);
-                let var = self.resolve_place(mir_bb, place)?;
-                if is_string {
-                    self.fmt_arg_string_vars.insert(var.id());
-                }
-                Ok(var)
-            }
+            Operand::Copy(place) | Operand::Move(place) => self.resolve_place(mir_bb, place),
             Operand::Const(value) => self.emit_constant(mir_bb, &value),
         }
     }
@@ -4354,46 +4328,6 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                // `alloc::fmt::format(args)` over a recognized `format_args!`
-                // chain whose every `{}` placeholder is a `&str`/`String`
-                // `Display` (so each renders by identity).  Fold it to the
-                // StringRepr str-const + `add` concat (`emit_fmt_concat` →
-                // `ll_strconcat`, parity with `rstr.do_stringformat` on the
-                // all-string subset) and neutralize the chain's unregistered
-                // `fmt::Arguments::new` / `fmt::rt::Argument::new_*` ctors so
-                // the now-dead construction subgraph lifts.  Any chain
-                // outside the subset (a `Debug` placeholder, a non-string
-                // `Display`, a width/precision/positional spec, or an
-                // un-typed argument) is declined and keeps the ordinary
-                // lowering — the fold never fires unless every argument is
-                // provably string-family.
-                if args.len() == 1
-                    && self.is_fmt_format_call(&reg)
-                    && let Some(chain) = extract_fmt_chain(&self.graph, &args[0])
-                    && self.fmt_chain_all_string_display(&chain)
-                    && let Some(paths) = chain
-                        .args
-                        .iter()
-                        .map(|a| self.fmt_value_path(&a.value, bb_id))
-                        .collect::<Option<Vec<_>>>()
-                {
-                    // Each `Argument::new_*(&v)` call terminates its own
-                    // MIR block, so a placeholder value `v` is usually
-                    // dead by the `format()` block — thread it forward
-                    // along the (merge-free) construction chain so the
-                    // concat's operand is in scope.
-                    let mut threaded = chain.clone();
-                    for (arg, path) in threaded.args.iter_mut().zip(&paths) {
-                        arg.value = self.thread_along_path(&arg.value, path);
-                    }
-                    self.neutralize_fmt_chain_ctors(&args[0]);
-                    let res = emit_fmt_concat(&mut self.graph, bb_id, &threaded);
-                    self.local_var[dest_local] = Some(res);
-                    let target_bb = self.block_id[target];
-                    let link_args = self.edge_args(mir_bb, target)?;
-                    self.graph.set_goto(bb_id, target_bb, link_args);
-                    return Ok(());
-                }
                 // Resolve the target function's fully-qualified path
                 // through the FunId → FunDecl table. `Trait` here is
                 // Charon's "trait-bound generic resolved at extraction
@@ -5295,151 +5229,6 @@ impl<'a> Lowering<'a> {
                     } if segments.first().map(String::as_str) == Some("__str_const")
                 )
             })
-    }
-
-    /// Whether every placeholder of a recovered `format_args!` chain
-    /// renders by identity: a `Display` (`{}`, not `{:?}` `Debug`) of a
-    /// string-family value (`fmt_arg_string_vars`).  Only then is the
-    /// str-const + `add` concat ([`emit_fmt_concat`]) a faithful
-    /// substitute for the runtime render (`rstr.do_stringformat`'s
-    /// per-argument `ll_str` is the identity on a string).  A `Debug`
-    /// placeholder (adds quotes/escapes), a non-string `Display` (an
-    /// integer's `ll_int2dec`), or an argument whose type was never
-    /// stamped string-family ⇒ decline the whole chain (fail-closed).
-    fn fmt_chain_all_string_display(&self, chain: &FmtChain) -> bool {
-        chain.args.iter().all(|a| {
-            a.kind == FmtArgKind::Display && self.fmt_arg_string_vars.contains(&a.value.id())
-        })
-    }
-
-    /// Replace this `format_args!` chain's unregistered constructor calls
-    /// — the single `fmt::Arguments::new(pieces, args)` that produced
-    /// `fmt_args_var` and each `fmt::rt::Argument::new_display`/`new_debug`
-    /// element of its args array — in place with the `__str_const("")`
-    /// dummy the flowspace adapter folds to an empty-string `Constant`.
-    /// After the fold binds the result to the concat, `fmt_args_var` and
-    /// its whole construction subgraph are dead; neutralizing only the
-    /// unregistered `Call`s (the bytes/array/tuple ops already lift) lets
-    /// the dead subgraph translate instead of tripping the
-    /// `not registered in PyreCallRegistry` wall, without removing ops
-    /// (no index shift, no dangling cross-block inputarg).
-    fn neutralize_fmt_chain_ctors(&mut self, fmt_args_var: &Variable) {
-        use crate::model::{CallTarget, OpKind, ValueType};
-        let dummy = || OpKind::Call {
-            target: CallTarget::FunctionPath {
-                segments: vec!["__str_const".to_string(), String::new()],
-            },
-            args: vec![],
-            result_ty: ValueType::Ref(None),
-        };
-        let mut positions: Vec<(BlockId, usize)> = Vec::new();
-        let Some((ab, ai)) = resolve_to_producer_op(&self.graph, fmt_args_var) else {
-            return;
-        };
-        positions.push((ab, ai));
-        // The `Arguments::new(pieces, args)` second operand is the args
-        // array; each element is an `Argument::new_*` ctor to neutralize.
-        let args_var = match self
-            .graph
-            .blocks
-            .iter()
-            .find(|b| b.id == ab)
-            .and_then(|b| b.operations.get(ai))
-            .map(|op| &op.kind)
-        {
-            Some(OpKind::Call { args, .. }) => args.get(1).cloned(),
-            _ => None,
-        };
-        if let Some(args_var) = args_var
-            && let Some(arg_elems) = read_array_literal_elements(&self.graph, &args_var)
-        {
-            for elem in &arg_elems {
-                if let Some(p) = resolve_to_producer_op(&self.graph, elem) {
-                    positions.push(p);
-                }
-            }
-        }
-        for (b, i) in positions {
-            if let Some(op) = self.graph.block_mut(b).operations.get_mut(i) {
-                op.kind = dummy();
-            }
-        }
-    }
-
-    /// Whether `v` is defined in block `b` — bound as one of its
-    /// `inputargs` or produced by one of its operations.
-    fn block_defines(&self, b: BlockId, v: &Variable) -> bool {
-        let blk = self.graph.block(b);
-        blk.inputargs.iter().any(|a| a.id() == v.id())
-            || blk
-                .operations
-                .iter()
-                .any(|op| op.result.as_ref().is_some_and(|r| r.id() == v.id()))
-    }
-
-    /// The block chain `[target, .., def]` (target first) from `target`
-    /// back to the block that defines `value`, each hop a single incoming
-    /// `Link`.  `Some(vec![target])` when `value` is already in scope at
-    /// `target`; `None` when a hop has zero or several incoming links (a
-    /// merge — no single forward path to thread along).  Read-only: used
-    /// to pre-check that every `format_args!` placeholder value can be
-    /// carried to the `format()` block before any graph mutation.
-    fn fmt_value_path(&self, value: &Variable, target: BlockId) -> Option<Vec<BlockId>> {
-        if self.block_defines(target, value) {
-            return Some(vec![target]);
-        }
-        let mut path = vec![target];
-        let mut cur = target;
-        loop {
-            let mut incoming = self
-                .graph
-                .blocks
-                .iter()
-                .flat_map(|b| b.exits.iter().map(move |l| (b.id, l.target)))
-                .filter(|(_, t)| *t == cur);
-            let (src, _) = incoming.next()?;
-            if incoming.next().is_some() {
-                return None; // merge: no single forward path
-            }
-            path.push(src);
-            if self.block_defines(src, value) {
-                return Some(path);
-            }
-            cur = src;
-            if path.len() > 4096 {
-                return None; // runaway guard
-            }
-        }
-    }
-
-    /// Thread `value` forward from its defining block to the chain's
-    /// final block (`path` is `[target, .., def]` as returned by
-    /// [`Lowering::fmt_value_path`]), appending it to each hop's single
-    /// `Link` and a fresh `inputarg` to each successor.  Returns the
-    /// in-`target` Variable.  Each block on a [`fmt_value_path`] chain has
-    /// exactly one incoming `Link`, so growing that `Link`'s args and the
-    /// block's `inputargs` in lock-step preserves the arity invariant.
-    fn thread_along_path(&mut self, value: &Variable, path: &[BlockId]) -> Variable {
-        let mut chain: Vec<BlockId> = path.to_vec();
-        chain.reverse(); // [def, .., target]
-        let mut carried = value.clone();
-        for w in chain.windows(2) {
-            let (from, to) = (w[0], w[1]);
-            let new_input = Variable::new();
-            if let Some(link) = self
-                .graph
-                .block_mut(from)
-                .exits
-                .iter_mut()
-                .find(|l| l.target == to)
-            {
-                link.args
-                    .push(crate::model::LinkArg::Value(carried.clone()));
-            }
-            self.graph.block_mut(to).inputargs.push(new_input.clone());
-            carried = new_input;
-        }
-        carried
     }
 
     /// The blanket `impl<I: Iterator> IntoIterator for I`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3770,12 +3770,25 @@ impl<'a> Lowering<'a> {
     /// consts (`FUNCTION_OBJECT_SIZE`, `W_DICT_OBJECT_SIZE`, …) otherwise
     /// lower to (a `FunctionPath` the rtyper cannot register).
     ///
-    /// `None` for any non-trivial initializer (the `size_of` result must
-    /// flow straight to the return local — `dest` = `_0` — so a computed
-    /// const like `size_of::<A>() + size_of::<B>()` keeps the accessor
-    /// path), a non-ADT type argument (primitive / pointer / tuple, which
-    /// has no `TypeDecl` layout to read), or a layout Charon left
-    /// unresolved.
+    /// Accepts only the *exact* shape — `_0` (the const's value) is written
+    /// once, by a single `size_of`/`align_of` call, unconditionally — and
+    /// returns `None` for anything richer so it keeps the residual accessor
+    /// path, mirroring the strict single-statement acceptance in
+    /// [`Self::const_eval_global`].  Rejected:
+    ///   * a `Switch` terminator (data-dependent control flow), so the call
+    ///     can never be made conditional;
+    ///   * any statement that assigns `_0` (a computed value such as
+    ///     `size_of::<A>() + size_of::<B>()`, whose `+` writes `_0`);
+    ///   * a second `_0`-defining call, or a `_0`-defining call to any
+    ///     function other than `size_of`/`align_of`;
+    ///   * a body with no `Return`.
+    /// Linear `Goto`s and panic-cleanup terminators (`Abort`,
+    /// `UnwindResume`, `Drop`, `Assert`), plus calls and assignments that
+    /// do *not* write `_0`, are permitted: none of them define the const
+    /// value, so with no `Switch` the single `size_of` call is its
+    /// unconditional sole definer.  Also `None` for a non-ADT type argument
+    /// (primitive / pointer / tuple, which has no `TypeDecl` layout to
+    /// read) or a layout Charon left unresolved.
     fn fold_size_const_global(&self, def_id: u64) -> Option<OpKind> {
         let gd = self.llbc.global_by_id(def_id)?;
         if gd
@@ -3788,38 +3801,79 @@ impl<'a> Lowering<'a> {
         }
         let init_id = gd.rest.get("init")?.as_u64()?;
         let body = self.llbc.fn_by_id(init_id)?.unstructured()?;
+
+        // The single `size_of`/`align_of` call that defines `_0`, captured
+        // as `(want_align, type_argument)`.  `term()`/`stmt_kind()` return
+        // owned values, so the type expression is cloned out of the call.
+        let mut found: Option<(bool, serde_json::Value)> = None;
+        let mut saw_return = false;
         for block in &body.body {
-            let Ok(TermKind::Call { call, .. }) = block.term() else {
-                continue;
-            };
-            // The size/align result must be the const's own value: a
-            // temporary destination means a computed const we must leave
-            // to the accessor path.
-            if !matches!(call.dest.kind, PlaceKind::Local(0)) {
-                continue;
+            for stmt in &block.statements {
+                match stmt.stmt_kind() {
+                    Ok(StmtKind::StorageLive(_))
+                    | Ok(StmtKind::StorageDead(_))
+                    | Ok(StmtKind::PlaceMention(_)) => {}
+                    // A statement writing `_0` means the value is computed,
+                    // not the bare `size_of`/`align_of` call result.
+                    Ok(StmtKind::Assign(place, _)) if matches!(place.kind, PlaceKind::Local(0)) => {
+                        return None;
+                    }
+                    // An assignment to a temporary cannot reach `_0` without
+                    // an `_0` write we already reject, so it is inert here.
+                    Ok(StmtKind::Assign(_, _)) => {}
+                    // `Assert` statements and anything unparsed: bail.
+                    _ => return None,
+                }
             }
-            let CallFunc::Regular(reg) = &call.func else {
-                continue;
-            };
-            let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
-                continue;
-            };
-            let want_align = match self.llbc.fn_by_id(*id)?.item_meta.name_path().as_str() {
-                "core::mem::size_of" => false,
-                "core::mem::align_of" => true,
-                _ => continue,
-            };
-            let ty = reg.generics.get("types")?.as_array()?.first()?;
-            let adt = self.resolve_tyexpr_to_adt_def_id(ty)?;
-            let layout = self.llbc.type_by_id(adt)?.layout_for_target("")?;
-            let value = if want_align {
-                layout.align
-            } else {
-                layout.size
-            }?;
-            return Some(OpKind::ConstInt(value as i64));
+            match block.term() {
+                // Data-dependent control flow or an unreadable terminator:
+                // the const value would not be the unconditional size_of.
+                Ok(TermKind::Switch { .. }) | Ok(TermKind::Unknown) | Err(_) => {
+                    return None;
+                }
+                Ok(TermKind::Return) => saw_return = true,
+                Ok(TermKind::Call { call, .. })
+                    if matches!(call.dest.kind, PlaceKind::Local(0)) =>
+                {
+                    let CallFunc::Regular(reg) = &call.func else {
+                        return None;
+                    };
+                    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+                        return None;
+                    };
+                    let want_align = match self.llbc.fn_by_id(*id)?.item_meta.name_path().as_str() {
+                        "core::mem::size_of" => false,
+                        "core::mem::align_of" => true,
+                        // `_0` defined by some other function: not a bare
+                        // size_of/align_of const.
+                        _ => return None,
+                    };
+                    // A second `_0`-defining call makes the value
+                    // order-dependent; only a single one is foldable.
+                    if found.is_some() {
+                        return None;
+                    }
+                    let ty = reg.generics.get("types")?.as_array()?.first()?.clone();
+                    found = Some((want_align, ty));
+                }
+                // `Goto` / `Abort` / `UnwindResume` / `Drop` / `Assert`, and
+                // any call that does not define `_0`: linear continuation or
+                // panic cleanup, none of which write the const value.
+                Ok(_) => {}
+            }
         }
-        None
+        let (want_align, ty) = found?;
+        if !saw_return {
+            return None;
+        }
+        let adt = self.resolve_tyexpr_to_adt_def_id(&ty)?;
+        let layout = self.llbc.type_by_id(adt)?.layout_for_target("")?;
+        let value = if want_align {
+            layout.align
+        } else {
+            layout.size
+        }?;
+        Some(OpKind::ConstInt(value as i64))
     }
 
     // -----------------------------------------------------------------------

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3982,6 +3982,19 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<String as AsRef<str>>::as_ref` / `String::as_str` /
+                // `<String as Borrow<str>>::borrow` — a `&str` view of the
+                // same string, identity in the lifted value model, so alias
+                // the destination to the receiver instead of emitting an
+                // `as_ref` method call the rtyper cannot route on the
+                // classdef-less string receiver.
+                if args.len() == 1 && self.is_string_to_str_identity(&reg, &call.dest.ty) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // Workspace `Index::index` / `IndexMut::index_mut`
                 // impls (`FixedObjectArray` and friends) bottom out at
                 // raw-slice construction (`as_mut_slice` →
@@ -4944,6 +4957,40 @@ impl<'a> Lowering<'a> {
         }
         deref_impl_owner_leaf(self.llbc, fd)
             .is_some_and(|leaf| matches!(leaf.as_str(), "String" | "Vec"))
+    }
+
+    /// `<String as AsRef<str>>::as_ref(&self) -> &str`,
+    /// `String::as_str(&self) -> &str`, and
+    /// `<String as Borrow<str>>::borrow(&self) -> &str` — every one
+    /// returns a `&str` view of the same string, an identity in the
+    /// lifted value model (Rust `String`/`&str`/`str` all lower to the
+    /// immutable rpy_string).  Without the intercept the call keeps a
+    /// `CallTarget::Method` `as_ref` getattr the rtyper cannot route on
+    /// the classdef-less string receiver (the `Cannot find attribute
+    /// "as_ref" on UnicodeString` wall).  Bind the destination to the
+    /// receiver instead, the same alias shape as the container deref
+    /// above.  Gated on the `str`-typed result so `String`'s sibling
+    /// `AsRef<[u8]>` / `AsRef<OsStr>` / `AsRef<Path>` impls — whose
+    /// `&[u8]`/etc. result is a *different* value-model family — keep
+    /// their ordinary lowering.
+    fn is_string_to_str_identity(&self, reg: &RegularCall, dest_ty: &TyRef) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        let np = fd.item_meta.name_path();
+        let Some(leaf) = np.rsplit("::").next() else {
+            return false;
+        };
+        if !matches!(leaf, "as_ref" | "as_str" | "borrow") {
+            return false;
+        }
+        if deref_impl_owner_leaf(self.llbc, fd).as_deref() != Some("String") {
+            return false;
+        }
+        tyref_strips_to_str(dest_ty, self.llbc)
     }
 
     /// The blanket `impl<I: Iterator> IntoIterator for I`
@@ -7461,6 +7508,20 @@ fn tyref_is_string_adt(ty: &TyRef, llbc: &Llbc) -> bool {
         .and_then(adt_node_def_id)
         .and_then(|id| llbc.type_by_id(id))
         .is_some_and(|td| td.item_meta.name_path() == "alloc::string::String")
+}
+
+/// Whether a `TyRef` resolves (behind `Ref`/dedup/hash-cons wrappers) to
+/// the `str` builtin — the unsized string slice (`{"Builtin": "Str"}`).
+/// Distinct from `[u8]` (the `Slice` builtin) and from `[T]`/`Box`/named
+/// ADTs, so it pins the string-family result of a `String -> &str` view
+/// apart from `String`'s sibling `AsRef<[u8]>` / `AsRef<OsStr>` impls.
+fn tyref_strips_to_str(ty: &TyRef, llbc: &Llbc) -> bool {
+    tyref_node(ty, llbc)
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+        .and_then(|n| n.as_object()?.get("Adt")?.as_object()?.get("id")?.as_object())
+        .and_then(|id| id.get("Builtin"))
+        .and_then(serde_json::Value::as_str)
+        == Some("Str")
 }
 
 /// The qualified declaration path of a `TyRef`'s base ADT, after

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3962,7 +3962,9 @@ impl<'a> Lowering<'a> {
                     && (matches!(self.blanket_into_devirt(&reg), Some(IntoDevirt::Identity))
                         || self.trait_clause_into_string_identity(&reg, &call.dest.ty)
                         || self.is_noop_ptr_cast(&reg)
-                        || self.is_reflexive_into_iter(&reg))
+                        || self.is_reflexive_into_iter(&reg)
+                        || self.is_hint_must_use(&reg)
+                        || self.is_arguments_from_str(&reg))
                 {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -4015,6 +4017,17 @@ impl<'a> Lowering<'a> {
                 // `as_ref` method call the rtyper cannot route on the
                 // classdef-less string receiver.
                 if args.len() == 1 && self.is_string_to_str_identity(&reg, &call.dest.ty) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `<str|String as ToString>::to_string` on a string-family
+                // receiver — a `String` clone that is an identity in the
+                // lifted value model, so alias the destination to the
+                // receiver instead of emitting an unregistered `to_string`.
+                if args.len() == 1 && self.is_to_string_identity(&reg, first_arg_ty.as_ref()) {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -4204,6 +4217,23 @@ impl<'a> Lowering<'a> {
                         },
                     });
                     self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `alloc::fmt::format` of a no-placeholder constant
+                // message — `format!("literal")`, whose `format_args!`
+                // lowered to `Arguments::from_str` (aliased to its
+                // `__str_const` operand by the identity fold above).  The
+                // render of a constant string is that string, so alias the
+                // result to the constant instead of leaving an unregistered
+                // `alloc::fmt::format` call.
+                if args.len() == 1
+                    && self.is_fmt_format_call(&reg)
+                    && self.traces_to_str_const(&args[0])
+                {
+                    self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -5059,6 +5089,31 @@ impl<'a> Lowering<'a> {
         tyref_strips_to_str(dest_ty, self.llbc)
     }
 
+    /// `<str as ToString>::to_string` / `<String as ToString>::to_string`
+    /// (`alloc::string::<Impl>::to_string`) — a `String` clone of a value
+    /// that is already a string in the lifted model (`String`/`&str`/`str`
+    /// all lower to the immutable rpy_string), so it is an identity.  The
+    /// path alone cannot tell the string specialization from the blanket
+    /// `impl<T: Display> ToString for T` (both monomorphize to the same
+    /// `<Impl>::to_string`), so gate on the receiver type: fold only when
+    /// the argument is itself string-family.  A non-string `to_string`
+    /// (an integer's `ll_int2dec`) has a receiver outside the family and
+    /// keeps its ordinary lowering.
+    fn is_to_string_identity(&self, reg: &RegularCall, first_arg_ty: Option<&TyRef>) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        if !fd.item_meta.name_path().ends_with("::to_string") {
+            return false;
+        }
+        first_arg_ty.is_some_and(|ty| {
+            tyref_is_string_adt(ty, self.llbc) || tyref_strips_to_str(ty, self.llbc)
+        })
+    }
+
     /// `alloc::fmt::format(args)` (the `format!` macro's String producer)
     /// — the call whose `format_args!` argument the #277 recognizer
     /// back-traces.  `write!`/`writeln!` lower to `fmt::Write::write_fmt`
@@ -5073,6 +5128,58 @@ impl<'a> Lowering<'a> {
             let segs: Vec<String> = np.split("::").map(str::to_string).collect();
             fmt_path_ends_with(&segs, &["fmt", "format"])
         })
+    }
+
+    /// `fmt::Arguments::from_str(s)` — the no-placeholder `format_args!`
+    /// constructor a constant message lowers to (`debug_assert!` /
+    /// `assert!` / `panic!` with a literal, and `format!("literal")`).
+    /// Its sole argument is the `&'static str` literal itself (an already
+    /// string-family value in the lifted model), so the `Arguments` is the
+    /// constant string: the caller aliases the destination to that operand
+    /// instead of emitting the unregistered ctor.  The result then flows
+    /// either to a residualized panic (`Abort` → `RaiseImplicit`) or to
+    /// `alloc::fmt::format` (handled by [`Self::traces_to_str_const`]).
+    fn is_arguments_from_str(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        // `from_str` is an inherent-impl associated function on
+        // `core::fmt::Arguments`, so its `name_path()` carries an `<Impl>`
+        // placeholder, not the owner name — resolve the owner the same way
+        // `call_target_segments` spells the `["fmt", "Arguments",
+        // "from_str"]` `FunctionPath` (via `impl_method_owner_for_fundecl`).
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            impl_method_owner_for_fundecl(self.llbc, fd).is_some_and(|(owner, leaf)| {
+                leaf == "from_str" && owner.ends_with("fmt::Arguments")
+            })
+        })
+    }
+
+    /// Whether `var` is produced by a `__str_const` synthetic call (a
+    /// string literal — see [`Lowering::emit_constant`]), following the
+    /// cross-block back-trace.  Used to recognize `alloc::fmt::format`
+    /// applied to a constant message (a folded `Arguments::from_str`),
+    /// whose render is the constant itself.
+    fn traces_to_str_const(&self, var: &Variable) -> bool {
+        use crate::model::{CallTarget, OpKind};
+        resolve_to_producer_op(&self.graph, var)
+            .and_then(|(b, i)| {
+                self.graph
+                    .blocks
+                    .iter()
+                    .find(|blk| blk.id == b)
+                    .and_then(|blk| blk.operations.get(i))
+                    .map(|op| &op.kind)
+            })
+            .is_some_and(|kind| {
+                matches!(
+                    kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.first().map(String::as_str) == Some("__str_const")
+                )
+            })
     }
 
     /// Whether every placeholder of a recovered `format_args!` chain
@@ -5233,6 +5340,21 @@ impl<'a> Lowering<'a> {
         self.llbc.fn_by_id(*id).is_some_and(|fd| {
             fd.item_meta.name_path() == "core::iter::traits::collect::<Impl>::into_iter"
         })
+    }
+
+    /// `core::hint::must_use(value)` — the identity wrapper
+    /// (`pub const fn must_use<T>(value: T) -> T`) the compiler inserts to
+    /// carry an `unused_must_use` lint through macro-generated code.  It
+    /// returns its argument unchanged and `core` has no graph body for it
+    /// (an unregistered callee), so the callsite aliases its argument
+    /// instead of calling the missing identity body.
+    fn is_hint_must_use(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::hint::must_use")
     }
 
     /// `f64::is_nan(self)` — `core` has no graph body (Opaque), so the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1779,6 +1779,23 @@ impl<'a> Lowering<'a> {
         postorder.into_iter().rev().collect()
     }
 
+    /// Stub `bb_id` as a dead bare-raise block: clear its body / exits /
+    /// exitswitch, close it with a `set_raise`, and mark it `dead`.  Used
+    /// for blocks the framestate threading must not lower — model-
+    /// unreachable orphan `on_unwind` chains and `If`-arms a const-bool
+    /// discriminant folded away (see [`Self::lower_framestate`]).  The
+    /// real-path `function_graph_to_flowspace` prunes `dead` blocks
+    /// (`remove_dead_blocks` parity), so the stub's orphan etype/evalue
+    /// never reach the rtyper as undefined operands.
+    fn stub_dead_block(&mut self, bb_id: BlockId) {
+        let blk = self.graph.block_mut(bb_id);
+        blk.operations.clear();
+        blk.exits.clear();
+        blk.exitswitch = None;
+        self.graph.set_raise(bb_id, "mir-dead");
+        self.graph.block_mut(bb_id).dead = true;
+    }
+
     /// Lower the body threading locals as block inputargs / phis via
     /// per-block [`FrameState`]s, instead of the function-wide monotonic
     /// `local_var` table.  Restricted to acyclic bodies (the caller gates
@@ -1835,11 +1852,30 @@ impl<'a> Lowering<'a> {
 
         // Pass 1 — RPO walk: setstate, inputargs, lower, snapshot, union.
         for &bb in &rpo {
-            let st = entry_state[bb].clone().ok_or_else(|| {
-                LowerError::Unsupported(format!(
-                    "framestate: reachable bb{bb} has no entry state (RPO/union bug)"
-                ))
-            })?;
+            let st = match entry_state[bb].clone() {
+                Some(st) => st,
+                None => {
+                    // No live predecessor edge reached this block.  RPO
+                    // over `model_succs` visits every model-predecessor
+                    // before `bb`, and each unions its *lowered* exits
+                    // into `bb`'s entry; a still-empty entry here means
+                    // every model edge into `bb` was an `If`-arm that
+                    // `lower_switch` folded away on a const-bool
+                    // discriminant (a translation-time `const` gate such
+                    // as `if WITHPREBUILTINT`), so `bb` is unreachable in
+                    // the produced graph even though `mir_model_reachable`
+                    // — which reads the raw terminator, pre-fold — marks
+                    // it reachable.  Stub it dead exactly like the model-
+                    // unreachable orphan chains below; the real-path
+                    // adapter's reachability prune removes it, and
+                    // threading dead state would only mint phis the legacy
+                    // fallback cannot type.  `bb` is never bb0 (the
+                    // startblock is seeded and visited first), so a bare
+                    // raise stub is well-formed.
+                    self.stub_dead_block(self.block_id[bb]);
+                    continue;
+                }
+            };
             self.setstate(&st);
             let bb_id = self.block_id[bb];
             // The startblock keeps its parameter inputargs + Input ops;
@@ -1901,30 +1937,33 @@ impl<'a> Lowering<'a> {
         // Model-unreachable blocks: orphan `on_unwind` cleanup chains that
         // no lowered exit targets — `lower_terminator` strips every unwind
         // edge (Goto / Assert / Drop / Call all forward to the success
-        // continuation only), so `model_succs` is exactly the set of
-        // lowered exits and an unreachable block here is genuinely
-        // unreferenced.  Mark them `dead` and stub a bare raise so the
-        // graph stays closed for the legacy fallback path, which consumes
-        // this same `FunctionGraph`.  The real path's
-        // `function_graph_to_flowspace` prunes `dead` blocks outright
-        // (`remove_dead_blocks` parity), so the stub's orphan etype/evalue
-        // never reach the rtyper as undefined operands.
+        // continuation only).  `model_succs` is a *superset* of the
+        // lowered exits — it reads the raw terminator and so still lists an
+        // `If`-arm a const-bool discriminant later folds away — but it is
+        // never a subset, so `reachable[bb]` false (outside the
+        // `model_succs` closure) is a sufficient deadness signal: such a
+        // block is genuinely unreferenced.  (The folded-arm case, where a
+        // block IS in the closure yet has no live lowered predecessor, is
+        // caught in Pass 1 by the empty-entry stub above.)  Mark them
+        // `dead` so the graph stays closed for the legacy fallback path,
+        // which consumes this same `FunctionGraph`.
         for bb in 0..n {
             if reachable[bb] {
                 continue;
             }
-            let bb_id = self.block_id[bb];
-            let blk = self.graph.block_mut(bb_id);
-            blk.operations.clear();
-            blk.exits.clear();
-            blk.exitswitch = None;
-            self.graph.set_raise(bb_id, "mir-dead");
-            self.graph.block_mut(bb_id).dead = true;
+            self.stub_dead_block(self.block_id[bb]);
         }
 
         // Pass 2 — re-argument the goto / branch links from framestates.
         for &bb in &rpo {
             let bb_id = self.block_id[bb];
+            // A block Pass 1 stubbed dead (empty-entry const-fold orphan)
+            // has no exit state and a bare-raise body — its links carry no
+            // framestate args to re-argument.  Skip it; the final guard
+            // and the real-path dead-block prune both ignore it too.
+            if self.graph.block(bb_id).dead {
+                continue;
+            }
             let ex = exit_state[bb].clone().ok_or_else(|| {
                 LowerError::Unsupported(format!("framestate: bb{bb} missing exit state in pass 2"))
             })?;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1363,6 +1363,19 @@ struct Lowering<'a> {
     /// rewires into `ExitSwitch::LastException` exits after the body
     /// lowering completes.
     result_exc_call_results: Vec<Variable>,
+    /// `Variable.id()`s whose binding was resolved from a `Copy`/`Move`
+    /// operand whose place type is the string value-model family
+    /// (`String` ADT or the `str` builtin).  The `#277` `format_args!`
+    /// recognizer ([`Lowering::fmt_chain_all_string_display`]) consults
+    /// this set to verify every `{}` placeholder argument renders by
+    /// identity (a `&str`/`String` `Display`) before folding the chain to
+    /// a string concat; an argument absent from the set is not provably
+    /// string-family and the whole chain is left unfolded (fail-closed).
+    /// The post-build graph cannot recover this — `tyref_to_value_type`
+    /// collapses both `String` and `&str` to `Ref(None)` — so the
+    /// classification is stamped here at resolve time when the Charon
+    /// `TyRef` is still in hand.
+    fmt_arg_string_vars: std::collections::HashSet<u64>,
 }
 
 impl<'a> Lowering<'a> {
@@ -1493,6 +1506,7 @@ impl<'a> Lowering<'a> {
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
+            fmt_arg_string_vars: std::collections::HashSet::new(),
         })
     }
 
@@ -2974,7 +2988,19 @@ impl<'a> Lowering<'a> {
     /// Resolve an [`Operand`] to the Variable the IR should reference.
     fn resolve_operand(&mut self, mir_bb: usize, op: Operand) -> Result<Variable, LowerError> {
         match op {
-            Operand::Copy(place) | Operand::Move(place) => self.resolve_place(mir_bb, place),
+            Operand::Copy(place) | Operand::Move(place) => {
+                // Record the resolved Variable as string-family when the
+                // operand's place types as `String`/`&str`, so the #277
+                // `format_args!` recognizer can verify a placeholder
+                // argument renders by identity (see `fmt_arg_string_vars`).
+                let is_string = tyref_is_string_adt(&place.ty, self.llbc)
+                    || tyref_strips_to_str(&place.ty, self.llbc);
+                let var = self.resolve_place(mir_bb, place)?;
+                if is_string {
+                    self.fmt_arg_string_vars.insert(var.id());
+                }
+                Ok(var)
+            }
             Operand::Const(value) => self.emit_constant(mir_bb, &value),
         }
     }
@@ -4183,6 +4209,46 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `alloc::fmt::format(args)` over a recognized `format_args!`
+                // chain whose every `{}` placeholder is a `&str`/`String`
+                // `Display` (so each renders by identity).  Fold it to the
+                // StringRepr str-const + `add` concat (`emit_fmt_concat` →
+                // `ll_strconcat`, parity with `rstr.do_stringformat` on the
+                // all-string subset) and neutralize the chain's unregistered
+                // `fmt::Arguments::new` / `fmt::rt::Argument::new_*` ctors so
+                // the now-dead construction subgraph lifts.  Any chain
+                // outside the subset (a `Debug` placeholder, a non-string
+                // `Display`, a width/precision/positional spec, or an
+                // un-typed argument) is declined and keeps the ordinary
+                // lowering — the fold never fires unless every argument is
+                // provably string-family.
+                if args.len() == 1
+                    && self.is_fmt_format_call(&reg)
+                    && let Some(chain) = extract_fmt_chain(&self.graph, &args[0])
+                    && self.fmt_chain_all_string_display(&chain)
+                    && let Some(paths) = chain
+                        .args
+                        .iter()
+                        .map(|a| self.fmt_value_path(&a.value, bb_id))
+                        .collect::<Option<Vec<_>>>()
+                {
+                    // Each `Argument::new_*(&v)` call terminates its own
+                    // MIR block, so a placeholder value `v` is usually
+                    // dead by the `format()` block — thread it forward
+                    // along the (merge-free) construction chain so the
+                    // concat's operand is in scope.
+                    let mut threaded = chain.clone();
+                    for (arg, path) in threaded.args.iter_mut().zip(&paths) {
+                        arg.value = self.thread_along_path(&arg.value, path);
+                    }
+                    self.neutralize_fmt_chain_ctors(&args[0]);
+                    let res = emit_fmt_concat(&mut self.graph, bb_id, &threaded);
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // Resolve the target function's fully-qualified path
                 // through the FunId → FunDecl table. `Trait` here is
                 // Charon's "trait-bound generic resolved at extraction
@@ -4991,6 +5057,166 @@ impl<'a> Lowering<'a> {
             return false;
         }
         tyref_strips_to_str(dest_ty, self.llbc)
+    }
+
+    /// `alloc::fmt::format(args)` (the `format!` macro's String producer)
+    /// — the call whose `format_args!` argument the #277 recognizer
+    /// back-traces.  `write!`/`writeln!` lower to `fmt::Write::write_fmt`
+    /// (a `Result`), never `fmt::format`, so the two-segment tail keeps
+    /// the match precise.
+    fn is_fmt_format_call(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            let np = fd.item_meta.name_path();
+            let segs: Vec<String> = np.split("::").map(str::to_string).collect();
+            fmt_path_ends_with(&segs, &["fmt", "format"])
+        })
+    }
+
+    /// Whether every placeholder of a recovered `format_args!` chain
+    /// renders by identity: a `Display` (`{}`, not `{:?}` `Debug`) of a
+    /// string-family value (`fmt_arg_string_vars`).  Only then is the
+    /// str-const + `add` concat ([`emit_fmt_concat`]) a faithful
+    /// substitute for the runtime render (`rstr.do_stringformat`'s
+    /// per-argument `ll_str` is the identity on a string).  A `Debug`
+    /// placeholder (adds quotes/escapes), a non-string `Display` (an
+    /// integer's `ll_int2dec`), or an argument whose type was never
+    /// stamped string-family ⇒ decline the whole chain (fail-closed).
+    fn fmt_chain_all_string_display(&self, chain: &FmtChain) -> bool {
+        chain.args.iter().all(|a| {
+            a.kind == FmtArgKind::Display && self.fmt_arg_string_vars.contains(&a.value.id())
+        })
+    }
+
+    /// Replace this `format_args!` chain's unregistered constructor calls
+    /// — the single `fmt::Arguments::new(pieces, args)` that produced
+    /// `fmt_args_var` and each `fmt::rt::Argument::new_display`/`new_debug`
+    /// element of its args array — in place with the `__str_const("")`
+    /// dummy the flowspace adapter folds to an empty-string `Constant`.
+    /// After the fold binds the result to the concat, `fmt_args_var` and
+    /// its whole construction subgraph are dead; neutralizing only the
+    /// unregistered `Call`s (the bytes/array/tuple ops already lift) lets
+    /// the dead subgraph translate instead of tripping the
+    /// `not registered in PyreCallRegistry` wall, without removing ops
+    /// (no index shift, no dangling cross-block inputarg).
+    fn neutralize_fmt_chain_ctors(&mut self, fmt_args_var: &Variable) {
+        use crate::model::{CallTarget, OpKind, ValueType};
+        let dummy = || OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__str_const".to_string(), String::new()],
+            },
+            args: vec![],
+            result_ty: ValueType::Ref(None),
+        };
+        let mut positions: Vec<(BlockId, usize)> = Vec::new();
+        let Some((ab, ai)) = resolve_to_producer_op(&self.graph, fmt_args_var) else {
+            return;
+        };
+        positions.push((ab, ai));
+        // The `Arguments::new(pieces, args)` second operand is the args
+        // array; each element is an `Argument::new_*` ctor to neutralize.
+        let args_var = match self
+            .graph
+            .blocks
+            .iter()
+            .find(|b| b.id == ab)
+            .and_then(|b| b.operations.get(ai))
+            .map(|op| &op.kind)
+        {
+            Some(OpKind::Call { args, .. }) => args.get(1).cloned(),
+            _ => None,
+        };
+        if let Some(args_var) = args_var
+            && let Some(arg_elems) = read_array_literal_elements(&self.graph, &args_var)
+        {
+            for elem in &arg_elems {
+                if let Some(p) = resolve_to_producer_op(&self.graph, elem) {
+                    positions.push(p);
+                }
+            }
+        }
+        for (b, i) in positions {
+            if let Some(op) = self.graph.block_mut(b).operations.get_mut(i) {
+                op.kind = dummy();
+            }
+        }
+    }
+
+    /// Whether `v` is defined in block `b` — bound as one of its
+    /// `inputargs` or produced by one of its operations.
+    fn block_defines(&self, b: BlockId, v: &Variable) -> bool {
+        let blk = self.graph.block(b);
+        blk.inputargs.iter().any(|a| a.id() == v.id())
+            || blk
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref().is_some_and(|r| r.id() == v.id()))
+    }
+
+    /// The block chain `[target, .., def]` (target first) from `target`
+    /// back to the block that defines `value`, each hop a single incoming
+    /// `Link`.  `Some(vec![target])` when `value` is already in scope at
+    /// `target`; `None` when a hop has zero or several incoming links (a
+    /// merge — no single forward path to thread along).  Read-only: used
+    /// to pre-check that every `format_args!` placeholder value can be
+    /// carried to the `format()` block before any graph mutation.
+    fn fmt_value_path(&self, value: &Variable, target: BlockId) -> Option<Vec<BlockId>> {
+        if self.block_defines(target, value) {
+            return Some(vec![target]);
+        }
+        let mut path = vec![target];
+        let mut cur = target;
+        loop {
+            let mut incoming = self
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|b| b.exits.iter().map(move |l| (b.id, l.target)))
+                .filter(|(_, t)| *t == cur);
+            let (src, _) = incoming.next()?;
+            if incoming.next().is_some() {
+                return None; // merge: no single forward path
+            }
+            path.push(src);
+            if self.block_defines(src, value) {
+                return Some(path);
+            }
+            cur = src;
+            if path.len() > 4096 {
+                return None; // runaway guard
+            }
+        }
+    }
+
+    /// Thread `value` forward from its defining block to the chain's
+    /// final block (`path` is `[target, .., def]` as returned by
+    /// [`Lowering::fmt_value_path`]), appending it to each hop's single
+    /// `Link` and a fresh `inputarg` to each successor.  Returns the
+    /// in-`target` Variable.  Each block on a [`fmt_value_path`] chain has
+    /// exactly one incoming `Link`, so growing that `Link`'s args and the
+    /// block's `inputargs` in lock-step preserves the arity invariant.
+    fn thread_along_path(&mut self, value: &Variable, path: &[BlockId]) -> Variable {
+        let mut chain: Vec<BlockId> = path.to_vec();
+        chain.reverse(); // [def, .., target]
+        let mut carried = value.clone();
+        for w in chain.windows(2) {
+            let (from, to) = (w[0], w[1]);
+            let new_input = Variable::new();
+            if let Some(link) = self
+                .graph
+                .block_mut(from)
+                .exits
+                .iter_mut()
+                .find(|l| l.target == to)
+            {
+                link.args.push(crate::model::LinkArg::Value(carried.clone()));
+            }
+            self.graph.block_mut(to).inputargs.push(new_input.clone());
+            carried = new_input;
+        }
+        carried
     }
 
     /// The blanket `impl<I: Iterator> IntoIterator for I`
@@ -8875,9 +9101,6 @@ fn scalar_value_to_i64(v: &serde_json::Value) -> Option<i64> {
 /// `None` when `var` traces to a `Const`, a function input (no producing
 /// op), a phi merge (a block with more than one incoming `Link`, so no
 /// single producer), or a producer not yet emitted into `graph`.
-//
-// Staged for the #277 recognizer; not yet wired into the call dispatch.
-#[allow(dead_code)]
 fn resolve_to_producer_op(
     graph: &FunctionGraph,
     var: &crate::flowspace::model::Variable,
@@ -8944,9 +9167,6 @@ fn resolve_to_producer_op(
 /// untouched) on any high-bit control byte other than `0xC0` — i.e. a
 /// format spec with width/precision/fill or an explicit positional/named
 /// argument — and on non-UTF-8 literal bytes.
-//
-// Staged for the #277 recognizer; not yet wired into the call dispatch.
-#[allow(dead_code)]
 fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
     let mut pieces: Vec<String> = Vec::new();
     let mut current = String::new();
@@ -8997,9 +9217,6 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, usize)> {
 /// once the ctor is found. Returns `None` if `array_var` is not produced
 /// by an `Array` ctor, or its `__pos_i` writes are not the contiguous
 /// range `0..n`.
-//
-// Staged for the #277 recognizer; not yet wired into the call dispatch.
-#[allow(dead_code)]
 fn read_array_literal_elements(
     graph: &FunctionGraph,
     array_var: &crate::flowspace::model::Variable,
@@ -9042,9 +9259,6 @@ fn read_array_literal_elements(
 /// following cross-block links via [`resolve_to_producer_op`]. Used to
 /// read the packed-format pieces byte array (each `__pos_i` element is a
 /// `ConstInt` byte).
-//
-// Staged for the #277 recognizer; not yet wired into the call dispatch.
-#[allow(dead_code)]
 fn resolve_const_int(
     graph: &FunctionGraph,
     var: &crate::flowspace::model::Variable,
@@ -9063,7 +9277,6 @@ fn resolve_const_int(
 /// `new_debug` constructor in the parallel args array (the packed pieces
 /// template does not encode the choice).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 enum FmtArgKind {
     Display,
     Debug,
@@ -9072,7 +9285,6 @@ enum FmtArgKind {
 /// One placeholder argument recovered from a `format_args!` chain: the
 /// value Variable the placeholder renders and its Display/Debug flavour.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct FmtArg {
     value: crate::flowspace::model::Variable,
     kind: FmtArgKind,
@@ -9082,7 +9294,6 @@ struct FmtArg {
 /// pieces interleaved with the rendered placeholder arguments
 /// (`pieces.len() == args.len() + 1`).
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct FmtChain {
     pieces: Vec<String>,
     args: Vec<FmtArg>,
@@ -9092,7 +9303,6 @@ struct FmtChain {
 /// crate-qualified spelling (`core::fmt::Arguments::new`) and the
 /// crate-stripped front-end spelling (`fmt::Arguments::new`) both
 /// resolve.
-#[allow(dead_code)]
 fn fmt_path_ends_with(segments: &[String], tail: &[&str]) -> bool {
     segments.len() >= tail.len()
         && segments[segments.len() - tail.len()..]
@@ -9103,7 +9313,6 @@ fn fmt_path_ends_with(segments: &[String], tail: &[&str]) -> bool {
 
 /// The `fmt::Arguments::new(pieces, args)` constructor that `format_args!`
 /// builds from the on-stack pieces+args arrays.
-#[allow(dead_code)]
 fn is_arguments_new_path(segments: &[String]) -> bool {
     fmt_path_ends_with(segments, &["Arguments", "new"])
 }
@@ -9111,7 +9320,6 @@ fn is_arguments_new_path(segments: &[String]) -> bool {
 /// Classify a `fmt::rt::Argument::new_display` / `new_debug` constructor
 /// path. Any other path (positional/named/width-bearing argument ctor) is
 /// not in the recognized subset.
-#[allow(dead_code)]
 fn fmt_argument_ctor_kind(segments: &[String]) -> Option<FmtArgKind> {
     if fmt_path_ends_with(segments, &["Argument", "new_display"]) {
         Some(FmtArgKind::Display)
@@ -9128,7 +9336,6 @@ fn fmt_argument_ctor_kind(segments: &[String]) -> Option<FmtArgKind> {
 /// value written into that tuple field. Returns `var` unchanged when it
 /// is not produced by a `FieldRead` (value passed directly), and `None`
 /// when the tuple field has conflicting writers.
-#[allow(dead_code)]
 fn unwrap_fmt_arg_tuple_ref(
     graph: &FunctionGraph,
     var: &crate::flowspace::model::Variable,
@@ -9180,7 +9387,6 @@ fn unwrap_fmt_arg_tuple_ref(
 /// element is the result of a `fmt::rt::Argument::new_display` /
 /// `new_debug` constructor, whose sole argument back-traces (through the
 /// tuple-ref wrap) to the rendered value.
-#[allow(dead_code)]
 fn extract_fmt_arg(
     graph: &FunctionGraph,
     arg_elem: &crate::flowspace::model::Variable,
@@ -9212,7 +9418,6 @@ fn extract_fmt_arg(
 /// Returns `None` (the recognizer leaves the graph untouched) on any
 /// shape outside the recognized subset, so it never fires on an
 /// unsupported chain.
-#[allow(dead_code)]
 fn extract_fmt_chain(
     graph: &FunctionGraph,
     fmt_args_var: &crate::flowspace::model::Variable,
@@ -9254,7 +9459,6 @@ fn extract_fmt_chain(
 /// constant lowering uses (see [`Lowering::emit_constant`]); the flowspace
 /// adapter pre-folds it to the upstream string `Constant` and types it as
 /// a String.
-#[allow(dead_code)]
 fn emit_str_const(graph: &mut FunctionGraph, bb_id: BlockId, text: &str) -> Variable {
     use crate::model::{CallTarget, OpKind, ValueType};
     let var = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
@@ -9275,7 +9479,6 @@ fn emit_str_const(graph: &mut FunctionGraph, bb_id: BlockId, text: &str) -> Vari
 /// Variable. The `"add"` opname passes through the flowspace adapter
 /// unchanged; when both operands type as String the rtyper routes it to
 /// `pair(StringRepr, StringRepr).rtype_add` → `direct_call(ll_strconcat)`.
-#[allow(dead_code)]
 fn emit_str_add(
     graph: &mut FunctionGraph,
     bb_id: BlockId,
@@ -10258,33 +10461,6 @@ mod tests {
 
         // A non-Array producer (plain ConstInt) is rejected.
         assert_eq!(read_array_literal_elements(&graph, &elements[0]), None);
-    }
-
-    /// Throwaway IR-capture probe for the #277 fmt recognizer: dumps the
-    /// lowered front-end op sequence for `stack_underflow_error` (the
-    /// canonical `type_error(format!("…{x}"))` chain) so the byte-array
-    /// piece decoder can be anchored to the real `Array`/`ConstInt` shape.
-    /// Ignored by default (loads the 242MB real LLBC); run with
-    /// `cargo test -p majit-translate --lib dump_fmt_chain_ir -- --ignored --nocapture`.
-    #[test]
-    #[ignore]
-    fn dump_fmt_chain_ir() {
-        let path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../build/llbc/pyre-interpreter.ullbc"
-        );
-        let llbc = Llbc::load(path).expect("load real LLBC");
-        let graph = super::lower_function(&llbc, "stack_underflow_error")
-            .expect("lower stack_underflow_error");
-        for block in &graph.blocks {
-            eprintln!("block {:?} inputargs={:?}", block.id, block.inputargs);
-            for (idx, op) in block.operations.iter().enumerate() {
-                eprintln!("  [{idx}] result={:?} kind={:?}", op.result, op.kind);
-            }
-            for link in &block.exits {
-                eprintln!("  exit -> {:?} args={:?}", link.target, link.args);
-            }
-        }
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3812,7 +3812,11 @@ impl<'a> Lowering<'a> {
             let ty = reg.generics.get("types")?.as_array()?.first()?;
             let adt = self.resolve_tyexpr_to_adt_def_id(ty)?;
             let layout = self.llbc.type_by_id(adt)?.layout_for_target("")?;
-            let value = if want_align { layout.align } else { layout.size }?;
+            let value = if want_align {
+                layout.align
+            } else {
+                layout.size
+            }?;
             return Some(OpKind::ConstInt(value as i64));
         }
         None
@@ -5375,7 +5379,8 @@ impl<'a> Lowering<'a> {
                 .iter_mut()
                 .find(|l| l.target == to)
             {
-                link.args.push(crate::model::LinkArg::Value(carried.clone()));
+                link.args
+                    .push(crate::model::LinkArg::Value(carried.clone()));
             }
             self.graph.block_mut(to).inputargs.push(new_input.clone());
             carried = new_input;
@@ -7923,7 +7928,13 @@ fn tyref_is_string_adt(ty: &TyRef, llbc: &Llbc) -> bool {
 fn tyref_strips_to_str(ty: &TyRef, llbc: &Llbc) -> bool {
     tyref_node(ty, llbc)
         .and_then(|n| strip_ty_wrappers(n, llbc))
-        .and_then(|n| n.as_object()?.get("Adt")?.as_object()?.get("id")?.as_object())
+        .and_then(|n| {
+            n.as_object()?
+                .get("Adt")?
+                .as_object()?
+                .get("id")?
+                .as_object()
+        })
         .and_then(|id| id.get("Builtin"))
         .and_then(serde_json::Value::as_str)
         == Some("Str")

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -347,21 +347,31 @@ pub(crate) fn lower_result_exc_returns(
         };
         // The shell must flow out through this block's single
         // unconditional exit, and through nothing else.
-        let consumers = count_var_uses(graph, &ctor_var);
-        // ctor result + FieldWrite base + one link arg.
-        if consumers.link_uses != 1 || consumers.op_uses != 1 {
-            return Err(format!(
-                "{}: block {bi} Result shell has unexpected consumers \
-                 (op_uses={}, link_uses={}) — only the payload FieldWrite \
-                 and one exit arg are supported",
-                graph.name, consumers.op_uses, consumers.link_uses
-            ));
-        }
         if graph.blocks[bi].exits.len() != 1 || graph.blocks[bi].exitswitch.is_some() {
             return Err(format!(
                 "{}: block {bi} Result shell block has a conditional exit — \
                  unsupported shape",
                 graph.name
+            ));
+        }
+        let consumers = count_var_uses(graph, &ctor_var);
+        // The shell's only op use is the `__pos_0` payload FieldWrite
+        // base.  Its link uses are forwarding exit args, all in the single
+        // exit asserted above: the monotonic lowering forwards the shell
+        // once, but the framestate-threaded lowering can carry the same
+        // value in several `mergeable` slots (a value occupying both a
+        // locals and a stack cell appears once per slot in
+        // `getoutputargs`), so `link_uses` may exceed 1.  Every slot
+        // reaches the returnblock (verified below); the `Ok` rewrite
+        // replaces every occurrence with the payload and the `Err` rewrite
+        // discards the exit wholesale (`set_raise_values` → `set_goto`),
+        // so multiple forwarding slots lower soundly.
+        if consumers.op_uses != 1 || consumers.link_uses < 1 {
+            return Err(format!(
+                "{}: block {bi} Result shell has unexpected consumers \
+                 (op_uses={}, link_uses={}) — expected the single __pos_0 \
+                 payload FieldWrite and at least one forwarding exit arg",
+                graph.name, consumers.op_uses, consumers.link_uses
             ));
         }
         // Verify the value reaches returnblock through pure forwarding.
@@ -897,6 +907,21 @@ fn rewire_one_call_site(
                     // call result itself flows in its place.
                     normal_args.push(LinkArg::Value(r.clone()));
                     payload_positions.push(i);
+                } else if *v == disc_var {
+                    // The framestate-threaded lowering carries the
+                    // ControlFlow `__discriminant` temporary forward on
+                    // the continue edge (the monotonic lowering does
+                    // not).  Block C — its only reader, the discriminant
+                    // switch — is removed by this rewrite, so the value
+                    // has no A-scope origin; but the continue arm is the
+                    // `Continue` case (`split_diamond_exits` keys it to
+                    // discriminant `0`), so the value here is the
+                    // constant `0`.  Carry that constant; the now-dead
+                    // downstream threading is left to the post-rewrite
+                    // `simplify_lowered_graph` dead-variable sweep.
+                    normal_args.push(LinkArg::Const(crate::flowspace::model::Constant::new(
+                        crate::flowspace::model::ConstValue::Int(0),
+                    )));
                 } else {
                     let v_a = back_substitute(graph, &[(a, b), (b, c)], v, &name)?;
                     normal_args.push(LinkArg::Value(v_a));

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -597,6 +597,7 @@ fn analyze_pipeline_from_module_paths(
         String,
         Option<String>,
         Vec<String>,
+        crate::model::FunctionGraph,
     )> = Vec::new();
     let mut canonical_function_graphs = std::collections::HashMap::new();
     // `bookkeeper.py:353-409 getdesc` / `newfuncdesc` keys on the host
@@ -685,6 +686,7 @@ fn analyze_pipeline_from_module_paths(
                     owner.clone(),
                     func.return_type.clone(),
                     func.hints.clone(),
+                    func.graph.clone(),
                 ));
                 let types = trait_concrete_impl_types
                     .entry(trait_leaf.as_str())
@@ -1099,7 +1101,7 @@ fn analyze_pipeline_from_module_paths(
     }
     let mut concrete_impl_counts: std::collections::HashMap<(String, String), usize> =
         std::collections::HashMap::new();
-    for (trait_leaf, _, method_name, _, _, _) in &concrete_trait_methods {
+    for (trait_leaf, _, method_name, _, _, _, _) in &concrete_trait_methods {
         *concrete_impl_counts
             .entry((trait_leaf.clone(), method_name.clone()))
             .or_insert(0) += 1;
@@ -1114,7 +1116,7 @@ fn analyze_pipeline_from_module_paths(
         String,
         std::collections::BTreeSet<String>,
     > = std::collections::HashMap::new();
-    for (_, trait_qualified, _, owner, _, _) in &concrete_trait_methods {
+    for (_, trait_qualified, _, owner, _, _, _) in &concrete_trait_methods {
         // Keyed by the trait's qualified `name_path()` — two distinct
         // traits sharing a leaf name must not pool their impl owners
         // (`tyref_generic_trait_bound_root` resolves bound-trait
@@ -1155,20 +1157,21 @@ fn analyze_pipeline_from_module_paths(
         })
         .collect();
     call_control.set_trait_unique_impls(trait_unique_impls);
-    for (trait_leaf, _, method_name, owner, return_type, hints) in &concrete_trait_methods {
+    for (trait_leaf, _, method_name, _owner, return_type, hints, graph) in &concrete_trait_methods {
         let key = (trait_leaf.clone(), method_name.clone());
         if concrete_impl_counts.get(&key) != Some(&1) || default_trait_methods.contains(&key) {
             continue;
         }
-        let Some(graph) = mir_graph_lookup
-            .lookup_impl_method(owner, method_name)
-            .cloned()
-        else {
-            continue;
-        };
+        // Use this trait-impl method's own graph rather than
+        // `lookup_impl_method(owner, method_name)`: when the impl owner
+        // also has a same-named *inherent* method (e.g. `PyFrame` has both
+        // the inherent `peek_at` and `<PyFrame as SharedOpcodeHandler>::
+        // peek_at`), the two collide on the `(owner, name)` key and the
+        // lookup resolves to `Err(())` (ambiguous), silently dropping the
+        // single-impl devirtualization.  The carried graph is unambiguous.
         let graph = match return_type {
-            Some(rt) => graph.with_return_type(rt),
-            None => graph,
+            Some(rt) => graph.clone().with_return_type(rt),
+            None => graph.clone(),
         };
         let direct_path =
             crate::parse::CallPath::from_segments([trait_leaf.as_str(), method_name.as_str()]);

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -394,6 +394,15 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::w_type_set_uses_object_setattr",
         crate::opcode_ops::bh_w_type_set_uses_object_setattr as *const (),
     );
+    // `lookup_exc_class_for_kind` reads the TLS `EXC_CLASS_BY_KIND`
+    // registry the tracer cannot model; its residual call rides a C-ABI
+    // bridge that reconstructs the `ExcKind` from the integer arg slot.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::excobject::lookup_exc_class_for_kind",
+        "pyre_object::lookup_exc_class_for_kind",
+        crate::opcode_ops::bh_lookup_exc_class_for_kind as *const (),
+    );
 
     for (nargs, (module_path, root_path)) in CALLABLE_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::callable_call_helper(nargs) {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -373,6 +373,28 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         crate::opcode_ops::bh_store_subscr_fn as *const (),
     );
 
+    // `dont_look_inside` runtime-state accessors residualised at trace
+    // time (TLS / per-type atomic the tracer cannot model).  Their
+    // residual call resolves its address here by qualified path; a
+    // missing entry would fall back to a symbolic hash that SEGVs at
+    // trace time.  `shadow_stack_len` carries a JIT-representable
+    // `-> int` signature and binds its Rust `fn` directly (the
+    // `PyFrame::nlocals` / `get_current_exception` precedent);
+    // `w_type_set_uses_object_setattr` rides a C-ABI bridge that
+    // normalises its `bool` argument.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_roots::shadow_stack_len",
+        "pyre_object::shadow_stack_len",
+        pyre_object::gc_roots::shadow_stack_len as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::typeobject::w_type_set_uses_object_setattr",
+        "pyre_object::w_type_set_uses_object_setattr",
+        crate::opcode_ops::bh_w_type_set_uses_object_setattr as *const (),
+    );
+
     for (nargs, (module_path, root_path)) in CALLABLE_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::callable_call_helper(nargs) {
             push_alias_pair(&mut entries, module_path, root_path, fnptr);

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -443,6 +443,23 @@ pub extern "C" fn bh_w_type_set_uses_object_setattr(obj: i64, v: i64) {
     }
 }
 
+/// C-ABI residual bridge for the `dont_look_inside`
+/// [`pyre_object::excobject::lookup_exc_class_for_kind`]: its `ExcKind`
+/// parameter does not match the integer arg slot a residual call
+/// supplies, so reconstruct it from `i64` here before forwarding. The
+/// `PyObjectRef` result rides back as `i64` (null = not registered).
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn bh_lookup_exc_class_for_kind(kind_disc: i64) -> i64 {
+    use pyre_object::excobject::{EXC_KIND_COUNT, ExcKind, lookup_exc_class_for_kind};
+    if kind_disc < 0 || kind_disc as usize >= EXC_KIND_COUNT {
+        return 0;
+    }
+    // Safety: bounds-checked above; `ExcKind` is `repr(u8)` with
+    // contiguous discriminants `0..EXC_KIND_COUNT`.
+    let kind: ExcKind = unsafe { std::mem::transmute(kind_disc as u8) };
+    lookup_exc_class_for_kind(kind) as i64
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -432,6 +432,17 @@ pub extern "C" fn bh_store_subscr_fn(obj: i64, key: i64, value: i64) -> i64 {
     1
 }
 
+/// C-ABI residual bridge for the `dont_look_inside`
+/// [`pyre_object::typeobject::w_type_set_uses_object_setattr`]: its
+/// `bool` parameter does not match the integer arg slot a residual call
+/// supplies, so normalise it from `i64` here before forwarding.
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn bh_w_type_set_uses_object_setattr(obj: i64, v: i64) {
+    unsafe {
+        pyre_object::typeobject::w_type_set_uses_object_setattr(obj as PyObjectRef, v != 0);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -155,11 +155,18 @@ pub static TYPEOBJECT_CACHE: OnceLock<HashMap<usize, usize>> = OnceLock::new();
 /// Get the cached W_TypeObject for a builtin runtime type.
 ///
 /// PyPy: `space.gettypefor(cls)` / `space.gettypeobject(typedef)`
+///
+/// Reads the per-type `instantiate` slot (`rclass.py:739-743`
+/// `new_instance`), an `AtomicPtr` seeded by `init_typeobjects()`'s
+/// `set_instantiate` loop — the same source that backs
+/// `TYPEOBJECT_CACHE`. The slot read is a single field load the JIT can
+/// model, where the `usize`-keyed `HashMap` lookup is not.
 pub fn gettypefor(tp: *const PyType) -> Option<PyObjectRef> {
-    TYPEOBJECT_CACHE
-        .get()
-        .and_then(|reg| reg.get(&(tp as usize)).copied())
-        .map(|v| v as PyObjectRef)
+    if tp.is_null() {
+        return None;
+    }
+    let w = unsafe { pyre_object::get_instantiate(&*tp) };
+    if w.is_null() { None } else { Some(w) }
 }
 
 /// Get the W_TypeObject for any PyObjectRef.
@@ -191,8 +198,8 @@ pub fn r#type(obj: PyObjectRef) -> Option<PyObjectRef> {
                 return Some(w_class);
             }
             let kind = pyre_object::w_exception_get_kind(obj);
-            let name = pyre_object::excobject::exc_kind_name(kind);
-            if let Some(cls) = crate::builtins::lookup_exc_class(name) {
+            let cls = pyre_object::excobject::lookup_exc_class_for_kind(kind);
+            if !cls.is_null() {
                 return Some(cls);
             }
         }

--- a/pyre/pyre-object/src/excobject.rs
+++ b/pyre/pyre-object/src/excobject.rs
@@ -576,6 +576,11 @@ pub fn register_exc_class_for_kind(kind: ExcKind, cls: PyObjectRef) {
     });
 }
 
+/// Reads the thread-local `EXC_CLASS_BY_KIND`, a runtime-mutable root
+/// the tracer cannot type; the JIT residualises the read instead of
+/// tracing into it (`@dont_look_inside`, `rlib/jit.py:139`). The residual
+/// call resolves its address by qualified path in `jit_trace_fnaddrs`.
+#[majit_macros::dont_look_inside]
 pub fn lookup_exc_class_for_kind(kind: ExcKind) -> PyObjectRef {
     EXC_CLASS_BY_KIND.with(|cell| cell.get()[kind as u8 as usize])
 }

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -131,7 +131,14 @@ pub fn pin_root(root: PyObjectRef) {
 /// Current length of the thread-local shadow stack. Used by
 /// [`RootScope::new`] to capture the save-point and by tests to
 /// observe pin/pop behaviour.
-#[inline]
+///
+/// Reads the thread-local `SHADOW_STACK`, a runtime-mutable root the
+/// tracer cannot type; the JIT residualises the read instead of tracing
+/// into it (`@dont_look_inside`, `rlib/jit.py:139`). The attribute forces
+/// `#[inline(never)]` so the residual call has a stable symbol; the read
+/// rides on top of the surrounding allocation, so the lost inlining is
+/// in the noise.
+#[majit_macros::dont_look_inside]
 pub fn shadow_stack_len() -> usize {
     SHADOW_STACK.with(|s| s.borrow().len())
 }

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -178,12 +178,16 @@ const _: () = {
     assert!(std::mem::size_of::<AtomicPtr<PyObject>>() == std::mem::size_of::<*mut PyObject>());
     assert!(std::mem::offset_of!(PyType, subclassrange_min) == 0);
     assert!(std::mem::offset_of!(PyType, subclassrange_max) == 8);
-    // `name: &'static str` is a fat pointer (ptr + len = 16 bytes),
-    // placing `instantiate` at offset 32. The JIT reads this slot at a
-    // raw offset via the exact Charon struct layout; the heuristic
-    // fallback sizes `&str` as 8 bytes and would compute offset 24 — a
-    // silent miscompile. This assert pins the true offset.
-    assert!(std::mem::offset_of!(PyType, instantiate) == 32);
+    // `instantiate` must sit immediately after `name` with no padding, so
+    // its offset is exactly `offset_of(name) + size_of::<&str>()`: 32 on a
+    // 64-bit JIT host (`&str` is a 16-byte fat pointer), 24 on 32-bit
+    // targets such as wasm32 (`&str` is 8 bytes). The JIT reads this slot
+    // at a raw offset via the exact Charon struct layout on the 64-bit
+    // host; this assert pins the no-padding invariant on every target.
+    assert!(
+        std::mem::offset_of!(PyType, instantiate)
+            == std::mem::offset_of!(PyType, name) + std::mem::size_of::<&'static str>()
+    );
 };
 
 pub static INT_TYPE: PyType = new_pytype("int");
@@ -219,7 +223,8 @@ pub const SUBCLASSRANGE_MAX_OFFSET: usize = std::mem::offset_of!(PyType, subclas
 
 /// Field offset of `instantiate` within PyType (OBJECT_VTABLE).
 /// rclass.py:172 — `('instantiate', Ptr(FuncType([], OBJECTPTR)))`.
-/// Equals 32: `name` is a 16-byte fat pointer, not the 8-byte heuristic.
+/// 32 on a 64-bit host (`name` is a 16-byte fat pointer); 24 on 32-bit
+/// targets where `&str` is 8 bytes.
 pub const INSTANTIATE_OFFSET: usize = std::mem::offset_of!(PyType, instantiate);
 
 /// rclass.py:1126-1127 `ll_cast_to_object(obj)`.

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -178,6 +178,12 @@ const _: () = {
     assert!(std::mem::size_of::<AtomicPtr<PyObject>>() == std::mem::size_of::<*mut PyObject>());
     assert!(std::mem::offset_of!(PyType, subclassrange_min) == 0);
     assert!(std::mem::offset_of!(PyType, subclassrange_max) == 8);
+    // `name: &'static str` is a fat pointer (ptr + len = 16 bytes),
+    // placing `instantiate` at offset 32. The JIT reads this slot at a
+    // raw offset via the exact Charon struct layout; the heuristic
+    // fallback sizes `&str` as 8 bytes and would compute offset 24 — a
+    // silent miscompile. This assert pins the true offset.
+    assert!(std::mem::offset_of!(PyType, instantiate) == 32);
 };
 
 pub static INT_TYPE: PyType = new_pytype("int");
@@ -210,6 +216,11 @@ pub const SUBCLASSRANGE_MIN_OFFSET: usize = std::mem::offset_of!(PyType, subclas
 /// Field offset of `subclassrange_max` within PyType (OBJECT_VTABLE).
 /// rclass.py:169 — second field in OBJECT_VTABLE.
 pub const SUBCLASSRANGE_MAX_OFFSET: usize = std::mem::offset_of!(PyType, subclassrange_max);
+
+/// Field offset of `instantiate` within PyType (OBJECT_VTABLE).
+/// rclass.py:172 — `('instantiate', Ptr(FuncType([], OBJECTPTR)))`.
+/// Equals 32: `name` is a 16-byte fat pointer, not the 8-byte heuristic.
+pub const INSTANTIATE_OFFSET: usize = std::mem::offset_of!(PyType, instantiate);
 
 /// rclass.py:1126-1127 `ll_cast_to_object(obj)`.
 ///

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -614,6 +614,12 @@ pub unsafe fn w_type_get_uses_object_setattr(obj: PyObjectRef) -> bool {
 }
 /// Write-side companion to [`w_type_get_uses_object_setattr`]
 /// (typeobject.py:276, 340).
+///
+/// Mutates the per-type `uses_object_setattr` atomic — a side effect on
+/// runtime type state the tracer cannot model, so the JIT residualises
+/// the call rather than tracing into it (`@dont_look_inside`,
+/// `rlib/jit.py:139`).
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_type_set_uses_object_setattr(obj: PyObjectRef, v: bool) {
     if obj.is_null() || !is_type(obj) {
         return;


### PR DESCRIPTION
#97 

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Charon cutover census drain: a batch of MIR-frontend folds and JIT-side residualizations so more interpreter graphs rtype through the real LLBC frontend instead of falling back to the legacy walker. Each change targets a specific rtype-skip or annotator wall.

**MIR-frontend identity & const folds** (`majit-translate/src/front/mir.rs`)

- `<String | Vec<T> as Deref>::deref` / `deref_mut` fold to the receiver — `*s` is identity in the lifted value model (String/&str both lower to `rpy_string`, Vec/&[T] to `rpy_list`), removing the classdef-less `deref` method call the rtyper could not route.
- `<String as AsRef<str>>::as_ref`, `String::as_str`, `<String as Borrow<str>>::borrow`, and `<str | String as ToString>::to_string` fold to the receiver identity, gated on a `str`-family result so the sibling `AsRef<[u8]>` / `AsRef<Path>` and the blanket `impl<T: Display> ToString` keep their ordinary lowering. Clears the "Cannot find attribute as_ref on UnicodeString" wall.
- `core::hint::must_use(x)` folds to identity.
- `format!("literal")` and `fmt::Arguments::from_str(s)` (the no-placeholder `format_args!` constructor) alias to the constant string.
- `format!("…{}…", <&str | String>)` folds to a string-const + `__str_concat` left concat when every placeholder renders by identity (a `&str`/`String` `Display`); chains with a `Debug` placeholder, a non-string `Display`, a width/precision/positional spec, or an un-typed argument are declined and keep the ordinary lowering. The concat is emitted as a `__str_concat` marker call so rtype-skipped graphs lower it to the wired `residual_call_r_r` rather than an unwired `int_add/rr>r`.
- `size_of::<T>()` / `align_of::<T>()` `NamedConst` globals fold to the concrete byte size / alignment from Charon's layout, accepted only when `_0` is defined exactly once, unconditionally, by a single such call. Clears the `FUNCTION_OBJECT_SIZE` / `W_DICT_OBJECT_SIZE` walls.

**Devirtualization** (`majit-translate/src/lib.rs`)

- Single-impl required-trait-method devirt now binds the direct path to the trait-impl's own graph instead of an `(owner, name)` lookup that collided when the owner also defines a same-named inherent method (`PyFrame` has both the inherent `peek_at` and `<PyFrame as SharedOpcodeHandler>::peek_at`). Clears the `peek_at` registration gap and lifts the opcode helpers that call it (`execute_get_len`, `opcode_copy_value`, `opcode_for_iter`, `opcode_get_iter`, `opcode_list_append`).

**JIT accessor residualization** (`pyre-interpreter`, `pyre-object`)

- `gc_roots::shadow_stack_len` (TLS `SHADOW_STACK` read) and `typeobject::w_type_set_uses_object_setattr` (per-type mutation) are residualized rather than traced into, the latter through a new `bh_w_type_set_uses_object_setattr` C-ABI bridge; both targets are registered in `jit_trace_fnaddrs`.
- `typedef::gettypefor` reads the per-type `instantiate` `AtomicPtr` slot (seeded by `init_typeobjects`, the same source that backs `TYPEOBJECT_CACHE`) instead of a usize-keyed `HashMap`; `pyobject.rs` asserts `offset_of!(PyType, instantiate) == 32` and exports `INSTANTIATE_OFFSET`. `r#type`'s exception fallback looks the class up by kind index (`lookup_exc_class_for_kind`, residualized via the `bh_lookup_exc_class_for_kind` bridge) instead of by name.

**Verification**

- `check.py` dynasm 127/127 + cranelift 127/127.
- `cargo test --all --no-default-features --features {dynasm,cranelift}` green on both backends (6203 / 0).
- The unwired-opname snapshot `default_bh_builder_unwired_set_matches_task_85_snapshot` is empty.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized string formatting and concatenation operations through better constant folding and call-site detection.
  * Enhanced trait method resolution to more reliably register concrete implementations, avoiding ambiguity issues.
  * Strengthened JIT tracing by marking mutable runtime state boundaries, improving residual code generation.
  * Optimized compile-time size and alignment constant folding to reduce runtime overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->