### PR TITLE
optimizeopt: move the short-preamble inputarg rename to export time

### DIFF
--- a/majit/majit-gc/src/gcreftracer.rs
+++ b/majit/majit-gc/src/gcreftracer.rs
@@ -14,11 +14,32 @@
 //! Upstream models the array with a `GCREFTRACER` `GcStruct`
 //! (`gcreftracer.py:7-11`) carrying `array_base_addr` + `array_length`,
 //! registered with the GC via a custom trace hook
-//! (`register_custom_trace_hook`, `gcreftracer.py:30`). pyre has no
-//! custom-trace-hook facility; the established equivalent is the extra
-//! root walker registry (`shadow_stack::register_extra_root_walker`,
-//! walked at `collector.rs:668` minor and `collector.rs:1185` major), so
-//! a single module walker forwards every live table's slots.
+//! (`register_custom_trace_hook`, `gcreftracer.py:30`) and *reached* by
+//! the collector through the loop token's `asmmemmgr_gcreftracers`, which
+//! in RPython is a GC-managed list (`x86/assembler.py:823`,
+//! `model.py:294`) so the tracer header sits in the live object graph.
+//!
+//! pyre has the custom-trace-hook facility — `TypeInfo::custom_trace`
+//! (`trace.rs:314`, `register_custom_trace_hook` parity), already used by
+//! `JITFRAME` (`jitframe.rs:333`), the structural twin of `GCREFTRACER` —
+//! so a managed `GCREFTRACER` GcStruct with a slot-tracing hook is
+//! portable *in isolation*. What is not yet portable is the
+//! *reachability*: pyre's `CompiledLoopToken` is a Rust-owned struct and
+//! its `asmmemmgr_gcreftracers` is a `Mutex<Vec<Arc<dyn Any>>>` keepalive
+//! (`majit-backend/src/lib.rs:910`), not a GC edge — the collector has no
+//! object-graph path to a managed header. A GcStruct header would still
+//! need a GC root to be reached, and that root would be a walker over the
+//! Rust-owned keepalive — a header allocation, a hook, and a mark step
+//! added without removing the walker.
+//!
+//! So pyre forwards the slots directly from an extra root walker
+//! (`shadow_stack::register_extra_root_walker`, walked at
+//! `collector.rs:668` minor and `collector.rs:1185` major) over the
+//! live-table registry — the analog of RPython reaching the tracer
+//! through the CLT keepalive. Convergence path: once
+//! `asmmemmgr_gcreftracers` (or `CompiledLoopToken` itself) is GC-traced,
+//! this collapses to a managed `GCREFTRACER` GcStruct + custom trace
+//! hook, matching upstream exactly.
 
 use std::cell::Cell;
 use std::sync::{Arc, RwLock, Weak};

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2886,6 +2886,7 @@ impl OptContext {
                         preamble_op: std::rc::Rc::new((*entry.op).clone()),
                         invented_name: entry.invented_name,
                         same_as_source: entry.same_as_source.clone(),
+                        label_arg_idx: entry.label_arg_idx,
                     },
                 )
             })
@@ -3152,6 +3153,7 @@ impl OptContext {
                         preamble_op: std::rc::Rc::new(op),
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),
+                        label_arg_idx: produced_op.label_arg_idx,
                     };
                     builder_entries.push((produced_op.res.clone(), new_pop.clone()));
                     produced.push((*source, new_pop.clone()));
@@ -3194,6 +3196,7 @@ impl OptContext {
                                 preamble_op: std::rc::Rc::new(op),
                                 invented_name: produced_op.invented_name,
                                 same_as_source: produced_op.same_as_source.clone(),
+                                label_arg_idx: produced_op.label_arg_idx,
                             }
                         }
                         OpCode::GetarrayitemGcI
@@ -3234,6 +3237,7 @@ impl OptContext {
                                 preamble_op: std::rc::Rc::new(op),
                                 invented_name: produced_op.invented_name,
                                 same_as_source: produced_op.same_as_source.clone(),
+                                label_arg_idx: produced_op.label_arg_idx,
                             }
                         }
                         _ => continue,
@@ -3272,6 +3276,7 @@ impl OptContext {
                         preamble_op: std::rc::Rc::new(op),
                         invented_name: produced_op.invented_name,
                         same_as_source: produced_op.same_as_source.clone(),
+                        label_arg_idx: produced_op.label_arg_idx,
                     };
                     builder_entries.push((produced_op.res.clone(), new_pop.clone()));
                     produced.push((*source, new_pop.clone()));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3016,6 +3016,27 @@ impl Optimizer {
                             );
                         }
                     }
+                    // Resolve the carried slot by entry kind. An InputArg
+                    // label arg whose canonical result forwards away is absent
+                    // from `short_boxes.label_args`, so a re-lookup of
+                    // `canonical_result` returns None and the per-slot original
+                    // is lost; `produced.label_arg_idx` preserves the original
+                    // stamped slot through forwarding (the slot the renamed
+                    // `short_inputargs[i]` pairs with — consumed by
+                    // slot_to_original). For non-InputArg (Pure/LoopInvariant/
+                    // Heap) entries the result_map consumer needs the FORWARDED
+                    // slot: a Pure/LoopInvariant result proven equal to a label
+                    // arg it did not originally occupy must reuse
+                    // `short_args[slot]`, which `lookup_label_arg(canonical_
+                    // result)` reports (pre-217 forwarded-slot lookup, parity
+                    // with upstream Box-identity CompoundOp merge).
+                    let label_arg_idx = if produced.kind
+                        == crate::optimizeopt::shortpreamble::PreambleOpKind::InputArg
+                    {
+                        produced.label_arg_idx
+                    } else {
+                        short_boxes.lookup_label_arg(canonical_result)
+                    };
                     Some(crate::optimizeopt::shortpreamble::PreambleOp {
                         op: preamble_op,
                         // short_op.res travels with the entry — the SAME
@@ -3024,15 +3045,7 @@ impl Optimizer {
                         // upstream Box identity.
                         res: produced.res.clone(),
                         kind: produced.kind,
-                        // Carry the slot stamped when the ShortInputArg was
-                        // created (`add_short_input_arg`), not a re-lookup of the
-                        // forwarded `canonical_result`: an InputArg label arg
-                        // whose canonical result forwards away is absent from
-                        // `short_boxes.label_args`, so `lookup_label_arg` returns
-                        // None and the per-slot original is lost. `produced
-                        // .label_arg_idx` preserves the original slot through
-                        // forwarding (the slot `short_inputargs[i]` pairs with).
-                        label_arg_idx: produced.label_arg_idx,
+                        label_arg_idx,
                         invented_name: produced.invented_name,
                         same_as_source: produced.same_as_source.clone(),
                     })

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3024,7 +3024,15 @@ impl Optimizer {
                         // upstream Box identity.
                         res: produced.res.clone(),
                         kind: produced.kind,
-                        label_arg_idx: short_boxes.lookup_label_arg(canonical_result),
+                        // Carry the slot stamped when the ShortInputArg was
+                        // created (`add_short_input_arg`), not a re-lookup of the
+                        // forwarded `canonical_result`: an InputArg label arg
+                        // whose canonical result forwards away is absent from
+                        // `short_boxes.label_args`, so `lookup_label_arg` returns
+                        // None and the per-slot original is lost. `produced
+                        // .label_arg_idx` preserves the original slot through
+                        // forwarding (the slot `short_inputargs[i]` pairs with).
+                        label_arg_idx: produced.label_arg_idx,
                         invented_name: produced.invented_name,
                         same_as_source: produced.same_as_source.clone(),
                     })

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3029,7 +3029,11 @@ impl Optimizer {
                     // arg it did not originally occupy must reuse
                     // `short_args[slot]`, which `lookup_label_arg(canonical_
                     // result)` reports (pre-217 forwarded-slot lookup, parity
-                    // with upstream Box-identity CompoundOp merge).
+                    // with upstream Box-identity CompoundOp merge). For a label
+                    // arg duplicated across `label_args + virtuals`,
+                    // `lookup_label_arg` resolves to the LAST/live slot
+                    // (`potential_ops[box]` overwrite), matching the InputArg
+                    // branch's `live_slot` and upstream's surviving ShortInputArg.
                     let label_arg_idx = if produced.kind
                         == crate::optimizeopt::shortpreamble::PreambleOpKind::InputArg
                     {

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2713,7 +2713,10 @@ mod tests {
         let pure: Vec<_> = collected
             .iter()
             .filter(|(_, p)| {
-                matches!(p.kind, crate::optimizeopt::shortpreamble::PreambleOpKind::Pure)
+                matches!(
+                    p.kind,
+                    crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
+                )
             })
             .collect();
         assert_eq!(pure.len(), 1);
@@ -2834,7 +2837,10 @@ mod tests {
         let pure: Vec<_> = collected
             .iter()
             .filter(|(_, p)| {
-                matches!(p.kind, crate::optimizeopt::shortpreamble::PreambleOpKind::Pure)
+                matches!(
+                    p.kind,
+                    crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
+                )
             })
             .collect();
         assert_eq!(pure.len(), 1);
@@ -2889,7 +2895,10 @@ mod tests {
         let pure: Vec<_> = collected
             .iter()
             .filter(|(_, p)| {
-                matches!(p.kind, crate::optimizeopt::shortpreamble::PreambleOpKind::Pure)
+                matches!(
+                    p.kind,
+                    crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
+                )
             })
             .collect();
         assert_eq!(pure.len(), 1);

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2703,15 +2703,22 @@ mod tests {
             OpRef::int_op(0),
             OpRef::int_op(1),
         ]);
+        for arg in [OpRef::int_op(0), OpRef::int_op(1)] {
+            sb.add_short_input_arg(&mut ctx, arg, majit_ir::Type::Int);
+        }
         pass.produce_potential_short_preamble_ops(&mut sb, &mut ctx);
         let collected = sb.produced_ops(&mut ctx);
-        assert_eq!(collected.len(), 1);
-        assert!(matches!(
-            collected[0].1.kind,
-            crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
-        ));
-        assert_eq!(collected[0].1.preamble_op.opcode, OpCode::IntAdd);
-        assert_eq!(collected[0].1.preamble_op.pos.get(), OpRef::int_op(2));
+        // Label args are also produced as ShortInputargs; the imported pure op
+        // is the single non-InputArg short box.
+        let pure: Vec<_> = collected
+            .iter()
+            .filter(|(_, p)| {
+                matches!(p.kind, crate::optimizeopt::shortpreamble::PreambleOpKind::Pure)
+            })
+            .collect();
+        assert_eq!(pure.len(), 1);
+        assert_eq!(pure[0].1.preamble_op.opcode, OpCode::IntAdd);
+        assert_eq!(pure[0].1.preamble_op.pos.get(), OpRef::int_op(2));
     }
 
     #[test]
@@ -2817,14 +2824,21 @@ mod tests {
             OpRef::int_op(1),
             OpRef::int_op(2),
         ]);
+        // Seed the renamed ShortInputargs for the op's deps (0, 1); the op
+        // result (pos 2) is not a ShortInputArg.
+        for arg in [OpRef::int_op(0), OpRef::int_op(1)] {
+            sb.add_short_input_arg(&mut ctx, arg, majit_ir::Type::Int);
+        }
         pass.produce_potential_short_preamble_ops(&mut sb, &mut ctx);
         let collected = sb.produced_ops(&mut ctx);
-        assert_eq!(collected.len(), 1);
-        assert!(matches!(
-            collected[0].1.kind,
-            crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
-        ));
-        assert_eq!(collected[0].1.preamble_op.opcode, OpCode::IntAdd);
+        let pure: Vec<_> = collected
+            .iter()
+            .filter(|(_, p)| {
+                matches!(p.kind, crate::optimizeopt::shortpreamble::PreambleOpKind::Pure)
+            })
+            .collect();
+        assert_eq!(pure.len(), 1);
+        assert_eq!(pure[0].1.preamble_op.opcode, OpCode::IntAdd);
     }
 
     #[test]
@@ -2860,20 +2874,26 @@ mod tests {
             other => panic!("expected emitted demoted call, got {other:?}"),
         }
 
+        // Deps are the call args (100, 0, 1); the call result (pos 2) is not a
+        // label arg.
         let mut sb = crate::optimizeopt::shortpreamble::ShortBoxes::with_label_args(&[
             OpRef::int_op(0),
             OpRef::int_op(1),
-            OpRef::int_op(2),
             OpRef::int_op(100),
         ]);
+        for arg in [OpRef::int_op(0), OpRef::int_op(1), OpRef::int_op(100)] {
+            sb.add_short_input_arg(&mut ctx, arg, majit_ir::Type::Int);
+        }
         pass.produce_potential_short_preamble_ops(&mut sb, &mut ctx);
         let collected = sb.produced_ops(&mut ctx);
-        assert_eq!(collected.len(), 1);
-        assert!(matches!(
-            collected[0].1.kind,
-            crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
-        ));
-        assert_eq!(collected[0].1.preamble_op.opcode, OpCode::CallPureI);
+        let pure: Vec<_> = collected
+            .iter()
+            .filter(|(_, p)| {
+                matches!(p.kind, crate::optimizeopt::shortpreamble::PreambleOpKind::Pure)
+            })
+            .collect();
+        assert_eq!(pure.len(), 1);
+        assert_eq!(pure[0].1.preamble_op.opcode, OpCode::CallPureI);
     }
 
     #[test]
@@ -2928,23 +2948,29 @@ mod tests {
             other => panic!("expected emitted or pass-on from OptPure, got {other:?}"),
         }
 
-        // OptRewrite tracks loopinvariant for short preamble collection
+        // OptRewrite tracks loopinvariant for short preamble collection.
         let mut sb = crate::optimizeopt::shortpreamble::ShortBoxes::with_label_args(&[
             OpRef::int_op(0),
             OpRef::int_op(2),
             OpRef::int_op(100),
         ]);
+        // The func arg 100 is a known constant (produce_arg returns it
+        // unrenamed); only the real input 0 gets a renamed ShortInputArg.
+        sb.note_known_constant(OpRef::int_op(100));
+        sb.add_short_input_arg(&mut ctx, OpRef::int_op(0), majit_ir::Type::Int);
         rewrite.produce_potential_short_preamble_ops(&mut sb, &mut ctx);
         let collected = sb.produced_ops(&mut ctx);
-        assert_eq!(collected.len(), 1);
-        assert!(matches!(
-            collected[0].1.kind,
-            crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant
-        ));
-        assert_eq!(
-            collected[0].1.preamble_op.opcode,
-            OpCode::CallLoopinvariantI
-        );
+        let loopinv: Vec<_> = collected
+            .iter()
+            .filter(|(_, p)| {
+                matches!(
+                    p.kind,
+                    crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant
+                )
+            })
+            .collect();
+        assert_eq!(loopinv.len(), 1);
+        assert_eq!(loopinv[0].1.preamble_op.opcode, OpCode::CallLoopinvariantI);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -437,6 +437,7 @@ impl PreambleOp {
             preamble_op: std::rc::Rc::new(preamble_op),
             invented_name: self.invented_name,
             same_as_source: self.same_as_source.clone(),
+            label_arg_idx: self.label_arg_idx,
         })
     }
 }
@@ -935,6 +936,7 @@ impl ShortBoxes {
                 kind: PreambleOpKind::Heap,
                 invented_name: false,
                 same_as_source: None,
+                label_arg_idx: None,
             });
         }
         short_boxes
@@ -1240,6 +1242,13 @@ pub struct ProducedShortOp {
     /// Original result this invented name aliases.
     /// MIGRATION (#9): carried as a [`BoxRef`]; see [`PreambleOp::same_as_source`].
     pub same_as_source: Option<crate::r#box::BoxRef>,
+    /// Slot of this short box's result within the original
+    /// `label_args + virtuals`, i.e. `lookup_label_arg(canonical_result)`
+    /// carried over from [`PreambleOp::label_arg_idx`] across the export
+    /// boundary. `None` for a result that is not a label/virtual slot. Lets
+    /// the importer resolve the body-visible result slot directly instead of
+    /// matching the result against a parallel originals array.
+    pub label_arg_idx: Option<usize>,
 }
 
 /// Phase B B.1: helper used by `ProducedShortOp::produce_op` to seed a
@@ -3217,6 +3226,7 @@ pub fn produced_short_boxes_from_exported_boxes(
                     preamble_op: std::rc::Rc::new(preamble_op),
                     invented_name: entry.invented_name,
                     same_as_source: entry.same_as_source.clone(),
+                    label_arg_idx: entry.label_arg_idx,
                 },
             )
         })
@@ -3697,6 +3707,7 @@ mod tests {
                     },
                     invented_name: false,
                     same_as_source: None,
+                    label_arg_idx: None,
                 },
             ),
             (
@@ -3711,6 +3722,7 @@ mod tests {
                     },
                     invented_name: false,
                     same_as_source: None,
+                    label_arg_idx: None,
                 },
             ),
         ];

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -543,6 +543,17 @@ impl PotentialShortOp {
                         // freshly invented name.
                         alt.res = ctx.materialize_box_at(alias);
                         alt.invented_name = true;
+                        // shortpreamble.py:330 `lst[i].short_op.res = new_name`:
+                        // the alias result is now the freshly invented SameAs box,
+                        // not a label arg. `label_arg_idx` was set by
+                        // `lookup_label_arg` from the ORIGINAL result position, so it
+                        // must be cleared to stay consistent with the updated `res`
+                        // (upstream keys slot identity off `short_op.res`, which the
+                        // line above just rebound). Otherwise the import slot-lookup
+                        // (unroll.rs:4171) would map this invented alias onto the
+                        // loop-carried `short_args[slot]` instead of minting a fresh
+                        // result, collapsing the extra `same_as` identity.
+                        alt.label_arg_idx = None;
                         // shortpreamble.py:328 `ResOperation(opnum, [shortop.res])`
                         // — the alias source is the Box itself; resolve to
                         // the canonical (possibly producer-bound) box.
@@ -4041,6 +4052,68 @@ mod tests {
             alias.1.same_as_source.as_ref().map(|b| b.to_opref()),
             Some(OpRef::int_op(10))
         );
+    }
+
+    #[test]
+    fn test_compound_pure_loser_to_short_inputarg_clears_label_arg_idx() {
+        // shortpreamble.py:326-333 — when a Pure alternative loses the compound
+        // tie to the ShortInputArg, its result is rebound to a fresh SameAs box
+        // (`lst[i].short_op.res = new_name`), so the invented alias is no longer
+        // a label arg. pyre's `label_arg_idx` (the position proxy for "res is
+        // label arg N") must be cleared in lockstep; otherwise the import
+        // slot-lookup at unroll.rs (the path-2 Pure|LoopInvariant arm) would map
+        // the invented alias onto the loop-carried `short_args[slot]`, collapsing
+        // the distinct same_as identity into a wrong-result miscompile. (The
+        // sibling Heap-loser test above does NOT exercise this: path-2 ignores
+        // label_arg_idx for the Heap kind.)
+        let mut ctx = crate::optimizeopt::OptContext::new(256);
+        let mut sb =
+            ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(30), OpRef::int_op(31)]);
+        // pos 10 is both a label arg (slot 0) and a pure result (the case under
+        // test); seed all three label args (the pure deps 30/31 are
+        // ShortInputargs too).
+        sb.add_short_input_arg(&mut ctx, OpRef::int_op(10), majit_ir::Type::Int);
+        sb.add_short_input_arg(&mut ctx, OpRef::int_op(30), majit_ir::Type::Int);
+        sb.add_short_input_arg(&mut ctx, OpRef::int_op(31), majit_ir::Type::Int);
+
+        // A pure op whose result coincides with label arg 10, depending on the
+        // other two label args (avoids a self-referential in-production cycle).
+        let mut pure = Op::new(
+            OpCode::IntAdd,
+            &[
+                BoxRef::from_opref(OpRef::int_op(30)),
+                BoxRef::from_opref(OpRef::int_op(31)),
+            ],
+        );
+        pure.pos.set(OpRef::int_op(10));
+        sb.add_pure_op(&mut ctx, pure);
+
+        let produced = sb.produced_ops(&mut ctx);
+
+        // The compound at pos 10 prefers the ShortInputArg; the Pure becomes an
+        // invented alias.
+        let chosen = produced
+            .iter()
+            .find(|(result, _)| *result == OpRef::int_op(10))
+            .unwrap();
+        assert_eq!(chosen.1.kind, PreambleOpKind::InputArg);
+        assert!(!chosen.1.invented_name);
+        // The winning ShortInputArg keeps its label slot (box 10 = slot 0).
+        assert_eq!(chosen.1.label_arg_idx, Some(0));
+
+        let alias = produced
+            .iter()
+            .find(|(_, p)| p.kind == PreambleOpKind::Pure)
+            .unwrap();
+        assert!(alias.1.invented_name);
+        assert_eq!(
+            alias.1.same_as_source.as_ref().map(|b| b.to_opref()),
+            Some(OpRef::int_op(10))
+        );
+        // THE REGRESSION LOCK: the invented alias must NOT carry the original
+        // label slot. Before the fix this was Some(0) and the import collapsed
+        // the alias onto the loop-carried input.
+        assert_eq!(alias.1.label_arg_idx, None);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -681,16 +681,22 @@ impl ShortBoxes {
                  (shortpreamble.py:255-259)"
             );
         }
-        // shortpreamble.py:256 `box = label_args[i]` — record the original.
+        // shortpreamble.py:258 `self.short_inputargs.append(renamed)`: one
+        // renamed box per call, in caller order. The production caller
+        // (optimizer.rs preview loop) iterates `label_args + virtuals`
+        // (unroll.py:479) in order, appending one renamed box per slot, so
+        // this call's slot is `short_inputargs.len()`, captured before the
+        // push below.
+        let live_slot = self.short_inputargs.len();
+        // shortpreamble.py:256 `box = label_args[i]` — register the original
+        // so `is_reachable` / `produce_arg` membership resolve it.
         // `with_label_args` pre-seeds `label_args`; the standalone
-        // `create_short_boxes` path (empty `label_args`) appends here.
-        let label_arg_idx = match self.lookup_label_arg(arg) {
-            Some(idx) => idx,
-            None => {
-                self.label_args.push(arg);
-                self.label_args.len() - 1
-            }
-        };
+        // `create_short_boxes` path (empty `label_args`) appends here. A box
+        // duplicated across `label_args + virtuals` (a virtual field that
+        // coincides with a label arg) is registered once.
+        if self.lookup_label_arg(arg).is_none() {
+            self.label_args.push(arg);
+        }
         // shortpreamble.py:257 `renamed = OpHelpers.inputarg_from_tp(box.type)`
         // — a FRESH InputArg distinct from the original `box`. Its position
         // comes from the op-position counter so it is unique and accounted
@@ -700,22 +706,18 @@ impl ShortBoxes {
             arg_type,
             ctx.alloc_op_position_typed(arg_type).raw(),
         );
-        // shortpreamble.py:258 `self.short_inputargs.append(renamed)`: one
-        // renamed box per call, in caller order. The production caller
-        // (optimizer.rs preview loop) iterates `label_args + virtuals`
-        // (unroll.py:479) in order, appending one renamed box per slot, so
-        // `short_inputargs[i]` pairs positionally with that combined list.
-        //
-        // A box may appear twice in `label_args + virtuals` (a virtual field
-        // that coincides with a label arg). Upstream tolerates this: the
-        // `potential_ops[box]` assignment (shortpreamble.py:259) keys on the
-        // box, so the duplicate collapses to one produced entry while
-        // `short_inputargs` still holds a renamed box per slot. `label_arg_idx`
-        // is the box's first slot (`lookup_label_arg`), so the later duplicate
-        // slot's renamed box becomes a dead Label arg — never produced, never
-        // given info (shortpreamble.py:414-417 sets info only on produced
-        // boxes). `label_arg_idx == short_inputargs.len()` therefore holds only
-        // when the combined list is duplicate-free, so it is not asserted.
+        // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
+        // is a plain dict assignment, so for a box duplicated across the
+        // combined list it OVERWRITES: the LAST slot's `ShortInputArg`
+        // survives and `produce_arg` returns `short_inputargs[LAST]`, leaving
+        // the FIRST slot's renamed box a dead Label arg — never produced,
+        // never given info (shortpreamble.py:414-417 sets info only on
+        // produced boxes). pyre mirrors that by stamping `label_arg_idx =
+        // live_slot` (this call's slot) on the `potential_ops` entry below;
+        // the later duplicate call overwrites with its later slot, so
+        // `produce_arg` returns the same LAST-slot renamed box. In the
+        // duplicate-free case `live_slot == lookup_label_arg(arg)`, so the
+        // rename is unchanged.
         self.short_inputargs.push(renamed);
         // shortpreamble.py:257 `ShortInputArg(box, renamed)` — `res` is the
         // original `box`; the SAME_AS replay arg is that box. Exported
@@ -737,7 +739,7 @@ impl ShortBoxes {
                 res: arg_box,
                 op: std::rc::Rc::new(same_as),
                 kind: PreambleOpKind::InputArg,
-                label_arg_idx: Some(label_arg_idx),
+                label_arg_idx: Some(live_slot),
                 invented_name: false,
                 same_as_source: None,
             }),
@@ -4147,6 +4149,50 @@ mod tests {
         assert_eq!(sb.lookup_label_arg(OpRef::int_op(10)), Some(0));
         assert_eq!(sb.lookup_label_arg(OpRef::ref_op(11)), Some(1));
         assert!(sb.is_reachable(OpRef::int_op(10)));
+    }
+
+    #[test]
+    fn test_duplicate_slot_keeps_last_renamed_inputarg() {
+        // shortpreamble.py:255-259 — when a box appears at TWO slots of the
+        // combined `label_args + virtuals` (a virtual field coinciding with a
+        // label arg; empirically RefOp(50)/RefOp(174) in synth/tuple_unpacking),
+        // the `potential_ops[box] = ShortInputArg(box, renamed)` dict assignment
+        // OVERWRITES, so the LAST slot's renamed inputarg is the live one and
+        // `produce_arg` returns `short_inputargs[LAST]`; the FIRST slot's renamed
+        // box is the dead Label arg. pyre stamps `label_arg_idx = live_slot` (the
+        // current call's slot) so the later (overwriting) call records the LAST
+        // slot, matching upstream. Before the fix `lookup_label_arg`'s
+        // first-occurrence made produce_arg return short_inputargs[FIRST].
+        let mut ctx = crate::optimizeopt::OptContext::new(256);
+        // The SAME box at both slots: the production caller (optimizer.rs preview
+        // loop) iterates label_args+virtuals, so a coinciding box reaches
+        // add_short_input_arg once per slot.
+        let label_args = [OpRef::ref_op(50), OpRef::ref_op(50)];
+        let mut sb = ShortBoxes::with_label_args(&label_args);
+        sb.add_short_input_arg(&mut ctx, OpRef::ref_op(50), majit_ir::Type::Ref);
+        sb.add_short_input_arg(&mut ctx, OpRef::ref_op(50), majit_ir::Type::Ref);
+
+        // Two FRESH distinct renamed boxes, one per slot (shortpreamble.py:258).
+        let si = sb.create_short_inputargs(&label_args);
+        assert_eq!(si.len(), 2);
+        assert_ne!(si[0].to_opref(), si[1].to_opref());
+
+        // The duplicate collapses to ONE produced InputArg entry, keyed at the
+        // LAST slot (label_arg_idx == Some(1)), not the first (Some(0)).
+        let produced = sb.produced_ops(&mut ctx);
+        let inputarg_entries: Vec<_> = produced
+            .iter()
+            .filter(|(r, p)| *r == OpRef::ref_op(50) && p.kind == PreambleOpKind::InputArg)
+            .collect();
+        assert_eq!(inputarg_entries.len(), 1);
+        // THE REGRESSION LOCK: the overwriting (later) call must record the LAST
+        // slot, matching upstream's dict-overwrite. Some(0) before the fix.
+        assert_eq!(inputarg_entries[0].1.label_arg_idx, Some(1));
+
+        // produce_arg returns the LAST slot's renamed box.
+        let produced_arg = sb.produce_arg(&mut ctx, OpRef::ref_op(50)).unwrap();
+        assert_eq!(produced_arg.to_opref(), si[1].to_opref());
+        assert_ne!(produced_arg.to_opref(), si[0].to_opref());
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -689,15 +689,22 @@ impl ShortBoxes {
             arg_type,
             ctx.alloc_op_position_typed(arg_type).raw(),
         );
-        // `short_inputargs[i]` pairs with `label_args[i]`; callers feed args
-        // in label-arg order (production: optimizer.rs preview loop), so an
-        // append lands at the matching slot.
-        debug_assert_eq!(
-            label_arg_idx,
-            self.short_inputargs.len(),
-            "add_short_input_arg must be called in label_args order so \
-             short_inputargs[i] pairs with label_args[i]"
-        );
+        // shortpreamble.py:258 `self.short_inputargs.append(renamed)`: one
+        // renamed box per call, in caller order. The production caller
+        // (optimizer.rs preview loop) iterates `label_args + virtuals`
+        // (unroll.py:479) in order, appending one renamed box per slot, so
+        // `short_inputargs[i]` pairs positionally with that combined list.
+        //
+        // A box may appear twice in `label_args + virtuals` (a virtual field
+        // that coincides with a label arg). Upstream tolerates this: the
+        // `potential_ops[box]` assignment (shortpreamble.py:259) keys on the
+        // box, so the duplicate collapses to one produced entry while
+        // `short_inputargs` still holds a renamed box per slot. `label_arg_idx`
+        // is the box's first slot (`lookup_label_arg`), so the later duplicate
+        // slot's renamed box becomes a dead Label arg — never produced, never
+        // given info (shortpreamble.py:414-417 sets info only on produced
+        // boxes). `label_arg_idx == short_inputargs.len()` therefore holds only
+        // when the combined list is duplicate-free, so it is not asserted.
         self.short_inputargs.push(renamed);
         // shortpreamble.py:257 `ShortInputArg(box, renamed)` — `res` is the
         // original `box`; the SAME_AS replay arg is that box. Exported

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -3178,62 +3178,35 @@ pub fn extract_short_preamble(peeled_ops: &[Op]) -> ShortPreamble {
 }
 
 /// `unroll.py:497 ExportedState.short_boxes` shape: per-OpRef
-/// `ProducedShortOp` records derived from `ctx.exported_short_boxes`,
-/// with label-arg references in each preamble op renamed to the
-/// matching short-inputarg slot
-/// (`shortpreamble.py:269-270 ShortBoxes.create_short_boxes`).
+/// `ProducedShortOp` records derived from `ctx.exported_short_boxes`.
+///
+/// The label-arg → short-inputarg rename happens at EXPORT time inside
+/// `produce_arg` (shortpreamble.py:285/294): every short op the import
+/// path emits (Pure / Heap / LoopInvariant) already carries the renamed
+/// `short_inputargs` box in its args. The only exported entries that still
+/// reference an original label box are the `ShortInputArg` `SameAs*`
+/// stand-ins, and those are never emitted (`produce_op` returns None for
+/// `InputArg`, shortpreamble.py:233-234) nor read by any import consumer:
+/// `result_map` and the `produce_op` loop skip `InputArg`, the builder
+/// init skips entries with no `result_map` slot, and `use_box_recursive`'s
+/// arg recursion is rename-invariant for the `SameAs` self-reference. So
+/// no import-time arg rewrite is needed — the produced view is a plain
+/// filter + transform of `exported_short_boxes`.
 ///
 /// OVF guards are filtered out: the guard entry depends on the
 /// preceding `Int*Ovf` op and is re-emitted by the builder through
 /// `append_to_short`'s `is_ovf` branch, so the standalone guard must
 /// not appear in the produced map.
-///
-/// Phase B prep: extracted from
-/// `build_short_preamble_from_exported_boxes` so that future B1 wiring
-/// can store the same shape on `ExportedState.produced_short_boxes`
-/// (audit memo `box_identity_phase_b_surface_audit_2026_05_02.md`
-/// option (b)) without duplicating the rename logic.
 pub fn produced_short_boxes_from_exported_boxes(
-    label_args: &[OpRef],
-    short_inputargs: &[BoxRef],
     exported_short_boxes: &[PreambleOp],
 ) -> Vec<(OpRef, ProducedShortOp)> {
-    // optimizer.py:651-652 setarg(renamed_inputargs[i]) — the renamed
-    // operand IS the stored short-inputarg box object, not a fresh
-    // equal-positioned mint.
-    let inputarg_rename = |arg: OpRef| -> Option<&BoxRef> {
-        label_args
-            .iter()
-            .position(|&a| a == arg)
-            .and_then(|i| short_inputargs.get(i))
-    };
     exported_short_boxes
         .iter()
         .filter(|entry| !entry.op.opcode.is_guard_overflow())
         .map(|entry| {
-            let mut preamble_op = (*entry.op).clone();
-            // optimizer.py:651-652 setarg loop parity.
-            for i in 0..preamble_op.num_args() {
-                if let Some(renamed) = inputarg_rename(preamble_op.arg(i).to_opref()) {
-                    preamble_op.setarg(i, renamed.clone());
-                }
-            }
-            if let Some(fail_args) = preamble_op.fail_args_mut() {
-                for arg in fail_args {
-                    if let Some(renamed) = inputarg_rename(arg.to_opref()) {
-                        // Measured dead (PYRE_REMAP_PROBE 2026-06-11: 0 fires
-                        // across check.py corpus + lib tests) — exported short
-                        // boxes carry pure ops/guards without fail_args
-                        // referencing label args. Rewrite kept as a release
-                        // safety net.
-                        debug_assert!(
-                            false,
-                            "imported short-box fail_arg hit inputarg rename: {arg:?}"
-                        );
-                        *arg = majit_ir::operand::Operand::from_boxref(renamed);
-                    }
-                }
-            }
+            // Fresh clone per entry so the builder's on-object forwarded
+            // marker (`ShortPreambleBuilder::new`) mutates an isolated Rc.
+            let preamble_op = (*entry.op).clone();
             (
                 preamble_op.pos.get(),
                 ProducedShortOp {
@@ -3302,8 +3275,7 @@ pub fn build_short_preamble_from_exported_boxes(
     short_inputargs: &[BoxRef],
     exported_short_boxes: &[PreambleOp],
 ) -> ShortPreamble {
-    let produced =
-        produced_short_boxes_from_exported_boxes(label_args, short_inputargs, exported_short_boxes);
+    let produced = produced_short_boxes_from_exported_boxes(exported_short_boxes);
     build_short_preamble_from_produced_boxes(label_args, short_inputargs, &produced)
 }
 
@@ -3601,14 +3573,19 @@ mod tests {
 
     #[test]
     fn test_build_short_preamble_from_exported_boxes_uses_exported_order() {
+        // shortpreamble.py:285/294: the label-arg → short-inputarg rename
+        // happens at EXPORT time (produce_arg), so the exported short ops
+        // already carry the renamed `short_inputargs` boxes (10/11) in place
+        // of the original label args (0/1). The op-result positions (7/8) are
+        // not inputargs and are unchanged.
         let exported = vec![
             PreambleOp {
                 op: {
                     let mut op = Op::new(
                         OpCode::IntAdd,
                         &[
-                            BoxRef::from_opref(OpRef::int_op(0)),
-                            BoxRef::from_opref(OpRef::int_op(1)),
+                            BoxRef::from_opref(OpRef::int_op(10)),
+                            BoxRef::from_opref(OpRef::int_op(11)),
                         ],
                     );
                     op.pos.set(OpRef::int_op(7));
@@ -3626,7 +3603,7 @@ mod tests {
                         OpCode::IntSub,
                         &[
                             BoxRef::from_opref(OpRef::int_op(7)),
-                            BoxRef::from_opref(OpRef::int_op(1)),
+                            BoxRef::from_opref(OpRef::int_op(11)),
                         ],
                     );
                     op.pos.set(OpRef::int_op(8));
@@ -3950,18 +3927,14 @@ mod tests {
 
         let chosen = produced
             .iter()
-            .find(|(result, p)| {
-                *result == OpRef::int_op(10) && p.kind != PreambleOpKind::InputArg
-            })
+            .find(|(result, p)| *result == OpRef::int_op(10) && p.kind != PreambleOpKind::InputArg)
             .unwrap();
         assert_eq!(chosen.1.kind, PreambleOpKind::Pure);
         assert!(!chosen.1.invented_name);
 
         let alias = produced
             .iter()
-            .find(|(result, p)| {
-                *result != OpRef::int_op(10) && p.kind != PreambleOpKind::InputArg
-            })
+            .find(|(result, p)| *result != OpRef::int_op(10) && p.kind != PreambleOpKind::InputArg)
             .unwrap();
         assert_eq!(alias.1.kind, PreambleOpKind::Heap);
         assert!(alias.1.invented_name);
@@ -4013,9 +3986,7 @@ mod tests {
 
         let chosen = produced
             .iter()
-            .find(|(result, p)| {
-                *result == OpRef::int_op(20) && p.kind != PreambleOpKind::InputArg
-            })
+            .find(|(result, p)| *result == OpRef::int_op(20) && p.kind != PreambleOpKind::InputArg)
             .unwrap();
         assert_eq!(chosen.1.kind, PreambleOpKind::Pure);
         assert!(!chosen.1.invented_name);
@@ -4127,8 +4098,7 @@ mod tests {
 
         let produced = sb.produced_ops(&mut __ctx);
         let short_inputargs = sb.create_short_inputargs(&[OpRef::int_op(30), OpRef::int_op(31)]);
-        let label_arg_oprefs: Vec<OpRef> =
-            short_inputargs.iter().map(|b| b.to_opref()).collect();
+        let label_arg_oprefs: Vec<OpRef> = short_inputargs.iter().map(|b| b.to_opref()).collect();
         // #146/S8: the builder map keys by the entry res Box; re-key the
         // produced_ops list (keyed by `preamble_op.pos`) to res for new() and
         // look up by the res box of the int_op(10) entry.

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -595,9 +595,15 @@ impl ShortBoxes {
 
     /// shortpreamble.py:259 `self.potential_ops[box]` — resolve a label
     /// arg to its slot by the ORIGINAL box opref (not the renamed
-    /// `short_inputargs` box, which is a distinct identity).
+    /// `short_inputargs` box, which is a distinct identity). `potential_ops`
+    /// is box-keyed, so a box duplicated across `label_args + virtuals` (a
+    /// virtual field coinciding with a label arg) OVERWRITES to the LAST
+    /// occurrence's `ShortInputArg`; `rposition` mirrors that overwrite,
+    /// returning the live slot — consistent with `add_short_input_arg`
+    /// stamping `label_arg_idx = live_slot` (the last slot). For a
+    /// duplicate-free box `rposition == position`.
     pub fn lookup_label_arg(&self, opref: OpRef) -> Option<usize> {
-        self.label_args.iter().position(|&a| a == opref)
+        self.label_args.iter().rposition(|&a| a == opref)
     }
 
     /// RPython parity: check if opref is reachable in the short preamble.
@@ -4193,6 +4199,13 @@ mod tests {
         let produced_arg = sb.produce_arg(&mut ctx, OpRef::ref_op(50)).unwrap();
         assert_eq!(produced_arg.to_opref(), si[1].to_opref());
         assert_ne!(produced_arg.to_opref(), si[0].to_opref());
+
+        // `lookup_label_arg` mirrors `potential_ops[box]`'s last-wins overwrite,
+        // resolving the duplicated box to the LAST/live slot. This keeps the
+        // non-InputArg export lookup (optimizer.rs `lookup_label_arg(
+        // canonical_result)`) consistent with the InputArg entry's `live_slot`
+        // above. `rposition`; was `Some(0)` (first) before the fix.
+        assert_eq!(sb.lookup_label_arg(OpRef::ref_op(50)), Some(1));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -733,6 +733,21 @@ impl ShortBoxes {
         );
     }
 
+    /// shortpreamble.py:285/294 `return ...preamble_op`: for a ShortInputArg
+    /// the produced `preamble_op` IS the renamed inputarg box
+    /// (shortpreamble.py:257 `ShortInputArg(box, renamed)`). pyre stores the
+    /// renamed boxes in `short_inputargs`, paired with each label/virtual slot
+    /// by `label_arg_idx` (`lookup_label_arg`), so produce_arg returns that
+    /// renamed box — embedding the rename into the exported short op args at
+    /// export time, the same substitution the import rename pass performed
+    /// (`produced_short_boxes_from_exported_boxes`, `short_inputargs[position
+    /// of arg in label_args]`).
+    fn renamed_short_inputarg(&self, label_arg_idx: Option<usize>) -> BoxRef {
+        let idx = label_arg_idx
+            .expect("InputArg short box missing label_arg_idx (set by add_short_input_arg)");
+        self.short_inputargs[idx].clone()
+    }
+
     fn produce_arg(
         &mut self,
         ctx: &mut crate::optimizeopt::OptContext,
@@ -749,14 +764,15 @@ impl ShortBoxes {
                 // dependency's replay op object itself, so preamble-op
                 // args carry the dep replay handle.
                 //
-                // ShortInputArg: upstream `preamble_op` IS the inputarg
-                // box (shortpreamble.py:255-259), not an op. pyre models
-                // the replay as a SAME_AS op squatting the inputarg
-                // position; binding to that op retags the position into
-                // the op namespace (from_bound_op derives the OpRef from
-                // the box kind), so return the carried res box instead.
+                // ShortInputArg: upstream `preamble_op` IS the renamed
+                // inputarg box (shortpreamble.py:257 `ShortInputArg(box,
+                // renamed)`), so produce_arg returns the renamed
+                // short_inputargs box for this slot — the export-time
+                // rename. (`existing.res` is the ORIGINAL box, kept only
+                // as the info-lookup key, shortpreamble.py:417.)
                 if existing.kind == PreambleOpKind::InputArg {
-                    return Some(existing.res.clone());
+                    let label_arg_idx = existing.label_arg_idx;
+                    return Some(self.renamed_short_inputarg(label_arg_idx));
                 }
                 return Some(BoxRef::from_bound_op(&existing.preamble_op));
             }
@@ -780,23 +796,19 @@ impl ShortBoxes {
             .any(|(k, _)| k.to_opref() == opref)
         {
             // shortpreamble.py:291-294 `r = self.add_op_to_short(...);
-            // return r.preamble_op`. ShortInputArg: res box, see the
-            // produced arm above.
-            return self.materialize_one(ctx, opref).map(|produced| {
-                if produced.kind == PreambleOpKind::InputArg {
-                    produced.res.clone()
-                } else {
-                    BoxRef::from_bound_op(&produced.preamble_op)
-                }
-            });
+            // return r.preamble_op`. ShortInputArg: renamed short_inputargs
+            // box, see the produced arm above.
+            let produced = self.materialize_one(ctx, opref)?;
+            if produced.kind == PreambleOpKind::InputArg {
+                return Some(self.renamed_short_inputarg(produced.label_arg_idx));
+            }
+            return Some(BoxRef::from_bound_op(&produced.preamble_op));
         }
-        // Label args are always available as inputs (RPython: isinstance(op, InputArgIntOp)).
-        // Return the ORIGINAL label-arg box; exported entries carry original
-        // positions and are renamed to the matching short_inputargs slot at
-        // import. Match by the original opref, not the (distinct) renamed box.
-        if self.label_args.iter().any(|&a| a == opref) {
-            return Some(ctx.materialize_box_at(opref));
-        }
+        // shortpreamble.py:295-296 `else: return None`. Every label arg is
+        // registered as a ShortInputArg in `potential_ops`
+        // (`add_short_input_arg`, create_short_boxes:255-259), so a label arg
+        // is reached through the produced/potential arms above; an opref that
+        // is none of those is not produce-able.
         None
     }
 
@@ -3801,10 +3813,15 @@ mod tests {
 
     #[test]
     fn test_short_boxes() {
+        let mut __ctx = crate::optimizeopt::OptContext::new(256);
         let mut sb =
             ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(11), OpRef::int_op(12)]);
         assert_eq!(sb.num_label_args, 3);
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
+        // Production seeds a renamed ShortInputArg for every label arg
+        // (optimizer.rs preview loop); the pure/heap deps resolve through them.
+        for arg in [OpRef::int_op(10), OpRef::int_op(11), OpRef::int_op(12)] {
+            sb.add_short_input_arg(&mut __ctx, arg, majit_ir::Type::Int);
+        }
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
@@ -3822,13 +3839,19 @@ mod tests {
         heap.pos.set(OpRef::int_op(21));
         sb.add_heap_op(&mut __ctx, heap);
         let produced = sb.produced_ops(&mut __ctx);
-        assert_eq!(produced.len(), 2);
+        // 3 ShortInputArgs (one per label arg) + the pure and heap ops.
+        let non_input: Vec<_> = produced
+            .iter()
+            .filter(|(_, p)| p.kind != PreambleOpKind::InputArg)
+            .collect();
+        assert_eq!(non_input.len(), 2);
     }
 
     #[test]
     fn test_short_boxes_reject_unknown_nonconstant_dependency() {
+        let mut __ctx = crate::optimizeopt::OptContext::new(256);
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10)]);
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
+        sb.add_short_input_arg(&mut __ctx, OpRef::int_op(10), majit_ir::Type::Int);
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
@@ -3850,9 +3873,10 @@ mod tests {
 
     #[test]
     fn test_short_boxes_accept_known_constant_dependency() {
+        let mut __ctx = crate::optimizeopt::OptContext::new(256);
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10)]);
+        sb.add_short_input_arg(&mut __ctx, OpRef::int_op(10), majit_ir::Type::Int);
         sb.note_known_constant(OpRef::int_op(999));
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
@@ -3864,11 +3888,19 @@ mod tests {
         sb.add_pure_op(&mut __ctx, pure);
 
         let produced = sb.produced_ops(&mut __ctx);
-        assert_eq!(produced.len(), 1);
+        let renamed10 = sb.create_short_inputargs(&[OpRef::int_op(10)])[0].to_opref();
+        // 1 ShortInputArg (label arg 10) + the accepted pure op.
+        let non_input: Vec<_> = produced
+            .iter()
+            .filter(|(_, p)| p.kind != PreambleOpKind::InputArg)
+            .collect();
+        assert_eq!(non_input.len(), 1);
         let pure = produced
             .iter()
             .find(|(result, _)| *result == OpRef::int_op(20))
             .expect("missing produced pure op");
+        // The label-arg dep is renamed to its short_inputargs box; the known
+        // constant 999 passes through unchanged.
         assert_eq!(
             pure.1
                 .preamble_op
@@ -3876,15 +3908,19 @@ mod tests {
                 .iter()
                 .map(|a| a.to_opref())
                 .collect::<Vec<_>>(),
-            vec![OpRef::int_op(10), OpRef::int_op(999)]
+            vec![renamed10, OpRef::int_op(999)]
         );
     }
 
     #[test]
     fn test_short_boxes_compound_prefers_non_heap_and_emits_invented_alias() {
-        let mut sb =
-            ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(30), OpRef::int_op(31)]);
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
+        let mut __ctx = crate::optimizeopt::OptContext::new(256);
+        // Only the op DEPENDENCIES (30, 31) are label args; the compound result
+        // (pos 10) is an op result, not a label arg.
+        let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(30), OpRef::int_op(31)]);
+        for arg in [OpRef::int_op(30), OpRef::int_op(31)] {
+            sb.add_short_input_arg(&mut __ctx, arg, majit_ir::Type::Int);
+        }
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -3892,7 +3928,7 @@ mod tests {
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(10));
-        sb.add_potential_op(&mut __ctx, Some(0), heap, PreambleOpKind::Heap);
+        sb.add_potential_op(&mut __ctx, None, heap, PreambleOpKind::Heap);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
@@ -3902,21 +3938,30 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(10));
-        sb.add_potential_op(&mut __ctx, Some(0), pure, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, None, pure, PreambleOpKind::Pure);
 
         let produced = sb.produced_ops(&mut __ctx);
-        assert_eq!(produced.len(), 2);
+        // 2 ShortInputArgs (30, 31) + the compound@10 (Pure chosen + Heap alias).
+        let non_input_count = produced
+            .iter()
+            .filter(|(_, p)| p.kind != PreambleOpKind::InputArg)
+            .count();
+        assert_eq!(non_input_count, 2);
 
         let chosen = produced
             .iter()
-            .find(|(result, _)| *result == OpRef::int_op(10))
+            .find(|(result, p)| {
+                *result == OpRef::int_op(10) && p.kind != PreambleOpKind::InputArg
+            })
             .unwrap();
         assert_eq!(chosen.1.kind, PreambleOpKind::Pure);
         assert!(!chosen.1.invented_name);
 
         let alias = produced
             .iter()
-            .find(|(result, _)| *result != OpRef::int_op(10))
+            .find(|(result, p)| {
+                *result != OpRef::int_op(10) && p.kind != PreambleOpKind::InputArg
+            })
             .unwrap();
         assert_eq!(alias.1.kind, PreambleOpKind::Heap);
         assert!(alias.1.invented_name);
@@ -3928,9 +3973,13 @@ mod tests {
 
     #[test]
     fn test_short_boxes_nested_compound_emits_multiple_invented_aliases() {
-        let mut sb =
-            ShortBoxes::with_label_args(&[OpRef::int_op(20), OpRef::int_op(30), OpRef::int_op(31)]);
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
+        let mut __ctx = crate::optimizeopt::OptContext::new(256);
+        // Only the op DEPENDENCIES (30, 31) are label args; the compound result
+        // (pos 20) is an op result, not a label arg.
+        let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(30), OpRef::int_op(31)]);
+        for arg in [OpRef::int_op(30), OpRef::int_op(31)] {
+            sb.add_short_input_arg(&mut __ctx, arg, majit_ir::Type::Int);
+        }
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -3938,11 +3987,11 @@ mod tests {
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(&mut __ctx, Some(0), heap, PreambleOpKind::Heap);
+        sb.add_potential_op(&mut __ctx, None, heap, PreambleOpKind::Heap);
 
         let mut loopinv = Op::new(OpCode::CallI, &[BoxRef::from_opref(OpRef::int_op(30))]);
         loopinv.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(&mut __ctx, Some(0), loopinv, PreambleOpKind::LoopInvariant);
+        sb.add_potential_op(&mut __ctx, None, loopinv, PreambleOpKind::LoopInvariant);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
@@ -3952,21 +4001,30 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(&mut __ctx, Some(0), pure, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, None, pure, PreambleOpKind::Pure);
 
         let produced = sb.produced_ops(&mut __ctx);
-        assert_eq!(produced.len(), 3);
+        // 2 ShortInputArgs (30, 31) + the compound@20 (Pure chosen + 2 aliases).
+        let non_input_count = produced
+            .iter()
+            .filter(|(_, p)| p.kind != PreambleOpKind::InputArg)
+            .count();
+        assert_eq!(non_input_count, 3);
 
         let chosen = produced
             .iter()
-            .find(|(result, _)| *result == OpRef::int_op(20))
+            .find(|(result, p)| {
+                *result == OpRef::int_op(20) && p.kind != PreambleOpKind::InputArg
+            })
             .unwrap();
         assert_eq!(chosen.1.kind, PreambleOpKind::Pure);
         assert!(!chosen.1.invented_name);
 
         let aliases: Vec<_> = produced
             .iter()
-            .filter(|(result, _)| *result != OpRef::int_op(20))
+            .filter(|(result, p)| {
+                *result != OpRef::int_op(20) && p.kind != PreambleOpKind::InputArg
+            })
             .collect();
         assert_eq!(aliases.len(), 2);
         assert!(aliases.iter().all(|(_, produced)| produced.invented_name));
@@ -3979,7 +4037,10 @@ mod tests {
     fn test_rpython_create_short_boxes_prefers_short_inputarg_over_heap_result() {
         let mut ctx = crate::optimizeopt::OptContext::new(256);
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(30)]);
+        // pos 10 is both a label arg and a heap result (the case under test);
+        // seed both label args (the heap dep 30 must be a ShortInputArg too).
         sb.add_short_input_arg(&mut ctx, OpRef::int_op(10), majit_ir::Type::Int);
+        sb.add_short_input_arg(&mut ctx, OpRef::int_op(30), majit_ir::Type::Int);
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -3990,8 +4051,9 @@ mod tests {
         sb.add_heap_op(&mut ctx, heap);
 
         let produced = sb.produced_ops(&mut ctx);
-        assert_eq!(produced.len(), 2);
 
+        // The compound at pos 10 prefers the ShortInputArg; the Heap becomes an
+        // invented alias. (Label arg 30 is also produced as a ShortInputArg.)
         let chosen = produced
             .iter()
             .find(|(result, _)| *result == OpRef::int_op(10))
@@ -4001,9 +4063,8 @@ mod tests {
 
         let alias = produced
             .iter()
-            .find(|(result, _)| *result != OpRef::int_op(10))
+            .find(|(_, p)| p.kind == PreambleOpKind::Heap)
             .unwrap();
-        assert_eq!(alias.1.kind, PreambleOpKind::Heap);
         assert!(alias.1.invented_name);
         assert_eq!(
             alias.1.same_as_source.as_ref().map(|b| b.to_opref()),
@@ -4046,9 +4107,13 @@ mod tests {
 
     #[test]
     fn test_rpython_short_preamble_builder_add_op_to_short_builds_label_short_and_jump() {
-        let mut sb =
-            ShortBoxes::with_label_args(&[OpRef::int_op(10), OpRef::int_op(30), OpRef::int_op(31)]);
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
+        let mut __ctx = crate::optimizeopt::OptContext::new(256);
+        // The ovf result (pos 10) is an op result; its deps (30, 31) are the
+        // label args and become renamed ShortInputargs that the Label carries.
+        let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(30), OpRef::int_op(31)]);
+        for arg in [OpRef::int_op(30), OpRef::int_op(31)] {
+            sb.add_short_input_arg(&mut __ctx, arg, majit_ir::Type::Int);
+        }
 
         let mut ovf = Op::new(
             OpCode::IntAddOvf,
@@ -4058,9 +4123,12 @@ mod tests {
             ],
         );
         ovf.pos.set(OpRef::int_op(10));
-        sb.add_potential_op(&mut __ctx, Some(0), ovf, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, None, ovf, PreambleOpKind::Pure);
 
         let produced = sb.produced_ops(&mut __ctx);
+        let short_inputargs = sb.create_short_inputargs(&[OpRef::int_op(30), OpRef::int_op(31)]);
+        let label_arg_oprefs: Vec<OpRef> =
+            short_inputargs.iter().map(|b| b.to_opref()).collect();
         // #146/S8: the builder map keys by the entry res Box; re-key the
         // produced_ops list (keyed by `preamble_op.pos`) to res for new() and
         // look up by the res box of the int_op(10) entry.
@@ -4075,11 +4143,7 @@ mod tests {
             .1
             .res
             .clone();
-        let mut builder = ShortPreambleBuilder::new(
-            &[OpRef::int_op(10)],
-            &entries,
-            &[BoxRef::from_opref(OpRef::int_op(10))],
-        );
+        let mut builder = ShortPreambleBuilder::new(&label_arg_oprefs, &entries, &short_inputargs);
         let used = builder.add_op_to_short(&res10).unwrap();
         assert!(builder.add_preamble_op(&res10));
         assert_eq!(used.opcode, OpCode::IntAddOvf);
@@ -4103,9 +4167,13 @@ mod tests {
 
     #[test]
     fn test_rpython_short_preamble_builder_tracks_extra_same_as() {
-        let mut sb =
-            ShortBoxes::with_label_args(&[OpRef::int_op(20), OpRef::int_op(30), OpRef::int_op(31)]);
-        let mut __ctx = crate::optimizeopt::OptContext::new(0);
+        let mut __ctx = crate::optimizeopt::OptContext::new(256);
+        // The compound result (pos 20) is an op result; its deps (30, 31) are
+        // the label args / renamed ShortInputargs.
+        let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(30), OpRef::int_op(31)]);
+        for arg in [OpRef::int_op(30), OpRef::int_op(31)] {
+            sb.add_short_input_arg(&mut __ctx, arg, majit_ir::Type::Int);
+        }
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -4113,7 +4181,7 @@ mod tests {
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(&mut __ctx, Some(0), heap, PreambleOpKind::Heap);
+        sb.add_potential_op(&mut __ctx, None, heap, PreambleOpKind::Heap);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
@@ -4123,7 +4191,7 @@ mod tests {
             ],
         );
         pure.pos.set(OpRef::int_op(20));
-        sb.add_potential_op(&mut __ctx, Some(0), pure, PreambleOpKind::Pure);
+        sb.add_potential_op(&mut __ctx, None, pure, PreambleOpKind::Pure);
 
         let produced = sb.produced_ops(&mut __ctx);
         let (alias_result, alias_res) = produced

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4194,11 +4194,16 @@ impl OptUnroll {
                 crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
                 | crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant => {
                     // The short-box result that coincides with a label/virtual
-                    // slot maps to that slot's body OpRef. `produced.label_arg_idx`
-                    // is `lookup_label_arg(canonical_result)` recorded at export
-                    // (optimizer.rs), and `source` == `canonical_result` ==
-                    // `preamble_op.pos`, so it equals the position of `source`
-                    // within the original `label_args + virtuals`. (The renamed
+                    // slot maps to that slot's body OpRef. For these non-InputArg
+                    // kinds the export records `label_arg_idx` as
+                    // `lookup_label_arg(canonical_result)` (optimizer.rs is
+                    // kind-aware: InputArg keeps the stamped original slot, every
+                    // other kind takes the FORWARDED-result lookup). `source` ==
+                    // `canonical_result` == `preamble_op.pos`, so this slot is the
+                    // position of the FORWARDED `source` within the original
+                    // `label_args + virtuals` — a Pure/LoopInvariant result proven
+                    // equal to a label arg it did not originally occupy still
+                    // reuses that slot's `short_args[slot]`. (The renamed
                     // `short_inputargs[slot]` is a distinct box and would never
                     // equal `source` anyway.)
                     if let Some(slot) = produced.label_arg_idx {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1359,17 +1359,22 @@ impl UnrollOptimizer {
             }
             initial_sp.inputarg_infos = infos;
         }
-        // shortpreamble.py:255-259 renamed-short_inputargs: the short-preamble
-        // Label is the renamed `short_inputargs`, but use_box guards still
-        // reference the ORIGINAL Phase-1 label args because pyre keeps disjoint
-        // Phase-1/Phase-2 box namespaces. Seed `phase1_inputargs` with the
-        // per-slot originals (paired 1:1 with the renamed Label / jump_args) so
-        // inline_short_preamble (unroll.rs:3691) maps an original-referencing
-        // guard arg to its jump_arg. Dead duplicate / const-folded slots
-        // (`slot_to_original == None`) fall back to the renamed Label box —
-        // that slot is never referenced by a guard (the box's live slot maps
-        // it first), so the fallback is inert. No-op when the Label already IS
-        // the originals (the two box sets coincide).
+        // shortpreamble.py:255-259 renamed-short_inputargs: in THIS import path
+        // the short-preamble Label is the renamed `short_inputargs`, so seed
+        // `phase1_inputargs` with the per-slot ORIGINALS (paired 1:1 with the
+        // renamed Label / jump_args) as the second inline-mapping leg — see the
+        // load-bearing analysis at the consuming site in inline_short_preamble.
+        // NOTE (measured): the originals seeded here are empirically INERT — post
+        // #217 produce_arg embeds the renamed boxes into the short ops, so no short
+        // op references an original (0 of the 176 corpus consumptions of the
+        // phase1 leg were original boxes; the load-bearing consumptions all come
+        // from the build_short_preamble_struct producer, whose phase1 holds the
+        // RENAMED boxes). The field cannot be dropped on that account because the
+        // OTHER producer is load-bearing; see the convergence note at the consumer.
+        // Dead duplicate / const-folded slots (`slot_to_original == None`) fall
+        // back to the renamed Label box, leaving phase1[i] == inputargs[i] there
+        // (no insert at the consumer). No-op when the Label already IS the
+        // originals (the two box sets coincide).
         if initial_sp.phase1_inputargs.is_none() {
             let phase1: Vec<BoxRef> = initial_sp
                 .inputargs
@@ -3776,11 +3781,37 @@ impl OptUnroll {
             }
         }
 
-        // RPython parity: also map Phase 1 inputargs → jump_args.
-        // Short ops may reference Phase 1 OpRefs (from produce_arg's
-        // label_arg_positions check) that aren't in the current inputargs.
-        // In RPython, renamed inputargs are stable across compilations,
-        // so this situation doesn't arise.
+        // Map the second short-inputarg domain that the `inputargs → jump_args`
+        // seeding above does NOT cover. pyre keeps disjoint Phase-1/Phase-2 box
+        // namespaces (the export serializes boxes to integer OpRef positions), so
+        // a short preamble has two inputarg domains — the ORIGINAL Phase-1 label
+        // boxes and the RENAMED short_inputargs (shortpreamble.py:256-259) — and
+        // `short_preamble.inputargs` carries only one of them. The two producers
+        // assign OPPOSITE domains:
+        //   - the import seeding (this file, the `slot_to_original` block above):
+        //     inputargs = renamed Label, phase1_inputargs = originals;
+        //   - build_short_preamble_struct (shortpreamble.rs `if inputargs !=
+        //     &short_inputargs`): inputargs = original label_args, phase1_inputargs
+        //     = renamed short_inputargs.
+        // In the second (Extended/active-builder) case the short ops reference the
+        // RENAMED boxes — produce_arg embedded them at export (#217) — which are
+        // NOT in `inputargs` (= originals there), so THIS leg is the sole mapper
+        // that resolves them to jump_args. Measured LOAD-BEARING: 176 consumptions
+        // across the check.py corpus on both backends, all GuardNonnullClass /
+        // GetfieldGcPure over ref inputargs (the redundant-guard / pure-getfield
+        // elimination on loop-carried references). Dropping this leg routes those
+        // args to the None → InvalidLoop arm below — correct, but it loses the loop
+        // inlining for those traces. (The originals-domain seeding from the import
+        // path is, by contrast, empirically inert: 0 of the 176 consumptions were
+        // original boxes, because post-#217 no short op references an original.)
+        // Upstream needs no analog: its single Box namespace is stable across the
+        // boundary, so the renamed inputarg IS the object the short ops reference
+        // and unroll.py:393-396 seeds only short_inputargs → jump_args.
+        // CONVERGENCE (issue #217 step 5 "known blocker"): make
+        // build_short_preamble_struct build the Label from the RENAMED
+        // short_inputargs (matching the import-seeding convention, #217, and
+        // upstream); then `inputargs` covers the renamed short-op args directly and
+        // this leg plus the phase1_inputargs field can be removed.
         if let Some(ref phase1) = short_preamble.phase1_inputargs {
             for (i, phase1_inputarg) in phase1.iter().enumerate() {
                 let phase1_inputarg = phase1_inputarg.to_opref();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -721,7 +721,6 @@ impl UnrollOptimizer {
                             short_preamble: None,
                             renamed_inputargs: state.renamed_inputargs.clone(),
                             short_inputargs: Vec::new(),
-                            short_label_args: Vec::new(),
                             runtime_boxes: Vec::new(),
                             patchguardop: None,
                             phase1_emit_high_water: self.next_global_opref,
@@ -1138,7 +1137,6 @@ impl UnrollOptimizer {
             exported_vs,
             exported_end_args,
             exported_short_inputargs,
-            exported_short_label_args,
             exported_short_boxes_produced,
             exported_renamed_inputargs,
             exported_runtime_boxes,
@@ -1151,7 +1149,6 @@ impl UnrollOptimizer {
                 es.virtual_state.clone(),
                 es.end_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
                 es.short_inputargs.clone(),
-                es.short_label_args.clone(),
                 es.short_boxes.clone(),
                 es.renamed_inputargs
                     .iter()
@@ -1316,70 +1313,43 @@ impl UnrollOptimizer {
                 &exported_short_boxes_produced,
             )
         });
+        // Per-slot ORIGINAL box (what each renamed `short_inputargs[i]`
+        // replaces), recovered from the produced `InputArg` short boxes via
+        // `label_arg_idx` (shortpreamble.py:417 keys the info lookup by
+        // `produced_op.short_op.res`, the original). Shared by the two
+        // consumers below. Every label/virtual slot produces an InputArg
+        // entry, except a duplicate slot (one box appears twice in
+        // `label_args + virtuals`: the entry keys at its first slot, so the
+        // later dead slot stays None) and a const-folded slot (dropped at
+        // export, never surviving into Phase 2).
+        let mut slot_to_original: Vec<Option<OpRef>> = vec![None; initial_sp.inputargs.len()];
+        for (_, produced) in &exported_short_boxes_produced {
+            if !matches!(
+                produced.kind,
+                crate::optimizeopt::shortpreamble::PreambleOpKind::InputArg
+            ) {
+                continue;
+            }
+            if let Some(slot) = produced.label_arg_idx {
+                if slot < slot_to_original.len() {
+                    slot_to_original[slot] = Some(produced.res.to_opref());
+                }
+            }
+        }
         // shortpreamble.py:416-425 parity: attach PtrInfo to each short
         // inputarg. RPython keys the info by the ORIGINAL res box
         // (`op = produced_op.short_op.res; info = exported_infos.get(op)`)
         // and forwards it onto the renamed `preamble_op`. The renamed short
         // inputarg carries no PtrInfo of its own, so the lookup MUST use the
-        // original `short_label_args[i]` (paired 1:1 with `short_inputargs[i]`),
-        // not the renamed box — otherwise a distinct renamed identity yields
-        // None and the loop-carried info (e.g. KnownClass) is dropped.
+        // original box, not the renamed one — otherwise a distinct renamed
+        // identity yields None and the loop-carried info (e.g. KnownClass)
+        // is dropped. A dead duplicate slot's box carries no info
+        // (shortpreamble.py:414-417), so its None is correct.
         if let Some(ref final_ctx) = opt_p2.final_ctx {
-            debug_assert_eq!(
-                initial_sp.inputargs.len(),
-                exported_short_label_args.len(),
-                "short_inputargs must pair 1:1 with short_label_args for info carry"
-            );
-            // Per-slot original box (what each renamed short inputarg replaces),
-            // recovered from the produced InputArg short boxes via
-            // `label_arg_idx` — `shortpreamble.py:417` keys the info lookup by
-            // `produced_op.short_op.res` (the original) — instead of the
-            // parallel `short_label_args` array. Every label/virtual slot
-            // produces an InputArg entry (`add_short_input_arg` runs per slot,
-            // `produced_ops` materializes all, and the const-fold drop at the
-            // export boundary is inert for the portal), so the map is total.
-            let mut slot_to_original: Vec<Option<OpRef>> =
-                vec![None; initial_sp.inputargs.len()];
-            for (_, produced) in &exported_short_boxes_produced {
-                if !matches!(
-                    produced.kind,
-                    crate::optimizeopt::shortpreamble::PreambleOpKind::InputArg
-                ) {
-                    continue;
-                }
-                if let Some(slot) = produced.label_arg_idx {
-                    if slot < slot_to_original.len() {
-                        slot_to_original[slot] = Some(produced.res.to_opref());
-                    }
-                }
-            }
             let mut infos = Vec::with_capacity(initial_sp.inputargs.len());
             for (i, inputarg) in initial_sp.inputargs.iter().enumerate() {
                 // Phase-2 info of the original box this short inputarg renames.
                 let original = slot_to_original[i];
-                // Transitional lock vs the parallel `short_label_args` array
-                // (deleted once the rename moves to export time). A box that
-                // appears twice in `label_args + virtuals` produces ONE entry
-                // keyed at its first slot, so `slot_to_original` is None at the
-                // later (dead) duplicate slot while `short_label_args` still
-                // records the per-slot original. The dead slot's box carries no
-                // info (shortpreamble.py:414-417), so None is correct there;
-                // require an exact match only at live slots.
-                #[cfg(debug_assertions)]
-                {
-                    let expected = exported_short_label_args.get(i).copied();
-                    let is_dead_dup = original.is_none()
-                        && expected.map_or(false, |e| {
-                            exported_short_label_args[..i].contains(&e)
-                        });
-                    debug_assert!(
-                        original == expected || is_dead_dup,
-                        "inputarg_infos slot {i} original re-derived from \
-                         label_arg_idx ({original:?}) diverged from \
-                         short_label_args ({expected:?}) and is not a dead \
-                         duplicate slot"
-                    );
-                }
                 let info = original
                     .and_then(|o| final_ctx.get_box_replacement_box(o))
                     .or_else(|| final_ctx.resolve_box_box_opt(inputarg))
@@ -1391,27 +1361,32 @@ impl UnrollOptimizer {
         }
         // shortpreamble.py:255-259 renamed-short_inputargs: the short-preamble
         // Label is the renamed `short_inputargs`, but use_box guards still
-        // reference the ORIGINAL Phase-1 label args (`short_label_args`) because
-        // pyre keeps disjoint Phase-1/Phase-2 box namespaces. Seed
-        // `phase1_inputargs` with the originals (paired 1:1 with the renamed
-        // Label / jump_args) so inline_short_preamble (unroll.rs:3691) maps an
-        // original-referencing guard arg to its jump_arg. Mirrors the existing
-        // phase1_inputargs adaptation; no-op when the Label already IS the
-        // originals (the two box sets coincide).
-        if initial_sp.phase1_inputargs.is_none()
-            && initial_sp.inputargs.len() == exported_short_label_args.len()
-        {
-            let differs = exported_short_label_args
+        // reference the ORIGINAL Phase-1 label args because pyre keeps disjoint
+        // Phase-1/Phase-2 box namespaces. Seed `phase1_inputargs` with the
+        // per-slot originals (paired 1:1 with the renamed Label / jump_args) so
+        // inline_short_preamble (unroll.rs:3691) maps an original-referencing
+        // guard arg to its jump_arg. Dead duplicate / const-folded slots
+        // (`slot_to_original == None`) fall back to the renamed Label box —
+        // that slot is never referenced by a guard (the box's live slot maps
+        // it first), so the fallback is inert. No-op when the Label already IS
+        // the originals (the two box sets coincide).
+        if initial_sp.phase1_inputargs.is_none() {
+            let phase1: Vec<BoxRef> = initial_sp
+                .inputargs
+                .iter()
+                .enumerate()
+                .map(|(i, label)| {
+                    slot_to_original[i]
+                        .map(BoxRef::from_opref)
+                        .unwrap_or_else(|| label.clone())
+                })
+                .collect();
+            let differs = phase1
                 .iter()
                 .zip(initial_sp.inputargs.iter())
-                .any(|(orig, label)| *orig != label.to_opref());
+                .any(|(orig, label)| orig.to_opref() != label.to_opref());
             if differs {
-                initial_sp.phase1_inputargs = Some(
-                    exported_short_label_args
-                        .iter()
-                        .map(|&o| BoxRef::from_opref(o))
-                        .collect(),
-                );
+                initial_sp.phase1_inputargs = Some(phase1);
             }
         }
         let opt_unroll = OptUnroll::new();
@@ -2034,14 +2009,6 @@ pub struct ExportedState {
     /// objects themselves (shortpreamble.py:430 / unroll.py:480), shared
     /// with the renamed operands inside `short_boxes`.
     pub short_inputargs: Vec<crate::r#box::BoxRef>,
-    /// The ORIGINAL `label_args + virtuals` oprefs that `short_inputargs[i]`
-    /// renames (`shortpreamble.py:256 box = label_args[i]`). pyre stores
-    /// these explicitly because the renamed `short_inputargs[i]` no longer
-    /// carries the original identity; the exported short boxes reference
-    /// original positions and are renamed to `short_inputargs[i]` at import,
-    /// and the Phase-2 `result_map` slot lookup resolves a short-box key
-    /// (an original position) to its slot through this list.
-    pub short_label_args: Vec<OpRef>,
     /// unroll.py: runtime_boxes — live values at the original jump point.
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
     /// Default `Vec::new()` until the export site populates it; callers
@@ -2134,28 +2101,15 @@ impl ExportedState {
         exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
         renamed_inputargs: Vec<OpRef>,
         short_inputargs: Vec<crate::r#box::BoxRef>,
-        short_label_args: Vec<OpRef>,
     ) -> Self {
         // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
-        // pre-derives the per-OpRef ProducedShortOp view (with label-arg
-        // refs renamed to short-inputarg slots) and stores it directly,
-        // matching RPython's `ExportedState.short_boxes`.
-        //
-        // The rename source is `short_label_args` (= label_args + virtuals),
-        // the full list `short_inputargs[i]` corresponds to — NOT `end_args`
-        // (label args only). Exported ops can reference a virtual position
-        // through a ShortInputArg dependency, so virtuals must rename too
-        // (`shortpreamble.py:255-259` registers every `label_args + virtuals`
-        // entry as a ShortInputArg).
-        debug_assert_eq!(
-            short_label_args.len(),
-            short_inputargs.len(),
-            "short_label_args must pair 1:1 with short_inputargs"
-        );
+        // pre-derives the per-OpRef ProducedShortOp view and stores it
+        // directly, matching RPython's `ExportedState.short_boxes`. The
+        // label-arg → short-inputarg rename already happened at export time
+        // inside `produce_arg` (shortpreamble.py:285/294), so this is a
+        // plain GuardOverflow filter + transform of `exported_short_boxes`.
         let short_boxes =
             crate::optimizeopt::shortpreamble::produced_short_boxes_from_exported_boxes(
-                &short_label_args,
-                &short_inputargs,
                 &exported_short_boxes,
             );
         ExportedState {
@@ -2177,7 +2131,6 @@ impl ExportedState {
                 .map(|&a| BoxRef::from_opref(a))
                 .collect(),
             short_inputargs,
-            short_label_args,
             runtime_boxes: Vec::new(),
             patchguardop: None,
             phase1_emit_high_water: 0,
@@ -2306,12 +2259,6 @@ impl ExportedState {
         for arg in &self.short_inputargs {
             arg.walk_const_ptr_refs(visitor);
         }
-        // short_label_args are original label/virtual positions (op/inputarg
-        // kinds, never ConstPtr), so visit_opref is a no-op; walked for
-        // completeness and forward-compatibility.
-        for arg in &mut self.short_label_args {
-            visit_opref(arg, visitor);
-        }
         visit_boxrefs(&self.runtime_boxes, visitor);
         if let Some(patchguardop) = self.patchguardop.as_ref() {
             visit_op(patchguardop, visitor);
@@ -2366,9 +2313,11 @@ impl ExportedState {
         for arg in &self.short_inputargs {
             visit(arg.to_opref());
         }
-        for &arg in &self.short_label_args {
-            visit(arg);
-        }
+        // The original label/virtual positions that `short_inputargs` rename
+        // are reached through the `exported_short_boxes` walk below: every
+        // `ShortInputArg` entry carries its original as `preamble_op.res` and
+        // as the `SameAs*` op's `pos` (visited via `visit_op`). Const-folded
+        // slots never survive into Phase 2, so they need no high-water cover.
         for arg in &self.runtime_boxes {
             visit(arg.to_opref());
         }
@@ -2709,7 +2658,6 @@ impl Clone for ExportedState {
             short_preamble: self.short_preamble.clone(),
             renamed_inputargs: self.renamed_inputargs.clone(),
             short_inputargs: self.short_inputargs.clone(),
-            short_label_args: self.short_label_args.clone(),
             runtime_boxes: self.runtime_boxes.clone(),
             patchguardop: self.patchguardop.clone(),
             phase1_emit_high_water: self.phase1_emit_high_water,
@@ -3103,14 +3051,12 @@ impl OptUnroll {
         // RPython expands info from the post-`create_short_boxes` list (the
         // same `short_boxes` that survives into `ExportedState.short_boxes`).
         // pyre's analog is `produced_short_boxes_from_exported_boxes` (which
-        // applies the GuardOverflow filter and label-arg → short-inputarg
-        // rename); iterating the raw `exported_short_boxes` here would
-        // expand info for entries (e.g. standalone `GuardOverflow`) that
-        // PyPy never carries into `short_boxes`, polluting the dict.
+        // applies the GuardOverflow filter); iterating the raw
+        // `exported_short_boxes` here would expand info for entries (e.g.
+        // standalone `GuardOverflow`) that PyPy never carries into
+        // `short_boxes`, polluting the dict.
         let short_boxes_for_info =
             crate::optimizeopt::shortpreamble::produced_short_boxes_from_exported_boxes(
-                &short_args,
-                &short_inputargs,
                 &exported_short_boxes,
             );
         // unroll.py:481-484:
@@ -3168,10 +3114,6 @@ impl OptUnroll {
             exported_short_boxes,
             renamed_inputargs.to_vec(),
             short_inputargs,
-            // shortpreamble.py:255-259 rename source = `label_args + virtuals`
-            // (the full list `short_inputargs` corresponds to), not label
-            // args alone — virtuals are registered as ShortInputArgs too.
-            short_args.clone(),
         );
         // `OptContext::next_pos` is the strict upper bound on raw OpRefs
         // Phase 1 allocated, including intermediates folded / forwarded
@@ -4223,22 +4165,9 @@ impl OptUnroll {
                     // is `lookup_label_arg(canonical_result)` recorded at export
                     // (optimizer.rs), and `source` == `canonical_result` ==
                     // `preamble_op.pos`, so it equals the position of `source`
-                    // within the original `label_args + virtuals` — read it off
-                    // the produced entry instead of matching `source` against the
-                    // parallel originals array. (The renamed `short_inputargs[slot]`
-                    // is a distinct box and would never equal `source` anyway.)
-                    #[cfg(debug_assertions)]
-                    {
-                        let array_slot = exported_state
-                            .short_label_args
-                            .iter()
-                            .position(|a| *a == *source);
-                        debug_assert_eq!(
-                            produced.label_arg_idx, array_slot,
-                            "result_map slot re-derivation from label_arg_idx \
-                             diverged from short_label_args for {source:?}"
-                        );
-                    }
+                    // within the original `label_args + virtuals`. (The renamed
+                    // `short_inputargs[slot]` is a distinct box and would never
+                    // equal `source` anyway.)
                     if let Some(slot) = produced.label_arg_idx {
                         short_args.get(slot).copied()
                     } else {
@@ -5725,7 +5654,6 @@ mod tests {
             Vec::new(),
             vec![OpRef::int_op(14)],
             vec![BoxRef::from_opref(OpRef::int_op(23))],
-            vec![OpRef::int_op(23)],
         );
 
         assert_eq!(exported.opref_high_water(), 110);
@@ -5974,7 +5902,6 @@ mod tests {
             }],
             vec![old_ref],
             vec![BoxRef::from_opref(old_ref)],
-            vec![old_ref],
         );
         state.short_boxes.push((
             old_ref,
@@ -6754,14 +6681,18 @@ mod tests {
                 .with_signed(true)
                 .with_parent_descr(parent.clone(), 0),
         ) as majit_ir::DescrRef;
+        // shortpreamble.py:257/285: the export-time rename mints a fresh
+        // renamed short_inputarg per label/virtual slot, and exported short
+        // ops carry the renamed box in their args (not the original label
+        // arg). Seed the two slot boxes and use slot 0 — the GETFIELD
+        // receiver, whose original is int_op(10).
+        let si0 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
+        let si1 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
+        ctx.exported_short_inputargs = vec![si0.clone(), si1];
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
-                    let mut op = Op::with_descr(
-                        OpCode::GetfieldGcI,
-                        &[BoxRef::from_opref(OpRef::int_op(10))],
-                        field_descr.clone(),
-                    );
+                    let mut op = Op::with_descr(OpCode::GetfieldGcI, &[si0], field_descr.clone());
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
@@ -6969,7 +6900,6 @@ mod tests {
             }],
             Vec::new(),
             vec![BoxRef::from_opref(source)],
-            vec![source],
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
             8,
@@ -7202,16 +7132,19 @@ mod tests {
     fn test_exported_state_reimports_invented_short_alias_metadata() {
         let mut optimizer = crate::optimizeopt::optimizer::Optimizer::new();
         let mut ctx = crate::optimizeopt::OptContext::with_num_inputs(6, 0);
+        // shortpreamble.py:257/285: exported short ops carry the renamed
+        // short_inputargs in their args. Seed three slot boxes (label args
+        // 12/13/14) and rename the IntAdd operands to slots 0/1. The
+        // `same_as_source` alias is a ProducedShortOp field, not an op arg,
+        // so it keeps its original (int_op(14)).
+        let si0 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
+        let si1 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
+        let si2 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
+        ctx.exported_short_inputargs = vec![si0.clone(), si1.clone(), si2];
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
-                    let mut op = Op::new(
-                        OpCode::IntAdd,
-                        &[
-                            BoxRef::from_opref(OpRef::int_op(12)),
-                            BoxRef::from_opref(OpRef::int_op(13)),
-                        ],
-                    );
+                    let mut op = Op::new(OpCode::IntAdd, &[si0, si1]);
                     op.pos.set(OpRef::int_op(30));
                     std::rc::Rc::new(op)
                 },

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1319,9 +1319,11 @@ impl UnrollOptimizer {
         // `produced_op.short_op.res`, the original). Shared by the two
         // consumers below. Every label/virtual slot produces an InputArg
         // entry, except a duplicate slot (one box appears twice in
-        // `label_args + virtuals`: the entry keys at its first slot, so the
-        // later dead slot stays None) and a const-folded slot (dropped at
-        // export, never surviving into Phase 2).
+        // `label_args + virtuals`: the `potential_ops[box]` overwrite keys the
+        // single entry at its LAST slot — shortpreamble.py:259, mirrored by
+        // `live_slot` in add_short_input_arg — so the earlier dead slot stays
+        // None) and a const-folded slot (dropped at export, never surviving
+        // into Phase 2).
         let mut slot_to_original: Vec<Option<OpRef>> = vec![None; initial_sp.inputargs.len()];
         for (_, produced) in &exported_short_boxes_produced {
             if !matches!(

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4172,15 +4172,28 @@ impl OptUnroll {
             let result = match produced.kind {
                 crate::optimizeopt::shortpreamble::PreambleOpKind::Pure
                 | crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant => {
-                    // `source` is the short-box key = an ORIGINAL label/virtual
-                    // position. Match it against `short_label_args` (originals);
-                    // `short_inputargs[slot]` is now a distinct renamed box and
-                    // would never equal `source`.
-                    if let Some(slot) = exported_state
-                        .short_label_args
-                        .iter()
-                        .position(|a| *a == *source)
+                    // The short-box result that coincides with a label/virtual
+                    // slot maps to that slot's body OpRef. `produced.label_arg_idx`
+                    // is `lookup_label_arg(canonical_result)` recorded at export
+                    // (optimizer.rs), and `source` == `canonical_result` ==
+                    // `preamble_op.pos`, so it equals the position of `source`
+                    // within the original `label_args + virtuals` — read it off
+                    // the produced entry instead of matching `source` against the
+                    // parallel originals array. (The renamed `short_inputargs[slot]`
+                    // is a distinct box and would never equal `source` anyway.)
+                    #[cfg(debug_assertions)]
                     {
+                        let array_slot = exported_state
+                            .short_label_args
+                            .iter()
+                            .position(|a| *a == *source);
+                        debug_assert_eq!(
+                            produced.label_arg_idx, array_slot,
+                            "result_map slot re-derivation from label_arg_idx \
+                             diverged from short_label_args for {source:?}"
+                        );
+                    }
+                    if let Some(slot) = produced.label_arg_idx {
                         short_args.get(slot).copied()
                     } else {
                         Some(ctx.alloc_op_position_typed(result_type))
@@ -5928,6 +5941,7 @@ mod tests {
                 )),
                 invented_name: false,
                 same_as_source: Some(BoxRef::from_opref(old_ref)),
+                label_arg_idx: None,
             },
         ));
         state.short_box_const_values = short_box_const_values;

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1330,10 +1330,56 @@ impl UnrollOptimizer {
                 exported_short_label_args.len(),
                 "short_inputargs must pair 1:1 with short_label_args for info carry"
             );
+            // Per-slot original box (what each renamed short inputarg replaces),
+            // recovered from the produced InputArg short boxes via
+            // `label_arg_idx` — `shortpreamble.py:417` keys the info lookup by
+            // `produced_op.short_op.res` (the original) — instead of the
+            // parallel `short_label_args` array. Every label/virtual slot
+            // produces an InputArg entry (`add_short_input_arg` runs per slot,
+            // `produced_ops` materializes all, and the const-fold drop at the
+            // export boundary is inert for the portal), so the map is total.
+            let mut slot_to_original: Vec<Option<OpRef>> =
+                vec![None; initial_sp.inputargs.len()];
+            for (_, produced) in &exported_short_boxes_produced {
+                if !matches!(
+                    produced.kind,
+                    crate::optimizeopt::shortpreamble::PreambleOpKind::InputArg
+                ) {
+                    continue;
+                }
+                if let Some(slot) = produced.label_arg_idx {
+                    if slot < slot_to_original.len() {
+                        slot_to_original[slot] = Some(produced.res.to_opref());
+                    }
+                }
+            }
             let mut infos = Vec::with_capacity(initial_sp.inputargs.len());
             for (i, inputarg) in initial_sp.inputargs.iter().enumerate() {
                 // Phase-2 info of the original box this short inputarg renames.
-                let original = exported_short_label_args.get(i).copied();
+                let original = slot_to_original[i];
+                // Transitional lock vs the parallel `short_label_args` array
+                // (deleted once the rename moves to export time). A box that
+                // appears twice in `label_args + virtuals` produces ONE entry
+                // keyed at its first slot, so `slot_to_original` is None at the
+                // later (dead) duplicate slot while `short_label_args` still
+                // records the per-slot original. The dead slot's box carries no
+                // info (shortpreamble.py:414-417), so None is correct there;
+                // require an exact match only at live slots.
+                #[cfg(debug_assertions)]
+                {
+                    let expected = exported_short_label_args.get(i).copied();
+                    let is_dead_dup = original.is_none()
+                        && expected.map_or(false, |e| {
+                            exported_short_label_args[..i].contains(&e)
+                        });
+                    debug_assert!(
+                        original == expected || is_dead_dup,
+                        "inputarg_infos slot {i} original re-derived from \
+                         label_arg_idx ({original:?}) diverged from \
+                         short_label_args ({expected:?}) and is not a dead \
+                         duplicate slot"
+                    );
+                }
                 let info = original
                     .and_then(|o| final_ctx.get_box_replacement_box(o))
                     .or_else(|| final_ctx.resolve_box_box_opt(inputarg))


### PR DESCRIPTION
## Summary

Closes #217. Moves the short-preamble inputarg rename from **import time** to
**export time**, mirroring upstream `create_short_boxes` / `produce_arg`
(`shortpreamble.py:256-296`). The two pyre-only structures the deferral required
— the parallel `ExportedState.short_label_args` originals array and the
import-time rename pass — are deleted; the boundary now matches upstream.

## Acceptance criteria (all met)

- **Rename at export time** — `produce_arg` returns the renamed
  `short_inputargs[label_arg_idx]` box for a `ShortInputArg`, so exported short
  ops carry the renamed boxes in their args directly
  (`shortpreamble.py:256-280`/`285`/`294`).
- **`short_label_args` removed** — `ExportedState` no longer carries a parallel
  originals array (0 references repo-wide), matching `unroll.py:553-563`.
- **Import-time rename pass removed** — `produced_short_boxes_from_exported_boxes`
  is reduced to an OVF-guard filter + `PreambleOp → ProducedShortOp` shape
  transform; the `inputarg_rename` closure and `setarg`/`fail_args` rename loop
  are gone.
- **Per-op info keys off `res`** — the per-slot original used for the
  `inputarg_infos` lookup rides on `ProducedShortOp.res` (re-indexed by
  `label_arg_idx`), matching `shortpreamble.py:414-417` (`produced_op.short_op.res`).

## `phase1_inputargs` (issue step 5)

Retained and documented. The export-time rename does **not** make the Label and
guard namespaces coincide — pyre keeps disjoint Phase-1/Phase-2 box namespaces
(the export serializes boxes to integer positions), so use-box guards still
reference the original Phase-1 label args while the Label is the renamed
`short_inputargs`. The remaining dependency is documented at the seeding site
(`unroll.rs`), per the issue's "otherwise document the remaining dependency".

## Commits

1. `update doc` — gcreftracer.rs module-comment expansion (pre-existing, doc only).
2. carry `label_arg_idx` on `ProducedShortOp`; result_map reads it.
3. drop `add_short_input_arg` short_inputargs slot-pairing assert (no upstream basis).
4. derive short `inputarg_infos` originals from produced `label_arg_idx`.
5. **keystone**: rename short inputargs at export time in `produce_arg` (+ export
   `produced.label_arg_idx`, the forwarding-immune slot, instead of
   `lookup_label_arg(canonical_result)` — required under the canonical-box-identity
   model from #179).
6. remove import-time short-box arg rename and `short_label_args`.

## Validation

- `cargo test --workspace` green on **both** backends (dynasm + cranelift;
  metainterp lib 1316/1314).
- `python ./pyre/check.py` — dynasm 128/128, cranelift 128/128.
- x86_64 (Rosetta, cross-compiled) synth corpus 114/0, `trace.rs:820`
  resume-surface canary clean (GC/resume gate for short-preamble changes).
- Adversarial parity audit (per-AC + NEW-DEVIATION) vs RPython upstream: all
  criteria satisfied; the `label_arg_idx`/`slot_to_original` mechanism is a
  documented, justified position-namespace adaptation (pyre serializes boxes to
  positions across the boundary; upstream uses Box identity), not a new deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect position tracking in loop optimization compilation
  * Improved result mapping preservation in short-preamble operations
  * Enhanced loop unrolling phase handling and metadata consistency
  * Corrected GC edge tracking in specific reachability scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->