### PR TITLE
majit-gc: incminimark major-collection threshold + O(1) oldgen membership (#215); opt-in walker vframe inline (default off)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
 name = "majit-gc"
 version = "0.0.2"
 dependencies = [
+ "libc",
  "majit-ir",
 ]
 

--- a/majit/majit-gc/Cargo.toml
+++ b/majit/majit-gc/Cargo.toml
@@ -22,3 +22,7 @@ gc_stress = []
 
 [dependencies]
 majit-ir = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+# env.py:413-433 get_L2cache_darwin uses sysctl() to size the nursery.
+libc = { workspace = true }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -53,6 +53,17 @@ fn read_size_from_env(varname: &str) -> Option<usize> {
     (bytes > 0.0).then_some(bytes as usize)
 }
 
+fn read_float_from_env(varname: &str) -> Option<f64> {
+    // rpython/memory/gc/env.py:43-66 `read_float_from_env`: a plain float,
+    // or 0.0 (treated as absent) if it cannot be parsed.
+    let raw = std::env::var(varname).ok()?;
+    let value = raw.trim();
+    if value.is_empty() {
+        return None;
+    }
+    value.parse::<f64>().ok().filter(|v| *v > 0.0)
+}
+
 fn default_nursery_size() -> usize {
     // incminimark.py:459-470:
     //   newsize = env.read_from_env('PYPY_GC_NURSERY')
@@ -162,11 +173,6 @@ impl IncrementalMarkState {
     }
 }
 
-/// Default ratio of old-gen growth that triggers an incremental cycle.
-/// When old-gen bytes exceed `last_major_bytes * MAJOR_COLLECT_RATIO`,
-/// a new incremental cycle starts.
-const MAJOR_COLLECT_RATIO: f64 = 1.82;
-
 /// The MiniMark generational GC.
 #[allow(non_snake_case)] // _T_IS_RPYTHON_INSTANCE_BYTE keeps the RPython spelling
 pub struct MiniMarkGC {
@@ -210,9 +216,34 @@ pub struct MiniMarkGC {
     pub major_collections: usize,
     /// State for incremental major collection.
     incr_state: IncrementalMarkState,
-    /// Old-gen bytes at the end of the last completed major collection.
-    /// Used to decide when to start the next incremental cycle.
-    last_major_bytes: usize,
+    /// incminimark.py:304 `self.major_collection_threshold`. After a major
+    /// collection, the next one is triggered once the total old-gen size
+    /// grows to this many times the surviving size (TRANSLATION_PARAMS
+    /// default 1.82; `PYPY_GC_MAJOR_COLLECT` override).
+    major_collection_threshold: f64,
+    /// incminimark.py:305 `self.growth_rate_max`. Caps how fast the
+    /// next-major threshold may grow from one collection to the next
+    /// (TRANSLATION_PARAMS default 1.4; `PYPY_GC_GROWTH` override).
+    growth_rate_max: f64,
+    /// incminimark.py:307,488,562 `self.min_heap_size`. Floor below which the
+    /// next-major threshold is never set: `max(PYPY_GC_MIN or nursery*8,
+    /// nursery*major_collection_threshold)`. This floor is what stops
+    /// allocation-heavy, tiny-live-set workloads (e.g. recursive fib) from
+    /// thrashing major cycles off a near-zero surviving baseline.
+    min_heap_size: f64,
+    /// incminimark.py:308 `self.max_heap_size` (`PYPY_GC_MAX`; 0.0 = unbounded).
+    max_heap_size: f64,
+    /// incminimark.py:310 `self.max_delta` (`PYPY_GC_MAX_DELTA`). Caps the
+    /// absolute next-major threshold growth per cycle.
+    max_delta: f64,
+    /// incminimark.py:568 `self.next_major_collection_initial`. The
+    /// pre-reservation threshold; `set_major_threshold_from` grows the next
+    /// threshold relative to this value, bounded by `growth_rate_max`.
+    next_major_collection_initial: f64,
+    /// incminimark.py:569 `self.next_major_collection_threshold`. A new
+    /// incremental major cycle starts once `get_total_memory_used()` reaches
+    /// this value (`threshold_reached`).
+    next_major_collection_threshold: f64,
     /// Bytes promoted to old gen since the current incremental cycle started.
     ///
     /// Mirrors incminimark's `size_objects_made_old`.
@@ -275,6 +306,37 @@ impl MiniMarkGC {
     /// Create a new GC with custom configuration.
     pub fn with_config(config: GcConfig) -> Self {
         let nursery_size = config.nursery_size;
+
+        // incminimark.py:261,268,475-481 — major_collection_threshold /
+        // growth_rate_max from TRANSLATION_PARAMS, overridable by env.
+        let major_collection_threshold = read_float_from_env("PYPY_GC_MAJOR_COLLECT")
+            .filter(|v| *v > 1.0)
+            .unwrap_or(1.82);
+        let growth_rate_max = read_float_from_env("PYPY_GC_GROWTH")
+            .filter(|v| *v > 1.0)
+            .unwrap_or(1.4);
+        // incminimark.py:483-488 — min_heap_size: PYPY_GC_MIN, else nursery*8.
+        let mut min_heap_size = read_size_from_env("PYPY_GC_MIN")
+            .map(|v| v as f64)
+            .unwrap_or(nursery_size as f64 * 8.0);
+        // incminimark.py:490-492 — max_heap_size: PYPY_GC_MAX, else 0 (unbounded).
+        let max_heap_size = read_size_from_env("PYPY_GC_MAX")
+            .map(|v| v as f64)
+            .unwrap_or(0.0);
+        // incminimark.py:494-498 — max_delta: PYPY_GC_MAX_DELTA, else
+        // 0.125 * env.get_total_memory(). The total-memory probe (env.py) is
+        // not yet ported (issue 215 fix #3); until it lands, default to the
+        // pre-setup sentinel (incminimark.py:310 `float(r_uint(-1))`, i.e.
+        // unbounded) so the `total + max_delta` cap never binds and the
+        // `total * major_collection_threshold` term governs, matching
+        // incminimark on any heap small relative to total memory.
+        let max_delta = read_size_from_env("PYPY_GC_MAX_DELTA")
+            .map(|v| v as f64)
+            .unwrap_or(u64::MAX as f64);
+        // incminimark.py:562-563 — allocate_nursery floors min_heap_size by
+        // nursery_size * major_collection_threshold.
+        min_heap_size = min_heap_size.max(nursery_size as f64 * major_collection_threshold);
+
         let mut gc = MiniMarkGC {
             nursery: Nursery::new(config.nursery_size),
             oldgen: OldGen::new(),
@@ -288,7 +350,15 @@ impl MiniMarkGC {
             minor_collections: 0,
             major_collections: 0,
             incr_state: IncrementalMarkState::new(nursery_size),
-            last_major_bytes: 0,
+            major_collection_threshold,
+            growth_rate_max,
+            min_heap_size,
+            max_heap_size,
+            max_delta,
+            // incminimark.py:568-569 — both initialized to min_heap_size,
+            // then refined by set_major_threshold_from(0.0) below.
+            next_major_collection_initial: min_heap_size,
+            next_major_collection_threshold: min_heap_size,
             bytes_made_old_since_cycle: 0,
             threshold_bytes_made_old: 0,
             pinned_objects: VecSet::new(),
@@ -312,6 +382,8 @@ impl MiniMarkGC {
                 gc.card_page_shift += 1;
             }
         }
+        // incminimark.py:570 — allocate_nursery finalizes the first threshold.
+        gc.set_major_threshold_from(0.0, 0.0);
         gc._setup_guard_is_object();
         gc
     }
@@ -1106,15 +1178,48 @@ impl MiniMarkGC {
 
     // ── Incremental marking ──
 
-    /// Check whether old-gen growth warrants starting a new incremental
-    /// major collection cycle.
-    fn should_start_major_cycle(&self) -> bool {
-        if self.last_major_bytes == 0 {
-            // Never done a major collection. Use a minimum threshold so we
-            // don't start an incremental cycle with a nearly empty old gen.
-            return self.oldgen.total_bytes() > self.config.nursery_size;
+    /// incminimark.py:1264-1268 `get_total_memory_used`. Total memory the GC
+    /// is responsible for, NOT counting the nursery: old-gen objects plus
+    /// raw-malloced large objects. pyre's `oldgen.total_bytes()` already
+    /// aggregates promoted objects and large/raw objects allocated straight
+    /// into the old generation.
+    fn get_total_memory_used(&self) -> usize {
+        self.oldgen.total_bytes()
+    }
+
+    /// incminimark.py:1288-1290 `threshold_reached`. True once the old-gen
+    /// total has caught up to within `extra` of the next-major threshold,
+    /// i.e. it is time to make incremental major-collection progress.
+    fn threshold_reached(&self, extra: usize) -> bool {
+        (self.next_major_collection_threshold - self.get_total_memory_used() as f64)
+            < extra as f64
+    }
+
+    /// incminimark.py:575-594 `set_major_threshold_from`. Set the next-major
+    /// threshold, capping growth at `next_major_collection_initial *
+    /// growth_rate_max`, flooring at `min_heap_size`, and bounding by
+    /// `max_heap_size`. Returns whether the result was bounded by the heap max.
+    fn set_major_threshold_from(&mut self, mut threshold: f64, reserving_size: f64) -> bool {
+        let threshold_max = self.next_major_collection_initial * self.growth_rate_max;
+        if threshold > threshold_max {
+            threshold = threshold_max;
         }
-        self.oldgen.total_bytes() as f64 > self.last_major_bytes as f64 * MAJOR_COLLECT_RATIO
+        //
+        threshold += reserving_size;
+        if threshold < self.min_heap_size {
+            threshold = self.min_heap_size;
+        }
+        //
+        let bounded = if self.max_heap_size > 0.0 && threshold > self.max_heap_size {
+            threshold = self.max_heap_size;
+            true
+        } else {
+            false
+        };
+        //
+        self.next_major_collection_initial = threshold;
+        self.next_major_collection_threshold = threshold;
+        bounded
     }
 
     /// Begin a new incremental marking cycle.
@@ -1194,7 +1299,7 @@ impl MiniMarkGC {
     /// minors may need multiple consecutive steps so old-gen growth does not
     /// outrun marking.
     fn run_major_progress_after_minor(&mut self) {
-        if !self.incr_state.marking_in_progress && !self.should_start_major_cycle() {
+        if !self.incr_state.marking_in_progress && !self.threshold_reached(0) {
             return;
         }
 
@@ -1349,7 +1454,18 @@ impl MiniMarkGC {
             self.invalidate_old_weakrefs();
         }
         self.oldgen.sweep();
-        self.last_major_bytes = self.oldgen.total_bytes();
+        // incminimark.py:2566-2577 — set the threshold for the next major
+        // collection to `major_collection_threshold` times the surviving
+        // size, but no more than `max_delta` above it, floored at
+        // `min_heap_size` by set_major_threshold_from. (pyre has no
+        // `kept_alive_by_finalizer` accounting, so `total_memory_used` is the
+        // post-sweep old-gen size directly.)
+        let total_memory_used = self.get_total_memory_used() as f64;
+        self.set_major_threshold_from(
+            (total_memory_used * self.major_collection_threshold)
+                .min(total_memory_used + self.max_delta),
+            0.0,
+        );
         self.bytes_made_old_since_cycle = 0;
         self.threshold_bytes_made_old = 0;
     }
@@ -1758,7 +1874,7 @@ impl MiniMarkGC {
     /// If a cycle is already in progress, one bounded marking step is
     /// performed. Returns true if any GC work was done.
     pub fn gc_step(&mut self) -> bool {
-        if self.should_start_major_cycle() && !self.incr_state.marking_in_progress {
+        if self.threshold_reached(0) && !self.incr_state.marking_in_progress {
             self.start_incremental_cycle();
             let done = self.incremental_mark_step();
             if done {
@@ -4458,7 +4574,7 @@ mod tests {
         let mut gc = test_gc(256);
         gc.register_type(TypeInfo::simple(16));
 
-        // Force a minor collection to set last_major_bytes baseline.
+        // Force a full collection to establish the next-major threshold baseline.
         let obj = gc.alloc_with_type(0, 16);
         let mut root = obj;
         unsafe {
@@ -4511,8 +4627,13 @@ mod tests {
         // Promote everything to old gen.
         gc.collect_nursery();
 
-        // Add more old-gen objects to trigger the ratio threshold.
-        for _ in 0..200 {
+        // Add enough old-gen objects to cross the next-major threshold. The
+        // threshold is floored at `min_heap_size = nursery_size * 8` = 32KB
+        // for this 4096-byte nursery (incminimark.py:488,562), so the old gen
+        // must exceed 32KB before `gc_step` will start a cycle — a few hundred
+        // small objects is intentionally not enough under the parity-correct
+        // floor.
+        for _ in 0..4000 {
             gc.alloc_in_oldgen(tid, GcHeader::SIZE + 16);
         }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -27,41 +27,54 @@ pub struct GcConfig {
     pub card_page_indices: u32,
 }
 
-fn read_size_from_env(varname: &str) -> Option<usize> {
-    // rpython/memory/gc/env.py:17-40 `_read_float_and_factor_from_env`
-    // accepts plain numbers plus K/M/G suffixes, optionally followed by B.
+/// env.py:17-36 `_read_float_and_factor_from_env`. Parse `varname` as a float
+/// with an optional `k`/`m`/`g` size suffix (optionally followed by `b`/`B`),
+/// returning `(value, factor)`. `None` mirrors PyPy's `(0.0, 0)` absent /
+/// unparseable result, which callers treat as "unset".
+fn read_float_and_factor_from_env(varname: &str) -> Option<(f64, f64)> {
     let raw = std::env::var(varname).ok()?;
     let mut value = raw.trim();
     if value.is_empty() {
         return None;
     }
+    // env.py:20-21 — a trailing b/B is dropped before the k/m/g check.
     if value.len() > 1 && matches!(value.as_bytes().last(), Some(b'b' | b'B')) {
         value = &value[..value.len() - 1];
     }
     if value.is_empty() {
         return None;
     }
+    // env.py:22-31 — a k/m/g suffix sets the factor; otherwise factor 1.
     let (number, factor) = match value.as_bytes().last().copied() {
         Some(b'k') | Some(b'K') => (&value[..value.len() - 1], 1024.0),
         Some(b'm') | Some(b'M') => (&value[..value.len() - 1], 1024.0 * 1024.0),
         Some(b'g') | Some(b'G') => (&value[..value.len() - 1], 1024.0 * 1024.0 * 1024.0),
-        Some(_) => (value, 1.0),
-        None => return None,
+        _ => (value, 1.0),
     };
     let parsed = number.parse::<f64>().ok()?;
-    let bytes = parsed * factor;
+    Some((parsed, factor))
+}
+
+/// env.py:38-44 `read_from_env` / `read_uint_from_env`: `value * factor` as an
+/// integer byte count. `None` (unset / unparseable / non-positive) lets callers
+/// fall back to the default, mirroring PyPy's `if x > 0` guards. PyPy's
+/// `read_uint_from_env` r_uint-wraps a negative product to a huge positive; pyre
+/// treats non-positive as unset, differing only on nonsensical negative input.
+fn read_uint_from_env(varname: &str) -> Option<usize> {
+    let (value, factor) = read_float_and_factor_from_env(varname)?;
+    let bytes = value * factor;
     (bytes > 0.0).then_some(bytes as usize)
 }
 
+/// env.py:46-50 `read_float_from_env`: the plain float, but only when no size
+/// factor was given (`factor != 1` → unset). Callers apply their own `> 1.0`
+/// threshold gate.
 fn read_float_from_env(varname: &str) -> Option<f64> {
-    // rpython/memory/gc/env.py:43-66 `read_float_from_env`: a plain float,
-    // or 0.0 (treated as absent) if it cannot be parsed.
-    let raw = std::env::var(varname).ok()?;
-    let value = raw.trim();
-    if value.is_empty() {
+    let (value, factor) = read_float_and_factor_from_env(varname)?;
+    if factor != 1.0 {
         return None;
     }
-    value.parse::<f64>().ok().filter(|v| *v > 0.0)
+    Some(value)
 }
 
 /// env.py:387-411 `get_darwin_sysctl_signed`: read a signed integer sysctl by
@@ -127,7 +140,7 @@ fn default_nursery_size() -> usize {
     //   if newsize <= 0: newsize = defaultsize
     // estimate_best_nursery_size never returns <= 0 (its floor is the 4MB
     // unknown-cache fallback), so the final `defaultsize` arm is unreachable.
-    read_size_from_env("PYPY_GC_NURSERY").unwrap_or_else(estimate_best_nursery_size)
+    read_uint_from_env("PYPY_GC_NURSERY").unwrap_or_else(estimate_best_nursery_size)
 }
 
 /// env.py:67 `addressable_size = float(2**63)` for a 64-bit host: the most
@@ -410,16 +423,16 @@ impl MiniMarkGC {
             .filter(|v| *v > 1.0)
             .unwrap_or(1.4);
         // incminimark.py:483-488 — min_heap_size: PYPY_GC_MIN, else nursery*8.
-        let mut min_heap_size = read_size_from_env("PYPY_GC_MIN")
+        let mut min_heap_size = read_uint_from_env("PYPY_GC_MIN")
             .map(|v| v as f64)
             .unwrap_or(nursery_size as f64 * 8.0);
         // incminimark.py:490-492 — max_heap_size: PYPY_GC_MAX, else 0 (unbounded).
-        let max_heap_size = read_size_from_env("PYPY_GC_MAX")
+        let max_heap_size = read_uint_from_env("PYPY_GC_MAX")
             .map(|v| v as f64)
             .unwrap_or(0.0);
         // incminimark.py:494-498 — max_delta: PYPY_GC_MAX_DELTA, else
         // 0.125 * env.get_total_memory().
-        let max_delta = read_size_from_env("PYPY_GC_MAX_DELTA")
+        let max_delta = read_uint_from_env("PYPY_GC_MAX_DELTA")
             .map(|v| v as f64)
             .unwrap_or_else(|| 0.125 * get_total_memory());
         // incminimark.py:562-563 — allocate_nursery floors min_heap_size by
@@ -1545,7 +1558,12 @@ impl MiniMarkGC {
         // `kept_alive_by_finalizer` accounting, so `total_memory_used` is the
         // post-sweep old-gen size directly.)
         let total_memory_used = self.get_total_memory_used() as f64;
-        self.set_major_threshold_from(
+        // The `bounded` result is intentionally dropped: incminimark.py:2603-2615
+        // raises MemoryError when `bounded and threshold_reached(reserving_size)`,
+        // but pyre has no GC out-of-memory path, so only the threshold-capping
+        // side effect of `set_major_threshold_from` is used (the PYPY_GC_MAX OOM
+        // policy is unported).
+        let _bounded = self.set_major_threshold_from(
             (total_memory_used * self.major_collection_threshold)
                 .min(total_memory_used + self.max_delta),
             0.0,

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -64,31 +64,34 @@ fn read_float_from_env(varname: &str) -> Option<f64> {
     value.parse::<f64>().ok().filter(|v| *v > 0.0)
 }
 
+/// env.py:387-411 `get_darwin_sysctl_signed`: read a signed integer sysctl by
+/// name; 0 on any error.
+#[cfg(target_os = "macos")]
+fn get_darwin_sysctl_signed(name: &[u8]) -> i64 {
+    let mut val: i64 = 0;
+    let mut len = std::mem::size_of::<i64>();
+    let rc = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr() as *const libc::c_char,
+            &mut val as *mut i64 as *mut libc::c_void,
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 && len == std::mem::size_of::<i64>() {
+        val
+    } else {
+        0
+    }
+}
+
 /// env.py:413-433 `get_L2cache_darwin`. Returns the L2+L3 cache size in
 /// bytes via `sysctl`, or -1 when it cannot be determined.
 #[cfg(target_os = "macos")]
 fn get_l2cache() -> i64 {
-    // env.py:374-411 `get_darwin_sysctl_signed`: read a signed integer
-    // sysctl by name; 0 on any error.
-    fn sysctl_signed(name: &[u8]) -> i64 {
-        let mut val: i64 = 0;
-        let mut len = std::mem::size_of::<i64>();
-        let rc = unsafe {
-            libc::sysctlbyname(
-                name.as_ptr() as *const libc::c_char,
-                &mut val as *mut i64 as *mut libc::c_void,
-                &mut len,
-                std::ptr::null_mut(),
-                0,
-            )
-        };
-        if rc == 0 && len == std::mem::size_of::<i64>() {
-            val
-        } else {
-            0
-        }
-    }
-    let mangled = sysctl_signed(b"hw.l2cachesize\0") + sysctl_signed(b"hw.l3cachesize\0");
+    let mangled =
+        get_darwin_sysctl_signed(b"hw.l2cachesize\0") + get_darwin_sysctl_signed(b"hw.l3cachesize\0");
     if mangled > 0 { mangled } else { -1 }
 }
 
@@ -125,6 +128,36 @@ fn default_nursery_size() -> usize {
     // estimate_best_nursery_size never returns <= 0 (its floor is the 4MB
     // unknown-cache fallback), so the final `defaultsize` arm is unreachable.
     read_size_from_env("PYPY_GC_NURSERY").unwrap_or_else(estimate_best_nursery_size)
+}
+
+/// env.py:67 `addressable_size = float(2**63)` for a 64-bit host: the most
+/// memory the process could address, used as the fallback / upper clamp when
+/// the real total-memory probe is unavailable or larger.
+const ADDRESSABLE_SIZE: f64 = 9_223_372_036_854_775_808.0; // 2**63
+
+/// env.py:100-110 `get_total_memory_darwin`. Clamp the probed total memory:
+/// fall back to the addressable size when the probe failed (`<= 0`) and cap it
+/// at the addressable size otherwise.
+fn get_total_memory_darwin(result: i64) -> f64 {
+    if result <= 0 {
+        ADDRESSABLE_SIZE
+    } else {
+        (result as f64).min(ADDRESSABLE_SIZE)
+    }
+}
+
+/// env.py:117-127 `get_total_memory`. Total physical memory in bytes.
+/// macOS reads `hw.memsize` via `sysctl`; other platforms return the
+/// addressable size (env.py:126-127 "XXX implement me for other platforms";
+/// the Linux `/proc/meminfo` probe, env.py:70-98, is not yet ported).
+#[cfg(target_os = "macos")]
+fn get_total_memory() -> f64 {
+    get_total_memory_darwin(get_darwin_sysctl_signed(b"hw.memsize\0"))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn get_total_memory() -> f64 {
+    ADDRESSABLE_SIZE
 }
 
 impl Default for GcConfig {
@@ -293,8 +326,9 @@ pub struct MiniMarkGC {
     min_heap_size: f64,
     /// incminimark.py:308 `self.max_heap_size` (`PYPY_GC_MAX`; 0.0 = unbounded).
     max_heap_size: f64,
-    /// incminimark.py:310 `self.max_delta` (`PYPY_GC_MAX_DELTA`). Caps the
-    /// absolute next-major threshold growth per cycle.
+    /// incminimark.py:310,498 `self.max_delta` (`PYPY_GC_MAX_DELTA`, else
+    /// `0.125 * get_total_memory()`). Caps the absolute next-major threshold
+    /// growth per cycle.
     max_delta: f64,
     /// incminimark.py:568 `self.next_major_collection_initial`. The
     /// pre-reservation threshold; `set_major_threshold_from` grows the next
@@ -384,15 +418,10 @@ impl MiniMarkGC {
             .map(|v| v as f64)
             .unwrap_or(0.0);
         // incminimark.py:494-498 — max_delta: PYPY_GC_MAX_DELTA, else
-        // 0.125 * env.get_total_memory(). The total-memory probe (env.py) is
-        // not yet ported (issue 215 fix #3); until it lands, default to the
-        // pre-setup sentinel (incminimark.py:310 `float(r_uint(-1))`, i.e.
-        // unbounded) so the `total + max_delta` cap never binds and the
-        // `total * major_collection_threshold` term governs, matching
-        // incminimark on any heap small relative to total memory.
+        // 0.125 * env.get_total_memory().
         let max_delta = read_size_from_env("PYPY_GC_MAX_DELTA")
             .map(|v| v as f64)
-            .unwrap_or(u64::MAX as f64);
+            .unwrap_or_else(|| 0.125 * get_total_memory());
         // incminimark.py:562-563 — allocate_nursery floors min_heap_size by
         // nursery_size * major_collection_threshold.
         min_heap_size = min_heap_size.max(nursery_size as f64 * major_collection_threshold);

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -64,15 +64,67 @@ fn read_float_from_env(varname: &str) -> Option<f64> {
     value.parse::<f64>().ok().filter(|v| *v > 0.0)
 }
 
+/// env.py:413-433 `get_L2cache_darwin`. Returns the L2+L3 cache size in
+/// bytes via `sysctl`, or -1 when it cannot be determined.
+#[cfg(target_os = "macos")]
+fn get_l2cache() -> i64 {
+    // env.py:374-411 `get_darwin_sysctl_signed`: read a signed integer
+    // sysctl by name; 0 on any error.
+    fn sysctl_signed(name: &[u8]) -> i64 {
+        let mut val: i64 = 0;
+        let mut len = std::mem::size_of::<i64>();
+        let rc = unsafe {
+            libc::sysctlbyname(
+                name.as_ptr() as *const libc::c_char,
+                &mut val as *mut i64 as *mut libc::c_void,
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if rc == 0 && len == std::mem::size_of::<i64>() {
+            val
+        } else {
+            0
+        }
+    }
+    let mangled = sysctl_signed(b"hw.l2cachesize\0") + sysctl_signed(b"hw.l3cachesize\0");
+    if mangled > 0 { mangled } else { -1 }
+}
+
+/// env.py:437-438 `get_L2cache = globals().get('get_L2cache_' + sys.platform,
+/// lambda: -1)`. Non-macOS probes are not yet ported, so -1 (the 4MB
+/// unknown-cache fallback applies).
+#[cfg(not(target_os = "macos"))]
+fn get_l2cache() -> i64 {
+    -1
+}
+
+/// env.py:443-450 `best_nursery_size_for_L2cache`. About half the L2 cache,
+/// but only when it exceeds 8MB (so an L3-inclusive value does not size the
+/// nursery off L3); otherwise the 4MB unknown-cache fallback
+/// (`NURSERY_SIZE_UNKNOWN_CACHE`, env.py:440 = `DEFAULT_NURSERY_SIZE`).
+fn best_nursery_size_for_l2cache(l2cache: i64) -> usize {
+    if l2cache > 8 * 1024 * 1024 {
+        (l2cache / 2) as usize
+    } else {
+        DEFAULT_NURSERY_SIZE
+    }
+}
+
+/// env.py:452-456 `estimate_best_nursery_size`.
+fn estimate_best_nursery_size() -> usize {
+    best_nursery_size_for_l2cache(get_l2cache())
+}
+
 fn default_nursery_size() -> usize {
     // incminimark.py:459-470:
     //   newsize = env.read_from_env('PYPY_GC_NURSERY')
     //   if newsize <= 0: newsize = env.estimate_best_nursery_size()
     //   if newsize <= 0: newsize = defaultsize
-    //
-    // Pyre does not yet port the platform-specific cache estimator, so use
-    // env.py:441's 4MB unknown-cache fallback.
-    read_size_from_env("PYPY_GC_NURSERY").unwrap_or(DEFAULT_NURSERY_SIZE)
+    // estimate_best_nursery_size never returns <= 0 (its floor is the 4MB
+    // unknown-cache fallback), so the final `defaultsize` arm is unreachable.
+    read_size_from_env("PYPY_GC_NURSERY").unwrap_or_else(estimate_best_nursery_size)
 }
 
 impl Default for GcConfig {
@@ -160,6 +212,13 @@ struct IncrementalMarkState {
     /// Mirrors incminimark's `gc_increment_step`, which defaults to
     /// `nursery_size * 2`.
     mark_budget_per_step: usize,
+    /// Reusable scratch buffer for `mark_object`: the child refs of the
+    /// object currently being traced. Reused (cleared, capacity retained)
+    /// across calls so marking does not heap-allocate a fresh `Vec` per
+    /// object. RPython's `_collect_obj` visitor pushes straight onto the gray
+    /// stack; pyre collects into this buffer first to release the immutable
+    /// `self.types` borrow before mutating `self.incr_state.gray_stack`.
+    mark_scratch: Vec<GcRef>,
 }
 
 impl IncrementalMarkState {
@@ -169,6 +228,7 @@ impl IncrementalMarkState {
             marking_in_progress: false,
             objects_marked: 0,
             mark_budget_per_step: (nursery_size.saturating_mul(2)).max(1),
+            mark_scratch: Vec::new(),
         }
     }
 }
@@ -1364,55 +1424,67 @@ impl MiniMarkGC {
     /// Mark a single object: trace its GC pointer fields and push
     /// unmarked children onto the gray stack.
     fn mark_object(&mut self, obj_addr: usize) {
+        // Collect the object's child refs into the reused scratch buffer
+        // while `type_info` borrows `self.types`, then release that borrow
+        // before greying them (which mutates `self.incr_state.gray_stack`).
+        let mut scratch = std::mem::take(&mut self.incr_state.mark_scratch);
+        scratch.clear();
+
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
         let type_info = self.types.get(type_id);
 
         // custom_trace_hook parity for major GC marking.
         if let Some(trace_fn) = type_info.custom_trace {
-            let mut refs: Vec<GcRef> = Vec::new();
             unsafe {
                 trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
                     let field_ref = *slot_ptr;
                     if !field_ref.is_null() {
-                        refs.push(field_ref);
+                        scratch.push(field_ref);
                     }
                 });
             }
-            for field_ref in refs {
-                if self.is_managed_heap_object(field_ref.0) {
-                    let hdr = unsafe { header_of(field_ref.0) };
-                    if unsafe { !(*hdr).has_flag(flags::VISITED) } {
-                        unsafe { (*hdr).set_flag(flags::VISITED) };
-                        self.incr_state.gray_stack.push(field_ref.0);
+        } else {
+            // Trace fixed-part fields. The `is_managed_heap_object` guard
+            // (applied below) mirrors the `custom_trace` path and
+            // `seed_major_root`: a `Ptr(GcStruct)` field can transiently
+            // point at memory outside the GC-managed heap during the L1/L2
+            // stepping-stone state (e.g. `W_TupleObject.wrappeditems` →
+            // `std::alloc`'d ItemsBlock). In that window calling `header_of`
+            // on the field would dereference memory before the std::alloc'd
+            // block. Upstream RPython `_collect_obj`
+            // (incminimark.py:2739-2752) does not need this guard because
+            // RPython's type system guarantees every `Ptr(GcStruct)` is
+            // GC-managed; it converges away once every gc_ptr_offsets target
+            // is a real GC allocation.
+            for &offset in &type_info.gc_ptr_offsets {
+                let field_ref = unsafe { *((obj_addr + offset) as *const GcRef) };
+                if !field_ref.is_null() {
+                    scratch.push(field_ref);
+                }
+            }
+
+            // Trace variable-part items. Same `is_managed_heap_object`
+            // guard as the fixed-part loop — `items_have_gc_ptrs` blocks
+            // (e.g. `ItemsBlock` once it migrates to GC varsize) may
+            // transiently coexist with std::alloc'd siblings during the
+            // L1/L2 stepping-stone window.
+            if type_info.items_have_gc_ptrs && type_info.item_size > 0 {
+                let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
+                let items_start = obj_addr + type_info.size;
+                let item_size = type_info.item_size;
+                for i in 0..length {
+                    let field_ref =
+                        unsafe { *((items_start + i * item_size) as *const GcRef) };
+                    if !field_ref.is_null() {
+                        scratch.push(field_ref);
                     }
                 }
             }
-            return;
         }
 
-        let gc_ptr_offsets = type_info.gc_ptr_offsets.clone();
-        let items_have_gc_ptrs = type_info.items_have_gc_ptrs;
-        let item_size = type_info.item_size;
-        let length_offset = type_info.length_offset;
-        let base_size = type_info.size;
-
-        // Trace fixed-part fields. The `is_managed_heap_object` guard
-        // mirrors the `custom_trace` path above and `seed_major_root`
-        // (line 814): a `Ptr(GcStruct)` field can transiently point at
-        // memory outside the GC-managed heap during the L1/L2 stepping-
-        // stone state (e.g. `W_TupleObject.wrappeditems` →
-        // `std::alloc`'d ItemsBlock). In that
-        // window calling `header_of` on the field would dereference
-        // memory before the std::alloc'd block. Upstream RPython
-        // `_collect_obj` (incminimark.py:2739-2752) does not need this
-        // guard because RPython's type system guarantees every
-        // `Ptr(GcStruct)` is GC-managed. TODO:
-        // matches `mark_object`'s own custom_trace-path guard and
-        // converges away once every gc_ptr_offsets target is a real
-        // GC allocation.
-        for &offset in &gc_ptr_offsets {
-            let field_ref = unsafe { *((obj_addr + offset) as *const GcRef) };
-            if !field_ref.is_null() && self.is_managed_heap_object(field_ref.0) {
+        // `type_info` borrow ends here; now grey the collected children.
+        for &field_ref in &scratch {
+            if self.is_managed_heap_object(field_ref.0) {
                 let hdr = unsafe { header_of(field_ref.0) };
                 if unsafe { !(*hdr).has_flag(flags::VISITED) } {
                     unsafe { (*hdr).set_flag(flags::VISITED) };
@@ -1421,25 +1493,8 @@ impl MiniMarkGC {
             }
         }
 
-        // Trace variable-part items. Same `is_managed_heap_object`
-        // guard as the fixed-part loop — `items_have_gc_ptrs` blocks
-        // (e.g. `ItemsBlock` once it migrates to GC varsize) may
-        // transiently coexist with std::alloc'd siblings during the
-        // L1/L2 stepping-stone window.
-        if items_have_gc_ptrs && item_size > 0 {
-            let length = unsafe { *((obj_addr + length_offset) as *const usize) };
-            let items_start = obj_addr + base_size;
-            for i in 0..length {
-                let field_ref = unsafe { *((items_start + i * item_size) as *const GcRef) };
-                if !field_ref.is_null() && self.is_managed_heap_object(field_ref.0) {
-                    let hdr = unsafe { header_of(field_ref.0) };
-                    if unsafe { !(*hdr).has_flag(flags::VISITED) } {
-                        unsafe { (*hdr).set_flag(flags::VISITED) };
-                        self.incr_state.gray_stack.push(field_ref.0);
-                    }
-                }
-            }
-        }
+        // Return the buffer (with its capacity) for the next object.
+        self.incr_state.mark_scratch = scratch;
     }
 
     /// Complete the sweep phase after incremental marking finishes.
@@ -4550,6 +4605,23 @@ mod tests {
     fn test_can_optimize_cond_call() {
         let gc = test_gc(4096);
         assert!(gc.can_optimize_cond_call());
+    }
+
+    #[test]
+    fn test_estimate_best_nursery_size() {
+        // env.py:443-456 — half the L2 cache when it exceeds 8MB, else the
+        // 4MB unknown-cache fallback. Either way it must never return a size
+        // below the fallback, so the major-collection floor (nursery*8) is
+        // always well-defined.
+        let est = estimate_best_nursery_size();
+        assert!(est >= DEFAULT_NURSERY_SIZE, "estimate {est} below fallback");
+        // best_nursery_size_for_l2cache mirrors env.py's strict `> 8MB` test.
+        assert_eq!(best_nursery_size_for_l2cache(-1), DEFAULT_NURSERY_SIZE);
+        assert_eq!(best_nursery_size_for_l2cache(8 * 1024 * 1024), DEFAULT_NURSERY_SIZE);
+        assert_eq!(
+            best_nursery_size_for_l2cache(32 * 1024 * 1024),
+            16 * 1024 * 1024
+        );
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -103,8 +103,8 @@ fn get_darwin_sysctl_signed(name: &[u8]) -> i64 {
 /// bytes via `sysctl`, or -1 when it cannot be determined.
 #[cfg(target_os = "macos")]
 fn get_l2cache() -> i64 {
-    let mangled =
-        get_darwin_sysctl_signed(b"hw.l2cachesize\0") + get_darwin_sysctl_signed(b"hw.l3cachesize\0");
+    let mangled = get_darwin_sysctl_signed(b"hw.l2cachesize\0")
+        + get_darwin_sysctl_signed(b"hw.l3cachesize\0");
     if mangled > 0 { mangled } else { -1 }
 }
 
@@ -1293,8 +1293,7 @@ impl MiniMarkGC {
     /// total has caught up to within `extra` of the next-major threshold,
     /// i.e. it is time to make incremental major-collection progress.
     fn threshold_reached(&self, extra: usize) -> bool {
-        (self.next_major_collection_threshold - self.get_total_memory_used() as f64)
-            < extra as f64
+        (self.next_major_collection_threshold - self.get_total_memory_used() as f64) < extra as f64
     }
 
     /// incminimark.py:575-594 `set_major_threshold_from`. Set the next-major
@@ -1515,8 +1514,7 @@ impl MiniMarkGC {
                 let items_start = obj_addr + type_info.size;
                 let item_size = type_info.item_size;
                 for i in 0..length {
-                    let field_ref =
-                        unsafe { *((items_start + i * item_size) as *const GcRef) };
+                    let field_ref = unsafe { *((items_start + i * item_size) as *const GcRef) };
                     if !field_ref.is_null() {
                         scratch.push(field_ref);
                     }
@@ -4664,7 +4662,10 @@ mod tests {
         assert!(est >= DEFAULT_NURSERY_SIZE, "estimate {est} below fallback");
         // best_nursery_size_for_l2cache mirrors env.py's strict `> 8MB` test.
         assert_eq!(best_nursery_size_for_l2cache(-1), DEFAULT_NURSERY_SIZE);
-        assert_eq!(best_nursery_size_for_l2cache(8 * 1024 * 1024), DEFAULT_NURSERY_SIZE);
+        assert_eq!(
+            best_nursery_size_for_l2cache(8 * 1024 * 1024),
+            DEFAULT_NURSERY_SIZE
+        );
         assert_eq!(
             best_nursery_size_for_l2cache(32 * 1024 * 1024),
             16 * 1024 * 1024

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -131,7 +131,8 @@ impl OldGen {
             } else {
                 // Dead: free it. Dealloc from alloc_start (includes card header).
                 freed_bytes += obj_record.layout.size();
-                self.payloads.remove(&(obj_record.header_addr + GcHeader::SIZE));
+                self.payloads
+                    .remove(&(obj_record.header_addr + GcHeader::SIZE));
                 unsafe {
                     alloc::dealloc(obj_record.alloc_start as *mut u8, obj_record.layout);
                 }

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -30,6 +30,17 @@ struct OldObject {
 pub struct OldGen {
     /// All live old-gen objects.
     objects: Vec<OldObject>,
+    /// O(1) membership index: payload addresses (`header_addr +
+    /// GcHeader::SIZE`) of every live old-gen object. incminimark's
+    /// ArenaCollection answers "is this address an old object?" in O(1) from
+    /// arena page bounds; pyre's OldGen allocates each object individually
+    /// through the system allocator (see the struct doc — no contiguous
+    /// arena), so there is no range to test. This set restores that O(1)
+    /// `contains`, kept in sync with `objects` on alloc and sweep. Without it
+    /// `contains` is a linear scan that becomes a hot O(n²) under the
+    /// parity-correct major-collection threshold once the old gen is large
+    /// (issue 215: minor-collection `walk_jf_roots` calls `contains` per root).
+    payloads: std::collections::HashSet<usize>,
     /// Total bytes allocated in old gen.
     total_bytes: usize,
 }
@@ -41,6 +52,7 @@ impl OldGen {
     pub fn new() -> Self {
         OldGen {
             objects: Vec::new(),
+            payloads: std::collections::HashSet::new(),
             total_bytes: 0,
         }
     }
@@ -75,6 +87,7 @@ impl OldGen {
             layout,
         };
         self.objects.push(obj_record);
+        self.payloads.insert(header_ptr as usize + GcHeader::SIZE);
         self.total_bytes += alloc_size;
         header_ptr
     }
@@ -118,6 +131,7 @@ impl OldGen {
             } else {
                 // Dead: free it. Dealloc from alloc_start (includes card header).
                 freed_bytes += obj_record.layout.size();
+                self.payloads.remove(&(obj_record.header_addr + GcHeader::SIZE));
                 unsafe {
                     alloc::dealloc(obj_record.alloc_start as *mut u8, obj_record.layout);
                 }
@@ -136,15 +150,12 @@ impl OldGen {
         }
     }
 
-    /// Check whether `obj_addr` is the payload address of a tracked old-gen object.
-    ///
-    /// Linear over `objects`; the write barrier does not use this (it gates on
-    /// the `TRACK_YOUNG_PTRS` header flag), so the callers are cold paths
-    /// (`is_managed_heap_object`, weakref scanning).
+    /// Check whether `obj_addr` is the payload address of a tracked old-gen
+    /// object. O(1) via the `payloads` index (see its field doc). Called per
+    /// root in minor collection (`walk_jf_roots`) and per traced field in
+    /// `is_managed_heap_object`, so it must not be a linear scan.
     pub fn contains(&self, obj_addr: usize) -> bool {
-        self.objects
-            .iter()
-            .any(|obj_record| obj_record.header_addr + GcHeader::SIZE == obj_addr)
+        self.payloads.contains(&obj_addr)
     }
 
     /// Mark an old-gen object as visited (for major collection).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6864,6 +6864,26 @@ fn walker_capture_multi_frame_inline_snapshot(
             }
         }
     }
+    // #124 Approach B (M2): the callee (top) frame carries the guard's raw
+    // JitCode byte offset as the resume coordinate (mirror of the single-frame
+    // path).  A branch guard stashes its own callee pc in
+    // `BRANCH_GUARD_JITCODE_PC`; otherwise the guard's own offset is
+    // `callee_op_pc`.  `after_residual_call` guards resume BEFORE the call and
+    // keep the sentinel.  The paused caller frames resume at the CALL return
+    // point via the Python pc → pc_map path, so they keep the sentinel too (no
+    // kept-stack coordinate is carried for them in M2).  Computed BEFORE the box
+    // collection so it queries liveness at the SAME coordinate the decoder
+    // resumes at.
+    let callee_jitcode_pc: i32 = {
+        let g = BRANCH_GUARD_JITCODE_PC.with(|c| c.get());
+        if g != usize::MAX {
+            g as i32
+        } else if after_residual_call {
+            majit_ir::resumedata::NO_JITCODE_PC
+        } else {
+            callee_op_pc as i32
+        }
+    };
     let callee_boxes = collect_callee_active_boxes(
         ctx.registers_i,
         ctx.registers_r,
@@ -6871,6 +6891,7 @@ fn walker_capture_multi_frame_inline_snapshot(
         callee_jitcode_index as u32,
         callee_py_pc,
         callee_op_pc,
+        callee_jitcode_pc,
     )?;
 
     // Publish the OUTERMOST caller's vable scalars for its resume coordinate so
@@ -6917,25 +6938,6 @@ fn walker_capture_multi_frame_inline_snapshot(
     }
 
     let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
-
-    // #124 Approach B (M2): the callee (top) frame carries the guard's raw
-    // JitCode byte offset as the resume coordinate (mirror of the
-    // single-frame path).  A branch guard stashes its own callee pc in
-    // `BRANCH_GUARD_JITCODE_PC`; otherwise the guard's own offset is
-    // `callee_op_pc`.  `after_residual_call` guards resume BEFORE the call
-    // and keep the sentinel.  The paused caller frames resume at the CALL
-    // return point via the Python pc → pc_map path, so they keep the
-    // sentinel too (no kept-stack coordinate is carried for them in M2).
-    let callee_jitcode_pc: i32 = {
-        let g = BRANCH_GUARD_JITCODE_PC.with(|c| c.get());
-        if g != usize::MAX {
-            g as i32
-        } else if after_residual_call {
-            majit_ir::resumedata::NO_JITCODE_PC
-        } else {
-            callee_op_pc as i32
-        }
-    };
 
     // Frame tuples, OUTERMOST-FIRST: the paused caller chain, then the callee
     // top frame last (innermost).
@@ -7737,10 +7739,20 @@ fn collect_callee_active_boxes(
     callee_jitcode_index: u32,
     callee_py_pc: u32,
     callee_op_pc: usize,
+    carried_jitcode_pc: i32,
 ) -> Result<Vec<OpRef>, DispatchError> {
-    let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+    // The resume decoder consumes this frame's section per the liveness at the
+    // carried `jitcode_pc` (`setposition` → `get_current_position_info`), not
+    // the lossy `pc_map(callee_py_pc)` window.  Query the SAME carried
+    // coordinate so the encoder's box bank set agrees with the decoder's
+    // section sizes (mirror of `collect_outer_active_boxes`:5060 and
+    // `state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc`:1399).  A
+    // mismatched window let a callee that int-specializes a param encode a Ref
+    // where the decoder expects an int → `getvirtual_int: not a raw virtual`.
+    let banks = crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         callee_jitcode_index as i32,
         callee_py_pc as i32,
+        carried_jitcode_pc,
     );
     let mut active = Vec::with_capacity(banks.int.len() + banks.ref_.len() + banks.float.len());
     let diag = std::env::var_os("PYRE_FBW_MF_DIAG").is_some();


### PR DESCRIPTION
#215

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Two independent bodies of work.

### GC: incminimark major-collection threshold + O(1) oldgen membership (#215)

`majit/majit-gc`:

- Replace the `oldgen.total_bytes() > last_major_bytes * 1.82` major-cycle gating (no lower floor) with the incminimark threshold model: add `major_collection_threshold`, `growth_rate_max`, `min_heap_size`, `max_heap_size`, `max_delta`, `next_major_collection_initial`, `next_major_collection_threshold`, plus `get_total_memory_used`, `threshold_reached`, `set_major_threshold_from`. `min_heap_size` defaults to `max(PYPY_GC_MIN or nursery*8, nursery*major_collection_threshold)`, so a new major cycle no longer starts from a near-zero surviving baseline. This stops fib_recursive (tiny live set, large allocation volume) from thrashing major cycles (~3653 major collections for fib(34) drop to a handful; `seed_major_roots` leaves the profile).
- Add a `payloads` address index on `OldGen` for O(1) membership, restoring the per-jitframe-root / per-traced-field membership checks to O(1) after deferred majors grow the old gen (was an O(n) linear scan turning into O(n^2)).
- `mark_object`: collect a traced object's child refs into a reused `IncrementalMarkState.mark_scratch` buffer instead of allocating a fresh `Vec<GcRef>` (custom_trace path) or cloning `gc_ptr_offsets` (plain path) per marked object.
- Port `estimate_best_nursery_size` / `best_nursery_size_for_L2cache` / `get_L2cache_darwin`: when `PYPY_GC_NURSERY` is unset, size the nursery to half of L2+L3 when that exceeds 8MB, else the 4MB fallback. macOS reads `hw.l2cachesize`/`hw.l3cachesize` via sysctl; other platforms keep the 4MB fallback.
- Port `env.get_total_memory` (macOS `hw.memsize` via sysctl, clamped to the addressable size; other platforms return the addressable size). `max_delta` now defaults to `0.125 * get_total_memory()` when `PYPY_GC_MAX_DELTA` is unset, replacing the pre-setup sentinel `float(r_uint(-1))`.
- Extract `_read_float_and_factor_from_env` as a shared helper and rebuild the env readers on it: `read_uint_from_env` (value*factor, positive byte count) and `read_float_from_env` (value only when no size factor was given). Document that the `bounded` result of `set_major_threshold_from` is intentionally dropped (no GC out-of-memory path is ported).

fib_recursive (dynasm) 1.36s -> 0.88s.

### JIT: opt-in walker virtual-frame inline for self-recursive CALL_ASSEMBLER (default off)

`pyre/pyre-jit-trace/src/jitcode_dispatch.rs`, `majit/majit-metainterp/src/resume.rs`:

- Add `PYRE_FBW_VFRAME`-gated (default off, cached via `OnceLock`) vframe infrastructure that resolves an inlined callee's `getarrayitem_vable_r` / `setarrayitem_vable_r` / `arraylen_vable` ops and elides `setfield_vable_i(last_instr)` against a virtual frame seeded from the call args, so a self-recursive single-int callee inlines instead of emitting CALL_ASSEMBLER.
- `decode_ref` gains a TAGINT arm for const-int results that fold into ref slots under inlining.
- Seed the inline-subwalk's `outer_active_boxes` from the parent walk's register file at `entry_py_pc` so encoder and decoder frame-box counts agree at the inline-subwalk capture boundary (fixes an out-of-bounds resume-decode panic at fib(16+) when the flag is on).

With the flag on, fib(0..34) is byte-identical to flag-off and fully inlines the recursion (0 CallAssembler vs 10). The flag stays default OFF: the inline is correct but ~116x slower (105s vs 0.9s for fib(34)) because a recursive guard failure blackhole-resumes the whole outer subtree at interpreter speed; the inlined guards do not chain into JIT bridges the way CALL_ASSEMBLER does. That perf gap is the #62 / virtualizable-frame-bridge guard-refail blocker, unchanged here.

check.py 127/127 (GC) and 128/128 x2 (JIT, flag-off) on both backends.

## Self-review

This patch is AI-assisted; per-commit parity notes are inline in the commit messages.

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized garbage collector nursery sizing with environment-based configuration
  * Improved major collection cycle threshold management for more efficient collection cycles
  * Enhanced memory tracking with faster lookups
  * Added macOS system memory detection for better resource allocation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->