### PR TITLE
wasm: wasm32 JIT backend with wasmi and browser runtimes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,14 @@
 # thread's minimum stack so `cargo test` works without a manual
 # `RUST_MIN_STACK=…` prefix.
 RUST_MIN_STACK = "16777216"
+
+# Export the linker-synthesized `__indirect_function_table` from wasm32
+# builds. The JIT's `jit_call` trampoline resolves residual call targets by
+# their wasm table index (a `fn as usize` is a table index on wasm32) and so
+# needs the host to reach this table: the browser glue reads
+# `wasm.__indirect_function_table` (`pyre-wasm/www/index.html`) and the native
+# wasmtime runner reads the `__indirect_function_table` export. Without this
+# flag the table stays module-internal and indirect residual calls cannot be
+# dispatched.
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=--export-table"]

--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -17,9 +17,15 @@ The split is deliberate:
   and other new mismatches). They are the cost of the work just done, so they
   are fixed **now**, in this session, before the cycle is considered closed.
 - **Sections 3 & 4** are not this patch's fault — section 3 is pre-existing
-  debt and section 4 is intended structural adaptation. Stopping to fix those
-  would balloon the current diff and blur what this cycle changed, so they
-  become **follow-up tasks** picked up after the current work is wrapped up.
+  debt and section 4 is intended structural adaptation. But "pre-existing" and
+  "adaptation" are *classifications, not verdicts*: the reason to surface them
+  is to **decide** — per finding — whether to fix now, fix later, or
+  consciously leave in place with a cited justification. Each one gets a
+  reasoned disposition (Step 4), never an automatic skip. The common outcome is
+  a follow-up task, because chasing unrelated old debt would balloon the
+  current diff and blur what this cycle changed — but that is the *result of a
+  judgment*, not a reflex, and it is overridden when the fix is small, adjacent
+  to the work just done, or removes a latent bug this patch can now reach.
 
 ## Step 1 — Run the Codex review
 
@@ -97,33 +103,56 @@ unported upstream dependency, or cascades across many files), say so explicitly
 and move that single item to a follow-up task (Step 4) with the blocker named —
 but the default is to fix it here.
 
-## Step 4 — Defer sections 3 & 4 to follow-up tasks
+## Step 4 — Adjudicate sections 3 & 4 (decide; never reflex-defer)
 
-Sections 3 (pre-existing mismatches) and 4 (structural adaptations) are out of
-scope for the current diff. Don't widen this cycle's changes to chase them.
-Instead register each as a follow-up task in the harness task system with
-`TaskCreate`, so they surface after the current work is wrapped up:
+Sections 3 (pre-existing mismatches) and 4 (structural adaptations) are not
+this patch's fault, but that classification is **not a verdict**. The point of
+surfacing them is to reach a reasoned *disposition* on each one. "It's
+pre-existing" and "it's an adaptation" are never, by themselves, a reason to
+skip — that is exactly the reflex `/parity` Principle 7 forbids
+("PRE-EXISTING-ADAPTATION is a fix queue, not an absolution; 'it works today'
+is never a sufficient reason").
 
-- One task per distinct finding (or per tightly-related cluster). Title it with
-  the file and the gist; put the full Codex citation and reasoning in the body.
-- Tag section-4 items clearly as *candidate structural adaptations* — many are
-  legitimate and intended (Python 3.11↔3.14, CPython-compatible-compiler opcode
-  differences, GIL/free-threading, RPython↔Rust language gaps). The follow-up
-  task is to *verify and document* the adaptation (cite the upstream decision
-  point), not necessarily to "fix" it.
-- Section-3 items are pre-existing parity debt: the task is to port them back to
-  upstream shape later, per `/parity` Principle 7 (PRE-EXISTING-ADAPTATION is a
-  fix queue, not an absolution).
+For **each** finding (verify the citation against the upstream source first —
+Codex can misclassify, and a real regression sometimes lands in section 3/4),
+assign one disposition:
 
-Do not start working these tasks now — they are explicitly for after the
-current cycle closes.
+- **fix-now** — port it back in this session. This is the *default* under
+  `/parity` Principle 7 whenever the fix is self-contained and the original
+  blocker is gone. Choose it especially when the fix is small, sits in code
+  this patch already touches/depends on, or closes a latent bug the current
+  work can now reach. A fixed section-3/4 item moves into this cycle's diff
+  exactly like a section-1/2 fix; verify the same way (Step 3).
+- **won't-fix (documented)** — the divergence is *correct as-is*: a deliberate,
+  still-valid structural adaptation (RPython↔Rust language gap, 3.11↔3.14
+  opcode difference, GIL/free-threading, no-filesystem/no-libc on wasm, …).
+  Confirm the upstream decision point it encodes and ensure an in-code comment
+  cites it; if the comment is missing, that documentation *is* the fix and is
+  made now. Record the justification in the report.
+- **defer (blocked)** — fixing it is right but out of safe session scope: a
+  specific, cited, still-real blocker (an unported upstream dependency, a layout
+  change cascading across more files than this session can touch, a regression
+  rooted in another unported optimization), or it is unrelated old debt large
+  enough that pulling it in would balloon and blur this cycle's diff. Only then
+  register a follow-up task with `TaskCreate` — one per finding or tight
+  cluster, titled with the file and gist, body carrying the full Codex
+  citation, the named blocker, and the convergence path. These deferred tasks
+  are not worked now.
+
+The bias for unrelated section-3/4 debt is still toward a follow-up task rather
+than ballooning the diff — but reaching that outcome requires the judgment
+above, not a blanket "section 3/4 ⇒ defer". Stating only "it's pre-existing"
+as the reason is a process error.
 
 ## Step 5 — Report
 
 Close with a short summary:
 
-- Counts per section (e.g. `1: 2 fixed, 2: 1 fixed + 1 reclassified, 3: 3
-  deferred, 4: 2 deferred`).
+- Counts per section, each broken down by disposition — fixed-now /
+  won't-fix(documented) / deferred(blocked) / reclassified (e.g. `1: 2 fixed,
+  2: 1 fixed + 1 reclassified, 3: 1 fixed + 1 won't-fix, 4: 1 won't-fix + 1
+  deferred`). A bare "3: 2 deferred" with no per-item reasoning is a process
+  error (Step 4).
 - What was changed in-session and the verification result.
 - The follow-up tasks that were filed (ids/titles).
 - The raw report path (`.claude/codex-review-report.md`) for reference.

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -498,5 +498,13 @@ jobs:
     - name: Build pyre-wasm (${{ matrix.binding }})
       shell: bash
       run: |
+        # wasmi has no JS host, so getrandom uses its `custom` backend
+        # (see `__getrandom_v03_custom`), which needs this cfg; web uses
+        # `getrandom/wasm_js` via its feature instead. `.cargo/config.toml`
+        # supplies `--export-table` for wasm32, but a RUSTFLAGS env overrides
+        # (does not merge with) it, so re-include it when we set RUSTFLAGS.
+        if [ "${{ matrix.binding }}" = "wasmi" ]; then
+          export RUSTFLAGS='-C link-arg=--export-table --cfg getrandom_backend="custom"'
+        fi
         cargo build -p pyre-wasm --target wasm32-unknown-unknown \
           --no-default-features --features "${{ matrix.binding }}"

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -460,12 +460,6 @@ jobs:
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
-    - name: Compute LLBC fingerprint
-      id: llbc-fingerprint
-      shell: bash
-      run: |
-        value="$(scripts/extract-llbc.py --fingerprint pyre-object pyre-interpreter pyre-jit)"
-        echo "value=${value}" >> "$GITHUB_OUTPUT"
     - name: Restore Charon binary
       id: restore-charon
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -476,20 +470,24 @@ jobs:
         # the single-path save and always misses (failing the cache-hit gate).
         path: .pyre-build/charon
         key: charon-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}
-    - name: Restore LLBC
-      id: restore-llbc
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: build/llbc
-        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
-    - name: Check prepared cache hits
-      if: ${{ steps.restore-charon.outputs.cache-hit != 'true' || steps.restore-llbc.outputs.cache-hit != 'true' }}
+    - name: Install Charon
+      # Charon's cache key is shared repo-wide per OS/arch (no per-run
+      # fingerprint) so it usually stays LRU-warm, but the wasm matrix is the
+      # latest-scheduled consumer — late enough that the entry can be evicted
+      # before it runs. Reinstall on a miss instead of hard-failing (the same
+      # self-skipping installer prepare-charon-llbc uses).
+      if: steps.restore-charon.outputs.cache-hit != 'true'
       shell: bash
-      run: |
-        echo "cache miss from prepare-charon-llbc" >&2
-        echo "Charon cache hit: ${{ steps.restore-charon.outputs.cache-hit }}" >&2
-        echo "LLBC cache hit: ${{ steps.restore-llbc.outputs.cache-hit }}" >&2
-        exit 1
+      run: scripts/install-charon.py
+    - name: Download LLBC artifact
+      # Run-scoped handoff from prepare-charon-llbc. Unlike actions/cache, an
+      # artifact is exempt from the repo-wide 10 GB cache budget and its LRU
+      # eviction, so the ullbc set cannot vanish between prepare and this
+      # late-scheduled consumer (matches the other consumer jobs).
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
     - name: Verify prepared Charon/LLBC
       shell: bash
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,6 +2071,7 @@ dependencies = [
 name = "pyre-wasm-runner"
 version = "0.0.2"
 dependencies = [
+ "wasmprinter",
  "wasmtime",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "majit-backend",
  "majit-gc",
  "majit-ir",
+ "majit-translate",
  "smallvec",
  "wasm-bindgen",
  "wasm-encoder 0.245.1",
@@ -2058,6 +2059,7 @@ name = "pyre-wasm"
 version = "0.0.2"
 dependencies = [
  "getrandom 0.3.4",
+ "majit-backend",
  "pyre-interpreter",
  "pyre-jit",
  "pyre-object",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,7 @@ version = "0.0.2"
 dependencies = [
  "getrandom 0.3.4",
  "majit-backend",
+ "majit-metainterp",
  "pyre-interpreter",
  "pyre-jit",
  "pyre-object",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,7 +38,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object",
+ "object 0.37.3",
 ]
 
 [[package]]
@@ -43,6 +52,17 @@ name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "attribute-derive"
@@ -79,6 +99,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
@@ -206,6 +232,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -228,6 +256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -259,6 +296,15 @@ dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -304,6 +350,8 @@ version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
 dependencies = [
+ "serde",
+ "serde_derive",
  "wasmtime-internal-core",
 ]
 
@@ -326,6 +374,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "libm",
  "log",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
@@ -344,6 +393,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-srcgen",
  "heck",
+ "pulley-interpreter",
 ]
 
 [[package]]
@@ -368,6 +418,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
 dependencies = [
  "cranelift-bitset",
+ "serde",
+ "serde_derive",
  "wasmtime-internal-core",
 ]
 
@@ -439,6 +491,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +532,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -471,6 +566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,8 +592,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -545,10 +661,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endian-type"
@@ -602,6 +739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +761,84 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags 2.11.1",
+ "debugid",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
 
 [[package]]
 name = "generic-array"
@@ -738,6 +959,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -893,12 +1116,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1290,6 +1544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
 name = "memmap2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1681,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1749,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1794,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -1589,6 +1898,29 @@ checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1733,6 +2065,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyre-wasm-runner"
+version = "0.0.2"
+dependencies = [
+ "wasmtime",
+]
+
+[[package]]
 name = "pyre-wasm-test"
 version = "0.0.2"
 dependencies = [
@@ -1857,6 +2196,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,13 +2226,24 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1929,6 +2299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,7 +2342,7 @@ dependencies = [
  "rustpython-ruff_python_ast",
  "rustpython-ruff_text_size",
  "rustpython-wtf8",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode_names2 2.0.0",
 ]
 
@@ -1981,7 +2357,7 @@ dependencies = [
  "rustpython-ruff_python_parser",
  "rustpython-ruff_source_file",
  "rustpython-ruff_text_size",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2053,7 +2429,7 @@ dependencies = [
  "rustpython-ruff_python_trivia",
  "rustpython-ruff_source_file",
  "rustpython-ruff_text_size",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2203,6 +2579,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2245,6 +2625,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2298,10 +2687,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2376,6 +2774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termios"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,11 +2793,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2493,6 +2920,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +3056,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vecmap-rs"
@@ -2692,6 +3168,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-compose"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "log",
+ "petgraph",
+ "smallvec",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wat",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +3201,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -2748,13 +3261,229 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.11.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "futures",
+ "fxprof-processed-profile",
+ "gimli",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.39.1",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rayon",
+ "rustix",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "object 0.39.1",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef87f84d976e2f98a541eaf5837df0424e2039837fc20bd6cd4b4b5a322939c0"
+dependencies = [
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86991f201391afc1504e4fc363dc29b66f92af0287b4ac2efc3c0b0c19435eeb"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47fda091250d7ab839ea51e4d98190b6eee37e9de4ab2462e8fe8465369c1986"
+
+[[package]]
 name = "wasmtime-internal-core"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
 dependencies = [
+ "anyhow",
  "hashbrown 0.17.1",
  "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools",
+ "log",
+ "object 0.39.1",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
+dependencies = [
+ "cc",
+ "object 0.39.1",
+ "rustix",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
@@ -2767,6 +3496,82 @@ dependencies = [
  "libc",
  "wasmtime-internal-core",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.39.1",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
+dependencies = [
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object 0.39.1",
+ "target-lexicon",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce382df367ad2a2d48e139b191dbca3329f7232a43057dc9efc889dac54f1b0b"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "heck",
+ "indexmap",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wast"
+version = "252.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.252.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -2786,12 +3591,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
 ]
 
 [[package]]
@@ -2966,6 +3812,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,7 +3846,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -3038,7 +3896,7 @@ dependencies = [
  "wasm-encoder 0.244.0",
  "wasm-metadata",
  "wasmparser 0.244.0",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -3057,6 +3915,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -3167,3 +4044,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,7 @@ dependencies = [
  "caseless",
  "indexmap",
  "libc",
+ "lz4_flex",
  "majit-gc",
  "majit-ir",
  "majit-macros",
@@ -2060,7 +2061,6 @@ version = "0.0.2"
 dependencies = [
  "getrandom 0.3.4",
  "majit-backend",
- "majit-metainterp",
  "pyre-interpreter",
  "pyre-jit",
  "pyre-object",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "pyre/pyrex",
     "pyre/pyre-wasm",
     "pyre/pyre-wasm-test",
+    "pyre/pyre-wasm-runner",
 ]
 
 [workspace.dependencies]
@@ -116,7 +117,16 @@ dynasmrt = "5"
 wasm-encoder = { version = "0.245", default-features = false }
 wasm-bindgen = "0.2"
 wasmparser = "0.225"
-getrandom = { version = "0.3.4", features = ["wasm_js"] }
+# `wasm_js` is enabled only by `pyre-wasm`'s `web` feature (browser crypto via
+# wasm-bindgen). The native-host `wasmi` build instead selects getrandom's
+# `custom` backend (`--cfg getrandom_backend="custom"`) so it carries no
+# wasm-bindgen imports.
+getrandom = "0.3.4"
+# Native host runtime for the wasm runner. Pinned to the wasmtime release whose
+# `wasmtime-internal-*` support crates already ride along with cranelift 0.132
+# (the version the dynasm/cranelift backends use), so it reuses the existing
+# cranelift rather than duplicating it.
+wasmtime = "45"
 
 # system
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,3 +158,12 @@ insta = "1"
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+# The wasm32 build compiles with `-C panic=unwind -C target-feature=
+# +exception-handling` (so JIT trace-abort panics unwind to their catch_unwind
+# recovery sites instead of aborting the instance). Under that codegen,
+# multi-CGU ThinLTO of this crate sends rustc into unbounded recursion (SIGSEGV
+# in spawn_thin_lto_work). A single codegen unit skips the intra-crate ThinLTO
+# path entirely; the only cost is slightly slower compilation of this one crate.
+[profile.release.package.majit-translate]
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,12 +158,3 @@ insta = "1"
 [profile.dist]
 inherits = "release"
 lto = "thin"
-
-# The wasm32 build compiles with `-C panic=unwind -C target-feature=
-# +exception-handling` (so JIT trace-abort panics unwind to their catch_unwind
-# recovery sites instead of aborting the instance). Under that codegen,
-# multi-CGU ThinLTO of this crate sends rustc into unbounded recursion (SIGSEGV
-# in spawn_thin_lto_work). A single codegen unit skips the intra-crate ThinLTO
-# path entirely; the only cost is slightly slower compilation of this one crate.
-[profile.release.package.majit-translate]
-codegen-units = 1

--- a/majit/majit-backend-wasm/Cargo.toml
+++ b/majit/majit-backend-wasm/Cargo.toml
@@ -10,7 +10,7 @@ description = "WebAssembly backend for majit — generates wasm bytecodes via wa
 [features]
 default = ["web"]
 # Instantiate JIT-emitted trace modules through the browser
-# `WebAssembly` API via wasm-bindgen (`./jit_glue.js`).
+# `WebAssembly` API via wasm-bindgen (`js/jit_glue.js`).
 web = ["dep:wasm-bindgen"]
 # Instantiate JIT-emitted trace modules through plain wasm imports
 # supplied by a native embedder (e.g. a wasmi/wasmtime host). No

--- a/majit/majit-backend-wasm/Cargo.toml
+++ b/majit/majit-backend-wasm/Cargo.toml
@@ -21,6 +21,9 @@ host-import = []
 majit-ir = { workspace = true }
 majit-backend = { workspace = true }
 majit-gc = { workspace = true }
+# `BhDescr` (blackhole allocation descriptors) names the `bh_new*` override
+# parameter types, matching the `Backend` trait signature.
+majit-translate = { workspace = true }
 wasm-encoder = { workspace = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -545,11 +545,14 @@ fn build_function(
                 guard_idx += 1;
             }
             OpCode::GuardNoException => {
-                // x86/assembler.py:1797-1801 generate_guard_no_exception:
-                // fail the guard when a pending exception is present. The
-                // exception slot lives in the host's shared linear memory;
-                // load it by absolute address (the trace imports env.memory).
-                sink.i32_const(crate::jit_exc_value_addr() as i32);
+                // x86/assembler.py:1799-1801 generate_guard_no_exception:
+                // `CMP(pos_exception, imm0)` — fail the guard when a pending
+                // exception is present, keyed on the exception TYPE slot
+                // (pos_exception), the same slot GuardException reads and the
+                // one llgraph's `last_exception is not None` tests. The slot
+                // lives in the host's shared linear memory; load it by absolute
+                // address (the trace imports env.memory).
+                sink.i32_const(crate::jit_exc_type_addr() as i32);
                 sink.i64_load(mem64(0));
                 sink.i64_const(0);
                 sink.i64_ne();

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -408,13 +408,21 @@ fn build_function(
             OpCode::Label => {}
 
             OpCode::Jump => {
+                // The jump rebinds the loop's label args to the jump args — a
+                // parallel move. A jump arg may read a target local that another
+                // pair overwrites (e.g. the swap `x, y = y, x` → x<-y, y<-x), so
+                // resolving-then-storing each pair in turn would feed a clobbered
+                // value to a later read. Do all reads first (push every resolved
+                // jump arg onto the operand stack), then all writes (pop into the
+                // targets in reverse, the stack being LIFO).
                 let label_args = find_label_args(ops);
-                for (i, jump_arg) in op.getarglist().iter().enumerate() {
-                    if i < label_args.len() {
-                        let target_local = 1 + label_args[i].raw();
-                        emit_resolve(&mut sink, constants, jump_arg.to_opref());
-                        sink.local_set(target_local);
-                    }
+                let jump_args = op.getarglist();
+                let n = jump_args.len().min(label_args.len());
+                for jump_arg in jump_args.iter().take(n) {
+                    emit_resolve(&mut sink, constants, jump_arg.to_opref());
+                }
+                for i in (0..n).rev() {
+                    sink.local_set(1 + label_args[i].raw());
                 }
                 sink.br(0);
             }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1401,8 +1401,7 @@ fn build_function(
             // `jit_call` trampoline to the `wasm_jit_alloc` helper, then write
             // the vtable / length fields with pointer-width (i32) stores.
             OpCode::New | OpCode::NewWithVtable => {
-                let jit_call =
-                    jit_call_idx.expect("New op present but jit_call not imported");
+                let jit_call = jit_call_idx.expect("New op present but jit_call not imported");
                 let vi = op.pos.get().raw();
                 // llmodel.py:778-782: size, type_id, vtable from the size descr.
                 let descr = op.getdescr();
@@ -1458,13 +1457,13 @@ fn build_function(
                 }
             }
             OpCode::NewArray | OpCode::NewArrayClear => {
-                let jit_call =
-                    jit_call_idx.expect("NewArray op present but jit_call not imported");
+                let jit_call = jit_call_idx.expect("NewArray op present but jit_call not imported");
                 let vi = op.pos.get().raw();
                 let descr = op.getdescr();
                 let ad = descr.as_ref().and_then(|d| d.as_array_descr());
-                let (base_size, item_size) =
-                    ad.map_or((16i64, 8i64), |ad| (ad.base_size() as i64, ad.item_size() as i64));
+                let (base_size, item_size) = ad.map_or((16i64, 8i64), |ad| {
+                    (ad.base_size() as i64, ad.item_size() as i64)
+                });
                 let len_offset = ad
                     .and_then(|ad| ad.len_descr())
                     .map_or(0i64, |ld| ld.offset() as i64);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -28,6 +28,10 @@ use wasm_encoder::{
 const FRAME_SLOT_BASE: u64 = 8;
 const SLOT_SIZE: u64 = 8;
 
+/// Scratch i64 locals reserved past the value locals for `emit_umulhi`
+/// (al, ah, bl, bh, mid1).
+const UMULHI_SCRATCH: u32 = 5;
+
 /// Call area layout (fixed offsets from frame_ptr).
 const CALL_RESULT_OFS: u64 = 2000;
 const CALL_FUNC_OFS: u64 = 2008;
@@ -43,6 +47,98 @@ fn mem64(offset: u64) -> MemArg {
         align: 3,
         memory_index: 0,
     }
+}
+
+fn memarg(offset: u64, align: u32) -> MemArg {
+    MemArg {
+        offset,
+        align,
+        memory_index: 0,
+    }
+}
+
+/// Emit a width-correct integer load. The element address (i32) must be on
+/// the stack; the result is an i64, sign- or zero-extended from `size`
+/// bytes. Word-sized fields are 4 bytes on wasm32 (`isize`/`usize`/pointer),
+/// 8 bytes on 64-bit; reading a fixed 8 bytes here would fold in the next
+/// field's bytes on wasm32.
+fn emit_sized_int_load(sink: &mut InstructionSink<'_>, offset: u64, size: usize, signed: bool) {
+    match (size, signed) {
+        (8, _) => {
+            sink.i64_load(mem64(offset));
+        }
+        (4, true) => {
+            sink.i32_load(memarg(offset, 2));
+            sink.i64_extend_i32_s();
+        }
+        (4, false) => {
+            sink.i32_load(memarg(offset, 2));
+            sink.i64_extend_i32_u();
+        }
+        (2, true) => {
+            sink.i32_load16_s(memarg(offset, 1));
+            sink.i64_extend_i32_s();
+        }
+        (2, false) => {
+            sink.i32_load16_u(memarg(offset, 1));
+            sink.i64_extend_i32_u();
+        }
+        (1, true) => {
+            sink.i32_load8_s(memarg(offset, 0));
+            sink.i64_extend_i32_s();
+        }
+        (1, false) => {
+            sink.i32_load8_u(memarg(offset, 0));
+            sink.i64_extend_i32_u();
+        }
+        _ => {
+            sink.i64_load(mem64(offset));
+        }
+    }
+}
+
+/// Emit a width-correct integer store. The stack must hold
+/// `[addr_i32, value_i64]`; the low `size` bytes of the value are stored.
+/// A fixed 8-byte store would clobber the adjacent field/item (or run past
+/// the array end) for word-sized fields and pointer array items on wasm32.
+fn emit_sized_int_store(sink: &mut InstructionSink<'_>, offset: u64, size: usize) {
+    match size {
+        8 => {
+            sink.i64_store(mem64(offset));
+        }
+        4 => {
+            sink.i32_wrap_i64();
+            sink.i32_store(memarg(offset, 2));
+        }
+        2 => {
+            sink.i32_wrap_i64();
+            sink.i32_store16(memarg(offset, 1));
+        }
+        1 => {
+            sink.i32_wrap_i64();
+            sink.i32_store8(memarg(offset, 0));
+        }
+        _ => {
+            sink.i64_store(mem64(offset));
+        }
+    }
+}
+
+/// `(field_size, is_signed)` from an op's FieldDescr; defaults to word-sized
+/// signed when the descr is absent.
+fn field_size_sign_from_descr(op: &Op) -> (usize, bool) {
+    let descr = op.getdescr();
+    if let Some(fd) = descr.as_ref().and_then(|d| d.as_field_descr()) {
+        return (fd.field_size(), fd.is_field_signed());
+    }
+    (std::mem::size_of::<usize>(), true)
+}
+
+/// `(item_size, is_signed)` from an op's ArrayDescr; defaults to 8-byte
+/// signed when the descr is absent.
+fn array_item_size_sign_from_descr(op: &Op) -> (usize, bool) {
+    op.with_array_descr(|ad| (ad.item_size(), ad.is_item_signed()))
+        .unwrap_or((8, true))
 }
 
 /// llsupport/gc.py:563 GcLLDescr_framework
@@ -109,7 +205,20 @@ pub struct GuardGcTypeInfo {
 
 /// Check if any op in the trace is a CALL variant.
 fn has_call_ops(ops: &[Op]) -> bool {
-    ops.iter().any(|op| op.opcode.is_call())
+    // Allocation ops (`New*`, `Newstr`/`Newunicode`) also reach the host via
+    // the `jit_call` trampoline, so the import must be present for them too.
+    ops.iter().any(|op| {
+        op.opcode.is_call()
+            || matches!(
+                op.opcode,
+                OpCode::New
+                    | OpCode::NewWithVtable
+                    | OpCode::NewArray
+                    | OpCode::NewArrayClear
+                    | OpCode::Newstr
+                    | OpCode::Newunicode
+            )
+    })
 }
 
 fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit>, u32) {
@@ -170,6 +279,8 @@ pub fn build_wasm_module(
     vtable_offset: Option<usize>,
     classptr_to_typeid: &HashMap<i64, u32>,
     guard_gc_type_info: &GuardGcTypeInfo,
+    alloc_fn_ptr: i64,
+    alloc_array_fn_ptr: i64,
 ) -> Result<(Vec<u8>, Vec<GuardExit>), BackendError> {
     let (guards, num_vars) = collect_guards_and_vars(inputargs, ops);
     let needs_call = has_call_ops(ops);
@@ -228,6 +339,8 @@ pub fn build_wasm_module(
         vtable_offset,
         classptr_to_typeid,
         guard_gc_type_info,
+        alloc_fn_ptr,
+        alloc_array_fn_ptr,
     )?;
     codes.function(&func);
     module.section(&codes);
@@ -244,8 +357,13 @@ fn build_function(
     vtable_offset: Option<usize>,
     classptr_to_typeid: &HashMap<i64, u32>,
     guard_gc_type_info: &GuardGcTypeInfo,
+    alloc_fn_ptr: i64,
+    alloc_array_fn_ptr: i64,
 ) -> Result<Function, BackendError> {
-    let mut func = Function::new(vec![(num_vars, ValType::I64)]);
+    // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` extra i64
+    // locals past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) as scratch for
+    // the `UintMulHigh` 32-bit-split expansion (`emit_umulhi`).
+    let mut func = Function::new(vec![(num_vars + UMULHI_SCRATCH, ValType::I64)]);
     let mut sink = func.instructions();
 
     // Load inputs from frame into locals
@@ -257,15 +375,35 @@ fn build_function(
             .local_set(local_idx);
     }
 
-    let has_loop = ops.iter().any(|op| op.opcode == OpCode::Label);
+    // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
+    // preamble runs once on entry, the LABEL is the loop-back target, and
+    // JUMP branches back to it. Emit the `loop` at the LABEL (not the top)
+    // so the preamble is not re-executed every iteration; wrap everything in
+    // a `block` so guard exits `br` out to the function epilogue. Use the
+    // LAST label (a peeled trace may carry an outer entry label plus the
+    // inner loop header).
+    let loop_label_idx = ops.iter().rposition(|op| op.opcode == OpCode::Label);
+    let has_loop = loop_label_idx.is_some();
     if has_loop {
         sink.block(BlockType::Empty);
-        sink.loop_(BlockType::Empty);
     }
 
     let mut guard_idx = 0u32;
+    let mut in_loop_body = false;
 
-    for op in ops {
+    for (op_idx, op) in ops.iter().enumerate() {
+        if Some(op_idx) == loop_label_idx {
+            sink.loop_(BlockType::Empty);
+            in_loop_body = true;
+        }
+        // Depth (from statement level) of the enclosing `block` that guard
+        // exits `br` to: preamble = 0, loop body = 1 (the `loop` sits in
+        // between). `None` for straight-line traces (no block emitted).
+        let block_exit_depth = match (has_loop, in_loop_body) {
+            (false, _) => None,
+            (true, false) => Some(0u32),
+            (true, true) => Some(1u32),
+        };
         match op.opcode {
             OpCode::Label => {}
 
@@ -283,39 +421,39 @@ fn build_function(
 
             OpCode::Finish => {
                 emit_guard_exit(&mut sink, constants, guard_idx, op);
-                if has_loop {
-                    sink.br(1);
+                if let Some(d) = block_exit_depth {
+                    sink.br(d);
                 }
                 guard_idx += 1;
             }
 
             // ── Guards ──
             OpCode::GuardTrue => {
-                emit_guard_true(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_true(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardFalse => {
-                emit_guard_false(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_false(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardValue => {
                 emit_resolve(&mut sink, constants, op.arg(0).to_opref());
                 emit_resolve(&mut sink, constants, op.arg(1).to_opref());
                 sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardNonnull => {
                 emit_resolve(&mut sink, constants, op.arg(0).to_opref());
                 sink.i64_eqz();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardIsnull => {
                 emit_resolve(&mut sink, constants, op.arg(0).to_opref());
                 sink.i64_const(0);
                 sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardClass | OpCode::GuardNonnullClass => {
@@ -330,7 +468,17 @@ fn build_function(
                 if let Some(off_usize) = vtable_offset {
                     let off = off_usize as u64;
                     emit_resolve(&mut sink, constants, op.arg(0).to_opref());
-                    sink.i64_load(mem64(off));
+                    sink.i32_wrap_i64(); // struct ptr (i64) → i32 address
+                    // The typeptr (`ob_type`) is a pointer-width field: 4
+                    // bytes on wasm32. Reading it as i64 would fold in the
+                    // following field's bytes and never match the class
+                    // immediate. Load 4 bytes and zero-extend.
+                    sink.i32_load(MemArg {
+                        offset: off,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    sink.i64_extend_i32_u();
                     emit_resolve(&mut sink, constants, op.arg(1).to_opref());
                     sink.i64_ne();
                 } else {
@@ -359,7 +507,7 @@ fn build_function(
                     sink.i32_const(expected_typeid as i32);
                     sink.i32_ne();
                 }
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardNoOverflow => {
@@ -370,8 +518,8 @@ fn build_function(
             OpCode::GuardOverflow => {
                 // Always fails (no overflow detected in wasm MVP).
                 emit_guard_exit(&mut sink, constants, guard_idx, op);
-                if has_loop {
-                    sink.br(1);
+                if let Some(d) = block_exit_depth {
+                    sink.br(d);
                 }
                 guard_idx += 1;
             }
@@ -389,7 +537,7 @@ fn build_function(
                 sink.i64_load(mem64(0));
                 sink.i64_const(0);
                 sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardException => {
@@ -403,7 +551,7 @@ fn build_function(
                 sink.i64_load(mem64(0));
                 emit_resolve(&mut sink, constants, op.arg(0).to_opref());
                 sink.i64_ne();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
                 // Success path: capture the caught exception into the result
                 // var, then clear both slots.
@@ -433,6 +581,10 @@ fn build_function(
             OpCode::IntLshift => emit_binop(&mut sink, constants, op, BinOp::I64Shl),
             OpCode::IntRshift => emit_binop(&mut sink, constants, op, BinOp::I64ShrS),
             OpCode::UintRshift => emit_binop(&mut sink, constants, op, BinOp::I64ShrU),
+            // High 64 bits of the unsigned 64×64→128 product. The optimizer
+            // emits this for division/modulo-by-constant strength reduction;
+            // wasm has no mul-high instruction, so expand via 32-bit split.
+            OpCode::UintMulHigh => emit_umulhi(&mut sink, constants, op, num_vars),
 
             // Overflow variants: compute result + overflow flag
             OpCode::IntAddOvf => emit_ovf_binop(&mut sink, constants, op, BinOp::I64Add),
@@ -623,7 +775,8 @@ fn build_function(
                     emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // struct ptr (i64)
                     sink.i32_wrap_i64(); // convert to i32 address
                     let field_offset = field_offset_from_descr(op);
-                    sink.i64_load(mem64(field_offset));
+                    let (size, signed) = field_size_sign_from_descr(op);
+                    emit_sized_int_load(&mut sink, field_offset, size, signed);
                     sink.local_set(1 + vi);
                 }
             }
@@ -648,7 +801,8 @@ fn build_function(
                 sink.i32_wrap_i64();
                 let field_offset = field_offset_from_descr(op);
                 emit_resolve(&mut sink, constants, op.arg(1).to_opref()); // value
-                sink.i64_store(mem64(field_offset));
+                let (size, _signed) = field_size_sign_from_descr(op);
+                emit_sized_int_store(&mut sink, field_offset, size);
             }
 
             // ── Float field access ──
@@ -684,7 +838,8 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     // addr = base + base_size + index * item_size
                     emit_array_addr(&mut sink, constants, op);
-                    sink.i64_load(mem64(0));
+                    let (item_size, signed) = array_item_size_sign_from_descr(op);
+                    emit_sized_int_load(&mut sink, 0, item_size, signed);
                     sink.local_set(1 + vi);
                 }
             }
@@ -704,7 +859,12 @@ fn build_function(
             OpCode::SetarrayitemGc | OpCode::SetarrayitemRaw => {
                 emit_array_addr(&mut sink, constants, op);
                 emit_resolve(&mut sink, constants, op.arg(2).to_opref()); // value
-                sink.i64_store(mem64(0));
+                // A Ref item is pointer-width (4 bytes on wasm32). Storing a
+                // fixed 8 bytes would clobber the next item, or run past the
+                // array end on the last item and corrupt the heap. A Float
+                // item is 8 bytes, so its bit pattern stores via the i64 path.
+                let (item_size, _signed) = array_item_size_sign_from_descr(op);
+                emit_sized_int_store(&mut sink, 0, item_size);
             }
 
             // ── Interior field access ──
@@ -716,7 +876,8 @@ fn build_function(
                     sink.i32_wrap_i64();
                     let field_offset = field_offset_from_descr(op);
                     // Simplified: use field_offset directly (RPython computes base+index*itemsize+offset)
-                    sink.i64_load(mem64(field_offset));
+                    let (size, signed) = field_size_sign_from_descr(op);
+                    emit_sized_int_load(&mut sink, field_offset, size, signed);
                     sink.local_set(1 + vi);
                 }
             }
@@ -725,7 +886,8 @@ fn build_function(
                 sink.i32_wrap_i64();
                 let field_offset = field_offset_from_descr(op);
                 emit_resolve(&mut sink, constants, op.arg(2).to_opref()); // value
-                sink.i64_store(mem64(field_offset));
+                let (size, _signed) = field_size_sign_from_descr(op);
+                emit_sized_int_store(&mut sink, field_offset, size);
             }
 
             // ── String/Unicode ops (direct memory access) ──
@@ -852,7 +1014,7 @@ fn build_function(
                     // i64 in the constant pool or a frame slot).
                     emit_resolve(&mut sink, constants, op.arg(1).to_opref());
                     sink.i64_ne();
-                    emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                    emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 }
                 guard_idx += 1;
             }
@@ -920,7 +1082,7 @@ fn build_function(
                 // assembler.py:1942 guard_success_cc = Conditions['NZ']:
                 // guard passes when byte & flag != 0; fail when == 0.
                 sink.i32_eqz();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             // x86/assembler.py:1945-1980 genop_guard_guard_subclass.
@@ -1029,14 +1191,14 @@ fn build_function(
                 // assembler.py:1979 guard_success_cc = Conditions['B']:
                 // guard passes when sub <u limit; fail when sub >=u limit.
                 sink.i64_ge_u();
-                emit_guard_if_exit(&mut sink, constants, guard_idx, op, has_loop);
+                emit_guard_if_exit(&mut sink, constants, guard_idx, op, block_exit_depth);
                 guard_idx += 1;
             }
             OpCode::GuardFutureCondition | OpCode::GuardAlwaysFails => {
                 // GuardAlwaysFails always exits.
                 emit_guard_exit(&mut sink, constants, guard_idx, op);
-                if has_loop {
-                    sink.br(1);
+                if let Some(d) = block_exit_depth {
+                    sink.br(d);
                 }
                 guard_idx += 1;
             }
@@ -1185,10 +1347,119 @@ fn build_function(
             }
 
             // ── Allocation (via trampoline — treated as CALL) ──
-            OpCode::New | OpCode::NewWithVtable | OpCode::NewArray | OpCode::NewArrayClear => {
-                // These are handled by the optimizer and shouldn't normally
-                // appear in optimized traces (they become virtuals).
-                // If they do appear, skip — the host will handle on guard failure.
+            // llmodel.py:775-790 bh_new* parity: a `New*` survives
+            // optimization whenever the allocated object escapes the trace
+            // (e.g. reboxed result stored into a namespace). The trace cannot
+            // allocate inline (the GC is host-side), so route through the
+            // `jit_call` trampoline to the `wasm_jit_alloc` helper, then write
+            // the vtable / length fields with pointer-width (i32) stores.
+            OpCode::New | OpCode::NewWithVtable => {
+                let jit_call =
+                    jit_call_idx.expect("New op present but jit_call not imported");
+                let vi = op.pos.get().raw();
+                // llmodel.py:778-782: size, type_id, vtable from the size descr.
+                let descr = op.getdescr();
+                let sd = descr.as_ref().and_then(|d| d.as_size_descr());
+                let (size, type_id, vtable) = sd.map_or((16i64, 0i64, 0usize), |sd| {
+                    (sd.size() as i64, sd.type_id() as i64, sd.vtable())
+                });
+
+                // func_ptr = wasm_jit_alloc
+                sink.local_get(0);
+                sink.i64_const(alloc_fn_ptr);
+                sink.i64_store(mem64(CALL_FUNC_OFS));
+                // num_args = 2
+                sink.local_get(0);
+                sink.i64_const(2);
+                sink.i64_store(mem64(CALL_NARGS_OFS));
+                // arg0 = type_id
+                sink.local_get(0);
+                sink.i64_const(type_id);
+                sink.i64_store(mem64(CALL_ARGS_OFS));
+                // arg1 = size
+                sink.local_get(0);
+                sink.i64_const(size);
+                sink.i64_store(mem64(CALL_ARGS_OFS + SLOT_SIZE));
+                // call trampoline
+                sink.local_get(0);
+                sink.call(jit_call);
+
+                if !OpRef::raw_is_constant(vi) {
+                    // result pointer
+                    sink.local_get(0);
+                    sink.i64_load(mem64(CALL_RESULT_OFS));
+                    sink.local_set(1 + vi);
+
+                    // llmodel.py:779-781 write_int_at_mem(res, vtable_offset,
+                    // WORD, vtable). The `ob_type` field is pointer-width: 4
+                    // bytes on wasm32 (GuardClass reads it as i32), so store
+                    // the low 32 bits to avoid clobbering the next field.
+                    let write_vtable = op.opcode == OpCode::NewWithVtable
+                        && vtable != 0
+                        && vtable_offset.is_some();
+                    if write_vtable {
+                        let vt_off = vtable_offset.unwrap() as u64;
+                        sink.local_get(1 + vi);
+                        sink.i32_wrap_i64();
+                        sink.i32_const(vtable as i32);
+                        sink.i32_store(MemArg {
+                            offset: vt_off,
+                            align: 2,
+                            memory_index: 0,
+                        });
+                    }
+                }
+            }
+            OpCode::NewArray | OpCode::NewArrayClear => {
+                let jit_call =
+                    jit_call_idx.expect("NewArray op present but jit_call not imported");
+                let vi = op.pos.get().raw();
+                let descr = op.getdescr();
+                let ad = descr.as_ref().and_then(|d| d.as_array_descr());
+                let (base_size, item_size) =
+                    ad.map_or((16i64, 8i64), |ad| (ad.base_size() as i64, ad.item_size() as i64));
+                let len_offset = ad
+                    .and_then(|ad| ad.len_descr())
+                    .map_or(0i64, |ld| ld.offset() as i64);
+                let type_id = ad.map_or(0i64, |ad| ad.type_id() as i64);
+
+                // func_ptr = wasm_jit_alloc_array
+                sink.local_get(0);
+                sink.i64_const(alloc_array_fn_ptr);
+                sink.i64_store(mem64(CALL_FUNC_OFS));
+                // num_args = 5
+                sink.local_get(0);
+                sink.i64_const(5);
+                sink.i64_store(mem64(CALL_NARGS_OFS));
+                // arg0 = type_id
+                sink.local_get(0);
+                sink.i64_const(type_id);
+                sink.i64_store(mem64(CALL_ARGS_OFS));
+                // arg1 = base_size
+                sink.local_get(0);
+                sink.i64_const(base_size);
+                sink.i64_store(mem64(CALL_ARGS_OFS + SLOT_SIZE));
+                // arg2 = item_size
+                sink.local_get(0);
+                sink.i64_const(item_size);
+                sink.i64_store(mem64(CALL_ARGS_OFS + 2 * SLOT_SIZE));
+                // arg3 = length (op.arg(0))
+                sink.local_get(0);
+                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                sink.i64_store(mem64(CALL_ARGS_OFS + 3 * SLOT_SIZE));
+                // arg4 = len_offset
+                sink.local_get(0);
+                sink.i64_const(len_offset);
+                sink.i64_store(mem64(CALL_ARGS_OFS + 4 * SLOT_SIZE));
+                // call trampoline
+                sink.local_get(0);
+                sink.call(jit_call);
+
+                if !OpRef::raw_is_constant(vi) {
+                    sink.local_get(0);
+                    sink.i64_load(mem64(CALL_RESULT_OFS));
+                    sink.local_set(1 + vi);
+                }
             }
 
             // ── Misc ──
@@ -1278,7 +1549,10 @@ fn build_function(
 // ── Helpers ──
 
 fn find_label_args(ops: &[Op]) -> Vec<OpRef> {
-    for op in ops {
+    // The JUMP branches back to the loop-header label, which is the LAST
+    // label in a peeled trace (an outer entry label may precede it). The
+    // `loop` is emitted at that same label in `build_function`.
+    for op in ops.iter().rev() {
         if op.opcode == OpCode::Label {
             return op.getarglist().iter().map(|a| a.to_opref()).collect();
         }
@@ -1349,11 +1623,11 @@ fn emit_guard_true(
     constants: &majit_ir::VecAssoc<u32, i64>,
     guard_idx: u32,
     op: &Op,
-    has_loop: bool,
+    block_exit_depth: Option<u32>,
 ) {
     emit_resolve(sink, constants, op.arg(0).to_opref());
     sink.i64_eqz();
-    emit_guard_if_exit(sink, constants, guard_idx, op, has_loop);
+    emit_guard_if_exit(sink, constants, guard_idx, op, block_exit_depth);
 }
 
 fn emit_guard_false(
@@ -1361,26 +1635,30 @@ fn emit_guard_false(
     constants: &majit_ir::VecAssoc<u32, i64>,
     guard_idx: u32,
     op: &Op,
-    has_loop: bool,
+    block_exit_depth: Option<u32>,
 ) {
     emit_resolve(sink, constants, op.arg(0).to_opref());
     sink.i64_const(0);
     sink.i64_ne();
-    emit_guard_if_exit(sink, constants, guard_idx, op, has_loop);
+    emit_guard_if_exit(sink, constants, guard_idx, op, block_exit_depth);
 }
 
 /// Common guard exit: condition is on stack (i32), emit if + exit.
+///
+/// `block_exit_depth` is the statement-level depth of the enclosing exit
+/// `block` (preamble = 0, loop body = 1); the `+ 1` accounts for the `if`
+/// this opens. `None` for straight-line traces with no exit block.
 fn emit_guard_if_exit(
     sink: &mut InstructionSink<'_>,
     constants: &majit_ir::VecAssoc<u32, i64>,
     guard_idx: u32,
     op: &Op,
-    has_loop: bool,
+    block_exit_depth: Option<u32>,
 ) {
     sink.if_(BlockType::Empty);
     emit_guard_exit(sink, constants, guard_idx, op);
-    if has_loop {
-        sink.br(2); // if=0, loop=1, block=2
+    if let Some(d) = block_exit_depth {
+        sink.br(d + 1);
     }
     sink.end();
 }
@@ -1475,6 +1753,84 @@ fn emit_binop(
     emit_resolve(sink, constants, op.arg(0).to_opref());
     emit_resolve(sink, constants, op.arg(1).to_opref());
     apply_binop(sink, binop);
+    sink.local_set(1 + vi);
+}
+
+/// `UintMulHigh`: high 64 bits of the unsigned 64×64→128 product. Wasm has
+/// only `i64.mul` (low 64 bits), so compute via the classic 32-bit split:
+/// a = ah·2³²+al, b = bh·2³²+bl, with carry-safe intermediates
+///   mid1 = ah·bl + (al·bl >> 32)
+///   high = ah·bh + (mid1 >> 32) + ((al·bh + (mid1 & 0xFFFFFFFF)) >> 32)
+/// Uses the five scratch locals reserved at `num_vars+1 ..= num_vars+5`.
+fn emit_umulhi(
+    sink: &mut InstructionSink<'_>,
+    constants: &majit_ir::VecAssoc<u32, i64>,
+    op: &Op,
+    num_vars: u32,
+) {
+    let vi = op.pos.get().raw();
+    if OpRef::raw_is_constant(vi) {
+        return;
+    }
+    const MASK32: i64 = 0xFFFF_FFFF;
+    let al = num_vars + 1;
+    let ah = num_vars + 2;
+    let bl = num_vars + 3;
+    let bh = num_vars + 4;
+    let mid1 = num_vars + 5;
+
+    // al = a & 0xFFFFFFFF
+    emit_resolve(sink, constants, op.arg(0).to_opref());
+    sink.i64_const(MASK32);
+    sink.i64_and();
+    sink.local_set(al);
+    // ah = a >>u 32
+    emit_resolve(sink, constants, op.arg(0).to_opref());
+    sink.i64_const(32);
+    sink.i64_shr_u();
+    sink.local_set(ah);
+    // bl = b & 0xFFFFFFFF
+    emit_resolve(sink, constants, op.arg(1).to_opref());
+    sink.i64_const(MASK32);
+    sink.i64_and();
+    sink.local_set(bl);
+    // bh = b >>u 32
+    emit_resolve(sink, constants, op.arg(1).to_opref());
+    sink.i64_const(32);
+    sink.i64_shr_u();
+    sink.local_set(bh);
+
+    // mid1 = ah*bl + ((al*bl) >>u 32)
+    sink.local_get(al);
+    sink.local_get(bl);
+    sink.i64_mul();
+    sink.i64_const(32);
+    sink.i64_shr_u();
+    sink.local_get(ah);
+    sink.local_get(bl);
+    sink.i64_mul();
+    sink.i64_add();
+    sink.local_set(mid1);
+
+    // high = ah*bh + (mid1 >>u 32) + ((al*bh + (mid1 & MASK32)) >>u 32)
+    sink.local_get(ah);
+    sink.local_get(bh);
+    sink.i64_mul();
+    sink.local_get(mid1);
+    sink.i64_const(32);
+    sink.i64_shr_u();
+    sink.i64_add();
+    sink.local_get(al);
+    sink.local_get(bh);
+    sink.i64_mul();
+    sink.local_get(mid1);
+    sink.i64_const(MASK32);
+    sink.i64_and();
+    sink.i64_add();
+    sink.i64_const(32);
+    sink.i64_shr_u();
+    sink.i64_add();
+
     sink.local_set(1 + vi);
 }
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -526,8 +526,16 @@ fn build_function(
             OpCode::GuardOverflow => {
                 // Always fails (no overflow detected in wasm MVP).
                 emit_guard_exit(&mut sink, constants, guard_idx, op);
-                if let Some(d) = block_exit_depth {
-                    sink.br(d);
+                match block_exit_depth {
+                    Some(d) => {
+                        sink.br(d);
+                    }
+                    // Straight-line: return directly so the following ops and
+                    // the terminal Finish do not overwrite this exit.
+                    None => {
+                        sink.local_get(0);
+                        sink.return_();
+                    }
                 }
                 guard_idx += 1;
             }
@@ -864,6 +872,22 @@ fn build_function(
                     sink.local_set(1 + vi);
                 }
             }
+            OpCode::GetarrayitemGcF | OpCode::GetarrayitemGcPureF | OpCode::GetarrayitemRawF => {
+                let vi = op.pos.get().raw();
+                if !OpRef::raw_is_constant(vi) {
+                    // A Float item is 8 bytes; load it as f64 and carry its bit
+                    // pattern in the i64 value slot (the IntArray/value-slot ABI
+                    // is i64).
+                    emit_array_addr(&mut sink, constants, op);
+                    sink.f64_load(MemArg {
+                        offset: 0,
+                        align: 3,
+                        memory_index: 0,
+                    });
+                    sink.i64_reinterpret_f64();
+                    sink.local_set(1 + vi);
+                }
+            }
             OpCode::SetarrayitemGc | OpCode::SetarrayitemRaw => {
                 emit_array_addr(&mut sink, constants, op);
                 emit_resolve(&mut sink, constants, op.arg(2).to_opref()); // value
@@ -886,6 +910,21 @@ fn build_function(
                     // Simplified: use field_offset directly (RPython computes base+index*itemsize+offset)
                     let (size, signed) = field_size_sign_from_descr(op);
                     emit_sized_int_load(&mut sink, field_offset, size, signed);
+                    sink.local_set(1 + vi);
+                }
+            }
+            OpCode::GetinteriorfieldGcF => {
+                let vi = op.pos.get().raw();
+                if !OpRef::raw_is_constant(vi) {
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // array ptr
+                    sink.i32_wrap_i64();
+                    let field_offset = field_offset_from_descr(op);
+                    sink.f64_load(MemArg {
+                        offset: field_offset,
+                        align: 3,
+                        memory_index: 0,
+                    });
+                    sink.i64_reinterpret_f64();
                     sink.local_set(1 + vi);
                 }
             }
@@ -1538,7 +1577,19 @@ fn build_function(
             | OpCode::Keepalive => {}
 
             _ => {
-                // Unsupported opcode — skip silently.
+                // An opcode with no codegen arm. If it produces a value (a
+                // result local that later ops read), silently skipping it
+                // leaves a stale slot and yields wrong results, so decline the
+                // whole trace and let the metainterp fall back to the
+                // interpreter (correct, unaccelerated). Side-effect-free
+                // metadata opcodes that produce no value are enumerated above.
+                let vi = op.pos.get().raw();
+                if !OpRef::raw_is_constant(vi) {
+                    return Err(BackendError::Unsupported(format!(
+                        "wasm codegen: unhandled value-producing opcode {:?}",
+                        op.opcode
+                    )));
+                }
             }
         }
     }
@@ -1665,8 +1716,20 @@ fn emit_guard_if_exit(
 ) {
     sink.if_(BlockType::Empty);
     emit_guard_exit(sink, constants, guard_idx, op);
-    if let Some(d) = block_exit_depth {
-        sink.br(d + 1);
+    match block_exit_depth {
+        // Loop traces: `br` out of this `if` and the enclosing exit `block`
+        // (the `+ 1` accounts for the `if`) to the function epilogue.
+        Some(d) => {
+            sink.br(d + 1);
+        }
+        // Straight-line traces have no enclosing block, so fall-through would
+        // reach the terminal Finish and overwrite frame[0] with its
+        // fail_index, discarding this guard's exit. Return the frame pointer
+        // directly (the epilogue's value) to hand control to the metainterp.
+        None => {
+            sink.local_get(0);
+            sink.return_();
+        }
     }
     sink.end();
 }

--- a/majit/majit-backend-wasm/src/glue.rs
+++ b/majit/majit-backend-wasm/src/glue.rs
@@ -14,6 +14,9 @@
 //! Both expose the same `compile_module` / `execute` / `free` surface, so
 //! the rest of the backend stays binding-agnostic.
 
+#[cfg(all(feature = "web", feature = "host-import"))]
+compile_error!("features `web` and `host-import` are mutually exclusive; enable exactly one");
+
 #[cfg(feature = "web")]
 mod imports {
     use wasm_bindgen::prelude::*;

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -93,7 +93,6 @@ fn with_wasm_active_gc<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> Option<R> {
     })
 }
 
-
 /// `majit_gc::CheckIsObjectFn` installed by `set_gc_allocator`.
 /// Mirrors cranelift's `check_is_object_via_active_runtime`: dispatches
 /// through the wasm-thread-local GC allocator.
@@ -174,8 +173,12 @@ pub extern "C" fn wasm_jit_alloc_array(
     };
     WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
         Some(gc) => {
-            let obj =
-                gc.alloc_varsize_typed(type_id as u32, base_size as usize, item_size as usize, length);
+            let obj = gc.alloc_varsize_typed(
+                type_id as u32,
+                base_size as usize,
+                item_size as usize,
+                length,
+            );
             if obj.is_null() {
                 0
             } else {
@@ -450,7 +453,10 @@ fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
         if op.opcode.is_call_assembler() {
             // CALL_ASSEMBLER enters another trace's compiled token; the wasm
             // backend has no inter-module trace chaining (#62).
-            return Some(format!("wasm backend: {:?} (loop-callee inline)", op.opcode));
+            return Some(format!(
+                "wasm backend: {:?} (loop-callee inline)",
+                op.opcode
+            ));
         }
         match op.opcode {
             majit_ir::OpCode::Label => has_label = true,
@@ -475,7 +481,9 @@ fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
     // its GC) runs the loop. An all-inline allocating loop (no residual call)
     // stays compiled: it is fast and its bounded run does not exhaust memory.
     if has_label && has_new && has_call {
-        return Some("wasm backend: allocation + residual call in loop trace (no GC nursery)".into());
+        return Some(
+            "wasm backend: allocation + residual call in loop trace (no GC nursery)".into(),
+        );
     }
     None
 }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -40,7 +40,10 @@ pub fn jit_exc_raise(value: i64) {
     let exc_type = if value == 0 {
         0
     } else {
-        unsafe { *(value as *const i64) }
+        // `typeptr` is a machine pointer (32-bit on wasm32); read it at
+        // pointer width and zero-extend, so the high bits stay clear and
+        // `GuardException`'s type comparison matches the baked class pointer.
+        unsafe { *(value as *const usize) as i64 }
     };
     JIT_EXC_VALUE.store(value, Ordering::Relaxed);
     JIT_EXC_TYPE.store(exc_type, Ordering::Relaxed);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -87,6 +87,7 @@ fn with_wasm_active_gc<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> Option<R> {
     })
 }
 
+
 /// `majit_gc::CheckIsObjectFn` installed by `set_gc_allocator`.
 /// Mirrors cranelift's `check_is_object_via_active_runtime`: dispatches
 /// through the wasm-thread-local GC allocator.
@@ -136,6 +137,49 @@ fn wasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
             Some(gc) => gc.alloc_oldgen_typed(type_id, size),
             None => GcRef(0),
         }
+    })
+}
+
+/// JIT-trace allocation trampoline target for `New` / `NewWithVtable`.
+///
+/// A compiled trace cannot allocate directly (the GC lives behind the
+/// `WASM_ACTIVE_GC` thread-local), so the `New` codegen routes through the
+/// host `jit_call` trampoline, which resolves this function via the module's
+/// `__indirect_function_table` (its address is taken in `compile_loop`, so it
+/// lands in the table) and invokes it with `(type_id, size)`. Returns the new
+/// object pointer, or 0 when no GC is installed. The `ob_type` field for
+/// `NewWithVtable` is written inline by codegen at `vtable_offset`.
+pub extern "C" fn wasm_jit_alloc(type_id: i64, size: i64) -> i64 {
+    wasm_alloc_nursery_typed(type_id as u32, size as usize).0 as i64
+}
+
+/// JIT-trace variable-size allocation trampoline target for `NewArray` /
+/// `NewArrayClear`. Allocates `length` items and writes the length field at
+/// `len_offset`, mirroring [`WasmBackend::bh_new_array`].
+pub extern "C" fn wasm_jit_alloc_array(
+    type_id: i64,
+    base_size: i64,
+    item_size: i64,
+    length: i64,
+    len_offset: i64,
+) -> i64 {
+    let Ok(length) = usize::try_from(length) else {
+        return 0;
+    };
+    WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
+        Some(gc) => {
+            let obj =
+                gc.alloc_varsize_typed(type_id as u32, base_size as usize, item_size as usize, length);
+            if obj.is_null() {
+                0
+            } else {
+                unsafe {
+                    *((obj.0 as *mut u8).add(len_offset as usize) as *mut usize) = length;
+                }
+                obj.0 as i64
+            }
+        }
+        None => 0,
     })
 }
 
@@ -397,6 +441,81 @@ impl majit_backend::Backend for WasmBackend {
         "wasm"
     }
 
+    // ── Blackhole allocation (llmodel.py:775-790) ──
+    //
+    // The blackhole interpreter materializes virtuals (e.g. a virtualized
+    // `W_IntObject` loop variable forced at loop exit) through these. Without
+    // a real implementation `bhimpl_new*` returns 0 and the resumed frame
+    // carries null operands. Mirrors `CraneliftBackend`'s overrides but routes
+    // through the wasm thread-local GC; allocation inputs carry no unrooted GC
+    // refs, so no collection-suppression beyond the no-collect fixed-size path
+    // is required.
+
+    /// llmodel.py:775 bh_new(sizedescr).
+    fn bh_new(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
+        let size = sizedescr.as_size();
+        // TODO: get_type_id() returns the u64 path_hash cache key; the GC tid
+        // is its low 32 bits until gc_cache routing resolves the real tid.
+        let type_id = sizedescr.get_type_id() as u32;
+        WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
+            Some(gc) => gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64,
+            None => 0,
+        })
+    }
+
+    /// llmodel.py:778-782 bh_new_with_vtable(sizedescr): allocate, then write
+    /// the type pointer at `vtable_offset`.
+    fn bh_new_with_vtable(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
+        let size = sizedescr.as_size();
+        let vtable = sizedescr.get_vtable();
+        let type_id = sizedescr.get_type_id() as u32;
+        let ptr = WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
+            Some(gc) => gc.alloc_nursery_no_collect_typed(type_id, size).0 as i64,
+            None => 0,
+        });
+        if ptr != 0 && vtable != 0 {
+            if let Some(vt_off) = self.vtable_offset {
+                unsafe {
+                    *((ptr as *mut u8).add(vt_off) as *mut usize) = vtable;
+                }
+            }
+        }
+        ptr
+    }
+
+    /// llmodel.py:788 bh_new_array(length, arraydescr).
+    fn bh_new_array(&self, length: i64, arraydescr: &majit_translate::jitcode::BhDescr) -> i64 {
+        let length = usize::try_from(length).expect("bh_new_array length must be non-negative");
+        let (base_size, itemsize, _sign) = arraydescr.unpack_arraydescr_size();
+        let len_offset = arraydescr
+            .array_len_offset()
+            .expect("bh_new_array requires ArrayDescr.lendescr");
+        let type_id = arraydescr.get_type_id() as u32;
+        WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
+            Some(gc) => {
+                let obj = gc.alloc_varsize_typed(type_id, base_size, itemsize, length);
+                if obj.is_null() {
+                    0
+                } else {
+                    unsafe {
+                        *((obj.0 as *mut u8).add(len_offset) as *mut usize) = length;
+                    }
+                    obj.0 as i64
+                }
+            }
+            None => 0,
+        })
+    }
+
+    /// llmodel.py:790 bh_new_array_clear = bh_new_array (allocator zeroes).
+    fn bh_new_array_clear(
+        &self,
+        length: i64,
+        arraydescr: &majit_translate::jitcode::BhDescr,
+    ) -> i64 {
+        self.bh_new_array(length, arraydescr)
+    }
+
     fn compile_loop(
         &mut self,
         inputargs: &[InputArg],
@@ -417,6 +536,11 @@ impl majit_backend::Backend for WasmBackend {
 
         let typeid_table = self.collect_classptr_typeid_table(ops);
         let guard_gc_type_info = self.collect_guard_gc_type_info(ops);
+        // Allocation helpers reached from a compiled trace through the host
+        // `jit_call` trampoline. `fn as usize` is the `__indirect_function_table`
+        // index on wasm32; taking it here keeps the function in the table.
+        let alloc_fn_ptr = wasm_jit_alloc as *const () as usize as i64;
+        let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
         let (wasm_bytes, guard_exits) = codegen::build_wasm_module(
             inputargs,
             ops,
@@ -424,6 +548,8 @@ impl majit_backend::Backend for WasmBackend {
             self.vtable_offset,
             &typeid_table,
             &guard_gc_type_info,
+            alloc_fn_ptr,
+            alloc_array_fn_ptr,
         )?;
 
         // Build fail descriptors

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -57,6 +57,12 @@ pub fn jit_exc_take() -> i64 {
     value
 }
 
+/// Clear both exception slots without reading the value.
+pub fn jit_exc_clear() {
+    JIT_EXC_VALUE.store(0, Ordering::Relaxed);
+    JIT_EXC_TYPE.store(0, Ordering::Relaxed);
+}
+
 /// Address of `JIT_EXC_VALUE`, embedded as an immediate in JIT-emitted wasm
 /// so the trace can load/store it over the shared linear memory
 /// (`_store_and_reset_exception` parity).
@@ -438,6 +444,8 @@ unsafe impl Send for WasmBackend {}
 fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
     let mut has_label = false;
     let mut has_jump = false;
+    let mut has_new = false;
+    let mut has_call = false;
     for op in ops {
         if op.opcode.is_call_assembler() {
             // CALL_ASSEMBLER enters another trace's compiled token; the wasm
@@ -447,6 +455,11 @@ fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
         match op.opcode {
             majit_ir::OpCode::Label => has_label = true,
             majit_ir::OpCode::Jump => has_jump = true,
+            majit_ir::OpCode::New
+            | majit_ir::OpCode::NewWithVtable
+            | majit_ir::OpCode::NewArray
+            | majit_ir::OpCode::NewArrayClear => has_new = true,
+            opcode if opcode.is_call() => has_call = true,
             _ => {}
         }
     }
@@ -454,6 +467,15 @@ fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
     // no enclosing loop block, yielding invalid wasm.
     if has_jump && !has_label {
         return Some("wasm backend: JUMP to external loop (no local LABEL)".into());
+    }
+    // A loop that BOTH allocates and makes residual calls every iteration grows
+    // the heap without bound (the wasm backend has no GC malloc-nursery rewrite,
+    // so wasm_jit_alloc never collects) while the host-trampoline calls keep it
+    // running long enough to exhaust memory. Decline so the interpreter (with
+    // its GC) runs the loop. An all-inline allocating loop (no residual call)
+    // stays compiled: it is fast and its bounded run does not exhaust memory.
+    if has_label && has_new && has_call {
+        return Some("wasm backend: allocation + residual call in loop trace (no GC nursery)".into());
     }
     None
 }
@@ -699,6 +721,13 @@ impl majit_backend::Backend for WasmBackend {
         }
         #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
         {
+            // The pending-exception cell is global, unlike the native
+            // per-jitframe `jf_guard_exc`. A residual raise on a blackhole
+            // resume path (publish_residual_call_exception) writes it outside
+            // any trace and nothing clears it, so clear it before running this
+            // trace; otherwise jit_exc_take below would surface a stale
+            // exception from a previous frame's resume as this trace's.
+            jit_exc_clear();
             glue::execute(compiled.func_handle, _frame_ptr);
 
             // A GuardNoException / GuardException exit leaves the pending

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -432,6 +432,32 @@ impl WasmBackend {
 
 unsafe impl Send for WasmBackend {}
 
+/// Report why a trace cannot be compiled by the wasm backend, or `None` if it
+/// can. Declined traces fall back to the interpreter (correct, unaccelerated)
+/// instead of producing an invalid trace module.
+fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
+    let mut has_label = false;
+    let mut has_jump = false;
+    for op in ops {
+        if op.opcode.is_call_assembler() {
+            // CALL_ASSEMBLER enters another trace's compiled token; the wasm
+            // backend has no inter-module trace chaining (#62).
+            return Some(format!("wasm backend: {:?} (loop-callee inline)", op.opcode));
+        }
+        match op.opcode {
+            majit_ir::OpCode::Label => has_label = true,
+            majit_ir::OpCode::Jump => has_jump = true,
+            _ => {}
+        }
+    }
+    // A JUMP with no LABEL targets an external loop; codegen's `br` would have
+    // no enclosing loop block, yielding invalid wasm.
+    if has_jump && !has_label {
+        return Some("wasm backend: JUMP to external loop (no local LABEL)".into());
+    }
+    None
+}
+
 impl majit_backend::Backend for WasmBackend {
     fn cpu_tracker(&self) -> &std::sync::Arc<majit_backend::CpuTotalTracker> {
         &self.cpu_tracker
@@ -530,6 +556,21 @@ impl majit_backend::Backend for WasmBackend {
         }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
+
+        // Decline traces the wasm backend cannot compile correctly, so the
+        // metainterp falls back to the interpreter (correct, if unaccelerated)
+        // rather than installing a structurally-invalid trace module:
+        //   * CALL_ASSEMBLER inlines a loop-bearing callee by jumping into
+        //     another trace's compiled token. The wasm backend has no
+        //     inter-module trace chaining (each trace is its own module), so it
+        //     cannot execute the target — declining is the #62 loop-callee gap.
+        //   * A JUMP with no LABEL targets an external loop; codegen would emit
+        //     a `br 0` with no enclosing block, producing invalid wasm
+        //     ("expected i32 but nothing on stack").
+        if let Some(reason) = wasm_unsupported_trace_reason(ops) {
+            return Err(BackendError::Unsupported(reason));
+        }
+
         self.collect_constants_from_ops(ops);
         let trace_id = self.trace_counter;
         self.trace_counter += 1;

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -504,9 +504,17 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
     info.subclass_ranges.insert(0xCAFE, (10, 20));
 
     // gcremovetypeptr branch: vtable_offset = None.
-    let (bytes, guards) =
-        codegen::build_wasm_module(&inputargs, &ops, &constants, None, &HashMap::new(), &info, 0, 0)
-            .expect("wasm codegen should succeed when supports_guard_gc_type=true");
+    let (bytes, guards) = codegen::build_wasm_module(
+        &inputargs,
+        &ops,
+        &constants,
+        None,
+        &HashMap::new(),
+        &info,
+        0,
+        0,
+    )
+    .expect("wasm codegen should succeed when supports_guard_gc_type=true");
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 1);
 

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -50,6 +50,8 @@ fn test_empty_trace() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -114,6 +116,8 @@ fn test_int_add_loop() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -171,6 +175,8 @@ fn test_float_ops() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -204,6 +210,8 @@ fn test_call_generates_import() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -300,6 +308,8 @@ fn test_guard_types() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -346,6 +356,8 @@ fn test_exception_guards() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -385,6 +397,8 @@ fn test_guard_gc_type_uses_immediate_typeid() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -446,6 +460,8 @@ fn test_guard_is_object_lowers_to_typeinfo_test() {
         Some(0),
         &HashMap::new(),
         &enabled_guard_gc_type_info(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed when supports_guard_gc_type=true");
     validate_wasm(&bytes);
@@ -489,7 +505,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
 
     // gcremovetypeptr branch: vtable_offset = None.
     let (bytes, guards) =
-        codegen::build_wasm_module(&inputargs, &ops, &constants, None, &HashMap::new(), &info)
+        codegen::build_wasm_module(&inputargs, &ops, &constants, None, &HashMap::new(), &info, 0, 0)
             .expect("wasm codegen should succeed when supports_guard_gc_type=true");
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 1);
@@ -502,6 +518,8 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
         Some(8),
         &HashMap::new(),
         &info,
+        0,
+        0,
     )
     .expect("wasm codegen should succeed when vtable_offset is set");
     validate_wasm(&bytes2);
@@ -564,6 +582,8 @@ fn test_sameas_and_conversions() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -612,6 +632,8 @@ fn test_overflow_ops() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);

--- a/majit/majit-backend/src/call_stub.rs
+++ b/majit/majit-backend/src/call_stub.rs
@@ -503,3 +503,80 @@ pub fn collect_call_args(
     }
     (int_args, float_args)
 }
+
+/// Bucket `args_i` / `args_r` / `args_f` into a single positional list in
+/// `arg_classes` order, floats carried as their raw 64-bit pattern.
+///
+/// Unlike [`collect_call_args`] this does NOT split the arguments into the
+/// SysV/AAPCS integer + float register files — it preserves the original
+/// declaration order so a positional ABI (the wasm `call_indirect`, where
+/// arguments are stack-positional rather than register-file partitioned)
+/// receives them as the callee declares them. Used by the residual-host-call
+/// trampoline path (see [`residual_host_call`]).
+pub fn collect_call_args_positional(
+    arg_classes: &str,
+    args_i: Option<&[i64]>,
+    args_r: Option<&[i64]>,
+    args_f: Option<&[i64]>,
+) -> Vec<i64> {
+    let mut out: Vec<i64> = Vec::with_capacity(arg_classes.len());
+    let mut ii = 0usize;
+    let mut ri = 0usize;
+    let mut fi = 0usize;
+    for c in arg_classes.chars() {
+        match c {
+            'i' => {
+                out.push(args_i.expect("collect_call_args_positional: args_i missing")[ii]);
+                ii += 1;
+            }
+            'r' => {
+                out.push(args_r.expect("collect_call_args_positional: args_r missing")[ri]);
+                ri += 1;
+            }
+            // `f` (Float) and `L` (SignedLongLong) both live in the `args_f`
+            // storage bank; their raw 64-bit slot value is forwarded verbatim
+            // — the host trampoline coerces it to f64/i64 from the callee's
+            // reflected parameter type.
+            'f' | 'L' => {
+                out.push(args_f.expect("collect_call_args_positional: args_f missing")[fi]);
+                fi += 1;
+            }
+            other => panic!(
+                "collect_call_args_positional: unsupported arg class {other:?} \
+                 in arg_classes={arg_classes:?}"
+            ),
+        }
+    }
+    out
+}
+
+/// A host-provided trampoline that performs a residual call by reflecting the
+/// callee's real signature, rather than transmuting the raw funcptr to a
+/// statically-guessed `extern "C" fn`.
+///
+/// `func_ptr` is the raw callee address (a table index on wasm32); `args` is
+/// the positional argument list (floats as raw bits). The return value is the
+/// callee result as a 64-bit pattern (Void callees return 0; Ref returns the
+/// pointer; Float returns `f64::to_bits`).
+///
+/// Installed only where in-module static-signature dispatch is impossible:
+/// the wasm32 backend, whose `call_indirect` type-checks every call and so
+/// cannot reuse the uniform-`i64` transmute that the SysV/AAPCS C ABI tolerates
+/// on native backends. `None` (the default on dynasm/cranelift) keeps the
+/// direct transmute path.
+pub type ResidualHostCallFn = fn(func_ptr: usize, args: &[i64]) -> i64;
+
+thread_local! {
+    static RESIDUAL_HOST_CALL: std::cell::Cell<Option<ResidualHostCallFn>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Install the active residual-call host trampoline. Pass `None` to clear.
+pub fn set_residual_host_call(hook: Option<ResidualHostCallFn>) {
+    RESIDUAL_HOST_CALL.with(|c| c.set(hook));
+}
+
+/// The active residual-call host trampoline, or `None` for direct transmute.
+pub fn residual_host_call() -> Option<ResidualHostCallFn> {
+    RESIDUAL_HOST_CALL.with(|c| c.get())
+}

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2095,10 +2095,7 @@ pub trait Backend: Send {
                 (4, true) => (addr as *const i32).read_unaligned() as i64,
                 (4, false) => (addr as *const u32).read_unaligned() as i64,
                 (8, _) => (addr as *const i64).read_unaligned(),
-                other => panic!(
-                    "bh_getfield_gc_i: unsupported (size, signed) = {:?}",
-                    other,
-                ),
+                other => panic!("bh_getfield_gc_i: unsupported (size, signed) = {:?}", other,),
             }
         }
     }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2068,52 +2068,117 @@ pub trait Backend: Send {
 
     // ── model.py:216-228 field operations ──
     /// model.py:216 bh_getfield_gc_i(struct, fielddescr)
+    /// `llmodel.py:693-696 bh_getfield_gc_i` → `read_int_at_mem(struct,
+    /// ofs, size, sign)`.  `unpack_fielddescr_size` yields `(offset,
+    /// field_size, is_field_signed)`; the load mirrors the array
+    /// default's `read_unaligned` discrimination so byte/short fields
+    /// need not be naturally aligned.  Shared by pyre's raw-memory
+    /// backends (cranelift, dynasm, wasm); backends routing field reads
+    /// through their own runtime override.
     fn bh_getfield_gc_i(
         &self,
-        _struct_ptr: i64,
-        _fielddescr: &majit_translate::jitcode::BhDescr,
+        struct_ptr: i64,
+        fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> i64 {
-        0
+        let (offset, size, sign) = fielddescr.unpack_fielddescr_size();
+        let addr = (struct_ptr as usize).wrapping_add(offset);
+        // SAFETY: `struct_ptr` is a GC-managed struct pointer threaded
+        // through from the trace recorder / blackhole; `offset`/`size`
+        // come from the field descriptor.  `read_unaligned` mirrors
+        // `llmodel.py:490 read_int_at_mem`.
+        unsafe {
+            match (size, sign) {
+                (1, true) => (addr as *const i8).read_unaligned() as i64,
+                (1, false) => (addr as *const u8).read_unaligned() as i64,
+                (2, true) => (addr as *const i16).read_unaligned() as i64,
+                (2, false) => (addr as *const u16).read_unaligned() as i64,
+                (4, true) => (addr as *const i32).read_unaligned() as i64,
+                (4, false) => (addr as *const u32).read_unaligned() as i64,
+                (8, _) => (addr as *const i64).read_unaligned(),
+                other => panic!(
+                    "bh_getfield_gc_i: unsupported (size, signed) = {:?}",
+                    other,
+                ),
+            }
+        }
     }
-    /// model.py:217 bh_getfield_gc_r(struct, fielddescr)
+    /// model.py:217 bh_getfield_gc_r(struct, fielddescr) →
+    /// `read_ref_at_mem(struct, ofs)`.  Pointer-width load at the
+    /// field offset.  Shared by pyre's raw-memory backends.
     fn bh_getfield_gc_r(
         &self,
-        _struct_ptr: i64,
-        _fielddescr: &majit_translate::jitcode::BhDescr,
+        struct_ptr: i64,
+        fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> GcRef {
-        GcRef::NULL
+        let offset = fielddescr.as_offset();
+        // SAFETY: see `bh_getfield_gc_i`.
+        GcRef(unsafe { *((struct_ptr as *const u8).add(offset) as *const usize) })
     }
-    /// model.py:218 bh_getfield_gc_f(struct, fielddescr)
+    /// model.py:218 bh_getfield_gc_f(struct, fielddescr) →
+    /// `read_float_at_mem(struct, ofs)`.  Fixed `FLOATSTORAGE`-width
+    /// load at the field offset.  Shared by pyre's raw-memory backends.
     fn bh_getfield_gc_f(
         &self,
-        _struct_ptr: i64,
-        _fielddescr: &majit_translate::jitcode::BhDescr,
+        struct_ptr: i64,
+        fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> f64 {
-        0.0
+        let offset = fielddescr.as_offset();
+        let addr = (struct_ptr as usize).wrapping_add(offset);
+        // SAFETY: see `bh_getfield_gc_i`.
+        unsafe { (addr as *const f64).read_unaligned() }
     }
-    /// model.py:222 bh_setfield_gc_i(struct, newvalue, fielddescr)
+    /// model.py:222 / llmodel.py:716 bh_setfield_gc_i → `write_int_at_mem(struct,
+    /// ofs, size, value)`.  Size + sign come from `unpack_fielddescr_size`;
+    /// the store mirrors the field reader's width discrimination.  Shared by
+    /// pyre's raw-memory backends; the trait default was a silent no-op that
+    /// lost blackhole field writes (e.g. a rematerialized virtual's fields).
     fn bh_setfield_gc_i(
         &self,
-        _struct_ptr: i64,
-        _newvalue: i64,
-        _fielddescr: &majit_translate::jitcode::BhDescr,
+        struct_ptr: i64,
+        newvalue: i64,
+        fielddescr: &majit_translate::jitcode::BhDescr,
     ) {
+        let (offset, size, _sign) = fielddescr.unpack_fielddescr_size();
+        let addr = (struct_ptr as usize).wrapping_add(offset);
+        // SAFETY: `struct_ptr` is a GC-managed struct pointer; `offset`/`size`
+        // come from the field descriptor. `write_unaligned` matches the reader.
+        unsafe {
+            match size {
+                1 => (addr as *mut u8).write_unaligned(newvalue as u8),
+                2 => (addr as *mut u16).write_unaligned(newvalue as u16),
+                4 => (addr as *mut u32).write_unaligned(newvalue as u32),
+                8 => (addr as *mut i64).write_unaligned(newvalue),
+                other => panic!("bh_setfield_gc_i: unsupported field size {other}"),
+            }
+        }
     }
-    /// model.py:223 bh_setfield_gc_r(struct, newvalue, fielddescr)
+    /// model.py:223 / llmodel.py:723 bh_setfield_gc_r → pointer-width store at
+    /// the field offset plus the write barrier.
     fn bh_setfield_gc_r(
         &self,
-        _struct_ptr: i64,
-        _newvalue: GcRef,
-        _fielddescr: &majit_translate::jitcode::BhDescr,
+        struct_ptr: i64,
+        newvalue: GcRef,
+        fielddescr: &majit_translate::jitcode::BhDescr,
     ) {
+        let offset = fielddescr.as_offset();
+        // SAFETY: see `bh_setfield_gc_i`. `usize` is the pointer-width store.
+        unsafe { *((struct_ptr as *mut u8).add(offset) as *mut usize) = newvalue.0 };
+        // The store target may be an old-gen object holding a young ref; the
+        // active GC's barrier remembers it. No-op where no barrier is installed.
+        majit_gc::gc_write_barrier(GcRef(struct_ptr as usize));
     }
-    /// model.py:224 bh_setfield_gc_f(struct, newvalue, fielddescr)
+    /// model.py:224 / llmodel.py:728 bh_setfield_gc_f → `FLOATSTORAGE`-width
+    /// store at the field offset.
     fn bh_setfield_gc_f(
         &self,
-        _struct_ptr: i64,
-        _newvalue: f64,
-        _fielddescr: &majit_translate::jitcode::BhDescr,
+        struct_ptr: i64,
+        newvalue: f64,
+        fielddescr: &majit_translate::jitcode::BhDescr,
     ) {
+        let offset = fielddescr.as_offset();
+        let addr = (struct_ptr as usize).wrapping_add(offset);
+        // SAFETY: see `bh_setfield_gc_i`.
+        unsafe { (addr as *mut f64).write_unaligned(newvalue) };
     }
 
     // ── model.py:209-215, 247-253 array operations ──
@@ -2175,14 +2240,22 @@ pub trait Backend: Send {
             }
         }
     }
-    /// model.py:210 bh_getarrayitem_gc_r(array, index, arraydescr)
+    /// model.py:210 / llmodel.py:597 bh_getarrayitem_gc_r → pointer-width load
+    /// at `base_size + index * WORD`.  Shared by pyre's raw-memory backends;
+    /// the trait default returned NULL, losing reads of Ref array items (e.g. a
+    /// tuple element or a `locals_cells_stack_w` slot during blackhole resume).
     fn bh_getarrayitem_gc_r(
         &self,
-        _array_ptr: i64,
-        _index: i64,
-        _arraydescr: &majit_translate::jitcode::BhDescr,
+        array_ptr: i64,
+        index: i64,
+        arraydescr: &majit_translate::jitcode::BhDescr,
     ) -> GcRef {
-        GcRef::NULL
+        let base_size = arraydescr.array_base_size();
+        let item_addr = (array_ptr as usize)
+            .wrapping_add(base_size)
+            .wrapping_add((index as usize).wrapping_mul(std::mem::size_of::<usize>()));
+        // SAFETY: see `bh_getarrayitem_gc_i`. Ref items are pointer-width.
+        GcRef(unsafe { (item_addr as *const usize).read_unaligned() })
     }
     /// model.py:211 bh_getarrayitem_gc_f(array, index, arraydescr)
     ///
@@ -2220,32 +2293,63 @@ pub trait Backend: Send {
         // natural alignment — matching the dynasm backend's read_float_at_mem.
         unsafe { (item_addr as *const f64).read_unaligned() }
     }
-    /// model.py:247 bh_setarrayitem_gc_i(array, index, newvalue, arraydescr)
+    /// model.py:247 / llmodel.py:609 bh_setarrayitem_gc_i → typed store at
+    /// `base_size + index * itemsize`.  Width from `unpack_arraydescr_size`.
     fn bh_setarrayitem_gc_i(
         &self,
-        _array_ptr: i64,
-        _index: i64,
-        _newvalue: i64,
-        _arraydescr: &majit_translate::jitcode::BhDescr,
+        array_ptr: i64,
+        index: i64,
+        newvalue: i64,
+        arraydescr: &majit_translate::jitcode::BhDescr,
     ) {
+        let (base_size, itemsize, _sign) = arraydescr.unpack_arraydescr_size();
+        let item_addr = (array_ptr as usize)
+            .wrapping_add(base_size)
+            .wrapping_add((index as usize).wrapping_mul(itemsize));
+        // SAFETY: see `bh_setfield_gc_i`.
+        unsafe {
+            match itemsize {
+                1 => (item_addr as *mut u8).write_unaligned(newvalue as u8),
+                2 => (item_addr as *mut u16).write_unaligned(newvalue as u16),
+                4 => (item_addr as *mut u32).write_unaligned(newvalue as u32),
+                8 => (item_addr as *mut i64).write_unaligned(newvalue),
+                other => panic!("bh_setarrayitem_gc_i: unsupported itemsize {other}"),
+            }
+        }
     }
-    /// model.py:248 bh_setarrayitem_gc_r(array, index, newvalue, arraydescr)
+    /// model.py:248 / llmodel.py:613 bh_setarrayitem_gc_r → pointer-width store
+    /// at `base_size + index * WORD` plus the write barrier.
     fn bh_setarrayitem_gc_r(
         &self,
-        _array_ptr: i64,
-        _index: i64,
-        _newvalue: GcRef,
-        _arraydescr: &majit_translate::jitcode::BhDescr,
+        array_ptr: i64,
+        index: i64,
+        newvalue: GcRef,
+        arraydescr: &majit_translate::jitcode::BhDescr,
     ) {
+        let base_size = arraydescr.array_base_size();
+        let item_addr = (array_ptr as usize)
+            .wrapping_add(base_size)
+            .wrapping_add((index as usize).wrapping_mul(std::mem::size_of::<usize>()));
+        // SAFETY: see `bh_setfield_gc_i`.
+        unsafe { (item_addr as *mut usize).write_unaligned(newvalue.0) };
+        majit_gc::gc_write_barrier(GcRef(array_ptr as usize));
     }
-    /// model.py:249 bh_setarrayitem_gc_f(array, index, newvalue, arraydescr)
+    /// model.py:249 / llmodel.py:618 bh_setarrayitem_gc_f → `FLOATSTORAGE`-width
+    /// store at `base_size + index * WORD`.
     fn bh_setarrayitem_gc_f(
         &self,
-        _array_ptr: i64,
-        _index: i64,
-        _newvalue: f64,
-        _arraydescr: &majit_translate::jitcode::BhDescr,
+        array_ptr: i64,
+        index: i64,
+        newvalue: f64,
+        arraydescr: &majit_translate::jitcode::BhDescr,
     ) {
+        let base_size = arraydescr.array_base_size();
+        const FSIZE: usize = 8;
+        let item_addr = (array_ptr as usize)
+            .wrapping_add(base_size)
+            .wrapping_add((index as usize).wrapping_mul(FSIZE));
+        // SAFETY: see `bh_getarrayitem_gc_f`.
+        unsafe { (item_addr as *mut f64).write_unaligned(newvalue) };
     }
 
     // ── model.py: raw array operations ──
@@ -2356,48 +2460,124 @@ pub trait Backend: Send {
     fn bh_newstr(&self, _length: i64) -> i64 {
         0
     }
-    /// model.py:266 bh_call_i(func, args_i, args_r, args_f, calldescr)
+    /// model.py:266 bh_call_i(func, args_i, args_r, args_f, calldescr).
+    /// `llmodel.py:816 call_stub_i`: ABI-correct dispatch via the shared
+    /// arity table.  Default impl shared by pyre's raw-memory backends
+    /// (cranelift, dynasm, wasm) — the `extern "C"` transmute+call is
+    /// portable.  Without it `bhimpl_residual_call_*_i` silently no-ops.
     fn bh_call_i(
         &self,
-        _func: i64,
-        _args_i: Option<&[i64]>,
-        _args_r: Option<&[i64]>,
-        _args_f: Option<&[i64]>,
-        _calldescr: &majit_translate::jitcode::BhCallDescr,
+        func: i64,
+        args_i: Option<&[i64]>,
+        args_r: Option<&[i64]>,
+        args_f: Option<&[i64]>,
+        calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> i64 {
-        0
+        if func == 0 {
+            return 0;
+        }
+        if let Some(hook) = crate::call_stub::residual_host_call() {
+            let args = crate::call_stub::collect_call_args_positional(
+                &calldescr.arg_classes,
+                args_i,
+                args_r,
+                args_f,
+            );
+            return hook(func as usize, &args);
+        }
+        let (int_args, float_args) =
+            crate::call_stub::collect_call_args(&calldescr.arg_classes, args_i, args_r, args_f);
+        // SAFETY: `func` is a valid funcptr matching the (ints, floats) arity
+        // recovered from `calldescr.arg_classes`.
+        unsafe { crate::call_stub::bh_call_i_dispatch(func as usize, &int_args, &float_args) }
     }
-    /// model.py:268 bh_call_r(func, args_i, args_r, args_f, calldescr)
+    /// model.py:268 bh_call_r(func, args_i, args_r, args_f, calldescr).
+    /// `llmodel.py:818 bh_call_r`: GCREF-returning parallel — a host pointer
+    /// matches the integer dispatcher's return register, so wrap its result.
     fn bh_call_r(
         &self,
-        _func: i64,
-        _args_i: Option<&[i64]>,
-        _args_r: Option<&[i64]>,
-        _args_f: Option<&[i64]>,
-        _calldescr: &majit_translate::jitcode::BhCallDescr,
+        func: i64,
+        args_i: Option<&[i64]>,
+        args_r: Option<&[i64]>,
+        args_f: Option<&[i64]>,
+        calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> GcRef {
-        GcRef::NULL
+        if func == 0 {
+            return GcRef::NULL;
+        }
+        if let Some(hook) = crate::call_stub::residual_host_call() {
+            let args = crate::call_stub::collect_call_args_positional(
+                &calldescr.arg_classes,
+                args_i,
+                args_r,
+                args_f,
+            );
+            return GcRef(hook(func as usize, &args) as usize);
+        }
+        let (int_args, float_args) =
+            crate::call_stub::collect_call_args(&calldescr.arg_classes, args_i, args_r, args_f);
+        // SAFETY: see `bh_call_i`.
+        let raw =
+            unsafe { crate::call_stub::bh_call_i_dispatch(func as usize, &int_args, &float_args) };
+        GcRef(raw as usize)
     }
-    /// model.py:270 bh_call_f(func, args_i, args_r, args_f, calldescr)
+    /// model.py:270 bh_call_f(func, args_i, args_r, args_f, calldescr).
+    /// `llmodel.py:825 bh_call_f`: routes through the f64-typed dispatcher so
+    /// an f64 callee returns via the float register file.
     fn bh_call_f(
         &self,
-        _func: i64,
-        _args_i: Option<&[i64]>,
-        _args_r: Option<&[i64]>,
-        _args_f: Option<&[i64]>,
-        _calldescr: &majit_translate::jitcode::BhCallDescr,
+        func: i64,
+        args_i: Option<&[i64]>,
+        args_r: Option<&[i64]>,
+        args_f: Option<&[i64]>,
+        calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> f64 {
-        0.0
+        if func == 0 {
+            return 0.0;
+        }
+        if let Some(hook) = crate::call_stub::residual_host_call() {
+            let args = crate::call_stub::collect_call_args_positional(
+                &calldescr.arg_classes,
+                args_i,
+                args_r,
+                args_f,
+            );
+            // The trampoline returns an f64 callee result as its raw bits.
+            return f64::from_bits(hook(func as usize, &args) as u64);
+        }
+        let (int_args, float_args) =
+            crate::call_stub::collect_call_args(&calldescr.arg_classes, args_i, args_r, args_f);
+        // SAFETY: see `bh_call_i`.
+        unsafe { crate::call_stub::bh_call_f_dispatch(func as usize, &int_args, &float_args) }
     }
-    /// model.py:272 bh_call_v(func, args_i, args_r, args_f, calldescr)
+    /// model.py:272 bh_call_v(func, args_i, args_r, args_f, calldescr).
+    /// `llmodel.py:834 bh_call_v`: void-typed dispatch so a genuinely void
+    /// callee is invoked with the right C-ABI signature.
     fn bh_call_v(
         &self,
-        _func: i64,
-        _args_i: Option<&[i64]>,
-        _args_r: Option<&[i64]>,
-        _args_f: Option<&[i64]>,
-        _calldescr: &majit_translate::jitcode::BhCallDescr,
+        func: i64,
+        args_i: Option<&[i64]>,
+        args_r: Option<&[i64]>,
+        args_f: Option<&[i64]>,
+        calldescr: &majit_translate::jitcode::BhCallDescr,
     ) {
+        if func == 0 {
+            return;
+        }
+        if let Some(hook) = crate::call_stub::residual_host_call() {
+            let args = crate::call_stub::collect_call_args_positional(
+                &calldescr.arg_classes,
+                args_i,
+                args_r,
+                args_f,
+            );
+            let _ = hook(func as usize, &args);
+            return;
+        }
+        let (int_args, float_args) =
+            crate::call_stub::collect_call_args(&calldescr.arg_classes, args_i, args_r, args_f);
+        // SAFETY: see `bh_call_i`.
+        unsafe { crate::call_stub::bh_call_v_dispatch(func as usize, &int_args, &float_args) }
     }
 
     // ── model.py: additional bh_* helpers ──

--- a/majit/majit-metainterp/src/cpu.rs
+++ b/majit/majit-metainterp/src/cpu.rs
@@ -241,10 +241,12 @@ pub trait Cpu: Send + Sync {
         let lendescr = arraydescr.len_descr()?;
         let addr = array.0 + lendescr.offset();
         // SAFETY: caller has guaranteed `array` is a valid array gcref
-        // and `lendescr.offset()` is the registered length field
-        // offset; the length is a 64-bit signed integer per
-        // `WORD == 8` upstream (`llmodel.py:587`).
-        Some(unsafe { *(addr as *const i64) })
+        // and `lendescr.offset()` is the registered length field offset.
+        // The length is a machine-word (`Signed`/`WORD`) field
+        // (`llmodel.py:587`): read it at `usize` width so a 32-bit target
+        // (`WORD == 4`) does not pull the adjacent field into the high
+        // half. On 64-bit this is identical to the previous `i64` read.
+        Some(unsafe { *(addr as *const usize) as i64 })
     }
 
     /// `model.py:209+ cpu.bh_strlen` /

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -19,7 +19,39 @@
 
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use wasm_clock::Instant;
+
+/// Monotonic substitute for `std::time::Instant` on wasm32-unknown-unknown,
+/// which has no clock (`Instant::now()` there panics). The profiler only needs
+/// non-decreasing values to charge relative time against, so each `now()`
+/// advances a global counter; the resulting `MAJIT_STATS` timings are arbitrary
+/// but internally consistent and never panic. Mirrors the
+/// `Instant::now()` / `saturating_duration_since` surface the timer uses, so
+/// the timing code below is platform-agnostic.
+#[cfg(target_arch = "wasm32")]
+mod wasm_clock {
+    use core::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    static TICK_NS: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Clone, Copy, Debug)]
+    pub struct Instant(u64);
+
+    impl Instant {
+        pub fn now() -> Self {
+            Instant(TICK_NS.fetch_add(1, Ordering::Relaxed))
+        }
+
+        pub fn saturating_duration_since(self, earlier: Instant) -> Duration {
+            Duration::from_nanos(self.0.saturating_sub(earlier.0))
+        }
+    }
+}
 
 use majit_backend::CpuTotalTracker;
 use majit_ir::OpCode;

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -833,6 +833,7 @@ mod tests {
         opt.snapshot_boxes = snapshots;
         let result: Vec<Op> = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecAssoc::new(), 1024)
+            .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())
             .collect();
@@ -896,6 +897,7 @@ mod tests {
         opt.snapshot_boxes = snapshots;
         let result: Vec<Op> = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecAssoc::new(), 2)
+            .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())
             .collect();

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3327,7 +3327,7 @@ impl Optimization for OptHeap {
             | OptimizationResult::Restart(_) => {
                 self.last_emitted_removed = false;
             }
-            OptimizationResult::Remove | OptimizationResult::InvalidLoop => {}
+            OptimizationResult::Remove | OptimizationResult::InvalidLoop(_) => {}
         }
         result
     }
@@ -4565,7 +4565,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -4979,7 +4979,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -5687,7 +5687,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -6245,7 +6245,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -6344,7 +6344,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -6573,7 +6573,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -6655,7 +6655,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -6733,7 +6733,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -2315,7 +2315,7 @@ impl OptIntBounds {
             opcode,
             OpCode::IntAddOvf | OpCode::IntSubOvf | OpCode::IntMulOvf
         ) {
-            return OptimizationResult::InvalidLoop;
+            return OptimizationResult::InvalidLoop("GUARD_OVERFLOW after a non-overflowing op");
         }
         // intbounds.py:240: return self.emit(op)
         OptimizationResult::PassOn
@@ -3528,7 +3528,7 @@ mod tests {
                     ctx.emit(resolved_op.clone());
                     Some(resolved_op)
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             };

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -387,9 +387,10 @@ pub enum OptimizationResult {
     /// Pass the operation to the next pass unchanged.
     PassOn,
     /// rewrite.py:406 — a guard was proven to always fail; abort the trace.
-    /// RPython raises `InvalidLoop`; the optimizer catches it and discards
-    /// the loop or bridge.
-    InvalidLoop,
+    /// RPython raises `InvalidLoop`; pyre threads it as a value (the driver
+    /// converts it to `Err(InvalidLoop)` at the pass barrier) so it works
+    /// under `panic=abort`.  Carries the abandon reason for diagnostics.
+    InvalidLoop(&'static str),
 }
 
 /// optimizer.py:47-54: deferred postprocess for GUARD_CLASS/GUARD_NONNULL_CLASS.
@@ -540,14 +541,6 @@ pub use crate::optimizeopt::info::StringLengthResolver;
 pub use crate::optimizeopt::info::{StringConstantAllocator, StringContentResolver};
 
 use crate::optimizeopt::info::PtrInfoExt;
-
-/// `optimizer.py:867 raise SpeculativeError`.  Panic-based propagation
-/// reaches `unroll.py:122 except SpeculativeError: raise InvalidLoop`
-/// which the unroll-pass entry catches via `catch_unwind` to convert
-/// to an `InvalidLoop`.
-fn raise_speculative_error(reason: &'static str) -> ! {
-    std::panic::panic_any(crate::optimize::SpeculativeError(reason));
-}
 
 /// Context provided to optimization passes.
 ///
@@ -915,6 +908,18 @@ pub struct OptContext {
     /// `OptimizationResult::Remove`, reset on every successful
     /// `emit_operation` (see `Optimizer::emit_operation`).
     pub last_op_removed: bool,
+    /// Deferred `InvalidLoop` signal.  RPython `raise InvalidLoop`
+    /// abandons the trace; pyre carries the same signal as a
+    /// `Result<_, InvalidLoop>` threaded through the optimizer driver so
+    /// it works under `panic=abort` (wasm32) as well as `panic=unwind`.
+    /// Leaf sites that cannot return `Result` directly (e.g.
+    /// `get_const_info_mut_box`, deep inside a pass) record the signal
+    /// here and return a benign value; the driver checks it at the next
+    /// barrier (`propagate_from_pass_range`) and converts it to `Err`.
+    /// First write wins so the innermost reason is preserved.  `Cell` so
+    /// `&self` leaf methods (e.g. `protect_speculative_operation`) can
+    /// record without threading `&mut`.
+    pub pending_invalid_loop: std::cell::Cell<Option<crate::optimize::InvalidLoop>>,
 }
 
 /// heaptracker.py:66: `if name == 'typeptr': continue`
@@ -1592,6 +1597,32 @@ impl OptContext {
         }
     }
 
+    /// Record an `InvalidLoop` abandon signal from a leaf site that cannot
+    /// return `Result` directly.  First write wins so the innermost reason
+    /// survives.  The driver converts it to `Err` at the next barrier.
+    pub fn signal_invalid_loop(&self, reason: &'static str) {
+        let cur = self.pending_invalid_loop.take();
+        self.pending_invalid_loop
+            .set(Some(cur.unwrap_or(crate::optimize::InvalidLoop(reason))));
+    }
+
+    /// Consume any pending `InvalidLoop` signal recorded via
+    /// [`signal_invalid_loop`](Self::signal_invalid_loop).
+    pub fn take_invalid_loop(&self) -> Option<crate::optimize::InvalidLoop> {
+        self.pending_invalid_loop.take()
+    }
+
+    /// Non-consuming check for a pending `InvalidLoop` signal.  Used by
+    /// leaf sites (e.g. `constant_fold`) that must bail immediately after a
+    /// failed `protect_speculative_operation` without consuming the signal,
+    /// so the driver still aborts at its barrier.
+    pub fn has_pending_invalid_loop(&self) -> bool {
+        let v = self.pending_invalid_loop.take();
+        let present = v.is_some();
+        self.pending_invalid_loop.set(v);
+        present
+    }
+
     pub fn new(estimated_ops: usize) -> Self {
         OptContext {
             new_operations: Vec::with_capacity(estimated_ops),
@@ -1653,6 +1684,7 @@ impl OptContext {
             cpu: crate::cpu::default_cpu(),
             remove_gctypeptr: true,
             last_op_removed: false,
+            pending_invalid_loop: std::cell::Cell::new(None),
         }
     }
 
@@ -2199,6 +2231,7 @@ impl OptContext {
             cpu: crate::cpu::default_cpu(),
             remove_gctypeptr: true,
             last_op_removed: false,
+            pending_invalid_loop: std::cell::Cell::new(None),
         }
     }
 
@@ -5453,9 +5486,11 @@ impl OptContext {
         if let Value::Int(intval) = value {
             if let Some(mut bound) = op.int_bound_mut() {
                 if !bound.contains(intval as i64) {
-                    std::panic::panic_any(crate::optimize::InvalidLoop(
+                    drop(bound);
+                    self.signal_invalid_loop(
                         "constant int is outside the range allowed for that box",
-                    ));
+                    );
+                    return;
                 }
                 let _ = bound.make_eq_const(intval as i64);
             }
@@ -6613,6 +6648,12 @@ impl OptContext {
             }
         }
         self.protect_speculative_operation(op);
+        // protect_speculative_operation defers an `InvalidLoop` instead of
+        // raising; bail before reading the (now unvalidated) memory so the
+        // fold never dereferences an ill-typed speculative pointer.
+        if self.has_pending_invalid_loop() {
+            return None;
+        }
         let mut argboxes: Vec<Value> = Vec::with_capacity(op.num_args());
         for i in 0..op.num_args() {
             argboxes.push(
@@ -6639,14 +6680,14 @@ impl OptContext {
     /// optimizer.py:818-867 `protect_speculative_operation(op)` — when
     /// constant-folding a pure operation that reads memory from a
     /// gcref, validate the gcref is non-null and of a valid type;
-    /// raise `SpeculativeError` otherwise.
+    /// signal `InvalidLoop` otherwise.
     ///
     /// Returns `()` — matching upstream's Python `def protect_
     /// speculative_operation(self, op):` which has no return value.
-    /// Either returns normally (validation passed) or raises
-    /// `SpeculativeError` via `raise_speculative_error` (panic with
-    /// `crate::optimize::SpeculativeError`).  `unroll.py:119-123`
-    /// catches it at the unroll-phase boundary.
+    /// Either returns normally (validation passed) or records a deferred
+    /// `InvalidLoop` signal on the context (via `signal_invalid_loop`),
+    /// which `constant_fold` observes to bail out and the driver surfaces
+    /// as `Err(InvalidLoop)` at its next barrier (`unroll.py:119-123`).
     ///
     /// The `supports_guard_gc_type == false` gate that was previously
     /// inside this function has been moved to `constant_fold` (the
@@ -6696,7 +6737,7 @@ impl OptContext {
                 .and_then(|d| d.as_field_descr())
                 .expect("GETFIELD_GC_PURE_* descr must be a FieldDescr");
             if self.cpu.protect_speculative_field(gcref, fd).is_err() {
-                raise_speculative_error("protect_speculative_field");
+                self.signal_invalid_loop("protect_speculative_field");
             }
             return;
         }
@@ -6724,7 +6765,8 @@ impl OptContext {
                 .and_then(|d| d.as_array_descr())
                 .expect("array op descr must be an ArrayDescr");
             if self.cpu.protect_speculative_array(array, ad).is_err() {
-                raise_speculative_error("protect_speculative_array");
+                self.signal_invalid_loop("protect_speculative_array");
+                return;
             }
             if opnum == OpCode::ArraylenGc {
                 return;
@@ -6743,7 +6785,8 @@ impl OptContext {
                 v => unreachable!("STRGETITEM / STRLEN arg0 must be a gcref; got {:?}", v),
             };
             if self.cpu.protect_speculative_string(string).is_err() {
-                raise_speculative_error("protect_speculative_string");
+                self.signal_invalid_loop("protect_speculative_string");
+                return;
             }
             if opnum == OpCode::Strlen {
                 return;
@@ -6765,7 +6808,8 @@ impl OptContext {
                 ),
             };
             if self.cpu.protect_speculative_unicode(unicode).is_err() {
-                raise_speculative_error("protect_speculative_unicode");
+                self.signal_invalid_loop("protect_speculative_unicode");
+                return;
             }
             if opnum == OpCode::Unicodelen {
                 return;
@@ -6793,7 +6837,7 @@ impl OptContext {
             ),
         };
         if !(0 <= index && index < arraylength) {
-            raise_speculative_error("index out of bounds for constant-fold");
+            self.signal_invalid_loop("index out of bounds for constant-fold");
         }
     }
 
@@ -7654,11 +7698,12 @@ impl OptContext {
     /// call on the same address returns the same shared
     /// `StructPtrInfo`.
     ///
-    /// Returns `None` only when `opref` is not a constant pointer at all
+    /// Returns `None` when `opref` is not a constant pointer at all
     /// (matching PyPy's `getrawptrinfo` returning `None` for non-pointer
-    /// boxes — there's no `_get_info` to call). For a constant pointer
-    /// that resolves to a null `gcref`, this raises `InvalidLoop` via
-    /// `panic_any`, exactly as PyPy `info.py:720-721` does:
+    /// boxes — there's no `_get_info` to call), and also when a constant
+    /// pointer resolves to a null `gcref`. In the null case it additionally
+    /// records a deferred `InvalidLoop` signal on the context, mirroring
+    /// `info.py:720-721`:
     ///
     /// ```python
     /// def _get_info(self, descr, optheap):
@@ -7668,8 +7713,8 @@ impl OptContext {
     /// ```
     ///
     /// The trace was constant-folding through a null base pointer, which
-    /// is an impossible execution path; the optimizer aborts so the JIT
-    /// can retry with a different shape.
+    /// is an impossible execution path; the driver aborts the trace at its
+    /// next barrier so the JIT can retry with a different shape.
     /// Like `get_const_info_mut` but does NOT create an entry on miss.
     /// Returns `None` when:
     /// - `opref` is not a constant pointer
@@ -7743,11 +7788,12 @@ impl OptContext {
             Some(PtrInfo::Constant(g)) => g,
             _ => return None,
         };
-        // info.py:720-721: if not ref: raise InvalidLoop
+        // info.py:720-721: if not ref: raise InvalidLoop. Recorded as a
+        // deferred signal (checked by the driver) and `None` returned so
+        // callers take their existing "no info" path until the barrier aborts.
         if gcref.is_null() {
-            std::panic::panic_any(crate::optimize::InvalidLoop(
-                "ConstPtrInfo._get_info: null constant base pointer",
-            ));
+            self.signal_invalid_loop("ConstPtrInfo._get_info: null constant base pointer");
+            return None;
         }
         let addr = gcref.0;
         // info.py:722-725: info = optheap.const_infos.get(ref, None)
@@ -7810,11 +7856,11 @@ impl OptContext {
             Some(PtrInfo::Constant(g)) => g,
             _ => return None,
         };
-        // info.py:730-731: if not ref: raise InvalidLoop
+        // info.py:730-731: if not ref: raise InvalidLoop. Deferred signal +
+        // `None` return; the driver aborts at the next barrier.
         if gcref.is_null() {
-            std::panic::panic_any(crate::optimize::InvalidLoop(
-                "ConstPtrInfo._get_array_info: null constant base pointer",
-            ));
+            self.signal_invalid_loop("ConstPtrInfo._get_array_info: null constant base pointer");
+            return None;
         }
         let addr = gcref.0;
         Some(self.const_infos.entry(addr).or_insert_with(|| {
@@ -9764,27 +9810,22 @@ mod constant_ptr_info_tests {
     }
 
     /// info.py:719-720 `if not ref: raise InvalidLoop` — null protection.
-    /// `get_const_info_mut` raises `InvalidLoop` (via `panic_any`) when
-    /// the constant pointer resolves to a null `gcref`. Callers in PyPy
-    /// rely on the exception to abort the impossible trace shape so the
-    /// JIT can retry; the Rust port mirrors that contract.
-    ///
-    /// `panic_any(InvalidLoop)` is not a string panic so we use
-    /// `catch_unwind` + downcast to assert the typed payload, matching
-    /// how other optimizer passes catch the same exception.
+    /// `get_const_info_mut` records a deferred `InvalidLoop` signal and
+    /// returns `None` when the constant pointer resolves to a null `gcref`.
+    /// The driver aborts the impossible trace shape at the next barrier so
+    /// the JIT can retry; the Rust port mirrors that contract without
+    /// unwinding (so it works under `panic=abort`).
     #[test]
-    fn const_info_mut_raises_on_null_value_ref_constant() {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let mut ctx = OptContext::new(0);
-            let ref_null = OpRef::ref_op(10_007);
-            let seed_box = ctx.materialize_box_at(ref_null);
-            ctx.seed_constant(&seed_box, Value::Ref(GcRef(0)));
-            let _ = ctx.get_const_info_mut(ref_null, None);
-        }));
-        let err = result.expect_err("expected InvalidLoop panic");
-        let invalid = err
-            .downcast_ref::<crate::optimize::InvalidLoop>()
-            .expect("expected InvalidLoop payload");
+    fn const_info_mut_signals_invalid_loop_on_null_value_ref_constant() {
+        let mut ctx = OptContext::new(0);
+        let ref_null = OpRef::ref_op(10_007);
+        let seed_box = ctx.materialize_box_at(ref_null);
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0)));
+        let info = ctx.get_const_info_mut(ref_null, None);
+        assert!(info.is_none(), "null constant base must not yield ptr info");
+        let invalid = ctx
+            .take_invalid_loop()
+            .expect("expected pending InvalidLoop signal");
         assert!(invalid.0.contains("null constant base pointer"));
     }
 
@@ -9794,18 +9835,16 @@ mod constant_ptr_info_tests {
     /// case — null-pointer protection is uniform regardless of the
     /// underlying constant tag.
     #[test]
-    fn const_info_mut_raises_on_null_int_constant() {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let mut ctx = OptContext::new(0);
-            let opref = OpRef::int_op(10_010);
-            let seed_box = ctx.materialize_box_at(opref);
-            ctx.seed_constant(&seed_box, Value::Int(0));
-            let _ = ctx.get_const_info_mut(opref, None);
-        }));
-        let err = result.expect_err("expected InvalidLoop panic");
-        let invalid = err
-            .downcast_ref::<crate::optimize::InvalidLoop>()
-            .expect("expected InvalidLoop payload");
+    fn const_info_mut_signals_invalid_loop_on_null_int_constant() {
+        let mut ctx = OptContext::new(0);
+        let opref = OpRef::int_op(10_010);
+        let seed_box = ctx.materialize_box_at(opref);
+        ctx.seed_constant(&seed_box, Value::Int(0));
+        let info = ctx.get_const_info_mut(opref, None);
+        assert!(info.is_none(), "null constant base must not yield ptr info");
+        let invalid = ctx
+            .take_invalid_loop()
+            .expect("expected pending InvalidLoop signal");
         assert!(invalid.0.contains("null constant base pointer"));
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -8125,37 +8125,47 @@ impl OptContext {
             let field_descr = ensure_field_descr_arc
                 .as_field_descr()
                 .expect("ensure_ptr_info_arg0: field op without FieldDescr");
-            // optimizer.py:479-484: parent_descr.is_object() decides Instance vs Struct.
-            let parent_descr = field_descr.get_parent_descr().unwrap_or_else(|| {
-                panic!(
-                    "ensure_ptr_info_arg0: FieldDescr.get_parent_descr() returned None \
-                     for opcode={:?} descr={:?} field_name={:?} index_in_parent={} \
-                     offset={} field_type={:?}; the FieldDescr implementation must \
-                     override get_parent_descr() for parity with optimizer.py:478",
-                    op.opcode,
-                    op.getdescr(),
-                    field_descr.field_name(),
-                    field_descr.index_in_parent(),
-                    field_descr.offset(),
-                    field_descr.field_type(),
-                )
-            });
-            let is_object = parent_descr
-                .as_size_descr()
-                .expect(
-                    "ensure_ptr_info_arg0: FieldDescr.get_parent_descr() must point at a SizeDescr",
-                )
-                .is_object();
-            let mut new_info = if is_object {
-                PtrInfo::instance(Some(parent_descr.clone()), None)
+            if field_descr.is_w_class() {
+                // The `w_class`/typeptr header carries class identity, not a
+                // value field, so it has no parent SizeDescr. arg0 is just a
+                // non-null instance with no known layout — the same PtrInfo
+                // GUARD_CLASS builds (optimizer.py:488-489). OptVirtualize folds
+                // this read for virtuals (virtualize.rs `is_w_class`); a
+                // non-virtual heap object's `__class__` read reaches here.
+                PtrInfo::instance(None, None)
             } else {
-                PtrInfo::struct_ptr(parent_descr.clone())
-            };
-            // optimizer.py:484: opinfo.init_fields(parent_descr, descr.get_index())
-            // info.py:180-188 init_fields(parent_descr, index) sets self.descr
-            // and pre-allocates _fields by parent slot count.
-            new_info.init_fields(parent_descr, field_descr.index_in_parent());
-            new_info
+                // optimizer.py:479-484: parent_descr.is_object() decides Instance vs Struct.
+                let parent_descr = field_descr.get_parent_descr().unwrap_or_else(|| {
+                    panic!(
+                        "ensure_ptr_info_arg0: FieldDescr.get_parent_descr() returned None \
+                         for opcode={:?} descr={:?} field_name={:?} index_in_parent={} \
+                         offset={} field_type={:?}; the FieldDescr implementation must \
+                         override get_parent_descr() for parity with optimizer.py:478",
+                        op.opcode,
+                        op.getdescr(),
+                        field_descr.field_name(),
+                        field_descr.index_in_parent(),
+                        field_descr.offset(),
+                        field_descr.field_type(),
+                    )
+                });
+                let is_object = parent_descr
+                    .as_size_descr()
+                    .expect(
+                        "ensure_ptr_info_arg0: FieldDescr.get_parent_descr() must point at a SizeDescr",
+                    )
+                    .is_object();
+                let mut new_info = if is_object {
+                    PtrInfo::instance(Some(parent_descr.clone()), None)
+                } else {
+                    PtrInfo::struct_ptr(parent_descr.clone())
+                };
+                // optimizer.py:484: opinfo.init_fields(parent_descr, descr.get_index())
+                // info.py:180-188 init_fields(parent_descr, index) sets self.descr
+                // and pre-allocates _fields by parent slot count.
+                new_info.init_fields(parent_descr, field_descr.index_in_parent());
+                new_info
+            }
         } else if op.opcode.is_getarrayitem()
             || op.opcode == OpCode::SetarrayitemGc
             || op.opcode == OpCode::ArraylenGc

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1473,7 +1473,7 @@ impl Optimizer {
 
     /// optimizer.py: flush()
     /// Flush all passes' postponed state.
-    pub fn flush(&mut self, ctx: &mut OptContext) {
+    pub fn flush(&mut self, ctx: &mut OptContext) -> Result<(), crate::optimize::InvalidLoop> {
         for pass_idx in 0..self.passes.len() {
             // heap.flush() resolves the "next_optimization" emit_extra
             // target through `ctx.current_pass_idx`. Set it to the
@@ -1488,9 +1488,11 @@ impl Optimizer {
             // optimizer.send_extra_operation(op, self.next_optimization).
             // During flush we must preserve that contract: each pass's flush
             // output is processed only by downstream passes, never by the
-            // flushing pass again.
-            self.drain_extra_operations_from(pass_idx + 1, ctx);
+            // flushing pass again. send_extra_operation (via the drain) may
+            // raise InvalidLoop; propagate it like RPython's flush.
+            self.drain_extra_operations_from(pass_idx + 1, ctx)?;
         }
+        Ok(())
     }
 
     /// Build a short preamble from an optimized trace's preamble section.
@@ -2489,7 +2491,7 @@ impl Optimizer {
         // RPython: flush() before JUMP processing (export_state calls flush
         // before get_virtual_state). Phase 2 skips flush.
         if !self.skip_flush {
-            self.flush(&mut ctx);
+            self.flush(&mut ctx)?;
         }
 
         // RPython unroll.py:454-457:
@@ -2861,7 +2863,7 @@ impl Optimizer {
                 }
                 // unroll.py:203 self.flush() — force lazy sets before
                 // producing short preamble ops (heap.py:53 invariant).
-                self.flush(&mut ctx);
+                self.flush(&mut ctx)?;
 
                 // Now force all resolved (and dedup'd) args.
                 // unroll.py:454 `end_args = [force_box_for_end_of_preamble(a)
@@ -3219,8 +3221,9 @@ impl Optimizer {
         ctx.new_operations
             .retain(|_| keep_iter.next().unwrap_or(true));
 
-        // Drain remaining extra ops.
-        self.drain_extra_operations_from(0, &mut ctx);
+        // Drain remaining extra ops. send_extra_operation may raise
+        // InvalidLoop; propagate it.
+        self.drain_extra_operations_from(0, &mut ctx)?;
         // Path A — second finalize cascade also removed. Same rationale as
         // above: each emit_extra-queued op runs through `propagate_from_pass_range`
         // which resolves its incoming args at input time via
@@ -3824,7 +3827,7 @@ impl Optimizer {
         // pre-flush snapshot and let try_jump_to_existing_trace compute
         // VS internally — matching RPython 1:1.
         ctx.skip_flush_mode = retarget_close_jump;
-        self.flush(&mut ctx);
+        self.flush(&mut ctx)?;
 
         // unroll.py:204-205: force_at_the_end_of_preamble for each jump arg
         let saved_pass_idx = ctx.current_pass_idx;
@@ -6059,7 +6062,7 @@ mod tests {
         opt.add_pass(Box::new(FlushCounter { hits: hits.clone() }));
 
         let mut ctx = OptContext::new(0);
-        opt.flush(&mut ctx);
+        opt.flush(&mut ctx).unwrap();
 
         assert_eq!(hits.get(), 2);
     }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1505,14 +1505,18 @@ impl Optimizer {
     /// Send an extra operation through the pass chain as if it were
     /// a new operation from the trace. Used by passes that need to
     /// inject additional operations.
-    pub fn send_extra_operation(&mut self, op: &Op, ctx: &mut OptContext) {
+    pub fn send_extra_operation(
+        &mut self,
+        op: &Op,
+        ctx: &mut OptContext,
+    ) -> Result<(), crate::optimize::InvalidLoop> {
         let op_rc = std::rc::Rc::new(op.clone());
         // Register the producer for op_rc.pos before dispatch so a pass that
         // folds it via make_equal_to(from_bound_op(op_rc), ..) writes the
         // forwarding onto a host find_producer_op can reach (the normal trace
         // path registers via bind_input_resops; emit_extra does the same).
         ctx.register_extra_producer(&op_rc);
-        self.propagate_from_pass(0, &op_rc, ctx);
+        self.propagate_from_pass(0, &op_rc, ctx)
     }
 
     /// RPython optimizer.py: emit_extra(op, emit=False) parity.
@@ -1523,10 +1527,10 @@ impl Optimizer {
         after_pass_idx: usize,
         op: &Op,
         ctx: &mut OptContext,
-    ) {
+    ) -> Result<(), crate::optimize::InvalidLoop> {
         let op_rc = std::rc::Rc::new(op.clone());
         ctx.register_extra_producer(&op_rc);
-        self.propagate_from_pass(after_pass_idx + 1, &op_rc, ctx);
+        self.propagate_from_pass(after_pass_idx + 1, &op_rc, ctx)
     }
 
     /// optimizer.py:345-364: force_box — force a virtual to be materialized.
@@ -1984,7 +1988,14 @@ impl Optimizer {
         // (`bind_input_resops` / emit) carry identity instead.
         let ops_rc: Vec<majit_ir::OpRc> =
             ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
+        // This `&[Op]` convenience overload backs unit-test fixtures and the
+        // legacy `propagate_all_forward` / `optimize_trace_with_constants`
+        // helpers, not the production JIT path (which uses the `_oprc` /
+        // `_vable_out` / `optimize_bridge` `Result` entries).  An `InvalidLoop`
+        // here means a fixture built a contradictory trace, which should fail
+        // loudly rather than be silently swallowed.
         self.run_optimize_from_inputs(&ops_rc, constants, num_inputs, false)
+            .expect("optimize_with_constants_and_inputs: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())
             .collect()
@@ -2001,7 +2012,7 @@ impl Optimizer {
         ops: &[majit_ir::OpRc],
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
-    ) -> Vec<majit_ir::OpRc> {
+    ) -> Result<Vec<majit_ir::OpRc>, crate::optimize::InvalidLoop> {
         self.run_optimize_from_inputs(ops, constants, num_inputs, true)
     }
 
@@ -2011,7 +2022,7 @@ impl Optimizer {
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
         input_ops_from_ops: bool,
-    ) -> Vec<majit_ir::OpRc> {
+    ) -> Result<Vec<majit_ir::OpRc>, crate::optimize::InvalidLoop> {
         // Ensure new ops get positions beyond all original trace positions.
         // Original ops keep their tracer-assigned positions; new ops (constants,
         // force materializations) must not collide with them.
@@ -2049,7 +2060,7 @@ impl Optimizer {
         inputarg_base: u32,
         start_next_pos: u32,
         input_ops_from_ops: bool,
-    ) -> Vec<majit_ir::OpRc> {
+    ) -> Result<Vec<majit_ir::OpRc>, crate::optimize::InvalidLoop> {
         use majit_ir::OpRef;
         // Test-only auto-seed of `trace_inputargs` from the variant
         // tags of any InputArg*/IntOp/FloatOp/RefOp OpRef that references
@@ -2354,7 +2365,7 @@ impl Optimizer {
             // back to the interpreter — instead of letting
             // `inputarg_type_at_strict` hard-panic the worker thread.
             if (0..n).any(|i| ctx.inputarg_type_at(i).is_none()) {
-                std::panic::panic_any(crate::optimize::InvalidLoop(
+                return Err(crate::optimize::InvalidLoop(
                     "next_iteration_args longer than inputargs (full-body-walk \
                      cross-loop cut over a forced heap virtual)",
                 ));
@@ -2418,6 +2429,12 @@ impl Optimizer {
                 self,
                 &mut ctx,
             );
+            // unroll.py:483 `except InvalidLoop`: an incompatible imported
+            // virtual state recorded a deferred signal during import; abandon
+            // the loop before running Phase 2 against an incomplete import.
+            if let Some(e) = ctx.take_invalid_loop() {
+                return Err(e);
+            }
             if crate::optimizeopt::majit_log_enabled() {
                 if let Some((base, ref sa)) = ctx.imported_virtual_args {
                     eprintln!(
@@ -2466,7 +2483,7 @@ impl Optimizer {
                 last_op = Some((**op).clone());
                 break;
             }
-            self.propagate_one(op, &mut ctx);
+            self.propagate_one(op, &mut ctx)?;
         }
 
         // RPython: flush() before JUMP processing (export_state calls flush
@@ -2609,7 +2626,7 @@ impl Optimizer {
                 self.terminal_op = Some(terminal_op);
             } else {
                 // flush=True: send through passes (optimizer.py:555-556).
-                self.send_extra_operation(&terminal_op, &mut ctx);
+                self.send_extra_operation(&terminal_op, &mut ctx)?;
             }
         }
 
@@ -2698,420 +2715,433 @@ impl Optimizer {
         // spliced parity position below instead of appearing in
         // `ctx.new_operations` past the terminator.
         let mut extra_same_as_aliases: Vec<Op> = Vec::new();
-        self.exported_loop_state = jump.map(|jump| {
-            // RPython unroll.py:454-457 order:
-            //   end_args = [force_box_for_end_of_preamble(a) for a ...]
-            //   self.optimizer.flush()
-            //   virtual_state = self.get_virtual_state(end_args)
-            // — VS captured AFTER force + flush.
-            let original_jump_args: Vec<OpRef> = pre_jump_resolved_args.clone()
-                .map(|v| v.iter().map(|b| b.to_opref()).collect())
-                .unwrap_or_else(|| {
-                    jump.getarglist().iter()
-                        .map(|a| ctx.resolve_box_box(a).to_opref())
-                        .collect()
-                });
-            let mut resolved_args = original_jump_args.clone();
-            // Dedup: two cases require SameAs allocation at end of preamble.
-            //
-            // Case A — duplicate args: when two JUMP slots reference the same
-            // OpRef (e.g. b and t in fib_loop after b = t aliasing), create a
-            // fresh SameAs for the second occurrence so each slot has a
-            // distinct identity.
-            //
-            // Case B — preamble inputarg position used by a non-self slot:
-            // when JUMP slot j carries OpRef::int_op(k) and k < num_inputs, k != j,
-            // the export hands Phase 2 a `next_iteration_args[j] = OpRef::int_op(k)`
-            // entry that collides with body inputarg slot k's own source
-            // position. import_state forwards both `OpRef::int_op(j) → OpRef::int_op(k)` and
-            // `OpRef::int_op(k) → nia[k]`, and get_box_replacement walks the chain
-            // through OpRef::int_op(k), making body inputarg j resolve to nia[k]
-            // instead of OpRef::int_op(k). RPython avoids this with fresh-Box identity
-            // per phase; majit's flat OpRef space needs an explicit SameAs
-            // alias so nia[j] points outside the body inputarg position range.
-            {
-                let mut seen: majit_ir::vec_set::VecSet<OpRef> = majit_ir::vec_set::VecSet::new();
-                // RPython parity: positions already holding an emitted op
-                // are phase 1 results, not body inputarg sources. Only
-                // the UNUSED positions in 0..num_inputs correspond to
-                // trace inputargs (`InputArgRef/Int/Float` in RPython).
-                let emitted_positions: majit_ir::vec_set::VecSet<OpRef> = ctx
-                    .new_operations
-                    .iter()
-                    .map(|op| op.pos.get())
-                    .filter(|p| !p.is_none())
-                    .collect();
-                let original_args = resolved_args.clone();
-                for (slot_idx, arg) in resolved_args.iter_mut().enumerate() {
-                    if ctx.get_box_replacement_box(*arg).and_then(|cb| cb.const_value()).is_some() || *arg == OpRef::NONE {
-                        continue;
-                    }
-                    let is_dup = !seen.insert(*arg);
-                    // Case B fires only when slot k (where `k = arg.raw()`, the
-                    // position the current slot points at) holds a DIFFERENT
-                    // OpRef. If slot k self-forwards (original_args[k] ==
-                    // OpRef::int_op(k)), Phase 2 sets `forwarding[OpRef::int_op(k)] = OpRef::int_op(k)`
-                    // which is a no-op in make_equal_to — no chain forms, so no
-                    // aliasing is needed.
-                    let target_slot = arg.raw() as usize;
-                    let target_slot_self_forwards = original_args
-                        .get(target_slot)
-                        .map_or(true, |other| *other == *arg);
-                    let is_cross_inputarg = target_slot < num_inputs
-                        && target_slot != slot_idx
-                        && !emitted_positions.contains(arg)
-                        && !target_slot_self_forwards;
-                    if !is_dup && !is_cross_inputarg {
-                        continue;
-                    }
-                    let orig = *arg;
-                    // history.py:802-809 `record_same_as(box)` reads
-                    // `box.type` directly to pick `same_as_i/r/f` — there is
-                    // no guess-on-miss path in RPython. Match strict parity by
-                    // requiring `opref_type` to resolve; a None here is a
-                    // bookkeeping bug, not a recoverable case.
-                    let arg_type = ctx
-                        .opref_type(orig)
-                        .expect("propagate_from_pass_range SameAs: source OpRef missing Box.type");
-                    let same_as = OpCode::same_as_for_type(arg_type);
-                    let fresh = ctx.alloc_op_position_typed(arg_type);
-                    let arg0 = ctx.materialize_box_at(orig);
-                    let mut op = Op::new(same_as, &[arg0]);
-                    op.pos.set(fresh);
-                    // unroll.py:146 + compile.py:327 parity: accumulate the
-                    // alias op in `extra_same_as` and splice it between the
-                    // preamble body and the label at final assembly. Emitting
-                    // directly into `ctx.new_operations` would push the op
-                    // past the already-sent terminal JUMP and force the
-                    // loop-tail relocation workaround below.
-                    extra_same_as_aliases.push(op);
-                    let orig_box = ctx.get_box_replacement_box(orig);
-                    if let Some(info) = orig_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
-                        let fresh_info = match info {
-                            crate::optimizeopt::info::PtrInfo::Virtual(mut vinfo) => {
-                                for field in &mut vinfo.fields {
-                                    let orig_field = field.1.to_opref();
-                                    // RPython Box type parity: the alias
-                                    // inherits `box.type` from the original
-                                    // field. RPython Box always carries
-                                    // `box.type` (history.py:220), so a
-                                    // missing type here is an unrecoverable
-                                    // invariant violation — panic in release
-                                    // as well as debug.
-                                    let tp = ctx.opref_type(orig_field).unwrap_or_else(|| {
+        // `match` (not `jump.map(|jump| ...)`) so the `return Err(InvalidLoop)`
+        // for the preview virtual-state mismatch below propagates out of
+        // `optimize_with_constants_and_inputs_at`, not just the closure.
+        self.exported_loop_state = match jump {
+            Some(jump) => {
+                // RPython unroll.py:454-457 order:
+                //   end_args = [force_box_for_end_of_preamble(a) for a ...]
+                //   self.optimizer.flush()
+                //   virtual_state = self.get_virtual_state(end_args)
+                // — VS captured AFTER force + flush.
+                let original_jump_args: Vec<OpRef> = pre_jump_resolved_args
+                    .clone()
+                    .map(|v| v.iter().map(|b| b.to_opref()).collect())
+                    .unwrap_or_else(|| {
+                        jump.getarglist()
+                            .iter()
+                            .map(|a| ctx.resolve_box_box(a).to_opref())
+                            .collect()
+                    });
+                let mut resolved_args = original_jump_args.clone();
+                // Dedup: two cases require SameAs allocation at end of preamble.
+                //
+                // Case A — duplicate args: when two JUMP slots reference the same
+                // OpRef (e.g. b and t in fib_loop after b = t aliasing), create a
+                // fresh SameAs for the second occurrence so each slot has a
+                // distinct identity.
+                //
+                // Case B — preamble inputarg position used by a non-self slot:
+                // when JUMP slot j carries OpRef::int_op(k) and k < num_inputs, k != j,
+                // the export hands Phase 2 a `next_iteration_args[j] = OpRef::int_op(k)`
+                // entry that collides with body inputarg slot k's own source
+                // position. import_state forwards both `OpRef::int_op(j) → OpRef::int_op(k)` and
+                // `OpRef::int_op(k) → nia[k]`, and get_box_replacement walks the chain
+                // through OpRef::int_op(k), making body inputarg j resolve to nia[k]
+                // instead of OpRef::int_op(k). RPython avoids this with fresh-Box identity
+                // per phase; majit's flat OpRef space needs an explicit SameAs
+                // alias so nia[j] points outside the body inputarg position range.
+                {
+                    let mut seen: majit_ir::vec_set::VecSet<OpRef> =
+                        majit_ir::vec_set::VecSet::new();
+                    // RPython parity: positions already holding an emitted op
+                    // are phase 1 results, not body inputarg sources. Only
+                    // the UNUSED positions in 0..num_inputs correspond to
+                    // trace inputargs (`InputArgRef/Int/Float` in RPython).
+                    let emitted_positions: majit_ir::vec_set::VecSet<OpRef> = ctx
+                        .new_operations
+                        .iter()
+                        .map(|op| op.pos.get())
+                        .filter(|p| !p.is_none())
+                        .collect();
+                    let original_args = resolved_args.clone();
+                    for (slot_idx, arg) in resolved_args.iter_mut().enumerate() {
+                        if ctx
+                            .get_box_replacement_box(*arg)
+                            .and_then(|cb| cb.const_value())
+                            .is_some()
+                            || *arg == OpRef::NONE
+                        {
+                            continue;
+                        }
+                        let is_dup = !seen.insert(*arg);
+                        // Case B fires only when slot k (where `k = arg.raw()`, the
+                        // position the current slot points at) holds a DIFFERENT
+                        // OpRef. If slot k self-forwards (original_args[k] ==
+                        // OpRef::int_op(k)), Phase 2 sets `forwarding[OpRef::int_op(k)] = OpRef::int_op(k)`
+                        // which is a no-op in make_equal_to — no chain forms, so no
+                        // aliasing is needed.
+                        let target_slot = arg.raw() as usize;
+                        let target_slot_self_forwards = original_args
+                            .get(target_slot)
+                            .map_or(true, |other| *other == *arg);
+                        let is_cross_inputarg = target_slot < num_inputs
+                            && target_slot != slot_idx
+                            && !emitted_positions.contains(arg)
+                            && !target_slot_self_forwards;
+                        if !is_dup && !is_cross_inputarg {
+                            continue;
+                        }
+                        let orig = *arg;
+                        // history.py:802-809 `record_same_as(box)` reads
+                        // `box.type` directly to pick `same_as_i/r/f` — there is
+                        // no guess-on-miss path in RPython. Match strict parity by
+                        // requiring `opref_type` to resolve; a None here is a
+                        // bookkeeping bug, not a recoverable case.
+                        let arg_type = ctx.opref_type(orig).expect(
+                            "propagate_from_pass_range SameAs: source OpRef missing Box.type",
+                        );
+                        let same_as = OpCode::same_as_for_type(arg_type);
+                        let fresh = ctx.alloc_op_position_typed(arg_type);
+                        let arg0 = ctx.materialize_box_at(orig);
+                        let mut op = Op::new(same_as, &[arg0]);
+                        op.pos.set(fresh);
+                        // unroll.py:146 + compile.py:327 parity: accumulate the
+                        // alias op in `extra_same_as` and splice it between the
+                        // preamble body and the label at final assembly. Emitting
+                        // directly into `ctx.new_operations` would push the op
+                        // past the already-sent terminal JUMP and force the
+                        // loop-tail relocation workaround below.
+                        extra_same_as_aliases.push(op);
+                        let orig_box = ctx.get_box_replacement_box(orig);
+                        if let Some(info) = orig_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
+                            let fresh_info = match info {
+                                crate::optimizeopt::info::PtrInfo::Virtual(mut vinfo) => {
+                                    for field in &mut vinfo.fields {
+                                        let orig_field = field.1.to_opref();
+                                        // RPython Box type parity: the alias
+                                        // inherits `box.type` from the original
+                                        // field. RPython Box always carries
+                                        // `box.type` (history.py:220), so a
+                                        // missing type here is an unrecoverable
+                                        // invariant violation — panic in release
+                                        // as well as debug.
+                                        let tp = ctx.opref_type(orig_field).unwrap_or_else(|| {
                                         panic!(
                                             "virtual-field alias: orig_field {:?} has no resolvable box.type (RPython invariant violated)",
                                             orig_field,
                                         )
                                     });
-                                    // Producer-less alias resop: mint its
-                                    // bound box up front and forward it to the
-                                    // original field box.
-                                    let (ff, b_ff) = ctx.reserve_virtual_box(tp);
-                                    let b_orig = ctx.get_box_replacement(orig_field);
-                                    ctx.make_equal_to(&b_ff, &b_orig);
-                                    field.1 = BoxRef::from_opref(ff);
+                                        // Producer-less alias resop: mint its
+                                        // bound box up front and forward it to the
+                                        // original field box.
+                                        let (ff, b_ff) = ctx.reserve_virtual_box(tp);
+                                        let b_orig = ctx.get_box_replacement(orig_field);
+                                        ctx.make_equal_to(&b_ff, &b_orig);
+                                        field.1 = BoxRef::from_opref(ff);
+                                    }
+                                    crate::optimizeopt::info::PtrInfo::Virtual(vinfo)
                                 }
-                                crate::optimizeopt::info::PtrInfo::Virtual(vinfo)
+                                other => other,
+                            };
+                            if let Some(b) = ctx.get_box_replacement_box(fresh) {
+                                ctx.set_ptr_info(&b, fresh_info);
                             }
-                            other => other,
-                        };
-                        if let Some(b) = ctx.get_box_replacement_box(fresh) {
-                            ctx.set_ptr_info(&b, fresh_info);
+                        }
+                        *arg = fresh;
+                        // After allocating a fresh alias for an inputarg position,
+                        // update `seen` so the next slot referencing the same
+                        // original OpRef goes through the duplicate path and
+                        // gets its own fresh alias too.
+                        if is_cross_inputarg {
+                            seen.insert(fresh);
                         }
                     }
-                    *arg = fresh;
-                    // After allocating a fresh alias for an inputarg position,
-                    // update `seen` so the next slot referencing the same
-                    // original OpRef goes through the duplicate path and
-                    // gets its own fresh alias too.
-                    if is_cross_inputarg {
-                        seen.insert(fresh);
-                    }
                 }
-            }
-            // unroll.py:203 self.flush() — force lazy sets before
-            // producing short preamble ops (heap.py:53 invariant).
-            self.flush(&mut ctx);
+                // unroll.py:203 self.flush() — force lazy sets before
+                // producing short preamble ops (heap.py:53 invariant).
+                self.flush(&mut ctx);
 
-            // Now force all resolved (and dedup'd) args.
-            // unroll.py:454 `end_args = [force_box_for_end_of_preamble(a)
-            // for a in original_label_args]`.
-            ctx.preamble_end_args = Some(
-                resolved_args
+                // Now force all resolved (and dedup'd) args.
+                // unroll.py:454 `end_args = [force_box_for_end_of_preamble(a)
+                // for a in original_label_args]`.
+                ctx.preamble_end_args = Some(
+                    resolved_args
+                        .iter()
+                        .map(|&arg| self.force_box_for_end_of_preamble(arg, &mut ctx))
+                        .collect(),
+                );
+                // unroll.py:457 `virtual_state = self.get_virtual_state(end_args)`.
+                // VS is captured AFTER force + flush so its `Virtual` /
+                // `VStruct` entries match the `info.is_virtual()` predicate
+                // that `enum_forced_boxes` asserts. Virtuals that were
+                // forced into concrete instances by `force_at_the_end_of_preamble`
+                // come back as `NotVirtualStateInfo` here, exactly as they
+                // do in RPython.
+                let post_force_args: Vec<OpRef> = resolved_args
                     .iter()
-                    .map(|&arg| self.force_box_for_end_of_preamble(arg, &mut ctx))
-                    .collect(),
-            );
-            // unroll.py:457 `virtual_state = self.get_virtual_state(end_args)`.
-            // VS is captured AFTER force + flush so its `Virtual` /
-            // `VStruct` entries match the `info.is_virtual()` predicate
-            // that `enum_forced_boxes` asserts. Virtuals that were
-            // forced into concrete instances by `force_at_the_end_of_preamble`
-            // come back as `NotVirtualStateInfo` here, exactly as they
-            // do in RPython.
-            let post_force_args: Vec<OpRef> = resolved_args
-                .iter()
-                .map(|&a| {
-                    let resolved = ctx.get_replacement_opref(a);
-                    // bind-at-alloc: `export_state` below keys its
-                    // `ExportCache` by these resolved positions. A producer-less
-                    // value-bearing position resolves to a throwaway `from_opref`
-                    // box, so each `resolve_to_boxref` returns a distinct Rc
-                    // (ptr-Eq-unstable) and `export_single_value` logs it as an
-                    // unbound export key. Bind the canonical `_forwarded` host
-                    // once via `materialize_box_at` (a `SameAs*` synthetic in
-                    // `resop_refs`, memoized through `Op::box_cache`) so the
-                    // export key resolves to one ptr-stable host — the identity
-                    // the #188 `OpRef`→`BoxRef` `ExportCache` rekey requires. The
-                    // returned `OpRef` is unchanged (synthetic and orphan share
-                    // the position), so the exported state is byte-identical.
-                    if !resolved.is_none()
-                        && !resolved.is_constant()
-                        && ctx.get_box_replacement_box(resolved).is_none()
-                    {
-                        ctx.materialize_box_at(resolved);
-                    }
-                    resolved
-                })
-                .collect();
-            let preview_virtual_state =
-                crate::optimizeopt::virtualstate::export_state(&post_force_args, &ctx);
-            let vs_args = &post_force_args;
-            // virtualstate.py:687-689 / unroll.py:154-158: a virtual-state
-            // mismatch here raises `VirtualStatesCantMatch` and the outer
-            // `compile_loop_body` catches it as an `InvalidLoop` to skip
-            // jump-to-existing and either retrace or fall back to the
-            // interpretive path. Propagate via the `InvalidLoop` panic
-            // payload so the existing wrapper at unroll.rs:1146 catches
-            // and reroutes instead of crashing the worker thread.
-            let (preview_label_args, preview_virtuals) =
-                match preview_virtual_state.make_inputargs_and_virtuals(
-                    vs_args,
-                    self,
-                    &mut ctx,
-                    false,
-                ) {
+                    .map(|&a| {
+                        let resolved = ctx.get_replacement_opref(a);
+                        // bind-at-alloc: `export_state` below keys its
+                        // `ExportCache` by these resolved positions. A producer-less
+                        // value-bearing position resolves to a throwaway `from_opref`
+                        // box, so each `resolve_to_boxref` returns a distinct Rc
+                        // (ptr-Eq-unstable) and `export_single_value` logs it as an
+                        // unbound export key. Bind the canonical `_forwarded` host
+                        // once via `materialize_box_at` (a `SameAs*` synthetic in
+                        // `resop_refs`, memoized through `Op::box_cache`) so the
+                        // export key resolves to one ptr-stable host — the identity
+                        // the #188 `OpRef`→`BoxRef` `ExportCache` rekey requires. The
+                        // returned `OpRef` is unchanged (synthetic and orphan share
+                        // the position), so the exported state is byte-identical.
+                        if !resolved.is_none()
+                            && !resolved.is_constant()
+                            && ctx.get_box_replacement_box(resolved).is_none()
+                        {
+                            ctx.materialize_box_at(resolved);
+                        }
+                        resolved
+                    })
+                    .collect();
+                let preview_virtual_state =
+                    crate::optimizeopt::virtualstate::export_state(&post_force_args, &ctx);
+                let vs_args = &post_force_args;
+                // virtualstate.py:687-689 / unroll.py:154-158: a virtual-state
+                // mismatch here raises `VirtualStatesCantMatch` and the outer
+                // `compile_loop_body` catches it as an `InvalidLoop` to skip
+                // jump-to-existing and either retrace or fall back to the
+                // interpretive path. Propagate via the `InvalidLoop` panic
+                // payload so the existing wrapper at unroll.rs:1146 catches
+                // and reroutes instead of crashing the worker thread.
+                let (preview_label_args, preview_virtuals) = match preview_virtual_state
+                    .make_inputargs_and_virtuals(vs_args, self, &mut ctx, false)
+                {
                     Ok(pair) => pair,
-                    Err(()) => std::panic::panic_any(crate::optimize::InvalidLoop(
-                        "preview virtual state mismatch (VirtualStatesCantMatch)",
-                    )),
+                    Err(()) => {
+                        return Err(crate::optimize::InvalidLoop(
+                            "preview virtual state mismatch (VirtualStatesCantMatch)",
+                        ));
+                    }
                 };
-            let mut preview_short_args = preview_label_args.clone();
-            preview_short_args.extend(preview_virtuals);
-            let mut short_boxes =
-                crate::optimizeopt::shortpreamble::ShortBoxes::with_label_args(&preview_short_args);
-            for &arg in &preview_short_args {
-                // RPython shortpreamble.py:255-259 parity: each label arg
-                // is `box.type`, where Box objects intrinsically carry one
-                // of i / r / f. There is no `void` Box because Box always
-                // wraps a runtime value. Pyre recovers the same type from
-                // the typed OpRef variant or the trace's inputarg/op metadata.
-                let raw_type = ctx
+                let mut preview_short_args = preview_label_args.clone();
+                preview_short_args.extend(preview_virtuals);
+                let mut short_boxes =
+                    crate::optimizeopt::shortpreamble::ShortBoxes::with_label_args(
+                        &preview_short_args,
+                    );
+                for &arg in &preview_short_args {
+                    // RPython shortpreamble.py:255-259 parity: each label arg
+                    // is `box.type`, where Box objects intrinsically carry one
+                    // of i / r / f. There is no `void` Box because Box always
+                    // wraps a runtime value. Pyre recovers the same type from
+                    // the typed OpRef variant or the trace's inputarg/op metadata.
+                    let raw_type = ctx
                     .opref_type(arg)
                     .unwrap_or_else(|| {
                         panic!(
                             "preview short arg missing box.type: arg={arg:?} preview_short_args={preview_short_args:?}"
                         )
                     });
-                if raw_type == majit_ir::Type::Void {
-                    // shortpreamble.py:255-259 reads `box.type` from a
-                    // value Box and emits same_as_i/r/f. RPython has no
-                    // Void value Box here; reaching Void means Rust-side
-                    // OpRef/type bookkeeping lost Box identity and must not
-                    // silently drop the short-preamble inputarg.
-                    panic!(
-                        "preview short arg {arg:?} resolved to Type::Void; \
+                    if raw_type == majit_ir::Type::Void {
+                        // shortpreamble.py:255-259 reads `box.type` from a
+                        // value Box and emits same_as_i/r/f. RPython has no
+                        // Void value Box here; reaching Void means Rust-side
+                        // OpRef/type bookkeeping lost Box identity and must not
+                        // silently drop the short-preamble inputarg.
+                        panic!(
+                            "preview short arg {arg:?} resolved to Type::Void; \
                          short preamble inputargs must be int/ref/float value boxes \
                          (shortpreamble.py:255-259)"
-                    );
-                }
-                short_boxes.add_short_input_arg(&mut ctx, arg, raw_type);
-            }
-            self.produce_potential_short_preamble_ops(&mut short_boxes, &mut ctx);
-            let produced = short_boxes.produced_ops(&mut ctx);
-            // unroll.py:480 `short_inputargs = sb.create_short_inputargs(
-            // label_args + virtuals)` — read off the ShortBoxes object and
-            // carry to export_state through the ctx channel (sibling of
-            // `exported_short_boxes` below).
-            ctx.exported_short_inputargs =
-                short_boxes.create_short_inputargs(&preview_short_args);
-            // Carry the rooted InputArgRc pool alongside, index-aligned, so
-            // the renamed boxes stay bound to live `InputArg`s across the
-            // export boundary instead of shedding to position-only boxes.
-            ctx.exported_short_inputarg_refs = short_boxes.create_short_inputarg_refs();
-            // Single-object carry: each exported entry keeps the preview
-            // ProducedShortOp's replay Rc, so the pos/arg canonicalization
-            // below lands on the object that dep-replay operands reference
-            // (upstream exports the ResOperation objects themselves,
-            // unroll.py:478-487). The per-entry rewrites require each entry
-            // to own a distinct Rc.
-            #[cfg(debug_assertions)]
-            {
-                let mut seen: Vec<*const majit_ir::Op> = Vec::with_capacity(produced.len());
-                for (_, p) in &produced {
-                    let ptr = std::rc::Rc::as_ptr(&p.preamble_op);
-                    debug_assert!(
-                        !seen.contains(&ptr),
-                        "exported short boxes share a replay OpRc at {:?}",
-                        p.preamble_op.pos.get()
-                    );
-                    seen.push(ptr);
-                }
-            }
-            ctx.exported_short_boxes = produced
-                .into_iter()
-                .filter_map(|(result, produced)| {
-                    let canonical_result = ctx.get_replacement_opref(result);
-                    // A produced short box whose result forwards to an inline
-                    // Const after optimization is not a real short box: a pure
-                    // op (e.g. an IntLe on loop-constant args) folds to a Const,
-                    // whose value is reproduced by inlining at use sites. A
-                    // Const must never enter exported_short_boxes / used_boxes —
-                    // it has no box index, so the carried-slot `.raw()` in
-                    // unroll.rs panics. RPython folds such ops away before
-                    // short-box creation, so its short boxes are always genuine
-                    // value Boxes. (pyre never reaches here with a Const, so
-                    // this filter is inert for the PyFrame portal.)
-                    if canonical_result.is_constant() {
-                        return None;
+                        );
                     }
-                    let preamble_op = produced.preamble_op.clone();
-                    // RPython parity: key and preamble_op.pos must be the
-                    // same resolved value. Independent get_box_replacement
-                    // calls can diverge when forwarding chains differ.
-                    // Use canonical_result (resolved key) for both.
-                    preamble_op.pos.set(canonical_result);
-                    // optimizer.py:651-652 force_box loop parity.
-                    //
-                    // Resolve POSITIONALLY when a producer is registered at
-                    // this slot: replay-op args carry the dep replay handle
-                    // (produce_arg, shortpreamble.py:285) whose forwarded slot
-                    // is empty, so only the body producer registered at the
-                    // same position carries the Phase-1 forwarding to the
-                    // canonical end box this export boundary needs.
-                    //
-                    // When positional resolution finds NO producer, the carried
-                    // handle is unforwarded and resolves to itself
-                    // (resoperation.py:57-68): keep the handle OBJECT instead of
-                    // re-minting a producer-less position-only box, so its
-                    // identity (and the `Operand::Op`/`InputArg` shed) survives
-                    // the export. The encoded OpRef is identical either way
-                    // (`from_opref(arg.to_opref()) == arg.to_opref()`).
-                    for i in 0..preamble_op.num_args() {
-                        let arg = preamble_op.arg(i);
-                        // The `OpRef::none()` sentinel has no producer box
-                        // (`materialize_box_at` doc) — routing it through the
-                        // producer lookup is meaningless and trips the
-                        // `get_box_replacement` "box must exist" debug tripwire.
-                        if arg.is_none() {
-                            continue;
+                    short_boxes.add_short_input_arg(&mut ctx, arg, raw_type);
+                }
+                self.produce_potential_short_preamble_ops(&mut short_boxes, &mut ctx);
+                let produced = short_boxes.produced_ops(&mut ctx);
+                // unroll.py:480 `short_inputargs = sb.create_short_inputargs(
+                // label_args + virtuals)` — read off the ShortBoxes object and
+                // carry to export_state through the ctx channel (sibling of
+                // `exported_short_boxes` below).
+                ctx.exported_short_inputargs =
+                    short_boxes.create_short_inputargs(&preview_short_args);
+                // Carry the rooted InputArgRc pool alongside, index-aligned, so
+                // the renamed boxes stay bound to live `InputArg`s across the
+                // export boundary instead of shedding to position-only boxes.
+                ctx.exported_short_inputarg_refs = short_boxes.create_short_inputarg_refs();
+                // Single-object carry: each exported entry keeps the preview
+                // ProducedShortOp's replay Rc, so the pos/arg canonicalization
+                // below lands on the object that dep-replay operands reference
+                // (upstream exports the ResOperation objects themselves,
+                // unroll.py:478-487). The per-entry rewrites require each entry
+                // to own a distinct Rc.
+                #[cfg(debug_assertions)]
+                {
+                    let mut seen: Vec<*const majit_ir::Op> = Vec::with_capacity(produced.len());
+                    for (_, p) in &produced {
+                        let ptr = std::rc::Rc::as_ptr(&p.preamble_op);
+                        debug_assert!(
+                            !seen.contains(&ptr),
+                            "exported short boxes share a replay OpRc at {:?}",
+                            p.preamble_op.pos.get()
+                        );
+                        seen.push(ptr);
+                    }
+                }
+                ctx.exported_short_boxes = produced
+                    .into_iter()
+                    .filter_map(|(result, produced)| {
+                        let canonical_result = ctx.get_replacement_opref(result);
+                        // A produced short box whose result forwards to an inline
+                        // Const after optimization is not a real short box: a pure
+                        // op (e.g. an IntLe on loop-constant args) folds to a Const,
+                        // whose value is reproduced by inlining at use sites. A
+                        // Const must never enter exported_short_boxes / used_boxes —
+                        // it has no box index, so the carried-slot `.raw()` in
+                        // unroll.rs panics. RPython folds such ops away before
+                        // short-box creation, so its short boxes are always genuine
+                        // value Boxes. (pyre never reaches here with a Const, so
+                        // this filter is inert for the PyFrame portal.)
+                        if canonical_result.is_constant() {
+                            return None;
                         }
-                        let resolved = ctx
-                            .resolve_box_box_opt(&arg)
-                            .unwrap_or_else(|| arg.clone());
-                        preamble_op.setarg(i, resolved);
-                    }
-                    if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
-                        for arg in fail_args.iter_mut() {
+                        let preamble_op = produced.preamble_op.clone();
+                        // RPython parity: key and preamble_op.pos must be the
+                        // same resolved value. Independent get_box_replacement
+                        // calls can diverge when forwarding chains differ.
+                        // Use canonical_result (resolved key) for both.
+                        preamble_op.pos.set(canonical_result);
+                        // optimizer.py:651-652 force_box loop parity.
+                        //
+                        // Resolve POSITIONALLY when a producer is registered at
+                        // this slot: replay-op args carry the dep replay handle
+                        // (produce_arg, shortpreamble.py:285) whose forwarded slot
+                        // is empty, so only the body producer registered at the
+                        // same position carries the Phase-1 forwarding to the
+                        // canonical end box this export boundary needs.
+                        //
+                        // When positional resolution finds NO producer, the carried
+                        // handle is unforwarded and resolves to itself
+                        // (resoperation.py:57-68): keep the handle OBJECT instead of
+                        // re-minting a producer-less position-only box, so its
+                        // identity (and the `Operand::Op`/`InputArg` shed) survives
+                        // the export. The encoded OpRef is identical either way
+                        // (`from_opref(arg.to_opref()) == arg.to_opref()`).
+                        for i in 0..preamble_op.num_args() {
+                            let arg = preamble_op.arg(i);
+                            // The `OpRef::none()` sentinel has no producer box
+                            // (`materialize_box_at` doc) — routing it through the
+                            // producer lookup is meaningless and trips the
+                            // `get_box_replacement` "box must exist" debug tripwire.
                             if arg.is_none() {
                                 continue;
                             }
-                            *arg = majit_ir::operand::Operand::from_boxref(
-                                &ctx.get_box_replacement(arg.to_opref()),
-                            );
+                            let resolved =
+                                ctx.resolve_box_box_opt(&arg).unwrap_or_else(|| arg.clone());
+                            preamble_op.setarg(i, resolved);
                         }
-                    }
-                    // Resolve the carried slot by entry kind. An InputArg
-                    // label arg whose canonical result forwards away is absent
-                    // from `short_boxes.label_args`, so a re-lookup of
-                    // `canonical_result` returns None and the per-slot original
-                    // is lost; `produced.label_arg_idx` preserves the original
-                    // stamped slot through forwarding (the slot the renamed
-                    // `short_inputargs[i]` pairs with — consumed by
-                    // slot_to_original). For non-InputArg (Pure/LoopInvariant/
-                    // Heap) entries the result_map consumer needs the FORWARDED
-                    // slot: a Pure/LoopInvariant result proven equal to a label
-                    // arg it did not originally occupy must reuse
-                    // `short_args[slot]`, which `lookup_label_arg(canonical_
-                    // result)` reports (pre-217 forwarded-slot lookup, parity
-                    // with upstream Box-identity CompoundOp merge). For a label
-                    // arg duplicated across `label_args + virtuals`,
-                    // `lookup_label_arg` resolves to the LAST/live slot
-                    // (`potential_ops[box]` overwrite), matching the InputArg
-                    // branch's `live_slot` and upstream's surviving ShortInputArg.
-                    let label_arg_idx = if produced.kind
-                        == crate::optimizeopt::shortpreamble::PreambleOpKind::InputArg
-                    {
-                        produced.label_arg_idx
-                    } else {
-                        short_boxes.lookup_label_arg(canonical_result)
-                    };
-                    Some(crate::optimizeopt::shortpreamble::PreambleOp {
-                        op: preamble_op,
-                        // short_op.res travels with the entry — the SAME
-                        // box object the preview ProducedShortOp carries,
-                        // so the export/re-import round trip preserves
-                        // upstream Box identity.
-                        res: produced.res.clone(),
-                        kind: produced.kind,
-                        label_arg_idx,
-                        invented_name: produced.invented_name,
-                        same_as_source: produced.same_as_source.clone(),
+                        if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
+                            for arg in fail_args.iter_mut() {
+                                if arg.is_none() {
+                                    continue;
+                                }
+                                *arg = majit_ir::operand::Operand::from_boxref(
+                                    &ctx.get_box_replacement(arg.to_opref()),
+                                );
+                            }
+                        }
+                        // Resolve the carried slot by entry kind. An InputArg
+                        // label arg whose canonical result forwards away is absent
+                        // from `short_boxes.label_args`, so a re-lookup of
+                        // `canonical_result` returns None and the per-slot original
+                        // is lost; `produced.label_arg_idx` preserves the original
+                        // stamped slot through forwarding (the slot the renamed
+                        // `short_inputargs[i]` pairs with — consumed by
+                        // slot_to_original). For non-InputArg (Pure/LoopInvariant/
+                        // Heap) entries the result_map consumer needs the FORWARDED
+                        // slot: a Pure/LoopInvariant result proven equal to a label
+                        // arg it did not originally occupy must reuse
+                        // `short_args[slot]`, which `lookup_label_arg(canonical_
+                        // result)` reports (pre-217 forwarded-slot lookup, parity
+                        // with upstream Box-identity CompoundOp merge). For a label
+                        // arg duplicated across `label_args + virtuals`,
+                        // `lookup_label_arg` resolves to the LAST/live slot
+                        // (`potential_ops[box]` overwrite), matching the InputArg
+                        // branch's `live_slot` and upstream's surviving ShortInputArg.
+                        let label_arg_idx = if produced.kind
+                            == crate::optimizeopt::shortpreamble::PreambleOpKind::InputArg
+                        {
+                            produced.label_arg_idx
+                        } else {
+                            short_boxes.lookup_label_arg(canonical_result)
+                        };
+                        Some(crate::optimizeopt::shortpreamble::PreambleOp {
+                            op: preamble_op,
+                            // short_op.res travels with the entry — the SAME
+                            // box object the preview ProducedShortOp carries,
+                            // so the export/re-import round trip preserves
+                            // upstream Box identity.
+                            res: produced.res.clone(),
+                            kind: produced.kind,
+                            label_arg_idx,
+                            invented_name: produced.invented_name,
+                            same_as_source: produced.same_as_source.clone(),
+                        })
                     })
-                })
-                .collect();
-            if std::env::var_os("MAJIT_LOG").is_some() {
-                for entry in &ctx.exported_short_boxes {
-                    eprintln!(
-                        "[jit] exported_short_box: kind={:?} pos={:?} opcode={:?} args={:?} descr_idx={:?} invented={} same_as_source={:?}",
-                        entry.kind,
-                        entry.op.pos.get(),
-                        entry.op.opcode,
-                        entry.op.getarglist(),
-                        entry.op.getdescr().map(|d| d.index()),
-                        entry.invented_name,
-                        entry.same_as_source,
-                    );
+                    .collect();
+                if std::env::var_os("MAJIT_LOG").is_some() {
+                    for entry in &ctx.exported_short_boxes {
+                        eprintln!(
+                            "[jit] exported_short_box: kind={:?} pos={:?} opcode={:?} args={:?} descr_idx={:?} invented={} same_as_source={:?}",
+                            entry.kind,
+                            entry.op.pos.get(),
+                            entry.op.opcode,
+                            entry.op.getarglist(),
+                            entry.op.getdescr().map(|d| d.index()),
+                            entry.invented_name,
+                            entry.same_as_source,
+                        );
+                    }
                 }
+                let jump_arglist_oprefs: Vec<OpRef> =
+                    jump.getarglist().iter().map(|a| a.to_opref()).collect();
+                let exported_int_bounds =
+                    self.collect_exported_int_bounds(&jump_arglist_oprefs, &mut ctx);
+                // RPython unroll.py:186-193 + compile.py:1084: `info.renamed_inputargs`
+                // are the fresh per-iteration boxes from `trace.get_iter()`. They
+                // live in this run's iteration namespace, not the original
+                // frontend's. In pyre this maps to `[inputarg_base..inputarg_base
+                // + num_inputs)`: `inputarg_base = 0` for top-level loops
+                // (compile_loop / compile_retrace) where the frontend already
+                // owns `[0, num_inputs)`, and `inputarg_base = bridge_inputarg_base`
+                // for bridges, where `prepare_bridge_trace_for_optimizer`
+                // in pyjitpl/mod.rs shifts
+                // the iteration into a disjoint range.  Use `num_inputs` (the
+                // external loop-entry contract count) rather than `ctx.num_inputs`
+                // (which may be widened by virtualizable expansion).
+                // resoperation.py:719/727/739 InputArg{Int,Ref,Float}: each
+                // renamed inputarg's Box carries `.type` intrinsically
+                // (history.py:220). Mint typed variants from `inputarg_types`
+                // so the exported state's OpRefs match what Phase 2 will see
+                // under variant-aware Eq.
+                let renamed_inputargs: Vec<OpRef> = (0..num_inputs)
+                    .map(|i| {
+                        // opencoder.py:259 inputarg_from_tp parity — strict
+                        // box.type lookup, no InputArgVoid fallback.
+                        let pos = ctx.inputarg_base + i as u32;
+                        OpRef::input_arg_typed(pos, ctx.inputarg_type_at_strict(i))
+                    })
+                    .collect();
+                Some(crate::optimizeopt::unroll::export_state(
+                    &original_jump_args,
+                    &renamed_inputargs,
+                    self,
+                    &mut ctx,
+                    Some(&exported_int_bounds),
+                ))
             }
-            let jump_arglist_oprefs: Vec<OpRef> =
-                jump.getarglist().iter().map(|a| a.to_opref()).collect();
-            let exported_int_bounds =
-                self.collect_exported_int_bounds(&jump_arglist_oprefs, &mut ctx);
-            // RPython unroll.py:186-193 + compile.py:1084: `info.renamed_inputargs`
-            // are the fresh per-iteration boxes from `trace.get_iter()`. They
-            // live in this run's iteration namespace, not the original
-            // frontend's. In pyre this maps to `[inputarg_base..inputarg_base
-            // + num_inputs)`: `inputarg_base = 0` for top-level loops
-            // (compile_loop / compile_retrace) where the frontend already
-            // owns `[0, num_inputs)`, and `inputarg_base = bridge_inputarg_base`
-            // for bridges, where `prepare_bridge_trace_for_optimizer`
-            // in pyjitpl/mod.rs shifts
-            // the iteration into a disjoint range.  Use `num_inputs` (the
-            // external loop-entry contract count) rather than `ctx.num_inputs`
-            // (which may be widened by virtualizable expansion).
-            // resoperation.py:719/727/739 InputArg{Int,Ref,Float}: each
-            // renamed inputarg's Box carries `.type` intrinsically
-            // (history.py:220). Mint typed variants from `inputarg_types`
-            // so the exported state's OpRefs match what Phase 2 will see
-            // under variant-aware Eq.
-            let renamed_inputargs: Vec<OpRef> = (0..num_inputs)
-                .map(|i| {
-                    // opencoder.py:259 inputarg_from_tp parity — strict
-                    // box.type lookup, no InputArgVoid fallback.
-                    let pos = ctx.inputarg_base + i as u32;
-                    OpRef::input_arg_typed(pos, ctx.inputarg_type_at_strict(i))
-                })
-                .collect();
-            crate::optimizeopt::unroll::export_state(
-                &original_jump_args,
-                &renamed_inputargs,
-                self,
-                &mut ctx,
-                Some(&exported_int_bounds),
-            )
-        });
+            None => None,
+        };
         // RPython parity: propagate patchguardop to ExportedState so Phase 2
         // can use it for extra_guards from virtualstate (unroll.py:333-336).
         if let Some(ref mut es) = self.exported_loop_state {
@@ -3570,7 +3600,7 @@ impl Optimizer {
             }
         }
         self.final_ctx = Some(ctx);
-        ops
+        Ok(ops)
     }
 
     /// unroll.py:183-236: optimize_bridge()
@@ -3611,7 +3641,7 @@ impl Optimizer {
         // base into `optimize_with_constants_and_inputs_at` so step 3
         // seeds inputarg types at the shifted slots.
         bridge_inputarg_base: u32,
-    ) -> (Vec<majit_ir::OpRc>, bool) {
+    ) -> Result<(Vec<majit_ir::OpRc>, bool), crate::optimize::InvalidLoop> {
         // bridgeopt.py:124-185: deserialize_optimizer_knowledge
         // Store as pending — setup() inside optimize_with_constants_and_inputs
         // clears pass state, so we apply AFTER setup.
@@ -3678,6 +3708,7 @@ impl Optimizer {
             false,
         );
         self.skip_flush = skip_flush_saved;
+        let optimized_ops = optimized_ops?;
 
         // A bridge trace carries no GUARD_FUTURE_CONDITION
         // (reached_loop_header's GFC lives in pyre's loop-creation path,
@@ -3704,7 +3735,7 @@ impl Optimizer {
             .map_or(false, |op| op.opcode == OpCode::Jump);
 
         if !has_jump {
-            return (optimized_ops, false);
+            return Ok((optimized_ops, false));
         }
 
         let terminal_jump = terminal_jump.unwrap();
@@ -3752,12 +3783,12 @@ impl Optimizer {
                 // descr (`is_preamble_target`). Keep both the jump_op's forced
                 // args AND its descr; only re-send it through the pass chain.
                 let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
-                self.send_extra_operation(&jump_op, &mut ctx);
+                self.send_extra_operation(&jump_op, &mut ctx)?;
                 let mut result = optimized_ops;
                 result.extend(ctx.new_operations.drain(..));
-                return (result, false);
+                return Ok((result, false));
             }
-            return (optimized_ops, false);
+            return Ok((optimized_ops, false));
         }
 
         // unroll.py:203: self.flush()
@@ -3840,12 +3871,12 @@ impl Optimizer {
                     // into), not the ORIGIN `front_target_tokens`. Keep both
                     // jump_op's forced args AND its descr.
                     let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
-                    self.send_extra_operation(&jump_op, &mut ctx);
+                    self.send_extra_operation(&jump_op, &mut ctx)?;
                     let mut result = optimized_ops;
                     result.extend(ctx.new_operations.drain(..));
-                    return (result, false);
+                    return Ok((result, false));
                 }
-                return (optimized_ops, false);
+                return Ok((optimized_ops, false));
             }
         };
 
@@ -3853,7 +3884,7 @@ impl Optimizer {
         if vs.is_none() {
             let mut result = optimized_ops;
             result.extend(ctx.new_operations.drain(..));
-            return (result, false);
+            return Ok((result, false));
         }
 
         // unroll.py:214-218: retrace check
@@ -3873,7 +3904,7 @@ impl Optimizer {
                     &format!("Retracing ({}/{retrace_limit})", retraced_count + 1),
                 );
             }
-            return (optimized_ops, true);
+            return Ok((optimized_ops, true));
         }
 
         // unroll.py:220-227: retrace limit reached, try force_boxes=True.
@@ -3903,7 +3934,7 @@ impl Optimizer {
         if vs2.is_none() {
             let mut result = optimized_ops;
             result.extend(ctx.new_operations.drain(..));
-            return (result, false);
+            return Ok((result, false));
         }
 
         // unroll.py:228-229,238-242: jump_to_preamble → send_extra_operation.
@@ -3927,12 +3958,12 @@ impl Optimizer {
             // bridge crosses loops, so redirecting to it delivers args to the
             // wrong frame slots.
             let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
-            self.send_extra_operation(&jump_op, &mut ctx);
+            self.send_extra_operation(&jump_op, &mut ctx)?;
             let mut result = optimized_ops;
             result.extend(ctx.new_operations.drain(..));
-            (result, false)
+            Ok((result, false))
         } else {
-            (optimized_ops, false)
+            Ok((optimized_ops, false))
         }
     }
 
@@ -3949,30 +3980,24 @@ impl Optimizer {
         pre_opt_jump_args: &[OpRef],
         pre_vs: Option<crate::optimizeopt::virtualstate::VirtualState>,
     ) -> Result<Option<crate::optimizeopt::virtualstate::VirtualState>, ()> {
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            opt_unroll.jump_to_existing_trace_with_vs(
-                jump_args,
-                None,
-                front_target_tokens,
-                optimizer,
-                ctx,
-                force_boxes,
-                pre_opt_jump_args,
-                pre_vs,
-            )
-        })) {
-            Ok(vs) => Ok(vs),
-            Err(payload) => {
-                if payload
-                    .downcast_ref::<crate::optimize::InvalidLoop>()
-                    .is_some()
-                {
-                    Err(())
-                } else {
-                    // Not InvalidLoop — re-raise
-                    std::panic::resume_unwind(payload);
-                }
-            }
+        let vs = opt_unroll.jump_to_existing_trace_with_vs(
+            jump_args,
+            None,
+            front_target_tokens,
+            optimizer,
+            ctx,
+            force_boxes,
+            pre_opt_jump_args,
+            pre_vs,
+        );
+        // unroll.py:209-210 / 224-225 `except InvalidLoop`: a short-preamble
+        // replay that could not resolve its args records a deferred InvalidLoop
+        // signal on `ctx`; surface it as `Err(())` so the caller falls back to
+        // jump_to_preamble.
+        if ctx.take_invalid_loop().is_some() {
+            Err(())
+        } else {
+            Ok(vs)
         }
     }
 
@@ -4009,22 +4034,31 @@ impl Optimizer {
     /// The Emit variant's position tracking is handled by each pass
     /// and OptContext. Adding automatic replacement mapping here
     /// causes spurious forwarding that breaks heap/guard tests.
-    fn propagate_one(&mut self, op: &majit_ir::OpRc, ctx: &mut OptContext) {
-        self.propagate_from_pass(0, op, ctx);
+    fn propagate_one(
+        &mut self,
+        op: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> Result<(), crate::optimize::InvalidLoop> {
+        self.propagate_from_pass(0, op, ctx)
     }
 
-    fn drain_extra_operations_from(&mut self, _start_pass: usize, ctx: &mut OptContext) {
+    fn drain_extra_operations_from(
+        &mut self,
+        _start_pass: usize,
+        ctx: &mut OptContext,
+    ) -> Result<(), crate::optimize::InvalidLoop> {
         let end_pass = self.extra_operation_end_pass();
         let mut pending = std::collections::VecDeque::new();
         while let Some((start, op)) = ctx.extra_operations_after.pop_front() {
             pending.push_back((start, op));
         }
         while let Some((from_pass, op)) = pending.pop_front() {
-            self.propagate_from_pass_range(from_pass, end_pass, &op, ctx);
+            self.propagate_from_pass_range(from_pass, end_pass, &op, ctx)?;
             while let Some((start, op)) = ctx.extra_operations_after.pop_front() {
                 pending.push_front((start, op));
             }
         }
+        Ok(())
     }
 
     fn propagate_from_pass(
@@ -4032,8 +4066,8 @@ impl Optimizer {
         start_pass: usize,
         op: &majit_ir::OpRc,
         ctx: &mut OptContext,
-    ) {
-        self.propagate_from_pass_range(start_pass, self.passes.len(), op, ctx);
+    ) -> Result<(), crate::optimize::InvalidLoop> {
+        self.propagate_from_pass_range(start_pass, self.passes.len(), op, ctx)
     }
 
     fn extra_operation_end_pass(&self) -> usize {
@@ -4050,7 +4084,7 @@ impl Optimizer {
         end_pass: usize,
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
-    ) {
+    ) -> Result<(), crate::optimize::InvalidLoop> {
         // The canonical `OpRc` is threaded in so callers can resolve the
         // producer directly when they need a bound BoxRef. For this pass the
         // body reads through this `&Op` view (Deref), behaviour-identical.
@@ -4117,7 +4151,7 @@ impl Optimizer {
             let b_old = BoxRef::from_bound_op(op_rc);
             let b_new = ctx.get_box_replacement(new);
             ctx.make_equal_to(&b_old, &b_new);
-            return;
+            return Ok(());
         }
 
         // optimizer.py:570-589 parity: collect pass indices that need
@@ -4138,7 +4172,13 @@ impl Optimizer {
                 let pass = &mut self.passes[pass_idx];
                 pass.propagate_forward(&current_op, op_rc, ctx)
             };
-            self.drain_extra_operations_from(pass_idx + 1, ctx);
+            // A leaf site deep in the pass may have recorded a deferred
+            // `InvalidLoop` (e.g. `get_const_info_mut_box`) while still
+            // returning a benign result. Abort before acting on that result.
+            if let Some(e) = ctx.take_invalid_loop() {
+                return Err(e);
+            }
+            self.drain_extra_operations_from(pass_idx + 1, ctx)?;
             match result {
                 OptimizationResult::Emit(op) => {
                     // optimizer.py:576-581: collect postprocess for this pass
@@ -4146,13 +4186,13 @@ impl Optimizer {
                     if self.passes[pass_idx].have_postprocess_op(op.opcode) {
                         postprocess_passes.push(pass_idx);
                     }
-                    self.emit_operation(op.clone(), ctx, false);
+                    self.emit_operation(op.clone(), ctx, false)?;
                     // optimizer.py:585-589: invoke postprocess callbacks
                     // in reverse order after emission.
                     for &pp_idx in postprocess_passes.iter().rev() {
                         self.passes[pp_idx].propagate_postprocess(&op, ctx);
                     }
-                    return;
+                    return Ok(());
                 }
                 OptimizationResult::Replace(op) => {
                     debug_assert!(
@@ -4201,7 +4241,7 @@ impl Optimizer {
                     // re-dispatch reads/writes one canonical `_forwarded` host
                     // and the bound it accumulates survives emit's catch-up.
                     ctx.supersede_restart_producer(&restart_op_rc);
-                    self.propagate_from_pass_range(0, end_pass, &restart_op_rc, ctx);
+                    self.propagate_from_pass_range(0, end_pass, &restart_op_rc, ctx)?;
                     // Run any postprocess callbacks accumulated in the outer
                     // chain (passes that already returned PassOn for the
                     // original op before the Restart-returning pass fired).
@@ -4210,7 +4250,7 @@ impl Optimizer {
                     for &pp_idx in postprocess_passes.iter().rev() {
                         self.passes[pp_idx].propagate_postprocess(&current_op, ctx);
                     }
-                    return;
+                    return Ok(());
                 }
                 OptimizationResult::Remove => {
                     // optimizer.py:573-575: op removed → no postprocess.
@@ -4221,7 +4261,7 @@ impl Optimizer {
                     // (e.g. `optimize_GUARD_NO_EXCEPTION`,
                     // rewrite.py:712-718) can observe the drop.
                     ctx.last_op_removed = true;
-                    return;
+                    return Ok(());
                 }
                 OptimizationResult::PassOn => {
                     // optimizer.py:576-583: PASS_OP_ON path.
@@ -4233,10 +4273,8 @@ impl Optimizer {
                     }
                 }
                 // rewrite.py:406 — guard proven to always fail
-                OptimizationResult::InvalidLoop => {
-                    std::panic::panic_any(crate::optimize::InvalidLoop(
-                        "guard proven to always fail",
-                    ));
+                OptimizationResult::InvalidLoop(msg) => {
+                    return Err(crate::optimize::InvalidLoop(msg));
                 }
             }
         }
@@ -4244,11 +4282,12 @@ impl Optimizer {
         // If no pass handled it, emit as-is. An unreplaced pass-through is the
         // recorder input op verbatim (args re-resolved), so emit may reuse that
         // input op as the producer instead of cloning.
-        self.emit_operation(current_op.clone(), ctx, !replaced);
+        self.emit_operation(current_op.clone(), ctx, !replaced)?;
         // Postprocess in reverse order after emission.
         for &pp_idx in postprocess_passes.iter().rev() {
             self.passes[pp_idx].propagate_postprocess(&current_op, ctx);
         }
+        Ok(())
     }
 
     /// optimizer.py: _emit_operation — emit with guard tracking.
@@ -4259,7 +4298,12 @@ impl Optimizer {
     /// RPython optimizer.py:623-625: _emit_operation calls force_box(arg)
     /// on every arg before final emission. In majit, this forces any remaining
     /// virtual args that weren't caught by pass-level handlers.
-    fn emit_operation(&mut self, mut op: Op, ctx: &mut OptContext, reuse: bool) {
+    fn emit_operation(
+        &mut self,
+        mut op: Op,
+        ctx: &mut OptContext,
+        reuse: bool,
+    ) -> Result<(), crate::optimize::InvalidLoop> {
         // RPython optimizer.py:614: _emit_operation is on the Optimizer (last
         // "pass" in the chain). Any force_box called here should emit directly,
         // matching RPython's Optimizer.emit_extra which just calls self.emit(op).
@@ -4278,8 +4322,15 @@ impl Optimizer {
         {
             let end_pass = self.extra_operation_end_pass();
             while let Some((start, queued_op)) = ctx.extra_operations_after.pop_front() {
-                self.propagate_from_pass_range(start, end_pass, &queued_op, ctx);
+                self.propagate_from_pass_range(start, end_pass, &queued_op, ctx)?;
             }
+        }
+        // A pass `emitting_operation` / queued drain may have deferred an
+        // `InvalidLoop`; abort before emitting on inconsistent state. On the
+        // abort path the context is discarded, so `in_final_emission` need not
+        // be restored.
+        if let Some(e) = ctx.take_invalid_loop() {
+            return Err(e);
         }
 
         // optimizer.py:623-625: force_box on every arg unconditionally,
@@ -4302,6 +4353,11 @@ impl Optimizer {
                 "emit_operation canonical box to_opref diverged from force_box",
             );
             op.setarg(i, resolved);
+        }
+        // force_box may force a virtual whose materialization defers an
+        // `InvalidLoop`; abort before the emit / `expect` sites below.
+        if let Some(e) = ctx.take_invalid_loop() {
+            return Err(e);
         }
 
         // optimizer.py:626: self.metainterp_sd.profiler.count(Counters.OPT_OPS).
@@ -4364,13 +4420,18 @@ impl Optimizer {
                         crate::compile::copy_all_attributes_from(&new_descr, &old_descr);
                         ctx.new_operations[target_pos] = std::rc::Rc::new(op.clone());
                         ctx.in_final_emission = saved_in_final_emission;
-                        return;
+                        return Ok(());
                     }
                 }
             }
 
             // optimizer.py:637: op = self.emit_guard_operation(op, pendingfields)
             op = self.emit_guard_operation(op, ctx);
+            // emit_guard_operation may defer an `InvalidLoop` (e.g. a pending
+            // SETARRAYITEM index that is not a non-negative constant).
+            if let Some(e) = ctx.take_invalid_loop() {
+                return Err(e);
+            }
         } else {
             // optimizer.py:639-644: preserve last_guard_op for guard chaining
             // unless the op has side effects or is a call_pure that can raise.
@@ -4503,6 +4564,12 @@ impl Optimizer {
             }
         }
         ctx.in_final_emission = saved_in_final_emission;
+        // A post-emit `make_constant_box` / postprocess may have deferred an
+        // `InvalidLoop`; surface it so the driver abandons the trace.
+        if let Some(e) = ctx.take_invalid_loop() {
+            return Err(e);
+        }
+        Ok(())
     }
 
     /// optimizer.py:652-686 emit_guard_operation
@@ -4598,10 +4665,17 @@ impl Optimizer {
                             let boxindex = ctx.resolve_box_box(&pf_op.arg(1));
                             let idx = match boxindex.const_int() {
                                 Some(v) if (0..=i32::MAX as i64).contains(&v) => v,
-                                _ => std::panic::panic_any(crate::optimize::InvalidLoop(
-                                    "_add_pending_fields: SETARRAYITEM_GC index \
+                                // Defer the abort; the caller checks the signal
+                                // after `emit_guard_operation` returns and
+                                // abandons the trace before the bogus entry is
+                                // used.
+                                _ => {
+                                    ctx.signal_invalid_loop(
+                                        "_add_pending_fields: SETARRAYITEM_GC index \
                                              must be a non-negative Const i32 (TagOverflow)",
-                                )),
+                                    );
+                                    0
+                                }
                             };
                             (pf_op.arg(0), pf_op.arg(2), idx as i32)
                         } else {
@@ -5729,11 +5803,13 @@ mod tests {
         let (ops, inputs) = b.build();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         let num_inputs = inputs.len();
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            num_inputs,
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                num_inputs,
+            )
+            .expect("test: unexpected InvalidLoop");
         // The duplicate INT_ADD should be eliminated by CSE (OptPure).
         let add_count = result.iter().filter(|o| o.opcode == OpCode::IntAdd).count();
         assert_eq!(add_count, 1, "CSE should eliminate duplicate INT_ADD");
@@ -5930,11 +6006,13 @@ mod tests {
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         let num_inputs = inputs.len();
         opt.snapshot_boxes = seed_empty_guard_snapshots_oprc(&ops);
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            num_inputs,
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                num_inputs,
+            )
+            .expect("test: unexpected InvalidLoop");
         let ctx = OptContext::new(result.len());
         // Just verify the counting methods work
         assert_eq!(Optimizer::get_count_of_ops(&ctx), 0); // empty ctx
@@ -6300,7 +6378,9 @@ mod tests {
         )));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        let result = opt.optimize_with_constants_and_inputs_at(&[], &mut constants, 3, 0, 0, false);
+        let result = opt
+            .optimize_with_constants_and_inputs_at(&[], &mut constants, 3, 0, 0, false)
+            .expect("empty trace must not produce InvalidLoop");
 
         assert!(result.is_empty());
         // Empty trace, no emitted ops — carry must be empty. Inputarg
@@ -6661,11 +6741,13 @@ mod tests {
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         let num_inputs = inputs.len();
         opt.snapshot_boxes = seed_guard_snapshots_with_oprc(&ops, |_| vec![x_ref, y_ref]);
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            num_inputs,
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                num_inputs,
+            )
+            .expect("test: unexpected InvalidLoop");
 
         let guard = result
             .iter()

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1044,13 +1044,13 @@ impl Optimization for OptPure {
                 //      prefers the softer skip so the op stays in
                 //      the trace and the runtime guard fires.
                 // Every caller-invariant violation (missing box,
-                // descr, wrong Value variant) now panics inside
+                // descr, wrong Value variant) panics inside
                 // `constant_fold` / `protect_speculative_operation`,
-                // matching upstream's `AttributeError`.  Genuine
-                // SpeculativeError paths panic via
-                // `panic_any(SpeculativeError)` and are caught at
-                // `optimize_peeled_loop` /
-                // `optimize_with_constants_and_inputs_at` per
+                // matching upstream's `AttributeError`.  A genuine
+                // speculative-fold failure (ill-typed heap access) is
+                // recorded as a deferred `InvalidLoop` signal on the
+                // context; `constant_fold` then returns `None` and the
+                // driver aborts the trace at its next barrier per
                 // `unroll.py:119-123`.
                 if let Some(folded_value) = ctx.constant_fold(op) {
                     let b = ctx.materialize_box_at(op.pos.get());
@@ -1506,6 +1506,7 @@ mod tests {
         };
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&run_ops, constants, num_inputs as usize)
+            .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())
             .collect();
@@ -1662,11 +1663,13 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            inputs.len(),
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                inputs.len(),
+            )
+            .expect("test: unexpected InvalidLoop");
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallR);
@@ -1686,11 +1689,13 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            inputs.len(),
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                inputs.len(),
+            )
+            .expect("test: unexpected InvalidLoop");
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::SetfieldGc);
@@ -1728,11 +1733,13 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            inputs.len(),
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                inputs.len(),
+            )
+            .expect("test: unexpected InvalidLoop");
 
         assert_eq!(result.len(), 1);
     }
@@ -1765,11 +1772,13 @@ mod tests {
             call_pure_results: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             preamble_pure_ops: Vec::new(),
         }));
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            num_inputs as usize,
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                num_inputs as usize,
+            )
+            .expect("test: unexpected InvalidLoop");
 
         // All 17 unique ops should be emitted, plus the re-inserted one
         // (since the first was evicted from the LRU cache of size 16).
@@ -1890,11 +1899,13 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants_and_inputs_oprc(
-            &ops,
-            &mut majit_ir::VecAssoc::new(),
-            inputs.len(),
-        );
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::VecAssoc::new(),
+                inputs.len(),
+            )
+            .expect("test: unexpected InvalidLoop");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::CallF);
@@ -2898,8 +2909,9 @@ mod tests {
         opt.add_pass(Box::new(OptPure::new()));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        let result =
-            opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len());
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len())
+            .expect("test: unexpected InvalidLoop");
 
         assert!(result.is_empty());
         assert_eq!(constants.get(&op_pos), Some(&majit_ir::Value::Int(42)));
@@ -2970,8 +2982,9 @@ mod tests {
         opt.add_pass(Box::new(OptPure::new()));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        let result =
-            opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len());
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len())
+            .expect("test: unexpected InvalidLoop");
 
         // op0 collapses to the cached constant (removed); op1 is the residual
         // call that consumes it.

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -21,10 +21,14 @@ enum LoopInvariantEntry {
     Preamble(PreambleOp),
 }
 
+/// Yield the `OptimizationResult::InvalidLoop` control value so the driver
+/// (`propagate_from_pass_range`) converts it to `Err(InvalidLoop)` at the
+/// pass barrier.  RPython `raise InvalidLoop`; threaded as a value here so
+/// it works under `panic=abort`.  Use as `return raise_invalid_loop(msg)`.
 #[cold]
 #[inline(never)]
-fn raise_invalid_loop(msg: &'static str) -> ! {
-    std::panic::panic_any(crate::optimize::InvalidLoop(msg));
+fn raise_invalid_loop(msg: &'static str) -> OptimizationResult {
+    OptimizationResult::InvalidLoop(msg)
 }
 
 /// info.py:16-18: INFO_NULL / INFO_NONNULL / INFO_UNKNOWN
@@ -608,7 +612,7 @@ impl OptRewrite {
             if val != 0 {
                 return OptimizationResult::Remove;
             }
-            raise_invalid_loop("GUARD_TRUE proven to always fail");
+            return raise_invalid_loop("GUARD_TRUE proven to always fail");
         }
 
         OptimizationResult::PassOn
@@ -626,7 +630,7 @@ impl OptRewrite {
             if val == 0 {
                 return OptimizationResult::Remove;
             }
-            raise_invalid_loop("GUARD_FALSE proven to always fail");
+            return raise_invalid_loop("GUARD_FALSE proven to always fail");
         }
 
         OptimizationResult::PassOn
@@ -665,7 +669,7 @@ impl OptRewrite {
                 if actual_int == expected_int {
                     return OptimizationResult::Remove;
                 }
-                raise_invalid_loop("GUARD_VALUE proven to always fail");
+                return raise_invalid_loop("GUARD_VALUE proven to always fail");
             }
         } else if let (Some(actual), Some(expected)) = (
             ctx.resolve_box_box_opt(&arg0)
@@ -678,7 +682,7 @@ impl OptRewrite {
             }
             match actual {
                 Value::Int(_) | Value::Ref(_) => {
-                    raise_invalid_loop("GUARD_VALUE proven to always fail");
+                    return raise_invalid_loop("GUARD_VALUE proven to always fail");
                 }
                 Value::Float(_) => {
                     return OptimizationResult::Remove;
@@ -694,7 +698,7 @@ impl OptRewrite {
         let obj_info = obj_box.as_ref().and_then(|b| ctx.getptrinfo(b));
         if let Some(info) = obj_info {
             if info.is_virtual() {
-                raise_invalid_loop("promote of a virtual");
+                return raise_invalid_loop("promote of a virtual");
             }
             // rewrite.py:307-347: replace_old_guard_with_guard_value
             if let Some(old_guard) = obj_box
@@ -718,7 +722,7 @@ impl OptRewrite {
                         Value::Void => true,
                     };
                     if !c_nonnull {
-                        raise_invalid_loop(
+                        return raise_invalid_loop(
                             "GUARD_VALUE(..., NULL) follows some other guard that it is not NULL",
                         );
                     }
@@ -731,7 +735,7 @@ impl OptRewrite {
                         if let Some(arg1_box) = ctx.resolve_box_box_opt(&arg1) {
                             if let Some(expected_cls) = ctx.get_known_class(&arg1_box) {
                                 if prev_cls != expected_cls {
-                                    raise_invalid_loop(
+                                    return raise_invalid_loop(
                                         "GUARD_VALUE proven to always fail (class mismatch)",
                                     );
                                 }
@@ -821,7 +825,7 @@ impl OptRewrite {
                     }
                     // rewrite.py:404-407: known class mismatch is a
                     // proven-fail guard — abort the trace.
-                    raise_invalid_loop("GUARD_CLASS proven to always fail");
+                    return raise_invalid_loop("GUARD_CLASS proven to always fail");
                 }
             }
         }
@@ -1709,7 +1713,7 @@ impl Optimization for OptRewrite {
                         return OptimizationResult::Remove;
                     }
                     if info.is_null() {
-                        raise_invalid_loop("GUARD_NONNULL proven to always fail");
+                        return raise_invalid_loop("GUARD_NONNULL proven to always fail");
                     }
                 }
                 // rewrite.py:280-282 postprocess_GUARD_NONNULL:
@@ -1737,7 +1741,7 @@ impl Optimization for OptRewrite {
                         return OptimizationResult::Remove;
                     }
                     if info.is_nonnull() {
-                        raise_invalid_loop("GUARD_ISNULL proven to always fail");
+                        return raise_invalid_loop("GUARD_ISNULL proven to always fail");
                     }
                 }
                 // rewrite.py:197-198 postprocess_GUARD_ISNULL:
@@ -1759,7 +1763,7 @@ impl Optimization for OptRewrite {
                 //     return self.optimize_GUARD_CLASS(op)
                 if let Some(info) = ctx.getptrinfo(&op.arg(0).get_box_replacement(false)) {
                     if info.is_null() {
-                        raise_invalid_loop("GUARD_NONNULL_CLASS proven to always fail");
+                        return raise_invalid_loop("GUARD_NONNULL_CLASS proven to always fail");
                     }
                 }
                 self.optimize_guard_class(op, ctx)
@@ -2519,7 +2523,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     std::panic::panic_any(crate::optimize::InvalidLoop(
                         "guard proven to always fail",
                     ));
@@ -2750,17 +2754,15 @@ mod tests {
 
     #[test]
     fn test_guard_true_known_false() {
-        let err = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            run_one(
-                vec![same_i(), op_spec(OpCode::GuardTrue, &[0])],
-                1,
-                &[(OpRef::int_op(0), Value::Int(0))],
-            )
-        })) {
-            Ok(_) => panic!("guard_true(0) should abort as InvalidLoop"),
-            Err(err) => err,
-        };
-        assert!(err.downcast_ref::<crate::optimize::InvalidLoop>().is_some());
+        let (result, _) = run_one(
+            vec![same_i(), op_spec(OpCode::GuardTrue, &[0])],
+            1,
+            &[(OpRef::int_op(0), Value::Int(0))],
+        );
+        assert!(
+            matches!(result, OptimizationResult::InvalidLoop(_)),
+            "guard_true(0) should abort as InvalidLoop, got {result:?}"
+        );
     }
 
     #[test]
@@ -2781,17 +2783,15 @@ mod tests {
 
     #[test]
     fn test_guard_false_known_true() {
-        let err = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            run_one(
-                vec![same_i(), op_spec(OpCode::GuardFalse, &[0])],
-                1,
-                &[(OpRef::int_op(0), Value::Int(1))],
-            )
-        })) {
-            Ok(_) => panic!("guard_false(1) should abort as InvalidLoop"),
-            Err(err) => err,
-        };
-        assert!(err.downcast_ref::<crate::optimize::InvalidLoop>().is_some());
+        let (result, _) = run_one(
+            vec![same_i(), op_spec(OpCode::GuardFalse, &[0])],
+            1,
+            &[(OpRef::int_op(0), Value::Int(1))],
+        );
+        assert!(
+            matches!(result, OptimizationResult::InvalidLoop(_)),
+            "guard_false(1) should abort as InvalidLoop, got {result:?}"
+        );
     }
 
     #[test]
@@ -2871,7 +2871,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     std::panic::panic_any(crate::optimize::InvalidLoop(
                         "guard proven to always fail",
                     ));
@@ -2939,7 +2939,7 @@ mod tests {
                     OptimizationResult::PassOn => {
                         ctx.emit(resolved);
                     }
-                    OptimizationResult::InvalidLoop => {
+                    OptimizationResult::InvalidLoop(_) => {
                         std::panic::panic_any(crate::optimize::InvalidLoop(
                             "guard proven to always fail",
                         ));
@@ -3497,7 +3497,9 @@ mod tests {
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
         let num_inputs = inputs.len();
-        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
+            .expect("test: unexpected InvalidLoop");
 
         assert!(
             result.iter().any(|o| o.opcode == OpCode::IntNeg),
@@ -3520,7 +3522,9 @@ mod tests {
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
         let num_inputs = inputs.len();
-        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
+            .expect("test: unexpected InvalidLoop");
         assert!(!result.is_empty());
     }
 
@@ -3539,7 +3543,9 @@ mod tests {
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
         let num_inputs = inputs.len();
-        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
+            .expect("test: unexpected InvalidLoop");
         assert!(
             !result.iter().any(|o| o.opcode == OpCode::CondCallN),
             "COND_CALL_N(0, ...) should be removed"
@@ -3561,7 +3567,9 @@ mod tests {
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
         let num_inputs = inputs.len();
-        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
+            .expect("test: unexpected InvalidLoop");
         assert!(
             result.iter().any(|o| o.opcode == OpCode::CallN),
             "COND_CALL_N(1, ...) should become CALL_N"

--- a/majit/majit-metainterp/src/optimizeopt/simplify.rs
+++ b/majit/majit-metainterp/src/optimizeopt/simplify.rs
@@ -129,6 +129,7 @@ mod tests {
             &mut majit_ir::VecAssoc::new(),
             num_inputs,
         )
+        .expect("test: unexpected InvalidLoop")
         .into_iter()
         .map(|rc| (*rc).clone())
         .collect()

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -41,24 +41,19 @@ use crate::resume::SnapshotBox;
 /// `OptContext::protect_speculative_operation` and rethrow it as an
 /// `InvalidLoop` — the existing catch_unwind sites at the pyjitpl
 /// layer already convert that into a "skip retrace" outcome.
+/// unroll.py:119-123 / 122 `except SpeculativeError: raise InvalidLoop`.
+///
+/// Speculative-fold failures are now recorded as a deferred `InvalidLoop`
+/// signal on `OptContext` (see `protect_speculative_operation` /
+/// `constant_fold`) and surfaced as `Err(InvalidLoop)` by the optimizer
+/// driver, so there is no `SpeculativeError` panic left to catch.  This
+/// wrapper is retained as a structural marker of the upstream conversion
+/// point; it simply forwards the closure's result.
 fn with_speculative_to_invalid_loop<R, F>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
-        Ok(value) => value,
-        Err(payload) => {
-            if payload
-                .downcast_ref::<crate::optimize::SpeculativeError>()
-                .is_some()
-            {
-                std::panic::panic_any(crate::optimize::InvalidLoop(
-                    "Speculative heap access would be ill-typed",
-                ));
-            }
-            std::panic::resume_unwind(payload);
-        }
-    }
+    f()
 }
 
 fn is_trace_constant_ref(
@@ -440,6 +435,7 @@ impl UnrollOptimizer {
         num_inputs: usize,
     ) -> (Vec<majit_ir::OpRc>, usize) {
         self.optimize_trace_with_constants_and_inputs_vable(ops, constants, num_inputs, None)
+            .expect("optimize_trace_with_constants_and_inputs: unexpected InvalidLoop")
     }
 
     /// compile.py:275-308: compile_loop — 2-phase preamble peeling.
@@ -455,7 +451,7 @@ impl UnrollOptimizer {
         constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
         num_inputs: usize,
         vable_config: Option<crate::optimizeopt::virtualize::VirtualizableConfig>,
-    ) -> (Vec<majit_ir::OpRc>, usize) {
+    ) -> Result<(Vec<majit_ir::OpRc>, usize), crate::optimize::InvalidLoop> {
         self.optimize_trace_with_constants_and_inputs_vable_out(
             ops,
             constants,
@@ -477,41 +473,42 @@ impl UnrollOptimizer {
         num_inputs: usize,
         vable_config: Option<crate::optimizeopt::virtualize::VirtualizableConfig>,
         phase1_out: Option<&mut Option<(Vec<majit_ir::OpRc>, ExportedState)>>,
-    ) -> (Vec<majit_ir::OpRc>, usize) {
+    ) -> Result<(Vec<majit_ir::OpRc>, usize), crate::optimize::InvalidLoop> {
         // compile.py:362: if imported_state is pre-set (compile_retrace path),
         // skip Phase 1 and go directly to Phase 2 with the imported state.
-        let (mut exported_state, consts_p1, p1_ops) =
-            if let Some(pre_imported) = self.imported_state.take() {
-                // RPython uses object identity for Boxes, so a TraceIterator over a
-                // retrace can never numerically collide with the already optimized
-                // partial preamble. Majit's OpRef is the identity; when Phase 1 is
-                // skipped, recover the partial preamble high-water from the imported
-                // state before allocating Phase 2 input/result OpRefs.
-                self.next_global_opref = self
-                    .next_global_opref
-                    .max(num_inputs as u32)
-                    .max(pre_imported.opref_high_water());
-                // Retrace path: Phase 1 already done; the preamble producers
-                // live in the imported state's `partial_trace_operations`
-                // (export records them there from `phase1_emit_ops`, #104). The
-                // non-skip path populates `self.phase1_emit_ops` from `opt_p1`;
-                // restore the same pool here so Phase 2's producer lookup
-                // (`new_operations ∪ phase1_emit_ops ∪ resop_refs`) can reach a
-                // const-folded preamble producer that no other store carries.
-                // RPython keeps box `_forwarded` reachable across the retrace;
-                // this is the pyre analog. (Readers dedup, so double-coverage
-                // with `resop_refs` is idempotent.)
-                self.phase1_emit_ops = pre_imported.partial_trace_operations.clone();
-                // RPython: same Optimizer persists patchguardop. Recover here.
-                if self.phase1_patchguardop.is_none() {
-                    self.phase1_patchguardop = pre_imported.patchguardop.clone();
-                }
-                (pre_imported, constants.clone(), Vec::new())
-            } else {
-                // ── Phase 1: PreambleCompileData.optimize() ──
-                // ── Phase 1: optimize_preamble (compile.py:275-276) ──
-                let mut consts_p1 = constants.clone();
-                let mut opt_p1 = match vable_config.as_ref() {
+        let (mut exported_state, consts_p1, p1_ops) = if let Some(pre_imported) =
+            self.imported_state.take()
+        {
+            // RPython uses object identity for Boxes, so a TraceIterator over a
+            // retrace can never numerically collide with the already optimized
+            // partial preamble. Majit's OpRef is the identity; when Phase 1 is
+            // skipped, recover the partial preamble high-water from the imported
+            // state before allocating Phase 2 input/result OpRefs.
+            self.next_global_opref = self
+                .next_global_opref
+                .max(num_inputs as u32)
+                .max(pre_imported.opref_high_water());
+            // Retrace path: Phase 1 already done; the preamble producers
+            // live in the imported state's `partial_trace_operations`
+            // (export records them there from `phase1_emit_ops`, #104). The
+            // non-skip path populates `self.phase1_emit_ops` from `opt_p1`;
+            // restore the same pool here so Phase 2's producer lookup
+            // (`new_operations ∪ phase1_emit_ops ∪ resop_refs`) can reach a
+            // const-folded preamble producer that no other store carries.
+            // RPython keeps box `_forwarded` reachable across the retrace;
+            // this is the pyre analog. (Readers dedup, so double-coverage
+            // with `resop_refs` is idempotent.)
+            self.phase1_emit_ops = pre_imported.partial_trace_operations.clone();
+            // RPython: same Optimizer persists patchguardop. Recover here.
+            if self.phase1_patchguardop.is_none() {
+                self.phase1_patchguardop = pre_imported.patchguardop.clone();
+            }
+            (pre_imported, constants.clone(), Vec::new())
+        } else {
+            // ── Phase 1: PreambleCompileData.optimize() ──
+            // ── Phase 1: optimize_preamble (compile.py:275-276) ──
+            let mut consts_p1 = constants.clone();
+            let mut opt_p1 = match vable_config.as_ref() {
                 Some(c) => {
                     crate::optimizeopt::optimizer::Optimizer::default_pipeline_with_virtualizable(
                         c.clone(),
@@ -519,254 +516,297 @@ impl UnrollOptimizer {
                 }
                 None => crate::optimizeopt::optimizer::Optimizer::default_pipeline(),
             };
-                opt_p1.all_descrs = std::mem::take(&mut self.all_descrs);
-                opt_p1.callinfocollection = self.callinfocollection.clone();
-                opt_p1.cpu = self.cpu.clone();
-                opt_p1.trace_inputargs = self.trace_inputargs.clone();
-                opt_p1.snapshot_boxes = self.snapshot_boxes.clone();
-                opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
-                opt_p1.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
-                opt_p1.snapshot_vref_boxes = self.snapshot_vref_boxes.clone();
-                opt_p1.snapshot_frame_pcs = self.snapshot_frame_pcs.clone();
-                self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
-                    &mut opt_p1.snapshot_boxes,
-                    &mut opt_p1.snapshot_vable_boxes,
-                    &mut opt_p1.snapshot_vref_boxes,
-                ]));
-                opt_p1.call_pure_results = self.call_pure_results.clone();
-                // RPython optimize_preamble (unroll.py:101-103): flush=False.
-                // JUMP/FINISH is NOT sent through the pass pipeline; it's
-                // returned in info.jump_op for Phase 2 to consume.
-                opt_p1.skip_flush = true;
-                // RPython unroll.py:101-103 `optimize_preamble` calls
-                // `propagate_all_forward(trace.get_iter())`. `trace.get_iter()`
-                // is a fresh `TraceIterator` whose `next()` produces a freshly
-                // allocated `cls()` ResOperation for every visited op.
-                //
-                // Phase 1 routes the input ops through `TraceIterator::new`
-                // with `start_fresh = 0`. The recorder emits ops at
-                // monotonically increasing positions starting from
-                // `num_inputs` (recorder.rs `record_op` uses `op_count` for
-                // BOTH inputargs and ops, and ops follow inputargs), and
-                // `TraceIterator::next` allocates fresh OpRefs from `_fresh`
-                // which is also seeded at `num_inputs` after the inputarg
-                // pre-seed loop. Both void and non-void ops advance `_fresh`
-                // (see opencoder.rs::next), so the freshly produced OpRef
-                // sequence is bit-identical to the input — this wrap is a
-                // structural alignment with RPython's `trace.get_iter()`
-                // call site, not a functional change.
-                // opencoder.py:264 `inputarg_from_tp(arg.type)` — fresh inputargs
-                // are typed via `self.trace_inputargs`, the recorder-supplied
-                // Box list (length must equal `num_inputs`). Derive the &[Type]
-                // surface TraceIterator expects from each Box's variant tag
-                // (resoperation.py:719/727/739).
-                debug_assert_eq!(self.trace_inputargs.len(), num_inputs);
-                let p1_inputarg_types: Vec<majit_ir::Type> = self
-                    .trace_inputargs
-                    .iter()
-                    .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
-                    .collect();
-                // Wrap input ops as `Vec<OpRc>` so TraceIterator's `&[OpRc]`
-                // surface receives shared identity (history.py:528). The
-                // deep-clone here corresponds to PyPy's `cls()` per-op fresh
-                // allocation inside `TraceIterator.next` (opencoder.py:399-401).
-                let ops_oprc: Vec<majit_ir::OpRc> =
-                    ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
-                let mut p1_iter = crate::opencoder::TraceIterator::new(
-                    &ops_oprc,
-                    0,
-                    ops_oprc.len(),
-                    None,
-                    &p1_inputarg_types,
-                    0, // start_fresh = 0 — inputargs at [0..num_inputs)
+            opt_p1.all_descrs = std::mem::take(&mut self.all_descrs);
+            opt_p1.callinfocollection = self.callinfocollection.clone();
+            opt_p1.cpu = self.cpu.clone();
+            opt_p1.trace_inputargs = self.trace_inputargs.clone();
+            opt_p1.snapshot_boxes = self.snapshot_boxes.clone();
+            opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
+            opt_p1.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
+            opt_p1.snapshot_vref_boxes = self.snapshot_vref_boxes.clone();
+            opt_p1.snapshot_frame_pcs = self.snapshot_frame_pcs.clone();
+            self.replace_compile_snapshot_roots(Self::collect_snapshot_const_ptr_slots(&mut [
+                &mut opt_p1.snapshot_boxes,
+                &mut opt_p1.snapshot_vable_boxes,
+                &mut opt_p1.snapshot_vref_boxes,
+            ]));
+            opt_p1.call_pure_results = self.call_pure_results.clone();
+            // RPython optimize_preamble (unroll.py:101-103): flush=False.
+            // JUMP/FINISH is NOT sent through the pass pipeline; it's
+            // returned in info.jump_op for Phase 2 to consume.
+            opt_p1.skip_flush = true;
+            // RPython unroll.py:101-103 `optimize_preamble` calls
+            // `propagate_all_forward(trace.get_iter())`. `trace.get_iter()`
+            // is a fresh `TraceIterator` whose `next()` produces a freshly
+            // allocated `cls()` ResOperation for every visited op.
+            //
+            // Phase 1 routes the input ops through `TraceIterator::new`
+            // with `start_fresh = 0`. The recorder emits ops at
+            // monotonically increasing positions starting from
+            // `num_inputs` (recorder.rs `record_op` uses `op_count` for
+            // BOTH inputargs and ops, and ops follow inputargs), and
+            // `TraceIterator::next` allocates fresh OpRefs from `_fresh`
+            // which is also seeded at `num_inputs` after the inputarg
+            // pre-seed loop. Both void and non-void ops advance `_fresh`
+            // (see opencoder.rs::next), so the freshly produced OpRef
+            // sequence is bit-identical to the input — this wrap is a
+            // structural alignment with RPython's `trace.get_iter()`
+            // call site, not a functional change.
+            // opencoder.py:264 `inputarg_from_tp(arg.type)` — fresh inputargs
+            // are typed via `self.trace_inputargs`, the recorder-supplied
+            // Box list (length must equal `num_inputs`). Derive the &[Type]
+            // surface TraceIterator expects from each Box's variant tag
+            // (resoperation.py:719/727/739).
+            debug_assert_eq!(self.trace_inputargs.len(), num_inputs);
+            let p1_inputarg_types: Vec<majit_ir::Type> = self
+                .trace_inputargs
+                .iter()
+                .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
+                .collect();
+            // Wrap input ops as `Vec<OpRc>` so TraceIterator's `&[OpRc]`
+            // surface receives shared identity (history.py:528). The
+            // deep-clone here corresponds to PyPy's `cls()` per-op fresh
+            // allocation inside `TraceIterator.next` (opencoder.py:399-401).
+            let ops_oprc: Vec<majit_ir::OpRc> =
+                ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
+            let mut p1_iter = crate::opencoder::TraceIterator::new(
+                &ops_oprc,
+                0,
+                ops_oprc.len(),
+                None,
+                &p1_inputarg_types,
+                0, // start_fresh = 0 — inputargs at [0..num_inputs)
+            );
+            let mut p1_ops_in: Vec<majit_ir::OpRc> = Vec::with_capacity(ops.len());
+            while let Some(op) = p1_iter.next() {
+                p1_ops_in.push(op);
+            }
+            let p1_iter_fresh_hw = p1_iter._fresh;
+            // compile.py:275 `PreambleCompileData(trace, jumpargs, ...)` —
+            // the recorded JUMP arglist is the preamble's `runtime_boxes`
+            // (live_arg_boxes captured at the merge point). Capture it into a
+            // local here; `opt_p1.runtime_boxes` cannot carry it because
+            // `setup()` clears that field at the start of every optimize run
+            // (optimizer.rs `self.runtime_boxes.clear()`). Threaded into the
+            // exported state below so the peeled-loop close reads it as
+            // `state.runtime_boxes` (unroll.py:105 → :153/166) rather than the
+            // peeled body's own jump args.
+            let recorded_jump_args: Vec<OpRef> = ops
+                .iter()
+                .rfind(|op| op.opcode == OpCode::Jump)
+                .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
+                .unwrap_or_default();
+            // Hand opt_p1 the per-iter BoxRef pool that p1_iter
+            // allocated (slice 77b.A). trace.get_iter() per-call
+            // inputarg_from_tp(...) / cls() — each phase optimizes against a
+            // fresh Box identity set so _forwarded mutations cannot alias
+            // across phases.
+            //
+            // Const BoxRefs are NOT cached: `get_box_replacement_box`
+            // allocates `BoxRef::new_const(value)` per call from `const_pool`
+            // (`history.py:220` ConstInt(value) per-call-site parity).
+            // opt_p1's entry path seeds `const_pool` from the shared
+            // `constants` map (`optimizer.rs:1944`).
+            // unroll.py:100-110 `optimize_preamble` has no
+            // SpeculativeError catch — Phase 1 corresponds to the
+            // preamble, whose gcrefs are concrete runtime values
+            // from the recorded interpreter and never raise
+            // SpeculativeError under correct construction.  A raise
+            // here is a real bug and must propagate.
+            // Phase 1's input ops are the same recorder ops the seed names,
+            // so its `input_ops` can come from the seed too — only the read
+            // source changes; `_forwarded` writes are untouched. No
+            // forwarding yet at Phase 1 setup, so the seed is trivially the
+            // authoritative source here.
+            if let Some(seed) = &self.phase2_input_ops_seed {
+                opt_p1.explicit_input_ops_seed = Some(seed.clone());
+            }
+            let p1_ops =
+                opt_p1.run_optimize_from_inputs(&p1_ops_in, &mut consts_p1, num_inputs, false)?;
+            // RPython parity: Phase 1 optimizer may discover new constants
+            // via make_constant (e.g., constant-folded heap reads, guard
+            // class pointers). These live on the BoxRef forwarded chain
+            // (and in `ctx.const_pool` for const-namespace OpRefs) but
+            // not in `consts_p1` (which was only seeded from the input
+            // constants). Merge them back so
+            // build_short_preamble_from_exported_boxes can capture all
+            // constants referenced by short preamble ops.
+            if let Some(ref final_ctx) = opt_p1.final_ctx {
+                // history.py:220 box.type parity: every `Value` carries its
+                // Const class identity intrinsically; no companion type map
+                // needs threading alongside.
+                crate::optimizeopt::optimizer::merge_backend_constants_from_ctx(
+                    final_ctx,
+                    &mut consts_p1,
                 );
-                let mut p1_ops_in: Vec<majit_ir::OpRc> = Vec::with_capacity(ops.len());
-                while let Some(op) = p1_iter.next() {
-                    p1_ops_in.push(op);
-                }
-                let p1_iter_fresh_hw = p1_iter._fresh;
-                // compile.py:275 `PreambleCompileData(trace, jumpargs, ...)` —
-                // the recorded JUMP arglist is the preamble's `runtime_boxes`
-                // (live_arg_boxes captured at the merge point). Capture it into a
-                // local here; `opt_p1.runtime_boxes` cannot carry it because
-                // `setup()` clears that field at the start of every optimize run
-                // (optimizer.rs `self.runtime_boxes.clear()`). Threaded into the
-                // exported state below so the peeled-loop close reads it as
-                // `state.runtime_boxes` (unroll.py:105 → :153/166) rather than the
-                // peeled body's own jump args.
-                let recorded_jump_args: Vec<OpRef> = ops
-                    .iter()
-                    .rfind(|op| op.opcode == OpCode::Jump)
-                    .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
-                    .unwrap_or_default();
-                // Hand opt_p1 the per-iter BoxRef pool that p1_iter
-                // allocated (slice 77b.A). trace.get_iter() per-call
-                // inputarg_from_tp(...) / cls() — each phase optimizes against a
-                // fresh Box identity set so _forwarded mutations cannot alias
-                // across phases.
-                //
-                // Const BoxRefs are NOT cached: `get_box_replacement_box`
-                // allocates `BoxRef::new_const(value)` per call from `const_pool`
-                // (`history.py:220` ConstInt(value) per-call-site parity).
-                // opt_p1's entry path seeds `const_pool` from the shared
-                // `constants` map (`optimizer.rs:1944`).
-                // unroll.py:100-110 `optimize_preamble` has no
-                // SpeculativeError catch — Phase 1 corresponds to the
-                // preamble, whose gcrefs are concrete runtime values
-                // from the recorded interpreter and never raise
-                // SpeculativeError under correct construction.  A raise
-                // here is a real bug and must propagate.
-                // Phase 1's input ops are the same recorder ops the seed names,
-                // so its `input_ops` can come from the seed too — only the read
-                // source changes; `_forwarded` writes are untouched. No
-                // forwarding yet at Phase 1 setup, so the seed is trivially the
-                // authoritative source here.
-                if let Some(seed) = &self.phase2_input_ops_seed {
-                    opt_p1.explicit_input_ops_seed = Some(seed.clone());
-                }
-                let p1_ops =
-                    opt_p1.run_optimize_from_inputs(&p1_ops_in, &mut consts_p1, num_inputs, false);
-                // RPython parity: Phase 1 optimizer may discover new constants
-                // via make_constant (e.g., constant-folded heap reads, guard
-                // class pointers). These live on the BoxRef forwarded chain
-                // (and in `ctx.const_pool` for const-namespace OpRefs) but
-                // not in `consts_p1` (which was only seeded from the input
-                // constants). Merge them back so
-                // build_short_preamble_from_exported_boxes can capture all
-                // constants referenced by short preamble ops.
-                if let Some(ref final_ctx) = opt_p1.final_ctx {
-                    // history.py:220 box.type parity: every `Value` carries its
-                    // Const class identity intrinsically; no companion type map
-                    // needs threading alongside.
-                    crate::optimizeopt::optimizer::merge_backend_constants_from_ctx(
-                        final_ctx,
-                        &mut consts_p1,
-                    );
-                }
-                let p1_ni = opt_p1.final_num_inputs();
+            }
+            let p1_ni = opt_p1.final_num_inputs();
 
-                match opt_p1.exported_loop_state.take() {
-                    Some(mut state) => {
-                        // unroll.py:105 `export_state(..., runtime_boxes, ...)` —
-                        // carry the recorded JUMP args into ExportedState so the
-                        // peeled-loop close passes them to generate_guards as
-                        // `state.runtime_boxes` (unroll.py:153/166).
-                        state.runtime_boxes = recorded_jump_args
-                            .iter()
-                            .map(|&a| BoxRef::from_opref(a))
-                            .collect();
-                        // end_arg_types is already populated by
-                        // `Optimizer::optimize_with_constants_and_inputs_at`
-                        // using the optimizer-visible `ctx.opref_type()` (see
-                        // optimizer.rs:2405-2416). Overwriting it here with
-                        // `opcode.result_type()` + `Type::Ref` default would
-                        // retype Phase 1 inputarg OpRefs (absent from `p1_ops`)
-                        // as `Ref`, which later feeds the cross-type forward
-                        // assertion in `OptContext::make_equal_to`.
-                        // RPython Phase 1 → Phase 2 heap cache transfer:
-                        // RPython does NOT serialize heap cache in ExportedState.
-                        // HeapOps in the short preamble are replayed during Phase 2's
-                        // inline_short_preamble, populating the heap cache naturally
-                        // through OptHeap. serialize_optheap is only for bridgeopt.
-                        // opencoder.py:271 _index parity: Phase 2's TraceIterator
-                        // must allocate fresh boxes ABOVE Phase 1's high water
-                        // mark so the two phases' OpRef namespaces are disjoint
-                        // (RPython relies on Python identity to distinguish them;
-                        // majit relies on disjoint integer ranges). The high
-                        // water is `final_ctx.next_pos` after Phase 1 emit, with
-                        // a floor of `num_inputs` for empty traces.
-                        // Phase 1's emit-side high water (`final_ctx.next_pos`)
-                        // reflects only the positions `ctx.reserve_pos` handed
-                        // out; the per-iteration TraceIterator additionally
-                        // allocates fresh OpRefs via its `_fresh` counter and
-                        // those values can exceed `next_pos` for traces where
-                        // Phase 1 dropped or folded many ops. Taking the max
-                        // with `p1_iter_fresh_hw` keeps Phase 2's inputarg base
-                        // strictly above every OpRef Phase 1 ever allocated,
-                        // so Phase 2's own fresh OpRefs cannot collide with
-                        // positions in `phase1_emit_ops` / typed snapshots.
-                        self.next_global_opref = opt_p1
-                            .final_ctx
-                            .as_ref()
-                            .map(|c| c.next_pos)
-                            .unwrap_or(num_inputs as u32)
-                            .max(num_inputs as u32)
-                            .max(p1_iter_fresh_hw);
-                        // RPython Box type parity: Phase 1's emit ops carry
-                        // `op.type_` intrinsically; Phase 2's `op_at` reads it
-                        // directly to resolve cross-phase OpRefs that appear as
-                        // imported_label_args / fail_args / record_same_as
-                        // sources (history.py:220 parity).
-                        self.phase1_emit_ops = std::mem::take(&mut opt_p1.phase1_emit_ops);
-                        // RPython: same Optimizer instance keeps patchguardop.
-                        if self.phase1_patchguardop.is_none() {
-                            self.phase1_patchguardop = opt_p1.patchguardop.clone();
-                        }
-                        state.patchguardop = opt_p1.patchguardop.clone();
-                        self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
-                        // Box.type parity: retain Phase 1's renamed_inputargs so
-                        // the backend can read the reduced LABEL's declared types
-                        // off each typed InputArg OpRef. Clone only the field we
-                        // need to avoid keeping Phase 1 short preamble data alive
-                        // longer than before.
-                        let mut final_exported_state = ExportedState {
-                            end_args: Vec::new(),
-                            next_iteration_args: Vec::new(),
-                            end_arg_types: Vec::new(),
-                            virtual_state: state.virtual_state.clone(),
-                            exported_infos: crate::optimizeopt::vec_assoc::VecAssoc::new(),
-                            exported_short_boxes: Vec::new(),
-                            short_boxes: Vec::new(),
-                            short_box_const_values: crate::optimizeopt::vec_assoc::VecAssoc::new(),
-                            short_preamble: None,
-                            renamed_inputargs: state.renamed_inputargs.clone(),
-                            short_inputargs: Vec::new(),
-                            short_inputarg_refs: Vec::new(),
-                            runtime_boxes: Vec::new(),
-                            patchguardop: None,
-                            phase1_emit_high_water: self.next_global_opref,
-                            partial_trace_inputargs: Vec::new(),
-                            partial_trace_operations: Vec::new(),
-                            rooted_refs: Vec::new(),
-                            rooted_const_ptr_slots: Vec::new(),
-                            shadow_stack_base: 0,
-                        };
-                        final_exported_state.root_all_gcrefs();
-                        self.final_exported_state = Some(final_exported_state);
-                        (state, consts_p1, p1_ops)
+            match opt_p1.exported_loop_state.take() {
+                Some(mut state) => {
+                    // unroll.py:105 `export_state(..., runtime_boxes, ...)` —
+                    // carry the recorded JUMP args into ExportedState so the
+                    // peeled-loop close passes them to generate_guards as
+                    // `state.runtime_boxes` (unroll.py:153/166).
+                    state.runtime_boxes = recorded_jump_args
+                        .iter()
+                        .map(|&a| BoxRef::from_opref(a))
+                        .collect();
+                    // end_arg_types is already populated by
+                    // `Optimizer::optimize_with_constants_and_inputs_at`
+                    // using the optimizer-visible `ctx.opref_type()` (see
+                    // optimizer.rs:2405-2416). Overwriting it here with
+                    // `opcode.result_type()` + `Type::Ref` default would
+                    // retype Phase 1 inputarg OpRefs (absent from `p1_ops`)
+                    // as `Ref`, which later feeds the cross-type forward
+                    // assertion in `OptContext::make_equal_to`.
+                    // RPython Phase 1 → Phase 2 heap cache transfer:
+                    // RPython does NOT serialize heap cache in ExportedState.
+                    // HeapOps in the short preamble are replayed during Phase 2's
+                    // inline_short_preamble, populating the heap cache naturally
+                    // through OptHeap. serialize_optheap is only for bridgeopt.
+                    // opencoder.py:271 _index parity: Phase 2's TraceIterator
+                    // must allocate fresh boxes ABOVE Phase 1's high water
+                    // mark so the two phases' OpRef namespaces are disjoint
+                    // (RPython relies on Python identity to distinguish them;
+                    // majit relies on disjoint integer ranges). The high
+                    // water is `final_ctx.next_pos` after Phase 1 emit, with
+                    // a floor of `num_inputs` for empty traces.
+                    // Phase 1's emit-side high water (`final_ctx.next_pos`)
+                    // reflects only the positions `ctx.reserve_pos` handed
+                    // out; the per-iteration TraceIterator additionally
+                    // allocates fresh OpRefs via its `_fresh` counter and
+                    // those values can exceed `next_pos` for traces where
+                    // Phase 1 dropped or folded many ops. Taking the max
+                    // with `p1_iter_fresh_hw` keeps Phase 2's inputarg base
+                    // strictly above every OpRef Phase 1 ever allocated,
+                    // so Phase 2's own fresh OpRefs cannot collide with
+                    // positions in `phase1_emit_ops` / typed snapshots.
+                    self.next_global_opref = opt_p1
+                        .final_ctx
+                        .as_ref()
+                        .map(|c| c.next_pos)
+                        .unwrap_or(num_inputs as u32)
+                        .max(num_inputs as u32)
+                        .max(p1_iter_fresh_hw);
+                    // RPython Box type parity: Phase 1's emit ops carry
+                    // `op.type_` intrinsically; Phase 2's `op_at` reads it
+                    // directly to resolve cross-phase OpRefs that appear as
+                    // imported_label_args / fail_args / record_same_as
+                    // sources (history.py:220 parity).
+                    self.phase1_emit_ops = std::mem::take(&mut opt_p1.phase1_emit_ops);
+                    // RPython: same Optimizer instance keeps patchguardop.
+                    if self.phase1_patchguardop.is_none() {
+                        self.phase1_patchguardop = opt_p1.patchguardop.clone();
                     }
-                    None => {
-                        *constants = consts_p1;
-                        // Take back the descriptor table grown during Phase 1's pass
-                        // (`ensure_descr_index` appends at guard-resume serialization),
-                        // mirroring the Some branch's restore above. Without this the
-                        // non-peeled path drops those descriptors and publishes a stale
-                        // `all_descrs` back over the global table.
-                        self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
-                        // RPython: compile_loop uses flush=True — terminal op
-                        // (Finish/Jump) goes through the pass pipeline normally.
-                        // majit: flush=False stores it in terminal_op; restore it
-                        // here for non-peeled traces that return directly.
-                        let mut ops = p1_ops;
-                        if let Some(terminal) = opt_p1.terminal_op.take() {
-                            ops.push(std::rc::Rc::new(terminal));
-                        }
-                        // `compile.py:245` `jitcell_token.target_tokens = [target_token]`
-                        // / `:290` `jitcell_token.target_tokens = [start_descr]` —
-                        // PyPy unconditionally publishes one preamble target token
-                        // for any successful compile path (compile_simple_loop +
-                        // compile_loop both).  Phase 2 is bypassed here (no
-                        // exported_loop_state) but the loop still compiles, so
-                        // mirror the unconditional preamble registration so that
-                        // `JitCellToken.target_tokens` is non-empty at the
-                        // `has_compiled_targets` (`pyjitpl.py:3898`) read site.
-                        self.ensure_preamble_target_token();
-                        let loop_arity = closing_loop_contract_arity(&ops, p1_ni);
-                        self.clear_compile_snapshot_roots();
-                        return (ops, loop_arity);
-                    }
+                    state.patchguardop = opt_p1.patchguardop.clone();
+                    self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
+                    // Box.type parity: retain Phase 1's renamed_inputargs so
+                    // the backend can read the reduced LABEL's declared types
+                    // off each typed InputArg OpRef. Clone only the field we
+                    // need to avoid keeping Phase 1 short preamble data alive
+                    // longer than before.
+                    let mut final_exported_state = ExportedState {
+                        end_args: Vec::new(),
+                        next_iteration_args: Vec::new(),
+                        end_arg_types: Vec::new(),
+                        virtual_state: state.virtual_state.clone(),
+                        exported_infos: crate::optimizeopt::vec_assoc::VecAssoc::new(),
+                        exported_short_boxes: Vec::new(),
+                        short_boxes: Vec::new(),
+                        short_box_const_values: crate::optimizeopt::vec_assoc::VecAssoc::new(),
+                        short_preamble: None,
+                        renamed_inputargs: state.renamed_inputargs.clone(),
+                        short_inputargs: Vec::new(),
+                        short_inputarg_refs: Vec::new(),
+                        runtime_boxes: Vec::new(),
+                        patchguardop: None,
+                        phase1_emit_high_water: self.next_global_opref,
+                        partial_trace_inputargs: Vec::new(),
+                        partial_trace_operations: Vec::new(),
+                        rooted_refs: Vec::new(),
+                        rooted_const_ptr_slots: Vec::new(),
+                        shadow_stack_base: 0,
+                    };
+                    final_exported_state.root_all_gcrefs();
+                    self.final_exported_state = Some(final_exported_state);
+                    (state, consts_p1, p1_ops)
                 }
-            };
+                None => {
+                    *constants = consts_p1;
+                    // Take back the descriptor table grown during Phase 1's pass
+                    // (`ensure_descr_index` appends at guard-resume serialization),
+                    // mirroring the Some branch's restore above. Without this the
+                    // non-peeled path drops those descriptors and publishes a stale
+                    // `all_descrs` back over the global table.
+                    self.all_descrs = std::mem::take(&mut opt_p1.all_descrs);
+                    // RPython: compile_loop uses flush=True — terminal op
+                    // (Finish/Jump) goes through the pass pipeline normally.
+                    // majit: flush=False stores it in terminal_op; restore it
+                    // here for non-peeled traces that return directly.
+                    let mut ops = p1_ops;
+                    if let Some(terminal) = opt_p1.terminal_op.take() {
+                        ops.push(std::rc::Rc::new(terminal));
+                    }
+                    // `compile.py:245` `jitcell_token.target_tokens = [target_token]`
+                    // / `:290` `jitcell_token.target_tokens = [start_descr]` —
+                    // PyPy unconditionally publishes one preamble target token
+                    // for any successful compile path (compile_simple_loop +
+                    // compile_loop both).  Phase 2 is bypassed here (no
+                    // exported_loop_state) but the loop still compiles, so
+                    // mirror the unconditional preamble registration so that
+                    // `JitCellToken.target_tokens` is non-empty at the
+                    // `has_compiled_targets` (`pyjitpl.py:3898`) read site.
+                    self.ensure_preamble_target_token();
+                    let loop_arity = closing_loop_contract_arity(&ops, p1_ni);
+                    self.clear_compile_snapshot_roots();
+                    return Ok((ops, loop_arity));
+                }
+            }
+        };
+        self.clear_compile_snapshot_roots();
+        // unroll.py:454 end_args carry type via Box; export_state already
+        // populated `exported_state.end_arg_types` from ctx.
+        // RPython parity: Phase 2 needs patchguardop from Phase 1's
+        // GuardFutureCondition (unroll.py:333). Extract before dropping opt_p1.
+        let p1_patchguardop = exported_state.patchguardop.clone();
+
+        self.ensure_preamble_target_token();
+        // ── Phase 2: optimize_peeled_loop (compile.py:291-292) ──
+        let body_num_inputs = num_inputs;
+
+        if std::env::var_os("MAJIT_LOG").is_some() {
+            eprintln!(
+                "[jit] preamble peeling: {} virtual(s), phase1 end_args={} p1_patchguardop={}",
+                exported_state
+                    .virtual_state
+                    .state
+                    .iter()
+                    .filter(|s| s.is_virtual())
+                    .count(),
+                exported_state.end_args.len(),
+                p1_patchguardop
+                    .as_ref()
+                    .map(|p| p.rd_resume_position.get())
+                    .unwrap_or(-99),
+            );
+        }
+
+        // opencoder.py:259-404 parity: Phase 2 uses the same ops as Phase 1.
+        // RPython TraceIterator creates fresh Box objects per phase — each
+        // iterator has its own _cache, so Phase 2 results never collide with
+        // Phase 1. In majit, Phase 2 gets a separate OptContext, achieving
+        // the same isolation.
+        let mut consts_p2 = consts_p1.clone();
+
+        let mut opt_p2 = match vable_config.as_ref() {
+            Some(c) => {
+                crate::optimizeopt::optimizer::Optimizer::default_pipeline_with_virtualizable(
+                    c.clone(),
+                )
+            }
+            None => crate::optimizeopt::optimizer::Optimizer::default_pipeline(),
+        };
         self.clear_compile_snapshot_roots();
         // unroll.py:454 end_args carry type via Box; export_state already
         // populated `exported_state.end_arg_types` from ctx.
@@ -1024,7 +1064,7 @@ impl UnrollOptimizer {
                 // comes from `bind_input_resops` / emit.
                 false,
             )
-        });
+        })?;
         self.clear_compile_snapshot_roots();
         // RPython optimizer.py:614-625 freezes op arguments during
         // `_emit_operation`; optimizer.py:598-612 may then install a Const
@@ -1565,43 +1605,30 @@ impl UnrollOptimizer {
             let mut jumped = if skip_jump_to_existing {
                 false
             } else {
-                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    opt_unroll
-                        .jump_to_existing_trace(
-                            &body_jump_args,
-                            Some(&current_label_args),
-                            &mut self.target_tokens,
-                            &mut opt_p2,
-                            &mut jump_ctx,
-                            false,
-                            &runtime_boxes,
-                        )
-                        .is_none()
-                })) {
-                    Ok(result) => result,
-                    Err(payload) => {
-                        if payload
-                            .downcast_ref::<crate::optimize::InvalidLoop>()
-                            .is_some()
-                        {
-                            if let Some(reason) =
-                                payload.downcast_ref::<crate::optimize::InvalidLoop>()
-                            {
-                                if std::env::var_os("MAJIT_LOG_JTET").is_some() {
-                                    eprintln!(
-                                        "[jit][jte] InvalidLoop during force_boxes=false: {}",
-                                        reason.0
-                                    );
-                                }
-                            }
-                            // unroll.py:154-158: except InvalidLoop →
-                            // jump_to_preamble, skip retry
-                            invalid_loop = true;
-                            false
-                        } else {
-                            std::panic::resume_unwind(payload);
-                        }
+                let did_jump = opt_unroll
+                    .jump_to_existing_trace(
+                        &body_jump_args,
+                        Some(&current_label_args),
+                        &mut self.target_tokens,
+                        &mut opt_p2,
+                        &mut jump_ctx,
+                        false,
+                        &runtime_boxes,
+                    )
+                    .is_none();
+                if let Some(reason) = jump_ctx.take_invalid_loop() {
+                    if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                        eprintln!(
+                            "[jit][jte] InvalidLoop during force_boxes=false: {}",
+                            reason.0
+                        );
                     }
+                    // unroll.py:154-158: except InvalidLoop →
+                    // jump_to_preamble, skip retry
+                    invalid_loop = true;
+                    false
+                } else {
+                    did_jump
                 }
             };
             if std::env::var_os("MAJIT_LOG").is_some() {
@@ -1623,77 +1650,51 @@ impl UnrollOptimizer {
                         );
                     }
                     // unroll.py:164-168: force_boxes=True, except InvalidLoop: pass
-                    jumped = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        opt_unroll
-                            .jump_to_existing_trace(
-                                &body_jump_args,
-                                Some(&current_label_args),
-                                &mut self.target_tokens,
-                                &mut opt_p2,
-                                &mut jump_ctx,
-                                true,
-                                &runtime_boxes,
-                            )
-                            .is_none()
-                    })) {
-                        Ok(result) => result,
-                        Err(payload) => {
-                            if payload
-                                .downcast_ref::<crate::optimize::InvalidLoop>()
-                                .is_some()
-                            {
-                                if let Some(reason) =
-                                    payload.downcast_ref::<crate::optimize::InvalidLoop>()
-                                {
-                                    if std::env::var_os("MAJIT_LOG_JTET").is_some() {
-                                        eprintln!(
-                                            "[jit][jte] InvalidLoop during force_boxes=true retrace: {}",
-                                            reason.0
-                                        );
-                                    }
-                                }
-                                false // unroll.py:167-168: except InvalidLoop: pass
-                            } else {
-                                std::panic::resume_unwind(payload);
-                            }
+                    let did_jump = opt_unroll
+                        .jump_to_existing_trace(
+                            &body_jump_args,
+                            Some(&current_label_args),
+                            &mut self.target_tokens,
+                            &mut opt_p2,
+                            &mut jump_ctx,
+                            true,
+                            &runtime_boxes,
+                        )
+                        .is_none();
+                    jumped = if let Some(reason) = jump_ctx.take_invalid_loop() {
+                        if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                            eprintln!(
+                                "[jit][jte] InvalidLoop during force_boxes=true retrace: {}",
+                                reason.0
+                            );
                         }
+                        false // unroll.py:167-168: except InvalidLoop: pass
+                    } else {
+                        did_jump
                     };
                 } else {
                     // unroll.py:220-226: limit reached, try force_boxes=true
-                    jumped = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        opt_unroll
-                            .jump_to_existing_trace(
-                                &body_jump_args,
-                                Some(&current_label_args),
-                                &mut self.target_tokens,
-                                &mut opt_p2,
-                                &mut jump_ctx,
-                                true,
-                                &runtime_boxes,
-                            )
-                            .is_none()
-                    })) {
-                        Ok(result) => result,
-                        Err(payload) => {
-                            if payload
-                                .downcast_ref::<crate::optimize::InvalidLoop>()
-                                .is_some()
-                            {
-                                if let Some(reason) =
-                                    payload.downcast_ref::<crate::optimize::InvalidLoop>()
-                                {
-                                    if std::env::var_os("MAJIT_LOG_JTET").is_some() {
-                                        eprintln!(
-                                            "[jit][jte] InvalidLoop during force_boxes=true limit: {}",
-                                            reason.0
-                                        );
-                                    }
-                                }
-                                false // unroll.py:224-225: except InvalidLoop: pass
-                            } else {
-                                std::panic::resume_unwind(payload);
-                            }
+                    let did_jump = opt_unroll
+                        .jump_to_existing_trace(
+                            &body_jump_args,
+                            Some(&current_label_args),
+                            &mut self.target_tokens,
+                            &mut opt_p2,
+                            &mut jump_ctx,
+                            true,
+                            &runtime_boxes,
+                        )
+                        .is_none();
+                    jumped = if let Some(reason) = jump_ctx.take_invalid_loop() {
+                        if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                            eprintln!(
+                                "[jit][jte] InvalidLoop during force_boxes=true limit: {}",
+                                reason.0
+                            );
                         }
+                        false // unroll.py:224-225: except InvalidLoop: pass
+                    } else {
+                        did_jump
                     };
                     if !jumped {
                         // unroll.py:228: "Retrace count reached, jumping to preamble"
@@ -1871,7 +1872,7 @@ impl UnrollOptimizer {
             crate::debug::debug_print(&format!("consts_p2: {sorted_consts:?}"));
         }
         *constants = consts_p2;
-        (combined, p2_ni)
+        Ok((combined, p2_ni))
     }
 
     /// RPython compile.py uses the optimized loop state's inputargs contract,
@@ -3421,25 +3422,22 @@ impl OptUnroll {
         // optimizer.py:317 `with self.optimizer.cant_replace_guards():`
         // line-by-line — save current `can_replace_guards`, set False
         // for the guarded section, restore on exit. Nested scopes
-        // preserve the outer False via the saved oldval.
+        // preserve the outer False via the saved oldval. An InvalidLoop is
+        // recorded as a deferred signal on `ctx` (no unwinding), so a plain
+        // call + restore preserves the "restore on exit" contract.
         let oldval = optimizer.cant_replace_guards();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.jump_to_existing_trace_impl(
-                jump_args,
-                current_label_args,
-                target_tokens,
-                optimizer,
-                ctx,
-                force_boxes,
-                runtime_boxes,
-                pre_vs,
-            )
-        }));
+        let result = self.jump_to_existing_trace_impl(
+            jump_args,
+            current_label_args,
+            target_tokens,
+            optimizer,
+            ctx,
+            force_boxes,
+            runtime_boxes,
+            pre_vs,
+        );
         optimizer.restore_can_replace_guards(oldval);
-        match result {
-            Ok(vs) => vs,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
+        result
     }
 
     fn jump_to_existing_trace_impl(
@@ -3664,9 +3662,12 @@ impl OptUnroll {
                         // InvalidLoop, falling back to jump_to_preamble.
                         if !builder.setup(&sp, label_args, ctx) {
                             target_token.short_preamble_producer = Some(builder);
-                            std::panic::panic_any(crate::optimize::InvalidLoop(
-                                "short preamble has unresolvable Phase 1 args",
-                            ));
+                            // Drop the peeled trace and let the caller fall back
+                            // to jump_to_preamble. Recorded as a deferred
+                            // InvalidLoop signal (checked right after this
+                            // returns) so no unwinding is needed.
+                            ctx.signal_invalid_loop("short preamble has unresolvable Phase 1 args");
+                            return None;
                         }
                         ctx.activate_short_preamble_producer(builder);
                         extra = Self::inline_short_preamble(
@@ -3716,6 +3717,14 @@ impl OptUnroll {
                         );
                     }
                 }
+            }
+
+            // A short-preamble replay that hit an unresolvable Phase 1 arg or
+            // a structurally incompatible mapping recorded a deferred
+            // InvalidLoop signal above; abandon this jump attempt so the caller
+            // falls back to jump_to_preamble.
+            if ctx.has_pending_invalid_loop() {
+                return None;
             }
 
             // unroll.py:357-359: emit JUMP to target
@@ -3785,9 +3794,10 @@ impl OptUnroll {
                     jump_args.len()
                 );
             }
-            std::panic::panic_any(crate::optimize::InvalidLoop(
+            ctx.signal_invalid_loop(
                 "inline_short_preamble: short_inputargs/jump_args arity mismatch",
-            ));
+            );
+            return Vec::new();
         }
         for (i, short_inputarg) in short_preamble.inputargs.iter().enumerate() {
             let short_inputarg = short_inputarg.to_opref();
@@ -3956,18 +3966,20 @@ impl OptUnroll {
                             // RPython: _map_args raises KeyError for unmapped
                             // args. This is equivalent to InvalidLoop — the
                             // short preamble is structurally incompatible.
-                            // Panic propagates through jump_to_existing_trace
-                            // to the caller, which catches it and falls back
-                            // to jump_to_preamble (unroll.py:154-158, 209-211).
+                            // Recorded as a deferred InvalidLoop signal that
+                            // jump_to_existing_trace's caller observes, falling
+                            // back to jump_to_preamble (unroll.py:154-158,
+                            // 209-211).
                             if crate::optimizeopt::majit_log_enabled() {
                                 eprintln!(
                                     "[jit] inline_short_preamble: unmapped arg {:?} in {:?} — InvalidLoop",
                                     arg, new_op.opcode
                                 );
                             }
-                            std::panic::panic_any(crate::optimize::InvalidLoop(
+                            ctx.signal_invalid_loop(
                                 "inline_short_preamble: unmapped arg in short preamble",
-                            ));
+                            );
+                            return Vec::new();
                         }
                     }
                 }
@@ -4170,10 +4182,12 @@ impl OptUnroll {
             .make_inputargs(targetargs, optimizer, ctx, false)
         {
             Ok(args) => args,
+            // unroll.py:483 `raise InvalidLoop`: the imported virtual state is
+            // incompatible. Recorded as a deferred signal (checked by the
+            // caller) so the loop is abandoned without unwinding.
             Err(()) => {
-                std::panic::panic_any(crate::optimize::InvalidLoop(
-                    "Cannot import state, virtual states don't match",
-                ));
+                ctx.signal_invalid_loop("Cannot import state, virtual states don't match");
+                return Vec::new();
             }
         };
         // The short-preamble replay part of unroll.py:496-502 is performed
@@ -4526,6 +4540,13 @@ pub(crate) fn import_state_full(
     ctx: &mut OptContext,
 ) -> Vec<OpRef> {
     let label_args = OptUnroll::new().import_state(targetargs, exported_state, optimizer, ctx);
+    // import_state records a deferred InvalidLoop signal on `ctx` when the
+    // virtual states don't match; stop here (the caller observes the signal and
+    // abandons the loop) rather than replaying short preamble ops against an
+    // incomplete import.
+    if ctx.has_pending_invalid_loop() {
+        return label_args;
+    }
     optimizer.imported_label_args = Some(label_args.clone());
     if !optimizer.imported_virtuals.is_empty() {
         optimizer.install_imported_virtuals(ctx);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1792,7 +1792,12 @@ impl UnrollOptimizer {
                     // send_extra_operation, preserving any force_box /
                     // partial-inline operations already appended to
                     // _newoperations.
-                    opt_p2.send_extra_operation(&end_jump, &mut final_ctx);
+                    //
+                    // unroll.py:242 lets send_extra_operation raise
+                    // InvalidLoop; this function returns Result, so `?`
+                    // carries it out (final_ctx is abandoned with the
+                    // discarded trace).
+                    opt_p2.send_extra_operation(&end_jump, &mut final_ctx)?;
                     let redirected_tail_ops: Vec<majit_ir::OpRc> =
                         std::mem::take(&mut final_ctx.new_operations);
                     opt_p2.final_ctx = Some(final_ctx);
@@ -3562,7 +3567,15 @@ impl OptUnroll {
                         guard_op.rd_resume_position.set(rd_resume_position);
                         guard_op.setdescr(crate::optimizeopt::make_resume_at_position_descr());
                     }
-                    optimizer.send_extra_operation(&guard_op, ctx);
+                    // unroll.py:338 lets send_extra_operation raise InvalidLoop
+                    // (only VirtualStatesCantMatch is caught around it). This
+                    // function returns Option (flag convention), and
+                    // propagate consumed the flag into the Err, so re-defer it
+                    // for the caller's take_invalid_loop barrier and abort.
+                    if let Err(e) = optimizer.send_extra_operation(&guard_op, ctx) {
+                        ctx.signal_invalid_loop(e.0);
+                        return None;
+                    }
                 }
             }
 
@@ -3736,8 +3749,15 @@ impl OptUnroll {
             }
             let mut jump = Op::new(OpCode::Jump, &jump_args_box);
             jump.setdescr(target_token.as_jump_target_descr());
-            optimizer.send_extra_operation(&jump, ctx);
-            return None; // successfully jumped
+            // unroll.py:357 lets send_extra_operation raise InvalidLoop. This
+            // function returns Option (flag convention); propagate consumed
+            // the flag into the Err, so re-defer it for the caller's
+            // take_invalid_loop barrier (the None return below then reads as an
+            // aborted jump rather than a successful one).
+            if let Err(e) = optimizer.send_extra_operation(&jump, ctx) {
+                ctx.signal_invalid_loop(e.0);
+            }
+            return None; // successfully jumped (or aborted via deferred InvalidLoop)
         }
 
         Some(virtual_state)
@@ -4033,7 +4053,15 @@ impl OptUnroll {
                 // RPython sets mapping BEFORE send_extra_operation.
                 mapping.insert(sp_op.pos.get(), new_ref);
                 replay_index += 1;
-                optimizer.send_extra_operation(&new_op, ctx);
+                // unroll.py:414 lets send_extra_operation raise InvalidLoop.
+                // This function returns Vec (flag convention, as the arity /
+                // unmapped-arg signals above); propagate consumed the flag into
+                // the Err, so re-defer it for the caller's take_invalid_loop
+                // barrier and bail to jump_to_preamble.
+                if let Err(e) = optimizer.send_extra_operation(&new_op, ctx) {
+                    ctx.signal_invalid_loop(e.0);
+                    return Vec::new();
+                }
             }
 
             // unroll.py:417-423: force all except virtuals.
@@ -4062,7 +4090,14 @@ impl OptUnroll {
                 }
             }
             // unroll.py:424
-            optimizer.flush(ctx);
+            // flush may raise InvalidLoop via send_extra_operation; this
+            // function returns Vec (flag convention), so re-defer the
+            // consumed flag for the caller's take_invalid_loop barrier and
+            // bail to jump_to_preamble.
+            if let Err(e) = optimizer.flush(ctx) {
+                ctx.signal_invalid_loop(e.0);
+                return Vec::new();
+            }
             // unroll.py:426: done unless "short" has grown again
             if replay_index == current_short_len(short_preamble, ctx) {
                 break;

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -1016,11 +1016,15 @@ impl OptVirtualize {
                     // negative, out-of-range, or uninitialized slots.
                     // virtualize.py:282-284: None → InvalidLoop.
                     if index < 0 || (index as usize) >= vinfo.items.len() {
-                        return OptimizationResult::InvalidLoop;
+                        return OptimizationResult::InvalidLoop(
+                            "virtual array getitem index out of range",
+                        );
                     }
                     let item_ref = vinfo.items[index as usize].to_opref();
                     if item_ref.is_none() {
-                        return OptimizationResult::InvalidLoop;
+                        return OptimizationResult::InvalidLoop(
+                            "virtual array getitem from uninitialized slot",
+                        );
                     }
                     let b_old = BoxRef::from_bound_op(op_rc);
                     let b_item = ctx.get_box_replacement(item_ref);
@@ -1113,11 +1117,15 @@ impl OptVirtualize {
                 // info.py:663-668 getinteriorfield_virtual: -1 → None
                 // virtualize.py:394-396: None → InvalidLoop
                 if index < 0 || (index as usize) >= vinfo.element_fields.len() {
-                    return OptimizationResult::InvalidLoop;
+                    return OptimizationResult::InvalidLoop(
+                        "virtual interior field index out of range",
+                    );
                 }
                 let fld = get_field(&vinfo.element_fields[index as usize], field_idx);
                 if fld.is_none() {
-                    return OptimizationResult::InvalidLoop;
+                    return OptimizationResult::InvalidLoop(
+                        "virtual interior field from uninitialized slot",
+                    );
                 }
                 let fld = fld.unwrap();
                 let b_old = BoxRef::from_bound_op(op_rc);
@@ -2926,7 +2934,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved_op);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -3067,7 +3075,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }
@@ -3420,7 +3428,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => panic!("unexpected InvalidLoop in test"),
+                OptimizationResult::InvalidLoop(_) => panic!("unexpected InvalidLoop in test"),
             }
         }
 
@@ -3542,7 +3550,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved);
                 }
-                OptimizationResult::InvalidLoop => panic!("unexpected InvalidLoop in test"),
+                OptimizationResult::InvalidLoop(_) => panic!("unexpected InvalidLoop in test"),
             }
         }
 
@@ -5039,7 +5047,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved_op);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1761,7 +1761,7 @@ mod tests {
                 OptimizationResult::PassOn => {
                     ctx.emit(resolved_op);
                 }
-                OptimizationResult::InvalidLoop => {
+                OptimizationResult::InvalidLoop(_) => {
                     panic!("unexpected InvalidLoop in test");
                 }
             }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -6441,6 +6441,12 @@ fn build_concrete_values(
 }
 
 pub fn call_int_function(func_ptr: *const (), args: &[i64]) -> i64 {
+    // Where a backend cannot build a `call_indirect` whose type matches the
+    // callee's real signature (wasm32), route through the host trampoline,
+    // which reflects the signature and coerces each positional argument.
+    if let Some(hook) = majit_backend::call_stub::residual_host_call() {
+        return hook(func_ptr as usize, args);
+    }
     unsafe {
         match args {
             [] => {
@@ -6670,6 +6676,15 @@ pub fn call_ref_function(func_ptr: *const (), args: &[i64]) -> i64 {
 }
 
 pub fn call_void_function(func_ptr: *const (), args: &[i64]) {
+    // See `call_int_function`: the host trampoline reflects the callee's real
+    // signature, so a void-typed residual whose target actually returns `i64`
+    // (e.g. `store_subscr_fn`) — or genuinely returns `()`
+    // (`set_current_exception_fn`) — is dispatched without a wasm
+    // indirect-call type mismatch. The reflected result is discarded.
+    if let Some(hook) = majit_backend::call_stub::residual_host_call() {
+        let _ = hook(func_ptr as usize, args);
+        return;
+    }
     unsafe {
         match args {
             [] => {

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -4992,37 +4992,24 @@ impl<M: Clone> MetaInterp<M> {
             Vec<majit_ir::OpRc>,
             crate::optimizeopt::unroll::ExportedState,
         )> = None;
-        let optimize_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            unroll_opt.optimize_trace_with_constants_and_inputs_vable_out(
-                &trace_ops,
-                &mut constants,
-                num_trace_inputargs,
-                vable_config.clone(),
-                Some(&mut phase1_out),
-            )
-        }));
+        let optimize_result = unroll_opt.optimize_trace_with_constants_and_inputs_vable_out(
+            &trace_ops,
+            &mut constants,
+            num_trace_inputargs,
+            vable_config.clone(),
+            Some(&mut phase1_out),
+        );
         let mut retried_without_unroll = false;
         let (optimized_ops, final_num_inputs) = match optimize_result {
             Ok(result) => result,
-            Err(payload) => {
-                // Phase 2 panicked — unroll_opt dropped. Phase 1 results
-                // survive in phase1_out (written before Phase 2 started).
-                //
-                // unroll.py:119-123 `except SpeculativeError: raise
-                // InvalidLoop`: a SpeculativeError escaping the optimize
-                // pass (constant_fold of an ill-typed speculative heap
-                // access) is equivalent to an InvalidLoop — abandon the
-                // optimized trace and fall back, rather than re-raising and
-                // crashing the interpreter.
-                let invalid_reason = payload
-                    .downcast_ref::<crate::optimize::InvalidLoop>()
-                    .map(|inv| inv.0)
-                    .or_else(|| {
-                        payload
-                            .downcast_ref::<crate::optimize::SpeculativeError>()
-                            .map(|err| err.0)
-                    });
-                if let Some(reason) = invalid_reason {
+            // unroll.py:119-123 `except (InvalidLoop, SpeculativeError)`: a
+            // guard proven to always fail, or a speculative heap access proven
+            // ill-typed (now a deferred `InvalidLoop` signal rather than a
+            // panic), abandons the optimized trace. Phase 1 results survive in
+            // `phase1_out` (written before Phase 2 ran).
+            Err(invalid_loop) => {
+                let reason = invalid_loop.0;
+                {
                     if crate::majit_log_enabled() {
                         eprintln!(
                             "[jit] abort trace at key={} (InvalidLoop: {})",
@@ -5078,7 +5065,7 @@ impl<M: Clone> MetaInterp<M> {
                                 )
                             }));
                         match retry_result {
-                            Ok(retry_ops) => {
+                            Ok(Ok(retry_ops)) => {
                                 if crate::majit_log_enabled() {
                                     eprintln!(
                                         "[jit] retry without unroll succeeded at key={}",
@@ -5089,6 +5076,18 @@ impl<M: Clone> MetaInterp<M> {
                                 constants = retry_constants;
                                 let ni = simple_opt.final_num_inputs();
                                 (retry_ops, ni)
+                            }
+                            Ok(Err(_invalid_loop)) => {
+                                // The unroll-free retry also abandoned the trace.
+                                if crate::majit_log_enabled() {
+                                    eprintln!(
+                                        "[jit] retry without unroll hit InvalidLoop at key={}",
+                                        green_key
+                                    );
+                                }
+                                self.warm_state.abort_tracing(green_key, false);
+                                self.exported_state = None;
+                                return CompileOutcome::Aborted;
                             }
                             Err(payload) => {
                                 self.note_jit_panic_or_reraise(
@@ -5102,8 +5101,6 @@ impl<M: Clone> MetaInterp<M> {
                             }
                         }
                     }
-                } else {
-                    std::panic::resume_unwind(payload);
                 }
             }
         };
@@ -6213,30 +6210,24 @@ impl<M: Clone> MetaInterp<M> {
         // optimizer can continue from where it left off.
         unroll_opt.imported_state = Some(start_state);
 
-        let optimize_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            unroll_opt.optimize_trace_with_constants_and_inputs_vable(
-                &trace_ops,
-                &mut constants,
-                trace.inputargs.len(),
-                vable_config,
-            )
-        }));
+        let optimize_result = unroll_opt.optimize_trace_with_constants_and_inputs_vable(
+            &trace_ops,
+            &mut constants,
+            trace.inputargs.len(),
+            vable_config,
+        );
         let (body_ops, final_num_inputs) = match optimize_result {
             Ok(result) => result,
-            Err(payload) => {
-                if payload
-                    .downcast_ref::<crate::optimize::InvalidLoop>()
-                    .is_some()
-                {
-                    if crate::debug::have_debug_prints() {
-                        crate::debug::log_one(
-                            "jit-abort",
-                            &format!("compile_retrace: InvalidLoop at key={green_key}"),
-                        );
-                    }
-                    return false;
+            // A guard proven to always fail (deferred `InvalidLoop` signal):
+            // abandon the retrace.
+            Err(_invalid_loop) => {
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one(
+                        "jit-abort",
+                        &format!("compile_retrace: InvalidLoop at key={green_key}"),
+                    );
                 }
-                std::panic::resume_unwind(payload);
+                return false;
             }
         };
 
@@ -6720,41 +6711,35 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_vref_boxes = snapshot_vref_map;
         optimizer.snapshot_frame_pcs = snapshot_pc_map;
 
-        // Wrap in catch_unwind — InvalidLoop during optimization should
-        // abort the trace, not crash the process. Matches compile_loop.
-        let optimize_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            optimizer.optimize_with_constants_and_inputs_oprc(
-                // `trace.ops` are the canonical `Rc<Op>`, so `input_ops`
-                // seeds identity directly from them.
-                &trace.ops,
-                &mut constants,
-                trace.inputargs.len(),
-            )
-        }));
+        // InvalidLoop during optimization should abort the trace, not crash
+        // the process. Matches compile_loop.
+        let optimize_result = optimizer.optimize_with_constants_and_inputs_oprc(
+            // `trace.ops` are the canonical `Rc<Op>`, so `input_ops`
+            // seeds identity directly from them.
+            &trace.ops,
+            &mut constants,
+            trace.inputargs.len(),
+        );
         let optimized_ops = match optimize_result {
             Ok(ops) => ops,
-            Err(payload) => {
-                if payload
-                    .downcast_ref::<crate::optimize::InvalidLoop>()
-                    .is_some()
-                {
-                    if crate::debug::have_debug_prints() {
-                        crate::debug::log_one(
-                            "jit-abort",
-                            &format!("abort finish: InvalidLoop at key={green_key}"),
-                        );
-                    }
-                    self.warm_state.abort_tracing(green_key, true);
-                    // pyjitpl.py:2760 aborted_tracing() reads greenkey from
-                    // `current_merge_points`; pyre's analog reads it from
-                    // pending_abort_{green_key,permanent} staged here so the
-                    // caller-side `aborted_tracing(stb.reason)` hook payload
-                    // carries the real trace key instead of 0.
-                    self.pending_abort_green_key = Some(green_key);
-                    self.pending_abort_permanent = true;
-                    return Err(SwitchToBlackhole::giveup());
+            // A guard proven to always fail (deferred `InvalidLoop` signal):
+            // abort the trace and fall back to the blackhole interpreter.
+            Err(_invalid_loop) => {
+                if crate::debug::have_debug_prints() {
+                    crate::debug::log_one(
+                        "jit-abort",
+                        &format!("abort finish: InvalidLoop at key={green_key}"),
+                    );
                 }
-                std::panic::resume_unwind(payload);
+                self.warm_state.abort_tracing(green_key, true);
+                // pyjitpl.py:2760 aborted_tracing() reads greenkey from
+                // `current_merge_points`; pyre's analog reads it from
+                // pending_abort_{green_key,permanent} staged here so the
+                // caller-side `aborted_tracing(stb.reason)` hook payload
+                // carries the real trace key instead of 0.
+                self.pending_abort_green_key = Some(green_key);
+                self.pending_abort_permanent = true;
+                return Err(SwitchToBlackhole::giveup());
             }
         };
         // RPython optimizer.py:552-556 (flush=True): Finish/Jump is sent
@@ -7132,20 +7117,18 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_vref_boxes = snapshot_vref_map;
         optimizer.snapshot_frame_pcs = snapshot_pc_map;
 
-        let optimize_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            optimizer.optimize_with_constants_and_inputs_oprc(
-                // Canonical `Rc<Op>`; `input_ops` seeds identity from them.
-                &trace.ops,
-                &mut constants,
-                num_trace_inputargs,
-            )
-        }));
+        let optimize_result = optimizer.optimize_with_constants_and_inputs_oprc(
+            // Canonical `Rc<Op>`; `input_ops` seeds identity from them.
+            &trace.ops,
+            &mut constants,
+            num_trace_inputargs,
+        );
         let optimized_ops = match optimize_result {
             Ok(ops) => ops,
-            Err(payload) => {
-                let is_invalid_loop =
-                    self.note_jit_panic_or_reraise(payload, "compile_simple_loop", green_key);
-                if is_invalid_loop && crate::majit_log_enabled() {
+            // A guard proven to always fail (deferred `InvalidLoop` signal):
+            // abandon the loop.
+            Err(_invalid_loop) => {
+                if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] compile_simple_loop: InvalidLoop at key={}",
                         green_key
@@ -9129,56 +9112,34 @@ impl<M: Clone> MetaInterp<M> {
         let retrace_limit = self.warm_state.retrace_limit();
         let bridge_optimize_result = {
             let compiled = self.compiled_loops.get_mut(&green_key).unwrap();
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                optimizer.optimize_bridge(
-                    bridge_ops,
-                    &mut constants,
-                    bridge_inputargs.len(),
-                    &mut compiled.front_target_tokens,
-                    &bridge_runtime_boxes,
-                    true,
-                    retraced_count,
-                    retrace_limit,
-                    None,
-                    Some(loop_num_inputs),
-                    bridge_inputarg_base,
-                )
-            }))
+            optimizer.optimize_bridge(
+                bridge_ops,
+                &mut constants,
+                bridge_inputargs.len(),
+                &mut compiled.front_target_tokens,
+                &bridge_runtime_boxes,
+                true,
+                retraced_count,
+                retrace_limit,
+                None,
+                Some(loop_num_inputs),
+                bridge_inputarg_base,
+            )
         };
         let (optimized_ops, retrace_requested) = match bridge_optimize_result {
             Ok(result) => result,
-            Err(payload) => {
-                if payload
-                    .downcast_ref::<crate::optimize::InvalidLoop>()
-                    .is_some()
-                {
-                    if crate::majit_log_enabled() {
-                        eprintln!(
-                            "[jit] compile_entry_bridge: InvalidLoop target={} original={}",
-                            green_key, original_green_key
-                        );
-                    }
-                    return false;
+            // unroll.py:119-123 `except (InvalidLoop, SpeculativeError)`: a
+            // guard proven to always fail, or a speculative heap access proven
+            // ill-typed (now surfaced as a deferred `InvalidLoop` signal rather
+            // than a panic), abandons the function-entry bridge.
+            Err(_invalid_loop) => {
+                if crate::majit_log_enabled() {
+                    eprintln!(
+                        "[jit] compile_entry_bridge: InvalidLoop target={} original={}",
+                        green_key, original_green_key
+                    );
                 }
-                // unroll.py:119-123 `except SpeculativeError: raise InvalidLoop`
-                // — same as compile_bridge: optimize_bridge has no
-                // with_speculative_to_invalid_loop wrapper, so a speculative
-                // heap access proven ill-typed in a function-entry bridge must
-                // be caught here; otherwise the SpeculativeError re-unwinds past
-                // the extern "C" frames and aborts the process.
-                if payload
-                    .downcast_ref::<crate::optimize::SpeculativeError>()
-                    .is_some()
-                {
-                    if crate::majit_log_enabled() {
-                        eprintln!(
-                            "[jit] compile_entry_bridge: SpeculativeError->InvalidLoop target={} original={}",
-                            green_key, original_green_key
-                        );
-                    }
-                    return false;
-                }
-                std::panic::resume_unwind(payload);
+                return false;
             }
         };
         // optimizer.py:557 self.resumedata_memo.update_counters(profiler)
@@ -9699,54 +9660,34 @@ impl<M: Clone> MetaInterp<M> {
         // past compile_bridge.
         let bridge_optimize_result = {
             let compiled = self.compiled_loops.get_mut(&green_key).unwrap();
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                optimizer.optimize_bridge(
-                    bridge_ops,
-                    &mut constants,
-                    bridge_inputargs.len(),
-                    &mut compiled.front_target_tokens,
-                    &bridge_runtime_boxes,
-                    bridge_inline_short_preamble,
-                    retraced_count,
-                    retrace_limit,
-                    pending_bridge_rd,
-                    Some(loop_num_inputs),
-                    bridge_inputarg_base,
-                )
-            }))
+            optimizer.optimize_bridge(
+                bridge_ops,
+                &mut constants,
+                bridge_inputargs.len(),
+                &mut compiled.front_target_tokens,
+                &bridge_runtime_boxes,
+                bridge_inline_short_preamble,
+                retraced_count,
+                retrace_limit,
+                pending_bridge_rd,
+                Some(loop_num_inputs),
+                bridge_inputarg_base,
+            )
         };
         let (optimized_ops, retrace_requested) = match bridge_optimize_result {
             Ok(result) => result,
-            Err(payload) => {
-                if let Some(inv) = payload.downcast_ref::<crate::optimize::InvalidLoop>() {
-                    if crate::majit_log_enabled() {
-                        eprintln!(
-                            "[jit] compile_bridge: InvalidLoop(\"{}\") at key={} fail_index={}",
-                            inv.0, green_key, fail_index
-                        );
-                    }
-                    return false;
+            // compile.py:1077-1078 + unroll.py:119-123 `except (InvalidLoop,
+            // SpeculativeError)`: a guard proven to always fail, or a
+            // speculative heap access proven ill-typed (now a deferred
+            // `InvalidLoop` signal, not a panic), discards the bridge.
+            Err(inv) => {
+                if crate::majit_log_enabled() {
+                    eprintln!(
+                        "[jit] compile_bridge: InvalidLoop(\"{}\") at key={} fail_index={}",
+                        inv.0, green_key, fail_index
+                    );
                 }
-                // unroll.py:119-123 `except SpeculativeError: raise InvalidLoop`
-                // — a speculative heap access proven ill-typed discards the
-                // trace exactly like InvalidLoop. The loop path converts at the
-                // optimize boundary (with_speculative_to_invalid_loop); the
-                // bridge path has no such wrapper, so without this the
-                // SpeculativeError re-unwinds past the extern "C" bh_call_r
-                // frames and aborts the process.
-                if payload
-                    .downcast_ref::<crate::optimize::SpeculativeError>()
-                    .is_some()
-                {
-                    if crate::majit_log_enabled() {
-                        eprintln!(
-                            "[jit] compile_bridge: SpeculativeError->InvalidLoop at key={} fail_index={}",
-                            green_key, fail_index
-                        );
-                    }
-                    return false;
-                }
-                std::panic::resume_unwind(payload);
+                return false;
             }
         };
         // optimizer.py:557 self.resumedata_memo.update_counters(profiler)

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -86,6 +86,12 @@ pub struct VableArrayInfo {
     pub name: String,
     /// Type of array items.
     pub item_type: Type,
+    /// Byte size of a single item, taken from the field's array descriptor
+    /// (`unpack_arraydescr`).  This is the authoritative stride: 64-bit
+    /// payloads (e.g. `i64` list-strategy backing arrays) carry an explicit
+    /// 8-byte descriptor that `item_size_for_type` would under-size to a
+    /// machine word on 32-bit targets.
+    pub item_size: usize,
     /// Byte offset of the array pointer in the heap object.
     pub field_offset: usize,
     /// Storage model for the array field.
@@ -474,9 +480,11 @@ impl VirtualizableInfo {
         items_offset: usize,
         array_descr: DescrRef,
     ) {
+        let item_size = array_descr_item_size(&array_descr, item_type);
         self.array_fields.push(VableArrayInfo {
             name: name.into(),
             item_type,
+            item_size,
             field_offset,
             storage: VableArrayStorage::DirectPointer,
             length_offset,
@@ -501,9 +509,11 @@ impl VirtualizableInfo {
         items_offset: usize,
         array_descr: DescrRef,
     ) {
+        let item_size = array_descr_item_size(&array_descr, item_type);
         self.array_fields.push(VableArrayInfo {
             name: name.into(),
             item_type,
+            item_size,
             field_offset,
             storage: VableArrayStorage::EmbeddedArray { ptr_offset },
             length_offset,
@@ -527,9 +537,11 @@ impl VirtualizableInfo {
         len_fn: fn(*const u8) -> usize,
         array_descr: DescrRef,
     ) {
+        let item_size = array_descr_item_size(&array_descr, item_type);
         self.array_fields.push(VableArrayInfo {
             name: name.into(),
             item_type,
+            item_size,
             field_offset,
             storage: VableArrayStorage::RustVec {
                 data_ptr_fn,
@@ -982,7 +994,7 @@ impl VirtualizableInfo {
         unsafe {
             let ai = &self.array_fields[array_index];
             let array_ptr = ai.data_ptr(obj_ptr);
-            let item_offset = ai.items_offset + item_index * item_size_for_type(ai.item_type);
+            let item_offset = ai.items_offset + item_index * ai.item_size;
             match ai.item_type {
                 Type::Float => {
                     let ptr = array_ptr.add(item_offset) as *const f64;
@@ -1018,7 +1030,7 @@ impl VirtualizableInfo {
         unsafe {
             let ai = &self.array_fields[array_index];
             let array_ptr = ai.data_ptr(obj_ptr.cast_const()) as *mut u8;
-            let item_offset = ai.items_offset + item_index * item_size_for_type(ai.item_type);
+            let item_offset = ai.items_offset + item_index * ai.item_size;
             match ai.item_type {
                 Type::Float => {
                     let ptr = array_ptr.add(item_offset) as *mut f64;
@@ -1378,7 +1390,7 @@ unsafe fn read_virtualizable_array(
     let mut values = Vec::with_capacity(length);
     for i in 0..length {
         let array_ptr = array_info.data_ptr(obj_ptr);
-        let item_offset = array_info.items_offset + i * item_size_for_type(array_info.item_type);
+        let item_offset = array_info.items_offset + i * array_info.item_size;
         let val = match array_info.item_type {
             Type::Int | Type::Ref => *(array_ptr.add(item_offset) as *const i64),
             Type::Float => f64::to_bits(*(array_ptr.add(item_offset) as *const f64)) as i64,
@@ -1394,6 +1406,18 @@ unsafe fn read_virtualizable_array(
 /// Returns the byte size of a single item for the given JIT type, matching
 /// RPython's `llmemory.sizeof(ARRAY.OF)` / `ctypes.sizeof(...)` for
 /// standard types.
+/// Resolve the authoritative byte size of an array item from the field's array
+/// descriptor.  Falls back to the word-sized `item_size_for_type` only when the
+/// descriptor is not an array descriptor (malformed test descrs).  Using the
+/// descriptor keeps the blackhole/heap array stride in lock-step with the
+/// explicit item size the JIT codegen records (e.g. a fixed `8` for `i64`
+/// payloads), instead of re-deriving a machine word on 32-bit targets.
+fn array_descr_item_size(array_descr: &DescrRef, item_type: Type) -> usize {
+    majit_ir::descr::unpack_arraydescr(array_descr)
+        .map(|(_, item_size, _)| item_size)
+        .unwrap_or_else(|| item_size_for_type(item_type))
+}
+
 pub fn item_size_for_type(ty: Type) -> usize {
     match ty {
         // symbolic.py:get_size → sizeof(Signed) / sizeof(Ptr).  `Signed` is
@@ -1418,7 +1442,7 @@ pub fn item_size_for_type(ty: Type) -> usize {
 unsafe fn write_virtualizable_array(array_info: &VableArrayInfo, obj_ptr: *mut u8, values: &[i64]) {
     for (i, &val) in values.iter().enumerate() {
         let array_ptr = array_info.data_ptr(obj_ptr.cast_const()) as *mut u8;
-        let item_offset = array_info.items_offset + i * item_size_for_type(array_info.item_type);
+        let item_offset = array_info.items_offset + i * array_info.item_size;
         match array_info.item_type {
             Type::Int | Type::Ref => {
                 let ptr = array_ptr.add(item_offset) as *mut i64;
@@ -2621,9 +2645,10 @@ pub unsafe fn vable_read_array_item(
     index: usize,
 ) -> i64 {
     unsafe {
-        // Item width is type-dependent: a pointer array is 4 bytes/item on
-        // wasm32 (`size_of::<usize>()`), not 8.
-        let item_size = item_size_for_type(array.item_type);
+        // Stride from the field's array descriptor: a pointer array is
+        // `size_of::<usize>()` (4 bytes on wasm32) while an `i64` payload
+        // array is a fixed 8, regardless of word width.
+        let item_size = array.item_size;
         let data_ptr = match array.storage {
             VableArrayStorage::EmbeddedArray { ptr_offset } => {
                 let container = *(vable_ptr.add(array.field_offset) as *const *const u8);
@@ -2659,9 +2684,10 @@ pub unsafe fn vable_write_array_item(
     value: i64,
 ) {
     unsafe {
-        // Item width is type-dependent: a pointer array is 4 bytes/item on
-        // wasm32 (`size_of::<usize>()`), not 8.
-        let item_size = item_size_for_type(array.item_type);
+        // Stride from the field's array descriptor: a pointer array is
+        // `size_of::<usize>()` (4 bytes on wasm32) while an `i64` payload
+        // array is a fixed 8, regardless of word width.
+        let item_size = array.item_size;
         let data_ptr = match array.storage {
             VableArrayStorage::EmbeddedArray { ptr_offset } => {
                 let container = *(vable_ptr.add(array.field_offset) as *const *mut u8);

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -2710,11 +2710,23 @@ pub unsafe fn vable_write_array_item(
     }
 }
 
-/// virtualizable.py:218-222 clear_vable_token for blackhole context.
+/// virtualizable.py:218-222 clear_vable_token, blackhole context.
 ///
-/// In the blackhole, no compiled JIT code is running so the token should
-/// already be TOKEN_NONE. If it is TOKEN_TRACING_RESCALL, clear it.
-/// If it is Active (shouldn't happen in blackhole), force-clear to 0.
+/// Upstream `clear_vable_token` calls `force_now(virtualizable)` when the token
+/// is set, then asserts it cleared — `force_now` writes the live JIT-register
+/// copy of the virtualizable's fields back to the heap object. Here that step
+/// is intentionally omitted: it is a semantic no-op in the blackhole and pyre
+/// has no blackhole `force_now`. The Active token (a force_token = address of a
+/// live JIT frame) only exists while compiled JIT code holds the frame in
+/// registers; by the time the blackhole interprets a vable op, resume has
+/// already materialized every field into the heap object, so no register copy
+/// remains to force back. The token can only be TOKEN_NONE (nothing to do) or
+/// TOKEN_TRACING_RESCALL (a marker, no un-written-back state), so clearing it
+/// unconditionally reaches the same post-state as `force_now` + assert. (If a
+/// blackhole path were ever found to carry a live Active token, that would be a
+/// real bug needing a blackhole force_now — not the case under the current
+/// resume-materializes-then-interprets model, which all virtualizable JIT
+/// tests exercise without any force_now.)
 ///
 /// # Safety
 /// `obj_ptr` must point to a valid virtualizable object.
@@ -2723,8 +2735,6 @@ pub unsafe fn bh_clear_vable_token(vinfo: &VirtualizableInfo, obj_ptr: *mut u8) 
         let token_ptr = obj_ptr.add(vinfo.token_offset) as *mut usize;
         let token = *token_ptr;
         if token != 0 {
-            // TOKEN_TRACING_RESCALL or stale Active — clear unconditionally.
-            // In the blackhole, no JIT frame is active so forcing is not needed.
             *token_ptr = 0;
         }
     }

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -561,9 +561,11 @@ impl VirtualizableInfo {
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn tracing_before_residual_call(&self, obj_ptr: *mut u8) {
         unsafe {
-            let token_ptr = obj_ptr.add(self.token_offset) as *mut u64;
+            // The token is a word-sized (`Signed`) field: 4 bytes on wasm32.
+            // The all-ones sentinel truncates to `usize::MAX` at that width.
+            let token_ptr = obj_ptr.add(self.token_offset) as *mut usize;
             assert_eq!(*token_ptr, 0, "token should be NONE before residual call");
-            *token_ptr = TOKEN_TRACING_RESCALL;
+            *token_ptr = TOKEN_TRACING_RESCALL as usize;
         }
     }
 
@@ -576,10 +578,10 @@ impl VirtualizableInfo {
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn tracing_after_residual_call(&self, obj_ptr: *mut u8) -> bool {
         unsafe {
-            let token_ptr = obj_ptr.add(self.token_offset) as *mut u64;
+            let token_ptr = obj_ptr.add(self.token_offset) as *mut usize;
             if *token_ptr != 0 {
                 // Not forced — still TOKEN_TRACING_RESCALL
-                assert_eq!(*token_ptr, TOKEN_TRACING_RESCALL);
+                assert_eq!(*token_ptr, TOKEN_TRACING_RESCALL as usize);
                 *token_ptr = 0; // Clear back to TOKEN_NONE
                 false
             } else {
@@ -599,14 +601,14 @@ impl VirtualizableInfo {
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn force_now(&self, obj_ptr: *mut u8, force_fn: impl FnOnce(u64)) {
         unsafe {
-            let token_ptr = obj_ptr.add(self.token_offset) as *mut u64;
+            let token_ptr = obj_ptr.add(self.token_offset) as *mut usize;
             let token = *token_ptr;
-            if token == TOKEN_TRACING_RESCALL {
+            if token == TOKEN_TRACING_RESCALL as usize {
                 // During tracing — just clear the marker
                 *token_ptr = 0;
             } else if token != 0 {
                 // Active JIT frame — force it, then verify it cleared the token
-                force_fn(token);
+                force_fn(token as u64);
                 assert_eq!(*token_ptr, 0, "force_fn should have cleared the token");
             }
         }
@@ -618,8 +620,17 @@ impl VirtualizableInfo {
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn read_token(&self, obj_ptr: *const u8) -> VableToken {
         unsafe {
-            let token_ptr = obj_ptr.add(self.token_offset) as *const u64;
-            VableToken::from_raw(*token_ptr)
+            let token_ptr = obj_ptr.add(self.token_offset) as *const usize;
+            let raw = *token_ptr;
+            // The all-ones sentinel is stored width-truncated (`usize::MAX`
+            // on wasm32); widen it back to the canonical `u64::MAX` so
+            // `from_raw` matches.
+            let raw_u64 = if raw == TOKEN_TRACING_RESCALL as usize {
+                TOKEN_TRACING_RESCALL
+            } else {
+                raw as u64
+            };
+            VableToken::from_raw(raw_u64)
         }
     }
 
@@ -629,8 +640,8 @@ impl VirtualizableInfo {
     /// `obj_ptr` must point to a valid virtualizable object.
     pub unsafe fn write_token(&self, obj_ptr: *mut u8, token: VableToken) {
         unsafe {
-            let token_ptr = obj_ptr.add(self.token_offset) as *mut u64;
-            *token_ptr = token.to_raw();
+            let token_ptr = obj_ptr.add(self.token_offset) as *mut usize;
+            *token_ptr = token.to_raw() as usize;
         }
     }
 
@@ -879,9 +890,18 @@ impl VirtualizableInfo {
                     let ptr = obj_ptr.add(field.offset) as *const f64;
                     f64::to_bits(*ptr) as i64
                 }
+                // Pointer-width field: 4 bytes on wasm32. Reading 8 bytes
+                // would fold in the next field's bytes.
+                Type::Ref => {
+                    let ptr = obj_ptr.add(field.offset) as *const usize;
+                    *ptr as i64
+                }
+                // Word-sized `Signed` field (`isize`/`usize`): 4 bytes on
+                // wasm32. Read at word width and sign-extend so a negative
+                // `last_instr` round-trips.
                 _ => {
-                    let ptr = obj_ptr.add(field.offset) as *const i64;
-                    *ptr
+                    let ptr = obj_ptr.add(field.offset) as *const isize;
+                    *ptr as i64
                 }
             }
         }
@@ -901,9 +921,17 @@ impl VirtualizableInfo {
                     let ptr = obj_ptr.add(field.offset) as *mut f64;
                     *ptr = f64::from_bits(value as u64);
                 }
+                // Pointer-width field: 4 bytes on wasm32. Writing 8 bytes
+                // would clobber the adjacent field.
+                Type::Ref => {
+                    let ptr = obj_ptr.add(field.offset) as *mut usize;
+                    *ptr = value as usize;
+                }
+                // Word-sized `Signed` field (`isize`/`usize`): 4 bytes on
+                // wasm32. Writing 8 bytes would clobber the adjacent field.
                 _ => {
-                    let ptr = obj_ptr.add(field.offset) as *mut i64;
-                    *ptr = value;
+                    let ptr = obj_ptr.add(field.offset) as *mut isize;
+                    *ptr = value as isize;
                 }
             }
         }
@@ -960,6 +988,12 @@ impl VirtualizableInfo {
                     let ptr = array_ptr.add(item_offset) as *const f64;
                     f64::to_bits(*ptr) as i64
                 }
+                // Pointer-width item: 4 bytes on wasm32. Reading 8 bytes
+                // would fold in the next item's bytes.
+                Type::Ref => {
+                    let ptr = array_ptr.add(item_offset) as *const usize;
+                    *ptr as i64
+                }
                 _ => {
                     let ptr = array_ptr.add(item_offset) as *const i64;
                     *ptr
@@ -989,6 +1023,13 @@ impl VirtualizableInfo {
                 Type::Float => {
                     let ptr = array_ptr.add(item_offset) as *mut f64;
                     *ptr = f64::from_bits(value as u64);
+                }
+                // Pointer-width item: 4 bytes on wasm32. Writing 8 bytes
+                // would clobber the next item (or run past the array end on
+                // the last item, corrupting the adjacent heap chunk).
+                Type::Ref => {
+                    let ptr = array_ptr.add(item_offset) as *mut usize;
+                    *ptr = value as usize;
                 }
                 _ => {
                     let ptr = array_ptr.add(item_offset) as *mut i64;
@@ -1275,7 +1316,7 @@ unsafe fn write_virtualizable_boxes(info: &VirtualizableInfo, obj_ptr: *mut u8, 
 /// The caller must ensure `obj_ptr` points to a valid object.
 #[cfg(test)]
 unsafe fn reset_vable_token(info: &VirtualizableInfo, obj_ptr: *mut u8) {
-    let token_ptr = obj_ptr.add(info.token_offset) as *mut u64;
+    let token_ptr = obj_ptr.add(info.token_offset) as *mut usize;
     *token_ptr = 0;
 }
 
@@ -1285,7 +1326,7 @@ unsafe fn reset_vable_token(info: &VirtualizableInfo, obj_ptr: *mut u8) {
 /// The caller must ensure `obj_ptr` points to a valid object.
 pub unsafe fn is_token_nonnull(info: &VirtualizableInfo, obj_ptr: *const u8) -> bool {
     unsafe {
-        let token_ptr = obj_ptr.add(info.token_offset) as *const u64;
+        let token_ptr = obj_ptr.add(info.token_offset) as *const usize;
         *token_ptr != 0
     }
 }
@@ -1355,8 +1396,13 @@ unsafe fn read_virtualizable_array(
 /// standard types.
 pub fn item_size_for_type(ty: Type) -> usize {
     match ty {
-        // symbolic.py:get_size → sizeof(Signed) / sizeof(Ptr)
-        Type::Int => std::mem::size_of::<i64>(),
+        // symbolic.py:get_size → sizeof(Signed) / sizeof(Ptr).  `Signed` is
+        // the machine word (4 bytes on wasm32, 8 on 64-bit), matching the
+        // `isize`/`usize`/pointer virtualizable fields it describes.  A fixed
+        // 8 here would over-size word fields on wasm32.  Fixed-width 64-bit
+        // payloads (e.g. `W_IntObject.intval`, list-strategy backing arrays)
+        // carry their own explicit `8`-byte descriptors, not this helper.
+        Type::Int => std::mem::size_of::<isize>(),
         Type::Ref => std::mem::size_of::<usize>(),
         // symbolic.py:get_size → sizeof(Float) (C double)
         Type::Float => std::mem::size_of::<f64>(),
@@ -2575,7 +2621,9 @@ pub unsafe fn vable_read_array_item(
     index: usize,
 ) -> i64 {
     unsafe {
-        let item_size = 8usize; // i64/ptr size
+        // Item width is type-dependent: a pointer array is 4 bytes/item on
+        // wasm32 (`size_of::<usize>()`), not 8.
+        let item_size = item_size_for_type(array.item_type);
         let data_ptr = match array.storage {
             VableArrayStorage::EmbeddedArray { ptr_offset } => {
                 let container = *(vable_ptr.add(array.field_offset) as *const *const u8);
@@ -2593,7 +2641,11 @@ pub unsafe fn vable_read_array_item(
             0
         } else {
             let src = data_ptr.add(index * item_size);
-            std::ptr::read(src as *const i64)
+            if array.item_type == Type::Ref {
+                *(src as *const usize) as i64
+            } else {
+                std::ptr::read(src as *const i64)
+            }
         }
     }
 }
@@ -2607,7 +2659,9 @@ pub unsafe fn vable_write_array_item(
     value: i64,
 ) {
     unsafe {
-        let item_size = 8usize; // i64/ptr size
+        // Item width is type-dependent: a pointer array is 4 bytes/item on
+        // wasm32 (`size_of::<usize>()`), not 8.
+        let item_size = item_size_for_type(array.item_type);
         let data_ptr = match array.storage {
             VableArrayStorage::EmbeddedArray { ptr_offset } => {
                 let container = *(vable_ptr.add(array.field_offset) as *const *mut u8);
@@ -2621,7 +2675,11 @@ pub unsafe fn vable_write_array_item(
         };
         if !data_ptr.is_null() {
             let dest = data_ptr.add(index * item_size);
-            std::ptr::write(dest as *mut i64, value);
+            if array.item_type == Type::Ref {
+                std::ptr::write(dest as *mut usize, value as usize);
+            } else {
+                std::ptr::write(dest as *mut i64, value);
+            }
         }
     }
 }
@@ -2636,7 +2694,7 @@ pub unsafe fn vable_write_array_item(
 /// `obj_ptr` must point to a valid virtualizable object.
 pub unsafe fn bh_clear_vable_token(vinfo: &VirtualizableInfo, obj_ptr: *mut u8) {
     unsafe {
-        let token_ptr = obj_ptr.add(vinfo.token_offset) as *mut u64;
+        let token_ptr = obj_ptr.add(vinfo.token_offset) as *mut usize;
         let token = *token_ptr;
         if token != 0 {
             // TOKEN_TRACING_RESCALL or stale Active — clear unconditionally.

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -81,7 +81,27 @@ CARGO_CONFIG = {
         "extra": ["--no-default-features", "--features", "cranelift"],
         "bin": "pyre-cranelift",
     },
+    # The wasm backend is not a `pyrex` binary: it is the wasm32 build of
+    # `pyre-wasm` (full interpreter+JIT) executed by the native `pyre-wasm-runner`
+    # under wasmtime. `build_backend` special-cases it (see `wasm=True`).
+    "wasm": {
+        "bin": "pyre-wasm-runner",
+        "wasm": True,
+    },
 }
+
+# Module + linker flags for the wasm32 build of `pyre-wasm`:
+#   * `--export-table` exposes `__indirect_function_table` so the runner's
+#     `jit_call` trampoline can dispatch residual calls by table index;
+#   * `getrandom_backend="custom"` selects getrandom's custom backend (see
+#     `pyre-wasm/src/lib.rs`) so the module carries no wasm-bindgen imports.
+# `pyre-wasm` builds to the same `pyre_wasm.wasm` filename for both the `web`
+# and `wasmi` features, so a later default (web) build would clobber the
+# native-host module. Copy the wasmi build to a distinct, stable path the runner
+# reads, immune to that overwrite.
+WASM_BUILD_OUTPUT = "target/wasm32-unknown-unknown/release/pyre_wasm.wasm"
+WASM_MODULE_PATH = "target/wasm32-unknown-unknown/release/pyre_wasm.wasmi.wasm"
+WASM_RUSTFLAGS = '-C link-arg=--export-table --cfg getrandom_backend="custom"'
 
 # ── ANSI helpers ─────────────────────────────────────────────────────
 
@@ -230,6 +250,10 @@ def pyre_env():
         env["PYRE_STDLIB"] = PYRE_STDLIB
     if FBW_INLINE_MULTIFRAME_OFF:
         env["PYRE_FBW_INLINE_MULTIFRAME"] = "0"
+    # Point the wasm runner at the built module by absolute path so it resolves
+    # regardless of the child's working directory (ignored by other backends).
+    if "PYRE_WASM_MODULE" not in env and Path(WASM_MODULE_PATH).exists():
+        env["PYRE_WASM_MODULE"] = str(Path(WASM_MODULE_PATH).resolve())
     return env
 
 
@@ -278,6 +302,11 @@ def default_binary(backend):
     name = CARGO_CONFIG[backend]["bin"]
     return f"./target/release/{name}{EXE}"
 
+
+# Backends rendered in fixed-column displays, in order. Any enabled backend not
+# listed here still runs and is counted; it just falls outside the fixed columns.
+ALL_BACKENDS = ("dynasm", "cranelift", "wasm")
+
 # ── Check runner ─────────────────────────────────────────────────────
 
 class Check:
@@ -285,10 +314,12 @@ class Check:
         self.args = args
         self.results = []
         self.comparisons = []
-        self.dynasm_pass = self.dynasm_fail = 0
-        self.cranelift_pass = self.cranelift_fail = 0
-        self.dynasm_pyre = ""
-        self.cranelift_pyre = ""
+        # Per-backend bookkeeping, keyed by backend name so any backend
+        # (dynasm / cranelift / wasm / a single `--pyre-path` binary) is tracked
+        # uniformly.
+        self.pass_count = {}
+        self.fail_count = {}
+        self.pyre = {}
         self.snapshot_diffs = []
         self.snapshot_missing = []
 
@@ -298,7 +329,7 @@ class Check:
         return bool(self._pyre(backend))
 
     def _pyre(self, backend):
-        return self.dynasm_pyre if backend == "dynasm" else self.cranelift_pyre
+        return self.pyre.get(backend, "")
 
     def _timeout_scale(self, backend):
         if backend == "dynasm" and self.args.dynasm_timeout_scale is not None:
@@ -308,10 +339,7 @@ class Check:
         return self.args.timeout_scale
 
     def _set_pyre(self, backend, path):
-        if backend == "dynasm":
-            self.dynasm_pyre = path
-        else:
-            self.cranelift_pyre = path
+        self.pyre[backend] = path
 
     # ── comparison table ──
 
@@ -328,9 +356,9 @@ class Check:
                 "name": name,
                 "cpython": fmt_time(t_cpython),
                 "pypy": fmt_time(t_pypy),
-                "dynasm": "-",
-                "cranelift": "-",
             }
+            for b in ALL_BACKENDS:
+                entry[b] = "-"
             self.comparisons.append(entry)
             idx = len(self.comparisons) - 1
         else:
@@ -349,16 +377,10 @@ class Check:
 
     def _record(self, backend, passed, name, detail):
         if passed:
-            if backend == "dynasm":
-                self.dynasm_pass += 1
-            else:
-                self.cranelift_pass += 1
+            self.pass_count[backend] = self.pass_count.get(backend, 0) + 1
         else:
             self.results.append(f"{red('FAIL')} {backend} {name}  {detail}")
-            if backend == "dynasm":
-                self.dynasm_fail += 1
-            else:
-                self.cranelift_fail += 1
+            self.fail_count[backend] = self.fail_count.get(backend, 0) + 1
 
     # ── snapshot gate ──
 
@@ -403,6 +425,8 @@ class Check:
 
     def build_backend(self, backend):
         cfg = CARGO_CONFIG[backend]
+        if cfg.get("wasm"):
+            return self.build_wasm_backend()
         print(f"Building {cfg['bin']} (release, backend={backend})...")
         cmd = [
             "cargo", "build", "--release", "-p", "pyrex",
@@ -435,6 +459,57 @@ class Check:
         lines = (proc.stdout or "").strip().splitlines() + (proc.stderr or "").strip().splitlines()
         if lines:
             print(lines[-1])
+
+    def build_wasm_backend(self):
+        """Build the wasm32 `pyre-wasm` module and the native `pyre-wasm-runner`.
+
+        The runner loads the module (via `$PYRE_WASM_MODULE`, defaulting to
+        `WASM_MODULE_PATH`) and executes it under wasmtime, so two artefacts are
+        produced: the wasm module (needs the export-table / custom-getrandom
+        flags) and the host runner binary.
+        """
+        steps = [
+            (
+                "pyre-wasm (wasm32, --features wasmi)",
+                [
+                    "cargo", "build", "--release", "-p", "pyre-wasm",
+                    "--target", "wasm32-unknown-unknown",
+                    "--no-default-features", "--features", "wasmi",
+                ],
+                {**os.environ, "RUSTFLAGS": WASM_RUSTFLAGS},
+            ),
+            (
+                "pyre-wasm-runner (native wasmtime host)",
+                ["cargo", "build", "--release", "-p", "pyre-wasm-runner"],
+                None,
+            ),
+        ]
+        for label, cmd, env in steps:
+            print(f"Building {label}...")
+            print("  $ " + " ".join(cmd))
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, encoding="utf-8",
+                errors="replace", env=env,
+            )
+            if proc.returncode != 0:
+                print(f"ERROR: cargo build failed (exit {proc.returncode})")
+                if proc.stdout:
+                    print("─── cargo stdout ───")
+                    print(proc.stdout.rstrip())
+                if proc.stderr:
+                    print("─── cargo stderr ───")
+                    print(proc.stderr.rstrip())
+                print("────────────────────")
+                sys.exit(1)
+            lines = (proc.stderr or "").strip().splitlines()
+            if lines:
+                print(lines[-1])
+        if not Path(WASM_BUILD_OUTPUT).exists():
+            print(f"ERROR: wasm module not produced at {WASM_BUILD_OUTPUT}")
+            sys.exit(1)
+        # Snapshot the wasmi build to a stable path so a later `web` build of the
+        # same crate cannot overwrite the module the runner loads.
+        shutil.copyfile(WASM_BUILD_OUTPUT, WASM_MODULE_PATH)
 
     def _print_cargo_diagnostics(self, cargo_path):
         """Dump the toolchain state when cargo refuses to run.
@@ -489,7 +564,7 @@ class Check:
                 )
             except Exception:
                 pass
-        for backend in ("dynasm", "cranelift"):
+        for backend in ALL_BACKENDS:
             if self.enabled(backend):
                 try:
                     subprocess.run(
@@ -633,7 +708,7 @@ class Check:
         t_pypy = f"{pypy_cpu:.2f}" if pypy_code == 0 else "-"
         if pypy_code != 0:
             print(f"{red('CRASH')} (exit {pypy_code})")
-            for backend in ("dynasm", "cranelift"):
+            for backend in ALL_BACKENDS:
                 if self.enabled(backend):
                     self._record(backend, False, name, "pypy crash")
                     self._append_comparison(backend, name, t_cpython, "-", "FAIL")
@@ -681,7 +756,7 @@ class Check:
             print(f"{red('CRASH')} (exit {cpython_code})")
             cpython_output = None
             t_cpython = "-"
-            for backend in ("dynasm", "cranelift"):
+            for backend in ALL_BACKENDS:
                 if self.enabled(backend):
                     self._record(backend, False, name, "cpython crash")
                     self._append_comparison(backend, name, "-", "-", "FAIL")
@@ -697,7 +772,7 @@ class Check:
         )
         if pypy_code != 0:
             print(f"{red('CRASH')} (exit {pypy_code})")
-            for backend in ("dynasm", "cranelift"):
+            for backend in ALL_BACKENDS:
                 if self.enabled(backend):
                     self._record(backend, False, name, "pypy crash")
                     self._append_comparison(backend, name, t_cpython, "-", "FAIL")
@@ -707,7 +782,7 @@ class Check:
 
         if cpython_output is not None and cpython_output != pypy_output:
             print(f"    {'baseline':<10s}{red('WRONG')}  cpython output differs from pypy")
-            for backend in ("dynasm", "cranelift"):
+            for backend in ALL_BACKENDS:
                 if self.enabled(backend):
                     self._record(backend, False, name, "cpython/pypy output mismatch")
                     self._append_comparison(
@@ -715,7 +790,7 @@ class Check:
                     )
             return
 
-        for backend in ("dynasm", "cranelift"):
+        for backend in ALL_BACKENDS:
             if not self.enabled(backend):
                 continue
             self._run_backend_bench(
@@ -742,7 +817,7 @@ class Check:
 
     def print_backend_config(self):
         parts = []
-        for b in ("dynasm", "cranelift"):
+        for b in ALL_BACKENDS:
             if self.enabled(b):
                 parts.append(f"{b}={self._pyre(b)}(x{self._timeout_scale(b)})")
         if parts:
@@ -751,36 +826,20 @@ class Check:
     def print_comparison_table(self):
         if not self.comparisons:
             return
-        both = self.enabled("dynasm") and self.enabled("cranelift")
-        dynasm_only = self.enabled("dynasm") and not self.enabled("cranelift")
-        cranelift_only = self.enabled("cranelift") and not self.enabled("dynasm")
+        cols = [b for b in ALL_BACKENDS if self.enabled(b)]
+        if not cols:
+            return
 
         print(bold("Comparison"))
 
-        if both:
-            print(f"  {'benchmark':<35s} {'cpython':>8s} {'pypy':>8s} {'dynasm':>18s} {'cranelift':>18s}")
-            print("  " + "─" * 98)
-            for c in self.comparisons:
-                print(
-                    f"  {c['name']:<35s} {c['cpython']:>8s} {c['pypy']:>8s}"
-                    f" {c['dynasm']:>18s} {c['cranelift']:>18s}"
-                )
-        elif dynasm_only:
-            print(f"  {'benchmark':<35s} {'cpython':>8s} {'pypy':>8s} {'dynasm':>18s}")
-            print("  " + "─" * 76)
-            for c in self.comparisons:
-                print(
-                    f"  {c['name']:<35s} {c['cpython']:>8s} {c['pypy']:>8s}"
-                    f" {c['dynasm']:>18s}"
-                )
-        elif cranelift_only:
-            print(f"  {'benchmark':<35s} {'cpython':>8s} {'pypy':>8s} {'cranelift':>18s}")
-            print("  " + "─" * 76)
-            for c in self.comparisons:
-                print(
-                    f"  {c['name']:<35s} {c['cpython']:>8s} {c['pypy']:>8s}"
-                    f" {c['cranelift']:>18s}"
-                )
+        header = f"  {'benchmark':<35s} {'cpython':>8s} {'pypy':>8s}"
+        header += "".join(f" {b:>18s}" for b in cols)
+        print(header)
+        print("  " + "─" * (54 + 19 * len(cols)))
+        for c in self.comparisons:
+            row = f"  {c['name']:<35s} {c['cpython']:>8s} {c['pypy']:>8s}"
+            row += "".join(f" {c[b]:>18s}" for b in cols)
+            print(row)
 
     def print_summary(self):
         print()
@@ -792,12 +851,11 @@ class Check:
 
         failed_runs = 0
         enabled_runs = 0
-        for b in ("dynasm", "cranelift"):
+        for b in ALL_BACKENDS:
             if not self.enabled(b):
                 continue
             enabled_runs += 1
-            fail = self.dynasm_fail if b == "dynasm" else self.cranelift_fail
-            if fail > 0:
+            if self.fail_count.get(b, 0) > 0:
                 failed_runs += 1
 
         self.print_comparison_table()
@@ -823,11 +881,11 @@ class Check:
                 print(dim(f"threshold: ±{self.args.threshold}% vs baseline"))
             print()
 
-        for b in ("dynasm", "cranelift"):
+        for b in ALL_BACKENDS:
             if not self.enabled(b):
                 continue
-            p = self.dynasm_pass if b == "dynasm" else self.cranelift_pass
-            f = self.dynasm_fail if b == "dynasm" else self.cranelift_fail
+            p = self.pass_count.get(b, 0)
+            f = self.fail_count.get(b, 0)
             if f > 0:
                 print(f"{red('FAILED')}: {b} {f} failed, {p} passed")
             else:
@@ -854,7 +912,7 @@ def parse_args():
         description="pyre pre-merge check: correctness + regression guard + comparison",
         allow_abbrev=False,
     )
-    parser.add_argument("--backend", choices=["dynasm", "cranelift"], default="")
+    parser.add_argument("--backend", choices=["dynasm", "cranelift", "wasm"], default="")
     parser.add_argument("--timeout-scale", type=float, default=1.0)
     parser.add_argument("--dynasm-timeout-scale", type=float, default=None)
     parser.add_argument("--cranelift-timeout-scale", type=float, default=None)

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -101,7 +101,26 @@ CARGO_CONFIG = {
 # reads, immune to that overwrite.
 WASM_BUILD_OUTPUT = "target/wasm32-unknown-unknown/release/pyre_wasm.wasm"
 WASM_MODULE_PATH = "target/wasm32-unknown-unknown/release/pyre_wasm.wasmi.wasm"
-WASM_RUSTFLAGS = '-C link-arg=--export-table --cfg getrandom_backend="custom"'
+# `-C panic=unwind` so the JIT's `panic_any(InvalidLoop)` trace-abort signal
+# unwinds to its `catch_unwind` recovery sites instead of aborting the wasm
+# instance (wasm32-unknown-unknown defaults to panic=abort); nightly LLVM
+# lowers Rust unwinding to the wasm exception-handling proposal, enabled in the
+# runner via `Config::wasm_exceptions`. `+exception-handling` emits the EH
+# opcodes. The unwinding `std`/`panic_unwind` is supplied by `-Z build-std`
+# (the precompiled wasm32 std is panic=abort), which needs the nightly toolchain
+# and the `rust-src` component.
+WASM_RUSTFLAGS = (
+    '-C link-arg=--export-table --cfg getrandom_backend="custom"'
+    " -C panic=unwind -C target-feature=+exception-handling"
+)
+# Cargo flags selecting the nightly toolchain + build-std with the unwinding
+# panic runtime. Kept separate from the build args so the rationale lives with
+# WASM_RUSTFLAGS above.
+WASM_CARGO_TOOLCHAIN = "+nightly"
+WASM_BUILD_STD_FLAGS = [
+    "-Z", "build-std=std,panic_unwind",
+    "-Z", "build-std-features=panic-unwind",
+]
 
 # ── ANSI helpers ─────────────────────────────────────────────────────
 
@@ -472,11 +491,19 @@ class Check:
             (
                 "pyre-wasm (wasm32, --features wasmi)",
                 [
-                    "cargo", "build", "--release", "-p", "pyre-wasm",
+                    "cargo", WASM_CARGO_TOOLCHAIN, "build", "--release",
+                    "-p", "pyre-wasm",
                     "--target", "wasm32-unknown-unknown",
                     "--no-default-features", "--features", "wasmi",
+                    *WASM_BUILD_STD_FLAGS,
                 ],
-                {**os.environ, "RUSTFLAGS": WASM_RUSTFLAGS},
+                # nightly + EH-landing-pad codegen recurses deeper than the
+                # 16 MiB `.cargo/config` default; give rustc more headroom.
+                {
+                    **os.environ,
+                    "RUSTFLAGS": WASM_RUSTFLAGS,
+                    "RUST_MIN_STACK": "67108864",
+                },
             ),
             (
                 "pyre-wasm-runner (native wasmtime host)",

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -101,26 +101,17 @@ CARGO_CONFIG = {
 # reads, immune to that overwrite.
 WASM_BUILD_OUTPUT = "target/wasm32-unknown-unknown/release/pyre_wasm.wasm"
 WASM_MODULE_PATH = "target/wasm32-unknown-unknown/release/pyre_wasm.wasmi.wasm"
-# `-C panic=unwind` so the JIT's `panic_any(InvalidLoop)` trace-abort signal
-# unwinds to its `catch_unwind` recovery sites instead of aborting the wasm
-# instance (wasm32-unknown-unknown defaults to panic=abort); nightly LLVM
-# lowers Rust unwinding to the wasm exception-handling proposal, enabled in the
-# runner via `Config::wasm_exceptions`. `+exception-handling` emits the EH
-# opcodes. The unwinding `std`/`panic_unwind` is supplied by `-Z build-std`
-# (the precompiled wasm32 std is panic=abort), which needs the nightly toolchain
-# and the `rust-src` component.
-WASM_RUSTFLAGS = (
-    '-C link-arg=--export-table --cfg getrandom_backend="custom"'
-    " -C panic=unwind -C target-feature=+exception-handling"
-)
-# Cargo flags selecting the nightly toolchain + build-std with the unwinding
-# panic runtime. Kept separate from the build args so the rationale lives with
-# WASM_RUSTFLAGS above.
-WASM_CARGO_TOOLCHAIN = "+nightly"
-WASM_BUILD_STD_FLAGS = [
-    "-Z", "build-std=std,panic_unwind",
-    "-Z", "build-std-features=panic-unwind",
-]
+# The JIT's trace-abort signal (InvalidLoop / speculative-fold failure) is
+# propagated as a `Result`/deferred flag through the optimizer rather than a
+# panic, so the build needs neither unwinding nor `-Z build-std`: it runs on the
+# precompiled wasm32 std with the default `panic=abort`, on the stable toolchain.
+# `--export-table` exposes the indirect-call table the runner patches for JIT
+# re-entry; `getrandom_backend="custom"` selects the no-import getrandom backend.
+WASM_RUSTFLAGS = '-C link-arg=--export-table --cfg getrandom_backend="custom"'
+# Stable toolchain, no build-std. Kept as a (possibly empty) arg list so the
+# build invocation can splat it uniformly.
+WASM_CARGO_TOOLCHAIN = []
+WASM_BUILD_STD_FLAGS = []
 
 # ── ANSI helpers ─────────────────────────────────────────────────────
 
@@ -491,18 +482,15 @@ class Check:
             (
                 "pyre-wasm (wasm32, --features wasmi)",
                 [
-                    "cargo", WASM_CARGO_TOOLCHAIN, "build", "--release",
+                    "cargo", *WASM_CARGO_TOOLCHAIN, "build", "--release",
                     "-p", "pyre-wasm",
                     "--target", "wasm32-unknown-unknown",
                     "--no-default-features", "--features", "wasmi",
                     *WASM_BUILD_STD_FLAGS,
                 ],
-                # nightly + EH-landing-pad codegen recurses deeper than the
-                # 16 MiB `.cargo/config` default; give rustc more headroom.
                 {
                     **os.environ,
                     "RUSTFLAGS": WASM_RUSTFLAGS,
-                    "RUST_MIN_STACK": "67108864",
                 },
             ),
             (

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -96,9 +96,10 @@ CARGO_CONFIG = {
 #   * `getrandom_backend="custom"` selects getrandom's custom backend (see
 #     `pyre-wasm/src/lib.rs`) so the module carries no wasm-bindgen imports.
 # `pyre-wasm` builds to the same `pyre_wasm.wasm` filename for both the `web`
-# and `wasmi` features, so a later default (web) build would clobber the
+# and `wasmi` features, so a later build of the other flavour would clobber the
 # native-host module. Copy the wasmi build to a distinct, stable path the runner
-# reads, immune to that overwrite.
+# reads, immune to that overwrite. `pyre/pyre-wasm/build-web.sh` does the mirror
+# image for the web flavour (snapshot -> pyre_wasm.web.wasm, fed to wasm-bindgen).
 WASM_BUILD_OUTPUT = "target/wasm32-unknown-unknown/release/pyre_wasm.wasm"
 WASM_MODULE_PATH = "target/wasm32-unknown-unknown/release/pyre_wasm.wasmi.wasm"
 # The JIT's trace-abort signal (InvalidLoop / speculative-fold failure) is

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -11,6 +11,11 @@ default = ["host_env"]
 host_env = ["dep:rustpython-host_env"]
 cranelift = ["majit-metainterp/cranelift"]
 dynasm = ["majit-metainterp/dynasm"]
+# Embed the pure-Python stdlib closure needed for `import re` into the binary
+# and serve it from an in-memory VFS — the browser/web wasm target has no
+# filesystem. Off by default; the native and wasmtime-runner targets read the
+# real filesystem instead.
+wasm_vfs = ["dep:lz4_flex", "host_env"]
 
 [dependencies]
 pyre-object = { workspace = true }
@@ -35,3 +40,14 @@ siphasher = { workspace = true }
 caseless = { workspace = true }
 indexmap = { workspace = true }
 paste = { workspace = true }
+# Decompresses the embedded stdlib VFS blob at runtime (wasm_vfs). Decode-only,
+# no_std-compatible safe path; the encode side is unused here.
+lz4_flex = { version = "0.13", default-features = false, features = [
+    "safe-encode",
+    "safe-decode",
+], optional = true }
+
+[build-dependencies]
+# Compresses the embedded stdlib VFS blob at build time (only does work when the
+# wasm_vfs feature is enabled; otherwise build.rs returns early).
+lz4_flex = "0.13"

--- a/pyre/pyre-interpreter/build.rs
+++ b/pyre/pyre-interpreter/build.rs
@@ -1,0 +1,69 @@
+//! Build step for the `wasm_vfs` feature.
+//!
+//! The browser/web wasm target has no filesystem, so the pure-Python stdlib
+//! closure that `import re` transitively needs cannot be read from disk at
+//! runtime.  When `wasm_vfs` is enabled this packs that closure into a single
+//! lz4-compressed blob under `OUT_DIR`; `importing.rs` embeds the blob with
+//! `include_bytes!` and decompresses it into an in-memory VFS at startup.
+//!
+//! When the feature is off (every native build) this returns immediately and
+//! produces nothing.
+
+use std::path::Path;
+
+/// Pure-Python files reachable from `import re`.  The C-level dependencies
+/// (`_sre`, `_abc`, `_weakref`, `itertools`, `_collections`, `_thread`,
+/// `operator`) are builtin modules and are not embedded.  `abc.py` resolves
+/// `_abc` (a builtin), so `_py_abc.py` is not in the closure.
+const RE_CLOSURE: &[&str] = &[
+    "_collections_abc.py",
+    "abc.py",
+    "collections/__init__.py",
+    "copyreg.py",
+    "enum.py",
+    "functools.py",
+    "keyword.py",
+    "re/__init__.py",
+    "re/_casefix.py",
+    "re/_compiler.py",
+    "re/_constants.py",
+    "re/_parser.py",
+    "reprlib.py",
+    "types.py",
+];
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Only do work for the wasm_vfs feature; native builds need nothing here.
+    if std::env::var_os("CARGO_FEATURE_WASM_VFS").is_none() {
+        return;
+    }
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let stdlib_root = Path::new(&manifest_dir).join("../../lib-python/3");
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR");
+
+    // Serialize the closure into length-prefixed records:
+    //   [count: u32 LE]
+    //   repeated: [name_len: u32 LE][name utf8][src_len: u32 LE][src utf8]
+    let mut raw: Vec<u8> = Vec::new();
+    raw.extend_from_slice(&(RE_CLOSURE.len() as u32).to_le_bytes());
+    for rel in RE_CLOSURE {
+        let path = stdlib_root.join(rel);
+        println!("cargo:rerun-if-changed={}", path.display());
+        let src = std::fs::read(&path)
+            .unwrap_or_else(|e| panic!("wasm_vfs: cannot read {}: {e}", path.display()));
+        // VFS keys use forward slashes regardless of host separator.
+        let name = rel.as_bytes();
+        raw.extend_from_slice(&(name.len() as u32).to_le_bytes());
+        raw.extend_from_slice(name);
+        raw.extend_from_slice(&(src.len() as u32).to_le_bytes());
+        raw.extend_from_slice(&src);
+    }
+
+    let compressed = lz4_flex::block::compress_prepend_size(&raw);
+    let blob_path = Path::new(&out_dir).join("stdlib_vfs.lz4");
+    std::fs::write(&blob_path, &compressed)
+        .unwrap_or_else(|e| panic!("wasm_vfs: cannot write {}: {e}", blob_path.display()));
+}

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2192,65 +2192,90 @@ fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
 fn errno_is_eshutdown(e: i32) -> bool {
     e == libc::ESHUTDOWN
 }
-#[cfg(not(unix))]
+/// wasm32 has no libc errnos; match the darwin/BSD numeric value.
+#[cfg(target_arch = "wasm32")]
+fn errno_is_eshutdown(e: i32) -> bool {
+    e == 58
+}
+#[cfg(all(not(unix), not(target_arch = "wasm32")))]
 fn errno_is_eshutdown(_e: i32) -> bool {
     false
+}
+
+/// darwin/BSD numeric errnos for wasm32, which has no libc errno constants.
+/// Kept in sync with the `errno` module's host_env-off fallback so the errno →
+/// OSError-subclass remap selects the subclass a given `errno.X` value implies.
+#[cfg(target_arch = "wasm32")]
+mod wasm_errno {
+    pub const EAGAIN: i32 = 35;
+    pub const EWOULDBLOCK: i32 = 35;
+    pub const EINPROGRESS: i32 = 36;
+    pub const EALREADY: i32 = 37;
+    pub const EPIPE: i32 = 32;
+    pub const ECHILD: i32 = 10;
+    pub const ECONNABORTED: i32 = 53;
+    pub const ECONNREFUSED: i32 = 61;
+    pub const ECONNRESET: i32 = 54;
+    pub const EEXIST: i32 = 17;
+    pub const ENOENT: i32 = 2;
+    pub const EISDIR: i32 = 21;
+    pub const ENOTDIR: i32 = 20;
+    pub const EINTR: i32 = 4;
+    pub const EACCES: i32 = 13;
+    pub const EPERM: i32 = 1;
+    pub const ESRCH: i32 = 3;
+    pub const ETIMEDOUT: i32 = 60;
 }
 
 /// `interp_exceptions.py:1207-1227 ERRNO_MAP` — the OSError subclass the
 /// exact `OSError` constructor selects for a recognised errno, by
 /// registered class name.  Returns `None` for an unmapped errno.
 fn os_error_errno_subclass(errno: i64) -> Option<&'static str> {
+    // `ESHUTDOWN` is sourced through `errno_is_eshutdown` (MSVC CRT lacks it);
+    // the rest come from `libc`, or the darwin/BSD `wasm_errno` table on wasm32.
+    #[cfg(not(target_arch = "wasm32"))]
+    use libc::{
+        EACCES, EAGAIN, EALREADY, ECHILD, ECONNABORTED, ECONNREFUSED, ECONNRESET, EEXIST,
+        EINPROGRESS, EINTR, EISDIR, ENOENT, ENOTDIR, EPERM, EPIPE, ESRCH, ETIMEDOUT, EWOULDBLOCK,
+    };
+    #[cfg(target_arch = "wasm32")]
+    use wasm_errno::*;
+
     let Ok(e) = i32::try_from(errno) else {
         return None;
     };
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        let name = if e == libc::EAGAIN
-            || e == libc::EALREADY
-            || e == libc::EINPROGRESS
-            || e == libc::EWOULDBLOCK
-        {
-            "BlockingIOError"
-        } else if e == libc::EPIPE || errno_is_eshutdown(e) {
-            "BrokenPipeError"
-        } else if e == libc::ECHILD {
-            "ChildProcessError"
-        } else if e == libc::ECONNABORTED {
-            "ConnectionAbortedError"
-        } else if e == libc::ECONNREFUSED {
-            "ConnectionRefusedError"
-        } else if e == libc::ECONNRESET {
-            "ConnectionResetError"
-        } else if e == libc::EEXIST {
-            "FileExistsError"
-        } else if e == libc::ENOENT {
-            "FileNotFoundError"
-        } else if e == libc::EISDIR {
-            "IsADirectoryError"
-        } else if e == libc::ENOTDIR {
-            "NotADirectoryError"
-        } else if e == libc::EINTR {
-            "InterruptedError"
-        } else if e == libc::EACCES || e == libc::EPERM {
-            "PermissionError"
-        } else if e == libc::ESRCH {
-            "ProcessLookupError"
-        } else if e == libc::ETIMEDOUT {
-            "TimeoutError"
-        } else {
-            return None;
-        };
-        Some(name)
-    }
-    // wasm32-unknown-unknown's libc lacks the errno constants; the errno →
-    // OSError-subclass remap is a POSIX-host concern unavailable there, so no
-    // subclass is selected (consistent with the disabled POSIX modules).
-    #[cfg(target_arch = "wasm32")]
-    {
-        let _ = e;
-        None
-    }
+    let name = if e == EAGAIN || e == EALREADY || e == EINPROGRESS || e == EWOULDBLOCK {
+        "BlockingIOError"
+    } else if e == EPIPE || errno_is_eshutdown(e) {
+        "BrokenPipeError"
+    } else if e == ECHILD {
+        "ChildProcessError"
+    } else if e == ECONNABORTED {
+        "ConnectionAbortedError"
+    } else if e == ECONNREFUSED {
+        "ConnectionRefusedError"
+    } else if e == ECONNRESET {
+        "ConnectionResetError"
+    } else if e == EEXIST {
+        "FileExistsError"
+    } else if e == ENOENT {
+        "FileNotFoundError"
+    } else if e == EISDIR {
+        "IsADirectoryError"
+    } else if e == ENOTDIR {
+        "NotADirectoryError"
+    } else if e == EINTR {
+        "InterruptedError"
+    } else if e == EACCES || e == EPERM {
+        "PermissionError"
+    } else if e == ESRCH {
+        "ProcessLookupError"
+    } else if e == ETIMEDOUT {
+        "TimeoutError"
+    } else {
+        return None;
+    };
+    Some(name)
 }
 
 /// `_parse_init_args` yields an errno only for a 2..=5 argument call whose

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3139,6 +3139,11 @@ pub(crate) fn call_init_subclass_on_bases(
         .collect();
     let frame = {
         let stored = BUILD_CLASS_EXEC_CTX.with(|c| c.get());
+        let stored = if stored.is_null() {
+            LAST_EXEC_CTX.with(|c| c.get())
+        } else {
+            stored
+        };
         if stored.is_null() {
             std::ptr::null_mut()
         } else {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -72,6 +72,203 @@ pub(crate) mod host {
 use host::fs as host_fs;
 use host::os as host_os;
 
+// ── SourceProvider: the host-agnostic byte source for module loading ──
+// PyPy/CPython read module source from a filesystem.  pyre routes the three
+// FS touchpoints the import machinery actually exercises — the package/module
+// `is_file` probes in `find_in_dirs` and the `read_to_string` in
+// `load_source_module` — through one object, so the SAME import resolution
+// runs over a real kernel FS (native, and the wasmtime runner via host
+// imports) or an in-memory VFS (the browser/web build, populated from an
+// embedded stdlib bundle).  The import machinery never branches per host;
+// only the installed provider differs.
+#[cfg(feature = "host_env")]
+pub trait SourceProvider {
+    /// True when `path` names a readable regular file.
+    fn is_file(&self, path: &Path) -> bool;
+    /// True when `path` names a directory.
+    fn is_dir(&self, path: &Path) -> bool;
+    /// Read the whole file at `path` as UTF-8 source.
+    fn read_to_string(&self, path: &Path) -> std::io::Result<String>;
+}
+
+#[cfg(feature = "host_env")]
+thread_local! {
+    static SOURCE_PROVIDER: RefCell<Option<std::rc::Rc<dyn SourceProvider>>> =
+        const { RefCell::new(None) };
+}
+
+/// Install the byte source the import machinery reads through.  The wasm
+/// bootstrap installs a host-import-backed or in-memory-VFS provider before
+/// the first import; native/pyrex leaves it unset and the default kernel-FS
+/// provider answers every probe.
+#[cfg(feature = "host_env")]
+pub fn install_source_provider(provider: std::rc::Rc<dyn SourceProvider>) {
+    SOURCE_PROVIDER.with(|p| *p.borrow_mut() = Some(provider));
+}
+
+/// Run `f` against the installed provider, lazily defaulting to the platform's
+/// kernel-FS provider when none was installed.  The `Rc` is cloned out before
+/// `f` runs so the thread-local borrow is not held across the call (the import
+/// path is re-entrant).
+#[cfg(feature = "host_env")]
+fn with_source_provider<R>(f: impl FnOnce(&dyn SourceProvider) -> R) -> R {
+    let provider = SOURCE_PROVIDER.with(|p| {
+        let mut slot = p.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(default_source_provider());
+        }
+        slot.clone().unwrap()
+    });
+    f(&*provider)
+}
+
+#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+fn default_source_provider() -> std::rc::Rc<dyn SourceProvider> {
+    std::rc::Rc::new(HostFsProvider)
+}
+
+#[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+fn default_source_provider() -> std::rc::Rc<dyn SourceProvider> {
+    std::rc::Rc::new(NullSourceProvider)
+}
+
+/// Kernel-filesystem provider — the default on native and the wasmtime
+/// runner's real-FS path.  `is_file`/`is_dir` go straight to `std::fs::
+/// metadata` via the `Path` methods (matching the historical `find_in_dirs`
+/// probes); reads route through the host_env `fs` shim.
+#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+struct HostFsProvider;
+
+#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+impl SourceProvider for HostFsProvider {
+    fn is_file(&self, path: &Path) -> bool {
+        path.is_file()
+    }
+    fn is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
+    }
+    fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
+        host_fs::read_to_string(path)
+    }
+}
+
+/// Default provider on wasm before the bootstrap installs a real one: resolves
+/// nothing, preserving the historical "builtins only" behaviour.
+#[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+struct NullSourceProvider;
+
+#[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+impl SourceProvider for NullSourceProvider {
+    fn is_file(&self, _path: &Path) -> bool {
+        false
+    }
+    fn is_dir(&self, _path: &Path) -> bool {
+        false
+    }
+    fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("no source provider installed: {}", path.display()),
+        ))
+    }
+}
+
+// ── embedded-stdlib VFS (wasm_vfs) ───────────────────────────────────
+// The browser/web wasm target has no filesystem, so the pure-Python stdlib
+// closure that `import re` needs is compiled into the binary (see build.rs)
+// and served from this in-memory map.  Keys are `mount.join(<relpath>)`, so the
+// SAME `find_in_dirs` probes (`<dir>/re/__init__.py`, `<dir>/enum.py`, …) that
+// hit a real FS on native resolve here once `mount` is on sys.path.
+#[cfg(feature = "wasm_vfs")]
+pub static VFS_BLOB: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/stdlib_vfs.lz4"));
+
+#[cfg(feature = "wasm_vfs")]
+enum VfsEntry {
+    File(std::rc::Rc<str>),
+    Dir,
+}
+
+#[cfg(feature = "wasm_vfs")]
+struct VfsProvider {
+    map: HashMap<PathBuf, VfsEntry>,
+}
+
+#[cfg(feature = "wasm_vfs")]
+impl VfsProvider {
+    /// Decompress and parse the build-time blob into a `mount`-rooted map.
+    /// Each embedded file becomes a `File` entry at `mount/<relpath>`, plus a
+    /// synthetic `Dir` entry for every ancestor directory (so `is_dir` answers
+    /// for `re/`, `collections/`, and the mount itself).
+    fn from_blob(blob: &[u8], mount: &Path) -> Self {
+        let raw = lz4_flex::block::decompress_size_prepended(blob)
+            .expect("wasm_vfs: corrupt embedded stdlib blob");
+        let mut map: HashMap<PathBuf, VfsEntry> = HashMap::new();
+        map.insert(mount.to_path_buf(), VfsEntry::Dir);
+
+        let mut pos = 0usize;
+        let read_u32 = |raw: &[u8], pos: &mut usize| -> usize {
+            let n = u32::from_le_bytes(raw[*pos..*pos + 4].try_into().unwrap()) as usize;
+            *pos += 4;
+            n
+        };
+        let count = read_u32(&raw, &mut pos);
+        for _ in 0..count {
+            let name_len = read_u32(&raw, &mut pos);
+            let name = std::str::from_utf8(&raw[pos..pos + name_len])
+                .expect("wasm_vfs: non-utf8 module name")
+                .to_owned();
+            pos += name_len;
+            let src_len = read_u32(&raw, &mut pos);
+            let src = std::str::from_utf8(&raw[pos..pos + src_len])
+                .expect("wasm_vfs: non-utf8 module source")
+                .to_owned();
+            pos += src_len;
+
+            let full = mount.join(&name);
+            // Register every ancestor directory under `mount` as a Dir.
+            let mut ancestor = full.parent();
+            while let Some(dir) = ancestor {
+                if dir == mount || !dir.starts_with(mount) {
+                    break;
+                }
+                map.entry(dir.to_path_buf()).or_insert(VfsEntry::Dir);
+                ancestor = dir.parent();
+            }
+            map.insert(full, VfsEntry::File(std::rc::Rc::from(src.as_str())));
+        }
+        VfsProvider { map }
+    }
+}
+
+#[cfg(feature = "wasm_vfs")]
+impl SourceProvider for VfsProvider {
+    fn is_file(&self, path: &Path) -> bool {
+        matches!(self.map.get(path), Some(VfsEntry::File(_)))
+    }
+    fn is_dir(&self, path: &Path) -> bool {
+        matches!(self.map.get(path), Some(VfsEntry::Dir))
+    }
+    fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
+        match self.map.get(path) {
+            Some(VfsEntry::File(src)) => Ok(src.to_string()),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("not in embedded stdlib: {}", path.display()),
+            )),
+        }
+    }
+}
+
+/// Mount the embedded stdlib closure at `mount`, add `mount` to `sys.path`, and
+/// install the VFS as the import source.  Called by the web wasm bootstrap
+/// before the first import.
+#[cfg(feature = "wasm_vfs")]
+pub fn mount_embedded_stdlib(mount: &Path) {
+    let provider = VfsProvider::from_blob(VFS_BLOB, mount);
+    add_sys_path(mount);
+    install_source_provider(std::rc::Rc::new(provider));
+}
+
 // ── sys.modules cache ────────────────────────────────────────────────
 // PyPy equivalent: space.sys.get('modules') — a dict mapping module names
 // to module objects. We use a thread-local HashMap<String, PyObjectRef>.
@@ -728,10 +925,10 @@ pub fn set_sys_modules_dict(dict: PyObjectRef) {
 #[derive(Debug)]
 enum FindInfo {
     /// A .py source file was found.
-    #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+    #[cfg(feature = "host_env")]
     SourceFile { pathname: PathBuf },
     /// A package directory with __init__.py was found.
-    #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+    #[cfg(feature = "host_env")]
     Package { dirpath: PathBuf },
     /// A builtin (Rust-implemented) module was found.
     /// PyPy equivalent: C_BUILTIN modtype in find_module()
@@ -765,7 +962,25 @@ fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindIn
     return find_in_sys_path(partname);
 }
 
-#[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+// wasm has no current_exe / python3 spawn, so there is no `ensure_stdlib_path`
+// lazy detection; `sys.path` is seeded by the wasm bootstrap (the embedded-VFS
+// mount point, or the host stdlib root for the runner). Otherwise this mirrors
+// the native `find_module`: submodule imports search the parent package's
+// `__path__`, top-level names check builtins then sys.path — all FS probes go
+// through the installed `SourceProvider`.
+#[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindInfo> {
+    if let Some(dirs) = parent_dirs {
+        return find_in_dirs(partname, dirs);
+    }
+    let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(partname));
+    if is_builtin {
+        return Some(FindInfo::Builtin);
+    }
+    find_in_sys_path(partname)
+}
+
+#[cfg(not(feature = "host_env"))]
 fn find_module(partname: &str, _parent_dirs: Option<&[PathBuf]>) -> Option<FindInfo> {
     let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(partname));
     if is_builtin {
@@ -791,19 +1006,19 @@ fn ensure_stdlib_path() {
     });
 }
 
-#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+#[cfg(feature = "host_env")]
 fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
     for dir in dirs {
         // Check for package: <dir>/<partname>/__init__.py
         let pkg_dir = dir.join(partname);
         let init_file = pkg_dir.join("__init__.py");
-        if init_file.is_file() {
+        if with_source_provider(|p| p.is_file(&init_file)) {
             return Some(FindInfo::Package { dirpath: pkg_dir });
         }
 
         // Check for source file: <dir>/<partname>.py
         let source_file = dir.join(format!("{partname}.py"));
-        if source_file.is_file() {
+        if with_source_provider(|p| p.is_file(&source_file)) {
             return Some(FindInfo::SourceFile {
                 pathname: source_file,
             });
@@ -812,7 +1027,7 @@ fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
     None
 }
 
-#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+#[cfg(feature = "host_env")]
 fn find_in_sys_path(partname: &str) -> Option<FindInfo> {
     SYS_PATH.with(|p| find_in_dirs(partname, &p.borrow()))
 }
@@ -992,14 +1207,14 @@ pub fn appleveldef_install(ns: &mut DictStorage, source: &str, filename: &str, n
 //
 // Parse + execute a .py source file, producing a module object.
 
-#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+#[cfg(feature = "host_env")]
 fn load_source_module(
     modulename: &str,
     pathname: &Path,
     package_dir: Option<&Path>,
     execution_context: *const PyExecutionContext,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let source = host_fs::read_to_string(pathname).map_err(|e| {
+    let source = with_source_provider(|p| p.read_to_string(pathname)).map_err(|e| {
         crate::PyError::new(
             crate::PyErrorKind::ImportError,
             format!("cannot read '{}': {e}", pathname.display()),
@@ -1110,7 +1325,7 @@ fn load_source_module(
 // ── load_package ─────────────────────────────────────────────────────
 // PyPy equivalent: load_module with PKG_DIRECTORY modtype
 
-#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+#[cfg(feature = "host_env")]
 fn load_package(
     modulename: &str,
     dirpath: &Path,
@@ -1171,7 +1386,7 @@ fn load_part(
     };
 
     let module = match info {
-        #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+        #[cfg(feature = "host_env")]
         FindInfo::SourceFile { pathname } => {
             match load_source_module(modulename, &pathname, None, execution_context) {
                 Ok(m) => m,
@@ -1180,7 +1395,7 @@ fn load_part(
                 }
             }
         }
-        #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+        #[cfg(feature = "host_env")]
         FindInfo::Package { dirpath } => load_package(modulename, &dirpath, execution_context)?,
         FindInfo::Builtin => {
             // Same builtins-identity path as the full_is_builtin branch
@@ -1646,5 +1861,26 @@ mod tests {
         // Should not find a module that doesn't exist
         let result = find_module("__nonexistent_pyre_test_module__", None);
         assert!(result.is_none());
+    }
+
+    #[cfg(feature = "wasm_vfs")]
+    #[test]
+    fn test_embedded_vfs_round_trips() {
+        let mount = Path::new("/stdlib");
+        let vfs = VfsProvider::from_blob(VFS_BLOB, mount);
+
+        // `re` is a package: its `__init__.py` is a file and `re/` is a dir.
+        assert!(vfs.is_file(&mount.join("re/__init__.py")));
+        assert!(vfs.is_dir(&mount.join("re")));
+        assert!(vfs.is_dir(mount));
+
+        // A top-level module the closure pulls in.
+        assert!(vfs.is_file(&mount.join("enum.py")));
+
+        // Source is readable and non-empty; misses report NotFound.
+        let src = vfs.read_to_string(&mount.join("re/__init__.py")).unwrap();
+        assert!(src.contains("def compile"));
+        assert!(vfs.read_to_string(&mount.join("re/_nope.py")).is_err());
+        assert!(!vfs.is_file(&mount.join("re/_nope.py")));
     }
 }

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -84,7 +84,6 @@ pub mod select;
 pub mod sys;
 pub mod syslog;
 pub mod termios;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod time;
 pub mod unicodedata;
 pub mod zlib;

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -849,6 +849,8 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let c_fmt = std::ffi::CString::new(fmt_str)
         .map_err(|_| crate::PyError::value_error("embedded null in format string"))?;
 
+    // wasm32 has no libc `strftime`; the function raises rather than dropping
+    // `time` from the module registry (same policy as `gmtime`/`localtime`).
     #[cfg(target_arch = "wasm32")]
     {
         let _ = c_fmt;

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -435,11 +435,20 @@ struct c_tm {
 #[allow(non_camel_case_types)]
 type time_t = i64;
 
-#[cfg(feature = "host_env")]
+#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
 fn _c_gmtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
     host_time::gmtime_from_timestamp(seconds as host_time::TimeT)
         .map(|tm| libc_tm_to_c_tm(&tm))
         .ok_or_else(|| crate::PyError::value_error("unconvertible time"))
+}
+
+// wasm32 has no libc `struct tm` calendar conversions; the broken-down-time
+// functions raise rather than dropping `time` from the module registry.
+#[cfg(target_arch = "wasm32")]
+fn _c_gmtime(_seconds: time_t) -> Result<c_tm, crate::PyError> {
+    Err(crate::PyError::not_implemented(
+        "time.gmtime is unavailable on wasm32",
+    ))
 }
 
 // `interp_time.py c_gmtime` libc backend, used when the host_env
@@ -470,11 +479,18 @@ fn _c_gmtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
     Ok(msvc_tm_to_c_tm(&tm))
 }
 
-#[cfg(feature = "host_env")]
+#[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
 fn _c_localtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
     host_time::localtime_from_timestamp(seconds as host_time::TimeT)
         .map(|tm| libc_tm_to_c_tm(&tm))
         .ok_or_else(|| crate::PyError::value_error("unconvertible time"))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn _c_localtime(_seconds: time_t) -> Result<c_tm, crate::PyError> {
+    Err(crate::PyError::not_implemented(
+        "time.localtime is unavailable on wasm32",
+    ))
 }
 
 #[cfg(all(unix, not(feature = "host_env")))]
@@ -504,6 +520,7 @@ fn _c_localtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
 
 // ── Unix helpers ────────────────────────────────────────────────────
 
+#[cfg(not(target_arch = "wasm32"))]
 fn libc_tm_to_c_tm(tm: &libc::tm) -> c_tm {
     // `tm_gmtoff` / `tm_zone` only exist on the Unix `struct tm`.
     #[cfg(unix)]
@@ -534,6 +551,7 @@ fn libc_tm_to_c_tm(tm: &libc::tm) -> c_tm {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn c_tm_to_libc_tm(tm: &c_tm) -> libc::tm {
     unsafe {
         let mut out: libc::tm = std::mem::zeroed();
@@ -831,6 +849,13 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let c_fmt = std::ffi::CString::new(fmt_str)
         .map_err(|_| crate::PyError::value_error("embedded null in format string"))?;
 
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = c_fmt;
+        Err(crate::PyError::not_implemented(
+            "time.strftime is unavailable on wasm32",
+        ))
+    }
     // strftime is available on both Unix and Windows CRT.
     #[cfg(unix)]
     {
@@ -890,46 +915,51 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// time.mktime(tuple) — interp_time.mktime
 pub fn mktime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let mut tm = _gettmarg(args, false)?;
-    tm.tm_wday = -1;
-
-    #[cfg(feature = "host_env")]
-    let tt = {
-        let mut libc_tm = c_tm_to_libc_tm(&tm);
-        let result = host_time::mktime(&mut libc_tm);
-        tm.tm_wday = libc_tm.tm_wday;
-        result as i64
-    };
-    #[cfg(all(unix, not(feature = "host_env")))]
-    let tt: i64 = {
-        let mut libc_tm = c_tm_to_libc_tm(&tm);
-        let r = unsafe { libc::mktime(&mut libc_tm) };
-        tm.tm_wday = libc_tm.tm_wday;
-        r as i64
-    };
-    #[cfg(all(windows, not(feature = "host_env")))]
-    let tt: i64 = {
-        unsafe extern "C" {
-            fn _mktime64(out: *mut MsvcTm) -> i64;
-        }
-        let mut msvc_tm = c_tm_to_msvc_tm(&tm);
-        let r = unsafe { _mktime64(&mut msvc_tm) };
-        tm.tm_wday = msvc_tm.tm_wday;
-        r
-    };
+    // No libc `struct tm` calendar on wasm32 (and other bare targets).
     #[cfg(not(any(unix, windows)))]
-    let tt: i64 = {
-        return Err(crate::PyError::not_implemented(
-            "time.mktime requires host_env feature on this platform",
-        ));
-    };
-
-    if tt == -1 && tm.tm_wday == -1 {
-        return Err(crate::PyError::overflow_error(
-            "mktime argument out of range",
-        ));
+    {
+        let _ = args;
+        Err(crate::PyError::not_implemented(
+            "time.mktime is unavailable on this platform",
+        ))
     }
-    Ok(floatobject::w_float_new(tt as f64))
+    #[cfg(any(unix, windows))]
+    {
+        let mut tm = _gettmarg(args, false)?;
+        tm.tm_wday = -1;
+
+        #[cfg(feature = "host_env")]
+        let tt = {
+            let mut libc_tm = c_tm_to_libc_tm(&tm);
+            let result = host_time::mktime(&mut libc_tm);
+            tm.tm_wday = libc_tm.tm_wday;
+            result as i64
+        };
+        #[cfg(all(unix, not(feature = "host_env")))]
+        let tt: i64 = {
+            let mut libc_tm = c_tm_to_libc_tm(&tm);
+            let r = unsafe { libc::mktime(&mut libc_tm) };
+            tm.tm_wday = libc_tm.tm_wday;
+            r as i64
+        };
+        #[cfg(all(windows, not(feature = "host_env")))]
+        let tt: i64 = {
+            unsafe extern "C" {
+                fn _mktime64(out: *mut MsvcTm) -> i64;
+            }
+            let mut msvc_tm = c_tm_to_msvc_tm(&tm);
+            let r = unsafe { _mktime64(&mut msvc_tm) };
+            tm.tm_wday = msvc_tm.tm_wday;
+            r
+        };
+
+        if tt == -1 && tm.tm_wday == -1 {
+            return Err(crate::PyError::overflow_error(
+                "mktime argument out of range",
+            ));
+        }
+        Ok(floatobject::w_float_new(tt as f64))
+    }
 }
 
 /// time.asctime([tuple]) — interp_time.asctime
@@ -940,6 +970,13 @@ pub fn asctime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 fn _asctime_from_tm(tm: &c_tm) -> Result<PyObjectRef, crate::PyError> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = tm;
+        Err(crate::PyError::not_implemented(
+            "time.asctime is unavailable on wasm32",
+        ))
+    }
     #[cfg(unix)]
     {
         let libc_tm = c_tm_to_libc_tm(&tm);
@@ -972,6 +1009,13 @@ fn _asctime_from_tm(tm: &c_tm) -> Result<PyObjectRef, crate::PyError> {
 pub fn ctime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let seconds = _get_seconds(args);
 
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = seconds;
+        Err(crate::PyError::not_implemented(
+            "time.ctime is unavailable on wasm32",
+        ))
+    }
     #[cfg(unix)]
     {
         let tm = _c_localtime(seconds)?;

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1937,7 +1937,10 @@ pub fn float_floatval_descr() -> DescrRef {
 pub fn str_len_descr() -> DescrRef {
     // Python len(str) returns codepoint count.
     // unicodeobject.py:165 W_UnicodeObject._len() → _length field.
-    make_immutable_field_descr(STR_LEN_OFFSET, 8, Type::Int, false)
+    // `W_StrObject.len` is a `usize`: 8 bytes on 64-bit, 4 on wasm32 — a
+    // hardcoded 8 reads the adjacent field into the high half on a 32-bit
+    // target (blackhole resume of `len(str)`).
+    make_immutable_field_descr(STR_LEN_OFFSET, std::mem::size_of::<usize>(), Type::Int, false)
 }
 
 pub fn dict_storage_values_ptr_descr() -> DescrRef {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1940,7 +1940,12 @@ pub fn str_len_descr() -> DescrRef {
     // `W_StrObject.len` is a `usize`: 8 bytes on 64-bit, 4 on wasm32 — a
     // hardcoded 8 reads the adjacent field into the high half on a 32-bit
     // target (blackhole resume of `len(str)`).
-    make_immutable_field_descr(STR_LEN_OFFSET, std::mem::size_of::<usize>(), Type::Int, false)
+    make_immutable_field_descr(
+        STR_LEN_OFFSET,
+        std::mem::size_of::<usize>(),
+        Type::Int,
+        false,
+    )
 }
 
 pub fn dict_storage_values_ptr_descr() -> DescrRef {

--- a/pyre/pyre-jit-trace/src/frame_layout.rs
+++ b/pyre/pyre-jit-trace/src/frame_layout.rs
@@ -108,7 +108,9 @@ unsafe extern "C" fn pyre_clear_vable_token(obj_ptr: i64) {
     unsafe {
         let ptr = obj_ptr as *mut u8;
         if !ptr.is_null() {
-            let token_ptr = ptr.add(PYFRAME_VABLE_TOKEN_OFFSET) as *mut u64;
+            // `vable_token` is `usize` (pointer-width: 4 on wasm32). Writing
+            // 8 bytes would clobber the following field.
+            let token_ptr = ptr.add(PYFRAME_VABLE_TOKEN_OFFSET) as *mut usize;
             *token_ptr = 0;
         }
     }

--- a/pyre/pyre-jit-trace/src/pyre_cpu.rs
+++ b/pyre/pyre-jit-trace/src/pyre_cpu.rs
@@ -41,7 +41,10 @@ impl FieldDescr for PyreStrByteLenFieldDescr {
         STR_BYTE_LEN_OFFSET
     }
     fn field_size(&self) -> usize {
-        8
+        // `W_StrObject.byte_len` is a `usize`: 8 bytes on 64-bit, 4 on
+        // wasm32. A hardcoded 8 reads the adjacent field into the high
+        // half on a 32-bit target.
+        std::mem::size_of::<usize>()
     }
     fn field_type(&self) -> Type {
         Type::Int
@@ -67,7 +70,10 @@ impl FieldDescr for PyreUnicodeLenFieldDescr {
         STR_LEN_OFFSET
     }
     fn field_size(&self) -> usize {
-        8
+        // `W_StrObject.len` is a `usize`: 8 bytes on 64-bit, 4 on wasm32.
+        // A hardcoded 8 reads the adjacent field into the high half on a
+        // 32-bit target.
+        std::mem::size_of::<usize>()
     }
     fn field_type(&self) -> Type {
         Type::Int

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2278,7 +2278,7 @@ pub(crate) fn pyobject_array_descr() -> DescrRef {
     // canonicalizes across analyzer / runtime consumers.
     crate::descr::make_array_descr_with_full_id(
         0,
-        8,
+        std::mem::size_of::<usize>(),
         0,
         None,
         Type::Ref,
@@ -2310,7 +2310,7 @@ pub fn pyobject_gcarray_descr() -> DescrRef {
     // length header at offset 0, items start at `FIXED_ARRAY_ITEMS_OFFSET`.
     make_array_descr_with_type(
         pyre_object::FIXED_ARRAY_ITEMS_OFFSET,
-        8,
+        std::mem::size_of::<usize>(),
         PY_OBJECT_ARRAY_GC_TYPE_ID,
         Some(0),
         Type::Ref,
@@ -3058,8 +3058,9 @@ pub(crate) fn trace_raw_array_getitem_value(
 /// `opimpl_getfield_gc_r` against the `items` /  `wrappeditems` field)
 /// directly. The `pyobject_gcarray_descr` here is
 /// `Ptr(GcArray(OBJECTPTR))` with `base_size = ITEMS_BLOCK_ITEMS_OFFSET`
-/// (= length-prefix size), `item_size = 8`, `item_type = Ref`,
-/// matching `rpython/rtyper/lltypesystem/rlist.py:84` `GcArray(OBJECTPTR)`.
+/// (= length-prefix size), `item_size = sizeof(Ptr)` (word-sized: 4 on
+/// wasm32, 8 on 64-bit), `item_type = Ref`, matching
+/// `rpython/rtyper/lltypesystem/rlist.py:84` `GcArray(OBJECTPTR)`.
 ///
 /// Replaces the prior two-step `IntAdd(items_block, OFFSET) +
 /// raw-array op` deviation with the upstream single-op shape.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2082,6 +2082,9 @@ fn bridge_source_identity_from_descr(
 /// On failure (trace abort, start failure), returns false so the caller
 /// falls through to resume_in_blackhole (RPython pyjitpl.py:2906-2907
 /// SwitchToBlackhole → run_blackhole_interp_to_cancel_tracing).
+// On wasm the early unconditional decline makes the native bridge body
+// unreachable; the suppression is intentional and wasm-only.
+#[cfg_attr(target_arch = "wasm32", allow(unreachable_code))]
 pub fn trace_and_compile_from_bridge(
     // pyjitpl.py:2890 `handle_guard_failure(self, resumedescr, deadframe)`
     // threads `resumedescr` (the descr) as the canonical identity source
@@ -2120,6 +2123,23 @@ pub fn trace_and_compile_from_bridge(
         // the caller into `resume_in_blackhole` (pyjitpl.py:711).
         return false;
     };
+
+    // The wasm backend declines every compile_bridge (no inter-module trace
+    // chaining, #62), so a bridge attempt always falls back to a blackhole
+    // resume. Running the bridge tracer walk first executes the resumed region
+    // — any post-loop tail or exception handler — concretely, and the declined
+    // backend then drops the caller into resume_in_blackhole, which re-executes
+    // the same region: a side-effecting tail fires twice (and the wasted walk
+    // every iteration of a hot guard makes the loop time out). Skip the walk
+    // and resume in the blackhole exactly once. resume_in_blackhole_from_exit_
+    // layout decodes its own position from the exit layout, so no frame PC
+    // setup is owed here. Native compiles or cleanly aborts bridges, so this
+    // routing is wasm-only.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = (frame, raw_values, exit_layout, guard_exc, green_key, trace_id, fail_index);
+        return false;
+    }
 
     let info = {
         let (_, info) = crate::eval::driver_pair();

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -459,14 +459,26 @@ extern "C" fn jit_call_user_function_from_frame(
             // machinery sees it, bypassing try/except.
             let exc_obj = err.exc_object;
             if exc_obj != pyre_object::PY_NULL {
-                #[cfg(feature = "cranelift")]
-                majit_backend_cranelift::jit_exc_raise(exc_obj as i64);
-                #[cfg(feature = "dynasm")]
-                majit_backend_dynasm::jit_exc_raise(exc_obj as i64);
+                store_jit_exception(exc_obj as i64);
             }
             0 // garbage — GUARD_NO_EXCEPTION will fire
         }
     }
+}
+
+/// llmodel.py:194-199 _store_exception: publish a materialised exception
+/// object into the active backend's `_store_exception` cells so the
+/// GuardNoException after the call detects it. One arm per backend; the wasm
+/// backend keeps the pending exception in shared linear memory.
+pub(crate) fn store_jit_exception(value: i64) {
+    #[cfg(feature = "cranelift")]
+    majit_backend_cranelift::jit_exc_raise(value);
+    #[cfg(feature = "dynasm")]
+    majit_backend_dynasm::jit_exc_raise(value);
+    #[cfg(target_arch = "wasm32")]
+    majit_backend_wasm::jit_exc_raise(value);
+    #[cfg(not(any(feature = "cranelift", feature = "dynasm", target_arch = "wasm32")))]
+    let _ = value;
 }
 
 /// Backend bridge for pyre-interpreter's residual-call helpers, which
@@ -474,10 +486,7 @@ extern "C" fn jit_call_user_function_from_frame(
 /// exception object into the active backend's _store_exception cells so
 /// the GuardNoException after the call detects it.
 extern "C" fn jit_exc_raise_shim(value: i64) {
-    #[cfg(feature = "cranelift")]
-    majit_backend_cranelift::jit_exc_raise(value);
-    #[cfg(feature = "dynasm")]
-    majit_backend_dynasm::jit_exc_raise(value);
+    store_jit_exception(value);
 }
 
 /// Publish a raise from a may-force residual helper to BOTH executors.
@@ -492,10 +501,7 @@ extern "C" fn jit_exc_raise_shim(value: i64) {
 /// helper's NULL result flows to the consumer — keep both states in sync.
 fn publish_residual_call_exception(exc_obj: i64) {
     majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj));
-    #[cfg(feature = "cranelift")]
-    majit_backend_cranelift::jit_exc_raise(exc_obj);
-    #[cfg(feature = "dynasm")]
-    majit_backend_dynasm::jit_exc_raise(exc_obj);
+    store_jit_exception(exc_obj);
 }
 
 /// Drain the backend `_store_exception` cells (`jit_exc_clear`) without
@@ -519,6 +525,8 @@ pub(crate) fn drain_backend_jit_exc() {
     majit_backend_cranelift::jit_exc_clear();
     #[cfg(feature = "dynasm")]
     majit_backend_dynasm::jit_exc_clear();
+    #[cfg(target_arch = "wasm32")]
+    majit_backend_wasm::jit_exc_clear();
 }
 
 #[majit_macros::jit_may_force]
@@ -1957,10 +1965,7 @@ fn handle_blackhole_result(bh_result: BlackholeResult, _green_key: u64) -> Optio
                 // below (line 2120-2122) and with `lib.rs::jit_exc_raise`
                 // — every backend's blackhole resume publishes the
                 // pending exception, not just cranelift.
-                #[cfg(feature = "cranelift")]
-                majit_backend_cranelift::jit_exc_raise(exc_obj as i64);
-                #[cfg(feature = "dynasm")]
-                majit_backend_dynasm::jit_exc_raise(exc_obj as i64);
+                store_jit_exception(exc_obj as i64);
             }
             Some(0) // garbage return — GUARD_NO_EXCEPTION will fire
         }
@@ -2014,10 +2019,7 @@ fn handle_blackhole_result(bh_result: BlackholeResult, _green_key: u64) -> Optio
                     if exc_obj != pyre_object::PY_NULL {
                         majit_metainterp::blackhole::BH_LAST_EXC_VALUE
                             .with(|c| c.set(exc_obj as i64));
-                        #[cfg(feature = "cranelift")]
-                        majit_backend_cranelift::jit_exc_raise(exc_obj as i64);
-                        #[cfg(feature = "dynasm")]
-                        majit_backend_dynasm::jit_exc_raise(exc_obj as i64);
+                        store_jit_exception(exc_obj as i64);
                     }
                     Some(0)
                 }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2137,7 +2137,15 @@ pub fn trace_and_compile_from_bridge(
     // routing is wasm-only.
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = (frame, raw_values, exit_layout, guard_exc, green_key, trace_id, fail_index);
+        let _ = (
+            frame,
+            raw_values,
+            exit_layout,
+            guard_exc,
+            green_key,
+            trace_id,
+            fail_index,
+        );
         return false;
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3014,7 +3014,11 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame) };
     pyre_interpreter::call::register_eval_override(eval_with_jit);
     pyre_interpreter::call::register_set_jit_param_hook(set_jit_param_via_warmstate);
-    #[cfg(not(target_arch = "wasm32"))]
+    // The backend-agnostic registrations here — notably the JIT exception
+    // raiser (`register_jit_exc_raiser`) that `jit_publish_exception` routes
+    // residual-call raises through — are required on every backend; the
+    // cranelift/dynasm-specific blocks inside are already `cfg`-gated, so this
+    // is safe on wasm32 (where it is the only thing that installs the raiser).
     crate::call_jit::install_jit_call_bridge();
     init_callbacks();
     #[cfg(feature = "cranelift")]
@@ -3258,12 +3262,7 @@ pub fn portal_runner(frame: &mut PyFrame) -> pyre_object::PyObjectRef {
     match portal_runner_result(frame) {
         Ok(r) => r,
         Err(err) => {
-            #[cfg(feature = "cranelift")]
-            majit_backend_cranelift::jit_exc_raise(err.exc_object as i64);
-            #[cfg(feature = "dynasm")]
-            majit_backend_dynasm::jit_exc_raise(err.exc_object as i64);
-            #[cfg(not(any(feature = "cranelift", feature = "dynasm")))]
-            let _ = err;
+            crate::call_jit::store_jit_exception(err.exc_object as i64);
             pyre_object::PY_NULL
         }
     }

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -28,6 +28,17 @@
 //!   └── lib.rs (public API)
 //! ```
 
+// `wasm-web` / `wasm-host` select the wasm JIT backend's host binding and are
+// meaningful only on wasm32; reject misconfigurations early with a clear
+// message instead of letting them surface as undefined-symbol failures.
+#[cfg(all(feature = "wasm-web", feature = "wasm-host"))]
+compile_error!("features `wasm-web` and `wasm-host` are mutually exclusive; enable exactly one");
+#[cfg(all(
+    any(feature = "wasm-web", feature = "wasm-host"),
+    not(target_arch = "wasm32")
+))]
+compile_error!("features `wasm-web` / `wasm-host` require target_arch = \"wasm32\"");
+
 pub mod call_jit;
 pub mod driver;
 pub mod eval;

--- a/pyre/pyre-wasm-runner/Cargo.toml
+++ b/pyre/pyre-wasm-runner/Cargo.toml
@@ -13,3 +13,7 @@ path = "src/main.rs"
 # wasmtime vendors its own error type (`wasmtime::Error`) and re-exports a
 # `Context` trait, so the runner needs no separate `anyhow` dependency.
 wasmtime = { workspace = true }
+# Disassemble a trace module to WAT when it fails to compile, gated by
+# PYRE_WASM_DUMP_BAD_TRACE — used to debug JIT codegen bugs. Pinned to the
+# version wasmtime already resolves in the lockfile.
+wasmprinter = "0.248"

--- a/pyre/pyre-wasm-runner/Cargo.toml
+++ b/pyre/pyre-wasm-runner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pyre-wasm-runner"
+version.workspace = true
+edition.workspace = true
+publish = false
+description = "Native wasmtime host that runs the wasm32 build of pyre, satisfying the JIT host-import contract"
+
+[[bin]]
+name = "pyre-wasm-runner"
+path = "src/main.rs"
+
+[dependencies]
+# wasmtime vendors its own error type (`wasmtime::Error`) and re-exports a
+# `Context` trait, so the runner needs no separate `anyhow` dependency.
+wasmtime = { workspace = true }

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -126,12 +126,6 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     const WASM_STACK: usize = 256 * 1024 * 1024;
     config.max_wasm_stack(WASM_STACK);
     config.async_stack_size(WASM_STACK + 1024 * 1024);
-    // The wasm32 module is built with `-C panic=unwind` so the JIT's
-    // `panic_any(InvalidLoop)` trace-abort signal unwinds to its
-    // `catch_unwind` recovery sites (jump_to_preamble fallback) instead of
-    // aborting the instance. nightly LLVM lowers that to the exception-handling
-    // proposal, which wasmtime only accepts with this enabled.
-    config.wasm_exceptions(true);
     let engine = Engine::new(&config)?;
 
     let module = Module::from_file(&engine, module_path)
@@ -576,10 +570,8 @@ fn write_i64(mem: &Memory, mut store: impl AsContextMut, off: usize, v: i64) -> 
 
 /// Dump the module's imports and exports, for debugging the host contract.
 fn inspect_module(module_path: &PathBuf) -> Result<()> {
-    // Match `run`'s engine: the module carries exception-handling opcodes
-    // (panic=unwind) that wasmtime rejects at parse time without this.
-    let mut config = Config::new();
-    config.wasm_exceptions(true);
+    // Match `run`'s engine configuration.
+    let config = Config::new();
     let engine = Engine::new(&config)?;
     let module = Module::from_file(&engine, module_path)
         .with_context(|| format!("load wasm module {}", module_path.display()))?;

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -122,6 +122,12 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     const WASM_STACK: usize = 256 * 1024 * 1024;
     config.max_wasm_stack(WASM_STACK);
     config.async_stack_size(WASM_STACK + 1024 * 1024);
+    // The wasm32 module is built with `-C panic=unwind` so the JIT's
+    // `panic_any(InvalidLoop)` trace-abort signal unwinds to its
+    // `catch_unwind` recovery sites (jump_to_preamble fallback) instead of
+    // aborting the instance. nightly LLVM lowers that to the exception-handling
+    // proposal, which wasmtime only accepts with this enabled.
+    config.wasm_exceptions(true);
     let engine = Engine::new(&config)?;
 
     let module = Module::from_file(&engine, module_path)
@@ -446,7 +452,11 @@ fn write_i64(mem: &Memory, mut store: impl AsContextMut, off: usize, v: i64) -> 
 
 /// Dump the module's imports and exports, for debugging the host contract.
 fn inspect_module(module_path: &PathBuf) -> Result<()> {
-    let engine = Engine::new(&Config::new())?;
+    // Match `run`'s engine: the module carries exception-handling opcodes
+    // (panic=unwind) that wasmtime rejects at parse time without this.
+    let mut config = Config::new();
+    config.wasm_exceptions(true);
+    let engine = Engine::new(&config)?;
     let module = Module::from_file(&engine, module_path)
         .with_context(|| format!("load wasm module {}", module_path.display()))?;
     println!("imports:");

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1,0 +1,446 @@
+//! Native host that runs the wasm32 build of pyre under wasmtime so the full
+//! interpreter+JIT path executes outside a browser.
+//!
+//! It is the non-JS counterpart of `majit-backend-wasm/js/jit_glue.js` and
+//! implements the same host-import contract:
+//!
+//!   * the main module (`pyre-wasm` built with `--features wasmi`) imports
+//!     `pyre_jit.{jit_compile_wasm, jit_execute_wasm, jit_free_wasm}` and
+//!     exports `memory`, `__indirect_function_table`, `pyre_alloc`,
+//!     `pyre_dealloc`, and `pyre_run_python`;
+//!   * each JIT-emitted trace module imports `env.memory` (shared with the
+//!     main module) plus an optional `env.jit_call` trampoline, and exports a
+//!     `trace` function `(i32) -> i32`;
+//!   * the trampoline reads func_ptr / args from the frame call area, dispatches
+//!     through the main module's indirect function table (a `fn as usize` is a
+//!     table index on wasm32), and writes the result back.
+//!
+//! CLI: `pyre-wasm-runner <script.py>` runs the script and writes its output to
+//! stdout, matching the `pyrex` backend interface `pyre/check.py` drives. The
+//! wasm module is located via `$PYRE_WASM_MODULE` or `--module <path>`, else the
+//! default release artifact path.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use wasmtime::error::Context;
+use wasmtime::{
+    AsContext, AsContextMut, Caller, Config, Engine, Error, Extern, Func, Instance, Linker, Memory,
+    Module, Ref, Result, Store, Table, Val, ValType,
+};
+
+// Frame call-area offsets — must match `majit-backend-wasm/src/codegen.rs`.
+const CALL_RESULT_OFS: usize = 2000;
+const CALL_FUNC_OFS: usize = 2008;
+// The arg count also lives at offset 2016, but the trampoline derives arity
+// (and the exact value types) from the resolved function's wasm signature
+// instead, which is authoritative on wasm32. Kept for layout documentation.
+#[allow(dead_code)]
+const CALL_NARGS_OFS: usize = 2016;
+const CALL_ARGS_OFS: usize = 2024;
+
+const DEFAULT_MODULE: &str = "target/wasm32-unknown-unknown/release/pyre_wasm.wasm";
+
+/// Per-store host state shared by all import callbacks.
+#[derive(Default)]
+struct Host {
+    /// The main module's exported linear memory, shared with every trace.
+    memory: Option<Memory>,
+    /// The main module's `__indirect_function_table`, used by the trampoline.
+    table: Option<Table>,
+    /// Compiled trace `trace` functions, keyed by the id handed back to wasm.
+    traces: HashMap<u32, Func>,
+    next_id: u32,
+}
+
+fn main() {
+    let mut module_path: Option<PathBuf> = None;
+    let mut script: Option<PathBuf> = None;
+    let mut inspect = false;
+
+    let mut argv = std::env::args().skip(1);
+    while let Some(arg) = argv.next() {
+        match arg.as_str() {
+            "--inspect" => inspect = true,
+            "--module" => {
+                module_path = Some(PathBuf::from(
+                    argv.next()
+                        .unwrap_or_else(|| fatal("--module needs a path")),
+                ))
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "usage: pyre-wasm-runner [--module <pyre_wasm.wasm>] [--inspect] <script.py>"
+                );
+                std::process::exit(2);
+            }
+            other if other.starts_with('-') => fatal(&format!("unknown flag {other}")),
+            other => script = Some(PathBuf::from(other)),
+        }
+    }
+
+    let module_path = module_path
+        .or_else(|| std::env::var_os("PYRE_WASM_MODULE").map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_MODULE));
+
+    // The wasm runs on the calling thread's stack (sync wasmtime), so the
+    // deep interpreter recursion needs a large host stack to back the
+    // generous `max_wasm_stack` set in `run`.
+    let worker = std::thread::Builder::new()
+        .stack_size(512 * 1024 * 1024)
+        .spawn(move || -> Result<i32> {
+            if inspect {
+                inspect_module(&module_path)?;
+                return Ok(0);
+            }
+            let script = script.context("no script given")?;
+            let source = std::fs::read_to_string(&script)
+                .with_context(|| format!("read script {}", script.display()))?;
+            run(&module_path, &source)
+        })
+        .expect("spawn worker thread");
+
+    match worker.join() {
+        Ok(Ok(code)) => std::process::exit(code),
+        Ok(Err(e)) => fatal(&format!("{e:?}")),
+        Err(_) => fatal("worker thread panicked"),
+    }
+}
+
+fn fatal(msg: &str) -> ! {
+    eprintln!("pyre-wasm-runner: {msg}");
+    std::process::exit(1);
+}
+
+fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
+    let mut config = Config::new();
+    // Allow the interpreter's deep recursion before wasmtime raises a stack
+    // overflow trap; the interpreter's own recursion limit normally fires
+    // first. Kept below the worker thread's stack reservation. wasmtime
+    // requires `max_wasm_stack <= async_stack_size` even for sync execution,
+    // so the async stack is sized just above it.
+    const WASM_STACK: usize = 256 * 1024 * 1024;
+    config.max_wasm_stack(WASM_STACK);
+    config.async_stack_size(WASM_STACK + 1024 * 1024);
+    let engine = Engine::new(&config)?;
+
+    let module = Module::from_file(&engine, module_path)
+        .with_context(|| format!("load wasm module {}", module_path.display()))?;
+
+    let mut store = Store::new(&engine, Host::default());
+    store.data_mut().next_id = 1;
+
+    let linker = build_linker(&engine)?;
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .context("instantiate main module")?;
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .context("main module is missing its `memory` export")?;
+    let table = instance
+        .get_table(&mut store, "__indirect_function_table")
+        .context("main module is missing its `__indirect_function_table` export (build with --export-table)")?;
+    store.data_mut().memory = Some(memory);
+    store.data_mut().table = Some(table);
+
+    let alloc = instance.get_typed_func::<u32, u32>(&mut store, "pyre_alloc")?;
+    let run_python = instance.get_typed_func::<(u32, u32), u64>(&mut store, "pyre_run_python")?;
+    let dealloc = instance.get_typed_func::<(u32, u32), ()>(&mut store, "pyre_dealloc")?;
+
+    let src = source.as_bytes();
+    let len = src.len() as u32;
+    let in_ptr = if len == 0 {
+        0
+    } else {
+        let p = alloc.call(&mut store, len)?;
+        memory.write(&mut store, p as usize, src)?;
+        p
+    };
+
+    let packed = match run_python.call(&mut store, (in_ptr, len)) {
+        Ok(p) => p,
+        Err(e) => {
+            // wasm32-unknown-unknown has no stderr, but pyre-wasm's panic hook
+            // writes "panicked at …" into linear memory before the trap.
+            // Recover the formatted message (the heap String, not the static
+            // format template) so the real cause is visible.
+            for msg in recover_panic_messages(memory.data(&store)) {
+                eprintln!("pyre-wasm-runner: recovered panic: {msg}");
+            }
+            return Err(e);
+        }
+    };
+    let out_ptr = (packed >> 32) as u32;
+    let out_len = (packed & 0xffff_ffff) as u32;
+
+    let mut out = vec![0u8; out_len as usize];
+    if out_len != 0 {
+        memory.read(&store, out_ptr as usize, &mut out)?;
+        dealloc.call(&mut store, (out_ptr, out_len))?;
+    }
+    if len != 0 {
+        dealloc.call(&mut store, (in_ptr, len))?;
+    }
+
+    use std::io::Write;
+    std::io::stdout().write_all(&out)?;
+    std::io::stdout().flush()?;
+    Ok(0)
+}
+
+fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
+    let mut linker = Linker::new(engine);
+
+    linker.func_wrap(
+        "pyre_jit",
+        "jit_compile_wasm",
+        |mut caller: Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32| -> u32 {
+            match jit_compile(&mut caller, bytes_ptr, bytes_len) {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("[jit_compile_wasm] {e:?}");
+                    0
+                }
+            }
+        },
+    )?;
+
+    linker.func_wrap(
+        "pyre_jit",
+        "jit_execute_wasm",
+        |mut caller: Caller<'_, Host>, func_id: u32, frame_ptr: u32| -> u32 {
+            match jit_execute(&mut caller, func_id, frame_ptr) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("[jit_execute_wasm] {e:?}");
+                    0
+                }
+            }
+        },
+    )?;
+
+    linker.func_wrap(
+        "pyre_jit",
+        "jit_free_wasm",
+        |mut caller: Caller<'_, Host>, func_id: u32| {
+            caller.data_mut().traces.remove(&func_id);
+        },
+    )?;
+
+    Ok(linker)
+}
+
+/// Compile and instantiate a JIT-emitted trace module, sharing the main
+/// module's linear memory and wiring the `jit_call` trampoline.
+fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) -> Result<u32> {
+    let memory = caller
+        .data()
+        .memory
+        .context("main memory not initialized")?;
+
+    let mut bytes = vec![0u8; bytes_len as usize];
+    memory
+        .read(&*caller, bytes_ptr as usize, &mut bytes)
+        .context("read trace module bytes")?;
+
+    let engine = caller.engine().clone();
+    let module = Module::new(&engine, &bytes).context("compile trace module")?;
+
+    // A fresh trampoline per trace; it reads all state from `caller.data()`.
+    let jit_call = Func::wrap(
+        &mut *caller,
+        |mut inner: Caller<'_, Host>, frame_ptr: i32| {
+            if let Err(e) = jit_call_trampoline(&mut inner, frame_ptr as u32) {
+                eprintln!("[jit_call] {e:?}");
+            }
+        },
+    );
+
+    // Supply imports in the module's declared order.
+    let mut externs: Vec<Extern> = Vec::new();
+    for import in module.imports() {
+        match (import.module(), import.name()) {
+            ("env", "memory") => externs.push(Extern::Memory(memory)),
+            ("env", "jit_call") => externs.push(Extern::Func(jit_call)),
+            (m, n) => {
+                return Err(Error::msg(format!(
+                    "trace module has unexpected import {m}.{n}"
+                )));
+            }
+        }
+    }
+
+    let instance =
+        Instance::new(&mut *caller, &module, &externs).context("instantiate trace module")?;
+    let trace = instance
+        .get_func(&mut *caller, "trace")
+        .context("trace module is missing its `trace` export")?;
+
+    let host = caller.data_mut();
+    let id = host.next_id;
+    host.next_id += 1;
+    host.traces.insert(id, trace);
+    Ok(id)
+}
+
+/// Run a previously compiled trace, returning its guard-exit index.
+fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> Result<u32> {
+    let trace = *caller
+        .data()
+        .traces
+        .get(&func_id)
+        .with_context(|| format!("jit_execute_wasm: unknown func id {func_id}"))?;
+    let mut results = [Val::I32(0)];
+    trace.call(&mut *caller, &[Val::I32(frame_ptr as i32)], &mut results)?;
+    Ok(match results[0] {
+        Val::I32(x) => x as u32,
+        _ => 0,
+    })
+}
+
+/// Dispatch a residual call requested by a running trace.
+fn jit_call_trampoline(caller: &mut Caller<'_, Host>, frame_ptr: u32) -> Result<()> {
+    let memory = caller.data().memory.context("memory")?;
+    let table = caller.data().table.context("table")?;
+    let frame = frame_ptr as usize;
+
+    let func_ptr = read_u32(&memory, &*caller, frame + CALL_FUNC_OFS);
+
+    // `func_ptr == 0` is the "newstr" sentinel; without a host string
+    // allocator (matching the browser glue's null table slot) it yields 0.
+    if func_ptr == 0 {
+        write_i64(&memory, &mut *caller, frame + CALL_RESULT_OFS, 0)?;
+        return Ok(());
+    }
+
+    let func = match table.get(&mut *caller, func_ptr as u64) {
+        Some(Ref::Func(Some(f))) => f,
+        _ => {
+            write_i64(&memory, &mut *caller, frame + CALL_RESULT_OFS, 0)?;
+            return Ok(());
+        }
+    };
+
+    let ty = func.ty(&*caller);
+    let params: Vec<ValType> = ty.params().collect();
+    let mut args: Vec<Val> = Vec::with_capacity(params.len());
+    for (i, pty) in params.iter().enumerate() {
+        let raw = read_i64(&memory, &*caller, frame + CALL_ARGS_OFS + i * 8);
+        args.push(match pty {
+            ValType::I32 => Val::I32(raw as i32),
+            ValType::I64 => Val::I64(raw),
+            // Floats cross the call area as their raw bit pattern in an i64 slot.
+            ValType::F32 => Val::F32(raw as u32),
+            ValType::F64 => Val::F64(raw as u64),
+            other => {
+                return Err(Error::msg(format!(
+                    "unsupported residual-call param type {other:?}"
+                )));
+            }
+        });
+    }
+
+    let mut results: Vec<Val> = ty
+        .results()
+        .map(|t| match t {
+            ValType::I64 => Val::I64(0),
+            ValType::F32 => Val::F32(0),
+            ValType::F64 => Val::F64(0),
+            _ => Val::I32(0),
+        })
+        .collect();
+
+    // Mirror the browser glue's try/catch: a trapping residual target is
+    // reported as a zero result rather than aborting the whole run.
+    if let Err(e) = func.call(&mut *caller, &args, &mut results) {
+        eprintln!("[jit_call] residual target trapped: {e:?}");
+        write_i64(&memory, &mut *caller, frame + CALL_RESULT_OFS, 0)?;
+        return Ok(());
+    }
+
+    let result = match results.first() {
+        Some(Val::I32(x)) => (*x as u32) as i64, // zero-extend; high word stays 0
+        Some(Val::I64(x)) => *x,
+        Some(Val::F64(x)) => *x as i64,
+        Some(Val::F32(x)) => (*x as u64) as i64,
+        _ => 0,
+    };
+    write_i64(&memory, &mut *caller, frame + CALL_RESULT_OFS, result)?;
+    Ok(())
+}
+
+/// Scan wasm linear memory for panic messages pyre-wasm's hook wrote there.
+///
+/// The hook prepends a literal `[pyre panic] ` to the panic info, and that
+/// concatenation only exists at runtime (never as a static format template), so
+/// matching the combined prefix recovers the real formatted message — including
+/// the asserted values — rather than a `{…}`-placeholder template.
+fn recover_panic_messages(data: &[u8]) -> Vec<String> {
+    let needle = b"[pyre panic] panicked at";
+    let mut out: Vec<String> = Vec::new();
+    let mut from = 0;
+    while let Some(rel) = data[from..].windows(needle.len()).position(|w| w == needle) {
+        let pos = from + rel;
+        let end = data[pos..]
+            .iter()
+            .position(|&b| b == 0)
+            .map(|n| pos + n)
+            .unwrap_or((pos + 400).min(data.len()));
+        // Decode and cut at the first non-text byte (`U+FFFD` from lossy
+        // decoding of trailing String capacity garbage).
+        let text = String::from_utf8_lossy(&data[pos..end]);
+        let text = text
+            .split('\u{FFFD}')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if !text.is_empty() && !out.contains(&text) {
+            out.push(text);
+            if out.len() >= 4 {
+                break;
+            }
+        }
+        from = end + 1;
+    }
+    out
+}
+
+fn read_u32(mem: &Memory, store: impl AsContext, off: usize) -> u32 {
+    let mut b = [0u8; 4];
+    let _ = mem.read(store, off, &mut b);
+    u32::from_le_bytes(b)
+}
+
+fn read_i64(mem: &Memory, store: impl AsContext, off: usize) -> i64 {
+    let mut b = [0u8; 8];
+    let _ = mem.read(store, off, &mut b);
+    i64::from_le_bytes(b)
+}
+
+fn write_i64(mem: &Memory, mut store: impl AsContextMut, off: usize, v: i64) -> Result<()> {
+    mem.write(&mut store, off, &v.to_le_bytes())
+        .context("write call-area result")
+}
+
+/// Dump the module's imports and exports, for debugging the host contract.
+fn inspect_module(module_path: &PathBuf) -> Result<()> {
+    let engine = Engine::new(&Config::new())?;
+    let module = Module::from_file(&engine, module_path)
+        .with_context(|| format!("load wasm module {}", module_path.display()))?;
+    println!("imports:");
+    for import in module.imports() {
+        println!(
+            "  {}.{} : {:?}",
+            import.module(),
+            import.name(),
+            import.ty()
+        );
+    }
+    println!("exports:");
+    for export in module.exports() {
+        println!("  {} : {:?}", export.name(), export.ty());
+    }
+    Ok(())
+}

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -228,6 +228,26 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
         },
     )?;
 
+    // Reflective residual-call trampoline for the *recording* / blackhole
+    // path. The compiled trace reaches residual targets through `env.jit_call`
+    // on the child module; the in-module metainterp cannot reflect a function's
+    // wasm type to build a matching `call_indirect`, so it routes residual
+    // calls here instead. Reuses the same call-area protocol and signature
+    // reflection as `jit_call_trampoline` (the child's `env.jit_call`), so a
+    // residual target whose real signature is not the uniform `(i64…) -> i64`
+    // (e.g. the void `set_current_exception_fn`, or the `-> i64`
+    // `store_subscr_fn` invoked in a void context) is coerced correctly
+    // rather than trapping on an indirect-call type mismatch.
+    linker.func_wrap(
+        "pyre_jit",
+        "jit_call_host",
+        |mut caller: Caller<'_, Host>, frame_ptr: u32| {
+            if let Err(e) = jit_call_trampoline(&mut caller, frame_ptr) {
+                eprintln!("[jit_call_host] {e:?}");
+            }
+        },
+    )?;
+
     Ok(linker)
 }
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -271,7 +271,27 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
         .context("read trace module bytes")?;
 
     let engine = caller.engine().clone();
-    let module = Module::new(&engine, &bytes).context("compile trace module")?;
+    if std::env::var_os("PYRE_WASM_DUMP_ALL_TRACES").is_some() {
+        match wasmprinter::print_bytes(&bytes) {
+            Ok(wat) => eprintln!("=== trace module ({} bytes) ===\n{wat}", bytes.len()),
+            Err(pe) => eprintln!("[jit_compile_wasm] wat print failed: {pe}"),
+        }
+    }
+    let module = match Module::new(&engine, &bytes) {
+        Ok(m) => m,
+        Err(e) => {
+            if std::env::var_os("PYRE_WASM_DUMP_BAD_TRACE").is_some() {
+                let path = "/tmp/pyre_bad_trace.wasm";
+                let _ = std::fs::write(path, &bytes);
+                eprintln!("[jit_compile_wasm] dumped {} bytes to {path}", bytes.len());
+                match wasmprinter::print_bytes(&bytes) {
+                    Ok(wat) => eprintln!("--- WAT ---\n{wat}\n--- /WAT ---"),
+                    Err(pe) => eprintln!("[jit_compile_wasm] wat print failed: {pe}"),
+                }
+            }
+            return Err(e).context("compile trace module");
+        }
+    };
 
     // A fresh trampoline per trace; it reads all state from `caller.data()`.
     let jit_call = Func::wrap(

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -51,6 +51,10 @@ struct Host {
     /// Compiled trace `trace` functions, keyed by the id handed back to wasm.
     traces: HashMap<u32, Func>,
     next_id: u32,
+    /// Real stdlib root the wasm module's `pyre_host.*` imports read source
+    /// from (`$PYRE_STDLIB`, forwarded by `pyre/check.py`). The wasm side
+    /// seeds it on `sys.path`, so the host serves genuine absolute paths.
+    stdlib_root: Option<String>,
 }
 
 fn main() {
@@ -135,6 +139,7 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
 
     let mut store = Store::new(&engine, Host::default());
     store.data_mut().next_id = 1;
+    store.data_mut().stdlib_root = std::env::var("PYRE_STDLIB").ok();
 
     let linker = build_linker(&engine)?;
     let instance = linker
@@ -254,7 +259,106 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
         },
     )?;
 
+    // Host-filesystem imports for the wasmi build's module loader. The wasm32
+    // module has no filesystem of its own; these serve module source from the
+    // host's real stdlib (`$PYRE_STDLIB`). See `pyre-wasm`'s `host_fs_provider`.
+    linker.func_wrap(
+        "pyre_host",
+        "host_stdlib_root",
+        |mut caller: Caller<'_, Host>, buf_ptr: u32, buf_cap: u32| -> i64 {
+            host_stdlib_root(&mut caller, buf_ptr, buf_cap)
+        },
+    )?;
+    linker.func_wrap(
+        "pyre_host",
+        "host_is_dir",
+        |mut caller: Caller<'_, Host>, path_ptr: u32, path_len: u32| -> u32 {
+            match host_path(&mut caller, path_ptr, path_len) {
+                Some(p) => PathBuf::from(p).is_dir() as u32,
+                None => 0,
+            }
+        },
+    )?;
+    linker.func_wrap(
+        "pyre_host",
+        "host_file_size",
+        |mut caller: Caller<'_, Host>, path_ptr: u32, path_len: u32| -> i64 {
+            match host_path(&mut caller, path_ptr, path_len) {
+                Some(p) => match std::fs::metadata(&p) {
+                    Ok(m) if m.is_file() => m.len() as i64,
+                    _ => -1,
+                },
+                None => -1,
+            }
+        },
+    )?;
+    linker.func_wrap(
+        "pyre_host",
+        "host_read",
+        |mut caller: Caller<'_, Host>,
+         path_ptr: u32,
+         path_len: u32,
+         buf_ptr: u32,
+         buf_cap: u32|
+         -> i64 { host_read(&mut caller, path_ptr, path_len, buf_ptr, buf_cap) },
+    )?;
+
     Ok(linker)
+}
+
+/// Read a host path argument out of wasm linear memory as a `String`.
+fn host_path(caller: &mut Caller<'_, Host>, path_ptr: u32, path_len: u32) -> Option<String> {
+    let memory = caller.data().memory?;
+    let mut bytes = vec![0u8; path_len as usize];
+    memory.read(&*caller, path_ptr as usize, &mut bytes).ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+/// `pyre_host.host_stdlib_root`: write `$PYRE_STDLIB` into the wasm buffer.
+fn host_stdlib_root(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i64 {
+    let Some(root) = caller.data().stdlib_root.clone() else {
+        return -1;
+    };
+    let bytes = root.as_bytes();
+    if bytes.len() > buf_cap as usize {
+        // Report the needed length without writing; the caller can retry.
+        return bytes.len() as i64;
+    }
+    let Some(memory) = caller.data().memory else {
+        return -1;
+    };
+    if memory.write(&mut *caller, buf_ptr as usize, bytes).is_err() {
+        return -1;
+    }
+    bytes.len() as i64
+}
+
+/// `pyre_host.host_read`: read the host file into the wasm-provided buffer.
+fn host_read(
+    caller: &mut Caller<'_, Host>,
+    path_ptr: u32,
+    path_len: u32,
+    buf_ptr: u32,
+    buf_cap: u32,
+) -> i64 {
+    let Some(path) = host_path(caller, path_ptr, path_len) else {
+        return -1;
+    };
+    let data = match std::fs::read(&path) {
+        Ok(d) => d,
+        Err(_) => return -1,
+    };
+    let n = data.len().min(buf_cap as usize);
+    let Some(memory) = caller.data().memory else {
+        return -1;
+    };
+    if memory
+        .write(&mut *caller, buf_ptr as usize, &data[..n])
+        .is_err()
+    {
+        return -1;
+    }
+    n as i64
 }
 
 /// Compile and instantiate a JIT-emitted trace module, sharing the main

--- a/pyre/pyre-wasm/Cargo.toml
+++ b/pyre/pyre-wasm/Cargo.toml
@@ -22,7 +22,7 @@ web = ["dep:wasm-bindgen", "pyre-jit/wasm-web", "getrandom/wasm_js"]
 # shim in `src/lib.rs`), selected by building with
 # `--cfg getrandom_backend="custom"`, so the module carries no wasm-bindgen
 # imports a non-JS embedder could not satisfy.
-wasmi = ["pyre-jit/wasm-host"]
+wasmi = ["pyre-jit/wasm-host", "dep:majit-backend"]
 
 [dependencies]
 pyre-object = { workspace = true }
@@ -33,3 +33,7 @@ pyre-interpreter = { workspace = true }
 pyre-jit = { path = "../pyre-jit", version = "0.0.2", default-features = false }
 wasm-bindgen = { workspace = true, optional = true }
 getrandom = { workspace = true }
+# Only the `wasmi` (native-host) build installs the residual-call host
+# trampoline (`call_stub::set_residual_host_call`); the `web` build keeps
+# the in-module transmute path until the JS glue grows the matching import.
+majit-backend = { workspace = true, optional = true }

--- a/pyre/pyre-wasm/Cargo.toml
+++ b/pyre/pyre-wasm/Cargo.toml
@@ -37,3 +37,7 @@ getrandom = { workspace = true }
 # trampoline (`call_stub::set_residual_host_call`); the `web` build keeps
 # the in-module transmute path until the JS glue grows the matching import.
 majit-backend = { workspace = true, optional = true }
+# For the panic hook: classify `InvalidLoop` / `SpeculativeError` payloads
+# (the JIT's silent trace-abort signals) so their messages are suppressed,
+# mirroring pyrex. Already compiled for wasm32 transitively via pyre-jit.
+majit-metainterp = { workspace = true }

--- a/pyre/pyre-wasm/Cargo.toml
+++ b/pyre/pyre-wasm/Cargo.toml
@@ -14,10 +14,14 @@ crate-type = ["cdylib"]
 default = ["web"]
 # Browser / JS host: `run_python` is exported through wasm-bindgen and the
 # JIT instantiates trace modules via the `WebAssembly` API (`jit_glue.js`).
-web = ["dep:wasm-bindgen", "pyre-jit/wasm-web"]
+web = ["dep:wasm-bindgen", "pyre-jit/wasm-web", "getrandom/wasm_js"]
 # Native wasm host (wasmi / wasmtime): a plain C-ABI surface
 # (`pyre_alloc` / `pyre_dealloc` / `pyre_run_python`) is exported and the
 # JIT instantiates trace modules via plain wasm imports. No JavaScript.
+# getrandom uses its `custom` backend here (see the `__getrandom_v03_custom`
+# shim in `src/lib.rs`), selected by building with
+# `--cfg getrandom_backend="custom"`, so the module carries no wasm-bindgen
+# imports a non-JS embedder could not satisfy.
 wasmi = ["pyre-jit/wasm-host"]
 
 [dependencies]

--- a/pyre/pyre-wasm/Cargo.toml
+++ b/pyre/pyre-wasm/Cargo.toml
@@ -14,7 +14,14 @@ crate-type = ["cdylib"]
 default = ["web"]
 # Browser / JS host: `run_python` is exported through wasm-bindgen and the
 # JIT instantiates trace modules via the `WebAssembly` API (`jit_glue.js`).
-web = ["dep:wasm-bindgen", "pyre-jit/wasm-web", "getrandom/wasm_js"]
+# The browser has no filesystem, so the stdlib `import re` needs is embedded
+# and served from an in-memory VFS (`pyre-interpreter/wasm_vfs`).
+web = [
+    "dep:wasm-bindgen",
+    "pyre-jit/wasm-web",
+    "getrandom/wasm_js",
+    "pyre-interpreter/wasm_vfs",
+]
 # Native wasm host (wasmi / wasmtime): a plain C-ABI surface
 # (`pyre_alloc` / `pyre_dealloc` / `pyre_run_python`) is exported and the
 # JIT instantiates trace modules via plain wasm imports. No JavaScript.
@@ -37,7 +44,3 @@ getrandom = { workspace = true }
 # trampoline (`call_stub::set_residual_host_call`); the `web` build keeps
 # the in-module transmute path until the JS glue grows the matching import.
 majit-backend = { workspace = true, optional = true }
-# For the panic hook: classify `InvalidLoop` / `SpeculativeError` payloads
-# (the JIT's silent trace-abort signals) so their messages are suppressed,
-# mirroring pyrex. Already compiled for wasm32 transitively via pyre-jit.
-majit-metainterp = { workspace = true }

--- a/pyre/pyre-wasm/build-web.sh
+++ b/pyre/pyre-wasm/build-web.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Build the browser (web / wasm-bindgen) flavour of pyre-wasm and stage the
+# artefacts that www/index.html loads.
+#
+# Both the `web` and `wasmi` builds of this single crate emit to the shared
+# target/wasm32-unknown-unknown/release/pyre_wasm.wasm path, so a later build
+# of the other flavour (or check.py, which builds wasmi) overwrites it. This
+# script snapshots the web output to a feature-distinct pyre_wasm.web.wasm
+# immediately and feeds that snapshot to wasm-bindgen, so the deployed module
+# never depends on the shared path surviving. (check.py does the mirror image
+# for wasmi -> pyre_wasm.wasmi.wasm.)
+#
+# Requires: the wasm32-unknown-unknown rustup target and wasm-bindgen-cli
+# (`cargo install wasm-bindgen-cli`, matching the crate's wasm-bindgen version).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+target_dir="target/wasm32-unknown-unknown/release"
+raw_wasm="$target_dir/pyre_wasm.wasm"
+web_wasm="$target_dir/pyre_wasm.web.wasm"
+www_dir="pyre/pyre-wasm/www"
+glue_src="majit/majit-backend-wasm/js/jit_glue.js"
+
+if ! command -v wasm-bindgen >/dev/null 2>&1; then
+    echo "error: wasm-bindgen not found; run 'cargo install wasm-bindgen-cli'" >&2
+    exit 1
+fi
+
+# `web` selects the wasm-bindgen entry point, getrandom's wasm_js backend, and
+# the embedded stdlib VFS (no host filesystem in the browser). `--export-table`
+# exposes __indirect_function_table for the JIT glue (jit_set_table); unlike the
+# wasmi build, web does not use getrandom's `custom` backend.
+RUSTFLAGS='-C link-arg=--export-table' \
+    cargo build --release -p pyre-wasm \
+    --target wasm32-unknown-unknown \
+    --no-default-features --features web
+
+# Snapshot before anything else can clobber the shared output path, then drive
+# wasm-bindgen from the snapshot. `--out-name pyre_wasm` keeps the emitted
+# pyre_wasm.js / pyre_wasm_bg.wasm names index.html imports, regardless of the
+# snapshot's filename.
+cp "$raw_wasm" "$web_wasm"
+wasm-bindgen --target web --out-dir "$www_dir" --out-name pyre_wasm "$web_wasm"
+
+# The JIT glue module the page imports alongside the bindgen output.
+cp "$glue_src" "$www_dir/jit_glue.js"
+
+echo "web build staged in $www_dir (snapshot: $web_wasm)"

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -11,6 +11,41 @@ compile_error!("feature `wasmi` requires target_arch = \"wasm32\"");
 #[cfg(feature = "web")]
 use wasm_bindgen::prelude::*;
 
+// Native-host (`wasmi`) builds target wasm32-unknown-unknown, which has no OS
+// entropy. To avoid the wasm-bindgen-based `wasm_js` backend (whose imports a
+// non-JS embedder cannot satisfy), getrandom is wired to its `custom` backend
+// via `--cfg getrandom_backend="custom"`, which calls this hook. pyre seeds only
+// non-cryptographic uses (string hash key, the `random` module) from it, and the
+// values never affect check.py's oracle comparison, so a deterministic
+// SplitMix64 stream is sufficient.
+#[cfg(all(target_arch = "wasm32", feature = "wasmi"))]
+mod custom_getrandom {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    static STATE: AtomicU64 = AtomicU64::new(0x9e37_79b9_7f4a_7c15);
+
+    #[unsafe(no_mangle)]
+    unsafe extern "Rust" fn __getrandom_v03_custom(
+        dest: *mut u8,
+        len: usize,
+    ) -> Result<(), getrandom::Error> {
+        let mut i = 0;
+        while i < len {
+            let mut z = STATE
+                .fetch_add(0x9e37_79b9_7f4a_7c15, Ordering::Relaxed)
+                .wrapping_add(0x9e37_79b9_7f4a_7c15);
+            z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            z ^= z >> 31;
+            let bytes = z.to_le_bytes();
+            let n = core::cmp::min(8, len - i);
+            unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), dest.add(i), n) };
+            i += n;
+        }
+        Ok(())
+    }
+}
+
 use pyre_interpreter::*;
 
 use std::cell::RefCell;

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -113,28 +113,98 @@ mod residual_host {
     }
 }
 
+// Host-filesystem source provider for the native-host (`wasmi`) build.
+//
+// wasm32 has no filesystem, but the wasmtime runner does, so module source is
+// read through `pyre_host.*` host imports the runner satisfies. The runner
+// reports the real stdlib root (the `$PYRE_STDLIB` directory `pyre/check.py`
+// forwards); seeding it on `sys.path` lets the SAME import machinery that runs
+// on native resolve `import re` against genuine host paths. The browser/web
+// build has no such host, so it embeds the stdlib instead (`wasm_vfs`).
+#[cfg(all(target_arch = "wasm32", feature = "wasmi"))]
+mod host_fs_provider {
+    use pyre_interpreter::importing::SourceProvider;
+    use std::path::Path;
+
+    #[link(wasm_import_module = "pyre_host")]
+    unsafe extern "C" {
+        /// Write the real stdlib root path into `[buf, buf+cap)`; return its
+        /// byte length (without writing if it exceeds `cap`), or -1 if unset.
+        fn host_stdlib_root(buf_ptr: *mut u8, buf_cap: u32) -> i64;
+        /// 1 if `[path, path+len)` names a directory, else 0.
+        fn host_is_dir(path_ptr: *const u8, path_len: u32) -> u32;
+        /// Byte length of the regular file at `path`, or -1 if not a file.
+        fn host_file_size(path_ptr: *const u8, path_len: u32) -> i64;
+        /// Read the file at `path` into `[buf, buf+cap)`; return bytes written
+        /// (clamped to `cap`), or -1 on error.
+        fn host_read(path_ptr: *const u8, path_len: u32, buf_ptr: *mut u8, buf_cap: u32) -> i64;
+    }
+
+    struct HostFsProvider;
+
+    impl SourceProvider for HostFsProvider {
+        fn is_file(&self, path: &Path) -> bool {
+            let p = path.to_string_lossy();
+            unsafe { host_file_size(p.as_ptr(), p.len() as u32) >= 0 }
+        }
+        fn is_dir(&self, path: &Path) -> bool {
+            let p = path.to_string_lossy();
+            unsafe { host_is_dir(p.as_ptr(), p.len() as u32) != 0 }
+        }
+        fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
+            let p = path.to_string_lossy();
+            let size = unsafe { host_file_size(p.as_ptr(), p.len() as u32) };
+            if size < 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("{}", path.display()),
+                ));
+            }
+            let mut buf = vec![0u8; size as usize];
+            let n = unsafe {
+                host_read(
+                    p.as_ptr(),
+                    p.len() as u32,
+                    buf.as_mut_ptr(),
+                    buf.len() as u32,
+                )
+            };
+            if n < 0 {
+                return Err(std::io::Error::other(format!(
+                    "host_read failed: {}",
+                    path.display()
+                )));
+            }
+            buf.truncate(n as usize);
+            String::from_utf8(buf)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        }
+    }
+
+    /// Query the host for the stdlib root, seed it on `sys.path`, and install
+    /// the host-FS source provider.  Called once before the first import.
+    pub fn install() {
+        let mut buf = vec![0u8; 4096];
+        let n = unsafe { host_stdlib_root(buf.as_mut_ptr(), buf.len() as u32) };
+        if n > 0 && (n as usize) <= buf.len() {
+            if let Ok(root) = std::str::from_utf8(&buf[..n as usize]) {
+                pyre_interpreter::importing::add_sys_path(Path::new(root));
+            }
+        }
+        pyre_interpreter::importing::install_source_provider(std::rc::Rc::new(HostFsProvider));
+    }
+}
+
 static PANIC_HOOK: Once = Once::new();
 
 fn install_panic_hook() {
     PANIC_HOOK.call_once(|| {
         std::panic::set_hook(Box::new(|info| {
-            // The JIT raises `InvalidLoop` / `SpeculativeError` as panics to
-            // abandon a trace; the wasm32 module is built with `-C panic=unwind`
-            // so these unwind to their `catch_unwind` recovery sites
-            // (jump_to_preamble fallback) and execution continues. Their message
-            // is a false crash signal — suppress it so it does not pollute the
-            // captured output, mirroring pyrex's hook. A genuinely uncaught
-            // panic still surfaces here.
-            let payload = info.payload();
-            let is_silent_control_flow = payload
-                .downcast_ref::<majit_metainterp::optimize::InvalidLoop>()
-                .is_some()
-                || payload
-                    .downcast_ref::<majit_metainterp::optimize::SpeculativeError>()
-                    .is_some();
-            if is_silent_control_flow {
-                return;
-            }
+            // The module is built with the default `panic=abort`, so a panic
+            // ends the run. Record the formatted message in linear memory
+            // before the abort; the runner's `recover_panic_messages` scans for
+            // it (the browser glue surfaces it the same way) so the real cause
+            // is visible rather than a bare trap.
             let msg = format!("[pyre panic] {info}");
             OUTPUT_BUF.with(|buf| buf.borrow_mut().push_str(&msg));
         }));
@@ -160,6 +230,14 @@ fn run_python_impl(source: &str) -> String {
     #[cfg(all(target_arch = "wasm32", feature = "wasmi"))]
     residual_host::install();
     pyre_interpreter::importing::install_builtin_modules();
+    // Give the import machinery a source of module bytes. The browser has no
+    // filesystem, so the web build serves the embedded stdlib closure from an
+    // in-memory VFS; the native-host (`wasmi`) build reads the host filesystem
+    // through `pyre_host.*` imports the runner satisfies.
+    #[cfg(feature = "web")]
+    pyre_interpreter::importing::mount_embedded_stdlib(std::path::Path::new("/lib-python/3"));
+    #[cfg(all(target_arch = "wasm32", feature = "wasmi"))]
+    host_fs_provider::install();
     install_wasm_print_hook();
     OUTPUT_BUF.with(|buf| buf.borrow_mut().clear());
 

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -118,6 +118,23 @@ static PANIC_HOOK: Once = Once::new();
 fn install_panic_hook() {
     PANIC_HOOK.call_once(|| {
         std::panic::set_hook(Box::new(|info| {
+            // The JIT raises `InvalidLoop` / `SpeculativeError` as panics to
+            // abandon a trace; the wasm32 module is built with `-C panic=unwind`
+            // so these unwind to their `catch_unwind` recovery sites
+            // (jump_to_preamble fallback) and execution continues. Their message
+            // is a false crash signal — suppress it so it does not pollute the
+            // captured output, mirroring pyrex's hook. A genuinely uncaught
+            // panic still surfaces here.
+            let payload = info.payload();
+            let is_silent_control_flow = payload
+                .downcast_ref::<majit_metainterp::optimize::InvalidLoop>()
+                .is_some()
+                || payload
+                    .downcast_ref::<majit_metainterp::optimize::SpeculativeError>()
+                    .is_some();
+            if is_silent_control_flow {
+                return;
+            }
             let msg = format!("[pyre panic] {info}");
             OUTPUT_BUF.with(|buf| buf.borrow_mut().push_str(&msg));
         }));

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -175,6 +175,12 @@ fn run_python_impl(source: &str) -> String {
     // JIT-compiled loop — can resolve its parent frame instead of tripping the
     // fail-fast topframe assert.
     pyre_interpreter::call::set_last_exec_ctx(std::rc::Rc::as_ptr(&execution_context));
+    // Register the __build_class__ callback and seed its exec-context slot
+    // (pyrex setup_exec_context does the same). Without this, a `class Sub(...,
+    // kw=...)` body cannot resolve the live frame in call_init_subclass_on_bases
+    // and __init_subclass__ keyword arguments are rejected.
+    pyre_interpreter::call::register_build_class();
+    pyre_interpreter::call::set_build_class_exec_ctx(std::rc::Rc::as_ptr(&execution_context));
     let mut frame =
         match pyre_interpreter::pyframe::PyFrame::new_with_context(code, execution_context) {
             Ok(frame) => frame,

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -51,6 +51,68 @@ use pyre_interpreter::*;
 use std::cell::RefCell;
 use std::sync::Once;
 
+// Residual-call host trampoline for the native-host (`wasmi`) build.
+//
+// wasm32 `call_indirect` type-checks every call, so the in-module metainterp
+// cannot transmute a raw funcptr to a statically-guessed `extern "C" fn` and
+// call it — a residual target whose real signature is not the uniform
+// `(i64…) -> i64` traps. The compiled trace already round-trips such calls
+// through the host (`env.jit_call`); this routes the recording / blackhole
+// path through the symmetric `pyre_jit.jit_call_host` import, which reflects
+// the callee's wasm signature and coerces each positional argument.
+#[cfg(all(target_arch = "wasm32", feature = "wasmi"))]
+mod residual_host {
+    use core::cell::UnsafeCell;
+
+    // Call-area layout shared with `majit-backend-wasm` codegen and the host
+    // runner's `jit_call_trampoline`; offsets are relative to the frame-pointer
+    // base passed to the import.
+    const CALL_RESULT_OFS: usize = 2000;
+    const CALL_FUNC_OFS: usize = 2008;
+    const CALL_NARGS_OFS: usize = 2016;
+    const CALL_ARGS_OFS: usize = 2024;
+    const MAX_ARGS: usize = 16;
+    const SCRATCH_LEN: usize = CALL_ARGS_OFS + MAX_ARGS * 8;
+
+    #[link(wasm_import_module = "pyre_jit")]
+    unsafe extern "C" {
+        fn jit_call_host(frame_ptr: u32);
+    }
+
+    // A wasm32 module instance is single-threaded, so a shared scratch buffer
+    // needs no synchronization. Residual calls nest synchronously: each level
+    // writes its arguments, the host reads them before invoking the callee, and
+    // each level reads its result immediately after the host returns — so an
+    // inner call that reuses the buffer cannot clobber an outer call's
+    // already-consumed arguments or not-yet-written result.
+    struct Scratch(UnsafeCell<[u8; SCRATCH_LEN]>);
+    unsafe impl Sync for Scratch {}
+    static SCRATCH: Scratch = Scratch(UnsafeCell::new([0u8; SCRATCH_LEN]));
+
+    fn residual_host_call(func_ptr: usize, args: &[i64]) -> i64 {
+        assert!(
+            args.len() <= MAX_ARGS,
+            "residual_host_call: arity {} exceeds {MAX_ARGS}",
+            args.len()
+        );
+        let base = SCRATCH.0.get() as *mut u8;
+        unsafe {
+            (base.add(CALL_FUNC_OFS) as *mut i64).write_unaligned(func_ptr as i64);
+            (base.add(CALL_NARGS_OFS) as *mut i64).write_unaligned(args.len() as i64);
+            for (i, &a) in args.iter().enumerate() {
+                (base.add(CALL_ARGS_OFS + i * 8) as *mut i64).write_unaligned(a);
+            }
+            jit_call_host(base as u32);
+            (base.add(CALL_RESULT_OFS) as *const i64).read_unaligned()
+        }
+    }
+
+    /// Install the trampoline on the current thread. Idempotent.
+    pub fn install() {
+        majit_backend::call_stub::set_residual_host_call(Some(residual_host_call));
+    }
+}
+
 static PANIC_HOOK: Once = Once::new();
 
 fn install_panic_hook() {
@@ -78,6 +140,8 @@ fn install_wasm_print_hook() {
 /// (C-ABI) entry points below.
 fn run_python_impl(source: &str) -> String {
     install_panic_hook();
+    #[cfg(all(target_arch = "wasm32", feature = "wasmi"))]
+    residual_host::install();
     pyre_interpreter::importing::install_builtin_modules();
     install_wasm_print_hook();
     OUTPUT_BUF.with(|buf| buf.borrow_mut().clear());
@@ -88,11 +152,29 @@ fn run_python_impl(source: &str) -> String {
     };
 
     let execution_context = std::rc::Rc::new(PyExecutionContext::default());
+    // Seed the TLS execution-context slot (pyrex real_main does the same at
+    // boot). `getexecutioncontext().gettopframe()` must be live so a residual
+    // `bh_call_fn_impl` from a blackhole resume — e.g. a `print(...)` after a
+    // JIT-compiled loop — can resolve its parent frame instead of tripping the
+    // fail-fast topframe assert.
+    pyre_interpreter::call::set_last_exec_ctx(std::rc::Rc::as_ptr(&execution_context));
     let mut frame =
         match pyre_interpreter::pyframe::PyFrame::new_with_context(code, execution_context) {
             Ok(frame) => frame,
             Err(e) => return format!("Error: {e}"),
         };
+
+    // Register the `__main__` module in sys.modules (pyrex real_main does the
+    // same), reusing the canonical globals dict so `__main__.__dict__`,
+    // `globals()`, and `function.__globals__` share one identity. Without this,
+    // `sys.modules['__main__']` / `import __main__` raise KeyError.
+    let canonical = frame.get_w_globals_obj();
+    let main_module = pyre_object::moduleobject::w_module_new_aliasing_dict(
+        "__main__",
+        unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },
+        canonical,
+    );
+    pyre_interpreter::importing::set_sys_module("__main__", main_module);
 
     // catch_unwind to capture panics from JIT as error messages
     let eval_result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -154,14 +154,23 @@ mod host_abi {
     /// the host must free with `pyre_dealloc`.
     #[unsafe(no_mangle)]
     pub extern "C" fn pyre_run_python(ptr: *const u8, len: usize) -> u64 {
-        let source = if ptr.is_null() {
-            String::new()
+        let result = if ptr.is_null() || len == 0 {
+            run_python_impl("")
         } else {
-            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
-            String::from_utf8_lossy(bytes).into_owned()
+            // Reject a (ptr, len) that escapes linear memory before forming a
+            // slice; the embedder supplies these raw, so an out-of-range pair
+            // would otherwise be undefined behaviour.
+            let mem_bytes = core::arch::wasm32::memory_size(0).saturating_mul(65536);
+            match (ptr as usize).checked_add(len) {
+                Some(end) if end <= mem_bytes => {
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+                    run_python_impl(&String::from_utf8_lossy(bytes))
+                }
+                _ => "Error: input buffer out of wasm memory bounds".to_string(),
+            }
         };
 
-        let out = run_python_impl(&source).into_bytes();
+        let out = result.into_bytes();
         let out_len = out.len();
         let out_ptr = pyre_alloc(out_len);
         if out_len != 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Adds a WebAssembly (`wasm32-unknown-unknown`) target for the pyre JIT, so traces compile and execute both in the browser and in non-browser wasm embedders.

**New crates**
- `majit-backend-wasm` — a JIT backend that lowers optimized traces to wasm and dispatches them through the host function table: guards and de-opt exits, bridge resume in the blackhole, a per-trace exception cell, vable array ops, and JUMP label-arg rebind as a parallel move. Unsupported shapes (`CALL_ASSEMBLER`, external `JUMP`, some alloc+call loops) decline cleanly and fall back to the interpreter.
- `pyre-wasm` — the wasm module, with two mutually-exclusive bindings: `wasmi` (plain C-ABI for a native wasmi/wasmtime embedder) and `web` (wasm-bindgen, browser host).
- `pyre-wasm-runner` — a wasmtime host that runs the `wasmi` build outside a browser, wired into `check.py` as a `--backend wasm` path so the wasm JIT runs the full benchmark suite.

**Stable toolchain**
- JIT trace-aborts now signal via `Result` / a deferred flag instead of `panic_any` + `catch_unwind`, so `pyre-wasm` builds on stable Rust with the default `panic=abort` — no nightly, `-Z build-std`, or exception-handling feature.

**`import re` on wasm**
- A host-agnostic `SourceProvider` seam routes module discovery and source reads: the browser build embeds the `re` stdlib closure in an lz4 VFS; the wasmi runner serves it from the host filesystem through imports. Both mount at the same logical stdlib root, so the import machinery is identical across hosts.

**32-bit correctness**
- Pointer-width field/array access, machine-word length-field reads, vable array stride taken from the field descriptor (not a recomputed word size), `errno` → `OSError` subclass mapping, `time` importable, and related wasm32 fixes.

**Build & CI**
- `pyre-wasm/build-web.sh` stages the browser build under a distinct output name. The CI `wasm build` job hands the LLBC set over as a run-scoped artifact, self-heals a missing Charon install, and builds the `wasmi` leg with getrandom's `custom` backend (the `web` leg uses `getrandom/wasm_js`).

Verified locally: `check.py` dynasm 132/132, cranelift 132/132, wasm 118/118; `cargo fmt --all --check` clean.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
